### PR TITLE
CHAOS-3482: fail the required test gate when the run proves nothing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,15 @@ jobs:
               - 'ci/**'
               - 'migrations/**'
               - 'requirements.txt'
+              # Both test jobs `pip install -r requirements-docs.txt` before
+              # running anything, so it is part of the test environment. It
+              # was missing here until CHAOS-3482 Codex round 2: a PR touching
+              # only this file got code=false, skipped both test jobs, and the
+              # aggregator -- correctly, by its own rule -- called that a
+              # legitimate docs-only skip and reported the required check
+              # green. test_paths_filter_covers_every_file_the_test_jobs_install
+              # derives this list from the jobs' own install commands.
+              - 'requirements-docs.txt'
               - 'pyproject.toml'
               - 'pytest.ini'
               - 'alembic.ini'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,12 @@ jobs:
               - 'scripts/**'
               - 'alerts/**'
               - 'compose.yml'
+              # docker/Dockerfile is one of scripts/acceptance's
+              # RUNTIME_DEPENDENCY_PATHS: the acceptance suite hashes it and
+              # asserts on it, so a change here can turn the suite red -- but
+              # the filter did not select on it, so such a PR skipped every
+              # test job and the gate went green (CHAOS-3482 Codex round 4).
+              - 'docker/**'
               - 'deploy/**'
 
   # Fast, pytest-xdist-parallelized unit suite on the supported Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -315,31 +315,36 @@ jobs:
 
   # Required-status-check gate. Branch protection requires a check named
   # exactly "test"; the matrix above produces "test-matrix (3.14)"
-  # and the coverage job produces "coverage", neither of which match. This
-  # aggregator always runs, treating skipped (path filter, or coverage skipped
-  # on pull_request) as pass and failure/cancelled as fail. It is the single
-  # required check for both PRs and the merge queue. Do not remove.
+  # and the coverage job produces "coverage", neither of which match. It is the
+  # single required check for both PRs and the merge queue. Do not remove.
+  #
+  # The verdict lives in ci/aggregate_test_results.sh rather than inline here,
+  # so it can be driven through the whole result matrix by
+  # tests/tooling/test_aggregate_test_results.py. See that script's header for
+  # why `needs.changes.result` -- not the downstream results alone -- is what
+  # separates a legitimate skip from an upstream failure that skipped
+  # everything (CHAOS-3482).
   test:
     name: test
+    # Must remain `always()`. Under `!cancelled()` (or any condition that lets
+    # this job itself skip) a cancelled run leaves the REQUIRED check *skipped*,
+    # and branch protection counts a skipped required check as satisfied --
+    # which moves the silent pass one level up instead of closing it.
+    # Cancellation has to be reported by a job that actually ran, so this job
+    # runs unconditionally and the script fails the gate on `cancelled`.
     if: always()
-    needs: [test-matrix, coverage]
+    needs: [changes, test-matrix, coverage]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Aggregate test results
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_CODE: ${{ needs.changes.outputs.code }}
           MATRIX_RESULT: ${{ needs.test-matrix.result }}
           COVERAGE_RESULT: ${{ needs.coverage.result }}
         run: |
-          echo "test-matrix result: ${MATRIX_RESULT}"
-          echo "coverage result: ${COVERAGE_RESULT}"
-          for result in "${MATRIX_RESULT}" "${COVERAGE_RESULT}"; do
-            case "${result}" in
-              success|skipped)
-                ;;
-              failure|cancelled|*)
-                echo "test gate failed (${result})"
-                exit 1
-                ;;
-            esac
-          done
-          echo "test gate passed"
+          chmod +x ci/aggregate_test_results.sh
+          ./ci/aggregate_test_results.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
+        # A manual run is a request to test THIS ref, and it has no base/head
+        # diff to filter against; computing one against the default branch
+        # would let `gh workflow run test.yml` produce a run where every test
+        # job skipped and the required `test` check still went green
+        # (CHAOS-3482 Codex round 1). Leaving the filter unrun makes `code`
+        # empty, which the job conditions below and
+        # ci/aggregate_test_results.sh both read as "not 'true'" -- so the
+        # dispatch clause, not the path filter, is what selects the jobs.
+        # Same construction as lint.yml and typecheck.yml.
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             code:
@@ -61,8 +71,13 @@ jobs:
     # On merge_group, dorny/paths-filter has no PR base/head diff to compute and
     # can report code=false, which would skip every test job; the `test`
     # aggregator then treats the skip as a pass and an untested change reaches
-    # main. Always run in the merge queue regardless of the path filter.
-    if: github.event_name == 'merge_group' || needs.changes.outputs.code == 'true'
+    # main. Always run in the merge queue regardless of the path filter, and
+    # likewise on workflow_dispatch, where the filter is deliberately not run
+    # (see the `changes` job) so a manual run cannot test nothing.
+    if: >-
+      github.event_name == 'merge_group' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-26.04-arm
     # Test matrix needs package read access for dependency installs.
     permissions:
@@ -186,6 +201,14 @@ jobs:
   # verification + Codecov upload), never on pull_request. Reassigned from the
   # retired 3.11 leg to 3.12 and parallelized with xdist (CHAOS-2586); moved to
   # 3.14 to match the shipped interpreter (CHAOS-3419).
+  #
+  # It also does not run on workflow_dispatch, because the path filter that
+  # `code` comes from is not run there (see `changes`) and this condition is
+  # unchanged: a manual run is the fast-suite path, proved by test-matrix,
+  # which workflow_dispatch now always selects. The aggregator accepts this
+  # skip for the same reason it accepts the pull_request one -- the job's own
+  # condition did not select it -- and ci/aggregate_test_results.sh derives
+  # that from this exact expression.
   coverage:
     needs: [changes]
     if: >-

--- a/ci/aggregate_test_results.sh
+++ b/ci/aggregate_test_results.sh
@@ -21,17 +21,25 @@
 #                                This deliberately covers `cancelled` as well
 #                                as `failure` (both were observed producing the
 #                                false green) and `skipped`/empty.
