### PR TITLE
CHAOS-3123: compose the github work-item effect layer (sink constructor + multi-day deriver)

### DIFF
--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -447,6 +447,34 @@ question.
       hard requirement for these tests, not a nice-to-have, and say so at
       the top of any new oracle pair file that reaches outside
       `testdata/`.
+    - **REQUIREMENT: set `PYTHON` to the worktree's `.venv` for any DIRECT
+      `go test` run of a live oracle.** `pythonExecutable`
+      (`capabilities_test.go`) uses `$PYTHON`, else `python3` from `PATH`. If
+      `PATH` resolves to an ambient virtualenv (a pyenv `VIRTUAL_ENV` exported
+      by a shell profile, say) whose `dev_health_ops` is editable-installed
+      against a DIFFERENT worktree, a pair that imports the producer directly
+      (`from dev_health_ops.metrics... import ...`) compares your branch's Go
+      against **another checkout's Python** and reports PASS.
+      `ci/check_go.sh live-python-oracles` is safe: it exports
+      `PYTHONPATH="${ROOT}/src"` before `go test` (check_go.sh:230), which
+      precedes site-packages on `sys.path`. A bare `go test` carrying only the
+      two oracle env vars has no such protection. Measured both ways on one
+      branch: the bare run FAILs with `ImportError: cannot import name X from
+      'dev_health_ops...' (/…/ops-worktrees/<other>/src/…)`; the identical
+      command with `PYTHONPATH=$PWD/src` passes. The import error is the LUCKY
+      shape — loud. The dangerous shape is a foreign producer that imports
+      cleanly and quietly answers the comparison.
+      SCOPE: this reaches pairs that import `dev_health_ops` directly. Pairs
+      going through `load_live_module` are protected by its own
+      origin assertion and module-shadowing, measured separately as producing
+      byte-identical output under either interpreter — so a green
+      `load_live_module` pair is NOT automatically suspect.
+      Do NOT verify with `import dev_health_ops`: it reports the installed
+      package rather than what the pair loaded, and false-alarms on
+      `load_live_module` pairs. Verify what the PAIR resolved — for a
+      direct-import pair, `inspect.getsourcefile(<the imported producer>)`
+      must land inside the current worktree. This trap consumed real evidence
+      twice in one session (CHAOS-3123).
     - **A shared mutation harness proof command with no cache-bypass can
       report a false SURVIVED (or, worse, a false KILLED) depending on
       unrelated prior `go test` invocations in the same session** —

