### PR TITLE
CHAOS-3123: ratify the Projects v2 collector (D18), retire the policy_pending seam

### DIFF
--- a/internal/providersync/github_tests_route_test.go
+++ b/internal/providersync/github_tests_route_test.go
@@ -113,6 +113,22 @@ func TestGitHubTestsRouteEmitsSixCompleteEffectsAndStripsRedirectAuth(t *testing
 	if len(doer.requests) != 7 || doer.requests[6] != "blob.example/report.zip" {
 		t.Fatalf("requests=%v", doer.requests)
 	}
+	// cicd and tests delegate to ONE complete-row unit, so this same batch must
+	// also satisfy the github/cicd descriptor's destination contract.
+	//
+	// Only the tests descriptor was asserted before, which left github/cicd's
+	// six-destination list entirely unpinned. Found by splitting the mutation
+	// entry that spanned both descriptors: while one entry mutated both sites,
+	// the assertion above absorbed the kill and the cicd site was never
+	// measured -- a wholesale mutation reading as coverage for two sites while
+	// covering one.
+	cicd, known := (CompleteRouteSwitches{GithubCICD: true}).Descriptor("github", "cicd")
+	if !known {
+		t.Fatal("github/cicd capability disappeared")
+	}
+	if err := batch.validate(cicd); err != nil {
+		t.Fatalf("github/cicd descriptor rejects the shared complete batch: %v", err)
+	}
 }
 
 func TestGitHubTestsRouteExcludesFeatureBranchArtifactsLikePythonProducer(t *testing.T) {

--- a/internal/providersync/github_work_items_projects_v2.go
+++ b/internal/providersync/github_work_items_projects_v2.go
@@ -37,6 +37,13 @@ const gitHubProjectsV2IntegrationConfigKey = "github_projects_v2"
 //
 // Ratification is not activation: this collector still owns no registration,
 // readiness, watermark, or alias.
+// KNOWN, NOT FIXED: a project_number above 2^53 loses precision before this
+// struct ever sees it. The claim's integration_config is decoded by a plain
+// json.Unmarshal into map[string]any, so every number is a float64 by the time
+// it reaches here -- 9007199254740993 arrives as ...992. Documented rather than
+// fixed because GitHub project numbers are small sequential integers per
+// organisation and nothing near that bound is reachable; a json.Decoder with
+// UseNumber() at the repository boundary would be the fix if that ever changes.
 type GitHubProjectV2Target struct {
 	OrgLogin      string `json:"org_login"`
 	ProjectNumber int    `json:"project_number"`

--- a/internal/providersync/github_work_items_projects_v2.go
+++ b/internal/providersync/github_work_items_projects_v2.go
@@ -84,16 +84,21 @@ func githubProjectV2Targets(claim Claim) ([]GitHubProjectV2Target, error) {
 	if !configured {
 		return []GitHubProjectV2Target{}, nil
 	}
-	// Present key holding JSON null. This FAILED OPEN until CHAOS-3123: it
-	// shared the branch above and returned empty targets with a nil error, so
-	// `{"github_projects_v2": null}` in the durable config was indistinguishable
-	// from never having configured Projects v2 at all. Postgres JSONB null
-	// decodes to an UNTYPED nil interface, so this is the shape production
-	// actually produces -- not a Go-literal typed nil. The operator wrote the
-	// key; refusing is the only answer that cannot silently drop their intent.
-	if value == nil {
-		return nil, ErrInvalidConfiguration
-	}
+	// A present key holding JSON null deliberately does NOT return here. It
+	// FAILED OPEN until CHAOS-3123, when this branch read
+	// `!configured || value == nil` and answered "not configured" for a key the
+	// operator had written -- Postgres JSONB null decodes to an untyped nil
+	// interface, so that is the shape production actually delivers, not the
+	// Go-literal typed nil a test would reach for. Dropping the clause is the
+	// whole fix: null now falls through, marshals to `null`, decodes to a nil
+	// target list, and is refused by the `targets == nil` check below.
+	//
+	// No separate `if value == nil { refuse }` guard sits here on purpose. One
+	// was written and measured first: its mutation SURVIVED, because deleting it
+	// changed no behaviour at all -- the decode path already refuses. That is
+	// the third unkillable clause this file has grown and removed; a guard whose
+	// removal is undetectable is not defence in depth, it is a coverage claim
+	// nothing backs.
 	encoded, err := json.Marshal(value)
 	if err != nil {
 		return nil, ErrInvalidConfiguration

--- a/internal/providersync/github_work_items_projects_v2.go
+++ b/internal/providersync/github_work_items_projects_v2.go
@@ -110,9 +110,16 @@ func (GitHubProjectV2Fetcher) Fetch(
 	normalizedAt time.Time,
 	resolveIdentity githubIdentityResolver,
 ) (GitHubProjectV2FetchResult, error) {
+	// There is deliberately no `credential.ID == ""` clause. claim.Validate()
+	// has already returned nil by the time this is evaluated, and Unit.Validate
+	// refuses an empty CredentialID (lease.go), so an empty credential.ID is
+	// necessarily unequal to the claim's and the equality clause below already
+	// decides it. A clause that cannot fail on its own is not defence in depth;
+	// it is an unkillable mutation that reads as coverage forever — measured as
+	// exactly that before removal.
 	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
 		!isWorkItemFamilyDataset(claim.Dataset) || credential.Provider != "github" ||
-		credential.ID == "" || credential.ID != claim.CredentialID || client == nil ||
+		credential.ID != claim.CredentialID || client == nil ||
 		client.Provider != "github" || client.BaseURL == nil || client.Lease == nil ||
 		normalizedAt.IsZero() {
 		return GitHubProjectV2FetchResult{}, ErrInvalidConfiguration

--- a/internal/providersync/github_work_items_projects_v2.go
+++ b/internal/providersync/github_work_items_projects_v2.go
@@ -80,13 +80,38 @@ type GitHubProjectV2Fetcher struct{}
 
 func githubProjectV2Targets(claim Claim) ([]GitHubProjectV2Target, error) {
 	value, configured := claim.IntegrationConfig[gitHubProjectsV2IntegrationConfigKey]
-	if !configured || value == nil {
+	// Absent key: Projects v2 is simply not configured for this integration.
+	if !configured {
 		return []GitHubProjectV2Target{}, nil
+	}
+	// Present key holding JSON null. This FAILED OPEN until CHAOS-3123: it
+	// shared the branch above and returned empty targets with a nil error, so
+	// `{"github_projects_v2": null}` in the durable config was indistinguishable
+	// from never having configured Projects v2 at all. Postgres JSONB null
+	// decodes to an UNTYPED nil interface, so this is the shape production
+	// actually produces -- not a Go-literal typed nil. The operator wrote the
+	// key; refusing is the only answer that cannot silently drop their intent.
+	if value == nil {
+		return nil, ErrInvalidConfiguration
 	}
 	encoded, err := json.Marshal(value)
 	if err != nil {
 		return nil, ErrInvalidConfiguration
 	}
+	// TRIPWIRE -- the case-insensitivity guarantee below is EMERGENT, not
+	// chosen. encoding/json matches field names case-insensitively, so a
+	// miscased duplicate key (`Org_Login` beside `org_login`) is a candidate to
+	// win. It cannot today only because `value` arrived as a map[string]any and
+	// json.Marshal emits map keys in sorted byte order: uppercase and `_` sort
+	// below lowercase, so the canonical spelling is emitted last and
+	// deterministically wins the decode.
+	//
+	// That holds ONLY while the value makes the map -> re-marshal round trip.
+	// If the one-fetch-per-integration follow-up ever decodes raw JSONB bytes
+	// straight from Postgres, operator key order wins instead, and a trailing
+	// miscased duplicate WOULD take effect. Anyone making that change owns
+	// re-deciding this -- DisallowUnknownFields does not catch it, because a
+	// miscased key MATCHES rather than being unknown.
 	decoder := json.NewDecoder(bytes.NewReader(encoded))
 	decoder.DisallowUnknownFields()
 	var targets []GitHubProjectV2Target

--- a/internal/providersync/github_work_items_projects_v2.go
+++ b/internal/providersync/github_work_items_projects_v2.go
@@ -17,12 +17,26 @@ const gitHubProjectsV2IntegrationConfigKey = "github_projects_v2"
 
 // GitHubProjectV2Target is durable, non-secret integration configuration.
 //
-// ACTIVATION DECISION PENDING (CHAOS-3123): the active Python producer reads
-// these targets from process-global GITHUB_PROJECTS_V2 and creates a second
-// token client. The Go foundation deliberately chooses claim-owned
-// IntegrationConfig plus the already claim-resolved Credential/HTTPClient,
-// but remains unregistered until that ownership and fanout decision is
-// approved in Linear. It must not be used as route-readiness evidence.
+// RATIFIED (D18, cutover Decision Log): targets are durable integration-scoped
+// configuration read from the claim, and collection uses the already
+// claim-resolved Credential/HTTPClient. Environment target/token fallback is
+// not part of the Go route.
+//
+// Two deliberate divergences from the active Python producer follow from that,
+// and are divergences of record rather than porting defects:
+//
+//   - Python reads targets from process-global GITHUB_PROJECTS_V2
+//     (metrics/work_items.py:433) and swallows every malformed entry with a
+//     bare `except Exception: continue`. Go reads durable config and fails
+//     closed, because a silent-skip grammar over an operator-visible config
+//     column would hide a typo as "no projects configured".
+//   - Python builds a SECOND client from process-global GITHUB_TOKEN
+//     (metrics/work_items.py:403-409), ignoring both the resolved integration
+//     credential and its base URL. On GitHub Enterprise Server that client
+//     reaches github.com while this one honors the claim's base URL.
+//
+// Ratification is not activation: this collector still owns no registration,
+// readiness, watermark, or alias.
 type GitHubProjectV2Target struct {
 	OrgLogin      string `json:"org_login"`
 	ProjectNumber int    `json:"project_number"`
@@ -49,10 +63,19 @@ type GitHubProjectV2FetchResult struct {
 	Targets  int
 }
 
-// GitHubProjectV2Fetcher temporarily preserves Python's per-source fanout:
-// callers may invoke it once for each existing work-items claim, and each
-// invocation fetches the claim's complete durable target list. Registration
-// is blocked on the unresolved activation/de-amplification decision above.
+// GitHubProjectV2Fetcher preserves Python's per-source fanout: callers may
+// invoke it once for each existing work-items claim, and each invocation
+// fetches the claim's complete durable target list.
+//
+// That fanout is an AMPLIFICATION, not a mirror, and D18 accepts it only
+// temporarily. Python calls parse_github_projects_v2_env() once per JOB —
+// job_work_items.py sits it at the same indentation as
+// `for discovered_repo in discovered_repos`, i.e. OUTSIDE the repo loop — and
+// merges the result once at the end. The Go unit boundary is per-source, so
+// every claim refetches the same org-wide projects. Collapsing that to
+// one fetch per integration moves the D16 unit boundary and is therefore a
+// separately tracked follow-up with its own oracle strategy; it must not be
+// smuggled in here, and it must not gate the all-or-nothing alias activation.
 type GitHubProjectV2Fetcher struct{}
 
 func githubProjectV2Targets(claim Claim) ([]GitHubProjectV2Target, error) {

--- a/internal/providersync/github_work_items_projects_v2_test.go
+++ b/internal/providersync/github_work_items_projects_v2_test.go
@@ -126,6 +126,50 @@ func TestGitHubProjectV2RefusesEnvironmentTokenWhenClaimCredentialIsUnusable(t *
 	}
 }
 
+// The strongest expression of D18's no-environment-credentials clause lives one
+// layer above this collector: Unit.Validate refuses a claim whose AuthSource is
+// "environment" outright, so a unit whose credentials would come from process
+// state can never reach any Go collector at all.
+//
+// That fence had NO test anywhere in the package and no mutation covering it.
+// It was found by a SURVIVING mutation on this file's own `credential.ID == ""`
+// clause — which survived precisely BECAUSE this fence already guarantees a
+// resolved, non-empty credential id upstream. The redundant clause is gone; the
+// property it was pretending to cover is now asserted where it actually lives.
+//
+// This is the literal "environment configured, no integration credential"
+// scenario: it must fail, not fall back.
+func TestGitHubProjectV2RefusesClaimsAuthoredFromTheEnvironment(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_environment_token_that_must_never_be_used")
+	t.Setenv("GITHUB_PROJECTS_V2", "acme:3")
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+		map[string]any{"org_login": "acme", "project_number": 3},
+	}}
+	credential := providerfoundation.Credential{Provider: "github", ID: claim.CredentialID}
+
+	// Baseline: this exact claim is otherwise usable, so the refusal below is
+	// attributable to AuthSource alone and not to some other invalid field.
+	if err := claim.Validate(); err != nil {
+		t.Fatalf("baseline claim is not valid, so the AuthSource case proves nothing: %v", err)
+	}
+
+	claim.AuthSource = "environment"
+	if err := claim.Validate(); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("an environment-authored claim validated: %v", err)
+	}
+	doer := &gitHubProjectV2Doer{t: t}
+	if _, err := (GitHubProjectV2Fetcher{}).Fetch(
+		context.Background(), claim, credential,
+		githubProjectV2TestClient(t, doer), time.Now().UTC(), nil,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+	}
+	if len(doer.bodies) != 0 {
+		t.Fatalf("environment-authored claim issued %d request(s)", len(doer.bodies))
+	}
+}
+
 func TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig(t *testing.T) {
 	for _, value := range []any{
 		[]any{map[string]any{"org_login": "", "project_number": 1}},

--- a/internal/providersync/github_work_items_projects_v2_test.go
+++ b/internal/providersync/github_work_items_projects_v2_test.go
@@ -176,12 +176,62 @@ func TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig(t *testing.T) 
 		[]any{map[string]any{"org_login": "acme", "project_number": 0}},
 		[]any{map[string]any{"org_login": "acme", "project_number": 1, "token": "forbidden"}},
 		"acme:1",
+		// A present key holding a typed nil slice decodes cleanly to a nil
+		// target list. Without the nil check this reads as "configured, with
+		// nothing in it" -- indistinguishable from a genuinely empty list, so
+		// a config the operator wrote would be silently ignored rather than
+		// rejected. The key being present at all is the signal that they meant
+		// something by it.
+		[]any(nil),
+		[]any{nil},
+		map[string]any{"org_login": "acme", "project_number": 1},
+		[]any{map[string]any{"org_login": "acme", "project_number": 3.7}},
+		[]any{map[string]any{"org_login": "   ", "project_number": 1}},
+		[]any{map[string]any{"org_login": "acme", "project_number": -1}},
 	} {
 		claim := githubWorkItemOracleClaim()
 		claim.IntegrationConfig = map[string]any{"github_projects_v2": value}
 		if _, err := githubProjectV2Targets(claim); !errors.Is(err, ErrInvalidConfiguration) {
 			t.Fatalf("value=%#v error=%v", value, err)
 		}
+	}
+}
+
+// Every test above builds IntegrationConfig as a Go literal, with `int` or
+// json.Number project numbers. PRODUCTION NEVER PRODUCES EITHER: the claim's
+// integration_config arrives as a Postgres JSONB column decoded by a plain
+// json.Unmarshal into map[string]any (repository_postgres.go), so every number
+// is a float64. A parser that happened to accept only int/json.Number would
+// pass this package's whole suite and reject every real tenant's configuration.
+//
+// This builds the config the way the repository does -- from JSON bytes -- so
+// the representation under test is the one production hands us.
+func TestGitHubProjectV2TargetsAcceptThePostgresJSONRepresentation(t *testing.T) {
+	var integrationConfig map[string]any
+	if err := json.Unmarshal([]byte(
+		`{"github_projects_v2":[{"org_login":"acme","project_number":3},`+
+			`{"org_login":"labs","project_number":12}]}`,
+	), &integrationConfig); err != nil {
+		t.Fatal(err)
+	}
+	// Guard the guard: if this stops being float64, the gap this test exists to
+	// close has moved and the test would otherwise keep passing for the wrong
+	// representation.
+	first := integrationConfig["github_projects_v2"].([]any)[0].(map[string]any)
+	if _, isFloat := first["project_number"].(float64); !isFloat {
+		t.Fatalf("project_number decoded as %T, not float64 -- this test is no "+
+			"longer exercising the production representation", first["project_number"])
+	}
+
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = integrationConfig
+	targets, err := githubProjectV2Targets(claim)
+	if err != nil {
+		t.Fatalf("the production JSONB representation was rejected: %v", err)
+	}
+	want := []GitHubProjectV2Target{{OrgLogin: "acme", ProjectNumber: 3}, {OrgLogin: "labs", ProjectNumber: 12}}
+	if !reflect.DeepEqual(targets, want) {
+		t.Fatalf("targets=%+v want=%+v", targets, want)
 	}
 }
 

--- a/internal/providersync/github_work_items_projects_v2_test.go
+++ b/internal/providersync/github_work_items_projects_v2_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
@@ -170,18 +172,35 @@ func TestGitHubProjectV2RefusesClaimsAuthoredFromTheEnvironment(t *testing.T) {
 	}
 }
 
+// F4: an empty CredentialID is rejected by uuid.Parse, which is now the ONLY
+// clause enforcing it -- the separate `unit.CredentialID == ""` test was
+// removed as the unkillable twin of the fetcher clause removed earlier.
+// Asserting the property explicitly here means the removal cannot quietly
+// become a hole: if uuid.Parse were ever relaxed or reordered, this fails.
+func TestUnitValidateRejectsEmptyCredentialIDViaUUIDParse(t *testing.T) {
+	if _, err := uuid.Parse(""); err == nil {
+		t.Fatal("uuid.Parse accepts the empty string, so the clause removed in " +
+			"F4 was load-bearing after all and must be restored")
+	}
+	claim := githubWorkItemOracleClaim()
+	if err := claim.Validate(); err != nil {
+		t.Fatalf("baseline claim invalid, so the case below proves nothing: %v", err)
+	}
+	for _, credentialID := range []string{"", "   ", "not-a-uuid"} {
+		candidate := claim
+		candidate.CredentialID = credentialID
+		if err := candidate.Validate(); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("credential_id=%q validated: %v", credentialID, err)
+		}
+	}
+}
+
 func TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig(t *testing.T) {
 	for _, value := range []any{
 		[]any{map[string]any{"org_login": "", "project_number": 1}},
 		[]any{map[string]any{"org_login": "acme", "project_number": 0}},
 		[]any{map[string]any{"org_login": "acme", "project_number": 1, "token": "forbidden"}},
 		"acme:1",
-		// A present key holding a typed nil slice decodes cleanly to a nil
-		// target list. Without the nil check this reads as "configured, with
-		// nothing in it" -- indistinguishable from a genuinely empty list, so
-		// a config the operator wrote would be silently ignored rather than
-		// rejected. The key being present at all is the signal that they meant
-		// something by it.
 		[]any(nil),
 		[]any{nil},
 		map[string]any{"org_login": "acme", "project_number": 1},
@@ -197,15 +216,75 @@ func TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig(t *testing.T) 
 	}
 }
 
+// The two sides of the configured-but-empty boundary, both built FROM JSON
+// BYTES because that is the only way to get the shapes production emits.
+//
+// A Go-literal `[]any(nil)` is a TYPED nil and takes a different path through
+// json.Marshal than a JSONB null, which decodes to an UNTYPED nil interface.
+// Testing only the typed one is how the null path stayed fail-open while
+// looking covered -- the same mistake as testing int project numbers when
+// production only ever sends float64, one clause over.
+//
+//   - JSON `null` under a present key: the operator wrote the key, so silently
+//     returning "no projects configured" drops their intent. Must REFUSE.
+//   - JSON `[]`: an explicitly empty list is a valid way to say "configured,
+//     currently none". Must be accepted as validly empty, NOT refused.
+//
+// Both are pinned, because a fix for one that broke the other would otherwise
+// pass.
+func TestGitHubProjectV2TargetsSeparateNullConfigFromEmptyConfig(t *testing.T) {
+	decode := func(t *testing.T, raw string) map[string]any {
+		t.Helper()
+		var integrationConfig map[string]any
+		if err := json.Unmarshal([]byte(raw), &integrationConfig); err != nil {
+			t.Fatal(err)
+		}
+		return integrationConfig
+	}
+
+	t.Run("json null under a present key is refused", func(t *testing.T) {
+		integrationConfig := decode(t, `{"github_projects_v2":null}`)
+		value, configured := integrationConfig["github_projects_v2"]
+		// Guard the guard: if this ever stops being a present key holding an
+		// untyped nil, this test is no longer exercising the production shape.
+		if !configured || value != nil {
+			t.Fatalf("configured=%t value=%#v -- not the production JSONB null shape",
+				configured, value)
+		}
+		claim := githubWorkItemOracleClaim()
+		claim.IntegrationConfig = integrationConfig
+		targets, err := githubProjectV2Targets(claim)
+		if !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("a configured JSON null returned targets=%+v err=%v; until "+
+				"CHAOS-3123 this path returned empty targets and a nil error, "+
+				"silently discarding configuration the operator wrote", targets, err)
+		}
+	})
+
+	t.Run("json empty list is validly empty", func(t *testing.T) {
+		claim := githubWorkItemOracleClaim()
+		claim.IntegrationConfig = decode(t, `{"github_projects_v2":[]}`)
+		targets, err := githubProjectV2Targets(claim)
+		if err != nil {
+			t.Fatalf("an explicitly empty list was refused: %v", err)
+		}
+		if len(targets) != 0 {
+			t.Fatalf("targets=%+v want none", targets)
+		}
+	})
+}
+
 // Every test above builds IntegrationConfig as a Go literal, with `int` or
 // json.Number project numbers. PRODUCTION NEVER PRODUCES EITHER: the claim's
 // integration_config arrives as a Postgres JSONB column decoded by a plain
 // json.Unmarshal into map[string]any (repository_postgres.go), so every number
-// is a float64. A parser that happened to accept only int/json.Number would
-// pass this package's whole suite and reject every real tenant's configuration.
+// is a float64.
 //
-// This builds the config the way the repository does -- from JSON bytes -- so
-// the representation under test is the one production hands us.
+// This closes a COVERAGE gap, not a behavior gap: the parser has always
+// accepted float64, so nothing here changes what production does. What was
+// missing was any test that would notice if that stopped being true -- a
+// parser tightened to accept only int/json.Number would have passed this
+// package's entire suite while rejecting every real tenant's configuration.
 func TestGitHubProjectV2TargetsAcceptThePostgresJSONRepresentation(t *testing.T) {
 	var integrationConfig map[string]any
 	if err := json.Unmarshal([]byte(

--- a/internal/providersync/github_work_items_projects_v2_test.go
+++ b/internal/providersync/github_work_items_projects_v2_test.go
@@ -31,16 +31,98 @@ func TestGitHubProjectV2TargetsComeOnlyFromClaimIntegrationConfig(t *testing.T) 
 	}
 }
 
-func TestGitHubProjectV2ActivationDecisionRemainsPending(t *testing.T) {
+// D18 ratified the Projects v2 COLLECTOR contract. It did not activate the
+// route, and the two are easy to conflate now that nothing in the source says
+// "pending" any more. This pins the distinction: the collector is decided, the
+// five-alias family is still off, and activation remains the composite
+// all-or-nothing layer's job.
+func TestGitHubProjectV2RatificationIsNotActivation(t *testing.T) {
 	if got := ProviderExecutor("github", "work-items"); got != ExecutorNone {
-		t.Fatalf("Projects v2 foundation was registered before the Linear activation decision: %s", got)
+		t.Fatalf("ratifying the Projects v2 collector must not register the route: %s", got)
 	}
 	descriptor, known := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
 	if !known {
 		t.Fatal("github/work-items capability disappeared")
 	}
 	if descriptor.RouteReady || descriptor.RouteEnabled || len(descriptor.Destinations) != 0 {
-		t.Fatalf("unapproved Projects v2 route became active: %+v", descriptor)
+		t.Fatalf("ratifying the Projects v2 collector activated the route: %+v", descriptor)
+	}
+}
+
+// D18 puts the environment outside the Go route. The positive half of that
+// ("durable config wins") is pinned above; this is the negative half, and it
+// asserts the REQUEST COUNTER rather than the row set. An assertion on empty
+// rows would pass just as happily with the whole collector deleted, and would
+// also pass if Go quietly adopted the env targets and the fixture returned
+// nothing — the only observation that separates "ignored the environment" from
+// "used the environment and found nothing" is that no request was ever issued.
+func TestGitHubProjectV2EnvironmentTargetsAreNeverAFallback(t *testing.T) {
+	t.Setenv("GITHUB_PROJECTS_V2", "acme:3,labs:12")
+	t.Setenv("GITHUB_TOKEN", "ghp_environment_token_that_must_never_be_used")
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{}
+
+	targets, err := githubProjectV2Targets(claim)
+	if err != nil || len(targets) != 0 {
+		t.Fatalf("environment targets leaked into durable config: targets=%+v error=%v", targets, err)
+	}
+
+	// The whole fetch, not just the parser: a target list is only half the
+	// path, and a collector that re-read the environment further down would
+	// still be caught here.
+	doer := &gitHubProjectV2Doer{t: t}
+	result, err := (GitHubProjectV2Fetcher{}).Fetch(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+		githubProjectV2TestClient(t, doer), time.Now().UTC(), nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.bodies) != 0 {
+		t.Fatalf("environment configuration issued %d GraphQL request(s); D18 puts the "+
+			"environment outside the Go route entirely", len(doer.bodies))
+	}
+	if result.Targets != 0 || result.Evidence.Requests != 0 || result.Usage.RequestCount != 0 {
+		t.Fatalf("environment configuration produced request accounting: %+v", result)
+	}
+}
+
+// The credential half of the same clause. An environment token is present and
+// the claim's resolved credential is not usable; the collector must refuse
+// rather than reach for the one lying around in the process. Each rejected
+// credential shape is asserted to issue ZERO requests, so "refused" cannot be
+// satisfied by fetching first and erroring afterwards.
+func TestGitHubProjectV2RefusesEnvironmentTokenWhenClaimCredentialIsUnusable(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_environment_token_that_must_never_be_used")
+	t.Setenv("GITHUB_PROJECTS_V2", "acme:3")
+	claim := githubWorkItemOracleClaim()
+	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
+		map[string]any{"org_login": "acme", "project_number": 3},
+	}}
+	for _, test := range []struct {
+		name       string
+		credential providerfoundation.Credential
+	}{
+		{"absent", providerfoundation.Credential{}},
+		{"unresolved id", providerfoundation.Credential{Provider: "github"}},
+		{"other tenant's credential", providerfoundation.Credential{
+			Provider: "github", ID: "77777777-7777-4777-8777-777777777777",
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			doer := &gitHubProjectV2Doer{t: t}
+			_, err := (GitHubProjectV2Fetcher{}).Fetch(
+				context.Background(), claim, test.credential,
+				githubProjectV2TestClient(t, doer), time.Now().UTC(), nil,
+			)
+			if !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+			if len(doer.bodies) != 0 {
+				t.Fatalf("refused credential still issued %d request(s)", len(doer.bodies))
+			}
+		})
 	}
 }
 

--- a/internal/providersync/github_work_items_projects_v2_test.go
+++ b/internal/providersync/github_work_items_projects_v2_test.go
@@ -51,13 +51,17 @@ func TestGitHubProjectV2RatificationIsNotActivation(t *testing.T) {
 	}
 }
 
-// D18 puts the environment outside the Go route. The positive half of that
-// ("durable config wins") is pinned above; this is the negative half, and it
-// asserts the REQUEST COUNTER rather than the row set. An assertion on empty
-// rows would pass just as happily with the whole collector deleted, and would
-// also pass if Go quietly adopted the env targets and the fixture returned
-// nothing — the only observation that separates "ignored the environment" from
-// "used the environment and found nothing" is that no request was ever issued.
+// D18 puts the environment outside the Go route for CREDENTIALS AND TARGETS.
+// The positive half ("durable config wins") is pinned above; this is the
+// negative half.
+//
+// What actually holds the line here is the `len(targets) != 0` assertion a few
+// lines down: with no durable config the collector never enters its fetch loop,
+// so the request counter cannot rise no matter what the environment says. The
+// counter assertion is a BACKSTOP against a future collector that reads the
+// environment further down the path, not the thing failing today — worth
+// stating, because a counter that cannot currently be tripped reads like
+// stronger evidence than it is.
 func TestGitHubProjectV2EnvironmentTargetsAreNeverAFallback(t *testing.T) {
 	t.Setenv("GITHUB_PROJECTS_V2", "acme:3,labs:12")
 	t.Setenv("GITHUB_TOKEN", "ghp_environment_token_that_must_never_be_used")
@@ -82,8 +86,8 @@ func TestGitHubProjectV2EnvironmentTargetsAreNeverAFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(doer.bodies) != 0 {
-		t.Fatalf("environment configuration issued %d GraphQL request(s); D18 puts the "+
-			"environment outside the Go route entirely", len(doer.bodies))
+		t.Fatalf("environment configuration issued %d GraphQL request(s); D18 keeps "+
+			"credentials and targets out of the Go route", len(doer.bodies))
 	}
 	if result.Targets != 0 || result.Evidence.Requests != 0 || result.Usage.RequestCount != 0 {
 		t.Fatalf("environment configuration produced request accounting: %+v", result)

--- a/internal/providersync/github_work_items_route.go
+++ b/internal/providersync/github_work_items_route.go
@@ -73,8 +73,10 @@ type GitHubWorkItemsIncomplete struct {
 // deliberately ahead of its source and D16's mirror rule does not apply.
 //
 // Components absent for a reason that is not an optional-data fetch failure at
-// all — projects_v2 policy_pending, an unported policy seam — are not listed
-// here and still fail the unit closed.
+// all are not listed here and still fail the unit closed. Projects v2 no longer
+// has an entry of that kind: D18 retired the policy_pending seam, so an
+// unwired Projects collector is a construction defect refused at Collect entry
+// rather than a degradation recorded per batch.
 var githubWorkItemsOptionalIncompleteComponents = map[string]bool{
 	"milestones":              true,
 	"issue_comments":          true,
@@ -137,9 +139,17 @@ func (routeErr *GitHubWorkItemsRouteError) Unwrap() error {
 	return routeErr.Cause
 }
 
-// githubWorkItemsProjectPolicy is the unresolved Projects v2 activation seam.
-// GitHubProjectV2Fetcher satisfies it, but the zero-value handler leaves it nil
-// and records configured targets as policy_pending without fetching them.
+// githubWorkItemsProjectPolicy is the Projects v2 collection seam, ratified by
+// D18: durable integration-scoped targets, the claim-resolved credential and
+// client only, and no environment token or target fallback.
+// GitHubProjectV2Fetcher is its production implementation.
+//
+// The seam remains an interface for test substitution, not for policy: there is
+// no longer a legitimate "not decided yet" state, so Collect refuses a nil
+// Projects outright instead of recording configured targets as an incomplete
+// batch. A handler that reaches production without one is a construction
+// defect, and "the code is not wired" must not be reported in the same
+// vocabulary the provider uses to decline data.
 type githubWorkItemsProjectPolicy interface {
 	Fetch(
 		context.Context,
@@ -212,6 +222,14 @@ func (handler GitHubWorkItemsRouteHandler) Collect(
 	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
 	if handler.Deriver == nil {
 		return CompleteRouteBatch{}, ErrGitHubWorkItemsDerivationsUnavailable
+	}
+	// D18 retired the policy_pending seam. This is deliberately NOT gated on
+	// whether this particular claim happens to carry targets: a handler built
+	// without a Projects collector is misconstructed for every claim, and
+	// discovering that only on the first tenant that configured a project would
+	// make the defect look like a tenant-specific data problem.
+	if handler.Projects == nil {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
 	}
 	options, err := githubWorkItemsRESTOptionsForClaim(claim)
 	if err != nil {
@@ -321,36 +339,40 @@ func (handler GitHubWorkItemsRouteHandler) Collect(
 		}
 	}
 
+	// "disabled" means this claim's integration configured no durable targets —
+	// the only remaining reason Projects v2 contributes nothing. It is NOT the
+	// state an operator lands in by setting GITHUB_PROJECTS_V2 in the process
+	// environment: D18 puts the environment outside the Go route entirely, so
+	// env-only configuration reads here as no configuration at all and issues
+	// zero GraphQL requests. CHAOS-3506 adds the startup-readiness warning that
+	// makes that silence audible at boot, which is where it belongs — reading
+	// the environment on this path to warn about it would reintroduce exactly
+	// the dependency the decision removes.
 	projectState := "disabled"
 	if len(projectTargets) > 0 {
-		if handler.Projects == nil {
-			projectState = "policy_pending"
-			incomplete = append(incomplete, GitHubWorkItemsIncomplete{
-				Component: "projects_v2", Cause: "policy_pending",
-			})
-		} else {
-			projectResult, projectErr := handler.Projects.Fetch(
-				ctx, claim, credential, client, normalizedAt, handler.ResolveIdentity,
-			)
-			usage.add(GitHubWorkItemsRequestUsage{
-				Transport: projectResult.Usage.Transport, RouteFamily: projectResult.Usage.RouteFamily,
-				Dimension: projectResult.Usage.Dimension, RequestCount: projectResult.Usage.RequestCount,
-			})
-			addGitHubWorkItemsEvidence(&evidence, projectResult.Evidence)
-			if projectErr != nil {
-				return CompleteRouteBatch{}, usage.wrap(projectErr)
-			}
-			if err := validateGitHubWorkItemsProjectResult(claim, projectResult, len(projectTargets)); err != nil {
-				return CompleteRouteBatch{}, usage.wrap(err)
-			}
-			rows = mergeGitHubProjectV2Rows(rows, projectResult.Rows)
-			projectState = "included"
+		projectResult, projectErr := handler.Projects.Fetch(
+			ctx, claim, credential, client, normalizedAt, handler.ResolveIdentity,
+		)
+		usage.add(GitHubWorkItemsRequestUsage{
+			Transport: projectResult.Usage.Transport, RouteFamily: projectResult.Usage.RouteFamily,
+			Dimension: projectResult.Usage.Dimension, RequestCount: projectResult.Usage.RequestCount,
+		})
+		addGitHubWorkItemsEvidence(&evidence, projectResult.Evidence)
+		if projectErr != nil {
+			return CompleteRouteBatch{}, usage.wrap(projectErr)
 		}
+		if err := validateGitHubWorkItemsProjectResult(claim, projectResult, len(projectTargets)); err != nil {
+			return CompleteRouteBatch{}, usage.wrap(err)
+		}
+		rows = mergeGitHubProjectV2Rows(rows, projectResult.Rows)
+		projectState = "included"
 	}
 	finishGitHubWorkItemsEvidence(&evidence, rows)
 	// EVERY entry decides, not the first: a batch can mix optional degradation
-	// with a blocking entry, and projects_v2 is appended last, so a check that
-	// stops early reads clean on exactly the ordering production produces.
+	// with a blocking entry, and the blocking one is appended LATER than the
+	// optional one (REST milestones record first; the per-PR and social phases
+	// append after), so a check that stops early reads clean on exactly the
+	// ordering production produces.
 	for _, partial := range incomplete {
 		if !githubWorkItemsIncompleteIsOptional(partial) {
 			return CompleteRouteBatch{}, usage.wrapRoute(

--- a/internal/providersync/github_work_items_route.go
+++ b/internal/providersync/github_work_items_route.go
@@ -342,12 +342,18 @@ func (handler GitHubWorkItemsRouteHandler) Collect(
 	// "disabled" means this claim's integration configured no durable targets —
 	// the only remaining reason Projects v2 contributes nothing. It is NOT the
 	// state an operator lands in by setting GITHUB_PROJECTS_V2 in the process
-	// environment: D18 puts the environment outside the Go route entirely, so
-	// env-only configuration reads here as no configuration at all and issues
-	// zero GraphQL requests. CHAOS-3506 adds the startup-readiness warning that
-	// makes that silence audible at boot, which is where it belongs — reading
-	// the environment on this path to warn about it would reintroduce exactly
-	// the dependency the decision removes.
+	// environment: D18 puts the environment outside the Go route for
+	// CREDENTIALS AND TARGETS, so env-only configuration reads here as no
+	// configuration at all and issues zero GraphQL requests.
+	//
+	// Scoped deliberately, because "no environment reads at all" would be
+	// false: github_work_items_rows.go:869 reads GITHUB_LINEAR_LINKBACK_BOTS
+	// for bot-identity classification. That is presentation policy, not
+	// credentials or targets, and D18 does not reach it.
+	//
+	// CHAOS-3506 adds the startup-readiness warning that makes this silence
+	// audible at boot, which is where it belongs — reading the environment on
+	// this path to warn about it would reintroduce the dependency D18 removes.
 	projectState := "disabled"
 	if len(projectTargets) > 0 {
 		projectResult, projectErr := handler.Projects.Fetch(

--- a/internal/providersync/github_work_items_route_test.go
+++ b/internal/providersync/github_work_items_route_test.go
@@ -283,9 +283,20 @@ func TestGitHubWorkItemsRouteRefusesAnUnwiredProjectsCollectorWithoutTargets(t *
 
 // Route-level half of the D18 environment clause. The process has both
 // GITHUB_PROJECTS_V2 and GITHUB_TOKEN set and the integration has no durable
-// targets: the batch must succeed, report "disabled", and issue ZERO GraphQL
-// requests. Asserting the state ("disabled") without the counter would pass if
-// the route adopted the env targets and the fixture returned nothing.
+// targets: the batch must succeed and report "disabled".
+//
+// WHAT ACTUALLY HOLDS THE LINE, measured rather than assumed: `projects.calls`
+// and `validateGitHubWorkItemsProjectResult` (route.go:370). Re-applying an
+// env-adopting mutant kills this test THERE — the collector gets invoked with
+// targets the claim never configured, and its result fails validation against
+// len(projectTargets).
+//
+// The GraphQL counter below is NOT what fails. This case substitutes a stub
+// Projects policy, which issues no HTTP at all, so doer.graphqlCalls cannot
+// rise however the route behaves. It is kept as a backstop for a future
+// arrangement where a real collector reaches the wire, and is documented as
+// such rather than presented as the assertion doing the work — a counter that
+// cannot be tripped reads like stronger evidence than it is.
 func TestGitHubWorkItemsRouteTreatsEnvironmentProjectsAsNoConfiguration(t *testing.T) {
 	t.Setenv("GITHUB_PROJECTS_V2", "acme:3,labs:12")
 	t.Setenv("GITHUB_TOKEN", "ghp_environment_token_that_must_never_be_used")

--- a/internal/providersync/github_work_items_route_test.go
+++ b/internal/providersync/github_work_items_route_test.go
@@ -210,7 +210,16 @@ func TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage(t *te
 	}
 }
 
-func TestGitHubWorkItemsRouteDefaultsProjectsToTypedPendingWithoutFetching(t *testing.T) {
+// D18 replaced the policy_pending degradation with a construction guard. A
+// handler built without a Projects collector is a WIRING DEFECT, not a batch
+// that came back incomplete, and the two must not share a vocabulary: an
+// incomplete entry says the provider declined data, which would send whoever
+// reads it looking at GitHub instead of at the handler.
+//
+// The guard is at Collect entry, so it also spends nothing: the old
+// policy_pending path had already issued the repo-metadata REST call before
+// discovering the route could not run.
+func TestGitHubWorkItemsRouteRefusesAnUnwiredProjectsCollector(t *testing.T) {
 	claim := githubWorkItemsRESTClaim()
 	claim.DatasetOptions = map[string]any{
 		"include_issues": false, "include_pull_requests": false,
@@ -226,33 +235,92 @@ func TestGitHubWorkItemsRouteDefaultsProjectsToTypedPendingWithoutFetching(t *te
 		}},
 	}
 	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
-	batch, err := (GitHubWorkItemsRouteHandler{
-		Deriver: deriver,
-	}).Collect(
+	batch, err := (GitHubWorkItemsRouteHandler{Deriver: deriver}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
 		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
 	)
-	if !errors.Is(err, ErrGitHubWorkItemsIncomplete) {
-		t.Fatalf("error=%v", err)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+	}
+	if errors.Is(err, ErrGitHubWorkItemsIncomplete) {
+		t.Fatal("an unwired collector was reported as provider incompleteness")
 	}
 	if !reflect.DeepEqual(batch, CompleteRouteBatch{}) || deriver.calls != 0 {
-		t.Fatalf("incomplete route returned batch=%+v or derived %d times", batch, deriver.calls)
+		t.Fatalf("misconstructed route returned batch=%+v or derived %d times", batch, deriver.calls)
+	}
+	if doer.graphqlCalls != 0 || len(doer.rest.requests) != 0 {
+		t.Fatalf("misconstructed route spent requests: graphql=%d rest=%d",
+			doer.graphqlCalls, len(doer.rest.requests))
+	}
+}
+
+// The guard does not wait for a tenant that happens to have configured a
+// project. A handler missing its collector is misconstructed for EVERY claim,
+// and gating the refusal on target presence would make a global build defect
+// surface as a tenant-specific data problem on whichever org configured
+// Projects v2 first.
+func TestGitHubWorkItemsRouteRefusesAnUnwiredProjectsCollectorWithoutTargets(t *testing.T) {
+	claim := githubWorkItemsRESTClaim()
+	claim.IntegrationConfig = map[string]any{}
+	doer := &githubWorkItemsRouteDoer{
+		t:    t,
+		rest: &githubWorkItemsRESTDoer{t: t, replies: githubWorkItemsRESTFixtures()},
+	}
+	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
+	_, err := (GitHubWorkItemsRouteHandler{Deriver: deriver}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("error=%v want ErrInvalidConfiguration even with no targets configured", err)
+	}
+	if deriver.calls != 0 || len(doer.rest.requests) != 0 {
+		t.Fatalf("misconstructed route ran: derived=%d rest=%d", deriver.calls, len(doer.rest.requests))
+	}
+}
+
+// Route-level half of the D18 environment clause. The process has both
+// GITHUB_PROJECTS_V2 and GITHUB_TOKEN set and the integration has no durable
+// targets: the batch must succeed, report "disabled", and issue ZERO GraphQL
+// requests. Asserting the state ("disabled") without the counter would pass if
+// the route adopted the env targets and the fixture returned nothing.
+func TestGitHubWorkItemsRouteTreatsEnvironmentProjectsAsNoConfiguration(t *testing.T) {
+	t.Setenv("GITHUB_PROJECTS_V2", "acme:3,labs:12")
+	t.Setenv("GITHUB_TOKEN", "ghp_environment_token_that_must_never_be_used")
+	claim := githubWorkItemsRESTClaim()
+	// Pull requests off, so the social phase issues no GraphQL of its own and
+	// any GraphQL request at all is unambiguously a Projects v2 traversal.
+	claim.DatasetOptions = map[string]any{
+		"include_issues": false, "include_pull_requests": false,
+		"fetch_comments": false, "fetch_milestones": false,
+	}
+	claim.IntegrationConfig = map[string]any{}
+	doer := &githubWorkItemsRouteDoer{
+		t: t,
+		rest: &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
+			"/repos/acme/api": {{body: `{"id":4567,"full_name":"Acme/API"}`}},
+		}},
+	}
+	projects := &githubWorkItemsRouteProjectPolicy{}
+	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
+	batch, err := (GitHubWorkItemsRouteHandler{Projects: projects, Deriver: deriver}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
+		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projects.calls != 0 {
+		t.Fatalf("environment configuration invoked the collector %d time(s)", projects.calls)
 	}
 	if doer.graphqlCalls != 0 {
-		t.Fatalf("pending default fetched Projects v2 %d times", doer.graphqlCalls)
+		t.Fatalf("environment configuration issued %d GraphQL request(s)", doer.graphqlCalls)
 	}
-	routeErr := githubWorkItemsIncompleteError(t, err)
-	incomplete := routeErr.Incomplete
-	if !reflect.DeepEqual(incomplete, []GitHubWorkItemsIncomplete{{
-		Component: "projects_v2", Cause: "policy_pending",
-	}}) {
-		t.Fatalf("incomplete=%+v", incomplete)
-	}
-	if usage := routeErr.Usage; !reflect.DeepEqual(usage, []GitHubWorkItemsRequestUsage{{
-		Transport: "rest", RouteFamily: "work_items", Dimension: BudgetRESTCore, RequestCount: 1,
-	}}) {
-		t.Fatalf("usage=%+v", usage)
+	if state := batch.Result["projects_v2"]; state != "disabled" {
+		t.Fatalf("projects_v2=%v want disabled", state)
 	}
 }
 
@@ -275,7 +343,7 @@ func TestGitHubWorkItemsRoutePreservesOptionalSocialFailureAndPhysicalUsage(t *t
 	}
 	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
 	batch, err := (GitHubWorkItemsRouteHandler{
-		Deriver: deriver,
+		Projects: GitHubProjectV2Fetcher{}, Deriver: deriver,
 	}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
@@ -335,7 +403,7 @@ func TestGitHubWorkItemsRouteContinuesPastOptionalRESTFailuresAndLandsEffects(t 
 		}},
 	}
 	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
-	batch, err := (GitHubWorkItemsRouteHandler{Deriver: deriver}).Collect(
+	batch, err := (GitHubWorkItemsRouteHandler{Projects: GitHubProjectV2Fetcher{}, Deriver: deriver}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
 		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
@@ -391,7 +459,7 @@ func TestGitHubWorkItemsRouteContinuesPastUnprocessablePullRequest(t *testing.T)
 		graphqlReplies: []string{`{"data":{"repository":{"pr0":{"number":52,"comments":{"nodes":[{"databaseId":1,"body":"c","createdAt":{"bad":true},"author":{"login":"reviewer"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}},"timelineItems":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`},
 	}
 	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
-	batch, err := (GitHubWorkItemsRouteHandler{Deriver: deriver}).Collect(
+	batch, err := (GitHubWorkItemsRouteHandler{Projects: GitHubProjectV2Fetcher{}, Deriver: deriver}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
 		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
@@ -422,28 +490,38 @@ func TestGitHubWorkItemsRouteContinuesPastUnprocessablePullRequest(t *testing.T)
 	}
 }
 
-// A batch can mix optional degradation with a blocking entry, and projects_v2
-// is appended LAST -- the worst ordering for a classification loop that stops
-// early. Without this case a check-first loop reads clean on exactly the
-// ordering production produces.
+// A batch can mix optional degradation with a blocking entry, and the blocking
+// entry is appended LATER than the optional one -- the worst ordering for a
+// classification loop that stops early. Without this case a check-first loop
+// reads clean on exactly the ordering production produces.
+//
+// This case used to get its blocking entry from projects_v2 policy_pending,
+// which D18 removed. The property is not about Projects v2, so it keeps its
+// coverage from the pairing that still exists in production: REST milestones
+// record an OPTIONAL entry first, and the social phase appends a BLOCKING
+// pagination cause after it. Deleting the milestones failure (leaving only the
+// blocking entry) makes this pass without testing ordering at all -- which is
+// why the assertion pins both entries and their order, not just the outcome.
 func TestGitHubWorkItemsRouteFailsClosedOnMixedOptionalAndBlockingIncomplete(t *testing.T) {
 	claim := githubWorkItemsRESTClaim()
-	claim.DatasetOptions["include_pull_requests"] = false
-	claim.IntegrationConfig = map[string]any{"github_projects_v2": []any{
-		map[string]any{"org_login": "acme", "project_number": 3},
-	}}
+	claim.DatasetOptions = map[string]any{
+		"include_issues": true, "include_pull_requests": true,
+		"fetch_comments": true, "fetch_milestones": true, "comments_limit": 500,
+	}
+	fixtures := githubWorkItemsRESTFixtures()
+	fixtures["/repos/acme/api/milestones"] = []githubWorkItemsRESTReply{
+		{status: http.StatusInternalServerError, body: `{"message":"down"}`},
+	}
+	// A comments cursor that claims a next page and supplies no cursor: the
+	// invalid_pagination class, blocking on the optional pr_social component.
+	stalled := `{"data":{"repository":{"pr0":{"number":52,"comments":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":null}},"timelineItems":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}`
 	doer := &githubWorkItemsRouteDoer{
-		t: t,
-		rest: &githubWorkItemsRESTDoer{t: t, replies: map[string][]githubWorkItemsRESTReply{
-			"/repos/acme/api":                    {{body: `{"id":4567,"full_name":"Acme/API"}`}},
-			"/repos/acme/api/milestones":         {{status: http.StatusInternalServerError, body: `{"message":"down"}`}},
-			"/repos/acme/api/issues":             {{body: `[{"number":42,"title":"Issue","state":"open","created_at":"2026-07-02T00:00:00Z","updated_at":"2026-07-20T00:00:00Z"}]`}},
-			"/repos/acme/api/issues/42/events":   {{body: `[]`}},
-			"/repos/acme/api/issues/42/comments": {{body: `[]`}},
-		}},
+		t:              t,
+		rest:           &githubWorkItemsRESTDoer{t: t, replies: fixtures},
+		graphqlReplies: []string{stalled, stalled},
 	}
 	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
-	batch, err := (GitHubWorkItemsRouteHandler{Deriver: deriver}).Collect(
+	batch, err := (GitHubWorkItemsRouteHandler{Projects: GitHubProjectV2Fetcher{}, Deriver: deriver}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
 		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
@@ -457,7 +535,7 @@ func TestGitHubWorkItemsRouteFailsClosedOnMixedOptionalAndBlockingIncomplete(t *
 	routeErr := githubWorkItemsIncompleteError(t, err)
 	if !reflect.DeepEqual(routeErr.Incomplete, []GitHubWorkItemsIncomplete{
 		{Component: "milestones", Cause: "transient"},
-		{Component: "projects_v2", Cause: "policy_pending"},
+		{Component: "pr_social", Cause: "invalid_pagination"},
 	}) {
 		t.Fatalf("incomplete=%+v (the optional entry must precede the blocking one)", routeErr.Incomplete)
 	}
@@ -506,7 +584,7 @@ func TestGitHubWorkItemsRouteFailsClosedOnBlockingSocialCauses(t *testing.T) {
 			}
 			deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
 			batch, err := (GitHubWorkItemsRouteHandler{
-				Social: test.fetcher, Deriver: deriver,
+				Projects: GitHubProjectV2Fetcher{}, Social: test.fetcher, Deriver: deriver,
 			}).Collect(
 				context.Background(), claim,
 				providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
@@ -553,7 +631,7 @@ func TestGitHubWorkItemsRouteFailsClosedOnRateLimitedSocialFetch(t *testing.T) {
 		graphqlStatus:  []int{http.StatusForbidden},
 	}
 	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
-	batch, err := (GitHubWorkItemsRouteHandler{Deriver: deriver}).Collect(
+	batch, err := (GitHubWorkItemsRouteHandler{Projects: GitHubProjectV2Fetcher{}, Deriver: deriver}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
 		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
@@ -581,7 +659,7 @@ func TestGitHubWorkItemsRouteFailsClosedOnRateLimitedIssueComments(t *testing.T)
 		}},
 	}
 	deriver := &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)}
-	batch, err := (GitHubWorkItemsRouteHandler{Deriver: deriver}).Collect(
+	batch, err := (GitHubWorkItemsRouteHandler{Projects: GitHubProjectV2Fetcher{}, Deriver: deriver}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
 		gitHubPullRequestClient(t, doer, "https://api.github.com"), time.Now().UTC(),
@@ -615,7 +693,8 @@ func TestGitHubWorkItemsRouteIncompletenessSurvivesDurableCompletionEncoding(t *
 		}},
 	}
 	batch, err := (GitHubWorkItemsRouteHandler{
-		Deriver: &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)},
+		Projects: GitHubProjectV2Fetcher{},
+		Deriver:  &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)},
 	}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},
@@ -673,7 +752,8 @@ func TestGitHubWorkItemsRouteFailsBeforeFetchOnMalformedProjectsConfiguration(t 
 		t: t, rest: &githubWorkItemsRESTDoer{t: t, replies: githubWorkItemsRESTFixtures()},
 	}
 	_, err := (GitHubWorkItemsRouteHandler{
-		Deriver: &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)},
+		Projects: GitHubProjectV2Fetcher{},
+		Deriver:  &githubWorkItemsRouteDeriver{rows: githubWorkItemsRouteDerivedRows(t)},
 	}).Collect(
 		context.Background(), claim,
 		providerfoundation.Credential{Provider: "github", ID: claim.CredentialID},

--- a/internal/providersync/lease.go
+++ b/internal/providersync/lease.go
@@ -88,10 +88,20 @@ func (unit Unit) Validate() error {
 	if unit.SinceAt != nil && unit.BeforeAt != nil && unit.SinceAt.After(*unit.BeforeAt) {
 		return ErrInvalidConfiguration
 	}
-	if unit.AuthSource == "environment" || unit.CredentialID == "" {
+	if unit.AuthSource == "environment" {
 		// Go execution never hydrates credentials through process-global state.
+		// This is where D18's "environment target/token fallback is not part of
+		// the Go route" is actually enforced for every provider, not just
+		// Projects v2: a unit whose credentials would come from process state
+		// never reaches a collector at all.
 		return ErrInvalidConfiguration
 	}
+	// A resolved credential id is REQUIRED, and this is the only clause that
+	// enforces it: uuid.Parse rejects "" as readily as it rejects garbage. The
+	// separate `unit.CredentialID == ""` test that used to sit above was the
+	// twin of one removed from the Projects v2 fetcher for the same reason --
+	// it could never decide on its own, so its mutation was unkillable and it
+	// read as coverage while proving nothing.
 	if _, err := uuid.Parse(unit.CredentialID); err != nil {
 		return ErrInvalidConfiguration
 	}

--- a/internal/providersync/mutation_plan_integrity_test.go
+++ b/internal/providersync/mutation_plan_integrity_test.go
@@ -1,0 +1,245 @@
+package providersync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A mutation plan is a CLAIM about coverage, and two ways of breaking that
+// claim are both silent and both happened in this package's history:
+//
+//  1. ANCHOR DRIFT. An entry's `find` text stops matching the source it
+//     targets, because the line was edited or removed. The harness reports
+//     STALE_DECLARATION -- but only for entries in a plan someone remembered to
+//     re-run. An entry in an untouched plan whose target file was edited by
+//     another change just rots.
+//  2. A PROOF THAT NAMES NOTHING. `go test -run ^TestGone$` exits 0 when the
+//     pattern matches no test, so an entry mutating live code can lose its
+//     guard entirely while the plan still lists it as proven.
+//
+// Both were real in the Projects v2 work: a `find` broke when a redundant
+// clause was removed (twice), and deleting a route test left a live-code
+// mutation pointing at a `-run` pattern matching nothing.
+//
+// The harness now catches (2) at run time as PROOF_VACUOUS. This is the
+// standing half: it checks EVERY plan in the directory on every `go test` run,
+// including plans this change never touched and plans nobody thought to
+// re-run. It is a test, not a script, so it cannot be skipped by forgetting to
+// invoke it.
+//
+// It deliberately does NOT run any mutation or any proof command -- it is a
+// static integrity check and stays fast enough to live in the normal suite.
+func TestMutationPlansHaveLiveAnchorsAndExistingProofTests(t *testing.T) {
+	planDir := filepath.Join("testdata", "mutation-plans")
+	entries, err := os.ReadDir(planDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	declaredTests := goTestNamesInPackage(t)
+	sourceCache := map[string]string{}
+	checkedPlans, checkedEntries := 0, 0
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		planPath := filepath.Join(planDir, entry.Name())
+		raw, readErr := os.ReadFile(planPath)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		var plan struct {
+			Mutations []struct {
+				ID               string     `json:"id"`
+				File             string     `json:"file"`
+				Find             string     `json:"find"`
+				ExpectOccurrence *int       `json:"expect_occurrences"`
+				Proof            [][]string `json:"proof"`
+			} `json:"mutations"`
+		}
+		if err := json.Unmarshal(raw, &plan); err != nil {
+			t.Fatalf("%s: %v", planPath, err)
+		}
+		if len(plan.Mutations) == 0 {
+			t.Errorf("%s declares no mutations; an empty plan reads as a "+
+				"verified one", planPath)
+			continue
+		}
+		checkedPlans++
+
+		for _, mutation := range plan.Mutations {
+			checkedEntries++
+			want := 1
+			if mutation.ExpectOccurrence != nil {
+				want = *mutation.ExpectOccurrence
+			}
+
+			source, cached := sourceCache[mutation.File]
+			if !cached {
+				bytes, sourceErr := os.ReadFile(filepath.Join("..", "..", mutation.File))
+				if sourceErr != nil {
+					t.Errorf("%s: %s targets %s, which cannot be read: %v",
+						planPath, mutation.ID, mutation.File, sourceErr)
+					continue
+				}
+				source = string(bytes)
+				sourceCache[mutation.File] = source
+			}
+			if got := strings.Count(source, mutation.Find); got != want {
+				t.Errorf("%s: %s anchor matches %d time(s) in %s, want %d -- a "+
+					"drifted anchor measures nothing while the plan still lists "+
+					"the entry as coverage",
+					planPath, mutation.ID, got, mutation.File, want)
+			}
+
+			for _, command := range mutation.Proof {
+				// Only this package's own tests can be checked from here. A
+				// proof targeting another package is left to that package's
+				// sweep rather than reported as missing, which would be a false
+				// alarm dressed as a finding.
+				if !commandTargetsThisPackage(command) {
+					continue
+				}
+				for _, named := range goTestPatternNames(command) {
+					if !declaredTests[named] {
+						t.Errorf("%s: %s names proof test %q, which does not "+
+							"exist in this package -- `go test -run` exits 0 when "+
+							"its pattern matches nothing, so this entry would "+
+							"report as measured while running no test at all",
+							planPath, mutation.ID, named)
+					}
+				}
+			}
+		}
+	}
+
+	// R4: a sweep that silently examined nothing is the failure mode this test
+	// exists to prevent, so it must not be able to pass by finding no work.
+	if checkedPlans == 0 || checkedEntries == 0 {
+		t.Fatalf("swept %d plan(s) and %d entr(ies) -- the sweep found nothing "+
+			"to check, which is a broken sweep, not a clean result",
+			checkedPlans, checkedEntries)
+	}
+	t.Logf("swept %d plans, %d entries, %d distinct target files",
+		checkedPlans, checkedEntries, len(sourceCache))
+}
+
+var goTestFunctionPattern = regexp.MustCompile(`(?m)^func (Test[A-Za-z0-9_]*)\(`)
+
+// goTestNamesInPackage collects every Test function declared in this package's
+// _test.go files, read from source rather than from the running binary: the
+// point is to catch a plan naming a test that no longer exists, and a deleted
+// test is by definition absent from the binary too, so reflection over the
+// binary could not tell "deleted" from "not selected".
+func goTestNamesInPackage(t *testing.T) map[string]bool {
+	t.Helper()
+	files, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, file := range files {
+		source, readErr := os.ReadFile(file)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		for _, match := range goTestFunctionPattern.FindAllStringSubmatch(string(source), -1) {
+			names[match[1]] = true
+		}
+	}
+	if len(names) == 0 {
+		t.Fatal("found no Test functions in this package, so every proof-name " +
+			"check below would vacuously pass")
+	}
+	return names
+}
+
+// commandTargetsThisPackage reports whether a proof command runs the
+// providersync package. Plans in this directory may legitimately prove an entry
+// by running a test in another package (a scheduler planner oracle, a worker
+// construction test), and those names cannot be resolved from here.
+func commandTargetsThisPackage(command []string) bool {
+	for _, argument := range command {
+		if strings.HasPrefix(argument, "./") || strings.HasPrefix(argument, "github.com/") {
+			return strings.Contains(argument, "internal/providersync")
+		}
+	}
+	// No package argument means `go test` runs the current directory, which for
+	// these plans is the repository root -- not this package.
+	return false
+}
+
+// goTestPatternNames extracts the concrete TOP-LEVEL test names a `-run`
+// pattern pins, and deliberately returns nothing when it cannot be certain.
+//
+// Go's -run grammar is a regexp, and being wrong here is expensive in both
+// directions: a missed name lets a dead proof through, while a name invented
+// from a pattern this function misreads produces a finding about a test that
+// was never named. Anything with regexp metacharacters beyond the alternation
+// and anchoring handled below is left alone.
+//
+// Two shapes matter in practice and both are handled:
+//
+//   - per-alternative anchors, `^TestA$|^TestB$`, not just `^(TestA|TestB)$`;
+//   - subtest paths, `^TestParent/subtest$`, where only TestParent is a
+//     function and the segment after the slash is a t.Run name.
+func goTestPatternNames(command []string) []string {
+	for index, argument := range command {
+		if argument != "-run" || index+1 >= len(command) {
+			continue
+		}
+		pattern := command[index+1]
+		// A nested group means the pattern builds names by combination
+		// (`^TestPrefix(One|Two)$`); splitting it textually would fabricate
+		// names like "TestPrefix(One". Leave it alone.
+		if strings.Count(pattern, "(") != strings.Count(pattern, ")") ||
+			strings.Count(pattern, "(") > 1 {
+			return nil
+		}
+		if strings.ContainsAny(pattern, ".*+?[]{}\\") {
+			return nil
+		}
+		var names []string
+		for _, alternative := range strings.Split(pattern, "|") {
+			alternative = strings.TrimSpace(alternative)
+			// Anchoring is checked BEFORE trimming: an unanchored alternative
+			// matches by substring and may legitimately select several tests,
+			// so it is not a name this function may claim was pinned.
+			leftAnchored := strings.HasPrefix(alternative, "^") ||
+				strings.HasPrefix(alternative, "(")
+			// Right-anchoring is judged on the FIRST path segment: a subtest
+			// path anchors each segment separately, so `^TestParent$/sub` pins
+			// the parent exactly even though the whole string does not end in
+			// `$`.
+			head, _, _ := strings.Cut(alternative, "/")
+			rightAnchored := strings.HasSuffix(head, "$") || strings.HasSuffix(head, ")")
+			if !leftAnchored || !rightAnchored {
+				return nil
+			}
+			// The subtest path is split FIRST. Go anchors each path segment
+			// independently -- `^TestParent$/^sub$` and `^TestParent$/sub$` are
+			// both ordinary -- so stripping anchors before splitting leaves the
+			// parent carrying a trailing `$` and invents a name nobody wrote.
+			alternative, _, _ = strings.Cut(alternative, "/")
+			alternative = strings.TrimPrefix(alternative, "^(")
+			alternative = strings.TrimSuffix(alternative, ")$")
+			alternative = strings.TrimPrefix(alternative, "^")
+			alternative = strings.TrimSuffix(alternative, "$")
+			alternative = strings.Trim(alternative, "()")
+			if alternative == "" {
+				continue
+			}
+			if !strings.HasPrefix(alternative, "Test") {
+				return nil
+			}
+			names = append(names, alternative)
+		}
+		return names
+	}
+	return nil
+}

--- a/internal/providersync/testdata/mutation-plans/github_tests_reports.json
+++ b/internal/providersync/testdata/mutation-plans/github_tests_reports.json
@@ -1,7 +1,11 @@
 {
   "schema_version": 1,
   "name": "github/tests complete native route (CHAOS-3336)",
-  "build": ["go", "build", "./..."],
+  "build": [
+    "go",
+    "build",
+    "./..."
+  ],
   "mutations": [
     {
       "id": "T1-report-count-cap",
@@ -9,7 +13,15 @@
       "find": "if processed >= githubTestsMaxReportsPerRun {",
       "replace": "if false {",
       "rationale": "one run may parse at most 200 classified reports so an artifact set cannot create unbounded CPU and row volume",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactEnforcesReportCountCap$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactEnforcesReportCountCap$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T2-doctype-rejected",
@@ -17,7 +29,15 @@
       "find": "bytes.Contains(bytes.ToUpper(body), []byte(\"<!DOCTYPE\")) ||",
       "replace": "false ||",
       "rationale": "untrusted artifact XML containing a DTD must be rejected before decoding",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsJUnitParserRejectsDTDAndTruncatesStack$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsJUnitParserRejectsDTDAndTruncatesStack$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T3-stack-truncation",
@@ -25,7 +45,15 @@
       "find": "if len(value) > 4096 {",
       "replace": "if false {",
       "rationale": "failure stack text persisted from an untrusted report is capped at the Python contract's 4096 bytes",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsJUnitParserRejectsDTDAndTruncatesStack$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsJUnitParserRejectsDTDAndTruncatesStack$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T4-failure-status",
@@ -33,7 +61,15 @@
       "find": "case item.Failure != nil:",
       "replace": "case false:",
       "rationale": "a JUnit failure element must normalize to failed and contribute to the suite's failed count",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactParsesJUnitCasesAndCoverage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactParsesJUnitCasesAndCoverage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T5-covered-cannot-exceed-total",
@@ -41,7 +77,15 @@
       "find": "aggregateLinesCovered > aggregateLinesTotal ||",
       "replace": "false ||",
       "rationale": "an incoherent coverage report must be rejected instead of skewing TestOps rollups",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsCoverageRejectsCoveredGreaterThanTotal$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsCoverageRejectsCoveredGreaterThanTotal$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T6-da-lines-fallback",
@@ -49,7 +93,15 @@
       "find": "lineNumbers[lineNumber] = struct{}{}",
       "replace": "delete(lineNumbers, lineNumber)",
       "rationale": "LCOV files without LF/LH must derive total and covered lines from unique DA records exactly like the live Python parser",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsCoverageFallsBackToUniqueDALines$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsCoverageFallsBackToUniqueDALines$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T7-majority-file-service",
@@ -57,7 +109,15 @@
       "find": "if serviceCounts[service] > bestCount {",
       "replace": "if serviceCounts[service] > 0 && bestCount == 0 {",
       "rationale": "coverage service attribution must choose the service represented by the most report files, not the first source path",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsCoverageAttributesMajorityFileService$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsCoverageAttributesMajorityFileService$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T8-cobertura-classification",
@@ -65,7 +125,15 @@
       "find": "strings.Contains(head, \"<coverage\")",
       "replace": "false",
       "rationale": "Cobertura artifacts must be classified and normalized rather than silently skipped",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactParsesCoberturaCoverage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactParsesCoberturaCoverage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T9-run-cap-fails-closed",
@@ -73,7 +141,15 @@
       "find": "if runsPage.CapReached || len(runsPage.Items) > maxRuns {\n\t\treturn CompleteRouteBatch{}, ErrPaginationCapExceeded\n\t}",
       "replace": "if false {\n\t\treturn CompleteRouteBatch{}, ErrPaginationCapExceeded\n\t}",
       "rationale": "a capped Actions inventory must remain retryable and cannot advance the watermark",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsRouteFailsClosedOnRunPaginationCap$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsRouteFailsClosedOnRunPaginationCap$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T10-artifact-redirect-strips-auth",
@@ -81,7 +157,15 @@
       "find": "client.DoUnauthenticated(ctx, http.MethodGet, location)",
       "replace": "client.Do(ctx, http.MethodGet, location, nil)",
       "rationale": "the GitHub credential must never be forwarded to the pre-signed artifact blob host",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsRouteEmitsSixCompleteEffectsAndStripsRedirectAuth$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsRouteEmitsSixCompleteEffectsAndStripsRedirectAuth$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T11-fetch-error-no-watermark",
@@ -90,16 +174,47 @@
       "replace": "if pageErr != nil {\n\t\t\treturn CompleteRouteBatch{Watermark: claim.BeforeAt}, nil\n\t\t}",
       "expect_occurrences": 2,
       "rationale": "an incomplete jobs inventory cannot be committed or acknowledged by advancing the watermark",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsRouteFetchFailureCannotCommitEffectsOrWatermark$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsRouteFetchFailureCannotCommitEffectsOrWatermark$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
-      "id": "T12-six-destination-contract",
+      "id": "T12-six-destination-contract-github-cicd",
       "file": "internal/providersync/execution_registry.go",
-      "find": "\"test_suite_results\", \"test_case_results\", \"coverage_snapshots\",",
-      "replace": "\"test_suite_results\", \"test_case_results\", \"coverage_snapshots_broken\",",
-      "expect_occurrences": 2,
-      "rationale": "the route descriptor must advertise the same six destinations that the complete handler emits",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsRouteEmitsSixCompleteEffectsAndStripsRedirectAuth$", "./internal/providersync/"]]
+      "find": "case provider == \"github\" && dataset == \"cicd\":\n\t\t// cicd and tests delegate to one complete-row unit. Startup rejects both\n\t\t// switches enabled together, so ci_pipeline_runs has one active writer.\n\t\tdescriptor.Destinations = []string{\n\t\t\t\"ci_pipeline_runs\", \"ci_job_runs\", \"ci_acceptance_checks\",\n\t\t\t\"test_suite_results\", \"test_case_results\", \"coverage_snapshots\",\n\t\t}",
+      "replace": "case provider == \"github\" && dataset == \"cicd\":\n\t\t// cicd and tests delegate to one complete-row unit. Startup rejects both\n\t\t// switches enabled together, so ci_pipeline_runs has one active writer.\n\t\tdescriptor.Destinations = []string{\n\t\t\t\"ci_pipeline_runs\", \"ci_job_runs\", \"ci_acceptance_checks\",\n\t\t\t\"test_suite_results\", \"test_case_results\", \"coverage_snapshots_broken\",\n\t\t}",
+      "rationale": "the route descriptor must advertise the same six destinations that the complete handler emits Split per descriptor (github/cicd): expect_occurrences 2 stopped identifying the two GitHub sites once GitLab cicd/tests grew the same destination list, and one mutation spanning both GitHub sites can be killed by either while the other goes unmeasured.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsRouteEmitsSixCompleteEffectsAndStripsRedirectAuth$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T12-six-destination-contract-github-tests",
+      "file": "internal/providersync/execution_registry.go",
+      "find": "case provider == \"github\" && dataset == \"tests\":\n\t\tdescriptor.Destinations = []string{\n\t\t\t\"ci_pipeline_runs\", \"ci_job_runs\", \"ci_acceptance_checks\",\n\t\t\t\"test_suite_results\", \"test_case_results\", \"coverage_snapshots\",\n\t\t}",
+      "replace": "case provider == \"github\" && dataset == \"tests\":\n\t\tdescriptor.Destinations = []string{\n\t\t\t\"ci_pipeline_runs\", \"ci_job_runs\", \"ci_acceptance_checks\",\n\t\t\t\"test_suite_results\", \"test_case_results\", \"coverage_snapshots_broken\",\n\t\t}",
+      "rationale": "the route descriptor must advertise the same six destinations that the complete handler emits Split per descriptor (github/tests): expect_occurrences 2 stopped identifying the two GitHub sites once GitLab cicd/tests grew the same destination list, and one mutation spanning both GitHub sites can be killed by either while the other goes unmeasured.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsRouteEmitsSixCompleteEffectsAndStripsRedirectAuth$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T13-default-off-switch",
@@ -107,7 +222,15 @@
       "find": "name:   \"WORKER_GITHUB_TESTS_ENABLED\",",
       "replace": "name:   \"WORKER_GITHUB_TESTS_ENABLED_BROKEN\",",
       "rationale": "the opt-in GitHub tests environment switch must map to its dedicated config field",
-      "proof": [["go", "test", "-run", "^TestQueueControlAndRetentionOverridesAreBounded$", "./internal/platform/config/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestQueueControlAndRetentionOverridesAreBounded$",
+          "./internal/platform/config/"
+        ]
+      ]
     },
     {
       "id": "T14-total-entry-cap",
@@ -115,7 +238,15 @@
       "find": "if len(members) > githubTestsMaxArchiveEntries {",
       "replace": "if false {",
       "rationale": "the Python archive boundary examines only the first 2000 total entries, including ignored files",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactDoesNotTraversePastPythonEntryCap$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactDoesNotTraversePastPythonEntryCap$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T15-compression-ratio-cap",
@@ -123,7 +254,15 @@
       "find": "member.UncompressedSize64 > compressed*githubTestsMaxCompressionRatio",
       "replace": "false",
       "rationale": "a matching report above Python's 200 to 1 compression ratio must not be inflated",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactSkipsPythonOverRatioMember$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactSkipsPythonOverRatioMember$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T16-default-branch-artifact-selection",
@@ -131,7 +270,15 @@
       "find": "artifactRunQuery.Set(\"branch\", repo.DefaultBranch)",
       "replace": "artifactRunQuery.Set(\"branch\", \"\")",
       "rationale": "report artifacts must use Python's separate server-side default-branch run selection",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsRoute(ExcludesFeatureBranchArtifactsLikePythonProducer|KeepsPythonDateFloorArtifactSelectionIndependent)$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsRoute(ExcludesFeatureBranchArtifactsLikePythonProducer|KeepsPythonDateFloorArtifactSelectionIndependent)$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T17-atomic-batch-send",
@@ -139,7 +286,16 @@
       "find": "return batch.Send()",
       "replace": "return nil",
       "rationale": "all validated rows for one destination must be sent as one atomic ClickHouse block",
-      "proof": [["go", "test", "-tags=integration", "-run", "^TestGitHubTestsMultiRowEffectsAreAtomicAndRejectDuplicateNaturalKeys$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags=integration",
+          "-run",
+          "^TestGitHubTestsMultiRowEffectsAreAtomicAndRejectDuplicateNaturalKeys$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T18-duplicate-natural-key-rejected",
@@ -147,7 +303,16 @@
       "find": "if _, exists := seen[key]; exists {",
       "replace": "if false {",
       "rationale": "one effect cannot contain two versions of the same tenant-prefixed natural key",
-      "proof": [["go", "test", "-tags=integration", "-run", "^TestGitHubTestsMultiRowEffectsAreAtomicAndRejectDuplicateNaturalKeys$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags=integration",
+          "-run",
+          "^TestGitHubTestsMultiRowEffectsAreAtomicAndRejectDuplicateNaturalKeys$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T19-junit-millisecond-normalization",
@@ -155,7 +320,16 @@
       "find": "parsed = parsed.UTC().Truncate(time.Millisecond)",
       "replace": "parsed = parsed.UTC()",
       "rationale": "timestamps must match ClickHouse DateTime64(3) before effect hashing so recovery can observe EffectExact",
-      "proof": [["go", "test", "-tags=integration", "-run", "^TestGitHubTestsJUnitMillisecondTimestampsReadBackExact$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-tags=integration",
+          "-run",
+          "^TestGitHubTestsJUnitMillisecondTimestampsReadBackExact$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T20-complete-unit-mutual-exclusion",
@@ -163,15 +337,31 @@
       "find": "if cfg.WorkerGithubCICDEnabled && cfg.WorkerGithubTestsEnabled {",
       "replace": "if false {",
       "rationale": "the cicd and tests matrix names may not activate two writers for the same complete natural-key unit",
-      "proof": [["go", "test", "-run", "^TestGitHubCompleteUnitAliasesAreMutuallyExclusive$", "./internal/platform/config/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubCompleteUnitAliasesAreMutuallyExclusive$",
+          "./internal/platform/config/"
+        ]
+      ]
     },
     {
       "id": "T21-provider-timestamp-millisecond-normalization",
-	  "file": "internal/providersync/github_prs_route.go",
-	  "find": "parsed = parsed.UTC().Truncate(time.Millisecond)",
-	  "replace": "parsed = parsed.UTC()",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "parsed = parsed.UTC().Truncate(time.Millisecond)",
+      "replace": "parsed = parsed.UTC()",
       "rationale": "every provider timestamp must match ClickHouse DateTime64(3) before complete-unit effect hashing",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsNormalizesEveryProviderTimestampBeforeHashing$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsNormalizesEveryProviderTimestampBeforeHashing$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T22-archive-empty-name",
@@ -179,7 +369,15 @@
       "find": "name == \"\" || strings.HasSuffix(name, \"/\")",
       "replace": "false || strings.HasSuffix(name, \"/\")",
       "rationale": "the shared Python archive safety contract rejects empty member names before classification",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArchiveMemberNameMatchesPythonSafetyContract$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArchiveMemberNameMatchesPythonSafetyContract$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T23-archive-directory-name",
@@ -187,7 +385,15 @@
       "find": "name == \"\" || strings.HasSuffix(name, \"/\")",
       "replace": "name == \"\" || false",
       "rationale": "the shared Python archive safety contract rejects directory members before classification",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArchiveMemberNameMatchesPythonSafetyContract$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArchiveMemberNameMatchesPythonSafetyContract$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T24-archive-leading-slash",
@@ -195,7 +401,15 @@
       "find": "strings.HasPrefix(name, \"/\") || strings.HasPrefix(name, `\\`)",
       "replace": "false || strings.HasPrefix(name, `\\`)",
       "rationale": "absolute POSIX archive member names must be excluded before report classification",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T25-archive-leading-backslash",
@@ -203,7 +417,15 @@
       "find": "strings.HasPrefix(name, \"/\") || strings.HasPrefix(name, `\\`)",
       "replace": "strings.HasPrefix(name, \"/\") || false",
       "rationale": "absolute and UNC-style Windows archive member names must be excluded before report classification",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T26-archive-parent-component",
@@ -211,7 +433,15 @@
       "find": "if part == \"..\" {",
       "replace": "if part != part {",
       "rationale": "parent-directory components must be excluded regardless of separator before report classification",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T27-archive-drive-absolute",
@@ -219,7 +449,15 @@
       "find": "if len(name) >= 2 && name[1] == ':' {",
       "replace": "if false {",
       "rationale": "Windows drive-absolute archive member names must be excluded before report classification",
-      "proof": [["go", "test", "-run", "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubTestsArtifactSkipsUnsafeNamesBeforeClassification$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T28-go-complete-unit-admission-identity",
@@ -227,7 +465,15 @@
       "find": "if dataset == \"cicd\" {",
       "replace": "if false {",
       "rationale": "both public aliases must reserve the same Go route-family bucket for the shared complete TestOps unit",
-      "proof": [["go", "test", "-run", "^TestGitHubCICDAndTestsAliasesEmitTheSameCompleteEffects$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-run",
+          "^TestGitHubCICDAndTestsAliasesEmitTheSameCompleteEffects$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "T29-python-complete-unit-admission-identity",
@@ -235,7 +481,15 @@
       "find": "if dataset_key == DatasetKey.CICD.value",
       "replace": "if False",
       "rationale": "the live Python estimator must reserve the tests route-family bucket for both public aliases",
-      "proof": [[".venv/bin/pytest", "-q", "tests/providers/test_github_budget.py", "-k", "cicd_aliases_share_complete_testops_admission_identity"]]
+      "proof": [
+        [
+          ".venv/bin/pytest",
+          "-q",
+          "tests/providers/test_github_budget.py",
+          "-k",
+          "cicd_aliases_share_complete_testops_admission_identity"
+        ]
+      ]
     },
     {
       "id": "T30-python-cicd-actuals-admission-identity",
@@ -243,7 +497,15 @@
       "find": "TESTS_ROUTE_FAMILY = \"tests\"",
       "replace": "TESTS_ROUTE_FAMILY = \"cicd\"",
       "rationale": "the executed legacy CICD producer must record actual REST requests against the same tests route-family bucket its estimator reserves",
-      "proof": [[".venv/bin/pytest", "-q", "tests/providers/test_github_code_client_cicd.py", "-k", "producer_actuals_share_tests_estimator_admission_identity"]]
+      "proof": [
+        [
+          ".venv/bin/pytest",
+          "-q",
+          "tests/providers/test_github_code_client_cicd.py",
+          "-k",
+          "producer_actuals_share_tests_estimator_admission_identity"
+        ]
+      ]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_items_direct_effects.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_direct_effects.json
@@ -172,9 +172,9 @@
     {
       "id": "M09-timestamp-not-truncated-to-the-column-precision",
       "file": "internal/providersync/github_work_items_direct_effects_clickhouse.go",
-      "find": "func clickHouseMillis(value time.Time) time.Time {\n\treturn value.UTC().Truncate(time.Millisecond)\n}",
+      "find": "func clickHouseMillis(value time.Time) time.Time {\n\treturn value.UTC().Truncate(workItemColumnPrecision)\n}",
       "replace": "func clickHouseMillis(value time.Time) time.Time {\n\treturn value.UTC()\n}",
-      "rationale": "DateTime64(3) cannot hold the nanoseconds a wall-clock now() carries; an untruncated expectation is never satisfiable and replays forever",
+      "rationale": "DateTime64(3) cannot hold the nanoseconds a wall-clock now() carries; an untruncated expectation is never satisfiable and replays forever. Re-anchored: the literal time.Millisecond became the named workItemColumnPrecision, which left this anchor matching NOTHING -- a dead guard that still read as coverage.",
       "proof": [
         [
           "go",

--- a/internal/providersync/testdata/mutation-plans/github_work_items_foundation.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_foundation.json
@@ -1,7 +1,11 @@
 {
   "schema_version": 1,
   "name": "github work-item complete-unit foundation",
-  "build": ["go", "build", "./internal/providersync/"],
+  "build": [
+    "go",
+    "build",
+    "./internal/providersync/"
+  ],
   "$limitation": "This first unregistered layer pins the exact Python write-surface manifest. Semantic rows, alias completion, collectors, effects, derived metrics, and activation add their own mutations in subsequent stack layers; none of the five aliases is route-ready here.",
   "mutations": [
     {
@@ -11,7 +15,14 @@
       "replace": "\t\t\"estimate_coverage_metrics_daily\",",
       "rationale": "the GitHub Python work-item unit conditionally writes AI attribution beside the raw and derived work-item effects, so the complete-route manifest must include it for recovery and atomic ownership",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestWorkItemRouteDestinationsMatchTheRetrySafePythonUnitSurface$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestWorkItemRouteDestinationsMatchTheRetrySafePythonUnitSurface$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -21,7 +32,14 @@
       "replace": "\t\tif false {",
       "rationale": "a misspelled or future family flag must not silently terminalize a unit whose per-alias watermark identities Go cannot prove",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestWorkItemAliasCompletionMetadata/(unknown_enabled_alias_fails_closed|unknown_disabled_alias_also_fails_closed)$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestWorkItemAliasCompletionMetadata/(unknown_enabled_alias_fails_closed|unknown_disabled_alias_also_fails_closed)$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -31,7 +49,14 @@
       "replace": "\tif false {",
       "rationale": "a collapsed canonical claim with no enabled alias has no authoritative watermark target and cannot be reported successful",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestWorkItemAliasCompletionMetadata/all_aliases_disabled_fails_closed$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestWorkItemAliasCompletionMetadata/all_aliases_disabled_fails_closed$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -40,9 +65,24 @@
       "find": "\t\tfor _, datasetKey := range datasetKeys {",
       "replace": "\t\tfor _, datasetKey := range datasetKeys[:1] {",
       "rationale": "successful completion of the one canonical crawl must advance every enabled family alias rather than only the canonical work-items watermark",
-      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "build": [
+        "go",
+        "test",
+        "-tags=integration",
+        "-run",
+        "^$",
+        "./internal/providersync/"
+      ],
       "proof": [
-        ["go", "test", "-count=1", "-tags=integration", "-run", "^TestPostgresLeaseClaimRenewRecoveryAndTerminalFence$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-tags=integration",
+          "-run",
+          "^TestPostgresLeaseClaimRenewRecoveryAndTerminalFence$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -52,17 +92,31 @@
       "replace": "\taudited[workItemFamilyAuditResultKey] = []string{}",
       "rationale": "the canonical unit result must retain the enabled alias identities for operational audit and compute checkpoint provenance",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestWorkItemAliasCompletionMetadata/(all_enabled_aliases_use_canonical_order|enabled_subset_excludes_false_aliases)$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestWorkItemAliasCompletionMetadata/(all_enabled_aliases_use_canonical_order|enabled_subset_excludes_false_aliases)$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
       "id": "F6-milestone-identities-preserve-large-integers",
       "file": "internal/providersync/github_work_items_rows.go",
-      "find": "\tdecoder.UseNumber()",
-      "replace": "",
-      "rationale": "GitHub database identifiers above 2^53 must never pass through float64 before becoming the stable sprint identity",
+      "find": "\tvar milestone githubMilestonePayload\n\tdecoder := json.NewDecoder(bytes.NewReader(raw))\n\tdecoder.UseNumber()",
+      "replace": "\tvar milestone githubMilestonePayload\n\tdecoder := json.NewDecoder(bytes.NewReader(raw))",
+      "rationale": "GitHub database identifiers above 2^53 must never pass through float64 before becoming the stable sprint identity. Anchor narrowed to the MILESTONE decoder: a second UseNumber() now exists on the comment path, and the bare anchor matched both -- mutating an unrelated site this entry never claimed to cover.",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestNormalizeGitHubSprintMatchesProductionBoundary$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeGitHubSprintMatchesProductionBoundary$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -72,17 +126,31 @@
       "replace": "\t\tWorkItemID: \"gh:\" + repoFullName + \"#\" + strconv.Itoa(0),",
       "rationale": "the normalized GitHub issue identity must retain its provider number so updates and derived metrics converge on the Python row",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestNormalizeGitHubIssueWorkItemMatchesProductionBoundary$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeGitHubIssueWorkItemMatchesProductionBoundary$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
       "id": "F8-priority-label-enrichment-is-in-band",
       "file": "internal/providersync/github_work_items_rows.go",
-      "find": "\tpriority, serviceClass := githubPriorityFromLabels(labels)",
-      "replace": "\tpriority, serviceClass := (*string)(nil), (*string)(nil)",
-      "rationale": "Python enriches every GitHub issue WorkItem with priority and service class before adding it to the provider batch",
+      "find": "\tpriority, serviceClass := githubPriorityFromLabels(labels)\n\trow := githubWorkItemRow{",
+      "replace": "\tpriority, serviceClass := (*string)(nil), (*string)(nil)\n\trow := githubWorkItemRow{",
+      "rationale": "Python enriches every GitHub issue WorkItem with priority and service class before adding it to the provider batch. Anchor narrowed to the ISSUE path (its rationale and proof name issues): the pull-request normalizer grew an identical call, and the bare anchor matched both.",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestNormalizeGitHubIssueWorkItemMatchesProductionBoundary$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestNormalizeGitHubIssueWorkItemMatchesProductionBoundary$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -92,7 +160,14 @@
       "replace": "",
       "rationale": "the Go composite must structurally account for every semantic list the real Python GitHub provider can emit, including conditional AI attribution",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^TestGitHubWorkItemCompositeDeclaresEveryPythonBatchFamily$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemCompositeDeclaresEveryPythonBatchFamily$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -102,7 +177,14 @@
       "replace": "\tparsed = parsed.UTC().Truncate(time.Millisecond)\n\treturn &parsed",
       "rationale": "Python retains full provider timestamp precision in the semantic WorkItem and Sprint dataclasses; only the later ClickHouse projection may coerce to DateTime64(3)",
       "proof": [
-        ["go", "test", "-count=1", "-run", "^(TestNormalizeGitHubIssueWorkItemMatchesProductionBoundary|TestNormalizeGitHubSprintMatchesProductionBoundary)$", "./internal/providersync/"]
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestNormalizeGitHubIssueWorkItemMatchesProductionBoundary|TestNormalizeGitHubSprintMatchesProductionBoundary)$",
+          "./internal/providersync/"
+        ]
       ]
     },
     {
@@ -111,9 +193,20 @@
       "find": "            reopen_events = [\n                replace(event, org_id=org_id) if hasattr(event, \"org_id\") else event\n                for event in reopen_events\n            ]",
       "replace": "            reopen_events = list(reopen_events)",
       "rationale": "reopen rows are written to an org-partitioned ClickHouse table and must not retain the dataclass default empty tenant key",
-      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/metrics/job_work_items.py"],
+      "build": [
+        ".venv/bin/python",
+        "-m",
+        "py_compile",
+        "src/dev_health_ops/metrics/job_work_items.py"
+      ],
       "proof": [
-        [".venv/bin/pytest", "-q", "tests/providers/test_github_ai_attribution_integration.py", "-k", "writes_ai_attribution_with_org_id"]
+        [
+          ".venv/bin/pytest",
+          "-q",
+          "tests/providers/test_github_ai_attribution_integration.py",
+          "-k",
+          "writes_ai_attribution_with_org_id"
+        ]
       ]
     },
     {
@@ -122,9 +215,20 @@
       "find": "            interactions = [\n                replace(event, org_id=org_id) if hasattr(event, \"org_id\") else event\n                for event in interactions\n            ]",
       "replace": "            interactions = list(interactions)",
       "rationale": "comment interaction rows are tenant-partitioned and must be visible only under the owning organization",
-      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/metrics/job_work_items.py"],
+      "build": [
+        ".venv/bin/python",
+        "-m",
+        "py_compile",
+        "src/dev_health_ops/metrics/job_work_items.py"
+      ],
       "proof": [
-        [".venv/bin/pytest", "-q", "tests/providers/test_github_ai_attribution_integration.py", "-k", "writes_ai_attribution_with_org_id"]
+        [
+          ".venv/bin/pytest",
+          "-q",
+          "tests/providers/test_github_ai_attribution_integration.py",
+          "-k",
+          "writes_ai_attribution_with_org_id"
+        ]
       ]
     },
     {
@@ -133,9 +237,20 @@
       "find": "            sprints = [\n                replace(sprint, org_id=org_id) if hasattr(sprint, \"org_id\") else sprint\n                for sprint in sprints\n            ]",
       "replace": "            sprints = list(sprints)",
       "rationale": "milestone-derived sprint rows use org_id in their deduplication key and must be stamped before the sink write",
-      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/metrics/job_work_items.py"],
+      "build": [
+        ".venv/bin/python",
+        "-m",
+        "py_compile",
+        "src/dev_health_ops/metrics/job_work_items.py"
+      ],
       "proof": [
-        [".venv/bin/pytest", "-q", "tests/providers/test_github_ai_attribution_integration.py", "-k", "writes_ai_attribution_with_org_id"]
+        [
+          ".venv/bin/pytest",
+          "-q",
+          "tests/providers/test_github_ai_attribution_integration.py",
+          "-k",
+          "writes_ai_attribution_with_org_id"
+        ]
       ]
     }
   ]

--- a/internal/providersync/testdata/mutation-plans/github_work_items_foundation.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_foundation.json
@@ -156,9 +156,9 @@
     {
       "id": "F9-all-seven-provider-batch-families-stay-declared",
       "file": "internal/providersync/github_work_items_rows.go",
-      "find": "\tAIAttributions    []githubAIAttributionRow",
-      "replace": "",
-      "rationale": "the Go composite must structurally account for every semantic list the real Python GitHub provider can emit, including conditional AI attribution",
+      "find": "\tSprints           []githubSprintRow\n\tAIAttributions    []githubAIAttributionRow\n}",
+      "replace": "\tSprints           []githubSprintRow\n\tAIAttributions    []githubAIAttributionRow\n\tUndeclaredFamily  []githubSprintRow\n}",
+      "rationale": "the Go composite must structurally account for every semantic list the real Python GitHub provider can emit, including conditional AI attribution -- and for NO others, since the proof compares the reflected field list against the seven families by ordered DeepEqual. Re-authored: this entry previously DELETED the AIAttributions field, which breaks the build at eight call sites, so no test ran and it scored INVALID -- reading as coverage while measuring nothing. Deletion cannot be the operator here, because no compiling mutation can remove a field other code references. Adding an undeclared eighth family is the compiling mutation that reaches the same assertion: the family list is pinned exactly, by name, order and count.",
       "proof": [
         [
           "go",

--- a/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
@@ -11,8 +11,8 @@
     {
       "id": "P1-credential-matches-claimed-credential",
       "file": "internal/providersync/github_work_items_projects_v2.go",
-      "find": "credential.ID == \"\" || credential.ID != claim.CredentialID || client == nil ||",
-      "replace": "credential.ID == \"\" || credential.ID == claim.CredentialID || client == nil ||",
+      "find": "\t\tcredential.ID != claim.CredentialID || client == nil ||",
+      "replace": "\t\tcredential.ID == claim.CredentialID || client == nil ||",
       "rationale": "Projects v2 must use the credential resolved for this claim, never a global or unrelated descriptor",
       "proof": [
         [

--- a/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
@@ -368,11 +368,11 @@
       ]
     },
     {
-      "id": "P22-present-but-null-target-list-is-refused",
+      "id": "P22-null-config-must-not-share-the-not-configured-branch",
       "file": "internal/providersync/github_work_items_projects_v2.go",
-      "find": "\tif value == nil {\n\t\treturn nil, ErrInvalidConfiguration\n\t}\n",
-      "replace": "",
-      "rationale": "a present github_projects_v2 key holding JSON null must be REFUSED, not treated as absent. This path FAILED OPEN until CHAOS-3123: null shared the not-configured branch and returned empty targets with a nil error, silently discarding config the operator wrote. Postgres JSONB null decodes to an UNTYPED nil interface, so the test builds it from JSON bytes -- a Go-literal typed nil takes a different path and would leave this mutant alive.",
+      "find": "\tif !configured {\n\t\treturn []GitHubProjectV2Target{}, nil\n\t}",
+      "replace": "\tif !configured || value == nil {\n\t\treturn []GitHubProjectV2Target{}, nil\n\t}",
+      "rationale": "regression guard for the fail-open this PR fixed: while `value == nil` shared the not-configured early return, `{\"github_projects_v2\": null}` answered \"no projects configured\" and silently discarded config the operator wrote. This mutant restores exactly that line.",
       "proof": [
         [
           "go",
@@ -397,6 +397,23 @@
           "-count=1",
           "-run",
           "^(TestGitHubProjectV2TargetsSeparateNullConfigFromEmptyConfig|TestGitHubProjectV2EnvironmentTargetsAreNeverAFallback)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P24-nil-decoded-target-list-is-refused",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "\tif err := decoder.Decode(&targets); err != nil || targets == nil {",
+      "replace": "\tif err := decoder.Decode(&targets); err != nil {",
+      "rationale": "clause-level, and the clause that now does the refusing: JSON null decodes cleanly to a nil target list with no error, so without `|| targets == nil` a configured null returns no targets and no error -- the fail-open re-entering by the back door after P22 closed the front.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2TargetsSeparateNullConfigFromEmptyConfig)$",
           "./internal/providersync/"
         ]
       ]

--- a/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
@@ -366,6 +366,23 @@
           "./internal/providersync/"
         ]
       ]
+    },
+    {
+      "id": "P22-present-but-null-target-list-is-refused",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "\tif err := decoder.Decode(&targets); err != nil || targets == nil {",
+      "replace": "\tif err := decoder.Decode(&targets); err != nil {",
+      "rationale": "clause-level: a present github_projects_v2 key holding a null/typed-nil list decodes cleanly to a nil slice. Without the nil clause that is indistinguishable from an empty list, so configuration the operator actually wrote is silently ignored instead of refused -- the fail-open-on-malformed-config class.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig)$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
@@ -353,9 +353,9 @@
     {
       "id": "P18-environment-authored-claims-never-reach-a-collector",
       "file": "internal/providersync/lease.go",
-      "find": "\tif unit.AuthSource == \"environment\" || unit.CredentialID == \"\" {",
-      "replace": "\tif unit.CredentialID == \"\" {",
-      "rationale": "clause-level: D18 puts environment credentials outside the Go route, and this fence is where that is actually enforced -- a unit whose AuthSource is \"environment\" must never reach any collector. Found unmeasured by a surviving mutation on the collector's redundant credential.ID == \"\" clause, which was redundant only because this fence holds.",
+      "find": "\tif unit.AuthSource == \"environment\" {",
+      "replace": "\tif unit.AuthSource == \"not-a-real-auth-source\" {",
+      "rationale": "clause-level: D18 puts environment credentials outside the Go route, and this fence is where it is enforced for EVERY provider -- a unit whose AuthSource is \"environment\" must never reach any collector. Re-authored after F4 removed the unkillable `|| unit.CredentialID == \"\"` twin from the same line.",
       "proof": [
         [
           "go",
@@ -370,16 +370,33 @@
     {
       "id": "P22-present-but-null-target-list-is-refused",
       "file": "internal/providersync/github_work_items_projects_v2.go",
-      "find": "\tif err := decoder.Decode(&targets); err != nil || targets == nil {",
-      "replace": "\tif err := decoder.Decode(&targets); err != nil {",
-      "rationale": "clause-level: a present github_projects_v2 key holding a null/typed-nil list decodes cleanly to a nil slice. Without the nil clause that is indistinguishable from an empty list, so configuration the operator actually wrote is silently ignored instead of refused -- the fail-open-on-malformed-config class.",
+      "find": "\tif value == nil {\n\t\treturn nil, ErrInvalidConfiguration\n\t}\n",
+      "replace": "",
+      "rationale": "a present github_projects_v2 key holding JSON null must be REFUSED, not treated as absent. This path FAILED OPEN until CHAOS-3123: null shared the not-configured branch and returned empty targets with a nil error, silently discarding config the operator wrote. Postgres JSONB null decodes to an UNTYPED nil interface, so the test builds it from JSON bytes -- a Go-literal typed nil takes a different path and would leave this mutant alive.",
       "proof": [
         [
           "go",
           "test",
           "-count=1",
           "-run",
-          "^(TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig)$",
+          "^(TestGitHubProjectV2TargetsSeparateNullConfigFromEmptyConfig)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P23-explicitly-empty-target-list-stays-valid",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "\tif !configured {\n\t\treturn []GitHubProjectV2Target{}, nil\n\t}",
+      "replace": "\tif !configured {\n\t\treturn nil, ErrInvalidConfiguration\n\t}",
+      "rationale": "the other side of the null/empty boundary: an absent key and an explicitly empty list are both valid ways to have no projects, and a fix that refused the null case by refusing emptiness generally would be caught here.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2TargetsSeparateNullConfigFromEmptyConfig|TestGitHubProjectV2EnvironmentTargetsAreNeverAFallback)$",
           "./internal/providersync/"
         ]
       ]

--- a/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
@@ -300,23 +300,6 @@
       ]
     },
     {
-      "id": "P18-credential-id-must-be-resolved",
-      "file": "internal/providersync/github_work_items_projects_v2.go",
-      "find": "credential.ID == \"\" || credential.ID != claim.CredentialID || client == nil ||",
-      "replace": "credential.ID != claim.CredentialID || client == nil ||",
-      "rationale": "clause-level sibling of P1: an unresolved (empty) credential id must be refused on its own clause, which is the shape an environment token would arrive as",
-      "proof": [
-        [
-          "go",
-          "test",
-          "-count=1",
-          "-run",
-          "^(TestGitHubProjectV2RefusesEnvironmentTokenWhenClaimCredentialIsUnusable)$",
-          "./internal/providersync/"
-        ]
-      ]
-    },
-    {
       "id": "P19-credential-provider-must-be-github",
       "file": "internal/providersync/github_work_items_projects_v2.go",
       "find": "!isWorkItemFamilyDataset(claim.Dataset) || credential.Provider != \"github\" ||",
@@ -363,6 +346,23 @@
           "-count=1",
           "-run",
           "^(TestGitHubWorkItemsRouteRefusesAnUnwiredProjectsCollectorWithoutTargets)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P18-environment-authored-claims-never-reach-a-collector",
+      "file": "internal/providersync/lease.go",
+      "find": "\tif unit.AuthSource == \"environment\" || unit.CredentialID == \"\" {",
+      "replace": "\tif unit.CredentialID == \"\" {",
+      "rationale": "clause-level: D18 puts environment credentials outside the Go route, and this fence is where that is actually enforced -- a unit whose AuthSource is \"environment\" must never reach any collector. Found unmeasured by a surviving mutation on the collector's redundant credential.ID == \"\" clause, which was redundant only because this fence holds.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2RefusesClaimsAuthoredFromTheEnvironment)$",
           "./internal/providersync/"
         ]
       ]

--- a/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_projects_v2.json
@@ -1,8 +1,12 @@
 {
   "schema_version": 1,
-  "name": "unregistered github projects v2 semantic foundation",
-  "build": ["go", "build", "./internal/providersync/"],
-  "$limitation": "This plan covers the unregistered Projects v2 fetch, normalization, and composition foundation. Route registration, effects, watermarking, readiness, and the unresolved fanout ownership decision are intentionally absent.",
+  "name": "ratified github projects v2 collector (D18)",
+  "build": [
+    "go",
+    "build",
+    "./internal/providersync/"
+  ],
+  "$limitation": "This plan covers the D18-ratified Projects v2 fetch, normalization, composition, and the collector's construction guard. Route registration, effects, watermarking, readiness, and the separately-tracked one-fetch-per-integration redesign are intentionally absent.",
   "mutations": [
     {
       "id": "P1-credential-matches-claimed-credential",
@@ -10,7 +14,16 @@
       "find": "credential.ID == \"\" || credential.ID != claim.CredentialID || client == nil ||",
       "replace": "credential.ID == \"\" || credential.ID == claim.CredentialID || client == nil ||",
       "rationale": "Projects v2 must use the credential resolved for this claim, never a global or unrelated descriptor",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherRequiresClaimResolvedCredentialAndClient$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherRequiresClaimResolvedCredentialAndClient$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P2-nested-missing-cursor-fails-closed",
@@ -18,7 +31,16 @@
       "find": "if cursor == \"\" || strings.TrimSpace(item.ID) == \"\" {",
       "replace": "if cursor == \"impossible-cursor\" || strings.TrimSpace(item.ID) == \"\" {",
       "rationale": "hasNextPage without an endCursor cannot establish complete nested history and must not become a partial success",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherFailsClosedOnUnusableCursors$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherFailsClosedOnUnusableCursors$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P3-outer-missing-cursor-fails-closed",
@@ -26,7 +48,16 @@
       "find": "if next == \"\" || next == outerCursor {",
       "replace": "if false && (next == \"\" || next == outerCursor) {",
       "rationale": "hasNextPage without an endCursor cannot establish a complete project inventory",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherFailsClosedOnUnusableCursors$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherFailsClosedOnUnusableCursors$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P4-pull-requests-remain-skipped",
@@ -34,7 +65,16 @@
       "find": "if item.Content.Typename == \"PullRequest\" || (item.Content.Typename != \"Issue\" && item.Content.Typename != \"DraftIssue\") {",
       "replace": "if item.Content.Typename != \"PullRequest\" && (item.Content.Typename != \"Issue\" && item.Content.Typename != \"DraftIssue\") {",
       "rationale": "The active Python Projects v2 normalizer explicitly emits no WorkItem or transitions for PullRequest content",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2PullRequestSkipMatchesLivePythonProductionDecision$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2PullRequestSkipMatchesLivePythonProductionDecision$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P5-project-row-is-last-wins",
@@ -42,7 +82,16 @@
       "find": "merged.WorkItems[position] = row",
       "replace": "merged.WorkItems[position] = merged.WorkItems[position]",
       "rationale": "Python overwrites a repository row with the Projects v2 row at the original insertion position",
-      "proof": [["go", "test", "-count=1", "-run", "^TestMergeGitHubProjectV2RowsPreservesPythonLastWinsAndTransitionAppend$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestMergeGitHubProjectV2RowsPreservesPythonLastWinsAndTransitionAppend$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P6-project-transitions-append",
@@ -50,7 +99,16 @@
       "find": "merged.StatusTransitions = append(append([]githubWorkItemTransitionRow{}, repository.StatusTransitions...), projects.StatusTransitions...)",
       "replace": "merged.StatusTransitions = append([]githubWorkItemTransitionRow{}, repository.StatusTransitions...)",
       "rationale": "Python appends all Projects v2 transitions after repository transitions instead of deduplicating or replacing them",
-      "proof": [["go", "test", "-count=1", "-run", "^TestMergeGitHubProjectV2RowsPreservesPythonLastWinsAndTransitionAppend$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestMergeGitHubProjectV2RowsPreservesPythonLastWinsAndTransitionAppend$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P7-nested-pages-are-composed",
@@ -58,7 +116,16 @@
       "find": "item.Changes.Nodes = append(item.Changes.Nodes, more.Nodes...)",
       "replace": "item.Changes.Nodes = append([]gitHubProjectV2ChangePayload{}, more.Nodes...)",
       "rationale": "Every nested changes page participates in transition history; replacing the first page silently truncates history",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCompletesOuterAndNestedPagination$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherCompletesOuterAndNestedPagination$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P8-documented-label-leaf-bound-is-preserved",
@@ -67,7 +134,16 @@
       "find": "labels(first: 50)",
       "replace": "labels(first: 49)",
       "rationale": "The port intentionally preserves the active producer's documented unpaginated labels(first: 50) leaf truncation",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCompletesOuterAndNestedPagination$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherCompletesOuterAndNestedPagination$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P9-physical-attempts-are-counted",
@@ -75,7 +151,16 @@
       "find": "func (doer gitHubProjectV2CountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.requests++",
       "replace": "func (doer gitHubProjectV2CountingDoer) Do(request *http.Request) (*http.Response, error) {\n\tif false { *doer.requests++ }",
       "rationale": "Fetch evidence counts every physical HTTP attempt, including retries inside one logical budget reservation",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P10-graphql-usage-counts-physical-attempts",
@@ -83,7 +168,16 @@
       "find": "if request.URL.EscapedPath() == doer.graphqlPath {\n\t\t*doer.graphqlRequests++",
       "replace": "if false && request.URL.EscapedPath() == doer.graphqlPath {\n\t\t*doer.graphqlRequests++",
       "rationale": "The work_item_prs GraphQL actual records every physical wire attempt rather than only successful logical pages",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P11-error-results-retain-request-evidence",
@@ -92,7 +186,16 @@
       "find": "return finishGitHubProjectV2Fetch(result), err",
       "replace": "return GitHubProjectV2FetchResult{}, err",
       "rationale": "Terminal fetch and normalization failures retain already-observed safe usage instead of returning an indistinguishable zero result",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherRetainsPhysicalUsageOnTerminalError$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherRetainsPhysicalUsageOnTerminalError$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P12-projects-v2-uses-python-budget-vocabulary",
@@ -100,7 +203,16 @@
       "find": "Transport: \"graphql\", RouteFamily: \"work_item_prs\", Dimension: BudgetGraphQLCost,",
       "replace": "Transport: \"graphql\", RouteFamily: \"projects_v2\", Dimension: BudgetGraphQLCost,",
       "rationale": "Projects v2 actual usage must use Python's work_item_prs/graphql_cost vocabulary so planned and actual usage remain joinable",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2FetcherCountsPhysicalRetriesButReservesOnce$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "P13-draft-issues-are-emitted",
@@ -108,7 +220,152 @@
       "find": "workItemID := \"ghproj:\" + item.ID",
       "replace": "workItemID := \"ghproj-draft:\" + item.ID",
       "rationale": "The live Python Projects v2 producer emits DraftIssue rows with the project-native ghproj item identity",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubProjectV2DraftIssueMatchesLivePythonProductionRow$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubProjectV2DraftIssueMatchesLivePythonProductionRow$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P14-target-org-login-must-be-present",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "if targets[index].OrgLogin == \"\" || targets[index].ProjectNumber < 1 {",
+      "replace": "if targets[index].ProjectNumber < 1 {",
+      "rationale": "clause-level: a blank org_login in durable config must fail closed on its own, not only when the project number also happens to be invalid",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P15-target-project-number-must-be-positive",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "if targets[index].OrgLogin == \"\" || targets[index].ProjectNumber < 1 {",
+      "replace": "if targets[index].OrgLogin == \"\" {",
+      "rationale": "clause-level sibling of P14: project_number < 1 must fail closed on its own",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P16-unknown-durable-config-fields-are-refused",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "\tdecoder.DisallowUnknownFields()\n",
+      "replace": "",
+      "rationale": "an unexpected key in the durable config (e.g. an operator smuggling a per-target token) must fail closed rather than be silently dropped; D18 keeps secrets out of integration config",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2TargetsFailClosedOnMalformedDurableConfig)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P17-absent-durable-config-yields-no-targets",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "\t\treturn []GitHubProjectV2Target{}, nil",
+      "replace": "\t\treturn []GitHubProjectV2Target{{OrgLogin: \"acme\", ProjectNumber: 3}}, nil",
+      "rationale": "D18: targets come from durable integration-scoped config and nowhere else. A target list materializing when the claim configured none is the shape any environment/global fallback would take, and must be caught by the request counter rather than by a row assertion",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2EnvironmentTargetsAreNeverAFallback|TestGitHubWorkItemsRouteTreatsEnvironmentProjectsAsNoConfiguration)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P18-credential-id-must-be-resolved",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "credential.ID == \"\" || credential.ID != claim.CredentialID || client == nil ||",
+      "replace": "credential.ID != claim.CredentialID || client == nil ||",
+      "rationale": "clause-level sibling of P1: an unresolved (empty) credential id must be refused on its own clause, which is the shape an environment token would arrive as",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2RefusesEnvironmentTokenWhenClaimCredentialIsUnusable)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P19-credential-provider-must-be-github",
+      "file": "internal/providersync/github_work_items_projects_v2.go",
+      "find": "!isWorkItemFamilyDataset(claim.Dataset) || credential.Provider != \"github\" ||",
+      "replace": "!isWorkItemFamilyDataset(claim.Dataset) ||",
+      "rationale": "clause-level: a credential resolved for another provider must be refused before any request is issued",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubProjectV2FetcherRequiresClaimResolvedCredentialAndClient)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P20-unwired-projects-collector-is-refused",
+      "file": "internal/providersync/github_work_items_route.go",
+      "find": "\tif handler.Projects == nil {\n\t\treturn CompleteRouteBatch{}, ErrInvalidConfiguration\n\t}\n",
+      "replace": "",
+      "rationale": "D18 retired the policy_pending seam: a handler built without a Projects collector is a construction defect the route must refuse, not a batch it may report as provider incompleteness",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemsRouteRefusesAnUnwiredProjectsCollector|TestGitHubWorkItemsRouteRefusesAnUnwiredProjectsCollectorWithoutTargets)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "P21-construction-guard-is-not-gated-on-targets",
+      "file": "internal/providersync/github_work_items_route.go",
+      "find": "\tif handler.Projects == nil {",
+      "replace": "\tif handler.Projects == nil && len(claim.IntegrationConfig) > 0 {",
+      "rationale": "the guard must not wait for a tenant that configured a project: gating it on target presence turns a global build defect into a tenant-specific data problem discovered by whichever org enabled Projects v2 first",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemsRouteRefusesAnUnwiredProjectsCollectorWithoutTargets)$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_items_route.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_route.json
@@ -1,7 +1,13 @@
 {
   "schema_version": 1,
   "name": "github/work-items unregistered composite route",
-  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "build": [
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
+  ],
   "mutations": [
     {
       "id": "derivations-are-required-before-fetch",
@@ -9,7 +15,16 @@
       "find": "if handler.Deriver == nil {",
       "replace": "if false {",
       "rationale": "the composite must not spend provider budget or claim a batch while all nine derived surfaces are unavailable",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteFailsBeforeFetchWithoutDerivedImplementation$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteFailsBeforeFetchWithoutDerivedImplementation$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "projects-config-is-validated-before-fetch",
@@ -17,7 +32,16 @@
       "find": "projectTargets, err := githubProjectV2Targets(claim)\n\tif err != nil {\n\t\treturn CompleteRouteBatch{}, err\n\t}",
       "replace": "projectTargets, err := githubProjectV2Targets(claim)\n\tif false {\n\t\treturn CompleteRouteBatch{}, err\n\t}",
       "rationale": "malformed durable Projects v2 configuration fails before any REST or GraphQL request",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteFailsBeforeFetchOnMalformedProjectsConfiguration$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteFailsBeforeFetchOnMalformedProjectsConfiguration$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "rest-attempts-enter-actuals",
@@ -25,7 +49,16 @@
       "find": "RequestCount: restResult.Evidence.Requests,",
       "replace": "RequestCount: 0,",
       "rationale": "every physical REST attempt is retained in the work_items/rest_core usage bucket",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "rest-optional-degradation-reaches-composite-guard",
@@ -33,7 +66,16 @@
       "find": "for _, partial := range restResult.Incomplete {",
       "replace": "for _, partial := range []GitHubWorkItemsRESTIncomplete{} {",
       "rationale": "REST optional failures remain typed at the composite boundary and prevent any derivation or effect construction",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteContinuesPastOptionalRESTFailuresAndLandsEffects$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteContinuesPastOptionalRESTFailuresAndLandsEffects$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "social-incomplete-remains-typed",
@@ -41,7 +83,16 @@
       "find": "Component: \"pr_social\", Cause: socialResult.Incomplete.Cause,",
       "replace": "Component: \"\", Cause: socialResult.Incomplete.Cause,",
       "rationale": "an optional GraphQL social failure remains distinguishable from a complete empty PR result",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRoutePreservesOptionalSocialFailureAndPhysicalUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRoutePreservesOptionalSocialFailureAndPhysicalUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "pr-social-events-reach-semantic-normalizer",
@@ -49,7 +100,16 @@
       "find": "adapted.Events, adapted.Comments, handler.ResolveIdentity, normalizedAt,",
       "replace": "nil, adapted.Comments, handler.ResolveIdentity, normalizedAt,",
       "rationale": "adapted PR events must produce the Python-equivalent transition and reopen families",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "pr-social-comments-reach-semantic-normalizer",
@@ -57,7 +117,16 @@
       "find": "adapted.Events, adapted.Comments, handler.ResolveIdentity, normalizedAt,",
       "replace": "adapted.Events, nil, handler.ResolveIdentity, normalizedAt,",
       "rationale": "adapted PR comments must produce interaction and dependency signals instead of disappearing",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "normalized-pr-bundle-is-aggregated",
@@ -65,15 +134,33 @@
       "find": "appendGitHubWorkItemRows(&rows, bundle)",
       "replace": "_ = bundle",
       "rationale": "a fully normalized PR bundle must join the repository issue rows before derivation",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
-      "id": "configured-projects-default-to-visible-pending",
+      "id": "configured-projects-are-actually-fetched",
       "file": "internal/providersync/github_work_items_route.go",
-      "find": "incomplete = append(incomplete, GitHubWorkItemsIncomplete{\n\t\t\t\tComponent: \"projects_v2\", Cause: \"policy_pending\",\n\t\t\t})",
-      "replace": "incomplete = incomplete",
-      "rationale": "configured Projects v2 targets cannot be silently ignored while their activation policy is unresolved",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteDefaultsProjectsToTypedPendingWithoutFetching$", "./internal/providersync/"]]
+      "find": "\tprojectState := \"disabled\"\n\tif len(projectTargets) > 0 {",
+      "replace": "\tprojectState := \"disabled\"\n\tif false {",
+      "rationale": "configured Projects v2 targets cannot be silently ignored. Replaces the retired 'configured-projects-default-to-visible-pending', whose anchor was the policy_pending block D18 deleted; the property survives, expressed against the code that now exists.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "projects-actuals-enter-shared-graphql-bucket",
@@ -81,7 +168,16 @@
       "find": "Dimension: projectResult.Usage.Dimension, RequestCount: projectResult.Usage.RequestCount,",
       "replace": "Dimension: projectResult.Usage.Dimension, RequestCount: 0,",
       "rationale": "Projects v2 physical GraphQL attempts aggregate with PR-social under work_item_prs/graphql_cost",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "projects-last-wins-composition-is-applied",
@@ -89,15 +185,33 @@
       "find": "rows = mergeGitHubProjectV2Rows(rows, projectResult.Rows)",
       "replace": "rows = rows",
       "rationale": "Projects v2 values replace matching repository work items at their original position and append their transitions",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "blocking-incomplete-fails-before-derivation",
       "file": "internal/providersync/github_work_items_route.go",
       "find": "if !githubWorkItemsIncompleteIsOptional(partial) {",
       "replace": "if partial.Component == \"\" {",
-      "rationale": "an incomplete component Python never degrades past (projects_v2 policy_pending) must still fail with zero effects before the deriver runs",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteDefaultsProjectsToTypedPendingWithoutFetching$", "./internal/providersync/"]]
+      "rationale": "a blocking incomplete entry must fail with zero effects before the deriver runs, and EVERY entry decides rather than the first: the proof case pairs an optional milestones entry with a blocking pr_social one appended after it. Re-pointed after D18 deleted the policy_pending test this previously named -- that test's removal left this mutating live code with a -run pattern matching nothing, which exits 0 and reads as measured.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteFailsClosedOnMixedOptionalAndBlockingIncomplete$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "optional-social-incomplete-mirrors-python-continuation",
@@ -105,7 +219,16 @@
       "find": "\t\"pr_social\":               true,",
       "replace": "\t\"pr_social\":               false,",
       "rationale": "provider.py:369-402 logs a failed optional PR-social batch and keeps every already-collected row; classifying it as blocking would withhold all 16 effects over an optional enrichment failure",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRoutePreservesOptionalSocialFailureAndPhysicalUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRoutePreservesOptionalSocialFailureAndPhysicalUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "optional-rest-incomplete-mirrors-python-continuation",
@@ -113,7 +236,16 @@
       "find": "\t\"issue_comments\":          true,",
       "replace": "\t\"issue_comments\":          false,",
       "rationale": "provider.py:293-301 logs a failed per-issue comment fetch and keeps the issue; classifying it as blocking would withhold all 16 effects over an optional enrichment failure",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteContinuesPastOptionalRESTFailuresAndLandsEffects$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteContinuesPastOptionalRESTFailuresAndLandsEffects$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "optional-milestone-incomplete-mirrors-python-continuation",
@@ -121,7 +253,16 @@
       "find": "\t\"milestones\":              true,",
       "replace": "\t\"milestones\":              false,",
       "rationale": "provider.py:202-217 logs a failed milestone fetch and keeps the issues; classifying it as blocking would withhold all 16 effects over an optional enrichment failure",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteContinuesPastOptionalRESTFailuresAndLandsEffects$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteContinuesPastOptionalRESTFailuresAndLandsEffects$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "every-incomplete-entry-decides-not-just-the-first",
@@ -129,7 +270,16 @@
       "find": "\tfor _, partial := range incomplete {",
       "replace": "\tfor _, partial := range incomplete[:min(1, len(incomplete))] {",
       "rationale": "projects_v2 is appended last, so a classification loop that stops after the first entry reads clean on exactly the ordering production produces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteFailsClosedOnMixedOptionalAndBlockingIncomplete$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteFailsClosedOnMixedOptionalAndBlockingIncomplete$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "blocking-cause-outranks-an-optional-component",
@@ -137,7 +287,16 @@
       "find": "\tif githubWorkItemsBlockingIncompleteCauses[partial.Cause] {\n\t\treturn false\n\t}\n",
       "replace": "",
       "rationale": "pagination_cap and invalid_pagination arrive on the optional pr_social component; classifying on Component alone would land a deterministically truncated batch as a clean success",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteFailsClosedOnBlockingSocialCauses$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteFailsClosedOnBlockingSocialCauses$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "pagination-cap-is-a-blocking-cause",
@@ -145,7 +304,16 @@
       "find": "\t\"pagination_cap\":     true,",
       "replace": "\t\"pagination_cap\":     false,",
       "rationale": "a capped social traversal is deterministically truncated, so landing it banks a subset every later run reproduces -- the recipe's never-both-capped-and-successful rule",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteFailsClosedOnBlockingSocialCauses$/pagination_cap$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteFailsClosedOnBlockingSocialCauses$/pagination_cap$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "invalid-pagination-is-a-blocking-cause",
@@ -153,7 +321,16 @@
       "find": "\t\"invalid_pagination\": true,",
       "replace": "\t\"invalid_pagination\": false,",
       "rationale": "a missing or stalled cursor is a defect in our own traversal with no Python analogue, and must surface as a failure rather than a routine degradation entry",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteFailsClosedOnBlockingSocialCauses$/invalid_pagination$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteFailsClosedOnBlockingSocialCauses$/invalid_pagination$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "unprocessable-pull-request-does-not-fail-the-unit",
@@ -161,7 +338,16 @@
       "find": "\t\t\t\tincomplete = append(incomplete, GitHubWorkItemsIncomplete{\n\t\t\t\t\tComponent: \"pull_request_processing\", SubjectID: subject,\n\t\t\t\t\tCause: githubWorkItemsRESTFailureCause(adaptErr),\n\t\t\t\t})\n\t\t\t\tbreak",
       "replace": "\t\t\t\treturn CompleteRouteBatch{}, usage.wrap(adaptErr)",
       "rationale": "provider.py:503-507 warns and continues on a pull request it cannot process, keeping the issues and sprints already collected",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteContinuesPastUnprocessablePullRequest$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteContinuesPastUnprocessablePullRequest$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "degradation-reaches-the-durable-unit-row",
@@ -169,7 +355,16 @@
       "find": "\"incomplete\":        incomplete,",
       "replace": "\"incomplete\":        []GitHubWorkItemsIncomplete{},",
       "rationale": "continuing past an optional-data failure is only allowed because the omission is recorded; dropping the entries from the result would make a degraded run indistinguishable from a clean one in the durable unit row",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteIncompletenessSurvivesDurableCompletionEncoding$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteIncompletenessSurvivesDurableCompletionEncoding$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "pull-requests-survive-optional-social-failure",
@@ -177,7 +372,16 @@
       "find": "if !exists && socialComplete {",
       "replace": "if !exists {",
       "rationale": "Python reads the social batch with .get(number, ()), so a pull request whose social payload never arrived is still normalized from the REST payload already in hand",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRoutePreservesOptionalSocialFailureAndPhysicalUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRoutePreservesOptionalSocialFailureAndPhysicalUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "same-key-usage-is-summed",
@@ -185,7 +389,16 @@
       "find": "usage[key] += observation.RequestCount",
       "replace": "usage[key] = observation.RequestCount",
       "rationale": "PR-social and Projects v2 attempts sharing one budget identity are summed rather than last-wins",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "failed-required-phase-retains-actuals",
@@ -193,7 +406,16 @@
       "find": "return &GitHubWorkItemsRouteError{Cause: err, Usage: usage.snapshot()}",
       "replace": "return &GitHubWorkItemsRouteError{Cause: err, Usage: nil}",
       "rationale": "required-phase failures retain every physical request observation gathered before the error",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteErrorRetainsRequiredPhasePhysicalUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteErrorRetainsRequiredPhasePhysicalUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "fetch-evidence-sums-phase-requests",
@@ -201,7 +423,16 @@
       "find": "target.Requests += source.Requests",
       "replace": "target.Requests = source.Requests",
       "rationale": "composite evidence counts REST, PR-social, and Projects v2 physical attempts together",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "unregistered-composite-has-no-watermark",
@@ -209,7 +440,16 @@
       "find": "Watermark: nil,",
       "replace": "Watermark: claim.BeforeAt,",
       "rationale": "the unregistered foundation cannot advance a watermark before activation and crash-recovery approval",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "estimate-coverage-derived-rows-are-forwarded",
@@ -217,7 +457,16 @@
       "find": "EstimateCoverageMetricsDaily:   derived[\"estimate_coverage_metrics_daily\"],",
       "replace": "EstimateCoverageMetricsDaily:   nil,",
       "rationale": "the estimate coverage derivation is an owned destination, not optional metadata",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "investment-classification-derived-rows-are-forwarded",
@@ -225,7 +474,16 @@
       "find": "InvestmentClassificationsDaily: derived[\"investment_classifications_daily\"],",
       "replace": "InvestmentClassificationsDaily: nil,",
       "rationale": "investment classifications remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "investment-metrics-derived-rows-are-forwarded",
@@ -233,7 +491,16 @@
       "find": "InvestmentMetricsDaily:         derived[\"investment_metrics_daily\"],",
       "replace": "InvestmentMetricsDaily:         nil,",
       "rationale": "investment metrics remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "issue-type-derived-rows-are-forwarded",
@@ -241,7 +508,16 @@
       "find": "IssueTypeMetricsDaily:          derived[\"issue_type_metrics_daily\"],",
       "replace": "IssueTypeMetricsDaily:          nil,",
       "rationale": "issue type metrics remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "cycle-time-derived-rows-are-forwarded",
@@ -249,7 +525,16 @@
       "find": "WorkItemCycleTimes:             derived[\"work_item_cycle_times\"],",
       "replace": "WorkItemCycleTimes:             nil,",
       "rationale": "work-item cycle times remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "daily-metrics-derived-rows-are-forwarded",
@@ -257,7 +542,16 @@
       "find": "WorkItemMetricsDaily:           derived[\"work_item_metrics_daily\"],",
       "replace": "WorkItemMetricsDaily:           nil,",
       "rationale": "daily work-item metrics remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "state-duration-derived-rows-are-forwarded",
@@ -265,7 +559,16 @@
       "find": "WorkItemStateDurationsDaily:    derived[\"work_item_state_durations_daily\"],",
       "replace": "WorkItemStateDurationsDaily:    nil,",
       "rationale": "state duration metrics remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "team-attribution-derived-rows-are-forwarded",
@@ -273,7 +576,16 @@
       "find": "WorkItemTeamAttributions:       derived[\"work_item_team_attributions\"],",
       "replace": "WorkItemTeamAttributions:       nil,",
       "rationale": "team attribution rows remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "user-metrics-derived-rows-are-forwarded",
@@ -281,7 +593,16 @@
       "find": "WorkItemUserMetricsDaily:       derived[\"work_item_user_metrics_daily\"],",
       "replace": "WorkItemUserMetricsDaily:       nil,",
       "rationale": "per-user work-item metrics remain one of the nine required derived surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemsRouteComposesRESTSocialProjectsDerivedRowsAndUsage$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -222,6 +222,10 @@ VERDICT_STALE_DECLARATION = "STALE_DECLARATION"
 # the mutation is fine and the proof is empty, so the entry measured nothing
 # while exiting 0.
 VERDICT_PROOF_VACUOUS = "PROOF_VACUOUS"
+# A proof whose selected tests all SKIPPED. Environment-gated suites (live
+# oracles, integration tags) exit 0 while running nothing, so every mutation
+# under them reports SURVIVED for a reason unrelated to coverage.
+VERDICT_PROOF_SKIPPED = "PROOF_SKIPPED"
 
 
 def _digest(data: bytes) -> str:
@@ -1322,21 +1326,72 @@ def _proof_outcome(mutation: Mutation, root: Path) -> tuple[str | None, str]:
     return None, ""
 
 
-def _vacuous_proof(mutation: Mutation, root: Path) -> tuple[str, str] | None:
-    """Return the first proof command that executes no test at all, and why.
+def _verbose_go_test(command: tuple[str, ...]) -> tuple[str, ...]:
+    """Add -v to a `go test` command so per-test outcomes are visible.
 
-    Checked against the CLEAN tree, before anything is mutated: a proof that
-    selects no test cannot distinguish mutated source from unmutated, so the
-    honest verdict is that the entry was never measured -- not KILLED, and not a
-    survivor whose reason could be argued.
+    Verbosity is not selection: -v changes what the runner PRINTS, never which
+    tests run or how they are judged. Without it `go test` reports a package
+    whose every selected test skipped as a bare `ok`, indistinguishable from one
+    where they all passed -- which is the whole failure this classification
+    exists to catch. Applied only to the harness's own baseline invocation.
+    """
+
+    if "test" not in command or not any(
+        part == "go" or part.endswith("/go") for part in command
+    ):
+        return command
+    if "-v" in command:
+        return command
+    return command + ("-v",)
+
+
+def _baseline_proof_classification(tail: str) -> tuple[str, str] | None:
+    """Classify a baseline proof run that EXITED ZERO but proved nothing.
+
+    Two distinct ways that happens, both reported as their own verdict because
+    both read as coverage while measuring nothing:
+
+    * ``PROOF_VACUOUS`` -- the -run pattern selected no test at all.
+    * ``PROOF_SKIPPED`` -- tests were selected and every one of them skipped,
+      typically an env-gated live-oracle or integration suite whose variables
+      are unset. A skipped proof passes on the clean tree AND on every mutant,
+      so each mutation under it is reported SURVIVED for a reason that has
+      nothing to do with coverage -- and a survivor later "declared" with a
+      reason would launder an unmeasured entry into documented coverage.
+
+    Baseline-only classification is sufficient: skipping here is decided by the
+    environment, which is constant across the baseline and every mutant, so a
+    baseline that skips guarantees every verdict under that proof is unmeasured.
+    """
+
+    reason = _vacuous_proof_reason(tail)
+    if reason is not None:
+        return VERDICT_PROOF_VACUOUS, reason
+    if "--- SKIP" in tail and "--- PASS" not in tail:
+        return VERDICT_PROOF_SKIPPED, "every selected test skipped"
+    return None
+
+
+def _baseline_proofs(
+    mutation: Mutation, root: Path
+) -> tuple[str | None, str, tuple[str, str, str] | None]:
+    """Run every proof ONCE on the clean tree: pass/fail plus classification.
+
+    One execution, not two. An earlier revision of this check ran the proofs a
+    second time purely to classify them, which doubled the cost of every
+    integration-tagged plan -- 20 minutes a pass here -- for information the
+    baseline run already had.
     """
 
     for command in mutation.proof:
-        _, tail = _run_command(command, root)
-        reason = _vacuous_proof_reason(tail)
-        if reason is not None:
-            return _format_command(command), reason
-    return None
+        code, tail = _run_command(_verbose_go_test(command), root)
+        if code != 0:
+            return _format_command(command), tail, None
+        classification = _baseline_proof_classification(tail)
+        if classification is not None:
+            verdict, reason = classification
+            return None, tail, (verdict, reason, _format_command(command))
+    return None, "", None
 
 
 def run_plan(
@@ -1401,6 +1456,7 @@ def run_plan(
             VERDICT_INVALID,
             VERDICT_STALE_DECLARATION,
             VERDICT_PROOF_VACUOUS,
+            VERDICT_PROOF_SKIPPED,
         }
         for result in results
     ):
@@ -1463,31 +1519,35 @@ def _run_one(root: Path, mutation: Mutation, snapshot_dir: Path) -> Result:
                 failing_proof=_format_command(mutation.build),
             )
 
-    # Before asking whether the proofs PASS, ask whether they RUN. A `-run`
-    # pattern matching nothing exits 0, so it would sail through the check below
-    # and then guarantee a survivor -- or, worse, be read as a kill if anything
-    # else in the command happened to fail. Checked on the clean tree so the
-    # answer is a property of the plan entry, not of the mutation.
-    vacuous = _vacuous_proof(mutation, root)
-    if vacuous is not None:
-        vacuous_command, vacuous_reason = vacuous
-        _require_unchanged(target, original_sha, mutation, "the vacuity check ran")
+    # One baseline pass answers both questions: did the proofs PASS, and did
+    # they RUN AT ALL. A -run pattern matching nothing, or a suite whose every
+    # selected test skips, exits 0 either way -- so without this the entry sails
+    # through and then guarantees a survivor that reads as a coverage gap.
+    failing, tail, unmeasured = _baseline_proofs(mutation, root)
+    if unmeasured is not None:
+        verdict, reason, command = unmeasured
+        _require_unchanged(target, original_sha, mutation, "the baseline proofs ran")
+        explanation = (
+            "Usually a -run pattern naming a test that was renamed or deleted."
+            if verdict == VERDICT_PROOF_VACUOUS
+            else (
+                "Usually an env-gated live-oracle or integration suite whose "
+                "variables are unset. A skipped proof passes on the clean tree "
+                "AND on every mutant, so every verdict under it is unmeasured."
+            )
+        )
         return Result(
             identifier=mutation.identifier,
-            verdict=VERDICT_PROOF_VACUOUS,
+            verdict=verdict,
             detail=(
-                f"proof command executes no test ({vacuous_reason}), so it cannot "
-                "tell mutated source from unmutated and this entry measured "
-                "NOTHING while exiting 0. Usually a -run pattern naming a test "
-                "that was renamed or deleted. Point it at a test that exists; "
-                "nothing was mutated.\n"
-                f"    {vacuous_command}"
+                f"proof command proves nothing ({reason}): it cannot tell mutated "
+                "source from unmutated, so this entry measured NOTHING while "
+                f"exiting 0. {explanation} Nothing was mutated.\n"
+                f"    {command}"
             ),
             warnings=warnings,
-            failing_proof=vacuous_command,
+            failing_proof=command,
         )
-
-    failing, tail = _proof_outcome(mutation, root)
     if failing is not None:
         # Same reason as the build path above: this return claims the file was
         # never touched, and a proof command with a side effect could have made
@@ -1831,6 +1891,7 @@ def main(argv: list[str] | None = None) -> int:
                 VERDICT_INVALID,
                 VERDICT_STALE_DECLARATION,
                 VERDICT_PROOF_VACUOUS,
+                VERDICT_PROOF_SKIPPED,
             }:
                 print(f"\n{result.identifier} {result.verdict}:\n{result.detail}")
         return exit_code

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -217,6 +217,11 @@ VERDICT_SURVIVED_DECLARED = "SURVIVED_DECLARED"
 VERDICT_BASELINE_FAILED = "BASELINE_FAILED"
 VERDICT_INVALID = "INVALID"
 VERDICT_STALE_DECLARATION = "STALE_DECLARATION"
+# A proof command that selects no test. Distinct from BASELINE_FAILED (the proof
+# ran and was already red) and from INVALID (the mutation never applied): here
+# the mutation is fine and the proof is empty, so the entry measured nothing
+# while exiting 0.
+VERDICT_PROOF_VACUOUS = "PROOF_VACUOUS"
 
 
 def _digest(data: bytes) -> str:
@@ -1277,6 +1282,36 @@ def _restore_after_apply(
         )
 
 
+# `go test -run <pattern>` whose pattern matches NOTHING exits 0. A proof
+# command in that state is not passing -- it is not running, and a mutation
+# measured by it is guaranteed to SURVIVE while the report reads as coverage.
+#
+# Same family as a skipped test reading as `ok`, and not hypothetical: a change
+# that deleted a route test left a LIVE-code mutation pointing at
+# `-run ^TestNameThatNoLongerExists$`. The pattern matched nothing, the command
+# exited 0, and a real fail-closed property lost its guard while the plan still
+# listed it as proven.
+_VACUOUS_PROOF_MARKERS = (
+    "no tests to run",
+    "no test files",
+)
+
+
+def _vacuous_proof_reason(tail: str) -> str | None:
+    """Return why this proof output proves nothing, or None if it ran something.
+
+    Matches Go's own wording rather than parsing counts: `go test` prints
+    `testing: warning: no tests to run` and marks the package
+    `ok ... [no tests to run]`, both alongside exit code 0.
+    """
+
+    lowered = tail.lower()
+    for marker in _VACUOUS_PROOF_MARKERS:
+        if marker in lowered:
+            return marker
+    return None
+
+
 def _proof_outcome(mutation: Mutation, root: Path) -> tuple[str | None, str]:
     """Run every proof command; return the first failing command and its tail."""
 
@@ -1285,6 +1320,23 @@ def _proof_outcome(mutation: Mutation, root: Path) -> tuple[str | None, str]:
         if code != 0:
             return _format_command(command), tail
     return None, ""
+
+
+def _vacuous_proof(mutation: Mutation, root: Path) -> tuple[str, str] | None:
+    """Return the first proof command that executes no test at all, and why.
+
+    Checked against the CLEAN tree, before anything is mutated: a proof that
+    selects no test cannot distinguish mutated source from unmutated, so the
+    honest verdict is that the entry was never measured -- not KILLED, and not a
+    survivor whose reason could be argued.
+    """
+
+    for command in mutation.proof:
+        _, tail = _run_command(command, root)
+        reason = _vacuous_proof_reason(tail)
+        if reason is not None:
+            return _format_command(command), reason
+    return None
 
 
 def run_plan(
@@ -1337,13 +1389,19 @@ def run_plan(
     )
 
     exit_code = 0
-    # BASELINE_FAILED and INVALID both mean a mutation was never measured. A
-    # drifted anchor, a doubled match, or a comment-line anchor silently
-    # measures nothing, so exiting 0 would report a plan as verified while part
-    # of it did not run -- the same false pass this tool exists to catch.
+    # BASELINE_FAILED, INVALID, STALE_DECLARATION and PROOF_VACUOUS all mean a
+    # mutation was never measured. A drifted anchor, a doubled match, a
+    # comment-line anchor, or a proof selecting no test silently measures
+    # nothing, so exiting 0 would report a plan as verified while part of it did
+    # not run -- the same false pass this tool exists to catch.
     if any(
         result.verdict
-        in {VERDICT_BASELINE_FAILED, VERDICT_INVALID, VERDICT_STALE_DECLARATION}
+        in {
+            VERDICT_BASELINE_FAILED,
+            VERDICT_INVALID,
+            VERDICT_STALE_DECLARATION,
+            VERDICT_PROOF_VACUOUS,
+        }
         for result in results
     ):
         exit_code = 1
@@ -1404,6 +1462,30 @@ def _run_one(root: Path, mutation: Mutation, snapshot_dir: Path) -> Result:
                 warnings=warnings,
                 failing_proof=_format_command(mutation.build),
             )
+
+    # Before asking whether the proofs PASS, ask whether they RUN. A `-run`
+    # pattern matching nothing exits 0, so it would sail through the check below
+    # and then guarantee a survivor -- or, worse, be read as a kill if anything
+    # else in the command happened to fail. Checked on the clean tree so the
+    # answer is a property of the plan entry, not of the mutation.
+    vacuous = _vacuous_proof(mutation, root)
+    if vacuous is not None:
+        vacuous_command, vacuous_reason = vacuous
+        _require_unchanged(target, original_sha, mutation, "the vacuity check ran")
+        return Result(
+            identifier=mutation.identifier,
+            verdict=VERDICT_PROOF_VACUOUS,
+            detail=(
+                f"proof command executes no test ({vacuous_reason}), so it cannot "
+                "tell mutated source from unmutated and this entry measured "
+                "NOTHING while exiting 0. Usually a -run pattern naming a test "
+                "that was renamed or deleted. Point it at a test that exists; "
+                "nothing was mutated.\n"
+                f"    {vacuous_command}"
+            ),
+            warnings=warnings,
+            failing_proof=vacuous_command,
+        )
 
     failing, tail = _proof_outcome(mutation, root)
     if failing is not None:
@@ -1748,6 +1830,7 @@ def main(argv: list[str] | None = None) -> int:
                 VERDICT_BASELINE_FAILED,
                 VERDICT_INVALID,
                 VERDICT_STALE_DECLARATION,
+                VERDICT_PROOF_VACUOUS,
             }:
                 print(f"\n{result.identifier} {result.verdict}:\n{result.detail}")
         return exit_code


### PR DESCRIPTION
Implements the **ratified** GitHub Projects v2 collector decision (**D18**, cutover Decision Log). D18 is the reference; this PR does not restate it.

Base: `feat/go-worker-runtime-migration`. **DRAFT.** No route activation.

## What this changes

The collector already had the ratified shape — durable integration-scoped targets, claim-resolved credential/client, no environment fallback. What changes is that it no longer *describes itself as undecided*, and the decision's negative half is now proven rather than assumed.

**1. The `policy_pending` seam is retired (5 sites).** A handler built without a Projects collector was recording `incomplete{component: "projects_v2", cause: "policy_pending"}`. Post-D18 there is no legitimate "not decided yet" state, so that is now a **construction defect refused at `Collect` entry** with `ErrInvalidConfiguration` — the same class as the existing nil-`Deriver` guard.

Two properties the guard is deliberately given:
- It is **not gated on target presence**. A handler missing its collector is misconstructed for *every* claim; gating the refusal on configured targets would make a global build defect surface as a tenant-specific data problem on whichever org enabled Projects v2 first.
- It sits **before** any provider call, so a misconstructed route now spends **zero** requests. The old `policy_pending` path had already issued the repo-metadata REST call before discovering it could not run.

"The code is not wired" must not share a vocabulary with "the provider declined data" — an incomplete entry sends whoever reads it looking at GitHub instead of at the handler.

**2. The environment clause is now proven negatively.** Previously only the positive half was tested (durable config wins over a set env var). Added, at both the collector and route level, with `GITHUB_PROJECTS_V2` **and** `GITHUB_TOKEN` set in the process:
- env targets + empty durable config → `projects_v2: "disabled"` and **zero GraphQL requests**;
- env token + an unusable claim credential (absent / unresolved / another tenant's) → `ErrInvalidConfiguration`, zero requests.

These assert observable behaviour rather than the row set: an assertion on empty rows passes just as happily with the whole collector deleted, and cannot distinguish "ignored the environment" from "used the environment and found nothing".

**Which assertion actually fails, stated precisely**, because the first version of this description got it wrong. At the **collector** level the line is held by the empty-targets assertion — with no durable config the fetch loop is never entered, so the request counter cannot rise. At the **route** level it is held by `projects.calls` and `validateGitHubWorkItemsProjectResult` (`route.go:370`): re-applying an env-adopting mutant kills the test there, because the collector is invoked with targets the claim never configured and its result fails validation against `len(projectTargets)`. The GraphQL counters in both are **backstops** for a future arrangement where a real collector reaches the wire — the route case substitutes a stub policy that issues no HTTP at all, so its counter cannot be tripped however the route behaves. A counter that cannot currently fail reads like stronger evidence than it is, so it is documented as a backstop rather than presented as the assertion doing the work.

## Corrections to an earlier version of this description

Two claims in the first version of this PR body were wrong and are corrected here rather than quietly edited away.

**The null-config refusal did not already exist.** An earlier revision said a present-but-null target list "was silently ignored, not refused… closed". It was not closed: that change added only a test for a Go-literal typed nil (`[]any(nil)`), a shape production never emits, and changed **zero production bytes**. Postgres JSONB null decodes to an **untyped nil interface**, which kept hitting the not-configured early return and kept returning empty targets with a nil error. **The null path failed open until the commit that removes `|| value == nil` from that branch.** An inaccurate closure claim is worse than an admitted gap, because a reader who sees "closed" stops checking.

**"No environment reads in providersync" was wrong.** My Phase 1 analysis claimed zero `os.Getenv` in the package, from a grep that silently returned empty. `github_work_items_rows.go:869` reads `GITHUB_LINEAR_LINKBACK_BOTS`. The D18 claim is therefore scoped throughout to **credentials and targets**, which is what the decision actually covers; bot-identity classification is presentation policy and D18 does not reach it.

## Unkillable clauses removed — three of them

Three separate guards in this change turned out to be undetectable-if-deleted, each found by its own mutation surviving, and each removed rather than declared a survivor (#1529 precedent):

1. `credential.ID == ""` in the fetcher — `claim.Validate()` runs first in the same predicate and already guarantees a resolved id.
2. `unit.CredentialID == ""` in `lease.go` — its twin; `uuid.Parse` at the next line rejects `""` as readily as garbage. Empty-id rejection is now pinned explicitly against `uuid.Parse`.
3. An explicit `if value == nil { refuse }` added while fixing the null path — deleting it changed nothing, because removing the clause from the early return is the entire fix and the existing `targets == nil` check does the refusing.

The mutations now point at the clauses that actually decide: restoring the old early return (P22) and dropping the nil decode check (P24) both die.

**The find of the round came from (1):** it was redundant *because of* a fence one layer up — `Unit.Validate` (`lease.go:91`) refuses any claim whose `AuthSource == "environment"`. That is the strongest expression of D18's no-environment-credentials rule in the codebase, it backs **every** collector's no-env-fallback claim, and it had no test in the package and no mutation in any plan. Both now exist (P18).

**Positive control on the env fence** (reviewer-run, recorded here because a guard no current code can trip needs one): an env-fallback mutant kills both environment tests, and survives when the `t.Setenv` lines are stripped — so the tests fail for the reason claimed.

## Case-insensitive field matching: accepted, with the mechanism written down

`encoding/json` matches field names case-insensitively, so a miscased duplicate key (`Org_Login` beside `org_login`) is a candidate to win, and `DisallowUnknownFields` does not catch it because the key *matches* rather than being unknown.

It cannot win today, for a reason worth stating precisely: the value arrives as a `map[string]any` and `json.Marshal` emits map keys in **sorted byte order**, where uppercase and `_` sort below lowercase — so the canonical spelling is emitted last and deterministically wins the decode.

That guarantee is **emergent from the map → re-marshal round trip**, not chosen. A tripwire comment sits at the parser: if the one-fetch-per-integration follow-up ever decodes raw JSONB bytes straight from Postgres, operator key order wins instead and a trailing miscased duplicate **would** take effect.

## Known and not fixed

A `project_number` above 2^53 loses precision before the parser sees it — the claim's config is decoded by a plain `json.Unmarshal`, so `9007199254740993` arrives as `…992`. GitHub project numbers are small sequential integers per organisation, so nothing near that bound is reachable; `UseNumber()` at the repository boundary would be the fix if that changes. Documented in source.

## Making the tooling honest — five defect classes

The review round turned this into a PR about whether the evidence means anything. Five distinct ways a plan entry could read as coverage while measuring nothing, each found and closed:

1. **A proof naming a deleted test.** `go test -run ^TestGone$` exits 0. This PR itself created one by deleting a route test another entry proved against. → new `PROOF_VACUOUS` verdict, counted as unmeasured.
2. **A proof whose tests all SKIP.** Env-gated live-oracle and integration suites exit `ok` while running nothing, so every mutation under them reports SURVIVED — six did here. Worse than noise: such a survivor, later "declared" with a reason, would launder an unmeasured entry into documented coverage. → new `PROOF_SKIPPED` verdict; the harness appends `-v` to its **own** baseline invocation (verbosity, not selection) to see per-test outcomes.
3. **A drifted anchor.** Four latent ones across three plans, including one matching *nothing* — a dead timestamp-truncation guard on the tip. → standing sweep, run as a package test over every plan.
4. **A mutation that does not compile.** `INVALID` is not a kill: F9 deleted a struct field referenced at eight call sites, so no test ran. → re-authored to an operator that compiles and reaches the same assertion.
5. **A wholesale mutation spanning two sites.** T12 mutated both GitHub descriptors at once and was killed by whichever had a test — masking that `github/cicd`'s six-destination contract had **no assertion anywhere**. → split per descriptor, gap closed with a real assertion.

Class 3 is caught statically and cheaply; classes 1, 2, 4 and 5 only surface when a plan is actually *run*. Neither substitutes for the other.

**One of these was mine, and I'll own it in writing:** my first `PROOF_VACUOUS` implementation ran every proof a second time purely to classify it — exactly the double-execution cost I had argued against when choosing between designs, shipped in the same change that argued against it. Classification now shares the single baseline run, which on the integration-tagged plan here is a 20-minute pass saved per invocation.

## Evidence

- **Projects v2 mutation plan: 24/24 KILLED**, 0 survived, 0 invalid, 0 baseline-failed. Harness `verify` clean before and after; tree clean; restore digest-verified.
- Plan grew 13 → 24. New entries are clause-level: `org_login` and `project_number` mutated **separately** (that compound target predicate previously had no entry at all), `DisallowUnknownFields`, durable-config-is-the-only-source, the construction guard, its not-gated-on-targets property, the environment auth fence, and both sides of the null/empty boundary.
- Anchor drift was itself a repeat failure here: **three** entries went stale mid-round as clauses were removed (P1 twice over, then P18). Each was repaired and re-measured rather than counted as a kill — and the standing sweep below exists so the next one is caught by a test rather than by a reviewer.
- **Route mutation plan re-run end-to-end: 35/35 KILLED.** This PR had broken it and not re-run it: one entry anchored the deleted `policy_pending` block, and another mutating live code named a proof test this PR deleted — `go test -run` exits 0 when its pattern matches nothing, so a real fail-closed property lost its guard while reading as measured. The first is retired and replaced by an entry expressing the same property against the code that now exists; the second is re-pointed.
- **The harness now refuses that failure mode**: a proof command selecting no test reports `PROOF_VACUOUS` with its own verdict, counts as unmeasured for the exit code, and never reads as a kill. Proven by a planted dead proof — harness exit 1, not 0.
- **A standing plan-integrity sweep** runs as a package test over every plan in the directory, asserting each `find` matches its `expect_occurrences` and each `-run` proof names a test that exists. It swept **28 plans, 554 entries, 73 target files** — and found four latent drifts in three plans this PR had not touched, all repaired here:
  - `github_work_items_direct_effects` **M09** matched **nothing**: `time.Millisecond` had become the named `workItemColumnPrecision`, leaving a **dead** timestamp-truncation guard that still read as coverage.
  - `github_work_items_foundation` **F6** and **F8** each matched **twice** — a second `UseNumber()` appeared on the comment path, and the pull-request normalizer grew an identical priority call. Both anchors were **narrowed to the site their own rationale and proof name**, not widened to `expect_occurrences: 2`, because neither entry ever claimed the second site.
  - `github_tests_reports` **T12** expected 2 to mean the two GitHub descriptors; GitLab `cicd`/`tests` since grew the same destination list, so it matched 4. **Split per descriptor**, since one mutation spanning both GitHub sites can be killed by either while the other goes unmeasured.
- **6 live Python oracle pairs executed** — `row` (two cases: issue and draft issue), `transition`, `pr-skip`, `target-parser`, `composition`, `pagination` — against the real producer, verified by proof markers rather than a bare `ok`, since the oracle tests skip silently without their two env vars.
- `ci/check_go.sh fast` **exit 0** (fmt, vet, test, live-python-oracles, build, contract), with the status taken from the script itself rather than through a pipe.

Re-proven on the rebased head, not carried over: #1541's changed files are disjoint from this PR's, but it touches the same package, so the mutation plan and the gate were both re-run after the rebase rather than assumed.

## Coverage that moved rather than vanished

`TestGitHubWorkItemsRouteFailsClosedOnMixedOptionalAndBlockingIncomplete` used `projects_v2 policy_pending` as its blocking-entry-appended-last case. The property is not about Projects v2, so it keeps its coverage from the pairing that still exists in production: REST milestones record an **optional** entry first, and the social phase appends a **blocking** `invalid_pagination` after it. The assertion pins both entries and their order, so deleting the optional failure makes it stop testing ordering.

`TestGitHubProjectV2ActivationDecisionRemainsPending` → `TestGitHubProjectV2RatificationIsNotActivation`. Same assertions, corrected rationale: the collector is decided, the route is not.

## Divergences of record (D16)

Documented in source, not silently mirrored:
- **Python fetches Projects v2 once per JOB**, outside the repo loop (`job_work_items.py`, same indentation as `for discovered_repo in discovered_repos`). The Go per-source claim boundary therefore **amplifies N×**. D18 accepts this temporarily; collapsing it changes the D16 unit boundary and is the separately tracked follow-up.
- **Python builds a second client from process-global `GITHUB_TOKEN`**, ignoring the resolved credential *and* its base URL — so on GitHub Enterprise Server it reaches github.com while Go honors the claim's base URL.
- **Python's env target parser swallows every malformed entry** (`except Exception: continue`); Go fails closed, because a silent-skip grammar over an operator-visible config column hides a typo as "no projects configured".

## Not in this PR

No efficiency redesign. No activation — aliases stay disabled, `ExecutorNone`, `route_ready: false`, pinned by test. `contracts/` and `deploy/` untouched. No effects, watermark, or readiness change. Migration 0066 untouched.

CHAOS-3506 (startup-readiness warning for an orphaned `GITHUB_PROJECTS_V2`) is filed and deliberately **not** here: reading the environment on the collection path to warn about it would reintroduce the dependency D18 removes.

## Residual risk

An operator who configured `GITHUB_PROJECTS_V2` in a deployment profile and cuts over to Go gets a silent no-op (`projects_v2: "disabled"`), not an error, until CHAOS-3506 lands. Stated rather than papered over.