-#   test-matrix skipped       -> legitimate ONLY on a non-merge_group event
-#                                with changes code == 'false' (a genuine
-#                                docs-only change). The merge queue has no
-#                                base/head diff for dorny/paths-filter, so the
-#                                job runs there unconditionally and a skip is
-#                                never legitimate.
+#   test-matrix skipped       -> legitimate ONLY when the path filter actually
+#                                decided against it (changes code == 'false')
+#                                on an event where the filter governs. The
+#                                merge queue has no base/head diff for
+#                                dorny/paths-filter, and workflow_dispatch does
+#                                not run the filter at all, so on both of those
+#                                the job runs unconditionally and a skip is
+#                                never legitimate. (workflow_dispatch was a
+#                                surviving zero-test green until Codex round 1
+#                                on this branch: a manual run whose filter said
+#                                code=false skipped both jobs and passed.)
 #   coverage skipped          -> legitimate whenever the job's own condition
 #                                did not select it: on every pull_request (by
 #                                design, CHAOS-2586 -- the coverage-gated suite
 #                                runs at merge time and on main, not in the
-#                                iterative PR loop), and on a docs-only push.
+#                                iterative PR loop), on a docs-only push, and
+#                                on workflow_dispatch. In all three the proof
+#                                comes from test-matrix, which those events do
+#                                select.
 #   anything else             -> FAIL, including an unrecognized or empty
 #                                result string. Unknown state is not evidence.
 #
@@ -77,7 +85,9 @@ if [[ "${CHANGES_RESULT}" != "success" ]]; then
 fi
 
 matrix_selected="false"
-if [[ "${EVENT_NAME}" == "merge_group" || "${CHANGES_CODE}" == "true" ]]; then
+if [[ "${EVENT_NAME}" == "merge_group" ||
+  "${EVENT_NAME}" == "workflow_dispatch" ||
+  "${CHANGES_CODE}" == "true" ]]; then
   matrix_selected="true"
 fi
 

--- a/ci/aggregate_test_results.sh
+++ b/ci/aggregate_test_results.sh
@@ -22,8 +22,9 @@
 #                                as `failure` (both were observed producing the
 #                                false green) and `skipped`/empty.
 #   test-matrix skipped       -> legitimate ONLY when the path filter actually
-#                                decided against it (changes code == 'false')
-#                                on an event where the filter governs. The
+#                                decided against it -- changes code LITERALLY
+#                                'false', not merely "not 'true'" -- on an
+#                                event where the filter governs. The
 #                                merge queue has no base/head diff for
 #                                dorny/paths-filter, and workflow_dispatch does
 #                                not run the filter at all, so on both of those
@@ -84,16 +85,30 @@ if [[ "${CHANGES_RESULT}" != "success" ]]; then
   gate_failed
 fi
 
-matrix_selected="false"
-if [[ "${EVENT_NAME}" == "merge_group" ||
-  "${EVENT_NAME}" == "workflow_dispatch" ||
-  "${CHANGES_CODE}" == "true" ]]; then
-  matrix_selected="true"
+# Selection is deliberately asymmetric with the `if:` expressions it mirrors.
+# Those ask "did this evaluate true?"; this asks "can the skip be EXPLAINED?",
+# and only a literal `false` from the path filter explains one. `code` is the
+# empty string whenever the filter did not publish a decision -- a renamed
+# output, a step made conditional, a filter that succeeded without producing
+# the key -- and every one of those used to read as "not 'true'", i.e. as a
+# docs-only change, which is a green required check with nothing run
+# (CHAOS-3482 Codex round 3). Treating an undecided `code` as SELECTED costs
+# nothing when the jobs actually ran, and fails the gate when they did not.
+matrix_selected="true"
+if [[ "${EVENT_NAME}" != "merge_group" ]] &&
+  [[ "${EVENT_NAME}" != "workflow_dispatch" ]] &&
+  [[ "${CHANGES_CODE}" == "false" ]]; then
+  matrix_selected="false"
 fi
 
+# coverage is excluded outright from pull_request (CHAOS-2586) and from
+# workflow_dispatch (no path filter runs there, so its condition can never
+# select it); otherwise the merge queue always selects it, and elsewhere the
+# same explain-the-skip rule applies.
 coverage_selected="false"
 if [[ "${EVENT_NAME}" != "pull_request" ]] &&
-  [[ "${EVENT_NAME}" == "merge_group" || "${CHANGES_CODE}" == "true" ]]; then
+  [[ "${EVENT_NAME}" != "workflow_dispatch" ]] &&
+  [[ "${EVENT_NAME}" == "merge_group" || "${CHANGES_CODE}" != "false" ]]; then
   coverage_selected="true"
 fi
 

