### PR TITLE
CHAOS-3489: close the last two here-document pipe wedges under ci/

### DIFF
--- a/ci/run_live_backend_e2e.sh
+++ b/ci/run_live_backend_e2e.sh
@@ -53,6 +53,191 @@ run_python() {
   exit "${EXIT_MISSING_DEP}"
 }
 
+# ---------------------------------------------------------------------------
+# The Python programs this harness runs, held as shell strings rather than
+# here-documents.
+#
+# WHY NOT HERE-DOCUMENTS (CHAOS-3489, same class as CHAOS-3362 — do not
+# "simplify" them back). Bash delivers a here-document by writing it into a
+# pipe and only THEN forking the command that reads it, so the writing shell
+# briefly holds both ends of that pipe itself. If the document does not fit in
+# the pipe buffer, the write can never complete: nothing is reading, and
+# because the writer owns the read end it cannot even get EPIPE. It blocks
+# forever, before the interpreter is ever exec'd.
+#
+# Measured on this host with `cat >/dev/null <<EOF`, timeout 5:
+#
+#     400 bytes -> ok, 0.30s
+#     512 bytes -> WEDGED
+#    1024 bytes -> WEDGED
+#    4000 bytes -> WEDGED
+#
+# while `lsof` reports those same pipes with the nominal 16384-byte capacity.
+# Nominal is not actual: macOS hands out a small pipe buffer and defers
+# expansion under kernel pipe-memory pressure, which a host running many
+# concurrent agent sessions sits in persistently. Two of these programs were
+# permanently over the line (2240 and 1201 bytes) and every one of them runs on
+# the main path, so a wedge here stalls the whole harness with no output.
+#
+# Hosted CI runners have normal pipe buffers, so this never wedged in CI; it
+# wedges on a developer machine, which is exactly the condition CHAOS-3362
+# spent three days being misattributed to ClickHouse.
+#
+# The fix is to remove the pipe, not to shrink the programs: each is written to
+# a private temp file with the `printf` BUILTIN (in-process, no pipe, no fork)
+# and Python is handed that path. `cat >file <<EOF` would NOT help — the pipe
+# IS the here-document delivery mechanism, not something the reader introduces,
+# which is why the repro above uses `cat`. All seven are converted, not only
+# the two over budget: 400 bytes is the largest size measured to COMPLETE, the
+# 382-byte one below sits one edit away from it, and a mixed file invites the
+# next stage to be added in the wedging shape.
+#
+# CONSTRAINT: these are single-quoted shell strings, so no program may contain
+# a single-quote character. tests/tooling/test_local_validate_heredocs.py
+# enforces that, checks each one compiles as Python, and budgets every
+# here-document under ci/ at the measured 400 bytes.
+# ---------------------------------------------------------------------------
+
+PY_PROG_REDIS_PING='import os
+import sys
+
+import valkey
+
+client = valkey.from_url(os.environ["REDIS_URL"])
+try:
+    client.ping()
+except Exception:
+    sys.exit(1)
+'
+
+# NOTE: the users INSERT binds auth_provider as a parameter rather than
+# inlining the SQL literal it used to carry. Same value reaching the same
+# column via the same SQLAlchemy text() call — the literal simply cannot be
+# spelled inside a single-quoted shell string.
+PY_PROG_AUTH_TOKEN='import hashlib, jwt, uuid, os
+from datetime import datetime, timedelta, timezone
+
+user_id = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+org_id = uuid.UUID(os.getenv("E2E_ORG_ID", "11111111-2222-3333-4444-555555555555"))
+
+pg_uri = os.getenv("POSTGRES_URI", os.getenv("DATABASE_URI", ""))
+if pg_uri:
+    sync_uri = pg_uri.replace("+asyncpg", "", 1)
+    from sqlalchemy import create_engine, text
+    engine = create_engine(sync_uri)
+    from dev_health_ops.models.git import Base
+    import dev_health_ops.models.users  # register models
+    Base.metadata.create_all(engine, checkfirst=True)
+    now = datetime.now(timezone.utc).isoformat()
+    with engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO organizations (id, slug, name, settings, tier, is_active, created_at, updated_at)"
+            " VALUES (:id, :slug, :name, :settings, :tier, true, :now, :now)"
+            " ON CONFLICT (id) DO NOTHING"
+        ), {"id": str(org_id), "slug": "e2e-org", "name": "E2E Org",
+            "settings": "{}", "tier": "enterprise", "now": now})
+        conn.execute(text(
+            "INSERT INTO users (id, email, is_active, is_verified, is_superuser, auth_provider, created_at, updated_at)"
+            " VALUES (:id, :email, true, false, false, :auth_provider, :now, :now)"
+            " ON CONFLICT (id) DO NOTHING"
+        ), {"id": str(user_id), "email": "e2e@test.local", "auth_provider": "local", "now": now})
+        conn.execute(text(
+            "INSERT INTO memberships (id, user_id, org_id, role, created_at, updated_at)"
+            " VALUES (:mid, :uid, :oid, :role, :now, :now)"
+            " ON CONFLICT DO NOTHING"
+        ), {"mid": str(uuid.uuid4()), "uid": str(user_id), "oid": str(org_id),
+            "role": "admin", "now": now})
+    engine.dispose()
+
+enc_key = os.getenv("SETTINGS_ENCRYPTION_KEY", "dev-key-not-for-prod")
+secret = hashlib.sha256(enc_key.encode()).hexdigest()
+payload = {
+    "sub": str(user_id),
+    "email": "e2e@test.local",
+    "org_id": str(org_id),
+    "role": "admin",
+    "is_superuser": False,
+    "type": "access",
+    "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+    "iat": datetime.now(timezone.utc),
+    "jti": str(uuid.uuid4()),
+}
+print(jwt.encode(payload, secret, algorithm="HS256"))
+'
+
+PY_PROG_READY_HEALTH='import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+payload = json.loads(path.read_text())
+assert payload.get("status") == "ok", payload
+services = payload.get("services", {})
+assert services.get("clickhouse") == "ok", services
+assert services.get("postgres") in ("ok", "not_configured"), services
+'
+
+PY_PROG_JWT_SECRET='import hashlib, os
+enc_key = os.environ["ENC_KEY_INPUT"]
+print(hashlib.sha256(enc_key.encode()).hexdigest())
+'
+
+PY_PROG_ASSERT_HEALTH='import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert payload["status"] == "ok", payload
+services = payload.get("services", {})
+assert services.get("clickhouse") == "ok", services
+assert services.get("postgres") in ("ok", "not_configured"), services
+'
+
+PY_PROG_ASSERT_META='import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert payload.get("backend") == "clickhouse", payload
+assert payload.get("limits", {}).get("max_days") == 365, payload
+assert payload.get("limits", {}).get("max_repos") == 1000, payload
+supported = payload.get("supported_endpoints", [])
+assert "/api/v1/home" in supported, supported
+'
+
+PY_PROG_ASSERT_HOME='import json
+import os
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+freshness = payload.get("freshness", {})
+assert "last_ingested_at" in freshness, freshness
+sources = freshness.get("sources", {})
+allowed_states = {"ok", "degraded", "down", "stale", "unknown", "not_configured", "error"}
+fixture_provider = os.environ.get("FIXTURE_PROVIDER", "github")
+expected_sources = {"ci"}
+if fixture_provider != "synthetic":
+    expected_sources.add(fixture_provider)
+assert set(sources) == expected_sources, sources
+for key in expected_sources:
+    assert key in sources, sources
+    assert str(sources.get(key, "")).lower() in allowed_states, sources
+coverage = freshness.get("coverage", {})
+assert float(coverage.get("repos_covered_pct", 0.0)) > 0.0, coverage
+deltas = payload.get("deltas", [])
+assert len(deltas) >= 1, len(deltas)
+for row in deltas:
+    assert "metric" in row, row
+    assert "value" in row, row
+tiles = payload.get("tiles", {})
+for key in ("understand", "measure", "align", "execute"):
+    assert key in tiles, tiles
+constraint = payload.get("constraint", {})
+assert constraint.get("title"), constraint
+assert constraint.get("evidence"), constraint
+'
+
 require_cmd curl
 
 CLICKHOUSE_URI_DEFAULT="clickhouse://ch:ch@127.0.0.1:8123/default"