--- a/internal/providersync/github_work_items_composition.go
+++ b/internal/providersync/github_work_items_composition.go
@@ -1,0 +1,357 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// ErrGitHubWorkItemSinkIncomplete reports a composite sink built while one or
+// more destination adapters are unported. It always wraps the destination names
+// so a caller learns WHICH surfaces are absent, never only that some are.
+var ErrGitHubWorkItemSinkIncomplete = errors.New(
+	"github work-item clickhouse sink is missing destination adapters",
+)
+
+// NewGitHubWorkItemClickHouseEffects wires every landed destination adapter
+// onto the composite sink.
+//
+// It REGISTERS AND ACTIVATES NOTHING. cmd/dev-health-worker/provider_sync.go
+// gains no case for the work-item family here, the provider matrix still marks
+// all five aliases route_ready: false, and the route still returns a nil
+// watermark -- so the only thing that can reach this constructor today is a
+// test. Activation is a separate change that must first satisfy the unmet D17
+// obligation recorded on GitHubWorkItemsIncomplete.
+//
+// The returned sink is USABLE ONLY when the error is nil. On an incomplete
+// build the sink is returned alongside the error rather than zeroed, because
+// the caller that wants to report the gap needs MissingDestinations from it;
+// every write and readback still fails closed through complete().
+//
+// Lease flow mirrors the established BuildExecutor pattern: one ClickHouse
+// connection and the LeaseSession that owns the claim, passed to every adapter
+// that accepts a guard. The seven direct adapters deliberately hold no guard of
+// their own -- the composite asserts the lease before and after each write on
+// their behalf -- so the guard here is the only one they get.
+func NewGitHubWorkItemClickHouseEffects(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+) (GitHubWorkItemClickHouseEffects, error) {
+	if conn == nil || lease == nil {
+		return GitHubWorkItemClickHouseEffects{}, ErrInvalidConfiguration
+	}
+	sink := GitHubWorkItemClickHouseEffects{
+		Lease: lease,
+
+		// Seven direct fact surfaces.
+		AIAttribution:        GitHubAIAttributionClickHouseAdapter{Conn: conn},
+		Sprints:              GitHubSprintsClickHouseAdapter{Conn: conn},
+		WorkItemDependencies: GitHubWorkItemDependenciesClickHouseAdapter{Conn: conn},
+		WorkItemInteractions: GitHubWorkItemInteractionsClickHouseAdapter{Conn: conn},
+		WorkItemReopenEvents: GitHubWorkItemReopenEventsClickHouseAdapter{Conn: conn},
+		WorkItemTransitions:  GitHubWorkItemTransitionsClickHouseAdapter{Conn: conn},
+		WorkItems:            GitHubWorkItemsClickHouseAdapter{Conn: conn},
+
+		// Metric triplet.
+		WorkItemCycleTimes: GitHubWorkItemCycleTimesClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+		WorkItemMetricsDaily: GitHubWorkItemMetricsDailyClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+		WorkItemUserMetricsDaily: GitHubWorkItemUserMetricsDailyClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+
+		// Derived landing surfaces.
+		EstimateCoverageMetricsDaily: GitHubEstimateCoverageClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+		WorkItemStateDurationsDaily: GitHubWorkItemStateDurationsClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+		WorkItemTeamAttributions: GitHubWorkItemTeamAttributionsClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+
+		// investment_classifications_daily, investment_metrics_daily and
+		// issue_type_metrics_daily stay nil until their engines are ported.
+		// They are left unset rather than filled with a no-op adapter: a no-op
+		// would let complete() report a sink that silently writes nothing to
+		// three real tables.
+	}
+	if missing := sink.MissingDestinations(); len(missing) > 0 {
+		return sink, fmt.Errorf(
+			"%w: %s", ErrGitHubWorkItemSinkIncomplete, strings.Join(missing, ", "),
+		)
+	}
+	return sink, nil
+}
+
+// githubWorkItemDerivedOwnedDestinations is what the ported builders speak for
+// today: the metric triplet plus the three derived landing surfaces. It is a
+// strict subset of githubWorkItemDerivedDestinations, which the route requires
+// in full.
+var githubWorkItemDerivedOwnedDestinations = func() []string {
+	owned := slices.Concat(
+		githubWorkItemMetricTripletDestinations,
+		githubWorkItemDerivedSurfaceDestinations,
+	)
+	slices.Sort(owned)
+	return owned
+}()
+
+// githubWorkItemEngineDeriver is the PR-C seam for the three engine-dependent
+// destinations. It is deliberately UNEXPORTED and has no production setter: the
+// only thing that can install one is a test inside this package, which is what
+// lets the composition be proven end-to-end without fabricating the engines'
+// output in production. When the engines land they replace this seam.
+type githubWorkItemEngineDeriver interface {
+	Derive(
+		context.Context,
+		Claim,
+		githubWorkItemRows,
+		time.Time,
+		githubWorkItemDerivationContext,
+	) (map[string][]json.RawMessage, error)
+}
+
+// GitHubWorkItemDeriver implements githubWorkItemsDeriver over the ported
+// builders. It owns the multi-day loop the route's single Derive call hides.
+type GitHubWorkItemDeriver struct {
+	// Source loads the donor attribution facts. A nil Source is a
+	// configuration error, never a reason to derive without context: a missing
+	// donor writes a DIFFERENT team onto every derived surface rather than
+	// omitting a row, which D17 ratifies as fail-closed.
+	Source githubWorkItemDerivationContextSource
+
+	// engine is nil in every production build; see githubWorkItemEngineDeriver.
+	engine githubWorkItemEngineDeriver
+}
+
+// githubWorkItemDerivedMaxBackfillDays bounds the day loop.
+//
+// DIVERGENCE FROM PYTHON, deliberate: job_work_items.py bounds nothing here
+// because its window arrives from a CLI flag an operator typed. A sync unit's
+// window arrives from the planner, which chunks backfills (backfill.chunker),
+// so a window wider than a year means the chunker did not run -- and every day
+// in the loop re-derives every surface over the full row set. Failing closed on
+// an absurd window is the same rail, for the same reason, as the 100k donor cap
+// in loadGitHubWorkItemDerivationContext: a silently enormous loop produces a
+// confidently wrong-looking result far later than an immediate refusal does.
+const githubWorkItemDerivedMaxBackfillDays = 366
+
+// githubWorkItemDerivedDays mirrors resolve_date_range (utils/cli.py:81-117)
+// composed with _date_range (job_work_items.py:112-117), which together produce
+// the `days` list that job_work_items.py:1210 iterates.
+//
+// Python works in whole dates; a sync unit carries instants. The mapping:
+//
+//   - `before` is EXCLUSIVE, so the last included day is the day containing the
+//     last instant strictly before BeforeAt. Expressing it as
+//     date(BeforeAt - 1ns) reduces to Python's `before - 1 day` exactly on the
+//     midnight-aligned boundaries a date flag can produce, and keeps a
+//     mid-day BeforeAt from dropping the partially covered day it does cover.
+//   - no BeforeAt means Python's default `before = utc_today() + 1 day`, whose
+//     end_day is today. normalizedAt is this run's clock, so its UTC date is
+//     that day.
+//   - SinceAt present computes backfill_days from the range, as cli.py:108-112
+//     does; absent, the range is the single end day (backfill defaults to 1).
+//
+// Days ascend, matching the order Python appends rows in.
+func githubWorkItemDerivedDays(claim Claim, normalizedAt time.Time) ([]time.Time, error) {
+	if normalizedAt.IsZero() {
+		return nil, ErrInvalidConfiguration
+	}
+	endDay := githubWorkItemDerivedUTCDate(normalizedAt)
+	if claim.BeforeAt != nil {
+		if claim.BeforeAt.IsZero() {
+			return nil, ErrInvalidConfiguration
+		}
+		endDay = githubWorkItemDerivedUTCDate(claim.BeforeAt.Add(-time.Nanosecond))
+	}
+	startDay := endDay
+	if claim.SinceAt != nil {
+		if claim.SinceAt.IsZero() {
+			return nil, ErrInvalidConfiguration
+		}
+		startDay = githubWorkItemDerivedUTCDate(*claim.SinceAt)
+	}
+	if startDay.After(endDay) {
+		// cli.py:110 exits on --since after --before. A unit whose window is
+		// inverted is malformed, not an empty-but-valid range: deriving zero
+		// days would land an all-empty derived manifest that readback then
+		// treats as a successful no-op.
+		return nil, ErrInvalidConfiguration
+	}
+	days := make([]time.Time, 0, githubWorkItemDerivedMaxBackfillDays)
+	for day := startDay; !day.After(endDay); day = day.AddDate(0, 0, 1) {
+		if len(days) == githubWorkItemDerivedMaxBackfillDays {
+			return nil, ErrInvalidConfiguration
+		}
+		days = append(days, day)
+	}
+	return days, nil
+}
+
+func githubWorkItemDerivedUTCDate(value time.Time) time.Time {
+	utc := value.UTC()
+	return time.Date(utc.Year(), utc.Month(), utc.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// Derive runs every ported derived builder once per day in the unit's window.
+//
+// The derivation context is loaded ONCE, outside the loop. That mirrors
+// job_work_items.py:1195-1209, where the context and the linked-issue resolver
+// are built before `for d in days`, and it is what
+// buildGitHubWorkItemDerivedSurfaces documents as its caller's contract. A
+// per-day reload would also re-read donor facts that cannot change within a
+// run, and would give two days of one run different attribution.
+//
+// CHAOS-3494 IS MIRRORED, NOT FIXED. buildGitHubWorkItemTeamAttributions takes
+// no day, and Python calls it INSIDE the day loop
+// (job_work_items.py:1232-1239), so an n-day window recomputes and re-emits
+// byte-identical attribution rows n times. The call stays inside this loop for
+// the same reason: D16 requires the port to mirror the producer bug-for-bug so
+// the differential oracle can prove parity, and hoisting it out would silently
+// repair a defect the oracle is pinning. work_item_team_attributions is the
+// only affected surface -- every other derived destination carries `day` in its
+// rows, so its per-day output genuinely differs.
+//
+// The duplicate rows are NOT deduplicated here. They collapse at persistence:
+// the adapter applies githubWorkItemDerivedSortingKeyDedupe to both the write
+// and the readback expectation, and the table is a ReplacingMergeTree. That
+// split is deliberate and separately asserted -- multiplicity n at this layer,
+// collapse to one at the readback layer. Deduplicating here would erase the
+// mirrored defect from the manifest the oracle compares.
+func (deriver GitHubWorkItemDeriver) Derive(
+	ctx context.Context,
+	claim Claim,
+	rows githubWorkItemRows,
+	normalizedAt time.Time,
+) (map[string][]json.RawMessage, error) {
+	if ctx == nil || deriver.Source == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "work-items" ||
+		normalizedAt.IsZero() {
+		return nil, ErrInvalidConfiguration
+	}
+	days, err := githubWorkItemDerivedDays(claim, normalizedAt)
+	if err != nil {
+		return nil, err
+	}
+	derivationContext, err := loadGitHubWorkItemDerivationContext(
+		ctx, claim, rows, deriver.Source, normalizedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	// Every owned destination is present from the start, so a destination that
+	// legitimately produces no rows on any day is still reported as evaluated.
+	derived := make(map[string][]json.RawMessage, len(githubWorkItemDerivedDestinations))
+	for _, destination := range githubWorkItemDerivedOwnedDestinations {
+		derived[destination] = []json.RawMessage{}
+	}
+	for _, day := range days {
+		triplet, err := buildGitHubWorkItemMetricTriplet(
+			claim, rows, day, normalizedAt, derivationContext,
+		)
+		if err != nil {
+			return nil, err
+		}
+		tripletRows, err := triplet.derivedRows()
+		if err != nil {
+			return nil, err
+		}
+		if err := githubWorkItemMergeDerivedRows(derived, tripletRows); err != nil {
+			return nil, err
+		}
+		surfaces, err := buildGitHubWorkItemDerivedSurfaces(
+			claim, rows, day, normalizedAt, derivationContext,
+		)
+		if err != nil {
+			return nil, err
+		}
+		surfaceRows, err := surfaces.derivedRows()
+		if err != nil {
+			return nil, err
+		}
+		if err := githubWorkItemMergeDerivedRows(derived, surfaceRows); err != nil {
+			return nil, err
+		}
+	}
+	if deriver.engine != nil {
+		engineRows, err := deriver.engine.Derive(
+			ctx, claim, rows, normalizedAt, derivationContext,
+		)
+		if err != nil {
+			return nil, err
+		}
+		for destination, rows := range engineRows {
+			if !slices.Contains(githubWorkItemDerivedDestinations, destination) {
+				return nil, ErrInvalidConfiguration
+			}
+			if _, owned := derived[destination]; owned {
+				// The engine seam may not restate a destination a ported
+				// builder already owns; two producers for one destination
+				// could disagree with nothing comparing them.
+				return nil, ErrInvalidConfiguration
+			}
+			derived[destination] = rows
+		}
+	}
+	if missing := githubWorkItemMissingDerivedDestinations(derived); len(missing) > 0 {
+		// Fails closed rather than emitting empty slices for the unported
+		// destinations. An empty slice is indistinguishable from "evaluated,
+		// produced nothing", which is precisely the claim this port cannot
+		// honestly make about a metric whose engine does not exist yet.
+		return nil, fmt.Errorf(
+			"%w: %s",
+			ErrGitHubWorkItemsDerivationsUnavailable, strings.Join(missing, ", "),
+		)
+	}
+	return derived, nil
+}
+
+// githubWorkItemMergeDerivedRows appends one builder's output onto the
+// accumulator. Appending rather than assigning is what preserves per-day
+// accumulation across the loop, including the CHAOS-3494 duplicates.
+func githubWorkItemMergeDerivedRows(
+	derived map[string][]json.RawMessage,
+	produced map[string][]json.RawMessage,
+) error {
+	for destination, rows := range produced {
+		existing, owned := derived[destination]
+		if !owned {
+			// A builder claiming a destination outside the owned set means the
+			// subsets have drifted apart; landing it would give one
+			// destination two producers.
+			return ErrInvalidConfiguration
+		}
+		derived[destination] = append(existing, rows...)
+	}
+	return nil
+}
+
+// githubWorkItemMissingDerivedDestinations names the canonical derived
+// destinations the deriver could not produce, in canonical order.
+func githubWorkItemMissingDerivedDestinations(
+	derived map[string][]json.RawMessage,
+) []string {
+	missing := make([]string, 0, len(githubWorkItemDerivedDestinations))
+	for _, destination := range githubWorkItemDerivedDestinations {
+		if _, produced := derived[destination]; !produced {
+			missing = append(missing, destination)
+		}
+	}
+	return missing
+}
+
+var _ githubWorkItemsDeriver = GitHubWorkItemDeriver{}

--- a/internal/providersync/github_work_items_composition.go
+++ b/internal/providersync/github_work_items_composition.go
@@ -33,8 +33,15 @@ var ErrGitHubWorkItemSinkIncomplete = errors.New(
 //
 // The returned sink is USABLE ONLY when the error is nil. On an incomplete
 // build the sink is returned alongside the error rather than zeroed, because
-// the caller that wants to report the gap needs MissingDestinations from it;
-// every write and readback still fails closed through complete().
+// the caller that wants to report the gap needs MissingDestinations from it.
+//
+// A caller that drops the error is still safe THROUGH THE COMMITTER, and the
+// claim stops exactly there: WriteEffect and InspectEffect are the only methods
+// EffectSink and EffectReadback expose, both go through resolve, and resolve is
+// the only caller of complete -- so every write and readback on that surface
+// fails closed. The adapter fields are exported and independently usable, so a
+// caller holding the struct can invoke one directly and never reach complete.
+// That is by design, and it is not a path the committer has.
 //
 // Lease flow mirrors the established BuildExecutor pattern: one ClickHouse
 // connection and the LeaseSession that owns the claim, passed to every adapter

--- a/internal/providersync/github_work_items_composition.go
+++ b/internal/providersync/github_work_items_composition.go
@@ -109,16 +109,44 @@ var githubWorkItemDerivedOwnedDestinations = func() []string {
 	return owned
 }()
 
+// githubWorkItemDerivedEngineDestinations is what the unported engines owe: the
+// canonical derived set minus what the ported builders already speak for.
+// Derived rather than hand-listed, so it cannot disagree with either.
+var githubWorkItemDerivedEngineDestinations = func() []string {
+	owed := make([]string, 0, len(githubWorkItemDerivedDestinations))
+	for _, destination := range githubWorkItemDerivedDestinations {
+		if !slices.Contains(githubWorkItemDerivedOwnedDestinations, destination) {
+			owed = append(owed, destination)
+		}
+	}
+	return owed
+}()
+
 // githubWorkItemEngineDeriver is the PR-C seam for the three engine-dependent
 // destinations. It is deliberately UNEXPORTED and has no production setter: the
 // only thing that can install one is a test inside this package, which is what
 // lets the composition be proven end-to-end without fabricating the engines'
 // output in production. When the engines land they replace this seam.
+//
+// IT TAKES A DAY AND IS CALLED ONCE PER DAY. All three destinations it will
+// serve are per-day in Python and stamp `day=d` on every row: issue-type
+// metrics (job_work_items.py:1346), investment classifications (:1387) and
+// investment metrics (:1433) are all built inside the :1238 day loop, from
+// state that resets each iteration. A seam invoked once for the whole window
+// could not express that shape -- and a merge that ASSIGNED rather than
+// appended would silently keep only the last day's rows the moment a real
+// per-day engine replaced the stub. Shaped correctly now, while the only
+// implementation is a test double and the change costs nothing.
+//
+// PR-C OBLIGATION: the ported engines emit rows for the day they are handed,
+// not for the window. The per-day merge accumulates across days exactly as it
+// does for the ported builders.
 type githubWorkItemEngineDeriver interface {
 	Derive(
 		context.Context,
 		Claim,
 		githubWorkItemRows,
+		time.Time,
 		time.Time,
 		githubWorkItemDerivationContext,
 	) (map[string][]json.RawMessage, error)
@@ -151,7 +179,7 @@ const githubWorkItemDerivedMaxBackfillDays = 366
 
 // githubWorkItemDerivedDays mirrors resolve_date_range (utils/cli.py:81-117)
 // composed with _date_range (job_work_items.py:112-117), which together produce
-// the `days` list that job_work_items.py:1210 iterates.
+// the `days` list that job_work_items.py:1238 iterates.
 //
 // Python works in whole dates; a sync unit carries instants. The mapping:
 //
@@ -210,7 +238,7 @@ func githubWorkItemDerivedUTCDate(value time.Time) time.Time {
 // Derive runs every ported derived builder once per day in the unit's window.
 //
 // The derivation context is loaded ONCE, outside the loop. That mirrors
-// job_work_items.py:1195-1209, where the context and the linked-issue resolver
+// job_work_items.py:1216-1236, where the context and the linked-issue resolver
 // are built before `for d in days`, and it is what
 // buildGitHubWorkItemDerivedSurfaces documents as its caller's contract. A
 // per-day reload would also re-read donor facts that cannot change within a
@@ -218,7 +246,7 @@ func githubWorkItemDerivedUTCDate(value time.Time) time.Time {
 //
 // CHAOS-3494 IS MIRRORED, NOT FIXED. buildGitHubWorkItemTeamAttributions takes
 // no day, and Python calls it INSIDE the day loop
-// (job_work_items.py:1232-1239), so an n-day window recomputes and re-emits
+// (job_work_items.py:1260), so an n-day window recomputes and re-emits
 // byte-identical attribution rows n times. The call stays inside this loop for
 // the same reason: D16 requires the port to mirror the producer bug-for-bug so
 // the differential oracle can prove parity, and hoisting it out would silently
@@ -286,25 +314,17 @@ func (deriver GitHubWorkItemDeriver) Derive(
 		if err := githubWorkItemMergeDerivedRows(derived, surfaceRows); err != nil {
 			return nil, err
 		}
-	}
-	if deriver.engine != nil {
+		if deriver.engine == nil {
+			continue
+		}
 		engineRows, err := deriver.engine.Derive(
-			ctx, claim, rows, normalizedAt, derivationContext,
+			ctx, claim, rows, day, normalizedAt, derivationContext,
 		)
 		if err != nil {
 			return nil, err
 		}
-		for destination, rows := range engineRows {
-			if !slices.Contains(githubWorkItemDerivedDestinations, destination) {
-				return nil, ErrInvalidConfiguration
-			}
-			if _, owned := derived[destination]; owned {
-				// The engine seam may not restate a destination a ported
-				// builder already owns; two producers for one destination
-				// could disagree with nothing comparing them.
-				return nil, ErrInvalidConfiguration
-			}
-			derived[destination] = rows
+		if err := githubWorkItemMergeEngineRows(derived, engineRows); err != nil {
+			return nil, err
 		}
 	}
 	if missing := githubWorkItemMissingDerivedDestinations(derived); len(missing) > 0 {
@@ -336,6 +356,32 @@ func githubWorkItemMergeDerivedRows(
 			return ErrInvalidConfiguration
 		}
 		derived[destination] = append(existing, rows...)
+	}
+	return nil
+}
+
+// githubWorkItemMergeEngineRows accumulates the engine seam's per-day output.
+//
+// It deliberately does NOT pre-open the engine's destinations. A key is created
+// only by an engine that actually emitted for it, so a destination the engine
+// never produced stays ABSENT and the missing-destination check fails the run
+// closed. Pre-opening them would hand every unported destination an empty slice
+// -- indistinguishable from "evaluated, produced nothing", which is exactly the
+// fabrication this deriver exists to refuse.
+//
+// Membership is checked against the ENGINE's destinations rather than against
+// presence in `derived`, so an engine restating a ported builder's destination
+// is rejected instead of giving that surface two producers with nothing
+// comparing them.
+func githubWorkItemMergeEngineRows(
+	derived map[string][]json.RawMessage,
+	produced map[string][]json.RawMessage,
+) error {
+	for destination, rows := range produced {
+		if !slices.Contains(githubWorkItemDerivedEngineDestinations, destination) {
+			return ErrInvalidConfiguration
+		}
+		derived[destination] = append(derived[destination], rows...)
 	}
 	return nil
 }

--- a/internal/providersync/github_work_items_composition_integration_test.go
+++ b/internal/providersync/github_work_items_composition_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// This file proves the READBACK half of the two-layer CHAOS-3494 assertion.
+//
+// The manifest half lives in github_work_items_composition_test.go: an n-day
+// window emits n byte-identical work_item_team_attributions rows, mirroring
+// Python's in-loop call to a builder that takes no `day`. This file proves what
+// happens to those duplicates at persistence, against the REAL schema.
+//
+// It is the assertion the composition layer could not safely inherit. If a
+// duplicate-carrying batch answered Conflict, the effect committer would rewrite
+// the destination on every recovery pass forever, and mirroring the Python defect
+// would have turned a harmless write amplification into an unbounded one.
+
+// githubWorkItemMultiDayAttributionRows is what GitHubWorkItemDeriver produces
+// for an n-day window: the SAME row, n times. computed_at is constant across the
+// loop because Python passes one computed_at into every day's call, which is
+// precisely why the copies are byte-identical rather than merely similar.
+func githubWorkItemMultiDayAttributionRows(days int) []githubWorkItemTeamAttributionRow {
+	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	teamID, teamName := "t1", "Team One"
+	row := githubWorkItemTeamAttributionRow{
+		WorkItemID: "acme/api#1", Provider: "github", Source: "repo_ownership",
+		IsPrimary: 1, Confidence: "high", Evidence: "repo:acme/api",
+		// Non-zero nanoseconds: the column is DateTime64(3), so a builder that
+		// failed to quantize would store a different value than it compared.
+		ComputedAt: time.Date(2026, 8, 5, 0, 30, 0, 123456789, time.UTC),
+		RepoID:     &repoID, TeamID: &teamID, TeamName: &teamName,
+		OrgID: githubDerivedIntegrationOrg,
+	}
+	rows := make([]githubWorkItemTeamAttributionRow, 0, days)
+	for range days {
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// TestGitHubWorkItemTeamAttributionsAnswerExactForMultiDayDuplicates is the
+// blocking question for the composition layer, answered by execution rather than
+// by reading the comparator.
+func TestGitHubWorkItemTeamAttributionsAnswerExactForMultiDayDuplicates(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	sink := GitHubWorkItemTeamAttributionsClickHouseEffects{
+		Conn: conn, Lease: githubDerivedIntegrationLease(),
+	}
+
+	const days = 3
+	rows := githubWorkItemMultiDayAttributionRows(days)
+	effect := githubDerivedIntegrationEffect(t, githubTeamAttributionsDestination, rows)
+	identity := githubDerivedIntegrationIdentity(githubTeamAttributionsDestination, len(rows))
+
+	// Non-vacuity: the batch must really carry the duplicates. If a future
+	// change deduplicated at the manifest layer this test would otherwise
+	// silently become an ordinary single-row readback.
+	if len(effect.Rows) != days {
+		t.Fatalf("effect carries %d rows, want %d byte-identical duplicates",
+			len(effect.Rows), days)
+	}
+	for index := 1; index < len(effect.Rows); index++ {
+		if string(effect.Rows[index]) != string(effect.Rows[0]) {
+			t.Fatalf("row[%d] differs from row[0]; the duplicates are not identical:\n%s\n%s",
+				index, effect.Rows[index], effect.Rows[0])
+		}
+	}
+
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil ||
+		inspection != EffectAbsent {
+		t.Fatalf("before write: inspection = %v, err = %v, want EffectAbsent", inspection, err)
+	}
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	// THE VERDICT. Conflict here would mean the committer rewrites this
+	// destination on every recovery pass, forever.
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil ||
+		inspection != EffectExact {
+		t.Fatalf("duplicate-carrying batch: inspection = %v, err = %v, want EffectExact",
+			inspection, err)
+	}
+
+	// Replay the identical batch, as recovery does. A rewrite loop shows up
+	// here as a verdict that stops being Exact once a second generation of
+	// duplicates is on disk.
+	if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectGitHubWorkItemEffect(ctx, identity, effect); err != nil ||
+		inspection != EffectExact {
+		t.Fatalf("replayed duplicate batch: inspection = %v, err = %v, want EffectExact",
+			inspection, err)
+	}
+
+	// And the storage side of the split: n identical rows in the manifest
+	// collapse to exactly ONE stored row. Asserted against the real table, not
+	// inferred from the ReplacingMergeTree declaration.
+	var stored uint64
+	if err := conn.QueryRow(ctx, `
+SELECT count() FROM work_item_team_attributions FINAL
+WHERE org_id = ? AND work_item_id = ? AND provider = ? AND source = ?`,
+		githubDerivedIntegrationOrg, "acme/api#1", "github", "repo_ownership",
+	).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != 1 {
+		t.Fatalf("stored rows = %d, want 1: %d-day write amplification did not collapse",
+			stored, days)
+	}
+}

--- a/internal/providersync/github_work_items_composition_integration_test.go
+++ b/internal/providersync/github_work_items_composition_integration_test.go
@@ -105,11 +105,20 @@ func TestGitHubWorkItemTeamAttributionsAnswerExactForMultiDayDuplicates(t *testi
 	// And the storage side of the split: n identical rows in the manifest
 	// collapse to exactly ONE stored row. Asserted against the real table, not
 	// inferred from the ReplacingMergeTree declaration.
+	// The fence names the FULL sorting key -- (org_id, repo_id, work_item_id,
+	// ifNull(team_id,''), source) per 051_team_attribution_dimensions.sql:91.
+	// A partial fence cannot produce a false PASS here (this table has exactly
+	// one row), but fencing the whole key is the standard: a partial one stops
+	// being equivalent the moment a sibling row exists, and that is not a
+	// property a reader should have to re-derive.
 	var stored uint64
 	if err := conn.QueryRow(ctx, `
 SELECT count() FROM work_item_team_attributions FINAL
-WHERE org_id = ? AND work_item_id = ? AND provider = ? AND source = ?`,
-		githubDerivedIntegrationOrg, "acme/api#1", "github", "repo_ownership",
+WHERE org_id = ? AND repo_id = ? AND work_item_id = ?
+  AND ifNull(team_id, '') = ? AND source = ?`,
+		githubDerivedIntegrationOrg,
+		uuid.MustParse("11111111-1111-4111-8111-111111111111"),
+		"acme/api#1", "t1", "repo_ownership",
 	).Scan(&stored); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/providersync/github_work_items_composition_oracle_test.go
+++ b/internal/providersync/github_work_items_composition_oracle_test.go
@@ -1,0 +1,167 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// The multi-day differential pair for CHAOS-3494 (#1541 review M8).
+//
+// The Go side here runs the REAL production loop -- GitHubWorkItemDeriver.Derive
+// -- rather than calling the builder n times itself. That is the whole point: a
+// test that re-implemented the loop would agree with Python about multiplicity
+// while the shipped deriver did something else entirely.
+
+// githubDerivedMultiDayOracleCases carries `Days` instead of `Day`. The window
+// is deliberately three days: two would not distinguish "repeats once" from
+// "repeats per day", and the fixture keeps one item with a team-bearing repo so
+// the compute has a real candidate to emit rather than only the unassigned
+// fallback.
+func githubDerivedMultiDayOracleCases() []oracleCase {
+	return []oracleCase{
+		{
+			ID: "three_day_backfill_repeats_attributions",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg,
+				"Days":  []any{"2026-08-03", "2026-08-04", "2026-08-05"},
+				// Whole-second ComputedAt: the stamp-quantization divergence is
+				// pinned by its own test, and letting it vary here would mix two
+				// independent properties into one comparison.
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#1", map[string]any{"story_points": 3}),
+					githubDerivedOracleItem("acme/api#2", nil),
+				},
+				"Transitions": []any{},
+			},
+		},
+	}
+}
+
+// githubMultiDayOracleSource feeds loadGitHubWorkItemDerivationContext the same
+// facts the Python pair reads, so neither side sees a fact set the other did
+// not.
+type githubMultiDayOracleSource struct {
+	facts githubWorkItemDerivationFacts
+	loads int
+}
+
+func (source *githubMultiDayOracleSource) Load(
+	context.Context, Claim, githubWorkItemDerivationLoadRequest,
+) (githubWorkItemDerivationFacts, error) {
+	source.loads++
+	return source.facts, nil
+}
+
+// TestGitHubWorkItemTeamAttributionsMatchLivePythonProductionAcrossDays is the
+// multiplicity pin. Python emits n copies because its no-day compute sits inside
+// the day loop; the Go deriver must emit the same n copies in the same order.
+func TestGitHubWorkItemTeamAttributionsMatchLivePythonProductionAcrossDays(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"github/work-items/team-attributions-multiday",
+		githubDerivedMultiDayOracleCases(),
+		func(t *testing.T, input map[string]any) githubTeamAttributionColumns {
+			t.Helper()
+			return newGitHubTeamAttributionColumns(
+				githubMultiDayOracleAttributions(t, input),
+			)
+		},
+		nil,
+	)
+}
+
+// githubMultiDayOracleAttributions runs the production deriver over the case's
+// window and decodes the destination back into typed rows.
+func githubMultiDayOracleAttributions(
+	t *testing.T, input map[string]any,
+) []githubWorkItemTeamAttributionRow {
+	t.Helper()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = input["OrgID"].(string)
+
+	days := input["Days"].([]any)
+	if len(days) < 2 {
+		t.Fatalf("multi-day case needs at least two days, got %d", len(days))
+	}
+	first, err := time.Parse("2006-01-02", days[0].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	last, err := time.Parse("2006-01-02", days[len(days)-1].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// BeforeAt is EXCLUSIVE, so it is the day AFTER the last included day --
+	// the same mapping resolve_date_range applies to its `--before` flag.
+	since := first
+	before := last.AddDate(0, 0, 1)
+	claim.SinceAt, claim.BeforeAt = &since, &before
+
+	computedAt, err := time.Parse(time.RFC3339Nano, input["ComputedAt"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rows := githubWorkItemRows{}
+	for _, raw := range input["WorkItems"].([]any) {
+		rows.WorkItems = append(rows.WorkItems, githubDerivedOracleGoItem(t, raw.(map[string]any)))
+	}
+	for _, raw := range input["Transitions"].([]any) {
+		rows.StatusTransitions = append(
+			rows.StatusTransitions, githubDerivedOracleGoTransition(t, raw.(map[string]any)),
+		)
+	}
+	for _, raw := range githubDerivedOracleList(input, "Dependencies") {
+		rows.Dependencies = append(
+			rows.Dependencies, githubDerivedOracleGoDependency(t, raw.(map[string]any)),
+		)
+	}
+
+	encodedFacts, err := json.Marshal(input["Facts"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var facts githubWorkItemDerivationFacts
+	if err := json.Unmarshal(encodedFacts, &facts); err != nil {
+		t.Fatal(err)
+	}
+	for _, raw := range githubDerivedOracleList(input, "Donors") {
+		facts.DonorItems = append(facts.DonorItems, githubWorkItemDerivationSubjectFromRow(
+			githubDerivedOracleGoItem(t, raw.(map[string]any)),
+		))
+	}
+
+	source := &githubMultiDayOracleSource{facts: facts}
+	deriver := GitHubWorkItemDeriver{Source: source, engine: githubWorkItemStubEngine{}}
+	derived, err := deriver.Derive(context.Background(), claim, rows, computedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The context load stays outside the loop on the Go side too; the Python
+	// pair builds its resolver cascade exactly once for the same reason.
+	if source.loads != 1 {
+		t.Fatalf("derivation context loads=%d want=1", source.loads)
+	}
+
+	encoded := derived[githubTeamAttributionsDestination]
+	// Non-vacuity, asserted against the case's own day count rather than a
+	// literal: a window that silently collapsed to one day would otherwise
+	// compare clean against a Python side that had also been handed one day.
+	if len(encoded) == 0 || len(encoded)%len(days) != 0 {
+		t.Fatalf("attribution rows=%d over %d days; expected a whole multiple",
+			len(encoded), len(days))
+	}
+	attributions := make([]githubWorkItemTeamAttributionRow, 0, len(encoded))
+	for _, raw := range encoded {
+		var row githubWorkItemTeamAttributionRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		attributions = append(attributions, row)
+	}
+	return attributions
+}

--- a/internal/providersync/github_work_items_composition_test.go
+++ b/internal/providersync/github_work_items_composition_test.go
@@ -328,6 +328,115 @@ func TestGitHubWorkItemDerivedDaysFailsClosedOnUnusableWindows(t *testing.T) {
 	}
 }
 
+// TestGitHubWorkItemEngineSeamIsInvokedPerDay pins the shape PR-C has to fill.
+// All three engine destinations are per-day in Python and stamp `day=d`
+// (job_work_items.py:1346/:1387/:1433, inside the :1238 loop), so a seam called
+// once per window could not express them -- and a merge that assigned rather
+// than appended would keep only the last day once a real engine replaced the
+// stub. Both failures are invisible while the stub returns empty, which is why
+// this asserts the days reaching the seam and the accumulated row count.
+func TestGitHubWorkItemEngineSeamIsInvokedPerDay(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	since := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	claim.SinceAt, claim.BeforeAt = &since, &before
+	recorder := &githubWorkItemRecordingEngine{}
+	deriver := GitHubWorkItemDeriver{
+		Source: &fakeGitHubWorkItemDerivationContextSource{}, engine: recorder,
+	}
+
+	derived, err := deriver.Derive(
+		context.Background(), claim, githubWorkItemDeriverFixture(claim),
+		time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDays := []time.Time{
+		time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
+	}
+	if !reflect.DeepEqual(recorder.days, wantDays) {
+		t.Fatalf("engine saw days=%v want=%v", recorder.days, wantDays)
+	}
+	// Accumulated, not overwritten: one row per day per destination.
+	for _, destination := range githubWorkItemUnportedDestinations {
+		rows := derived[destination]
+		if len(rows) != len(wantDays) {
+			t.Fatalf("%s has %d rows over %d days; the merge is not accumulating",
+				destination, len(rows), len(wantDays))
+		}
+		for index, row := range rows {
+			want := `{"day":"` + wantDays[index].Format("2006-01-02") + `"}`
+			if string(row) != want {
+				t.Errorf("%s row[%d]=%s want=%s", destination, index, row, want)
+			}
+		}
+	}
+}
+
+type githubWorkItemRecordingEngine struct{ days []time.Time }
+
+func (engine *githubWorkItemRecordingEngine) Derive(
+	_ context.Context,
+	_ Claim,
+	_ githubWorkItemRows,
+	day time.Time,
+	_ time.Time,
+	_ githubWorkItemDerivationContext,
+) (map[string][]json.RawMessage, error) {
+	engine.days = append(engine.days, day)
+	produced := make(map[string][]json.RawMessage, len(githubWorkItemUnportedDestinations))
+	for _, destination := range githubWorkItemUnportedDestinations {
+		produced[destination] = []json.RawMessage{
+			json.RawMessage(`{"day":"` + day.Format("2006-01-02") + `"}`),
+		}
+	}
+	return produced, nil
+}
+
+// TestGitHubWorkItemDerivedDaysCapIsTheStatedThreeSixtySix asserts the cap's
+// VALUE, not merely that some cap exists.
+//
+// The window here is written from LITERAL DATES with no reference to
+// githubWorkItemDerivedMaxBackfillDays. Deriving the fixture from the constant
+// -- as the fail-closed table above does -- keeps passing if the constant is
+// changed to any other number, so it measures the mechanism and not the bound.
+func TestGitHubWorkItemDerivedDaysCapIsTheStatedThreeSixtySix(t *testing.T) {
+	t.Parallel()
+	normalizedAt := time.Date(2026, 8, 6, 9, 15, 0, 0, time.UTC)
+	instant := func(value time.Time) *time.Time { return &value }
+	// 2025-08-06 .. 2026-08-06 inclusive is 366 days (2026 is not a leap year).
+	atCap := time.Date(2025, 8, 6, 0, 0, 0, 0, time.UTC)
+	overCap := time.Date(2025, 8, 5, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC)
+
+	claim := githubWorkItemOracleClaim()
+	claim.SinceAt, claim.BeforeAt = instant(atCap), instant(before)
+	days, err := githubWorkItemDerivedDays(claim, normalizedAt)
+	if err != nil {
+		t.Fatalf("a 366-day window must be accepted: %v", err)
+	}
+	if len(days) != 366 {
+		t.Fatalf("days=%d want=366", len(days))
+	}
+	if !days[0].Equal(atCap) {
+		t.Errorf("first day=%v want=%v", days[0], atCap)
+	}
+	if want := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC); !days[365].Equal(want) {
+		t.Errorf("last day=%v want=%v", days[365], want)
+	}
+
+	claim.SinceAt = instant(overCap)
+	if _, err := githubWorkItemDerivedDays(claim, normalizedAt); !errors.Is(
+		err, ErrInvalidConfiguration,
+	) {
+		t.Fatalf("a 367-day window must be refused: error=%v", err)
+	}
+}
+
 // githubWorkItemDeriverFixture is a corpus that produces rows on every ported
 // derived surface, so a multi-day assertion cannot pass by comparing empties.
 func githubWorkItemDeriverFixture(claim Claim) githubWorkItemRows {
@@ -459,6 +568,7 @@ func (engine githubWorkItemStubEngine) Derive(
 	_ context.Context,
 	_ Claim,
 	_ githubWorkItemRows,
+	day time.Time,
 	_ time.Time,
 	_ githubWorkItemDerivationContext,
 ) (map[string][]json.RawMessage, error) {
@@ -467,7 +577,12 @@ func (engine githubWorkItemStubEngine) Derive(
 	}
 	produced := make(map[string][]json.RawMessage, len(githubWorkItemUnportedDestinations))
 	for _, destination := range githubWorkItemUnportedDestinations {
-		produced[destination] = []json.RawMessage{}
+		// Stamped with the day it was handed: an engine call hoisted out of the
+		// loop, or a merge that assigned instead of appending, shows up as a
+		// missing or wrong-dated row rather than as an indistinguishable empty.
+		produced[destination] = []json.RawMessage{
+			json.RawMessage(`{"day":"` + day.Format("2006-01-02") + `"}`),
+		}
 	}
 	return produced, nil
 }
@@ -587,6 +702,7 @@ func (engine githubWorkItemOverreachingEngine) Derive(
 	_ Claim,
 	_ githubWorkItemRows,
 	_ time.Time,
+	_ time.Time,
 	_ githubWorkItemDerivationContext,
 ) (map[string][]json.RawMessage, error) {
 	produced := map[string][]json.RawMessage{
@@ -673,6 +789,7 @@ func (engine githubWorkItemSilentEngine) Derive(
 	_ context.Context,
 	_ Claim,
 	_ githubWorkItemRows,
+	_ time.Time,
 	_ time.Time,
 	_ githubWorkItemDerivationContext,
 ) (map[string][]json.RawMessage, error) {

--- a/internal/providersync/github_work_items_composition_test.go
+++ b/internal/providersync/github_work_items_composition_test.go
@@ -1,0 +1,812 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// githubWorkItemUnportedDestinations is the engine-dependent set this lane
+// deliberately leaves nil. Stated once, asserted from several directions below,
+// so PR-C gets exactly one place to update and every dependent assertion moves
+// with it.
+var githubWorkItemUnportedDestinations = []string{
+	"investment_classifications_daily",
+	"investment_metrics_daily",
+	"issue_type_metrics_daily",
+}
+
+type stubWorkItemConn struct{ driver.Conn }
+
+func githubWorkItemCompositionLease() providerfoundation.LeaseGuard {
+	return providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+}
+
+// TestNewGitHubWorkItemClickHouseEffectsRejectsMissingDependencies observes each
+// constructor guard failing on its own. A constructor that silently accepted a
+// nil connection would hand back a sink whose every adapter panics on first
+// use, far from the call site that omitted it.
+func TestNewGitHubWorkItemClickHouseEffectsRejectsMissingDependencies(t *testing.T) {
+	t.Parallel()
+	conn := stubWorkItemConn{}
+	lease := githubWorkItemCompositionLease()
+
+	for _, testCase := range []struct {
+		name  string
+		conn  driver.Conn
+		lease providerfoundation.LeaseGuard
+	}{
+		{name: "nil conn", conn: nil, lease: lease},
+		{name: "nil lease", conn: conn, lease: nil},
+		{name: "both nil", conn: nil, lease: nil},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			sink, err := NewGitHubWorkItemClickHouseEffects(testCase.conn, testCase.lease)
+			if !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+			// The zero sink must not be mistakable for a usable one.
+			if !reflect.DeepEqual(sink, GitHubWorkItemClickHouseEffects{}) {
+				t.Fatalf("rejected build returned a populated sink: %+v", sink)
+			}
+			if sink.complete() {
+				t.Fatal("rejected build reported itself complete")
+			}
+		})
+	}
+}
+
+// TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree is
+// the tripwire. It asserts the missing set is EXACTLY the three engine-dependent
+// destinations -- so when PR-C wires one, this test goes red and forces the
+// declaration to be updated rather than letting a stale "3 missing" claim ride.
+func TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree(
+	t *testing.T,
+) {
+	t.Parallel()
+	sink, err := NewGitHubWorkItemClickHouseEffects(
+		stubWorkItemConn{}, githubWorkItemCompositionLease(),
+	)
+	if !errors.Is(err, ErrGitHubWorkItemSinkIncomplete) {
+		t.Fatalf("error=%v want ErrGitHubWorkItemSinkIncomplete", err)
+	}
+	missing := sink.MissingDestinations()
+	if !reflect.DeepEqual(missing, githubWorkItemUnportedDestinations) {
+		t.Fatalf("missing=%v want=%v", missing, githubWorkItemUnportedDestinations)
+	}
+	// The names must reach the operator through the error, not only through a
+	// method nobody calls.
+	for _, destination := range githubWorkItemUnportedDestinations {
+		if !strings.Contains(err.Error(), destination) {
+			t.Errorf("error %q does not name %q", err.Error(), destination)
+		}
+	}
+	if sink.complete() {
+		t.Fatal("a sink missing three destinations reported itself complete")
+	}
+	// Every destination NOT in the unported set must be wired. Without this the
+	// test above would still pass if the constructor forgot a fourth adapter
+	// and the unported list were widened to match.
+	for _, destination := range workItemRouteDestinations() {
+		adapter, known := sink.adapterForDestination(destination)
+		wantWired := !slices.Contains(githubWorkItemUnportedDestinations, destination)
+		if !known {
+			t.Fatalf("destination %q is not dispatchable", destination)
+		}
+		if wantWired && adapter == nil {
+			t.Errorf("destination %q should be wired but is nil", destination)
+		}
+		if !wantWired && adapter != nil {
+			t.Errorf("destination %q should be unported but is wired", destination)
+		}
+	}
+	if sink.Lease == nil {
+		t.Fatal("composite lease guard was not installed")
+	}
+}
+
+// TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel nils each of the
+// sixteen slots in turn against an otherwise COMPLETE sink. A single mutation of
+// the whole completeness check would be killed by any one of these; only the
+// per-slot sweep proves no individual slot is unchecked.
+func TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("github", "work-items")
+	effects, err := BuildGitHubWorkItemEffects(GitHubWorkItemEffectRows{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	complete := githubWorkItemEffectsFixture(newSemanticWorkItemEffectBackend())
+	if got := complete.MissingDestinations(); len(got) != 0 {
+		t.Fatalf("fixture is not complete: missing=%v", got)
+	}
+
+	for _, destination := range workItemRouteDestinations() {
+		t.Run(destination, func(t *testing.T) {
+			t.Parallel()
+			mutated := githubWorkItemSinkWithout(
+				githubWorkItemEffectsFixture(newSemanticWorkItemEffectBackend()),
+				destination,
+			)
+			if got := mutated.MissingDestinations(); !reflect.DeepEqual(
+				got, []string{destination},
+			) {
+				t.Fatalf("missing=%v want=[%s]", got, destination)
+			}
+			if mutated.complete() {
+				t.Fatalf("sink without %s reported complete", destination)
+			}
+			// The gate must reject writes to EVERY destination, not only the
+			// one that is missing: a partial sink is not partially usable.
+			for _, effect := range effects {
+				if err := mutated.WriteEffect(
+					context.Background(), claim, effect,
+				); !errors.Is(err, ErrInvalidConfiguration) {
+					t.Fatalf("write %s with %s missing: error=%v",
+						effect.Destination, destination, err)
+				}
+				if _, err := mutated.InspectEffect(
+					context.Background(), claim, effect,
+				); !errors.Is(err, ErrInvalidConfiguration) {
+					t.Fatalf("inspect %s with %s missing: error=%v",
+						effect.Destination, destination, err)
+				}
+			}
+		})
+	}
+}
+
+// githubWorkItemSinkWithout clears exactly one slot by destination name. It
+// switches over the same canonical list the production dispatch does, so a
+// destination added without a case here fails the test rather than silently
+// leaving the sink complete.
+func githubWorkItemSinkWithout(
+	sink GitHubWorkItemClickHouseEffects,
+	destination string,
+) GitHubWorkItemClickHouseEffects {
+	switch destination {
+	case "ai_attribution":
+		sink.AIAttribution = nil
+	case "estimate_coverage_metrics_daily":
+		sink.EstimateCoverageMetricsDaily = nil
+	case "investment_classifications_daily":
+		sink.InvestmentClassificationsDaily = nil
+	case "investment_metrics_daily":
+		sink.InvestmentMetricsDaily = nil
+	case "issue_type_metrics_daily":
+		sink.IssueTypeMetricsDaily = nil
+	case "sprints":
+		sink.Sprints = nil
+	case "work_item_cycle_times":
+		sink.WorkItemCycleTimes = nil
+	case "work_item_dependencies":
+		sink.WorkItemDependencies = nil
+	case "work_item_interactions":
+		sink.WorkItemInteractions = nil
+	case "work_item_metrics_daily":
+		sink.WorkItemMetricsDaily = nil
+	case "work_item_reopen_events":
+		sink.WorkItemReopenEvents = nil
+	case "work_item_state_durations_daily":
+		sink.WorkItemStateDurationsDaily = nil
+	case "work_item_team_attributions":
+		sink.WorkItemTeamAttributions = nil
+	case "work_item_transitions":
+		sink.WorkItemTransitions = nil
+	case "work_item_user_metrics_daily":
+		sink.WorkItemUserMetricsDaily = nil
+	case "work_items":
+		sink.WorkItems = nil
+	default:
+		panic("unmapped destination " + destination)
+	}
+	return sink
+}
+
+// TestGitHubWorkItemDerivedDaysMirrorsResolveDateRange pins the day list against
+// resolve_date_range composed with _date_range. Each case names the Python
+// input it stands for.
+func TestGitHubWorkItemDerivedDaysMirrorsResolveDateRange(t *testing.T) {
+	t.Parallel()
+	normalizedAt := time.Date(2026, 8, 6, 9, 15, 0, 0, time.UTC)
+	day := func(year int, month time.Month, date int) time.Time {
+		return time.Date(year, month, date, 0, 0, 0, 0, time.UTC)
+	}
+	instant := func(value time.Time) *time.Time { return &value }
+
+	for _, testCase := range []struct {
+		name  string
+		since *time.Time
+		// before is the EXCLUSIVE window end.
+		before *time.Time
+		want   []time.Time
+	}{{
+		// No flags: before defaults to utc_today()+1d, so end_day is today and
+		// backfill is 1.
+		name: "no window is the single run day",
+		want: []time.Time{day(2026, 8, 6)},
+	}, {
+		// --before 2026-08-06 => end_day 2026-08-05, backfill 1.
+		name:   "midnight before is exclusive",
+		before: instant(day(2026, 8, 6)),
+		want:   []time.Time{day(2026, 8, 5)},
+	}, {
+		// No Python analogue -- a date flag cannot express it. A window ending
+		// mid-day still covers that day, so it must not be dropped.
+		name:   "mid-day before keeps the partially covered day",
+		before: instant(time.Date(2026, 8, 6, 14, 30, 0, 0, time.UTC)),
+		want:   []time.Time{day(2026, 8, 6)},
+	}, {
+		// --since 2026-08-03 --before 2026-08-06 => end_day 08-05,
+		// backfill_days = (08-05 - 08-03).days + 1 = 3.
+		name:   "since and before span an inclusive ascending range",
+		since:  instant(day(2026, 8, 3)),
+		before: instant(day(2026, 8, 6)),
+		want:   []time.Time{day(2026, 8, 3), day(2026, 8, 4), day(2026, 8, 5)},
+	}, {
+		name:   "since equal to end day is a single day",
+		since:  instant(day(2026, 8, 5)),
+		before: instant(day(2026, 8, 6)),
+		want:   []time.Time{day(2026, 8, 5)},
+	}, {
+		// A since timestamp mid-day still starts on that day: Python takes a
+		// date, and the day is covered.
+		name:   "since is truncated to its day",
+		since:  instant(time.Date(2026, 8, 4, 23, 59, 59, 0, time.UTC)),
+		before: instant(day(2026, 8, 6)),
+		want:   []time.Time{day(2026, 8, 4), day(2026, 8, 5)},
+	}} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			claim := githubWorkItemOracleClaim()
+			claim.SinceAt, claim.BeforeAt = testCase.since, testCase.before
+			days, err := githubWorkItemDerivedDays(claim, normalizedAt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(days, testCase.want) {
+				t.Fatalf("days=%v want=%v", days, testCase.want)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkItemDerivedDaysFailsClosedOnUnusableWindows(t *testing.T) {
+	t.Parallel()
+	normalizedAt := time.Date(2026, 8, 6, 9, 15, 0, 0, time.UTC)
+	day := func(year int, month time.Month, date int) time.Time {
+		return time.Date(year, month, date, 0, 0, 0, 0, time.UTC)
+	}
+	instant := func(value time.Time) *time.Time { return &value }
+
+	for _, testCase := range []struct {
+		name         string
+		since        *time.Time
+		before       *time.Time
+		normalizedAt time.Time
+	}{{
+		// cli.py:110 exits here rather than deriving an empty range.
+		name:  "since after end day",
+		since: instant(day(2026, 8, 9)), before: instant(day(2026, 8, 6)),
+	}, {
+		name: "zero normalizedAt", normalizedAt: time.Time{},
+	}, {
+		name: "zero before", before: instant(time.Time{}),
+	}, {
+		name: "zero since", since: instant(time.Time{}),
+	}, {
+		// One day past the cap. The planner chunks backfills, so a window this
+		// wide means it did not run.
+		name:   "window wider than the backfill cap",
+		since:  instant(day(2026, 8, 6).AddDate(0, 0, -githubWorkItemDerivedMaxBackfillDays)),
+		before: instant(day(2026, 8, 7)),
+	}} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			claim := githubWorkItemOracleClaim()
+			claim.SinceAt, claim.BeforeAt = testCase.since, testCase.before
+			at := normalizedAt
+			if testCase.name == "zero normalizedAt" {
+				at = testCase.normalizedAt
+			}
+			if _, err := githubWorkItemDerivedDays(claim, at); !errors.Is(
+				err, ErrInvalidConfiguration,
+			) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+		})
+	}
+}
+
+// githubWorkItemDeriverFixture is a corpus that produces rows on every ported
+// derived surface, so a multi-day assertion cannot pass by comparing empties.
+func githubWorkItemDeriverFixture(claim Claim) githubWorkItemRows {
+	return githubWorkItemRows{
+		WorkItems: []githubWorkItemRow{{
+			WorkItemID: "acme/api#1", Provider: "github", Title: "t", Type: "issue",
+			Status: "todo", ProjectID: stringPointer("acme/api"),
+			CreatedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
+			OrgID:     claim.OrgID,
+		}},
+		StatusTransitions: []githubWorkItemTransitionRow{{
+			WorkItemID: "acme/api#1", Provider: "github",
+			OccurredAt: time.Date(2026, 8, 3, 6, 0, 0, 0, time.UTC),
+			FromStatus: "todo", ToStatus: "in_progress", OrgID: claim.OrgID,
+		}, {
+			WorkItemID: "acme/api#1", Provider: "github",
+			OccurredAt: time.Date(2026, 8, 4, 6, 0, 0, 0, time.UTC),
+			FromStatus: "in_progress", ToStatus: "done", OrgID: claim.OrgID,
+		}},
+	}
+}
+
+// TestGitHubWorkItemDeriverMirrorsCHAOS3494WriteAmplification is the
+// manifest-layer half of the two-layer duplicate assertion.
+//
+// Python calls compute_work_item_team_attributions INSIDE its day loop with no
+// `day` argument, so an n-day window emits the same rows n times. The port
+// mirrors that per D16. The collapse to one row is asserted separately, at the
+// readback layer, where it actually happens.
+func TestGitHubWorkItemDeriverMirrorsCHAOS3494WriteAmplification(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	rows := githubWorkItemDeriverFixture(claim)
+	normalizedAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	source := &fakeGitHubWorkItemDerivationContextSource{}
+	deriver := GitHubWorkItemDeriver{
+		Source: source, engine: githubWorkItemStubEngine{},
+	}
+
+	single := claim
+	singleBefore := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	singleSince := time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC)
+	single.SinceAt, single.BeforeAt = &singleSince, &singleBefore
+	oneDay, err := deriver.Derive(context.Background(), single, rows, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oneDayAttributions := oneDay["work_item_team_attributions"]
+	if len(oneDayAttributions) == 0 {
+		t.Fatal("fixture produced no team attributions; the assertion would be vacuous")
+	}
+
+	multi := claim
+	multiBefore := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	multiSince := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	multi.SinceAt, multi.BeforeAt = &multiSince, &multiBefore
+	threeDay, err := deriver.Derive(context.Background(), multi, rows, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const days = 3
+	attributions := threeDay["work_item_team_attributions"]
+	if len(attributions) != days*len(oneDayAttributions) {
+		t.Fatalf("team attributions=%d want=%d (%d days x %d)",
+			len(attributions), days*len(oneDayAttributions), days,
+			len(oneDayAttributions))
+	}
+	// Not merely the same count -- the same BYTES, repeated. That is what makes
+	// it write amplification rather than three days of distinct output.
+	for index, row := range attributions {
+		want := oneDayAttributions[index%len(oneDayAttributions)]
+		if !reflect.DeepEqual(row, want) {
+			t.Fatalf("attribution[%d]=%s want=%s (rows must repeat byte-identically)",
+				index, row, want)
+		}
+	}
+
+	// Control: a day-carrying surface must NOT repeat identically, or the
+	// assertion above would be measuring a loop that ignores `day` everywhere.
+	durations := threeDay["work_item_state_durations_daily"]
+	if len(durations) < 2 {
+		t.Fatalf("state durations=%d; control needs at least two", len(durations))
+	}
+	if reflect.DeepEqual(durations[0], durations[1]) {
+		t.Fatal("state duration rows repeat identically across days; " +
+			"the day parameter is not reaching the builder")
+	}
+}
+
+// TestGitHubWorkItemDeriverLoadsDerivationContextOncePerRun pins the context
+// load outside the day loop, matching job_work_items.py:1195-1209.
+func TestGitHubWorkItemDeriverLoadsDerivationContextOncePerRun(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	since := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 8, 6, 0, 0, 0, 0, time.UTC)
+	claim.SinceAt, claim.BeforeAt = &since, &before
+	source := &countingGitHubWorkItemDerivationContextSource{}
+	deriver := GitHubWorkItemDeriver{Source: source, engine: githubWorkItemStubEngine{}}
+
+	if _, err := deriver.Derive(
+		context.Background(), claim, githubWorkItemDeriverFixture(claim),
+		time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if source.loads != 1 {
+		t.Fatalf("derivation context loads=%d want=1 over a five-day window", source.loads)
+	}
+}
+
+type countingGitHubWorkItemDerivationContextSource struct{ loads int }
+
+func (source *countingGitHubWorkItemDerivationContextSource) Load(
+	context.Context, Claim, githubWorkItemDerivationLoadRequest,
+) (githubWorkItemDerivationFacts, error) {
+	source.loads++
+	return githubWorkItemDerivationFacts{}, nil
+}
+
+// githubWorkItemStubEngine stands in for the unported engines so composition can
+// be proven today. It is test-only by construction: GitHubWorkItemDeriver.engine
+// is unexported and no production code path sets it.
+type githubWorkItemStubEngine struct{ err error }
+
+func (engine githubWorkItemStubEngine) Derive(
+	_ context.Context,
+	_ Claim,
+	_ githubWorkItemRows,
+	_ time.Time,
+	_ githubWorkItemDerivationContext,
+) (map[string][]json.RawMessage, error) {
+	if engine.err != nil {
+		return nil, engine.err
+	}
+	produced := make(map[string][]json.RawMessage, len(githubWorkItemUnportedDestinations))
+	for _, destination := range githubWorkItemUnportedDestinations {
+		produced[destination] = []json.RawMessage{}
+	}
+	return produced, nil
+}
+
+// TestGitHubWorkItemDeriverFailsClosedWithoutTheUnportedEngines proves the
+// deriver refuses to fabricate the three destinations it cannot compute, and
+// names them.
+func TestGitHubWorkItemDeriverFailsClosedWithoutTheUnportedEngines(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	deriver := GitHubWorkItemDeriver{Source: &fakeGitHubWorkItemDerivationContextSource{}}
+
+	derived, err := deriver.Derive(
+		context.Background(), claim, githubWorkItemDeriverFixture(claim),
+		time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrGitHubWorkItemsDerivationsUnavailable) {
+		t.Fatalf("error=%v want ErrGitHubWorkItemsDerivationsUnavailable", err)
+	}
+	if derived != nil {
+		t.Fatalf("failed derivation returned rows: %v", derived)
+	}
+	for _, destination := range githubWorkItemUnportedDestinations {
+		if !strings.Contains(err.Error(), destination) {
+			t.Errorf("error %q does not name %q", err.Error(), destination)
+		}
+	}
+	// The ported six must NOT appear: naming them would misreport what is
+	// actually missing.
+	for _, destination := range githubWorkItemDerivedOwnedDestinations {
+		if strings.Contains(err.Error(), destination) {
+			t.Errorf("error %q names ported destination %q", err.Error(), destination)
+		}
+	}
+}
+
+func TestGitHubWorkItemDeriverFailsClosedOnUnusableInput(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	rows := githubWorkItemDeriverFixture(claim)
+	normalizedAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	source := &fakeGitHubWorkItemDerivationContextSource{}
+
+	foreignDataset := claim
+	foreignDataset.Dataset = "work-item-labels"
+	foreignProvider := claim
+	foreignProvider.Provider = "gitlab"
+
+	for _, testCase := range []struct {
+		name    string
+		deriver GitHubWorkItemDeriver
+		claim   Claim
+		at      time.Time
+	}{
+		{name: "nil source", deriver: GitHubWorkItemDeriver{}, claim: claim, at: normalizedAt},
+		{
+			name: "zero normalizedAt", deriver: GitHubWorkItemDeriver{Source: source},
+			claim: claim, at: time.Time{},
+		},
+		{
+			// The canonical claim is the only one the composite serves; an
+			// alias dataset reaching here means the family collapsed wrong.
+			name: "alias dataset", deriver: GitHubWorkItemDeriver{Source: source},
+			claim: foreignDataset, at: normalizedAt,
+		},
+		{
+			name: "foreign provider", deriver: GitHubWorkItemDeriver{Source: source},
+			claim: foreignProvider, at: normalizedAt,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := testCase.deriver.Derive(
+				context.Background(), testCase.claim, rows, testCase.at,
+			); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+		})
+	}
+}
+
+// TestGitHubWorkItemDeriverRejectsEngineOverreach guards the seam boundary: an
+// engine that restated a ported destination would give one surface two
+// producers, with nothing comparing them.
+func TestGitHubWorkItemDeriverRejectsEngineOverreach(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	rows := githubWorkItemDeriverFixture(claim)
+	normalizedAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+
+	for _, testCase := range []struct {
+		name        string
+		destination string
+	}{
+		{name: "restates a ported destination", destination: "work_item_team_attributions"},
+		{name: "invents a destination", destination: "not_a_destination"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			deriver := GitHubWorkItemDeriver{
+				Source: &fakeGitHubWorkItemDerivationContextSource{},
+				engine: githubWorkItemOverreachingEngine{destination: testCase.destination},
+			}
+			if _, err := deriver.Derive(
+				context.Background(), claim, rows, normalizedAt,
+			); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+		})
+	}
+}
+
+type githubWorkItemOverreachingEngine struct{ destination string }
+
+func (engine githubWorkItemOverreachingEngine) Derive(
+	_ context.Context,
+	_ Claim,
+	_ githubWorkItemRows,
+	_ time.Time,
+	_ githubWorkItemDerivationContext,
+) (map[string][]json.RawMessage, error) {
+	produced := map[string][]json.RawMessage{
+		engine.destination: {},
+	}
+	for _, destination := range githubWorkItemUnportedDestinations {
+		produced[destination] = []json.RawMessage{}
+	}
+	return produced, nil
+}
+
+// TestGitHubWorkItemMergeDerivedRowsGuardsTheOwnedSet exercises the merge guard
+// directly. No ported builder can currently emit an unowned destination, so
+// without this test the guard is unreachable code that reads as protection --
+// it survived a mutation to `if false` until this case existed. It becomes
+// reachable the moment the owned-subset constant and the builders drift apart,
+// which is exactly when one destination would silently gain two producers.
+func TestGitHubWorkItemMergeDerivedRowsGuardsTheOwnedSet(t *testing.T) {
+	t.Parallel()
+	owned := func() map[string][]json.RawMessage {
+		derived := make(map[string][]json.RawMessage)
+		for _, destination := range githubWorkItemDerivedOwnedDestinations {
+			derived[destination] = []json.RawMessage{}
+		}
+		return derived
+	}
+
+	t.Run("rejects a destination outside the owned set", func(t *testing.T) {
+		t.Parallel()
+		// A canonical derived destination the ported builders do NOT own: the
+		// realistic drift, not an invented string.
+		if err := githubWorkItemMergeDerivedRows(owned(), map[string][]json.RawMessage{
+			"investment_metrics_daily": {},
+		}); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+		}
+	})
+
+	t.Run("accumulates rather than overwriting", func(t *testing.T) {
+		t.Parallel()
+		derived := owned()
+		first := json.RawMessage(`{"n":1}`)
+		second := json.RawMessage(`{"n":2}`)
+		for _, produced := range []json.RawMessage{first, second} {
+			if err := githubWorkItemMergeDerivedRows(
+				derived,
+				map[string][]json.RawMessage{"work_item_team_attributions": {produced}},
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+		got := derived["work_item_team_attributions"]
+		if !reflect.DeepEqual(got, []json.RawMessage{first, second}) {
+			t.Fatalf("merged=%v want both rows in call order", got)
+		}
+	})
+}
+
+// TestGitHubWorkItemDeriverPropagatesEngineFailure keeps a broken engine from
+// being read as an absent one.
+func TestGitHubWorkItemDeriverPropagatesEngineFailure(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	sentinel := errors.New("engine exploded")
+	deriver := GitHubWorkItemDeriver{
+		Source: &fakeGitHubWorkItemDerivationContextSource{},
+		engine: githubWorkItemStubEngine{err: sentinel},
+	}
+	if _, err := deriver.Derive(
+		context.Background(), claim, githubWorkItemDeriverFixture(claim),
+		time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC),
+	); !errors.Is(err, sentinel) {
+		t.Fatalf("error=%v want the engine's own failure", err)
+	}
+}
+
+// githubWorkItemSilentEngine returns success and nothing else -- the fail-open
+// shape: a producer that answers "fine, no rows" where it should have refused.
+type githubWorkItemSilentEngine struct {
+	rows map[string][]json.RawMessage
+}
+
+func (engine githubWorkItemSilentEngine) Derive(
+	_ context.Context,
+	_ Claim,
+	_ githubWorkItemRows,
+	_ time.Time,
+	_ githubWorkItemDerivationContext,
+) (map[string][]json.RawMessage, error) {
+	return engine.rows, nil
+}
+
+// TestGitHubWorkItemCompositionNeverFailsOpen probes the shape that blocked both
+// engine PRs: an input that should raise instead producing an empty-but-plausible
+// result. Nothing here is inferred from reading the code -- each case is run and
+// the refusal observed.
+func TestGitHubWorkItemCompositionNeverFailsOpen(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	rows := githubWorkItemDeriverFixture(claim)
+	normalizedAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+
+	t.Run("an engine that returns nothing at all is not a complete derivation", func(t *testing.T) {
+		t.Parallel()
+		deriver := GitHubWorkItemDeriver{
+			Source: &fakeGitHubWorkItemDerivationContextSource{},
+			engine: githubWorkItemSilentEngine{rows: nil},
+		}
+		if _, err := deriver.Derive(
+			context.Background(), claim, rows, normalizedAt,
+		); !errors.Is(err, ErrGitHubWorkItemsDerivationsUnavailable) {
+			t.Fatalf("error=%v want ErrGitHubWorkItemsDerivationsUnavailable", err)
+		}
+	})
+
+	t.Run("an engine covering only some destinations is refused", func(t *testing.T) {
+		t.Parallel()
+		partial := map[string][]json.RawMessage{
+			githubWorkItemUnportedDestinations[0]: {},
+		}
+		deriver := GitHubWorkItemDeriver{
+			Source: &fakeGitHubWorkItemDerivationContextSource{},
+			engine: githubWorkItemSilentEngine{rows: partial},
+		}
+		_, err := deriver.Derive(context.Background(), claim, rows, normalizedAt)
+		if !errors.Is(err, ErrGitHubWorkItemsDerivationsUnavailable) {
+			t.Fatalf("error=%v want ErrGitHubWorkItemsDerivationsUnavailable", err)
+		}
+		// The still-missing two must be named; the one it did cover must not.
+		for _, destination := range githubWorkItemUnportedDestinations[1:] {
+			if !strings.Contains(err.Error(), destination) {
+				t.Errorf("error %q does not name still-missing %q", err.Error(), destination)
+			}
+		}
+		if strings.Contains(err.Error(), githubWorkItemUnportedDestinations[0]) {
+			t.Errorf("error %q names %q, which the engine did cover",
+				err.Error(), githubWorkItemUnportedDestinations[0])
+		}
+	})
+
+	t.Run("a sink built from a rejected constructor call refuses every write", func(t *testing.T) {
+		t.Parallel()
+		// The caller that drops the error. The constructor hands back a
+		// populated sink so MissingDestinations stays readable, so the
+		// guarantee has to come from the write path refusing -- not from the
+		// caller having checked.
+		sink, err := NewGitHubWorkItemClickHouseEffects(
+			stubWorkItemConn{}, githubWorkItemCompositionLease(),
+		)
+		if err == nil {
+			t.Fatal("constructor unexpectedly reported a complete sink")
+		}
+		effects, buildErr := BuildGitHubWorkItemEffects(GitHubWorkItemEffectRows{})
+		if buildErr != nil {
+			t.Fatal(buildErr)
+		}
+		sinkClaim := nativeTestClaim("github", "work-items")
+		for _, effect := range effects {
+			if writeErr := sink.WriteEffect(
+				context.Background(), sinkClaim, effect,
+			); !errors.Is(writeErr, ErrInvalidConfiguration) {
+				t.Fatalf("write %s on an incomplete sink: error=%v",
+					effect.Destination, writeErr)
+			}
+		}
+	})
+}
+
+// TestGitHubWorkItemDeriverComposesTheFullSixteenEffectManifest is the
+// composition proof: real builders for the six ported destinations, the stub
+// engine for the three unported ones, through the route's effect construction,
+// into a complete sink that routes all sixteen.
+func TestGitHubWorkItemDeriverComposesTheFullSixteenEffectManifest(t *testing.T) {
+	t.Parallel()
+	claim := githubWorkItemOracleClaim()
+	rows := githubWorkItemDeriverFixture(claim)
+	normalizedAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	deriver := GitHubWorkItemDeriver{
+		Source: &fakeGitHubWorkItemDerivationContextSource{},
+		engine: githubWorkItemStubEngine{},
+	}
+
+	derived, err := deriver.Derive(context.Background(), claim, rows, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(derived) != len(githubWorkItemDerivedDestinations) {
+		t.Fatalf("derived destinations=%d want=%d",
+			len(derived), len(githubWorkItemDerivedDestinations))
+	}
+	for _, destination := range githubWorkItemDerivedDestinations {
+		if _, produced := derived[destination]; !produced {
+			t.Fatalf("derived map is missing %q", destination)
+		}
+	}
+
+	effects, err := buildGitHubWorkItemsRouteEffects(rows, derived)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(effects) != len(workItemRouteDestinations()) {
+		t.Fatalf("effects=%d want=%d", len(effects), len(workItemRouteDestinations()))
+	}
+
+	// A complete sink -- the shape NewGitHubWorkItemClickHouseEffects will
+	// return once PR-C lands -- must route every one of them.
+	backend := newSemanticWorkItemEffectBackend()
+	sink := githubWorkItemEffectsFixture(backend)
+	sinkClaim := nativeTestClaim("github", "work-items")
+	for _, effect := range effects {
+		if err := sink.WriteEffect(context.Background(), sinkClaim, effect); err != nil {
+			t.Fatalf("write %s: %v", effect.Destination, err)
+		}
+		inspection, err := sink.InspectEffect(context.Background(), sinkClaim, effect)
+		if err != nil || inspection != EffectExact {
+			t.Fatalf("inspect %s=%s error=%v", effect.Destination, inspection, err)
+		}
+	}
+	if len(backend.writeCounts) != len(workItemRouteDestinations()) {
+		t.Fatalf("destinations written=%d want=%d",
+			len(backend.writeCounts), len(workItemRouteDestinations()))
+	}
+}

--- a/internal/providersync/github_work_items_direct_effects_integration_test.go
+++ b/internal/providersync/github_work_items_direct_effects_integration_test.go
@@ -16,103 +16,28 @@ import (
 	"github.com/google/uuid"
 
 	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
 )
 
-// DDL transcribed from `SHOW CREATE TABLE` on a schema built by the real
-// migration chain (src/dev_health_ops/migrations/clickhouse, including the .py
-// migrations 027/042/044/061 that a .sql-only replay would miss). The column
-// DEFAULTs are part of the transcription on purpose: `org_id String DEFAULT
-// 'default'` and `relationship_semantics_version String DEFAULT 'legacy.v1'`
-// are what an omitted column actually stores, and a test that dropped them
-// would silently diverge from production on exactly the omission cases these
-// adapters mirror.
-const (
-	workItemsDDL = `
-CREATE TABLE work_items (
-  repo_id UUID, work_item_id String, provider String, title String,
-  description Nullable(String), type String, status String, status_raw String,
-  project_key String, project_id String, native_team_key String,
-  project_name String, assignees Array(String), reporter String,
-  created_at DateTime64(3), updated_at DateTime64(3),
-  started_at Nullable(DateTime64(3)), completed_at Nullable(DateTime64(3)),
-  closed_at Nullable(DateTime64(3)), labels Array(String),
-  story_points Nullable(Float64), sprint_id String, sprint_name String,
-  parent_id String, epic_id String, url String, last_synced DateTime64(3),
-  priority_raw Nullable(String), service_class Nullable(String),
-  due_at Nullable(DateTime64(3)), org_id String DEFAULT 'default',
-  source_id Nullable(UUID) DEFAULT NULL
-) ENGINE = ReplacingMergeTree(last_synced)
-ORDER BY (org_id, repo_id, work_item_id)`
-
-	workItemTransitionsDDL = `
-CREATE TABLE work_item_transitions (
-  repo_id UUID, work_item_id String, occurred_at DateTime64(3),
-  provider String, from_status String, to_status String,
-  from_status_raw String, to_status_raw String, actor String,
-  last_synced DateTime64(3), org_id String DEFAULT 'default',
-  source_id Nullable(UUID) DEFAULT NULL
-) ENGINE = ReplacingMergeTree(last_synced)
-ORDER BY (org_id, repo_id, work_item_id, occurred_at)`
-
-	workItemDependenciesDDL = `
-CREATE TABLE work_item_dependencies (
-  source_work_item_id String, target_work_item_id String,
-  relationship_type String, relationship_type_raw String,
-  last_synced DateTime64(3), org_id String DEFAULT 'default',
-  source_id Nullable(UUID) DEFAULT NULL,
-  relationship_semantics_version String DEFAULT 'legacy.v1'
-) ENGINE = ReplacingMergeTree(last_synced)
-ORDER BY (org_id, source_work_item_id, target_work_item_id, relationship_type)`
-
-	workItemReopenEventsDDL = `
-CREATE TABLE work_item_reopen_events (
-  work_item_id String, occurred_at DateTime64(3), from_status String,
-  to_status String, from_status_raw Nullable(String),
-  to_status_raw Nullable(String), actor Nullable(String),
-  last_synced DateTime64(3), org_id String DEFAULT 'default'
-) ENGINE = ReplacingMergeTree(last_synced)
-ORDER BY (org_id, work_item_id, occurred_at)`
-
-	workItemInteractionsDDL = `
-CREATE TABLE work_item_interactions (
-  work_item_id String, provider String, interaction_type String,
-  occurred_at DateTime64(3), actor Nullable(String), body_length UInt32,
-  last_synced DateTime64(3), org_id String DEFAULT 'default'
-) ENGINE = ReplacingMergeTree(last_synced)
-ORDER BY (org_id, work_item_id, occurred_at, interaction_type)`
-
-	sprintsDDL = `
-CREATE TABLE sprints (
-  provider String, sprint_id String, native_team_key String,
-  name Nullable(String), state Nullable(String),
-  started_at Nullable(DateTime64(3)), ended_at Nullable(DateTime64(3)),
-  completed_at Nullable(DateTime64(3)), last_synced DateTime64(3),
-  org_id String DEFAULT 'default'
-) ENGINE = ReplacingMergeTree(last_synced)
-ORDER BY (org_id, provider, sprint_id)`
-
-	aiAttributionDDL = `
-CREATE TABLE ai_attribution (
-  record_id UUID, org_id UUID, provider LowCardinality(String),
-  subject_type LowCardinality(String), subject_id String,
-  repo_id Nullable(UUID), kind LowCardinality(String),
-  source LowCardinality(String), confidence Float32, actor Nullable(String),
-  evidence String, observed_at DateTime64(3, 'UTC'),
-  ingested_at DateTime64(3, 'UTC'), superseded_by Nullable(UUID),
-  computed_at DateTime64(3, 'UTC') DEFAULT now64()
-) ENGINE = ReplacingMergeTree(computed_at)
-PARTITION BY toYYYYMM(observed_at)
-ORDER BY (org_id, provider, subject_type, repo_id, subject_id, source)
-SETTINGS allow_nullable_key = 1`
-)
+// This file authors NO DDL. Every table comes from the real migration chain
+// (src/dev_health_ops/migrations/clickhouse), applied by chschema through the
+// project's own canonical entrypoint -- the same call `migrate clickhouse
+// upgrade` makes, so the .py migrations 027/042/044/055/061 that a .sql-only
+// replay would miss are covered too.
+//
+// The previous hand-typed CREATE TABLE constants were a second, unversioned
+// copy of the schema: a readback test over them could only ever confirm what
+// the constants themselves declared. The sibling derived-surface tables had
+// already drifted that way (a PRE-053 enum kept a genuinely reachable row from
+// ever being rejected), which is what chschema was written to remove.
 
 // A negative-offset zone where the local date disagrees with the UTC date, so
 // any accidental local-time formatting shows up as a wrong day rather than
 // passing by coincidence.
 var workItemTestZone = time.FixedZone("test-west", -7*60*60)
 
-func newWorkItemEffectsConn(t *testing.T, ddl ...string) (context.Context, driver.Conn) {
+func newWorkItemEffectsConn(t *testing.T) (context.Context, driver.Conn) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -127,16 +52,15 @@ func newWorkItemEffectsConn(t *testing.T, ddl ...string) (context.Context, drive
 			t.Errorf("terminate ClickHouse: %v", err)
 		}
 	})
+	// Migrate BEFORE opening the Go connection, so a failure to apply the real
+	// chain surfaces as a migration failure rather than as a confusing "table
+	// does not exist" from the first query.
+	chschema.Apply(ctx, t, instance)
 	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
 	if err != nil {
 		t.Fatalf("open ClickHouse: %v", err)
 	}
 	t.Cleanup(func() { _ = conn.Close() })
-	for _, statement := range ddl {
-		if err := conn.Exec(ctx, statement); err != nil {
-			t.Fatalf("apply DDL: %v", err)
-		}
-	}
 	return ctx, conn
 }
 
@@ -199,7 +123,7 @@ func TestDirectAdaptersAnswerExactWhenARecoverySnapshotIsReplayed(t *testing.T) 
 
 	for _, testCase := range directAdapterCases(orgID, observed) {
 		t.Run(testCase.destination, func(t *testing.T) {
-			ctx, conn := newWorkItemEffectsConn(t, testCase.ddl)
+			ctx, conn := newWorkItemEffectsConn(t)
 			adapter := testCase.adapter(conn)
 			identity, effect := workItemEffect(t, testCase.destination, testCase.row)
 
@@ -236,7 +160,7 @@ func TestDirectAdaptersReadbackExcludesOtherTenantsAtTheSameKey(t *testing.T) {
 			continue
 		}
 		t.Run(testCase.destination, func(t *testing.T) {
-			ctx, conn := newWorkItemEffectsConn(t, testCase.ddl)
+			ctx, conn := newWorkItemEffectsConn(t)
 			adapter := testCase.adapter(conn)
 
 			foreignIdentity, foreignEffect := workItemEffect(t, testCase.destination, testCase.foreignRow)
@@ -292,7 +216,7 @@ func TestAIAttributionReadbackResolvesTheSupersededRowAcrossAMonthBoundary(t *te
 
 func aiAttributionSupersededRowCase(t *testing.T, crossPartitionMerge int) {
 	t.Helper()
-	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	ctx, conn := newWorkItemEffectsConn(t)
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(map[string]any{
 		"do_not_merge_across_partitions_select_final": crossPartitionMerge,
 	}))
@@ -351,7 +275,7 @@ func aiAttributionSupersededRowCase(t *testing.T, crossPartitionMerge int) {
 // map marshalling. Asserting the decoded map would pass while the stored string
 // differed in key order, spacing, and escaping.
 func TestAIAttributionStoresPythonEvidenceBytes(t *testing.T) {
-	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	ctx, conn := newWorkItemEffectsConn(t)
 	adapter := GitHubAIAttributionClickHouseAdapter{Conn: conn}
 	orgID := aiAttributionTestOrgID
 	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
@@ -386,7 +310,7 @@ func TestAIAttributionStoresPythonEvidenceBytes(t *testing.T) {
 // silently clobbered. Both directions are asserted against a real
 // ReplacingMergeTree rather than against the comparator in isolation.
 func TestWorkItemsReadbackDistinguishesStaleFromOverwritten(t *testing.T) {
-	ctx, conn := newWorkItemEffectsConn(t, workItemsDDL)
+	ctx, conn := newWorkItemEffectsConn(t)
 	adapter := GitHubWorkItemsClickHouseAdapter{Conn: conn}
 	orgID := workItemTestOrgID(t)
 	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
@@ -418,7 +342,7 @@ func TestWorkItemsReadbackDistinguishesStaleFromOverwritten(t *testing.T) {
 // A batch where some rows landed and others did not cannot be replayed without
 // rewriting the ones that did, so the committer must be told Conflict.
 func TestWorkItemsPartlyLandedBatchIsAConflict(t *testing.T) {
-	ctx, conn := newWorkItemEffectsConn(t, workItemsDDL)
+	ctx, conn := newWorkItemEffectsConn(t)
 	adapter := GitHubWorkItemsClickHouseAdapter{Conn: conn}
 	orgID := workItemTestOrgID(t)
 	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
@@ -452,7 +376,7 @@ func TestDirectAdaptersLeaveThePythonOmittedColumnsAtTheirDefaults(t *testing.T)
 	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
 
 	t.Run("work_items", func(t *testing.T) {
-		ctx, conn := newWorkItemEffectsConn(t, workItemsDDL)
+		ctx, conn := newWorkItemEffectsConn(t)
 		adapter := GitHubWorkItemsClickHouseAdapter{Conn: conn}
 		row := workItemTestRow(orgID, now)
 		// The semantic row carries all four; the sink still must not write them.
@@ -481,7 +405,7 @@ func TestDirectAdaptersLeaveThePythonOmittedColumnsAtTheirDefaults(t *testing.T)
 	})
 
 	t.Run("work_item_transitions", func(t *testing.T) {
-		ctx, conn := newWorkItemEffectsConn(t, workItemTransitionsDDL)
+		ctx, conn := newWorkItemEffectsConn(t)
 		adapter := GitHubWorkItemTransitionsClickHouseAdapter{Conn: conn}
 		row := workItemTransitionTestRow(orgID, now)
 		row.Provider = "github"
@@ -508,7 +432,6 @@ func TestDirectAdaptersLeaveThePythonOmittedColumnsAtTheirDefaults(t *testing.T)
 
 type directAdapterCase struct {
 	destination  string
-	ddl          string
 	adapter      func(driver.Conn) GitHubWorkItemEffectAdapter
 	row          any
 	foreignRow   any
@@ -526,7 +449,7 @@ func directAdapterCases(orgID string, now time.Time) []directAdapterCase {
 	foreignSprint := sprintTestRow(foreignTenantOrgID, now)
 	return []directAdapterCase{
 		{
-			destination: "work_items", ddl: workItemsDDL,
+			destination: "work_items",
 			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
 				return GitHubWorkItemsClickHouseAdapter{Conn: conn}
 			},
@@ -534,7 +457,7 @@ func directAdapterCases(orgID string, now time.Time) []directAdapterCase {
 			foreignOrgID: foreignTenantOrgID,
 		},
 		{
-			destination: "work_item_transitions", ddl: workItemTransitionsDDL,
+			destination: "work_item_transitions",
 			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
 				return GitHubWorkItemTransitionsClickHouseAdapter{Conn: conn}
 			},
@@ -542,7 +465,7 @@ func directAdapterCases(orgID string, now time.Time) []directAdapterCase {
 			foreignOrgID: foreignTenantOrgID,
 		},
 		{
-			destination: "work_item_dependencies", ddl: workItemDependenciesDDL,
+			destination: "work_item_dependencies",
 			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
 				return GitHubWorkItemDependenciesClickHouseAdapter{Conn: conn}
 			},
@@ -550,7 +473,7 @@ func directAdapterCases(orgID string, now time.Time) []directAdapterCase {
 			foreignOrgID: foreignTenantOrgID,
 		},
 		{
-			destination: "work_item_reopen_events", ddl: workItemReopenEventsDDL,
+			destination: "work_item_reopen_events",
 			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
 				return GitHubWorkItemReopenEventsClickHouseAdapter{Conn: conn}
 			},
@@ -558,7 +481,7 @@ func directAdapterCases(orgID string, now time.Time) []directAdapterCase {
 			foreignOrgID: foreignTenantOrgID,
 		},
 		{
-			destination: "work_item_interactions", ddl: workItemInteractionsDDL,
+			destination: "work_item_interactions",
 			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
 				return GitHubWorkItemInteractionsClickHouseAdapter{Conn: conn}
 			},
@@ -566,7 +489,7 @@ func directAdapterCases(orgID string, now time.Time) []directAdapterCase {
 			foreignOrgID: foreignTenantOrgID,
 		},
 		{
-			destination: "sprints", ddl: sprintsDDL,
+			destination: "sprints",
 			adapter: func(conn driver.Conn) GitHubWorkItemEffectAdapter {
 				return GitHubSprintsClickHouseAdapter{Conn: conn}
 			},
@@ -647,7 +570,7 @@ func aiAttributionTestRow(t *testing.T, orgID string, observed time.Time) github
 // The replay contract, for the one adapter directAdapterCases cannot carry
 // because its tenant column is a UUID rather than a String.
 func TestAIAttributionAnswersExactWhenARecoverySnapshotIsReplayed(t *testing.T) {
-	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	ctx, conn := newWorkItemEffectsConn(t)
 	adapter := GitHubAIAttributionClickHouseAdapter{Conn: conn}
 	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
 	identity, effect := aiAttributionEffect(t, aiAttributionTestRow(t, aiAttributionTestOrgID, observed))
@@ -672,7 +595,7 @@ func TestAIAttributionAnswersExactWhenARecoverySnapshotIsReplayed(t *testing.T) 
 // A row belonging to another tenant must not satisfy this tenant's readback
 // even at an identical subject key and partition.
 func TestAIAttributionReadbackExcludesOtherTenants(t *testing.T) {
-	ctx, conn := newWorkItemEffectsConn(t, aiAttributionDDL)
+	ctx, conn := newWorkItemEffectsConn(t)
 	adapter := GitHubAIAttributionClickHouseAdapter{Conn: conn}
 	observed := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
 
@@ -705,7 +628,7 @@ func TestDirectAdaptersSurviveTwoRowsSharingASortingKeyInOneBatch(t *testing.T) 
 	now := time.Date(2026, 8, 31, 23, 30, 0, 123456789, time.UTC)
 
 	t.Run("work_item_transitions", func(t *testing.T) {
-		ctx, conn := newWorkItemEffectsConn(t, workItemTransitionsDDL)
+		ctx, conn := newWorkItemEffectsConn(t)
 		adapter := GitHubWorkItemTransitionsClickHouseAdapter{Conn: conn}
 		first := workItemTransitionTestRow(orgID, now)
 		second := workItemTransitionTestRow(orgID, now)
@@ -716,7 +639,7 @@ func TestDirectAdaptersSurviveTwoRowsSharingASortingKeyInOneBatch(t *testing.T) 
 	})
 
 	t.Run("work_item_reopen_events", func(t *testing.T) {
-		ctx, conn := newWorkItemEffectsConn(t, workItemReopenEventsDDL)
+		ctx, conn := newWorkItemEffectsConn(t)
 		adapter := GitHubWorkItemReopenEventsClickHouseAdapter{Conn: conn}
 		first := workItemReopenTestRow(orgID, now)
 		second := workItemReopenTestRow(orgID, now)
@@ -727,7 +650,7 @@ func TestDirectAdaptersSurviveTwoRowsSharingASortingKeyInOneBatch(t *testing.T) 
 	})
 
 	t.Run("work_item_interactions", func(t *testing.T) {
-		ctx, conn := newWorkItemEffectsConn(t, workItemInteractionsDDL)
+		ctx, conn := newWorkItemEffectsConn(t)
 		adapter := GitHubWorkItemInteractionsClickHouseAdapter{Conn: conn}
 		first := workItemInteractionTestRow(orgID, now)
 		second := workItemInteractionTestRow(orgID, now)
@@ -738,7 +661,7 @@ func TestDirectAdaptersSurviveTwoRowsSharingASortingKeyInOneBatch(t *testing.T) 
 	})
 
 	t.Run("work_item_dependencies", func(t *testing.T) {
-		ctx, conn := newWorkItemEffectsConn(t, workItemDependenciesDDL)
+		ctx, conn := newWorkItemEffectsConn(t)
 		adapter := GitHubWorkItemDependenciesClickHouseAdapter{Conn: conn}
 		first := workItemDependencyTestRow(orgID, now)
 		second := workItemDependencyTestRow(orgID, now)
@@ -802,10 +725,7 @@ func assertCollapsesToTheLastRow(
 // a version column was plain DateTime (seconds) and a shared millisecond helper
 // left the verdict permanently Absent.
 func TestWorkItemTimestampColumnsAllHaveTheAssumedPrecision(t *testing.T) {
-	ctx, conn := newWorkItemEffectsConn(t,
-		workItemsDDL, workItemTransitionsDDL, workItemDependenciesDDL,
-		workItemReopenEventsDDL, workItemInteractionsDDL, sprintsDDL,
-		aiAttributionDDL)
+	ctx, conn := newWorkItemEffectsConn(t)
 
 	// The version column of each destination is called out separately: it is the
 	// one the comparator orders on, so a precision mismatch there decides

--- a/internal/providersync/github_work_items_direct_effects_integration_test.go
+++ b/internal/providersync/github_work_items_direct_effects_integration_test.go
@@ -23,7 +23,7 @@ import (
 // This file authors NO DDL. Every table comes from the real migration chain
 // (src/dev_health_ops/migrations/clickhouse), applied by chschema through the
 // project's own canonical entrypoint -- the same call `migrate clickhouse
-// upgrade` makes, so the .py migrations 027/042/044/055/061 that a .sql-only
+// upgrade` makes, so the .py migrations 027/042/055/061 that a .sql-only
 // replay would miss are covered too.
 //
 // The previous hand-typed CREATE TABLE constants were a second, unversioned

--- a/internal/providersync/github_work_items_effects_clickhouse.go
+++ b/internal/providersync/github_work_items_effects_clickhouse.go
@@ -309,3 +309,11 @@ func (sink GitHubWorkItemClickHouseEffects) MissingDestinations() []string {
 func (sink GitHubWorkItemClickHouseEffects) complete() bool {
 	return len(sink.MissingDestinations()) == 0
 }
+
+// The sibling-sink convention, and the reason it matters more here than
+// elsewhere: this composite is not registered yet, so nothing in the tree calls
+// it through either interface. Without these assertions a signature drift in
+// EffectSink or EffectReadback would compile cleanly and surface only when
+// activation first wires the sink up -- the most expensive moment to find it.
+var _ EffectSink = GitHubWorkItemClickHouseEffects{}
+var _ EffectReadback = GitHubWorkItemClickHouseEffects{}

--- a/internal/providersync/github_work_items_effects_clickhouse.go
+++ b/internal/providersync/github_work_items_effects_clickhouse.go
@@ -222,56 +222,90 @@ func (sink GitHubWorkItemClickHouseEffects) resolve(
 	if err != nil || !sink.complete() {
 		return GitHubWorkItemEffectIdentity{}, nil, ErrInvalidConfiguration
 	}
-	var adapter GitHubWorkItemEffectAdapter
-	switch effect.Destination {
-	case "ai_attribution":
-		adapter = sink.AIAttribution
-	case "estimate_coverage_metrics_daily":
-		adapter = sink.EstimateCoverageMetricsDaily
-	case "investment_classifications_daily":
-		adapter = sink.InvestmentClassificationsDaily
-	case "investment_metrics_daily":
-		adapter = sink.InvestmentMetricsDaily
-	case "issue_type_metrics_daily":
-		adapter = sink.IssueTypeMetricsDaily
-	case "sprints":
-		adapter = sink.Sprints
-	case "work_item_cycle_times":
-		adapter = sink.WorkItemCycleTimes
-	case "work_item_dependencies":
-		adapter = sink.WorkItemDependencies
-	case "work_item_interactions":
-		adapter = sink.WorkItemInteractions
-	case "work_item_metrics_daily":
-		adapter = sink.WorkItemMetricsDaily
-	case "work_item_reopen_events":
-		adapter = sink.WorkItemReopenEvents
-	case "work_item_state_durations_daily":
-		adapter = sink.WorkItemStateDurationsDaily
-	case "work_item_team_attributions":
-		adapter = sink.WorkItemTeamAttributions
-	case "work_item_transitions":
-		adapter = sink.WorkItemTransitions
-	case "work_item_user_metrics_daily":
-		adapter = sink.WorkItemUserMetricsDaily
-	case "work_items":
-		adapter = sink.WorkItems
-	default:
+	adapter, known := sink.adapterForDestination(effect.Destination)
+	if !known {
 		return GitHubWorkItemEffectIdentity{}, nil, ErrInvalidConfiguration
 	}
 	return identity, adapter, nil
 }
 
+// adapterForDestination is the ONE place a destination name maps onto a slot.
+// resolve and MissingDestinations both go through it, so the dispatch table and
+// the completeness report cannot drift into disagreeing about which surfaces
+// this sink owns -- the failure mode a second hand-written list invites, and
+// the one the named-field struct exists to prevent in the first place.
+//
+// The bool distinguishes "not a work-item destination at all" from "a
+// destination whose adapter is nil". Callers need both: the first is a
+// programming error, the second is the honest PR-C gap.
+func (sink GitHubWorkItemClickHouseEffects) adapterForDestination(
+	destination string,
+) (GitHubWorkItemEffectAdapter, bool) {
+	switch destination {
+	case "ai_attribution":
+		return sink.AIAttribution, true
+	case "estimate_coverage_metrics_daily":
+		return sink.EstimateCoverageMetricsDaily, true
+	case "investment_classifications_daily":
+		return sink.InvestmentClassificationsDaily, true
+	case "investment_metrics_daily":
+		return sink.InvestmentMetricsDaily, true
+	case "issue_type_metrics_daily":
+		return sink.IssueTypeMetricsDaily, true
+	case "sprints":
+		return sink.Sprints, true
+	case "work_item_cycle_times":
+		return sink.WorkItemCycleTimes, true
+	case "work_item_dependencies":
+		return sink.WorkItemDependencies, true
+	case "work_item_interactions":
+		return sink.WorkItemInteractions, true
+	case "work_item_metrics_daily":
+		return sink.WorkItemMetricsDaily, true
+	case "work_item_reopen_events":
+		return sink.WorkItemReopenEvents, true
+	case "work_item_state_durations_daily":
+		return sink.WorkItemStateDurationsDaily, true
+	case "work_item_team_attributions":
+		return sink.WorkItemTeamAttributions, true
+	case "work_item_transitions":
+		return sink.WorkItemTransitions, true
+	case "work_item_user_metrics_daily":
+		return sink.WorkItemUserMetricsDaily, true
+	case "work_items":
+		return sink.WorkItems, true
+	default:
+		return nil, false
+	}
+}
+
+// MissingDestinations names every canonical destination this sink cannot serve,
+// in workItemRouteDestinations order. It is the typed form of "13 of 16": a
+// caller, a test, or an operator reading a constructor error learns WHICH
+// surfaces are absent rather than only that something is.
+//
+// A destination the dispatch switch does not know is reported as missing rather
+// than skipped. If workItemRouteDestinations ever grows an entry nobody wired,
+// that entry must surface here -- silently omitting it would let the sink
+// report itself complete while a destination had no adapter at all.
+func (sink GitHubWorkItemClickHouseEffects) MissingDestinations() []string {
+	canonical := workItemRouteDestinations()
+	missing := make([]string, 0, len(canonical))
+	for _, destination := range canonical {
+		adapter, known := sink.adapterForDestination(destination)
+		if !known || adapter == nil {
+			missing = append(missing, destination)
+		}
+	}
+	return missing
+}
+
+// complete gates every write and readback. It stays an ALL-SIXTEEN gate while
+// the three engine-dependent destinations are unported: a sink that served the
+// thirteen it has would land a generation whose derived surfaces are silently
+// absent, which is exactly the "evaluated and produced no rows" versus "the
+// composite forgot a destination" distinction GitHubWorkItemEffectRows exists
+// to preserve.
 func (sink GitHubWorkItemClickHouseEffects) complete() bool {
-	return sink.AIAttribution != nil &&
-		sink.EstimateCoverageMetricsDaily != nil &&
-		sink.InvestmentClassificationsDaily != nil &&
-		sink.InvestmentMetricsDaily != nil &&
-		sink.IssueTypeMetricsDaily != nil && sink.Sprints != nil &&
-		sink.WorkItemCycleTimes != nil && sink.WorkItemDependencies != nil &&
-		sink.WorkItemInteractions != nil && sink.WorkItemMetricsDaily != nil &&
-		sink.WorkItemReopenEvents != nil &&
-		sink.WorkItemStateDurationsDaily != nil &&
-		sink.WorkItemTeamAttributions != nil && sink.WorkItemTransitions != nil &&
-		sink.WorkItemUserMetricsDaily != nil && sink.WorkItems != nil
+	return len(sink.MissingDestinations()) == 0
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_items_composition.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_composition.json
@@ -3,8 +3,10 @@
   "name": "github work-item effect-layer composition (sink constructor, deriver, multi-day loop)",
   "build": [
     "go",
-    "build",
-    "./..."
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
   ],
   "mutations": [
     {

--- a/internal/providersync/testdata/mutation-plans/github_work_items_composition.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_composition.json
@@ -1,0 +1,301 @@
+{
+  "schema_version": 1,
+  "name": "github work-item effect-layer composition (sink constructor, deriver, multi-day loop)",
+  "build": [
+    "go",
+    "build",
+    "./..."
+  ],
+  "mutations": [
+    {
+      "id": "C1-constructor-accepts-nil-conn",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tif conn == nil || lease == nil {",
+      "replace": "\tif lease == nil {",
+      "rationale": "A nil ClickHouse connection must be refused at construction. Accepted, it yields a sink whose every adapter dereferences nil on first write -- far from the call site that omitted it.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestNewGitHubWorkItemClickHouseEffectsRejectsMissingDependencies)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "C2-constructor-accepts-nil-lease",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tif conn == nil || lease == nil {",
+      "replace": "\tif conn == nil {",
+      "rationale": "A nil lease guard must be refused. The seven direct adapters hold no guard of their own and rely entirely on the composite asserting the lease around every write, so a nil guard silently removes lease enforcement for half the destinations.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestNewGitHubWorkItemClickHouseEffectsRejectsMissingDependencies)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "S1-missing-destinations-ignores-nil-adapter",
+      "file": "internal/providersync/github_work_items_effects_clickhouse.go",
+      "find": "\t\tif !known || adapter == nil {",
+      "replace": "\t\tif !known || (adapter == nil && false) {",
+      "rationale": "A destination whose adapter slot is nil must be reported missing. Without it complete() reports a 13-of-16 sink as usable and the committer lands a generation whose derived surfaces are silently absent.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel|TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "S2-missing-destinations-ignores-unknown-destination",
+      "file": "internal/providersync/github_work_items_effects_clickhouse.go",
+      "find": "\t\tif !known || adapter == nil {",
+      "replace": "\t\tif (!known && false) || adapter == nil {",
+      "rationale": "A canonical destination the dispatch switch does not know must be reported missing rather than skipped.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel|TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree)$",
+          "./internal/providersync/"
+        ]
+      ],
+      "expected_survivor_reason": "EQUIVALENT MUTANT, and measured as such rather than assumed. adapterForDestination returns (nil, false) TOGETHER on its default arm -- there is no arm returning a non-nil adapter with known=false -- so `adapter == nil` alone already catches every destination the switch does not know. No input class exists that distinguishes the two forms: it would require a canonical destination that is absent from the switch AND yields a non-nil adapter, which the function's own shape makes unconstructible. The clause is kept as a tripwire in case that pairing ever changes (a future switch returning a zero-value non-nil adapter would make it reachable), and NO coverage is claimed for it. Verified by running this mutation: both proofs stay green."
+    },
+    {
+      "id": "D1-chaos-3494-fixed-by-deriving-one-day",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tfor _, day := range days {",
+      "replace": "\tfor _, day := range days[:1] {",
+      "rationale": "CHAOS-3494 is MIRRORED per D16, not fixed. compute_work_item_team_attributions takes no day yet Python calls it inside the day loop (job_work_items.py:1260 inside :1238), so an n-day window re-emits byte-identical rows n times. Deriving one day is the 'obvious fix' that silently stops mirroring the producer and breaks the differential pin.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDeriverMirrorsCHAOS3494WriteAmplification|TestGitHubWorkItemEngineSeamIsInvokedPerDay)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "D2-derivation-context-reloaded-per-day",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tderivationContext, err := loadGitHubWorkItemDerivationContext(\n\t\tctx, claim, rows, deriver.Source, normalizedAt,\n\t)\n\tif err != nil {\n\t\treturn nil, err\n\t}",
+      "replace": "\tderivationContext, err := loadGitHubWorkItemDerivationContext(\n\t\tctx, claim, rows, deriver.Source, normalizedAt,\n\t)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\tfor range days {\n\t\tif _, err := loadGitHubWorkItemDerivationContext(\n\t\t\tctx, claim, rows, deriver.Source, normalizedAt,\n\t\t); err != nil {\n\t\t\treturn nil, err\n\t\t}\n\t}",
+      "rationale": "The derivation context is loaded ONCE outside the day loop, matching job_work_items.py:1216-1236 which builds the resolver cascade before its loop. A per-day reload re-reads donor facts that cannot change within a run and can give two days of one run different attribution.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDeriverLoadsDerivationContextOncePerRun)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "D3-fabricate-empty-rows-for-unported-engines",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tfor _, destination := range githubWorkItemDerivedOwnedDestinations {\n\t\tderived[destination] = []json.RawMessage{}\n\t}",
+      "replace": "\tfor _, destination := range githubWorkItemDerivedDestinations {\n\t\tderived[destination] = []json.RawMessage{}\n\t}",
+      "rationale": "Opening the three unported destinations with empty slices makes the deriver claim it evaluated metrics whose engines do not exist. An empty slice is indistinguishable from 'evaluated, produced nothing', which is exactly the claim this port cannot honestly make.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDeriverFailsClosedWithoutTheUnportedEngines|TestGitHubWorkItemCompositionNeverFailsOpen)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "D4-engine-destinations-pre-opened",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tfor _, day := range days {\n\t\ttriplet, err := buildGitHubWorkItemMetricTriplet(",
+      "replace": "\tif deriver.engine != nil {\n\t\tfor _, destination := range githubWorkItemDerivedEngineDestinations {\n\t\t\tderived[destination] = []json.RawMessage{}\n\t\t}\n\t}\n\tfor _, day := range days {\n\t\ttriplet, err := buildGitHubWorkItemMetricTriplet(",
+      "rationale": "REGRESSION GUARD for a defect this PR introduced and caught: pre-opening the engine's destination keys so the merge would accept them made a PARTIAL engine -- one covering some destinations and not others -- pass the missing-destination check with empty slices. The keys must be created only by an engine that actually emitted for them.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemCompositionNeverFailsOpen)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "W1-before-treated-as-inclusive",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "endDay = githubWorkItemDerivedUTCDate(claim.BeforeAt.Add(-time.Nanosecond))",
+      "replace": "endDay = githubWorkItemDerivedUTCDate(*claim.BeforeAt)",
+      "rationale": "Python's `before` is EXCLUSIVE (utils/cli.py:106 computes end_day = before - 1 day). Treating the unit's BeforeAt as inclusive derives one extra day for every window.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDerivedDaysMirrorsResolveDateRange)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "W2-inverted-window-yields-no-days",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tif startDay.After(endDay) {",
+      "replace": "\tif false {",
+      "rationale": "A window whose since is after its end is malformed, not an empty-but-valid range (cli.py:110 exits). Deriving zero days would land an all-empty derived manifest that readback then treats as a successful no-op.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDerivedDaysFailsClosedOnUnusableWindows)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "W3-backfill-cap-removed",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tif len(days) == githubWorkItemDerivedMaxBackfillDays {\n\t\t\treturn nil, ErrInvalidConfiguration\n\t\t}",
+      "replace": "\t\tif false {\n\t\t\treturn nil, ErrInvalidConfiguration\n\t\t}",
+      "rationale": "The day loop is otherwise unbounded and each day re-derives every surface over the full row set. Declared divergence from Python, same rail as the 100k donor cap.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDerivedDaysFailsClosedOnUnusableWindows|TestGitHubWorkItemDerivedDaysCapIsTheStatedThreeSixtySix)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "W4-backfill-cap-value-changed",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "githubWorkItemDerivedMaxBackfillDays = 366",
+      "replace": "githubWorkItemDerivedMaxBackfillDays = 100000",
+      "rationale": "The cap's VALUE, not merely the existence of a cap. Measured gap: the fail-closed table derives its window FROM the constant, so it stays green under this mutation; only the literal-dated case catches it.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDerivedDaysCapIsTheStatedThreeSixtySix)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E1-engine-may-restate-or-invent-a-destination",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tif !slices.Contains(githubWorkItemDerivedEngineDestinations, destination) {\n\t\t\treturn ErrInvalidConfiguration\n\t\t}",
+      "replace": "\t\tif false {\n\t\t\treturn ErrInvalidConfiguration\n\t\t}",
+      "rationale": "One guard, two input classes, both asserted by the proof's subtests: an engine RESTATING a ported builder's destination (two producers for one surface, with nothing comparing them) and an engine INVENTING a destination outside the canonical set.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDeriverRejectsEngineOverreach)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E2-engine-invoked-once-per-window",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tif deriver.engine == nil {\n\t\t\tcontinue\n\t\t}\n\t\tengineRows, err := deriver.engine.Derive(\n\t\t\tctx, claim, rows, day, normalizedAt, derivationContext,\n\t\t)",
+      "replace": "\t\tif deriver.engine == nil || !day.Equal(days[0]) {\n\t\t\tcontinue\n\t\t}\n\t\tengineRows, err := deriver.engine.Derive(\n\t\t\tctx, claim, rows, day, normalizedAt, derivationContext,\n\t\t)",
+      "rationale": "All three engine destinations are per-day in Python and stamp day=d (job_work_items.py:1346/:1387/:1433 inside the :1238 loop). A seam invoked once per window cannot express them.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemEngineSeamIsInvokedPerDay)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "E3-engine-merge-assigns-instead-of-appending",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tderived[destination] = append(derived[destination], rows...)",
+      "replace": "\t\tderived[destination] = rows",
+      "rationale": "Assign-not-append silently keeps only the LAST day's engine rows. Invisible while the stub returns empty, which is why the stub stamps the day it was handed.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemEngineSeamIsInvokedPerDay)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M1-merge-accepts-unowned-destination",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\texisting, owned := derived[destination]\n\t\tif !owned {",
+      "replace": "\t\texisting, owned := derived[destination]\n\t\tif false && !owned {",
+      "rationale": "A ported builder claiming a destination outside the owned subset means the subsets have drifted apart, giving one destination two producers. NOTE: this guard survived until a DIRECT unit test existed -- no builder can currently reach it, so it read as protection while being unreachable.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemMergeDerivedRowsGuardsTheOwnedSet)$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "M2-merge-assigns-instead-of-appending",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tderived[destination] = append(existing, rows...)",
+      "replace": "\t\tderived[destination] = append(existing[:0], rows...)",
+      "rationale": "Per-day accumulation across the day loop is what produces the CHAOS-3494 multiplicity at the manifest layer. Overwriting collapses an n-day window to its last day.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^(TestGitHubWorkItemDeriverMirrorsCHAOS3494WriteAmplification|TestGitHubWorkItemMergeDerivedRowsGuardsTheOwnedSet)$",
+          "./internal/providersync/"
+        ]
+      ]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_items_effects.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_effects.json
@@ -1,7 +1,13 @@
 {
   "schema_version": 1,
   "name": "github work-item 16-destination effect and readback foundation",
-  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "build": [
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
+  ],
   "mutations": [
     {
       "id": "E1-all-sixteen-destinations-are-unique",
@@ -9,7 +15,16 @@
       "find": "{\"work_items\", rows.WorkItems},",
       "replace": "{\"work_item_user_metrics_daily\", rows.WorkItems},",
       "rationale": "the complete work-item unit must account for all sixteen unique Python write surfaces",
-      "proof": [["go", "test", "-count=1", "-run", "^TestBuildGitHubWorkItemEffectsIsDeterministicAndExhaustive$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildGitHubWorkItemEffectsIsDeterministicAndExhaustive$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E2-conditional-empty-effects-remain-accounted-for",
@@ -17,7 +32,16 @@
       "find": "effects = append(effects, effect)",
       "replace": "if len(value.rows) > 0 { effects = append(effects, effect) }",
       "rationale": "an empty destination is a durable evaluated outcome, not permission to omit it from the effect manifest",
-      "proof": [["go", "test", "-count=1", "-run", "^TestBuildGitHubWorkItemEffectsIsDeterministicAndExhaustive$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildGitHubWorkItemEffectsIsDeterministicAndExhaustive$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E3-every-surface-requires-semantic-readback",
@@ -25,7 +49,16 @@
       "find": "value.destination, EffectReadbackRequired, value.rows,",
       "replace": "value.destination, EffectReplaySafe, value.rows,",
       "rationale": "none of the sixteen multi-table effects may blind-replay after an ambiguous write acknowledgement",
-      "proof": [["go", "test", "-count=1", "-run", "^TestBuildGitHubWorkItemEffectsIsDeterministicAndExhaustive$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestBuildGitHubWorkItemEffectsIsDeterministicAndExhaustive$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E4-readback-is-tenant-fenced",
@@ -33,7 +66,16 @@
       "find": "OrgID: claim.OrgID, Provider: claim.Provider, Dataset: claim.Dataset,",
       "replace": "OrgID: \"org-acme\", Provider: claim.Provider, Dataset: claim.Dataset,",
       "rationale": "effect inspection must use the claimed tenant rather than a constant or row-provided organization",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemClickHouseEffectsRoutesEverySurfaceWithFrozenIdentity$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemClickHouseEffectsRoutesEverySurfaceWithFrozenIdentity$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E5-readback-is-generation-fenced",
@@ -41,7 +83,16 @@
       "find": "Generation: claim.GenerationKey(), Destination: effect.Destination,",
       "replace": "Generation: \"sync-unit:wrong\", Destination: effect.Destination,",
       "rationale": "recovery must inspect the same stable sync-unit occurrence across lease owners",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemClickHouseEffectsRoutesEverySurfaceWithFrozenIdentity$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemClickHouseEffectsRoutesEverySurfaceWithFrozenIdentity$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E6-content-digest-is-recomputed-before-dispatch",
@@ -49,7 +100,16 @@
       "find": "rebuilt.ContentDigest != effect.ContentDigest ||",
       "replace": "false ||",
       "rationale": "a valid-looking digest from another batch cannot authorize different semantic rows",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E7-payload-size-is-recomputed-before-dispatch",
@@ -57,7 +117,16 @@
       "find": "rebuilt.PayloadBytes != effect.PayloadBytes {",
       "replace": "false {",
       "rationale": "manifest payload accounting cannot be trusted from a caller-mutated EffectBatch",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E8-incomplete-adapter-sets-fail-before-writing",
@@ -65,15 +134,33 @@
       "find": "if err != nil || !sink.complete() {",
       "replace": "if err != nil || false {",
       "rationale": "the dispatcher cannot start a generation unless all sixteen destination adapters are available",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E9-explicit-work-items-adapter-cannot-be-cross-wired",
       "file": "internal/providersync/github_work_items_effects_clickhouse.go",
-      "find": "case \"work_items\":\n\t\tadapter = sink.WorkItems",
-      "replace": "case \"work_items\":\n\t\tadapter = sink.WorkItemUserMetricsDaily",
-      "rationale": "each destination must reach its explicitly named table adapter",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemClickHouseEffectsRoutesEverySurfaceWithFrozenIdentity$", "./internal/providersync/"]]
+      "find": "case \"work_items\":\n\t\treturn sink.WorkItems, true",
+      "replace": "case \"work_items\":\n\t\treturn sink.WorkItemUserMetricsDaily, true",
+      "rationale": "each destination must reach its explicitly named table adapter. Anchor updated when the dispatch switch moved from resolve() into adapterForDestination (returns rather than assigns); the property and the proof are unchanged.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemClickHouseEffectsRoutesEverySurfaceWithFrozenIdentity$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E10-post-write-lease-fence-is-retained",
@@ -81,7 +168,16 @@
       "find": "return sink.Lease.Assert(ctx)\n}",
       "replace": "return nil\n}",
       "rationale": "a lease lost while a destination write is in flight must leave the effect ambiguous for exact readback recovery",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemEffectsFailClosedForTamperingMissingAdaptersAndLeaseLoss$",
+          "./internal/providersync/"
+        ]
+      ]
     },
     {
       "id": "E11-mid-write-exact-readback-prevents-duplicate-replay",
@@ -89,7 +185,16 @@
       "find": "case EffectExact, EffectAbsent, EffectConflict:\n\t\treturn inspection, nil",
       "replace": "case EffectExact, EffectAbsent, EffectConflict:\n\t\treturn EffectAbsent, nil",
       "rationale": "an exact destination already accepted before a crash must be marked committed instead of physically replayed",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEffectsRecoverMidWriteAndAccountForEmptyDestinations$", "./internal/providersync/"]]
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubWorkItemEffectsRecoverMidWriteAndAccountForEmptyDestinations$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions-multiday.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions-multiday.py
@@ -47,7 +47,7 @@ _LOOP = "for d in days:"
 
 
 def _assert_producer_still_calls_inside_the_day_loop() -> int:
-    """Assert the DEFECT still exists in the producer, and return its day count.
+    """Assert the DEFECT still exists in the producer; return the loop's line number.
 
     This pair's loop is authored HERE, not read out of the producer, so on its
     own it would keep passing after CHAOS-3494 was fixed: hoisting the call out

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions-multiday.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions-multiday.py
@@ -4,22 +4,26 @@ This pair exists to pin CHAOS-3494, not to re-prove single-day attribution
 (``github/work-items/team-attributions`` already does that).
 
 ``compute_work_item_team_attributions`` takes no ``day`` argument, yet
-``job_work_items.py:1232`` calls it INSIDE the caller's ``for d in days`` loop.
-A multi-day backfill therefore recomputes and re-emits byte-identical
+``job_work_items.py:1260`` calls it INSIDE the caller's ``for d in days`` loop
+(:1238). A multi-day backfill therefore recomputes and re-emits byte-identical
 attribution rows once per day -- pure write amplification. Per D16 the Go port
 mirrors that bug-for-bug rather than repairing it, so the multiplicity itself
 is the compared property: an n-day window must produce exactly n copies of the
 single-day result, in day order, on BOTH sides.
 
-The loop here mirrors the producer's structure exactly: the resolver cascade and
+The loop here mirrors the producer's structure: the resolver cascade and
 attribution context are built ONCE (``DerivedCase.__init__``, matching
-job_work_items.py:1195-1209 which builds them before the loop), and only the
+job_work_items.py:1216-1236 which builds them before the loop), and only the
 compute call repeats. Rebuilding the context per day would be a different
 program from the one in production, and would hide the very defect this pins.
 
-If CHAOS-3494 is ever fixed, this pair fails on both sides at once -- which is
-the intended signal: fix Python, then update the Go mirror and this case
-together under differential proof.
+WHAT THIS PAIR DOES AND DOES NOT PROVE. The loop is authored here, not read out
+of the producer, so the row comparison ALONE would survive the likeliest fix to
+CHAOS-3494 -- hoisting the call out of the day loop changes the producer without
+changing this file, and both sides would still be told to loop n times. The
+defect's continued existence is therefore asserted separately and at the source
+level by ``_assert_producer_still_calls_inside_the_day_loop``. That assertion,
+not the row comparison, is what fails when CHAOS-3494 is fixed.
 """
 
 from __future__ import annotations
@@ -29,6 +33,7 @@ from typing import Any
 from internal.providersync.testdata import oracle_registry
 from internal.providersync.testdata.field_reflection import dataclass_field_names
 from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    REPO_ROOT,
     SCHEMA_SOURCE,
     DerivedCase,
     columns,
@@ -36,12 +41,62 @@ from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpe
 
 _RECORD = "WorkItemTeamAttributionRecord"
 
+_JOB_SOURCE = REPO_ROOT / "src/dev_health_ops/metrics/job_work_items.py"
+_CALL = "compute_work_item_team_attributions("
+_LOOP = "for d in days:"
+
+
+def _assert_producer_still_calls_inside_the_day_loop() -> int:
+    """Assert the DEFECT still exists in the producer, and return its day count.
+
+    This pair's loop is authored HERE, not read out of the producer, so on its
+    own it would keep passing after CHAOS-3494 was fixed: hoisting the call out
+    of ``for d in days:`` changes the producer without changing this file, and
+    both sides would still agree on n copies because both sides would still be
+    told to loop n times.
+
+    So the mirrored defect is asserted at the SOURCE level. If someone hoists
+    the call, this raises and the pair fails -- which is the intended signal to
+    fix Python, then update the Go mirror and this case together under
+    differential proof.
+    """
+    lines = _JOB_SOURCE.read_text().splitlines()
+    loop_indices = [index for index, line in enumerate(lines) if line.strip() == _LOOP]
+    if len(loop_indices) != 1:
+        raise AssertionError(
+            f"expected exactly one {_LOOP!r} in {_JOB_SOURCE.name}, "
+            f"found {len(loop_indices)} -- the anchor this assertion rests on moved"
+        )
+    loop_index = loop_indices[0]
+    loop_indent = len(lines[loop_index]) - len(lines[loop_index].lstrip())
+
+    # Walk the loop body: everything indented deeper than the `for`, stopping at
+    # the first non-blank line that dedents back to or past it.
+    for index in range(loop_index + 1, len(lines)):
+        line = lines[index]
+        if not line.strip():
+            continue
+        if len(line) - len(line.lstrip()) <= loop_indent:
+            break
+        if _CALL in line:
+            return loop_index + 1
+    raise AssertionError(
+        f"{_CALL!r} is no longer inside the {_LOOP!r} block of "
+        f"{_JOB_SOURCE.name}. CHAOS-3494 appears to be FIXED. This pair pins the "
+        "defect, so fix the Go mirror (GitHubWorkItemDeriver keeps the call "
+        "inside its day loop) and this case together, under differential proof."
+    )
+
 
 def _fields() -> frozenset[str]:
     return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
 
 
 def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    # Assert the mirrored defect is still present in the producer before
+    # comparing anything against it.
+    _assert_producer_still_calls_inside_the_day_loop()
+
     days = case.get("Days")
     if not days:
         raise AssertionError(

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions-multiday.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_team-attributions-multiday.py
@@ -1,0 +1,88 @@
+"""Live Python oracle for team attributions over a MULTI-DAY window.
+
+This pair exists to pin CHAOS-3494, not to re-prove single-day attribution
+(``github/work-items/team-attributions`` already does that).
+
+``compute_work_item_team_attributions`` takes no ``day`` argument, yet
+``job_work_items.py:1232`` calls it INSIDE the caller's ``for d in days`` loop.
+A multi-day backfill therefore recomputes and re-emits byte-identical
+attribution rows once per day -- pure write amplification. Per D16 the Go port
+mirrors that bug-for-bug rather than repairing it, so the multiplicity itself
+is the compared property: an n-day window must produce exactly n copies of the
+single-day result, in day order, on BOTH sides.
+
+The loop here mirrors the producer's structure exactly: the resolver cascade and
+attribution context are built ONCE (``DerivedCase.__init__``, matching
+job_work_items.py:1195-1209 which builds them before the loop), and only the
+compute call repeats. Rebuilding the context per day would be a different
+program from the one in production, and would hide the very defect this pins.
+
+If CHAOS-3494 is ever fixed, this pair fails on both sides at once -- which is
+the intended signal: fix Python, then update the Go mirror and this case
+together under differential proof.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "WorkItemTeamAttributionRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    days = case.get("Days")
+    if not days:
+        raise AssertionError(
+            "the multi-day pair requires a non-empty 'Days' list; a single-day "
+            "case here would silently degrade into the existing pair and prove "
+            "nothing about write amplification"
+        )
+
+    # The context is built once, outside the loop, exactly as the producer does.
+    # `Day` is required by DerivedCase but unused by this compute; it is set to
+    # the first day so the case decodes, and the assertion below proves the
+    # output genuinely does not depend on it.
+    decoded = DerivedCase({**case, "Day": days[0]})
+
+    emitted: list[Any] = []
+    per_day: list[int] = []
+    for _ in days:
+        produced = list(decoded.team_attributions())
+        per_day.append(len(produced))
+        emitted.extend(produced)
+
+    if not per_day or per_day[0] == 0:
+        raise AssertionError(
+            "the fixture produced no attribution rows; the multiplicity "
+            "comparison would be vacuous"
+        )
+    if len(set(per_day)) != 1:
+        raise AssertionError(
+            f"per-day attribution counts differ ({per_day}); this compute is "
+            "supposed to ignore the day entirely"
+        )
+    return columns(emitted, _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/team-attributions-multiday",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        # No org_id exclusion, for the same reason as the single-day pair:
+        # compute_work_item_team_attributions copies item.org_id itself, so the
+        # value is genuinely comparable on both sides.
+    )
+)


### PR DESCRIPTION
Layer 4 of the GitHub work-item family: construct the sixteen-destination sink and implement the deriver seam the route already calls.

Targets `feat/go-worker-runtime-migration`. Stacked on #1541.

## No activation

Nothing here makes anything reachable. `contracts/provider-matrix/v1/matrix.json` untouched — all five aliases stay `go_executor: none` / `route_ready: false`. No case added to `cmd/dev-health-worker/provider_sync.go`. Migration 0066, deployment profiles and switches untouched. The route still returns `Watermark: nil`. `git diff --name-only` over `contracts/`, `cmd/`, `migrations/` and `.github/` is empty.

**UNMET OBLIGATION, re-asserted not discharged.** D17 §1 requires the activation layer to read the route's `incomplete` result key and refuse to advance alias watermarks for a degraded run. Composition creates no watermark, so it does not satisfy that obligation and must not be read as having done so. The note at `github_work_items_route.go:36-43` stands.

## Correction to the lane's premise

The deriver seam and the derived-row merge were **already wired**. `GitHubWorkItemsRouteHandler.Collect` calls `handler.Deriver.Derive` (route.go:362) and merges 7 direct + 9 derived through `BuildGitHubWorkItemEffects` (route.go:366), failing closed on a nil deriver and on any derived map that is not exactly the 9 canonical keys. The actual gaps were that **no type implemented `githubWorkItemsDeriver`** and **nothing constructed `GitHubWorkItemClickHouseEffects`**. That is what this PR adds.

## Sink construction

`NewGitHubWorkItemClickHouseEffects` wires the 13 landed adapters — 7 direct (#1537), the metric triplet (#1535), 3 derived landing surfaces (#1541) — and leaves `investment_classifications_daily`, `investment_metrics_daily`, `issue_type_metrics_daily` nil.

`complete()` stays an **all-sixteen** gate. A sink serving the 13 it has would land a generation whose derived surfaces are silently absent — the "evaluated and produced no rows" versus "forgot a destination" distinction `GitHubWorkItemEffectRows` exists to preserve. The gap becomes typed data instead: `MissingDestinations()` names the absent surfaces in canonical order and the constructor error wraps those names, with a test asserting the set is **exactly** the three, so wiring one turns it red rather than letting a stale claim ride.

`resolve()`'s sixteen-case switch became `adapterForDestination`, so the dispatch table and the completeness report are one list rather than two that can drift. Behavior-preserving; #1465's five existing sink tests pass untouched.

## Deriver and the multi-day loop

`GitHubWorkItemDeriver` runs every ported builder once per day in the unit's window, mirroring `job_work_items.py:1210 for d in days`. The window comes from `Unit.SinceAt`/`BeforeAt` under `resolve_date_range`'s rules (`utils/cli.py:81-117`). The derivation context loads **once, outside the loop**, as the producer does (`job_work_items.py:1195-1209`).

**CHAOS-3494 is mirrored, not fixed.** `compute_work_item_team_attributions` takes no `day` yet is called inside the loop, so an n-day window re-emits byte-identical rows n times. Per D16 the port reproduces that bug-for-bug so the differential oracle can prove parity. `work_item_team_attributions` is the only affected surface — every other derived destination carries `day` in its rows.

The duplicates are asserted at **two layers, because they mean different things at each**: multiplicity n in the effect manifest, collapse to exactly one row at readback. Deduplicating at the manifest would erase the defect the oracle pins; asserting multiplicity at readback would fail against storage that legitimately collapses.

The three unported destinations **fail closed** naming themselves rather than being stubbed as empty slices, which would be indistinguishable from "evaluated, produced nothing". An unexported, test-only engine seam proves the composition end-to-end without fabricating engine output in production.

## Declared divergences from Python

1. **`githubWorkItemDerivedMaxBackfillDays = 366`.** The day loop is otherwise unbounded and each day re-derives every surface over the full row set. Python bounds nothing here because its window is a typed CLI flag; a unit's window comes from the planner, which chunks backfills. Same rail, same reasoning, as the 100k donor cap in `loadGitHubWorkItemDerivationContext`. A window wider than the cap is refused, not truncated.
2. **`BeforeAt` is an instant; Python's `before` is a date.** Mapped as `date(BeforeAt - 1ns)`. This **reduces exactly to Python's `before - 1 day` on the midnight-aligned boundaries a date flag can produce**, and keeps a mid-day `BeforeAt` from dropping the day it partially covers (a case Python cannot express). Both arms are oracle-mirroring test cases.

## Evidence

**Mutations: a checked-in plan** (`internal/providersync/testdata/mutation-plans/github_work_items_composition.json`, 17 mutations) run by `scripts/mutation_harness.py --assert-all-killed`: **16 KILLED, 1 SURVIVED_DECLARED**, exit 0. Killed include: both constructor nil guards, CHAOS-3494 "fixed", context reloaded per day, engines fabricated as empty slices, `before` treated as inclusive, inverted window silently empty, backfill cap removed, engine restating a ported destination, engine inventing one, `MissingDestinations` ignoring a nil adapter, merge accepting an unowned destination, merge assigning instead of appending.

Three honest notes:

- **M6 was first reported SURVIVED, and that verdict was wrong.** The harness decided kills by grepping stdout instead of reading the exit code. Hand-checking showed the mutation fails 4 subtests. The harness was fixed to use exit codes and every mutation re-run; the reported table is from that second run.
- **M12 is a declared equivalent mutant, not a kill.** Measured reason: `adapterForDestination` returns `(nil, false)` together, so no input class reaches the `!known` clause with a non-nil adapter — `adapter == nil` alone already catches every unknown destination. The clause is kept as a tripwire and **no coverage is claimed for it**.
- Three mutations first came back INVALID (did not build — unused variable, which is not a kill). They were rewritten to build and then killed. **M13 only started killing after a direct unit test for the merge guard was added**; before that the guard was unreachable protection that read as coverage.

**The plan sweep caught real anchor drift.** Sweeping every existing plan that anchors into the files this PR edits found that the `adapterForDestination` extraction moved the dispatch switch out of `resolve()`, silently breaking `E9` in #1465's `github_work_items_effects.json` — its anchor matched **0** times, so the entry would have been unrunnable. Repaired and re-run: that plan is **11/11 KILLED** again. Without the sweep it would have landed broken.

**A correction to how the oracle evidence was first measured.** `pythonExecutable` takes `python3` from `PATH`, and on this machine that resolves to an ambient pyenv virtualenv whose `dev_health_ops` is installed editable against a *different* checkout. The first oracle runs therefore compared this branch's Go against another worktree's Python. Re-run with `PYTHON` pinned to this worktree's `.venv`, the multi-day pair still **passes**, and both mutations (Go deriving one day; Go deduplicating the manifest) are still observed **failing** — so the conclusion is unchanged, but it now rests on the right producer. Three unrelated live-oracle tests that failed under the ambient interpreter also pass under the pinned one, and fail identically on the base tip, so they are environmental and not introduced here. With `PYTHON` pinned the whole package passes with live oracles enabled.

**The duplicate-collapse question is answered by execution, not by reading the comparator.** A 3× byte-identical batch against real ClickHouse with the real migration chain: Absent → write → **Exact** → replay → **Exact**, and `count() FINAL` = **1**.

**Multi-day oracle is measured, not skipped.** New pair `github/work-items/team-attributions-multiday` runs the real Python producer in its day-loop shape against the real `GitHubWorkItemDeriver.Derive`. Passes with `DEV_HEALTH_LIVE_PYTHON_ORACLES=1` and observed **failing** under two mutations: Go deriving only the first day, and Go deduplicating the manifest.

**Gate-bypass surface.** The composite has exactly two I/O methods, `WriteEffect` and `InspectEffect`; both go through `resolve()`, which is the sole caller of `complete()`. `EffectSink` declares only `WriteEffect` and `EffectReadback` only `InspectEffect`, so **there is no gate-bypassing write path through the interfaces the committer uses**. The accurate claim stops there: the sink's adapter fields are exported, so a caller holding the struct could invoke an adapter directly and bypass the composite. That is by design — the adapters are independently usable and independently tested — but "no bypass exists" would overstate what the code guarantees. `var _ EffectSink` / `var _ EffectReadback` assertions are present; this composite is unregistered, so without them a signature drift would compile cleanly and surface only at activation. Verified by drifting `WriteEffect`'s signature and observing the build break at the assertion.

**Fail-open lens** (the class that blocked #1547/#1549): three probes assert refusal rather than empty-but-plausible output — an engine returning nothing, an engine covering only some destinations, and a caller that drops the constructor error. All three refuse; killed by mutating the missing-destination gate. Note the constructor returns a populated sink alongside its error so `MissingDestinations` stays readable. The precise guarantee: `complete()` refuses every write and readback **through the composite's `EffectSink`/`EffectReadback` surface — the only path the committer has** (`WriteEffect` and `InspectEffect` are the only methods those interfaces expose, both go through `resolve()`, and `resolve()` is the sole caller of `complete()`), and the third probe exercises exactly that drop-the-error caller. The claim stops there deliberately: the adapter fields are exported and independently usable, so a caller holding the struct can invoke one directly and never reach `complete()`. That is by design, and it is not a path the committer can take.

**Gates:** `ci/check_go.sh fmt`, `vet`, `integration-vet` clean; unit gate 53 packages ok / 0 failures; integration 10/10 pass, **zero skips**, 413s.

## Adjacent cleanup

#1537's integration tests no longer transcribe DDL. The seven hand-typed `CREATE TABLE` constants are replaced by `chschema.Apply`, which migrates through the project's own entrypoint and needs no table list. Hand-typed DDL is a second, unversioned copy of the schema that a readback test can only ever confirm against itself — the sibling derived tables had already drifted that way.

**Cost regression, flagged deliberately:** each container now applies the full migration chain (~15s) instead of one `CREATE TABLE`, taking this file's integration subset to ~413s. Correct but real. Optimization (shared/snapshot migrated containers) is tracked as **CHAOS-3515**, with the constraint recorded there that any truncation list must be derived rather than hand-written or it recreates the drift class this cleanup removed. Not restructured here.