--- a/ci/aggregate_test_results.sh
+++ b/ci/aggregate_test_results.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Verdict for the required `test` check in .github/workflows/test.yml.
+#
+# CHAOS-3482: the aggregator used to read only `needs.test-matrix.result` and
+# `needs.coverage.result`, and treat `skipped` as a pass. On 2026-08-06, during
+# a declared GitHub Actions outage, the `changes` job failed (and, on a rerun,
+# was cancelled) in "Set up job". Both test jobs then evaluated their `if:` to
+# false and reported `skipped`, the passing arm matched, and the single
+# REQUIRED check reported SUCCESS on a run where zero tests executed.
+# Reproduced 2 of 2 attempts -- not a rare race.
+#
+# The rule this file encodes: tolerate a skip only when you can NAME why it is
+# legitimate. That reason never lives in the skipped job's own result -- a skip
+# caused by a docs-only path filter and a skip caused by a dead upstream are
+# the same literal string. It lives in `changes`: its result (did the gating
+# decision happen at all?) and its `code` output (what did it decide?).
+#
+#   changes != success        -> FAIL. Nothing downstream can be trusted; the
+#                                selection that decides what must run never
+#                                completed, so the skips carry no information.
+#                                This deliberately covers `cancelled` as well
+#                                as `failure` (both were observed producing the
+#                                false green) and `skipped`/empty.
+#   test-matrix skipped       -> legitimate ONLY on a non-merge_group event
+#                                with changes code == 'false' (a genuine
+#                                docs-only change). The merge queue has no
+#                                base/head diff for dorny/paths-filter, so the
+#                                job runs there unconditionally and a skip is
+#                                never legitimate.
+#   coverage skipped          -> legitimate whenever the job's own condition
+#                                did not select it: on every pull_request (by
+#                                design, CHAOS-2586 -- the coverage-gated suite
+#                                runs at merge time and on main, not in the
+#                                iterative PR loop), and on a docs-only push.
+#   anything else             -> FAIL, including an unrecognized or empty
+#                                result string. Unknown state is not evidence.
+#
+# The "selected to run" predicates below MIRROR the `if:` conditions of
+# test-matrix and coverage in test.yml. tests/tooling/test_aggregate_test_results.py
+# pins both halves: it drives this script through the result matrix, and it
+# parses test.yml to assert those `if:` conditions still say what is modelled
+# here, so the two cannot drift apart silently.
+set -euo pipefail
+
+EVENT_NAME="${EVENT_NAME:-}"
+CHANGES_RESULT="${CHANGES_RESULT:-}"
+CHANGES_CODE="${CHANGES_CODE:-}"
+MATRIX_RESULT="${MATRIX_RESULT:-}"
+COVERAGE_RESULT="${COVERAGE_RESULT:-}"
+
+printf 'event: %s\n' "${EVENT_NAME:-<empty>}"
+printf 'changes result: %s (code=%s)\n' "${CHANGES_RESULT:-<empty>}" "${CHANGES_CODE:-<empty>}"
+printf 'test-matrix result: %s\n' "${MATRIX_RESULT:-<empty>}"
+printf 'coverage result: %s\n' "${COVERAGE_RESULT:-<empty>}"
+
+# Plain string rather than an array: this script is exercised by pytest on
+# developer macOS hosts, whose /bin/bash is 3.2, where `${#arr[@]}` on an empty
+# array is an unbound-variable error under `set -u`.
+FAILURES=""
+
+add_failure() {
+  FAILURES="${FAILURES}  - ${1}"$'\n'
+}
+
+gate_failed() {
+  printf 'test gate failed:\n' >&2
+  printf '%s' "${FAILURES}" >&2
+  exit 1
+}
+
+# The gating decision itself. Checked first and on its own: when `changes` did
+# not succeed, the downstream results are meaningless rather than merely
+# suspicious, and reporting on them would bury the real reason.
+if [[ "${CHANGES_RESULT}" != "success" ]]; then
+  add_failure "changes reported '${CHANGES_RESULT:-<empty>}', not 'success' -- the job that decides what must run did not complete, so the downstream '${MATRIX_RESULT:-<empty>}'/'${COVERAGE_RESULT:-<empty>}' results are not evidence that anything was tested"
+  gate_failed
+fi
+
+matrix_selected="false"
+if [[ "${EVENT_NAME}" == "merge_group" || "${CHANGES_CODE}" == "true" ]]; then
+  matrix_selected="true"
+fi
+
+coverage_selected="false"
+if [[ "${EVENT_NAME}" != "pull_request" ]] &&
+  [[ "${EVENT_NAME}" == "merge_group" || "${CHANGES_CODE}" == "true" ]]; then
+  coverage_selected="true"
+fi
+
+# shellcheck disable=SC2317  # invoked below, twice
+check_job() {
+  local name="$1" result="$2" selected="$3" legitimate_skip="$4"
+  case "${result}" in
+    success) ;;
+    skipped)
+      if [[ "${selected}" == "true" ]]; then
+        add_failure "${name} was skipped, but its job condition selected it to run (event=${EVENT_NAME:-<empty>}, changes code=${CHANGES_CODE:-<empty>}) -- an unexplained skip is an absence of proof, not a pass"
+      else
+        printf '%s skipped legitimately: %s\n' "${name}" "${legitimate_skip}"
+      fi
+      ;;
+    *)
+      add_failure "${name} reported '${result:-<empty>}'"
+      ;;
+  esac
+}
+
+check_job "test-matrix" "${MATRIX_RESULT}" "${matrix_selected}" \
+  "no gated path changed (changes code=${CHANGES_CODE:-<empty>}) on event ${EVENT_NAME:-<empty>}"
+check_job "coverage" "${COVERAGE_RESULT}" "${coverage_selected}" \
+  "the coverage-gated suite does not run on event ${EVENT_NAME:-<empty>} with changes code=${CHANGES_CODE:-<empty>} (CHAOS-2586)"
+
+if [[ -n "${FAILURES}" ]]; then
+  gate_failed
+fi
+
+printf 'test gate passed\n'