@@ -103,6 +288,44 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
+# A private SUBDIRECTORY of our own temp dir, not a shared /tmp and not TMP_DIR
+# itself: `python <script>` puts the script directory on sys.path[0] (where
+# `python -` put the CWD), so a stray .py sitting next to the script could
+# shadow a real module. Keeping the programs away from the JSON payloads this
+# harness also writes into TMP_DIR keeps that directory empty of anything but
+# our own programs. Removed by cleanup() along with TMP_DIR.
+PY_PROGRAM_DIR="${TMP_DIR}/py"
+
+write_py_program() {
+  local name="$1"
+  local text="$2"
+  # `printf` is a BUILTIN writing straight to the redirected file: no pipe, no
+  # fork, nothing that can block. Using `cat >file <<EOF` here would
+  # reintroduce exactly the here-document pipe this change exists to remove.
+  if ! printf '%s' "${text}" >"${PY_PROGRAM_DIR}/${name}"; then
+    echo "ERROR: could not write ${PY_PROGRAM_DIR}/${name}."
+    return 1
+  fi
+}
+
+write_py_programs() {
+  if ! mkdir -p "${PY_PROGRAM_DIR}"; then
+    echo "ERROR: could not create ${PY_PROGRAM_DIR}."
+    return 1
+  fi
+  write_py_program redis_ping.py "${PY_PROG_REDIS_PING}"
+  write_py_program auth_token.py "${PY_PROG_AUTH_TOKEN}"
+  write_py_program ready_health.py "${PY_PROG_READY_HEALTH}"
+  write_py_program jwt_secret.py "${PY_PROG_JWT_SECRET}"
+  write_py_program assert_health.py "${PY_PROG_ASSERT_HEALTH}"
+  write_py_program assert_meta.py "${PY_PROG_ASSERT_META}"
+  write_py_program assert_home.py "${PY_PROG_ASSERT_HOME}"
+}
+
+# Materialize before any stage runs: every stage below hands Python a path from
+# this directory.
+write_py_programs
+
 wait_for_redis() {
   # CHAOS-2702: fail fast (before burning time on fixture generation / API
   # boot) if the Valkey service container isn't reachable yet. Uses the
@@ -111,19 +334,7 @@ wait_for_redis() {
   # `valkey-cli`/`redis-cli` binary on the runner.
   local i
   for ((i = 1; i <= READINESS_ATTEMPTS; i++)); do
-    if REDIS_URL="${REDIS_URL}" run_python - <<'PY'
-import os
-import sys
-
-import valkey
-
-client = valkey.from_url(os.environ["REDIS_URL"])
-try:
-    client.ping()
-except Exception:
-    sys.exit(1)
-PY
-    then
+    if REDIS_URL="${REDIS_URL}" run_python "${PY_PROGRAM_DIR}/redis_ping.py"; then
       echo "Valkey ready after ${i} attempt(s)."
       return 0
     fi
@@ -134,57 +345,7 @@ PY
 }
 
 generate_auth_token() {
-  run_python - <<'PY'
-import hashlib, jwt, uuid, os
-from datetime import datetime, timedelta, timezone
-
-user_id = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
-org_id = uuid.UUID(os.getenv("E2E_ORG_ID", "11111111-2222-3333-4444-555555555555"))
-
-pg_uri = os.getenv("POSTGRES_URI", os.getenv("DATABASE_URI", ""))
-if pg_uri:
-    sync_uri = pg_uri.replace("+asyncpg", "", 1)
-    from sqlalchemy import create_engine, text
-    engine = create_engine(sync_uri)
-    from dev_health_ops.models.git import Base
-    import dev_health_ops.models.users  # register models
-    Base.metadata.create_all(engine, checkfirst=True)
-    now = datetime.now(timezone.utc).isoformat()
-    with engine.begin() as conn:
-        conn.execute(text(
-            "INSERT INTO organizations (id, slug, name, settings, tier, is_active, created_at, updated_at)"
-            " VALUES (:id, :slug, :name, :settings, :tier, true, :now, :now)"
-            " ON CONFLICT (id) DO NOTHING"
-        ), {"id": str(org_id), "slug": "e2e-org", "name": "E2E Org",
-            "settings": "{}", "tier": "enterprise", "now": now})
-        conn.execute(text(
-            "INSERT INTO users (id, email, is_active, is_verified, is_superuser, auth_provider, created_at, updated_at)"
-            " VALUES (:id, :email, true, false, false, 'local', :now, :now)"
-            " ON CONFLICT (id) DO NOTHING"
-        ), {"id": str(user_id), "email": "e2e@test.local", "now": now})
-        conn.execute(text(
-            "INSERT INTO memberships (id, user_id, org_id, role, created_at, updated_at)"
-            " VALUES (:mid, :uid, :oid, :role, :now, :now)"
-            " ON CONFLICT DO NOTHING"
-        ), {"mid": str(uuid.uuid4()), "uid": str(user_id), "oid": str(org_id),
-            "role": "admin", "now": now})
-    engine.dispose()
-
-enc_key = os.getenv("SETTINGS_ENCRYPTION_KEY", "dev-key-not-for-prod")
-secret = hashlib.sha256(enc_key.encode()).hexdigest()
-payload = {
-    "sub": str(user_id),
-    "email": "e2e@test.local",
-    "org_id": str(org_id),
-    "role": "admin",
-    "is_superuser": False,
-    "type": "access",
-    "exp": datetime.now(timezone.utc) + timedelta(hours=1),
-    "iat": datetime.now(timezone.utc),
-    "jti": str(uuid.uuid4()),
-}
-print(jwt.encode(payload, secret, algorithm="HS256"))
-PY
+  run_python "${PY_PROGRAM_DIR}/auth_token.py"
 }
 
 fetch_json() {
@@ -228,18 +389,7 @@ wait_for_ready() {
           -H "Accept: application/json" \
           "${BASE_URL}/health" || true
       )"
-      if [ "${health_status}" = "200" ] && run_python - "${readiness_file}" <<'PY'
-import json
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-payload = json.loads(path.read_text())
-assert payload.get("status") == "ok", payload
-services = payload.get("services", {})
-assert services.get("clickhouse") == "ok", services
-assert services.get("postgres") in ("ok", "not_configured"), services
-PY
+      if [ "${health_status}" = "200" ] && run_python "${PY_PROGRAM_DIR}/ready_health.py" "${readiness_file}"
       then
         echo "All dependencies healthy."
         return 0
@@ -294,11 +444,7 @@ DEV_HEALTH_POSTGRES_TEST_URI="${POSTGRES_URI}" \
 # value generate_auth_token() uses so tokens match between API and e2e client.
 if [ -z "${JWT_SECRET_KEY:-}" ]; then
   JWT_SECRET_KEY="$(
-    ENC_KEY_INPUT="${SETTINGS_ENCRYPTION_KEY:-dev-key-not-for-prod}" run_python - <<'PY'
-import hashlib, os
-enc_key = os.environ["ENC_KEY_INPUT"]
-print(hashlib.sha256(enc_key.encode()).hexdigest())
-PY
+    ENC_KEY_INPUT="${SETTINGS_ENCRYPTION_KEY:-dev-key-not-for-prod}" run_python "${PY_PROGRAM_DIR}/jwt_secret.py"
   )"
   export JWT_SECRET_KEY
 fi
@@ -325,70 +471,17 @@ AUTH_TOKEN="$(generate_auth_token)"
 echo "==> validating /health"
 HEALTH_FILE="${TMP_DIR}/health.json"
 fetch_json "/health" "${HEALTH_FILE}" "200"
-run_python - "${HEALTH_FILE}" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
-assert payload["status"] == "ok", payload
-services = payload.get("services", {})
-assert services.get("clickhouse") == "ok", services
-assert services.get("postgres") in ("ok", "not_configured"), services
-PY
+run_python "${PY_PROGRAM_DIR}/assert_health.py" "${HEALTH_FILE}"
 
 echo "==> validating /api/v1/meta"
 META_FILE="${TMP_DIR}/meta.json"
 fetch_json "/api/v1/meta" "${META_FILE}" "200"
-run_python - "${META_FILE}" <<'PY'
-import json
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
-assert payload.get("backend") == "clickhouse", payload
-assert payload.get("limits", {}).get("max_days") == 365, payload
-assert payload.get("limits", {}).get("max_repos") == 1000, payload
-supported = payload.get("supported_endpoints", [])
-assert "/api/v1/home" in supported, supported
-PY
+run_python "${PY_PROGRAM_DIR}/assert_meta.py" "${META_FILE}"
 
 echo "==> validating /api/v1/home"
 HOME_FILE="${TMP_DIR}/home.json"
 fetch_json "/api/v1/home" "${HOME_FILE}" "200"
-run_python - "${HOME_FILE}" <<'PY'
-import json
-import os
-import pathlib
-import sys
-
-payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
-freshness = payload.get("freshness", {})
-assert "last_ingested_at" in freshness, freshness
-sources = freshness.get("sources", {})
-allowed_states = {"ok", "degraded", "down", "stale", "unknown", "not_configured", "error"}
-fixture_provider = os.environ.get("FIXTURE_PROVIDER", "github")
-expected_sources = {"ci"}
-if fixture_provider != "synthetic":
-    expected_sources.add(fixture_provider)
-assert set(sources) == expected_sources, sources
-for key in expected_sources:
-    assert key in sources, sources
-    assert str(sources.get(key, "")).lower() in allowed_states, sources
-coverage = freshness.get("coverage", {})
-assert float(coverage.get("repos_covered_pct", 0.0)) > 0.0, coverage
-deltas = payload.get("deltas", [])
-assert len(deltas) >= 1, len(deltas)
-for row in deltas:
-    assert "metric" in row, row
-    assert "value" in row, row
-tiles = payload.get("tiles", {})
-for key in ("understand", "measure", "align", "execute"):
-    assert key in tiles, tiles
-constraint = payload.get("constraint", {})
-assert constraint.get("title"), constraint
-assert constraint.get("evidence"), constraint
-PY
+run_python "${PY_PROGRAM_DIR}/assert_home.py" "${HOME_FILE}"
 
 echo "==> running customer-push external-ingest live e2e test (CHAOS-2702)"
 (

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -6,9 +6,44 @@ EXIT_MISSING_DEP=3
 EXIT_MISSING_TOKENS=4
 EXIT_FAILURE=10
 
-usage() {
-  cat <<'EOF'
-Usage: ci/run_tests.sh <tier>
+# The usage text, held as a shell string rather than a here-document.
+#
+# WHY NOT A HERE-DOCUMENT (CHAOS-3489, same class as CHAOS-3362 — do not
+# "simplify" it back). Bash delivers a here-document by writing it into a pipe
+# and only THEN forking the command that reads it, so the writing shell briefly
+# holds both ends of that pipe itself. If the document does not fit in the pipe
+# buffer, the write can never complete: nothing is reading, and because the
+# writer owns the read end it cannot even get EPIPE. It blocks forever.
+#
+# Measured on this host with `cat >/dev/null <<EOF`, timeout 5:
+#
+#     400 bytes -> ok, 0.30s
+#     512 bytes -> WEDGED
+#    1024 bytes -> WEDGED
+#    4000 bytes -> WEDGED
+#
+# while `lsof` reports those same pipes with the nominal 16384-byte capacity.
+# Nominal is not actual: macOS hands out a small pipe buffer and defers
+# expansion under kernel pipe-memory pressure, which a host running many
+# concurrent agent sessions sits in persistently. This text is 800 bytes, i.e.
+# permanently over the line.
+#
+# Hosted CI runners have normal pipe buffers, so this never wedged in CI. It
+# wedges on a developer machine — and because usage() fires only on `--help` or
+# a bad argument, it wedged exactly when someone mistyped an invocation, which
+# is a bad moment to hang silently with no output at all.
+#
+# `printf` is a BUILTIN: it writes this string straight to stdout in-process,
+# with no pipe and no fork. A temp file would be pure ceremony here — the
+# payload is going to stdout, not to an interpreter that needs a path. Note
+# that `cat >file <<EOF` would NOT have fixed this: the pipe IS the
+# here-document delivery mechanism, not something the reader introduces, which
+# is why the repro above uses `cat`.
+#
+# CONSTRAINT: this is a single-quoted shell string, so the text must contain no
+# single-quote character. tests/tooling/test_local_validate_heredocs.py enforces
+# that, and budgets every here-document under ci/ at the measured 400 bytes.
+USAGE_TEXT='Usage: ci/run_tests.sh <tier>
 
 Tiers:
   unit         Run unit test suite (excludes integration test files)
@@ -23,7 +58,10 @@ Environment:
   TEST_RESULTS_DIR=...   Base directory for junit outputs (default: ./test-results)
   PYTEST_XDIST_WORKERS=auto   pytest-xdist worker count (-n). Set 0 to disable parallelism.
   PYTEST_DIST_MODE=loadscope  xdist distribution mode (loadscope keeps a module on one worker).
-EOF
+'
+
+usage() {
+  printf '%s' "${USAGE_TEXT}"
 }
 
 if [ "$#" -ne 1 ]; then

--- a/tests/_env_isolation.py
+++ b/tests/_env_isolation.py
@@ -140,14 +140,14 @@ CONDITIONAL_KEEP_ENV_NAMES: dict[str, str] = {
     # `ci/run_tests.sh` and `ci/local_validate.sh` mention neither REDIS_URL nor
     # VALKEY.
     #
-    # Requirement: ci/run_live_backend_e2e.sh:399 exports it, and :406 runs
+    # Requirement: ci/run_live_backend_e2e.sh:492 exports it, and :499 runs
     # tests/test_external_ingest_customer_push_live.py -- "the only module in
     # this repo that needs all three live services at once", which reads
     # REDIS_URL at import (:91) and skipifs the WHOLE MODULE without it (:96).
     # An unconditional scrub would turn that lane's coverage into a silent skip.
     #
     # LIVE_E2E_BASE_URL is that lane's own sentinel, exported at
-    # run_live_backend_e2e.sh:405 -- one line after REDIS_URL, same subshell.
+    # run_live_backend_e2e.sh:498 -- six lines after REDIS_URL, same subshell.
     "REDIS_URL": "LIVE_E2E_BASE_URL",
 }
 

--- a/tests/tooling/test_local_validate_heredocs.py
+++ b/tests/tooling/test_local_validate_heredocs.py
@@ -1,5 +1,14 @@
 """Regression coverage for the CHAOS-3362 here-document pipe wedge.
 
+The budget scan covers **every** ``ci/*.sh`` script, not just the one that wedged
+(CHAOS-3489). Two more sites of this exact class survived CHAOS-3362 because that
+changeset was scoped to the gate script: ``ci/run_tests.sh`` fed its 800-byte
+``usage()`` text through ``cat <<EOF``, and ``ci/run_live_backend_e2e.sh`` fed
+seven programs to Python through ``run_python - <<PY`` (two of them over the
+budget, at 2240 and 1201 bytes). Scanning the whole directory closes the class
+instead of the sites: a new script, or a new stage in an existing one, is covered
+the moment it lands.
+
 ``ci/local_validate.sh`` used to feed its argMax proof program to Python as a
 1269-byte here-document. Bash delivers a here-document by writing it into a pipe
 and only THEN forking the reader, so the writing shell transiently holds both
@@ -33,10 +42,25 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+CI_DIR = ROOT / "ci"
 SCRIPT = ROOT / "ci" / "local_validate.sh"
+
+# Scripts the budget scan must have actually read. A bare `glob` that silently
+# matched nothing -- moved directory, renamed extension -- would report zero
+# oversized here-documents and read as coverage, so the scan asserts these are
+# present rather than trusting whatever the glob returns.
+_REQUIRED_SCRIPTS = (
+    "check_go.sh",
+    "check_go_containers.sh",
+    "check_river_compat_static.sh",
+    "local_validate.sh",
+    "run_live_backend_e2e.sh",
+    "run_tests.sh",
+)
 
 # Largest here-document size measured to complete on the affected host. Anything
 # at or above this has been measured to block forever there.
@@ -83,6 +107,17 @@ def _heredocs(text: str) -> list[tuple[int, str, bytes]]:
     return found
 
 
+def _shell_string_programs(text: str, prefix: str) -> dict[str, str]:
+    """Every ``PREFIX_NAME='...'`` single-quoted shell string in ``text``.
+
+    A single-quoted shell string cannot contain a single quote, so the closing
+    quote is unambiguous: the first ``'`` at the start of a line.
+    """
+
+    pattern = re.compile(rf"^({prefix}[A-Z0-9_]+)='(.*?)^'$", re.S | re.M)
+    return {match.group(1): match.group(2) for match in pattern.finditer(text)}
+
+
 def _argmax_program(text: str) -> str:
     match = re.search(r"^ARGMAX_PROOF_PY='(.*?)'\n", text, re.S | re.M)
     assert match is not None, (
@@ -94,28 +129,96 @@ def _argmax_program(text: str) -> str:
     return match.group(1)
 
 
-def test_local_validate_has_no_heredoc_over_the_measured_pipe_budget() -> None:
-    """No here-document in the gate script may exceed the measured budget.
+def test_scanner_flags_an_oversized_heredoc_and_ignores_here_strings() -> None:
+    """The scanner itself must still be able to fail (CHAOS-3489).
 
-    Guards the whole class, not just the one call site that wedged: any stage
-    that grows a here-document past ~400 bytes reintroduces the same hang.
+    A directory-wide scan whose regex has rotted reports "no findings" over
+    every script and reads exactly like a clean bill of health. So plant the
+    defect the scan exists to catch and observe it caught, and plant the two
+    shapes it must NOT catch -- a here-STRING, whose content is a runtime
+    expansion this scanner cannot size, and a here-document quoted inside a
+    comment, which is prose rather than a redirection.
     """
 
-    assert SCRIPT.is_file(), f"gate script missing at {SCRIPT}"
-    text = SCRIPT.read_text(encoding="utf-8")
-    # The scan must have something to scan: an empty/renamed script would
-    # otherwise sail through with zero findings and read as coverage.
-    assert len(text) > 10_000, f"{SCRIPT} is unexpectedly small ({len(text)} bytes)"
+    oversized_body = "x" * (_HEREDOC_BUDGET_BYTES + 1)
+    planted = f"cat <<'EOF'\n{oversized_body}\nEOF\n"
+    found = _heredocs(planted)
+    assert [(line, delim) for line, delim, _ in found] == [(1, "EOF")], found
+    assert len(found[0][2]) > _HEREDOC_BUDGET_BYTES
 
-    oversized = [
-        (line, delimiter, len(body))
-        for line, delimiter, body in _heredocs(text)
-        if len(body) >= _HEREDOC_BUDGET_BYTES
-    ]
+    # Here-STRING: same delivery mechanism, but the content is a runtime value
+    # (ci/local_validate.sh:374 is a ~130-byte pid|lstart|cwd triple), so it is
+    # deliberately out of scope -- see the module docstring.
+    assert _heredocs('read -r a b c <<<"${target}"\n') == []
+    # Prose, not a redirection: these scripts document the hazard by quoting it.
+    assert _heredocs("  # Using `cat >file <<EOF` would reintroduce the pipe\n") == []
+
+
+def _tracked_ci_scripts() -> list[Path]:
+    """Every ``ci/*.sh`` git knows about, tracked or staged.
+
+    NOT ``CI_DIR.glob("*.sh")``. That scans whatever happens to be sitting in
+    the directory, so a developer's scratch copy of a script -- including a
+    copy of a PRE-FIX script kept around to compare against -- turns this into
+    a red gate about a file the repository does not contain. Adversarial review
+    hit exactly that. ``git ls-files`` also covers the index, so a genuinely
+    new script is scanned from the moment it is staged, which is before any
+    commit hook or CI run can see it.
+    """
+
+    result = subprocess.run(  # noqa: S603
+        ["git", "ls-files", "-z", "--", "ci/*.sh"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    # A failure here must not degrade into "nothing to scan": that reports zero
+    # findings and reads exactly like a clean result.
+    assert result.returncode == 0, (
+        f"git ls-files failed ({result.returncode}) in {ROOT}: {result.stderr}."
+        " The here-document budget scan cannot enumerate what to read, so it"
+        " must fail rather than report no findings."
+    )
+    return [ROOT / name for name in result.stdout.split("\0") if name]
+
+
+def test_no_ci_script_has_a_heredoc_over_the_measured_pipe_budget() -> None:
+    """No here-document under ``ci/`` may exceed the measured budget.
+
+    Guards the whole class over the whole directory, not the three call sites
+    that were found wedged (CHAOS-3362, CHAOS-3489): any script that grows a
+    here-document past ~400 bytes reintroduces the same hang, and every script
+    in here runs on developer machines where the small pipe buffer is real.
+    """
+
+    scripts = sorted(_tracked_ci_scripts())
+    names = {path.name for path in scripts}
+    missing = [name for name in _REQUIRED_SCRIPTS if name not in names]
+    assert not missing, (
+        f"the ci/ here-document scan found no {missing} to scan (git ls-files"
+        f" returned {sorted(names) or 'nothing'} under {CI_DIR}). A scan that"
+        " reads nothing reports no findings and looks identical to a clean"
+        " result -- fix the path or update _REQUIRED_SCRIPTS deliberately, do"
+        " not let it pass."
+    )
+
+    oversized: list[tuple[str, int, str, int]] = []
+    for path in scripts:
+        text = path.read_text(encoding="utf-8")
+        # Each script must have real content behind it, for the same reason.
+        assert len(text) > 500, f"{path} is unexpectedly small ({len(text)} bytes)"
+        oversized.extend(
+            (path.name, line, delimiter, len(body))
+            for line, delimiter, body in _heredocs(text)
+            if len(body) >= _HEREDOC_BUDGET_BYTES
+        )
+
     assert not oversized, (
         "here-document(s) at or above the measured pipe budget of "
         f"{_HEREDOC_BUDGET_BYTES} bytes: {oversized}. Bash writes a here-document"
-        " into a pipe it also holds the read end of, so this hangs the gate"
+        " into a pipe it also holds the read end of, so this hangs the script"
         " forever on hosts with a small effective pipe buffer (CHAOS-3362)."
         " Write the payload to a temp file with the printf BUILTIN instead --"
         " `cat >file <<EOF` is the same pipe and does NOT fix it."
@@ -175,3 +278,122 @@ def test_argmax_proof_program_contains_no_single_quote() -> None:
         "ARGMAX_PROOF_PY is a single-quoted shell string; the Python program"
         " inside it must not contain a single-quote character"
     )
+
+
+# --- ci/run_live_backend_e2e.sh (CHAOS-3489) -------------------------------
+
+E2E_SCRIPT = ROOT / "ci" / "run_live_backend_e2e.sh"
+
+# The seven programs the harness used to feed Python through `run_python - <<PY`.
+# Named explicitly rather than counted: a rename or a quiet deletion should fail
+# here and be re-checked, not pass because "seven of something" were found.
+_E2E_PROGRAMS = {
+    "PY_PROG_REDIS_PING": "redis_ping.py",
+    "PY_PROG_AUTH_TOKEN": "auth_token.py",
+    "PY_PROG_READY_HEALTH": "ready_health.py",
+    "PY_PROG_JWT_SECRET": "jwt_secret.py",
+    "PY_PROG_ASSERT_HEALTH": "assert_health.py",
+    "PY_PROG_ASSERT_META": "assert_meta.py",
+    "PY_PROG_ASSERT_HOME": "assert_home.py",
+}
+
+
+def test_e2e_harness_programs_are_all_present() -> None:
+    """Every converted program is still a shell string, written, and used.
+
+    Three separate things have to line up for a stage to work, and each fails
+    silently on its own: the program string exists, ``write_py_programs``
+    materializes it under ``PY_PROGRAM_DIR``, and some stage hands Python that
+    path. A program that is defined but never written produces a "can't open
+    file" at whatever hour that stage runs.
+    """
+
+    text = E2E_SCRIPT.read_text(encoding="utf-8")
+    programs = _shell_string_programs(text, "PY_PROG_")
+    assert set(programs) == set(_E2E_PROGRAMS), (
+        f"expected shell-string programs {sorted(_E2E_PROGRAMS)}, found"
+        f" {sorted(programs)} in {E2E_SCRIPT}. If a stage was legitimately"
+        " added or removed, update _E2E_PROGRAMS deliberately -- do not let a"
+        " program silently revert to a here-document."
+    )
+    for variable, filename in _E2E_PROGRAMS.items():
+        assert f'write_py_program {filename} "${{{variable}}}"' in text, (
+            f"{variable} is defined but write_py_programs() never writes it to"
+            f" {filename}; the stage using it would fail to open the file"
+        )
+        assert f'"${{PY_PROGRAM_DIR}}/{filename}"' in text, (
+            f"{filename} is written but no stage runs it; a materialized"
+            " program nothing executes is dead weight, and more likely means"
+            " the call site was missed"
+        )
+
+
+def test_e2e_harness_programs_are_valid_python() -> None:
+    """They are shell-string data now, so nothing else parses them."""
+
+    programs = _shell_string_programs(
+        E2E_SCRIPT.read_text(encoding="utf-8"), "PY_PROG_"
+    )
+    assert programs, f"no PY_PROG_* shell strings found in {E2E_SCRIPT}"
+    for variable, program in sorted(programs.items()):
+        compile(program, f"{variable}.py", "exec")
+
+
+def test_e2e_harness_programs_contain_no_single_quote() -> None:
+    """A single quote would end the shell string early and break the script.
+
+    This is why the users INSERT binds ``auth_provider`` as a parameter instead
+    of carrying the SQL literal it used to: the literal cannot be spelled here.
+    Verified against a live PostgreSQL before the swap -- both spellings produce
+    the same row, same column, same type.
+    """
+
+    programs = _shell_string_programs(
+        E2E_SCRIPT.read_text(encoding="utf-8"), "PY_PROG_"
+    )
+    assert programs, f"no PY_PROG_* shell strings found in {E2E_SCRIPT}"
+    offenders = sorted(name for name, program in programs.items() if "'" in program)
+    assert not offenders, (
+        f"{offenders} are single-quoted shell strings containing a single-quote"
+        " character; bash ends the assignment there and tries to run the rest"
+        " as commands"
+    )
+
+
+# --- ci/run_tests.sh (CHAOS-3489) ------------------------------------------
+
+RUN_TESTS_SCRIPT = ROOT / "ci" / "run_tests.sh"
+
+
+def test_run_tests_usage_still_documents_every_tier() -> None:
+    """usage() must still emit the text it used to, by running it.
+
+    The conversion was verified byte-for-byte against the here-document output
+    at the time. This guards the text from here on -- note it can only catch
+    drift, NOT the wedge: on a host with a normal pipe buffer the here-document
+    version passes this too. The budget scan above is what catches the wedge.
+    """
+
+    completed = subprocess.run(  # noqa: S603
+        ["bash", str(RUN_TESTS_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    # No argument -> usage on stdout, EXIT_USAGE. Nothing on stderr.
+    assert completed.returncode == 2, completed
+    assert completed.stderr == "", completed.stderr
+    output = completed.stdout
+    assert output.startswith("Usage: ci/run_tests.sh <tier>\n"), output
+    assert output.endswith("on one worker).\n"), output[-80:]
+    for tier in ("unit", "integration", "e2e", "live-e2e", "ci"):
+        assert f"\n  {tier} " in output, (tier, output)
+    for knob in (
+        "PYTEST_SINGLE_RETRY=1",
+        "PYTEST_DURATIONS=25",
+        "TEST_RESULTS_DIR=...",
+        "PYTEST_XDIST_WORKERS=auto",
+        "PYTEST_DIST_MODE=loadscope",
+    ):
+        assert knob in output, (knob, output)


### PR DESCRIPTION
Closes CHAOS-3489.

Two here-documents outside `ci/local_validate.sh` still carried the CHAOS-3362 defect; that changeset was scoped to the gate script. Bash delivers a here-document by writing it into a pipe and only THEN forking the reader, so the writing shell transiently holds both ends. If the document does not fit the pipe buffer the write can never complete: nothing is draining it, and the writer owning the read end cannot even receive EPIPE.

## This is not latent on a developer machine — it wedges TODAY

CHAOS-3489 frames both sites as latent. That framing is too generous for `ci/run_tests.sh`, which wedges on this host **right now**, reproduced 6 times out of 6 under `timeout 10`:

```
bash ci/run_tests.sh bogus-tier >file    -> rc=124, killed at 10s, 6/6
(this branch, same command)              -> rc=2,   22ms,          6/6
```

The wedged runs stop at exactly 404 bytes, and those 404 bytes end on `ERROR: Unknown tier 'bogus-tier'` — the statement immediately before `usage()`. Not one byte of the usage text is ever emitted, and the output prefix is identical to the fixed version's. The script dies in the here-document itself.

Being precise, because the conditions are narrower than "always": the same script on the same host does **not** wedge on the no-arg path (`bash ci/run_tests.sh`, 800 bytes, 15 ms), nor when stdout is piped rather than redirected to a file. What differs on the wedging path is that `usage()` is reached after the script has run its full preamble. That difference is not fully explained here.

The ticket's own repro, re-measured today on bash 5.3.15 (aarch64-apple-darwin25.4.0):

```
  400 bytes -> ok, 16ms
  512 bytes -> ok, 16ms
 1024 bytes -> WEDGED
 4000 bytes -> WEDGED
```

Today's threshold sits between 512 and 1024 where the ticket measured 512 already wedging. The scanner's budget stays at the ticket's 400 bytes — the largest size measured to COMPLETE across both sessions. A budget tracking whichever number this host reports on a given afternoon would be no budget at all.

Hosted runners have normal pipe buffers, so no site here is a CI risk. These wedge on developer machines — the condition CHAOS-3362 spent three days misattributing to ClickHouse.

## The change

**`ci/run_tests.sh`** — the 800-byte `usage()` text is now a shell string emitted with the `printf` BUILTIN: in-process, no pipe, no fork. Deliberately no temp file: the payload goes to stdout, not to an interpreter that needs a path, and stdout is a pipe someone else is already draining rather than one this shell holds both ends of. This site is also off the normal path — `usage()` fires only on `--help` or a bad argument — so it hung exactly when someone mistyped an invocation.

**`ci/run_live_backend_e2e.sh`** — all seven `run_python - <<PY` programs become single-quoted shell strings, written by `printf` into a private subdirectory of the harness's own `mktemp -d`, with Python handed the path. A subdirectory rather than a bare temp file because `python <script>` puts the script's directory on `sys.path[0]` where `python -` put the CWD; keeping the programs out of `TMP_DIR` proper also keeps them away from the JSON payloads the harness writes there. The existing `cleanup()` trap already removes it. All seven, not only the two over budget (2240 and 1201 bytes): 400 is the largest size measured to complete, the 382-byte one sits one edit away from it, and a mixed file invites the next stage to be added in the wedging shape.

`cat >file <<EOF` would not have helped anywhere here — the pipe IS the here-document delivery mechanism, not something the reader introduces, which is why the repro uses `cat`.

## Behavioral proof, every site

- **`usage()`**: stdout byte-identical (800 bytes, same sha) and stderr empty for both `ci/run_tests.sh` and `ci/run_tests.sh --help`; exit 2 unchanged. On the invalid-tier path the output ends with those same 800 bytes.
- **Six of the seven programs** are byte-identical to the here-document bodies they replace, materialized through the real script path and `cmp`-ed.
- **The seventh** differs by one deliberate line: the users INSERT binds `auth_provider` as a parameter, because the SQL literal `'local'` cannot be spelled inside a single-quoted shell string. Verified as a differential against a **live PostgreSQL** — each spelling into its own scratch database, `pg_dump --schema-only` identical (7319 lines, modulo pg_dump's per-run `\restrict` nonce), and organizations/users/memberships rows identical including `pg_typeof(auth_provider)`. Both tokens verify against the derived HS256 secret with identical stable claims; a second run left row counts at 1/1/1, so the `ON CONFLICT` path still holds through the bind.
- **Every program run old-vs-new on OK and FAILING payloads**: same exit code, same assertion text, same failing line. The only output difference is that the new form's traceback shows the source line, which `python -` could not re-read from stdin — strictly better diagnostics.
- **In-context, against live services** rather than extracted: `wait_for_redis` against the live valkey (ready on attempt 1) and against a dead port (fails in 2.3 s instead of wedging); the `JWT_SECRET_KEY` derivation inside its command substitution, matching `sha256(SETTINGS_ENCRYPTION_KEY)` exactly; `generate_auth_token` against live PostgreSQL; and `wait_for_ready` against a stub API, returning 0 when healthy and failing on the `clickhouse=down` payload — that guard observed failing, not assumed.
- **Not proven by execution**: the full harness never ran end to end. Its default `CLICKHOUSE_URI` points at the dev `default` database, which is off limits, so the stages that require it are unproven here and this PR does not claim otherwise.
- `shellcheck` output on both scripts is unchanged from `origin/main` (the same pre-existing SC2030/SC2031 infos in the e2e harness, nothing in `run_tests.sh`); `bash -n` clean.

## Test coverage

`tests/tooling/test_local_validate_heredocs.py` now budgets here-documents across **all** of `ci/*.sh` rather than the gate script alone, which closes the class instead of these two sites: a new script, or a new stage in an existing one, is covered the moment it is staged. It fails on `origin/main` naming all three oversized sites (`run_live_backend_e2e.sh:137` at 2241, `:359` at 1202, `run_tests.sh:10` at 800) and passes here. The documented here-string exclusion is kept — `<<<` content is a runtime expansion this scanner cannot size — and `ci/local_validate.sh:374` stays out of scope per the ticket.

The scan enumerates `git ls-files -- ci/*.sh`, not `Path.glob`. Adversarial review caught the difference the hard way: a scratch copy of the PRE-FIX script, left in `ci/` while comparing old against new, is picked up by a directory glob and turns the gate red over a file the repository does not contain. Going through the index scopes the check to what the repo is responsible for while still covering a genuinely new script from the moment it is staged — before any commit hook or CI run can see it. Verified in all three states: untracked scratch copy present → passes; same file staged → caught and named; clean tree → passes. A git failure asserts rather than degrading into an empty file list, since "nothing to scan" reports zero findings and reads exactly like a clean result.

For the same reason the scanner now has a self-test that plants an oversized here-document and requires it caught, plus the two shapes it must not catch. Confirmed: with the regex rotted to match only here-strings, the budget scan passes over every script and only the self-test fails.

The converted programs are shell-string data now, so nothing else parses them. New tests compile each one, reject a single-quote character in any of them, and require every program to be defined, materialized by `write_py_programs`, AND run by some stage — three things that each fail silently on their own. `usage()` gets a content test that runs the script; its docstring notes it can only catch text drift, not the wedge, since the here-document version passes it too on a host with a normal pipe buffer.

All seven new guards were observed failing against planted defects before being accepted: dropped `write_py_program` line, dropped call site, renamed `PY_PROG_` variable, planted Python syntax error, reintroduced single quote, dropped usage tier, rotted regex.

## Out of scope

`ci/check_go.sh` (CHAOS-3348) contains no `<<` of any kind. `ci/check_go_containers.sh:25` is now in scope of the scan and passes at 279 bytes, under the budget; left as a here-document rather than converted opportunistically. `ci/local_validate.sh:374`'s here-string is left alone per the ticket.