--- a/tests/tooling/test_aggregate_test_results.py
+++ b/tests/tooling/test_aggregate_test_results.py
@@ -1,0 +1,368 @@
+"""Contract for the required `test` gate's verdict (CHAOS-3482).
+
+The aggregator in ``.github/workflows/test.yml`` used to read only
+``needs.test-matrix.result`` and ``needs.coverage.result`` and accept
+``skipped`` from either. On 2026-08-06 (PR #1528, runs during a declared
+GitHub Actions outage) the ``changes`` job failed -- and on a rerun, was
+cancelled -- in "Set up job". Both test jobs then evaluated their ``if:`` to
+false and reported ``skipped``, the ``success|skipped`` arm matched, and the
+single REQUIRED check reported SUCCESS on a run in which zero tests ran.
+Reproduced 2 of 2 attempts.
+
+Why this needs a table and not one regression test: ``skipped`` is a
+legitimate pass in this workflow. ``coverage`` is excluded from every
+``pull_request`` by design (CHAOS-2586), and ``test-matrix`` is excluded from
+docs-only changes by the path filter. A repair that simply rejects ``skipped``
+turns every PR red; one that keeps accepting it leaves the hole open. The
+distinguishing information is not in the skipped job's result at all -- it is
+in ``changes``: whether the gating decision completed, and what it decided.
+The rows below are exactly the pairs that share a literal result string and
+must reach opposite verdicts.
+
+These tests execute the REAL ``ci/aggregate_test_results.sh`` -- the file the
+workflow runs, byte for byte -- not a reimplementation of its rules. The
+second half parses ``test.yml`` and asserts the ``if:`` conditions that the
+script mirrors still say what it models, so the script and the workflow cannot
+drift apart while every row here keeps passing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ci" / "aggregate_test_results.sh"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "test.yml"
+
+_PASS = True
+_FAIL = False
+
+# (id, event, changes result, changes code, test-matrix result, coverage
+# result, expected verdict). "code" is `needs.changes.outputs.code`, which is
+# the empty string whenever `changes` did not complete.
+_MATRIX: list[tuple[str, str, str, str, str, str, bool]] = [
+    # --- the incident, both observed upstream states -------------------------
+    ("changes-failure", "pull_request", "failure", "", "skipped", "skipped", _FAIL),
+    # The rerun 35 minutes later: `changes` cancelled, both test jobs reporting
+    # the same benign-looking `skipped` as a docs-only PR. This is the row the
+    # pre-fix rule passed.
+    (
+        "changes-cancelled-jobs-skipped",
+        "pull_request",
+        "cancelled",
+        "",
+        "skipped",
+        "skipped",
+        _FAIL,
+    ),
+    # A superseded push, where the cancellation reaches the test jobs too.
+    (
+        "changes-cancelled-jobs-cancelled",
+        "pull_request",
+        "cancelled",
+        "",
+        "cancelled",
+        "cancelled",
+        _FAIL,
+    ),
+    # `changes` has no `if:`, so a skip means something stranger still went
+    # wrong upstream. Unknown state is not evidence.
+    ("changes-skipped", "pull_request", "skipped", "", "skipped", "skipped", _FAIL),
+    ("everything-empty", "pull_request", "", "", "", "", _FAIL),
+    (
+        "changes-unknown-word",
+        "pull_request",
+        "neutral",
+        "",
+        "skipped",
+        "skipped",
+        _FAIL,
+    ),
+    # --- the legitimate passes that a naive "reject skipped" fix would break --
+    ("normal-pr", "pull_request", "success", "true", "success", "skipped", _PASS),
+    ("docs-only-pr", "pull_request", "success", "false", "skipped", "skipped", _PASS),
+    ("docs-only-push", "push", "success", "false", "skipped", "skipped", _PASS),
+    ("main-push", "push", "success", "true", "success", "success", _PASS),
+    ("merge-queue", "merge_group", "success", "false", "success", "success", _PASS),
+    ("dispatch", "workflow_dispatch", "success", "true", "success", "success", _PASS),
+    # --- skips that share the literal string but are NOT legitimate ----------
+    # Same `test-matrix: skipped` as docs-only-pr, opposite verdict: the path
+    # filter selected the job to run.
+    (
+        "matrix-skipped-but-selected",
+        "pull_request",
+        "success",
+        "true",
+        "skipped",
+        "skipped",
+        _FAIL,
+    ),
+    # dorny/paths-filter has no base/head diff in the merge queue and can
+    # report code=false, so test-matrix runs there unconditionally; a skip
+    # means an untested change is entering main.
+    (
+        "merge-queue-matrix-skipped",
+        "merge_group",
+        "success",
+        "false",
+        "skipped",
+        "success",
+        _FAIL,
+    ),
+    (
+        "merge-queue-coverage-skipped",
+        "merge_group",
+        "success",
+        "true",
+        "success",
+        "skipped",
+        _FAIL,
+    ),
+    # Same `coverage: skipped` as normal-pr, opposite verdict: off a PR with
+    # gated paths touched, the coverage job was selected.
+    (
+        "push-coverage-skipped-but-selected",
+        "push",
+        "success",
+        "true",
+        "success",
+        "skipped",
+        _FAIL,
+    ),
+    # --- downstream failures: current behaviour, must not regress ------------
+    ("matrix-failure", "pull_request", "success", "true", "failure", "skipped", _FAIL),
+    (
+        "matrix-cancelled",
+        "pull_request",
+        "success",
+        "true",
+        "cancelled",
+        "skipped",
+        _FAIL,
+    ),
+    ("coverage-failure", "push", "success", "true", "success", "failure", _FAIL),
+    ("coverage-cancelled", "push", "success", "true", "success", "cancelled", _FAIL),
+    (
+        "matrix-unknown-word",
+        "pull_request",
+        "success",
+        "true",
+        "neutral",
+        "skipped",
+        _FAIL,
+    ),
+]
+
+
+def _run(
+    *,
+    event: str,
+    changes: str,
+    code: str,
+    matrix: str,
+    coverage: str,
+    script: Path = SCRIPT,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "EVENT_NAME": event,
+            "CHANGES_RESULT": changes,
+            "CHANGES_CODE": code,
+            "MATRIX_RESULT": matrix,
+            "COVERAGE_RESULT": coverage,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("event", "changes", "code", "matrix", "coverage", "expected_pass"),
+    [pytest.param(*row[1:], id=row[0]) for row in _MATRIX],
+)
+def test_gate_verdict(
+    event: str,
+    changes: str,
+    code: str,
+    matrix: str,
+    coverage: str,
+    expected_pass: bool,
+) -> None:
+    # Given one combination of upstream job results the required gate can see
+    # When the real aggregation script judges it
+    proc = _run(
+        event=event, changes=changes, code=code, matrix=matrix, coverage=coverage
+    )
+
+    # Then the verdict is the one the check's meaning demands -- asserted on the
+    # exit status the required check actually consumes, AND on the printed
+    # verdict, so a script that exits 1 from an unrelated `set -e` trip cannot
+    # masquerade as this guard firing.
+    if expected_pass:
+        assert proc.returncode == 0, (
+            f"expected the gate to PASS for {event}/{changes}/code={code!r}/"
+            f"{matrix}/{coverage}; stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+        assert "test gate passed" in proc.stdout
+        assert "test gate failed" not in proc.stderr
+    else:
+        assert proc.returncode == 1, (
+            f"expected the gate to FAIL for {event}/{changes}/code={code!r}/"
+            f"{matrix}/{coverage}; stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+        assert "test gate failed" in proc.stderr
+        assert "test gate passed" not in proc.stdout
+
+
+def test_failure_output_names_the_upstream_job_that_caused_it() -> None:
+    # Given the incident's exact state
+    proc = _run(
+        event="pull_request",
+        changes="failure",
+        code="",
+        matrix="skipped",
+        coverage="skipped",
+    )
+
+    # Then the reason blames `changes`, not the two jobs that merely skipped:
+    # a gate that fails for the wrong stated reason sends the next responder to
+    # the wrong place.
+    assert proc.returncode == 1
+    assert "changes reported 'failure'" in proc.stderr
+
+
+def test_legitimate_skips_are_reported_with_their_reason() -> None:
+    # Given a docs-only pull request, where BOTH jobs skip legitimately
+    proc = _run(
+        event="pull_request",
+        changes="success",
+        code="false",
+        matrix="skipped",
+        coverage="skipped",
+    )
+
+    # Then the log names why each skip is accepted, so a reader of a green run
+    # can check the claim rather than trust it.
+    assert proc.returncode == 0
+    assert "test-matrix skipped legitimately" in proc.stdout
+    assert "coverage skipped legitimately" in proc.stdout
+
+
+# --------------------------------------------------------------------------
+# Workflow contract. The script models the two jobs' `if:` conditions; these
+# assert the workflow still holds up its end.
+# --------------------------------------------------------------------------
+
+
+def _workflow() -> dict[str, object]:
+    loaded = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _job(name: str) -> dict[str, object]:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs[name]
+    assert isinstance(job, dict)
+    return job
+
+
+def _steps(name: str) -> list[object]:
+    steps = _job(name)["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def _normalize(expression: object) -> str:
+    assert isinstance(expression, str)
+    return " ".join(expression.split())
+
+
+def test_aggregator_consumes_the_changes_job() -> None:
+    # Given the required gate
+    test_job = _job("test")
+
+    # Then it depends on `changes` -- without this the `needs.changes.*`
+    # expressions below resolve to empty and every verdict silently degrades to
+    # the pre-CHAOS-3482 rule.
+    assert test_job["needs"] == ["changes", "test-matrix", "coverage"]
+
+    step = next(
+        candidate
+        for candidate in _steps("test")
+        if isinstance(candidate, dict)
+        and candidate.get("name") == "Aggregate test results"
+    )
+    assert step["env"] == {
+        "EVENT_NAME": "${{ github.event_name }}",
+        "CHANGES_RESULT": "${{ needs.changes.result }}",
+        "CHANGES_CODE": "${{ needs.changes.outputs.code }}",
+        "MATRIX_RESULT": "${{ needs.test-matrix.result }}",
+        "COVERAGE_RESULT": "${{ needs.coverage.result }}",
+    }
+    # And it runs the script these tests exercise, rather than an inline copy
+    # of the rules that no test would see.
+    assert "ci/aggregate_test_results.sh" in _normalize(step["run"])
+
+
+def test_aggregator_runs_unconditionally() -> None:
+    # Given a run that gets cancelled
+    # When the gate's own condition is inspected
+    # Then it is `always()`: under `!cancelled()` this job would itself be
+    # skipped, and branch protection counts a skipped REQUIRED check as
+    # satisfied -- relocating the silent pass rather than closing it.
+    assert _normalize(_job("test")["if"]) == "always()"
+
+
+def test_aggregator_checks_out_the_repository() -> None:
+    # Given the verdict now lives in a file in the repo
+    steps = _steps("test")
+
+    # Then the gate checks the repo out before running it. (A missing checkout
+    # fails closed -- the step errors -- but it would fail every run, so this
+    # is a contract assertion, not a safety one.)
+    assert any(
+        isinstance(step, dict)
+        and str(step.get("uses", "")).startswith("actions/checkout@")
+        for step in steps
+    )
+
+
+def test_script_mirrors_the_test_matrix_selection_condition() -> None:
+    # Given the script treats `test-matrix: skipped` as legitimate exactly when
+    # the event is not merge_group and code != 'true'
+    # Then that is still the job's own condition. If this assertion fails, the
+    # script's model is stale: fix ci/aggregate_test_results.sh, do not just
+    # update the string.
+    assert _normalize(_job("test-matrix")["if"]) == (
+        "github.event_name == 'merge_group' || needs.changes.outputs.code == 'true'"
+    )
+
+
+def test_script_mirrors_the_coverage_selection_condition() -> None:
+    # Same contract for coverage, whose pull_request exclusion is the reason
+    # `skipped` cannot simply be rejected.
+    assert _normalize(_job("coverage")["if"]) == (
+        "github.event_name != 'pull_request' && "
+        "(github.event_name == 'merge_group' || needs.changes.outputs.code == 'true')"
+    )
+
+
+def test_changes_job_still_publishes_the_code_output() -> None:
+    # Given the whole rule keys off `needs.changes.outputs.code`
+    changes = _job("changes")
+    outputs = changes["outputs"]
+    assert isinstance(outputs, dict)
+
+    # Then the job still publishes it. A renamed output would make CHANGES_CODE
+    # empty, which the script treats as "not 'false'" -- fail-closed, but this
+    # names the cause instead of leaving a confusing red gate.
+    assert outputs["code"] == "${{ steps.filter.outputs.code }}"

--- a/tests/tooling/test_aggregate_test_results.py
+++ b/tests/tooling/test_aggregate_test_results.py
@@ -88,7 +88,9 @@ _MATRIX: list[tuple[str, str, str, str, str, str, bool]] = [
     ("docs-only-push", "push", "success", "false", "skipped", "skipped", _PASS),
     ("main-push", "push", "success", "true", "success", "success", _PASS),
     ("merge-queue", "merge_group", "success", "false", "success", "success", _PASS),
-    ("dispatch", "workflow_dispatch", "success", "true", "success", "success", _PASS),
+    # A manual run does not run the path filter at all, so `code` is empty and
+    # `coverage` is not selected; test-matrix carries the proof.
+    ("dispatch", "workflow_dispatch", "success", "", "success", "skipped", _PASS),
     # --- skips that share the literal string but are NOT legitimate ----------
     # Same `test-matrix: skipped` as docs-only-pr, opposite verdict: the path
     # filter selected the job to run.
@@ -119,6 +121,29 @@ _MATRIX: list[tuple[str, str, str, str, str, str, bool]] = [
         "success",
         "true",
         "success",
+        "skipped",
+        _FAIL,
+    ),
+    # The hole Codex found in the first version of this fix: a manual
+    # `gh workflow run test.yml` whose path filter reported code=false skipped
+    # both jobs and the gate went green with zero tests. The filter no longer
+    # runs on dispatch (so `code` is empty), and either way a dispatch run that
+    # skipped test-matrix is not evidence.
+    (
+        "dispatch-matrix-skipped",
+        "workflow_dispatch",
+        "success",
+        "",
+        "skipped",
+        "skipped",
+        _FAIL,
+    ),
+    (
+        "dispatch-matrix-skipped-filter-false",
+        "workflow_dispatch",
+        "success",
+        "false",
+        "skipped",
         "skipped",
         _FAIL,
     ),
@@ -343,8 +368,25 @@ def test_script_mirrors_the_test_matrix_selection_condition() -> None:
     # script's model is stale: fix ci/aggregate_test_results.sh, do not just
     # update the string.
     assert _normalize(_job("test-matrix")["if"]) == (
-        "github.event_name == 'merge_group' || needs.changes.outputs.code == 'true'"
+        "github.event_name == 'merge_group' || "
+        "github.event_name == 'workflow_dispatch' || "
+        "needs.changes.outputs.code == 'true'"
     )
+
+
+def test_path_filter_does_not_run_on_manual_dispatch() -> None:
+    # Given a manual run has no base/head diff worth filtering
+    filter_step = next(
+        step
+        for step in _steps("changes")
+        if isinstance(step, dict) and step.get("id") == "filter"
+    )
+
+    # Then the filter is not consulted there. If it were, its verdict would
+    # reach `code`, and `code == 'true'` is one of the ways a job gets
+    # selected -- which is how a manual run once skipped both test jobs and
+    # still reported a green required check.
+    assert _normalize(filter_step["if"]) == "github.event_name != 'workflow_dispatch'"
 
 
 def test_script_mirrors_the_coverage_selection_condition() -> None:

--- a/tests/tooling/test_aggregate_test_results.py
+++ b/tests/tooling/test_aggregate_test_results.py
@@ -28,6 +28,7 @@ drift apart while every row here keeps passing.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -309,6 +310,62 @@ def _steps(name: str) -> list[object]:
 def _normalize(expression: object) -> str:
     assert isinstance(expression, str)
     return " ".join(expression.split())
+
+
+def _code_filter_patterns() -> list[str]:
+    filter_step = next(
+        step
+        for step in _steps("changes")
+        if isinstance(step, dict) and step.get("id") == "filter"
+    )
+    with_block = filter_step["with"]
+    assert isinstance(with_block, dict)
+    filters = yaml.safe_load(with_block["filters"])
+    assert isinstance(filters, dict)
+    patterns = filters["code"]
+    assert isinstance(patterns, list)
+    return [str(pattern) for pattern in patterns]
+
+
+def _is_covered(path: str, patterns: list[str]) -> bool:
+    for pattern in patterns:
+        if pattern == path:
+            return True
+        if pattern.endswith("/**") and path.startswith(pattern[: -len("**")]):
+            return True
+    return False
+
+
+def test_paths_filter_covers_every_file_the_test_jobs_install() -> None:
+    # Given the aggregator now formally blesses `code == 'false'` skips, the
+    # filter's file list is what decides whether a change is untested. A file
+    # the test jobs consume but the filter omits is a green required check with
+    # zero tests run -- which is what `requirements-docs.txt` was until
+    # CHAOS-3482 Codex round 2.
+    patterns = _code_filter_patterns()
+    installed: set[str] = set()
+    for job_name in ("test-matrix", "coverage"):
+        for step in _steps(job_name):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            for match in re.finditer(r"pip install -r\s+(\S+)", run):
+                installed.add(match.group(1))
+
+    # Then the set is derived from the jobs themselves (not hand-listed here,
+    # which would go stale the moment a job installs something new) ...
+    assert installed, "no `pip install -r` found -- this guard measured nothing"
+
+    # ... and every one of those files is gated by the filter.
+    uncovered = sorted(path for path in installed if not _is_covered(path, patterns))
+    assert not uncovered, (
+        f"the test jobs install {uncovered}, but the `code` path filter does "
+        f"not select on them: a PR touching only those files skips every test "
+        f"job and the required gate goes green with nothing run. Filter "
+        f"patterns: {patterns}"
+    )
 
 
 def test_aggregator_consumes_the_changes_job() -> None:

--- a/tests/tooling/test_aggregate_test_results.py
+++ b/tests/tooling/test_aggregate_test_results.py
@@ -455,6 +455,29 @@ def test_paths_filter_covers_every_file_the_test_jobs_install() -> None:
     )
 
 
+def test_paths_filter_covers_the_acceptance_runtime_dependencies() -> None:
+    # Given the acceptance suite hashes a fixed set of runtime inputs and
+    # asserts on them, a change to any of them can turn the suite red
+    from scripts.acceptance.acceptance_artifact import RUNTIME_DEPENDENCY_PATHS
+
+    patterns = _code_filter_patterns()
+
+    # Then the filter selects on all of them. Read from the production tuple,
+    # not restated here: a path added there must reach this gate without
+    # anyone remembering to update a list in a test. (docker/Dockerfile was
+    # the entry this found missing -- CHAOS-3482 Codex round 4.)
+    assert RUNTIME_DEPENDENCY_PATHS, "empty inventory -- this guard measured nothing"
+    uncovered = sorted(
+        path for path in RUNTIME_DEPENDENCY_PATHS if not _is_covered(path, patterns)
+    )
+    assert not uncovered, (
+        f"the acceptance suite depends on {uncovered}, but the `code` path "
+        f"filter does not select on them: a PR touching only those files "
+        f"skips every test job and the required gate goes green with nothing "
+        f"run. Filter patterns: {patterns}"
+    )
+
+
 def test_aggregator_consumes_the_changes_job() -> None:
     # Given the required gate
     test_job = _job("test")

--- a/tests/tooling/test_aggregate_test_results.py
+++ b/tests/tooling/test_aggregate_test_results.py
@@ -70,6 +70,31 @@ _MATRIX: list[tuple[str, str, str, str, str, str, bool]] = [
         "cancelled",
         _FAIL,
     ),
+    # A job that fails at a late step still publishes the outputs its earlier
+    # steps set, so `changes: failure` can arrive WITH a usable-looking
+    # `code=false`. These two rows exist because a mutation sweep found the
+    # `changes`-result guard otherwise unpinned at the verdict level: every
+    # other failure row is also caught by the undecided-`code` rule, so
+    # deleting the guard entirely changed no verdict. Here it is the only
+    # thing standing between a dead gating job and a green gate.
+    (
+        "changes-failure-with-published-code",
+        "pull_request",
+        "failure",
+        "false",
+        "skipped",
+        "skipped",
+        _FAIL,
+    ),
+    (
+        "changes-cancelled-with-published-code",
+        "push",
+        "cancelled",
+        "false",
+        "skipped",
+        "skipped",
+        _FAIL,
+    ),
     # `changes` has no `if:`, so a skip means something stranger still went
     # wrong upstream. Unknown state is not evidence.
     ("changes-skipped", "pull_request", "skipped", "", "skipped", "skipped", _FAIL),
@@ -125,6 +150,30 @@ _MATRIX: list[tuple[str, str, str, str, str, str, bool]] = [
         "skipped",
         _FAIL,
     ),
+    # The merge queue selects coverage through its own clause, independent of
+    # `code` -- so a merge-queue coverage skip is illegitimate even when the
+    # filter said false. (Added because a mutation that deleted only that
+    # clause changed no verdict in an earlier version of this table.)
+    (
+        "merge-queue-coverage-skipped-code-false",
+        "merge_group",
+        "success",
+        "false",
+        "success",
+        "skipped",
+        _FAIL,
+    ),
+    # And the same undecided-`code` rule applies to coverage: on a push where
+    # the filter published no decision, its skip cannot be attributed to one.
+    (
+        "push-code-empty-coverage-skipped",
+        "push",
+        "success",
+        "",
+        "success",
+        "skipped",
+        _FAIL,
+    ),
     # The hole Codex found in the first version of this fix: a manual
     # `gh workflow run test.yml` whose path filter reported code=false skipped
     # both jobs and the gate went green with zero tests. The filter no longer
@@ -147,6 +196,44 @@ _MATRIX: list[tuple[str, str, str, str, str, str, bool]] = [
         "skipped",
         "skipped",
         _FAIL,
+    ),
+    # Codex round 3: `changes` succeeded but published no usable decision --
+    # a renamed output, a filter step made conditional, a filter that produced
+    # no key. "Not 'true'" used to read as "docs-only", so an undecided filter
+    # bought a green check with nothing run. Only a literal 'false' explains a
+    # skip.
+    ("pr-code-empty", "pull_request", "success", "", "skipped", "skipped", _FAIL),
+    (
+        "pr-code-not-a-boolean",
+        "pull_request",
+        "success",
+        "neutral",
+        "skipped",
+        "skipped",
+        _FAIL,
+    ),
+    ("push-code-empty", "push", "success", "", "skipped", "skipped", _FAIL),
+    # ... but an undecided `code` on a run where the jobs DID execute is not a
+    # gate failure. Fail-closed must not mean fail-noisy: these two would be
+    # red if the rule above were a hard validation of `code` instead of a
+    # question about whether a skip can be explained.
+    (
+        "pr-code-empty-but-matrix-ran",
+        "pull_request",
+        "success",
+        "",
+        "success",
+        "skipped",
+        _PASS,
+    ),
+    (
+        "merge-queue-code-empty",
+        "merge_group",
+        "success",
+        "",
+        "success",
+        "success",
+        _PASS,
     ),
     # Same `coverage: skipped` as normal-pr, opposite verdict: off a PR with
     # gated paths touched, the coverage job was selected.


### PR DESCRIPTION
Fixes CHAOS-3482.

## The defect

The required `test` aggregator read only `needs.test-matrix.result` and `needs.coverage.result`, and treated `skipped` as a pass. During the 2026-08-06 Actions outage the upstream `changes` job failed — and on a rerun 35 minutes later, was cancelled — in "Set up job". Both test jobs then evaluated their `if:` to false and reported `skipped`, the `success|skipped` arm matched, and the single REQUIRED check reported **SUCCESS on a run where zero tests executed**. Reproduced 2 of 2 attempts. Only `changes: FAILURE` also appearing in the rollup made the PR mergeable-blocked; a `cancelled` upstream would not have.

`skipped` cannot simply be rejected. `coverage` is excluded from every `pull_request` by design (CHAOS-2586) and `test-matrix` is excluded from docs-only changes by the path filter, so rejecting the literal string turns every PR red. **The reason a skip is legitimate is never in the skipped job's own result** — it is in `changes`: whether the gating decision completed, and what it decided.

## The fix

The verdict moves out of the inline step into `ci/aggregate_test_results.sh`, and the `test` job now `needs: [changes, test-matrix, coverage]`, passing `github.event_name`, `needs.changes.result` and `needs.changes.outputs.code`.

The rule: **a skip is legitimate only when the job's own `if:` provably selected against it**, which requires `code` to be *literally* `false` — not merely "not `true`". `changes != success` fails immediately, because a gating decision that did not complete makes every downstream result uninformative rather than merely suspicious.

`if: always()` is kept deliberately, and pinned by a test. Under `!cancelled()` (proposed on #1432) a cancelled run leaves the required check **skipped**, and branch protection counts a skipped required check as satisfied — that relocates the silent pass one level up instead of closing it. Cancellation must be reported by a job that ran.

### Full verdict matrix

| event | changes | code | test-matrix | coverage | verdict | why |
|---|---|---|---|---|---|---|
| pull_request | failure | — | skipped | skipped | **FAIL** | the incident |
| pull_request | cancelled | — | skipped | skipped | **FAIL** | the rerun, same false green |
| pull_request | cancelled | — | cancelled | cancelled | **FAIL** | superseded push |
| pull_request | failure | false | skipped | skipped | **FAIL** | a late-failing job still publishes earlier outputs |
| push | cancelled | false | skipped | skipped | **FAIL** | same |
| pull_request | skipped / empty / garbage | — | skipped | skipped | **FAIL** | unknown state is not evidence |
| pull_request | success | true | success | skipped | pass | normal PR (coverage excluded by design) |
| pull_request | success | false | skipped | skipped | pass | docs-only PR |
| push | success | false | skipped | skipped | pass | docs-only push |
| push | success | true | success | success | pass | main |
| merge_group | success | false | success | success | pass | merge queue runs both regardless of `code` |
| workflow_dispatch | success | — | success | skipped | pass | manual run; filter not run there |
| pull_request | success | true | skipped | skipped | **FAIL** | selected, yet skipped |
| merge_group | success | false | skipped | success | **FAIL** | merge queue skip is never legitimate |
| merge_group | success | false | success | skipped | **FAIL** | coverage is selected by the merge_group clause |
| workflow_dispatch | success | — / false | skipped | skipped | **FAIL** | a manual run that tested nothing |
| push | success | true | success | skipped | **FAIL** | coverage was selected |
| pull_request | success | — | skipped | skipped | **FAIL** | undecided filter ≠ docs-only |
| push | success | — | success | skipped | **FAIL** | same, for coverage |
| pull_request | success | — | success | skipped | pass | undecided `code`, but the job ran |
| merge_group | success | — | success | success | pass | same |
| any | success | true | failure / cancelled / unknown | * | **FAIL** | unchanged behaviour |
| any | success | true | * | failure / cancelled / unknown | **FAIL** | unchanged behaviour |

## Verification

A green run is what this bug *is*, so none is offered as proof.

**The guard observed failing.** The pre-fix aggregator was materialized from `origin/main`'s inline step and driven through the identical table: **17 of 32 rows wrong**. Post-fix: **0 of 32**. The two workflow-contract tests are RED against main's `test.yml`.

**Clause-level mutation, script.** Ten mutations, each deleting exactly one clause and each `bash -n`-valid: drop the `changes`-result guard; never select test-matrix; drop the merge_group exemption; drop the workflow_dispatch exemption; revert to "not `true`" selection; drop coverage's pull_request exclusion; drop its workflow_dispatch exclusion; drop its merge_group clause; make coverage treat undecided `code` as unselected; accept an unrecognized result. **10/10 killed, each by a named row.** The sweep found three guards that no row uniquely pinned — the four rows that close those are in the table above, added because of it.

**Mutation, workflow.** Ten defects planted in `test.yml` — drop `changes` from `needs`, `always()` → `!cancelled()`, drop `EVENT_NAME` from the step env, drop each `if:` clause, re-enable the filter on dispatch, rename the `code` output, drop the checkout, remove `requirements-docs.txt`, remove `docker/**` — each observed failing its specific guard, with the file restored byte-identical afterwards.

**Not a source-digest test.** The tests execute the real `ci/aggregate_test_results.sh` that the workflow runs, and derive their expectations from production sources: the two test jobs' own `pip install -r` targets, and `scripts/acceptance`'s `RUNTIME_DEPENDENCY_PATHS`. Both guards fail loudly on an empty measurement rather than passing when they find nothing.

`shellcheck` clean; `actionlint` clean apart from the pre-existing `ubuntu-26.04-arm` label notes; 92 tests pass across `tests/tooling` and the three other files that parse `test.yml`.

## Four more zero-test greens, found by adversarial review and fixed here

1. **workflow_dispatch.** A manual `gh workflow run test.yml` computed `code` against the default branch; a ref with no gated paths reported `code=false`, skipped both jobs, and passed. Now the filter does not run on dispatch and `test-matrix` is selected there unconditionally — the construction `lint.yml` and `typecheck.yml` already use.
2. **`requirements-docs.txt`.** Both test jobs install it before running anything, but it was not in the `code` filter, so a PR touching only it skipped everything and passed. Gated; the guard reads the jobs' own install commands rather than a hand-kept list.
3. **Undecided `code`.** After `changes` succeeded, "not `true`" read as docs-only — so a renamed output or a filter that published no decision bought a green check with nothing run. Selection is now the inverse question, and this deliberately is *not* a validation of `code`: on runs where the jobs executed, an odd value changes nothing, so fail-closed does not become fail-noisy.
4. **`docker/**`.** `docker/Dockerfile` is one of the acceptance suite's `RUNTIME_DEPENDENCY_PATHS` — hashed and asserted on — but was ungated. Added, with a guard that reads that production tuple.

## Known adjacent gaps, not fixed here

- **CHAOS-3513** — `lint.yml` and `typecheck.yml` carry the identical aggregator shape (`success|skipped`, no view of their own upstream `changes`). Same defect, same reachability. Mechanical follow-up: adopt this PR's script, no new design.
- **CHAOS-3514** — `tests/docs/*.py` run in this workflow's unit tier and read `docs/**` and `mkdocs.yml`, which the `code` filter does not select on, while `docs-guards.yml` runs standalone scripts rather than those tests. A docs-only PR can therefore break a `tests/docs` assertion that no gate executes. Closing it is a policy choice (full suite on every docs PR) or an ownership move, so it is filed for a decision rather than fixed here.
- Nothing here proves the path filter **complete**. The two guards cover what is derivable from production sources; a file that matters to the suite but appears in neither can still be missing.
