### PR TITLE
CHAOS-3497: publish a run's scope decision on every terminal, and say a widening out loud

### DIFF
--- a/docs/contribute/architecture/ask-dev-subject-preflight.md
+++ b/docs/contribute/architecture/ask-dev-subject-preflight.md
@@ -70,6 +70,16 @@ report *its* numbers under the name Nightfall — the same misattribution, one
 layer down. Dropping the page subject removes the entity that could be
 mislabelled.
 
+The widening is also **said out loud**. It is recorded machine-readably on
+`dev_scope_resolution.v1` (`outcome: organization_fallback`,
+`fallbacks: ["organization"]`), and the answer additionally carries one plain
+sentence — "I could not match the subject named in this question, so this
+answer covers the whole organization instead." — so a reader of the rendered
+answer, not only a reader of the wire, can tell that the thing they named was
+missed. The trigger is this branch specifically, not the `fallbacks` marker:
+a question that named no subject at all was never widened away from anything
+and is told nothing.
+
 Page context is used as the subject only when the question named nothing at
 all, including nothing we merely failed to type. Substituting the page's
 project for a name we could not parse would answer about one entity under

--- a/src/dev_health_ops/api/dev/contracts_v2/compat.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/compat.py
@@ -57,6 +57,7 @@ client can only ever see an approximation of the richer v2 frame):
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TypeVar
 
 from pydantic import BaseModel
@@ -87,11 +88,11 @@ from dev_health_ops.api.dev.contracts import (
 
 from .answer import DevAnswerV2
 from .base import EntityKind, FactDisclosure, OpaqueID, PublicOutcome
-from .frame import DevFrameVersions
+from .frame import DevAnswerFrame, DevFrameVersions
 from .subject import DevResolutionCandidate
 from .validators import CANONICAL_NO_ANSWER_COPY, CANONICAL_NO_ANSWER_REMEDIATION
 
-__all__ = ["project_answer_v2_to_v1"]
+__all__ = ["project_answer_v2_to_v1", "scope_resolution_from_frame"]
 
 _V1Model = TypeVar("_V1Model", bound=BaseModel)
 
@@ -203,6 +204,79 @@ def _project_clarification_candidate(
         ),
         repository_id=entity.repository_id,
         reason=candidate.reason,
+    )
+
+
+def scope_resolution_from_frame(
+    frame: DevAnswerFrame,
+    *,
+    requested_scope: DevScope,
+    resolved_at: datetime,
+) -> DevScopeResolution:
+    """The v1 scope resolution a preflight-terminated run actually reached.
+
+    Three cases, in priority order (CHAOS-3325's own rules, unchanged --
+    this function is the extraction of what ``_project_needs_clarification``
+    already did inline, so there is exactly ONE producer of this shape):
+
+    1. ``frame.clarification_candidates`` is non-empty (the preflight
+       ambiguous-mention case): every real, authorized ledger candidate is
+       projected and the outcome is ``AMBIGUOUS``, matching v1's own
+       "ambiguous carries candidates" invariant.
+    2. ``frame.subject_ref`` is set instead: one derived candidate from the
+       one real committed entity.
+    3. Neither: ``UNRESOLVED``, carrying nothing. An honest "not resolved,
+       nothing to offer" rather than a fabricated option.
+
+    CHAOS-3497 made this callable from ``orchestrator.run()``'s preflight
+    TERMINATE branch. Until then that branch published the run's *original*
+    top-level resolve on the wire -- which by construction can only be
+    ``exact``/``filtered``/``inherited``/``organization_fallback``, since
+    every unhealthy outcome already returned earlier. A reader therefore saw
+    "scope resolved: exact" one frame before an error saying the named
+    subject could not be found: the exact juxtaposition
+    ``no_match_terminal``'s module docstring says the PRD prohibits, and it
+    also left ``no_unauthorized_candidate_surfaces`` scanning a list that
+    STRUCTURALLY cannot hold candidates (v1 permits them only on
+    candidate-bearing outcomes), turning a loud "not measured" failure into
+    a silent vacuous pass over the wrong object.
+    """
+
+    if frame.clarification_candidates:
+        outcome = ScopeResolutionOutcome.AMBIGUOUS
+        candidates = [
+            _project_clarification_candidate(candidate)
+            for candidate in frame.clarification_candidates
+        ]
+    elif frame.subject_ref is not None:
+        outcome = ScopeResolutionOutcome.AMBIGUOUS
+        candidates = [
+            DevDisambiguationCandidate(
+                entity_ref=DevEntityRef(
+                    entity_type=_KIND_TO_ENTITY_TYPE.get(
+                        frame.subject_ref.entity_kind, EntityType.REPOSITORY
+                    ),
+                    entity_id=frame.subject_ref.entity_id,
+                    display_label=frame.subject_ref.display_label,
+                    repository_id=frame.subject_ref.repository_id,
+                ),
+                reason="Clarification requested before continuing.",
+            )
+        ]
+    else:
+        outcome = ScopeResolutionOutcome.UNRESOLVED
+        candidates = []
+    return DevScopeResolution(
+        schema_version="dev_scope_resolution.v1",
+        requested_scope=requested_scope,
+        resolved_scope=None,
+        outcome=outcome,
+        authorized_repository_ids=[],
+        authorized_entity_ids=[],
+        candidates=candidates,
+        fallbacks=[],
+        warnings=[],
+        resolved_at=resolved_at,
     )
 
 
@@ -402,41 +476,8 @@ def _project_needs_clarification(
     frame = answer.frame
     versions = _require_versions(frame.versions, answer.public_outcome)
     resolved = _build_resolved_scope(answer, organization_id, time_range)
-    if frame.clarification_candidates:
-        outcome = ScopeResolutionOutcome.AMBIGUOUS
-        candidates = [
-            _project_clarification_candidate(candidate)
-            for candidate in frame.clarification_candidates
-        ]
-    elif frame.subject_ref is not None:
-        outcome = ScopeResolutionOutcome.AMBIGUOUS
-        candidates = [
-            DevDisambiguationCandidate(
-                entity_ref=DevEntityRef(
-                    entity_type=_KIND_TO_ENTITY_TYPE.get(
-                        frame.subject_ref.entity_kind, EntityType.REPOSITORY
-                    ),
-                    entity_id=frame.subject_ref.entity_id,
-                    display_label=frame.subject_ref.display_label,
-                    repository_id=frame.subject_ref.repository_id,
-                ),
-                reason="Clarification requested before continuing.",
-            )
-        ]
-    else:
-        outcome = ScopeResolutionOutcome.UNRESOLVED
-        candidates = []
-    resolution = DevScopeResolution(
-        schema_version="dev_scope_resolution.v1",
-        requested_scope=resolved,
-        resolved_scope=None,
-        outcome=outcome,
-        authorized_repository_ids=[],
-        authorized_entity_ids=[],
-        candidates=candidates,
-        fallbacks=[],
-        warnings=[],
-        resolved_at=answer.generated_at,
+    resolution = scope_resolution_from_frame(
+        frame, requested_scope=resolved, resolved_at=answer.generated_at
     )
     return DevAnswer(
         schema_version="dev_answer.v1",

--- a/src/dev_health_ops/api/dev/no_match_terminal.py
+++ b/src/dev_health_ops/api/dev/no_match_terminal.py
@@ -68,8 +68,10 @@ __all__ = [
     "INTERNAL_TOKEN_DENYLIST",
     "NEVER_ATTESTABLE_TOKENS",
     "REFUSED_WITH_GROUNDING_SUMMARY",
+    "SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE",
     "WITHHELD_COPY",
     "attested_strings",
+    "disclose_scope_widening",
     "internal_token_leak",
     "internal_token_leak_field",
     "named_subject_not_found_answer",
@@ -211,6 +213,80 @@ _UNNAMED_SUBJECT_SENTENCE = (
 )
 _NO_SUBSTITUTION_SENTENCE = "I did not substitute organization-wide data."
 _CLOSEST_MATCHES_SENTENCE = "Here are the closest matches, if any."
+
+#: CHAOS-3497 part 2: the one sentence that discloses a widening in prose.
+#:
+#: When a bare name in the question cannot be resolved, the run does not stop
+#: -- it widens to organization scope and answers anyway (see
+#: ``subject_preflight``'s ``unresolved_untyped`` branch and its comment for
+#: why). That widening was recorded machine-readably
+#: (``dev_scope_resolution.v1.fallbacks == ["organization"]``, outcome
+#: ``organization_fallback``, no ``subject_ref`` on the frame) but said
+#: nowhere a person reading the rendered answer would see it: measured live
+#: 2026-08-06, ``resolved_scope.warnings`` was empty and the frame's
+#: ``limitations`` carried only unrelated provenance entries. A reader saw
+#: "answered with gaps" and no indication that the thing they named had been
+#: missed.
+#:
+#: Deliberately NOT keyed on ``fallbacks == ["organization"]``, which the
+#: ticket suggested. That marker has a second producer:
+#: ``scope_service.resolve`` sets it for a request that named no subject at
+#: all and was ALLOWED to default to the organization -- not a widening away
+#: from anything, and a reader must not be told their subject was missed when
+#: they never named one. Measured, that second producer is unreachable from
+#: Ask Dev today (``production_runtime._scope_request`` passes
+#: ``allow_organization_fallback=False``), so the two predicates currently
+#: agree -- ``test_chaos_3497_scope_observability`` pins exactly that, so this
+#: is a checked claim rather than a story, and the day the flag flips the copy
+#: does not start lying.
+#:
+#: The trigger is instead the preflight's own ``legacy_guard_required``: true
+#: on exactly the branch where a NAMED bare subject went unresolved and the
+#: organization was committed in its place.
+#:
+#: Names nothing the user typed: the unresolved span is available
+#: (``SubjectPreflightResult.unresolved_name_spans``) but echoing it here
+#: would reopen the producer-authored-copy channel this module's docstring
+#: closes, and the sentence is true and actionable without it.
+SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE = (
+    "I could not match the subject named in this question, so this answer "
+    "covers the whole organization instead."
+)
+
+
+#: ``DevAnswer.warnings``' own contract bound, read off the model so this
+#: cannot drift from it.
+_MAX_ANSWER_WARNINGS: int = next(
+    metadata.max_length
+    for metadata in DevAnswer.model_fields["warnings"].metadata
+    if getattr(metadata, "max_length", None) is not None
+)
+
+
+def disclose_scope_widening(answer: DevAnswer) -> DevAnswer:
+    """Add the widening disclosure to ``answer.warnings``, once.
+
+    Returns ``answer`` unchanged when the sentence is already present or the
+    contract's twenty-warning bound is already spent -- a disclosure that
+    cannot fit must not silently evict a warning the producer chose.
+
+    ``warnings`` is the right channel rather than a bespoke field: it is what
+    ``streaming`` publishes as ``warning`` frames and what
+    ``terminal_frames.wrap_legacy_answer_as_frame`` copies into the frame's
+    ``limitations``, so one append reaches both the wire and the rendered
+    answer. ``answered_with_gaps`` (what every wrapped legacy answer is)
+    requires disclosed limitations, so adding one can never invalidate the
+    frame.
+    """
+
+    if SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in answer.warnings:
+        return answer
+    if len(answer.warnings) >= _MAX_ANSWER_WARNINGS:
+        return answer
+    return answer.model_copy(
+        update={"warnings": [*answer.warnings, SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE]}
+    )
+
 
 #: The noun used when the question gave no entity noun of its own. Never
 #: "project": guessing a kind the search never confirmed would state

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -103,6 +103,7 @@ from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
 from .no_match_terminal import (
     attested_strings,
+    disclose_scope_widening,
     internal_token_leak_field,
     named_subject_not_found_answer,
     scrub_auxiliary_leaks,
@@ -388,6 +389,22 @@ class OrchestratorResult:
     tool_call_count: int
     provider_fingerprint: str | None
     model_fingerprint: str | None
+    #: CHAOS-3497: the run's OWN most recent completed scope resolution,
+    #: carried on every terminal -- not only the answering ones.
+    #:
+    #: ``streaming.stream_orchestrator`` used to read the resolution off
+    #: ``answer.resolved_scope``, which exists only when the run produced an
+    #: answer, so a run that resolved scope and then terminated without one
+    #: (insufficient_evidence, a refusal, a not-found) emitted no
+    #: ``scope.resolved`` frame at all. Its scope decision -- including a
+    #: silent widening from a named subject to organization scope -- was then
+    #: permanently unobservable on the wire, which is exactly the run shape
+    #: the no-silent-widening audit family exists to catch.
+    #:
+    #: ``None`` only when the run terminated BEFORE scope resolution
+    #: completed (a cancellation on the accepted state, the outer catch-all
+    #: on a fault raised before ``_resolve_with_cancellation`` returned).
+    scope_resolution: DevScopeResolution | None = None
 
     def __post_init__(self) -> None:
         if self.state not in TERMINAL_STATES:
@@ -876,6 +893,32 @@ class DevOrchestrator:
             nonlocal terminal_written
             if terminal_written:
                 raise RuntimeError("terminal state already written")
+            # CHAOS-3497 part 2: disclose a widening in PROSE, not only in
+            # `dev_scope_resolution.v1.fallbacks`.
+            #
+            # `legacy_guard_required` is true on exactly one branch: a bare
+            # name in the question went unresolved and `subject_preflight`
+            # committed the organization in its place so no page-derived
+            # subject could be narrated as the named one. That run then
+            # answers organization-wide, and until this the only trace was
+            # machine-readable -- a person reading the answer saw two
+            # unrelated limitations and no hint their subject was missed.
+            #
+            # Placed here, ahead of the leak scan and every record_*() write,
+            # so the sentence is scanned like any other user-visible copy and
+            # reaches the persisted answer, the persisted frame's
+            # `limitations`, and the stream's `warning` frames alike. The
+            # committed outcome is re-checked rather than assumed: the
+            # disclosure must state something that is actually true of the
+            # scope this answer was computed under.
+            if (
+                answer is not None
+                and preflight_result is not None
+                and preflight_result.legacy_guard_required
+                and answer.resolved_scope.outcome
+                is ScopeResolutionOutcome.ORGANIZATION_FALLBACK
+            ):
+                answer = disclose_scope_widening(answer)
             # CHAOS-3367: the one place every terminal in this module passes
             # through, and therefore the only place a user-visible-copy rule
             # can be enforced structurally rather than by asking ~35 call
@@ -1433,6 +1476,28 @@ class DevOrchestrator:
                 tool_call_count=len(tool_results),
                 provider_fingerprint=provider_fingerprint,
                 model_fingerprint=model_fingerprint,
+                # CHAOS-3497: the run's own scope decision, on EVERY terminal.
+                #
+                # On the answer path this is byte-identical to what
+                # ``streaming`` already published (``answer.resolved_scope``),
+                # so that path's wire output does not change at all.
+                #
+                # On a no-answer terminal it is the run's most recent
+                # COMPLETED resolution: ``last_resolve_scope_resolution``
+                # (every ``resolve_scope.v1`` attempt that produced an
+                # outcome, ambiguous/not-found included) when the model made
+                # one, else ``resolution`` (the initial resolve, or whatever
+                # the preflight committed over it). Preferring the tool
+                # attempt is deliberate and mirrors CHAOS-3367's own rule:
+                # publishing the committed organization ``resolution`` after a
+                # named subject failed to resolve is precisely the "scope
+                # outcome: exact while a named subject could not be found"
+                # juxtaposition the PRD prohibits.
+                scope_resolution=(
+                    answer.resolved_scope
+                    if answer is not None
+                    else (last_resolve_scope_resolution or resolution)
+                ),
             )
 
         def error(code: str, message: str, *, retryable: bool = False) -> DevError:

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -95,6 +95,7 @@ from .contracts_v2 import (
     QuestionIntentID,
 )
 from .contracts_v2.base import SourceRequirementState
+from .contracts_v2.compat import scope_resolution_from_frame
 from .contracts_v2.frame import DevAnswerFrame
 from .contracts_v2.narrative import DevNarrative
 from .contracts_v2.plan import DevInvestigationPlan
@@ -843,6 +844,24 @@ class DevOrchestrator:
         # up in the user's own question text.
         last_resolve_scope_resolution: DevScopeResolution | None = None
         last_resolve_scope_query: str | None = None
+        # CHAOS-3497: the resolution a preflight TERMINATE actually reached
+        # for the subject the question named -- set only on that branch, and
+        # the highest-priority thing `published_resolution()` reports.
+        #
+        # It has to be tracked separately because `_terminate()` commits
+        # NOTHING (`committed_resolution=None` on every one of its call
+        # sites), so `resolution` there is still the run's original top-level
+        # resolve. That value can only ever be healthy -- every unhealthy
+        # outcome already returned earlier -- so publishing it would put
+        # "scope resolved: exact" one frame ahead of an error saying the
+        # named subject could not be found, and would hand
+        # `no_unauthorized_candidate_surfaces` an object that STRUCTURALLY
+        # cannot carry candidates (v1 permits them only on candidate-bearing
+        # outcomes), flipping that security check from a loud "not measured"
+        # to a silent vacuous pass. Reproduced live before the fix: an
+        # ambiguous "Atlas" and a not-found "Nightfall" both published
+        # `inherited`, with zero candidates.
+        preflight_terminal_resolution: DevScopeResolution | None = None
         selected_event_sink = event_sink or self._event_sink
         # CHAOS-3297 stack #3 (team-lead boundary ruling, 2026-08-02): set
         # by the CHAOS-3295 plan-execution block below when a plan actually
@@ -873,6 +892,43 @@ class DevOrchestrator:
         #: internal denylisted token is never fail-closed over that
         #: collision.
         portfolio_attested_labels: tuple[str, ...] = ()
+
+        def published_resolution() -> DevScopeResolution | None:
+            """The scope decision a no-answer terminal reports on the wire.
+
+            Three sources, in priority order, and the order is the whole
+            point -- an auditor must be able to tell a run that resolved to
+            an exact subject from one that silently widened, and every
+            wrong choice here is a false answer to that question:
+
+            1. ``preflight_terminal_resolution`` -- the preflight
+               TERMINATE branch's own outcome for the subject the question
+               named. Nothing else describes that failure at all.
+            2. ``last_resolve_scope_resolution``, but ONLY while the run is
+               still on organization scope. This mirrors the diversion
+               guard the answer path already applies (see the
+               ``missed_subject_label`` branch): once a ``resolve_scope.v1``
+               call has committed a REAL narrower subject, a later failed
+               lookup for some other name did not change what this run
+               executed under, and reporting that miss as the run's scope
+               decision invents a resolution failure that never happened.
+            3. ``resolution`` -- the committed scope itself.
+
+            ``None`` only when the run ended before scope resolution
+            completed at all.
+            """
+
+            if preflight_terminal_resolution is not None:
+                return preflight_terminal_resolution
+            committed = resolution
+            still_organization_wide = (
+                committed is None
+                or committed.resolved_scope is None
+                or committed.resolved_scope.direct_scope is DirectScope.ORGANIZATION
+            )
+            if still_organization_wide and last_resolve_scope_resolution is not None:
+                return last_resolve_scope_resolution
+            return committed
 
         async def transition(state: RunState, safe_code: str | None = None) -> None:
             event = OrchestratorEvent(state=state, safe_code=safe_code)
@@ -1482,21 +1538,12 @@ class DevOrchestrator:
                 # ``streaming`` already published (``answer.resolved_scope``),
                 # so that path's wire output does not change at all.
                 #
-                # On a no-answer terminal it is the run's most recent
-                # COMPLETED resolution: ``last_resolve_scope_resolution``
-                # (every ``resolve_scope.v1`` attempt that produced an
-                # outcome, ambiguous/not-found included) when the model made
-                # one, else ``resolution`` (the initial resolve, or whatever
-                # the preflight committed over it). Preferring the tool
-                # attempt is deliberate and mirrors CHAOS-3367's own rule:
-                # publishing the committed organization ``resolution`` after a
-                # named subject failed to resolve is precisely the "scope
-                # outcome: exact while a named subject could not be found"
-                # juxtaposition the PRD prohibits.
+                # On a no-answer terminal it is ``published_resolution()``
+                # below -- the resolution this run actually executed under.
                 scope_resolution=(
                     answer.resolved_scope
                     if answer is not None
-                    else (last_resolve_scope_resolution or resolution)
+                    else published_resolution()
                 ),
             )
 
@@ -1840,6 +1887,21 @@ class DevOrchestrator:
                     candidate_attestation = tuple(
                         candidate.entity_ref.display_label
                         for candidate in preflight_result.answer.frame.clarification_candidates
+                    )
+                    # CHAOS-3497: built from the SAME frame the richer
+                    # terminal below persists, through the SAME projector
+                    # `compat` already uses for a replayed clarification --
+                    # so the resolution on the wire and the candidates the
+                    # user was shown can never be two different stories.
+                    # Set before every `finish()` in this branch, including
+                    # the leak-guard bail-out: a run whose terminal was
+                    # rewritten to `internal_error` still resolved what it
+                    # resolved, and hiding that is how the gap this ticket
+                    # closes got there in the first place.
+                    preflight_terminal_resolution = scope_resolution_from_frame(
+                        preflight_result.answer.frame,
+                        requested_scope=authorized_scope,
+                        resolved_at=datetime.now(UTC),
                     )
                     preflight_leak = internal_token_leak_field(
                         user_visible_strings_by_field(error=preflight_error),

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -833,6 +833,19 @@ def _replayed_result(
         tool_call_count=run.tool_call_count,
         provider_fingerprint=run.provider_fingerprint,
         model_fingerprint=run.model_fingerprint,
+        # CHAOS-3497: a replay must stream the same frames the live run did.
+        # ``streaming`` reads ``scope.resolved`` off this field now (so a
+        # no-answer terminal can publish one at all), and leaving it None
+        # here would silently DROP the frame from every replayed answer --
+        # a regression introduced by the very change that closes the gap.
+        #
+        # Only the answer branch can supply it. A replayed no-answer run has
+        # no persisted ``dev_scope_resolution.v1`` to read (the run row keeps
+        # ``terminal_error_payload`` and the frame, neither of which carries
+        # one), so it replays without the frame rather than with a fabricated
+        # one -- an honest known gap, filed rather than papered over: a live
+        # no-answer run publishes its resolution, its replay does not.
+        scope_resolution=answer.resolved_scope if answer is not None else None,
     )
 
 

--- a/src/dev_health_ops/api/dev/streaming.py
+++ b/src/dev_health_ops/api/dev/streaming.py
@@ -109,11 +109,28 @@ async def stream_orchestrator(
             yield public_event(StreamEventType.ERROR, error=error)
             yield public_event(StreamEventType.DONE, terminal_kind="error")
             return
-        if result.answer is not None:
+        # CHAOS-3497: emitted for EVERY terminal whose run got as far as
+        # completing scope resolution -- not only the answering ones.
+        #
+        # This frame used to be built from ``result.answer.resolved_scope``
+        # inside the answer branch below, so a run that resolved scope and
+        # then terminated without an answer (insufficient_evidence, a
+        # refusal, a not-found) published no scope decision at all. An
+        # auditor reading the wire could not tell a failed run that resolved
+        # to an exact subject from one that silently widened to organization
+        # scope -- and a run that widens and then fails to ground is exactly
+        # the shape the no-silent-widening audit family exists to catch.
+        #
+        # Ordering is unchanged for the answer path (scope.resolved, then
+        # warnings, then the terminal) and mirrors it for the error path
+        # (scope.resolved, then the terminal), so ``validate_stream``'s
+        # "terminal result immediately followed by done" rule still holds.
+        if result.scope_resolution is not None:
             yield public_event(
                 StreamEventType.SCOPE_RESOLVED,
-                scope_resolution=result.answer.resolved_scope,
+                scope_resolution=result.scope_resolution,
             )
+        if result.answer is not None:
             for warning in result.answer.warnings:
                 yield public_event(StreamEventType.WARNING, warning=warning)
             yield public_event(

--- a/tests/api/dev/test_chaos_3497_scope_observability.py
+++ b/tests/api/dev/test_chaos_3497_scope_observability.py
@@ -1,0 +1,516 @@
+"""CHAOS-3497: a run's scope decision must be observable on EVERY terminal.
+
+Two defects in one family, both about a scope decision that was made and then
+not disclosed.
+
+1. ``scope.resolved`` was emitted only inside ``if result.answer is not None``.
+   A run that resolved scope and then terminated without an answer
+   (insufficient_evidence, a refusal, a not-found) published nothing about
+   what it resolved -- so an auditor reading the wire could not tell a failed
+   run that resolved to an exact subject from one that silently widened to
+   organization scope. That is the whole point of the no-silent-widening
+   audit family, and the widen-then-fail run is exactly the shape it exists
+   to catch.
+
+2. When the preflight widens to organization scope because a named bare
+   subject went unresolved, the widening was recorded machine-readably
+   (``fallbacks == ["organization"]``) but said nowhere a person reading the
+   answer would see it.
+
+Every test here observes the state the system exists to reach -- the frame on
+the wire, the sentence in the rendered answer -- never that a code path ran.
+Negative controls sit beside the positives so a change that discloses
+*everything* (which would be its own defect: an ordinary organization-wide
+question was never widened away from anything) fails too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import (
+    DevAnswer,
+    DevError,
+    DevScope,
+    DevScopeResolution,
+    DirectScope,
+    ScopeResolutionOutcome,
+    StreamEventType,
+)
+from dev_health_ops.api.dev.contracts_v2 import PublicOutcome
+from dev_health_ops.api.dev.no_match_terminal import (
+    SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE,
+    disclose_scope_widening,
+)
+from dev_health_ops.api.dev.orchestrator import (
+    OrchestratorEvent,
+    OrchestratorResult,
+    RunState,
+)
+from dev_health_ops.api.dev.streaming import (
+    encode_sse,
+    stream_orchestrator,
+    validate_completed_stream,
+)
+from dev_health_ops.llm.agent.contracts import AgentUsage
+from tests._chaos_3292_preflight import (
+    ASK_DEV_PROJECT,
+    ORG_ID,
+    run_preflight_orchestrator,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _scope() -> DevScope:
+    return DevScope.model_validate(positive_fixtures()["dev_scope.v1"])
+
+
+def _resolution(outcome: ScopeResolutionOutcome) -> DevScopeResolution:
+    """A resolution in ``outcome``, valid for that outcome's own payload rules."""
+
+    scope = _scope()
+    resolved: DevScope | None = None
+    if outcome in {
+        ScopeResolutionOutcome.EXACT,
+        ScopeResolutionOutcome.FILTERED,
+        ScopeResolutionOutcome.INHERITED,
+    }:
+        resolved = scope
+    elif outcome is ScopeResolutionOutcome.ORGANIZATION_FALLBACK:
+        resolved = DevScope(
+            schema_version="dev_scope.v1",
+            organization_id=scope.organization_id,
+            direct_scope=DirectScope.ORGANIZATION,
+            repositories=[],
+            entity_refs=[],
+            team_ids=[],
+            time_range=scope.time_range,
+            comparison_range=scope.comparison_range,
+            surface_context=None,
+        )
+    return DevScopeResolution(
+        schema_version="dev_scope_resolution.v1",
+        requested_scope=scope,
+        resolved_scope=resolved,
+        outcome=outcome,
+        fallbacks=(
+            ["organization"]
+            if outcome is ScopeResolutionOutcome.ORGANIZATION_FALLBACK
+            else []
+        ),
+        resolved_at=datetime(2026, 8, 6, 12, 0, tzinfo=UTC),
+    )
+
+
+def _error_result(*, scope_resolution: DevScopeResolution | None) -> OrchestratorResult:
+    error = DevError(
+        schema_version="dev_error.v1",
+        request_id="request_01",
+        code="insufficient_evidence",
+        safe_message="There was not enough evidence to answer.",
+        retryable=False,
+    )
+    return OrchestratorResult(
+        run_id="run_01",
+        state=RunState.INSUFFICIENT_EVIDENCE,
+        answer=None,
+        error=error,
+        events=(OrchestratorEvent(RunState.INSUFFICIENT_EVIDENCE, error.code),),
+        usage=AgentUsage(),
+        tool_call_count=0,
+        provider_fingerprint=None,
+        model_fingerprint=None,
+        scope_resolution=scope_resolution,
+    )
+
+
+def _answer_result() -> OrchestratorResult:
+    answer = DevAnswer.model_validate(positive_fixtures()["dev_answer.v1"])
+    return OrchestratorResult(
+        run_id="run_01",
+        state=RunState.COMPLETED,
+        answer=answer,
+        error=None,
+        events=(OrchestratorEvent(RunState.COMPLETED),),
+        usage=AgentUsage(),
+        tool_call_count=1,
+        provider_fingerprint="provider_01",
+        model_fingerprint="model_01",
+        scope_resolution=answer.resolved_scope,
+    )
+
+
+async def _stream(result: OrchestratorResult, states: tuple[RunState, ...]):
+    async def run(sink):
+        for state in states:
+            await sink(OrchestratorEvent(state))
+        return result
+
+    return [
+        event
+        async for event in stream_orchestrator(
+            run_id="run_01", run_with_events=run, cancellation=asyncio.Event()
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. the wire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_answer_terminal_publishes_the_scope_it_actually_resolved() -> None:
+    """The defect, stated as the state the stream must reach.
+
+    An ``unresolved`` outcome is the one the corpus's own
+    ``scope_resolution_outcome_in`` cases declare and could never observe: it
+    only ever occurs on a run that terminates WITHOUT an answer.
+    """
+
+    events = await _stream(
+        _error_result(scope_resolution=_resolution(ScopeResolutionOutcome.UNRESOLVED)),
+        (RunState.ACCEPTED, RunState.RESOLVING_SCOPE, RunState.INSUFFICIENT_EVIDENCE),
+    )
+
+    validate_completed_stream(events)
+    resolved = [
+        event for event in events if event.event is StreamEventType.SCOPE_RESOLVED
+    ]
+    assert len(resolved) == 1
+    assert resolved[0].scope_resolution is not None
+    assert resolved[0].scope_resolution.outcome is ScopeResolutionOutcome.UNRESOLVED
+    # It is the RUN's own outcome on the wire, not a placeholder.
+    assert b'"outcome":"unresolved"' in encode_sse(resolved[0])
+
+
+@pytest.mark.asyncio
+async def test_scope_resolved_precedes_the_error_terminal() -> None:
+    """Ordering, which every consumer of this stream enforces positionally.
+
+    ``contracts.validate_stream`` and web's ``client.ts`` both require the
+    terminal frame to be immediately followed by ``done``; a ``scope.resolved``
+    emitted after ``error`` is a hard client-side failure, not a cosmetic one.
+    """
+
+    events = await _stream(
+        _error_result(
+            scope_resolution=_resolution(ScopeResolutionOutcome.ORGANIZATION_FALLBACK)
+        ),
+        (RunState.ACCEPTED, RunState.RESOLVING_SCOPE, RunState.FAILED),
+    )
+
+    kinds = [event.event for event in events]
+    assert kinds[-2:] == [StreamEventType.ERROR, StreamEventType.DONE]
+    assert kinds.index(StreamEventType.SCOPE_RESOLVED) < kinds.index(
+        StreamEventType.ERROR
+    )
+    assert [event.sequence for event in events] == list(range(len(events)))
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_never_resolved_scope_emits_no_scope_frame() -> None:
+    """Negative control: absent is honest when nothing was ever resolved.
+
+    A run cancelled or faulted before ``resolve`` returned has no scope
+    decision to publish, and inventing one would be worse than the gap this
+    ticket closes.
+    """
+
+    events = await _stream(
+        _error_result(scope_resolution=None),
+        (RunState.ACCEPTED, RunState.CANCELLED),
+    )
+
+    validate_completed_stream(events)
+    assert not [
+        event for event in events if event.event is StreamEventType.SCOPE_RESOLVED
+    ]
+
+
+@pytest.mark.asyncio
+async def test_answer_path_wire_shape_is_unchanged() -> None:
+    """Control on the path that already worked -- it must not move."""
+
+    result = _answer_result()
+    assert result.answer is not None
+    events = await _stream(
+        result,
+        (RunState.ACCEPTED, RunState.RESOLVING_SCOPE, RunState.COMPLETED),
+    )
+
+    validate_completed_stream(events)
+    kinds = [event.event for event in events]
+    assert kinds[0] is StreamEventType.RUN_STARTED
+    assert kinds[-2:] == [StreamEventType.ANSWER_COMPLETED, StreamEventType.DONE]
+    resolved = [
+        event for event in events if event.event is StreamEventType.SCOPE_RESOLVED
+    ]
+    assert len(resolved) == 1
+    # Still the answer's own embedded resolution, byte for byte.
+    assert resolved[0].scope_resolution == result.answer.resolved_scope
+    assert kinds.index(StreamEventType.SCOPE_RESOLVED) < kinds.index(
+        StreamEventType.ANSWER_COMPLETED
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. the orchestrator actually carries it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_carries_its_resolution_on_a_no_answer_terminal() -> None:
+    """End to end through the real orchestrator, not a hand-built result.
+
+    A resolver that returns ``unresolved`` drives the run to the
+    ``scope_not_found`` terminal -- the exact production shape the corpus's
+    ``scope.outcome.unresolved`` case declares -- and the resolution must
+    survive onto the result and out onto the wire.
+    """
+
+    from tests.api.dev.test_orchestrator import _orchestrator, _run
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _resolution(ScopeResolutionOutcome.UNRESOLVED)
+
+    orchestrator = _orchestrator([], script_id="chaos-3497", scope_resolver=resolve)
+    result = await _run(orchestrator)
+
+    assert result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert result.answer is None
+    assert result.error is not None and result.error.code == "scope_not_found"
+    assert result.scope_resolution is not None
+    assert result.scope_resolution.outcome is ScopeResolutionOutcome.UNRESOLVED
+
+    async def run_with_events(sink):
+        del sink
+        return result
+
+    events = [
+        event
+        async for event in stream_orchestrator(
+            run_id="run_01",
+            run_with_events=run_with_events,
+            cancellation=asyncio.Event(),
+        )
+    ]
+    validate_completed_stream(events)
+    assert [
+        event.scope_resolution.outcome
+        for event in events
+        if event.event is StreamEventType.SCOPE_RESOLVED
+        and event.scope_resolution is not None
+    ] == [ScopeResolutionOutcome.UNRESOLVED]
+
+
+@pytest.mark.asyncio
+async def test_the_deferred_corpus_invariants_become_satisfiable() -> None:
+    """The claim the ticket actually makes, executed rather than argued.
+
+    ~15 corpus cases are blocked because their invariants read
+    ``scope.resolved`` off the stream and their expected terminal is a
+    non-answer. Both blocked checkers are run here against a REAL stream
+    produced by the real orchestrator and the real SSE projection, shaped
+    exactly as ``test_wave4_corpus_runner_live._post_sse`` shapes it -- so
+    this measures the same bytes the corpus runner measures, not a
+    hand-authored fixture of what they might look like.
+
+    ``no_unauthorized_candidate_surfaces`` is the security one: it is
+    designed to FAIL, not skip, when nothing was observed. That is exactly
+    what it did on every one of these cases.
+    """
+
+    from scripts.acceptance.corpus.invariants import CHECKS, InvariantContext
+    from tests.api.dev.test_orchestrator import _orchestrator, _run
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _resolution(ScopeResolutionOutcome.UNRESOLVED)
+
+    result = await _run(
+        _orchestrator([], script_id="chaos-3497-corpus", scope_resolver=resolve)
+    )
+    assert result.answer is None, "a non-answer terminal is the whole point"
+
+    frames = [
+        event
+        async for event in stream_orchestrator(
+            run_id="run_01",
+            run_with_events=_replay(result),
+            cancellation=asyncio.Event(),
+        )
+    ]
+    validate_completed_stream(frames)
+    events = [
+        {"event": frame.event.value, "data": frame.model_dump(mode="json")}
+        for frame in frames
+    ]
+    context = InvariantContext(
+        resolution_path=None,
+        public_outcome=None,
+        events=events,
+        expectations={},
+    )
+
+    outcome_result = CHECKS["scope_resolution_outcome_in"](
+        {"allowed": ["unresolved"]}, context
+    )
+    assert outcome_result.passed, outcome_result.detail
+
+    candidate_result = CHECKS["no_unauthorized_candidate_surfaces"](
+        {"authorized_entity_ids": ["entity_01"]}, context
+    )
+    assert candidate_result.passed, candidate_result.detail
+    assert "was not measured" not in candidate_result.detail
+
+
+# ---------------------------------------------------------------------------
+# 3. the prose disclosure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_widened_run_says_so_in_user_facing_prose() -> None:
+    """A named bare subject that went unresolved must be disclosed in words.
+
+    Asserted on all three surfaces a reader can actually reach: the persisted
+    answer's warnings, the persisted frame's ``limitations`` (what the web
+    answer renders), and the ``warning`` frames on the wire.
+    """
+
+    project_ref = {
+        "entity_type": "project",
+        "entity_id": ASK_DEV_PROJECT.canonical_id,
+        "display_label": ASK_DEV_PROJECT.label,
+        "repository_id": None,
+    }
+    output = await run_preflight_orchestrator(
+        question="How is Nightfall doing?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        scope_overrides={"direct_scope": "project", "entity_refs": [project_ref]},
+        script_id="chaos-3497-widened",
+    )
+
+    assert output.preflight_outcomes() == ("proceeded_unresolved_bare_name",)
+    answer = output.result.answer
+    assert answer is not None, "this case answers organization-wide today"
+    assert answer.resolved_scope.outcome is ScopeResolutionOutcome.ORGANIZATION_FALLBACK
+    assert answer.resolved_scope.fallbacks == ["organization"]
+
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in answer.warnings
+
+    events = [
+        event
+        async for event in stream_orchestrator(
+            run_id="run_01",
+            run_with_events=_replay(output.result),
+            cancellation=asyncio.Event(),
+        )
+    ]
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in [
+        event.warning for event in events if event.event is StreamEventType.WARNING
+    ]
+
+
+def test_the_disclosure_reaches_the_frame_a_reader_actually_sees() -> None:
+    """``warnings`` is the channel because the frame's ``limitations`` mirror it.
+
+    Asserted here on a frame that really builds rather than through
+    ``run_preflight_orchestrator``: that harness's answer is the shared
+    ``dev_answer.v1`` fixture, whose unsigned evidence refs make
+    ``wrap_legacy_answer_as_frame`` fall back to an error frame -- a
+    pre-existing fixture gap documented in ``test_orchestrator.
+    _answer_with_signed_evidence``, not a property of this change. Asserting
+    through it would have been a test that cannot fail for the right reason.
+    """
+
+    from dev_health_ops.api.dev import terminal_frames
+    from tests.api.dev.test_orchestrator import _answer_with_signed_evidence
+
+    answer = DevAnswer.model_validate(
+        _answer_with_signed_evidence(script_id="chaos-3497-frame")
+    )
+    disclosed = disclose_scope_widening(answer)
+
+    frame = terminal_frames.wrap_legacy_answer_as_frame(disclosed, run_id="run_01")
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in frame.limitations
+    assert frame.public_outcome is PublicOutcome.ANSWERED_WITH_GAPS
+
+
+def test_the_disclosure_is_appended_once_and_never_evicts_a_warning() -> None:
+    """Idempotent, and it refuses to spend a warning slot it does not have."""
+
+    answer = DevAnswer.model_validate(positive_fixtures()["dev_answer.v1"])
+    once = disclose_scope_widening(answer)
+    twice = disclose_scope_widening(once)
+    assert once.warnings == twice.warnings
+    assert once.warnings[:-1] == list(answer.warnings)
+
+    full = answer.model_copy(update={"warnings": [f"w{index}" for index in range(20)]})
+    assert disclose_scope_widening(full).warnings == full.warnings
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_organization_wide_run_is_not_told_it_was_widened() -> None:
+    """Negative control: a run that widened nothing says nothing."""
+
+    output = await run_preflight_orchestrator(
+        question="How are we doing on delivery this month?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="chaos-3497-orgwide",
+    )
+
+    assert output.preflight_outcomes() == ("proceeded_organization_wide",)
+    answer = output.result.answer
+    assert answer is not None
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE not in answer.warnings
+
+
+@pytest.mark.asyncio
+async def test_the_widening_marker_alone_would_be_the_wrong_predicate() -> None:
+    """Why the disclosure is keyed on the preflight, not on ``fallbacks``.
+
+    ``fallbacks == ["organization"]`` has two producers. The second one --
+    ``scope_service.resolve``'s ``used_org_fallback`` -- fires for a request
+    that named NO subject at all and was allowed to default to the
+    organization; nothing was widened away from anything there, so keying
+    user-facing copy on the marker would state something false.
+
+    That producer is unreachable from Ask Dev today, and this pins BOTH halves
+    of that claim: the marker really is produced subject-free, and production
+    really does close the door. Without the second assertion the first is just
+    a fact about a module nobody calls that way.
+    """
+
+    from dev_health_ops.api.dev.production_runtime import _scope_request
+    from dev_health_ops.api.dev.scope_service import (
+        ScopeResolutionService,
+        ScopeResolveRequest,
+    )
+    from tests.api.dev.test_scope_service import FakeCatalog
+
+    service = ScopeResolutionService(FakeCatalog([]))
+    subject_free = await service.resolve(
+        org_id="org-a",
+        permission_fingerprint="perm-a",
+        request=ScopeResolveRequest(allow_organization_fallback=True),
+    )
+    assert subject_free.outcome is ScopeResolutionOutcome.ORGANIZATION_FALLBACK
+    assert "organization" in subject_free.fallbacks
+
+    assert _scope_request(_scope()).allow_organization_fallback is False
+
+
+def _replay(result: OrchestratorResult):
+    async def run_with_events(sink):
+        del sink
+        return result
+
+    return run_with_events

--- a/tests/api/dev/test_chaos_3497_scope_observability.py
+++ b/tests/api/dev/test_chaos_3497_scope_observability.py
@@ -679,7 +679,13 @@ async def test_the_widening_marker_alone_does_not_trigger_the_disclosure() -> No
         is ScopeResolutionOutcome.ORGANIZATION_FALLBACK
     )
     assert result.answer.resolved_scope.fallbacks == ["organization"]
-    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE not in result.answer.warnings
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE not in result.answer.warnings, (
+        "the disclosure trigger moved from the preflight's "
+        "`legacy_guard_required` to the `fallbacks` marker. This run named no "
+        "subject, so nothing was widened away from anything -- telling this "
+        "reader their subject could not be matched states something false. "
+        "Fix the predicate in orchestrator.finish(), not this test."
+    )
 
 
 def test_the_disclosure_reaches_the_frame_a_reader_actually_sees() -> None:
@@ -765,10 +771,21 @@ async def test_the_widening_marker_alone_would_be_the_wrong_predicate() -> None:
         permission_fingerprint="perm-a",
         request=ScopeResolveRequest(allow_organization_fallback=True),
     )
-    assert subject_free.outcome is ScopeResolutionOutcome.ORGANIZATION_FALLBACK
+    assert subject_free.outcome is ScopeResolutionOutcome.ORGANIZATION_FALLBACK, (
+        "HALF ONE MOVED: scope_service no longer produces the widening marker "
+        "for a subject-free request. If that producer is genuinely gone, the "
+        "marker has one producer again and keying the disclosure on it would "
+        "become safe -- re-derive the trigger deliberately, do not delete this."
+    )
     assert "organization" in subject_free.fallbacks
 
-    assert _scope_request(_scope()).allow_organization_fallback is False
+    assert _scope_request(_scope()).allow_organization_fallback is False, (
+        "HALF TWO MOVED: production now ASKS for the organization fallback, so "
+        "the second producer is reachable from Ask Dev and an ordinary "
+        "org-wide answer can carry fallbacks==['organization'] with no subject "
+        "ever missed. The disclosure must stay keyed on the preflight's "
+        "`legacy_guard_required`; anything reading the marker now lies."
+    )
 
 
 def _replay(result: OrchestratorResult):

--- a/tests/api/dev/test_chaos_3497_scope_observability.py
+++ b/tests/api/dev/test_chaos_3497_scope_observability.py
@@ -27,6 +27,7 @@ question was never widened away from anything) fails too.
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from datetime import UTC, datetime
 
 import pytest
@@ -37,9 +38,11 @@ from dev_health_ops.api.dev.contracts import (
     DevError,
     DevScope,
     DevScopeResolution,
+    DevToolResult,
     DirectScope,
     ScopeResolutionOutcome,
     StreamEventType,
+    ToolID,
 )
 from dev_health_ops.api.dev.contracts_v2 import PublicOutcome
 from dev_health_ops.api.dev.no_match_terminal import (
@@ -56,9 +59,17 @@ from dev_health_ops.api.dev.streaming import (
     stream_orchestrator,
     validate_completed_stream,
 )
-from dev_health_ops.llm.agent.contracts import AgentUsage
+from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
+from dev_health_ops.llm.agent.contracts import (
+    AgentFinalAnswer,
+    AgentToolRequest,
+    AgentUsage,
+)
+from dev_health_ops.llm.agent.scripted import ScriptedStep
 from tests._chaos_3292_preflight import (
     ASK_DEV_PROJECT,
+    ATLAS_PROJECT_ONE,
+    ATLAS_PROJECT_TWO,
     ORG_ID,
     run_preflight_orchestrator,
 )
@@ -145,6 +156,14 @@ def _answer_result() -> OrchestratorResult:
         model_fingerprint="model_01",
         scope_resolution=answer.resolved_scope,
     )
+
+
+def _bare_answer(script_id: str) -> dict:
+    """The shared answer fixture, model-fingerprinted for ``script_id``."""
+
+    from tests.api.dev.test_orchestrator import _answer
+
+    return _answer(script_id=script_id)
 
 
 async def _stream(result: OrchestratorResult, states: tuple[RunState, ...]):
@@ -372,6 +391,193 @@ async def test_the_deferred_corpus_invariants_become_satisfiable() -> None:
 
 
 # ---------------------------------------------------------------------------
+# 2b. the preflight TERMINATE path -- the shape MOST of the blocked corpus
+#     cases actually take, and the one a first cut of this fix got wrong
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_preflight_not_found_publishes_not_found_not_the_stale_scope() -> None:
+    """The run's OWN outcome for the subject the question named.
+
+    Reproduced before the fix: this published ``inherited`` -- the run's
+    original top-level resolve, which by construction can only ever be
+    healthy, because every unhealthy outcome already returned earlier. That
+    put "scope resolved: inherited" one frame ahead of an error saying the
+    named subject could not be found: the exact juxtaposition
+    ``no_match_terminal``'s module docstring says the PRD prohibits.
+    """
+
+    output = await run_preflight_orchestrator(
+        question="What's the status of the Nightfall project?",
+        entities=[(ORG_ID, ASK_DEV_PROJECT)],
+        script_id="chaos-3497-not-found",
+    )
+
+    assert output.preflight_outcomes() == ("unresolved_no_authorized_match",)
+    assert output.result.answer is None
+    published = output.result.scope_resolution
+    assert published is not None
+    assert published.outcome is ScopeResolutionOutcome.UNRESOLVED
+    assert published.resolved_scope is None
+
+
+@pytest.mark.asyncio
+async def test_an_ambiguous_preflight_publishes_the_candidates_it_showed() -> None:
+    """The security invariant gets a real measurement, not a vacuous one.
+
+    ``no_unauthorized_candidate_surfaces`` reads
+    ``scope_resolution.candidates``. Before the fix this terminal published
+    the stale healthy resolution, which v1 forbids from carrying candidates
+    at all -- so the check saw "one scope.resolved event, zero candidates"
+    and PASSED, having measured nothing. That is worse than the "not
+    measured" failure it replaced, and is the vacuity CHAOS-3219 removed.
+
+    The negative half matters as much as the positive: an authorized set
+    that excludes these candidates must FAIL, or "passed" means nothing.
+    """
+
+    from scripts.acceptance.corpus.invariants import CHECKS, InvariantContext
+
+    output = await run_preflight_orchestrator(
+        question="What's the status of the Atlas project?",
+        entities=[(ORG_ID, ATLAS_PROJECT_ONE), (ORG_ID, ATLAS_PROJECT_TWO)],
+        script_id="chaos-3497-ambiguous",
+    )
+
+    assert output.preflight_outcomes() == ("unresolved_ambiguous_candidates",)
+    published = output.result.scope_resolution
+    assert published is not None
+    assert published.outcome is ScopeResolutionOutcome.AMBIGUOUS
+    surfaced = sorted(
+        candidate.entity_ref.entity_id for candidate in published.candidates
+    )
+    assert surfaced == sorted(
+        [ATLAS_PROJECT_ONE.canonical_id, ATLAS_PROJECT_TWO.canonical_id]
+    ), "the candidates on the wire must be the ones the user was shown"
+
+    frames = [
+        event
+        async for event in stream_orchestrator(
+            run_id="run_01",
+            run_with_events=_replay(output.result),
+            cancellation=asyncio.Event(),
+        )
+    ]
+    validate_completed_stream(frames)
+    context = InvariantContext(
+        resolution_path=None,
+        public_outcome=None,
+        events=[
+            {"event": frame.event.value, "data": frame.model_dump(mode="json")}
+            for frame in frames
+        ],
+        expectations={},
+    )
+
+    authorized = CHECKS["no_unauthorized_candidate_surfaces"](
+        {"authorized_entity_ids": surfaced}, context
+    )
+    assert authorized.passed, authorized.detail
+    assert "was not measured" not in authorized.detail
+
+    # The discriminating half: if the check could not see these candidates
+    # it would pass here too, and would be worthless.
+    leaked = CHECKS["no_unauthorized_candidate_surfaces"](
+        {"authorized_entity_ids": ["some-other-entity"]}, context
+    )
+    assert not leaked.passed
+    assert "unauthorized candidate id(s) surfaced" in leaked.detail
+
+
+@pytest.mark.asyncio
+async def test_a_later_failed_lookup_does_not_overwrite_a_real_commit() -> None:
+    """A miss for one name must not be reported as the run's scope decision.
+
+    ``resolve_scope.v1`` records EVERY attempt that produced an outcome, but
+    only a successful one re-commits the run's scope. A run that committed a
+    real project and then failed to look up some other name still executed
+    under that project -- publishing the later miss would invent a
+    resolution failure that never happened, the mirror image of the defect
+    this ticket closes. Mirrors the diversion guard the answer path already
+    applies (organization scope only).
+    """
+
+    from tests.api.dev.test_orchestrator import (
+        _answer,
+        _not_found_resolution,
+        _orchestrator,
+        _organization_resolution,
+        _project_resolution,
+        _run,
+    )
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _organization_resolution()
+
+    committed = _project_resolution()
+    missed = _not_found_resolution()
+    results = [committed, missed]
+
+    async def execute(_context, request):
+        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        if request.tool_id is ToolID.RESOLVE_SCOPE:
+            payload["scope_resolution"] = results.pop(0).model_dump(mode="json")
+        return DevToolResult.model_validate(payload)
+
+    script_id = "chaos-3497-stale-miss"
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "Ask Dev project", "limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="resolve_scope.v1",
+                        arguments={"query": "Nightfall project", "limit": 25},
+                        call_id="tool_call_02",
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer(script_id=script_id, invalid_schema=True)
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer(script_id=script_id, invalid_schema=True)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            registry=AskDevToolRegistry({tool_id: execute for tool_id in ToolID}),
+            scope_resolver=resolve,
+        )
+    )
+
+    assert result.answer is None, "this run must reach a no-answer terminal"
+    assert result.scope_resolution is not None
+    assert result.scope_resolution.outcome is ScopeResolutionOutcome.EXACT, (
+        "the run executed under the committed project, not the later miss"
+    )
+    assert result.scope_resolution.model_dump(mode="json") == committed.model_dump(
+        mode="json"
+    )
+
+
+# ---------------------------------------------------------------------------
 # 3. the prose disclosure
 # ---------------------------------------------------------------------------
 
@@ -417,6 +623,63 @@ async def test_a_widened_run_says_so_in_user_facing_prose() -> None:
     assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in [
         event.warning for event in events if event.event is StreamEventType.WARNING
     ]
+
+
+@pytest.mark.asyncio
+async def test_the_widening_marker_alone_does_not_trigger_the_disclosure() -> None:
+    """The test that actually pins WHICH field the trigger reads.
+
+    The sibling organization-wide control does not discriminate this: that
+    scenario resolves ``inherited`` with empty ``fallbacks``, so a predicate
+    swapped to ``fallbacks`` would not fire there either and the control
+    would stay green while the copy became wrong. Measured, not assumed --
+    the swap was applied and every test still passed.
+
+    This one puts a run in the one state that separates the two predicates:
+    ``ORGANIZATION_FALLBACK`` with ``fallbacks == ["organization"]``, and NO
+    preflight (so ``legacy_guard_required`` is false because no bare name
+    went unresolved -- nothing was widened away from anything). Keyed on the
+    marker, this run would be told its subject was missed. It must not be.
+    """
+
+    from tests.api.dev.test_orchestrator import (
+        _answer_with_no_claims,
+        _orchestrator,
+        _run,
+    )
+
+    async def resolve(**_values) -> DevScopeResolution:
+        return _resolution(ScopeResolutionOutcome.ORGANIZATION_FALLBACK)
+
+    script_id = "chaos-3497-marker-only"
+    result = await _run(
+        _orchestrator(
+            [
+                ScriptedStep(
+                    decision=AgentToolRequest(
+                        tool_id="status_snapshot.v1",
+                        arguments={"limit": 25},
+                        call_id="tool_call_01",
+                    )
+                ),
+                ScriptedStep(
+                    decision=AgentFinalAnswer(
+                        _answer_with_no_claims(script_id=script_id)
+                    )
+                ),
+            ],
+            script_id=script_id,
+            scope_resolver=resolve,
+        )
+    )
+
+    assert result.answer is not None
+    assert (
+        result.answer.resolved_scope.outcome
+        is ScopeResolutionOutcome.ORGANIZATION_FALLBACK
+    )
+    assert result.answer.resolved_scope.fallbacks == ["organization"]
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE not in result.answer.warnings
 
 
 def test_the_disclosure_reaches_the_frame_a_reader_actually_sees() -> None:

--- a/tests/api/dev/test_router.py
+++ b/tests/api/dev/test_router.py
@@ -195,6 +195,13 @@ class FakeBoundedRuntime:
             tool_call_count=0,
             provider_fingerprint="provider-test",
             model_fingerprint="model-test",
+            # CHAOS-3497: the real producer (`orchestrator.finish()`) sets
+            # this on every terminal, and `streaming` builds the
+            # `scope.resolved` frame from it. A double that leaves it None
+            # silently drops that frame from every router test's live leg,
+            # which is how a stream can look fully asserted while missing an
+            # event -- exactly what this ticket is about.
+            scope_resolution=answer.resolved_scope,
         )
 
     async def aclose(self) -> None:
@@ -742,6 +749,13 @@ async def test_dev_message_stream_is_bounded_persisted_and_idempotent(
     assert first.text.count("event: done") == 1
     assert "raw_prompt" not in first.text
     assert "provider_response" not in first.text
+    # CHAOS-3497: `streaming` now builds this frame from
+    # `OrchestratorResult.scope_resolution` rather than reaching into
+    # `answer.resolved_scope`, so `_replayed_result` has to populate that
+    # field too. Counted on BOTH legs: nothing here asserted on
+    # `scope.resolved` before, so a replay silently losing the frame would
+    # have passed every existing check.
+    assert first.text.count("event: scope.resolved") == 1
 
     replay = await client.post(
         f"/api/v1/dev/conversations/{conversation_id}/messages",
@@ -751,6 +765,7 @@ async def test_dev_message_stream_is_bounded_persisted_and_idempotent(
     assert replay.text.count("event: run.started") == 1
     assert replay.text.count("event: answer.completed") == 1
     assert replay.text.count("event: done") == 1
+    assert replay.text.count("event: scope.resolved") == 1
 
     transcript = await client.get(
         f"/api/v1/dev/conversations/{conversation_id}/transcript",


### PR DESCRIPTION
Closes CHAOS-3497.

## Read this first: the first cut of this PR had a NO-SHIP defect

Three independent reviewers converged on the same finding, I reproduced it before touching code, and it is fixed here. It is worth stating up front because the failure mode is the one this wave exists to kill.

My first cut published, on a **preflight TERMINATE** terminal, the run's *original top-level resolve*. That value can only ever be healthy — every unhealthy outcome returns earlier in `run()`. Measured live before the fix, an ambiguous "Atlas" and a not-found "Nightfall" both published `inherited`. Preflight TERMINATE is the shape **most** of the ~15 blocked corpus cases actually take.

It was wrong in two directions at once:

1. It manufactured the exact *"scope outcome: exact while a named subject could not be found"* juxtaposition CHAOS-3367 exists to prevent — one frame ahead of the error saying the subject was not found.
2. Worse: `no_unauthorized_candidate_surfaces` reads `scope_resolution.candidates`, and v1 permits candidates only on candidate-bearing outcomes. So the security invariant would have seen *"one scope.resolved event, zero candidates"* and **PASSED having measured nothing** — strictly worse than the loud "not measured" failure it replaced, and precisely the vacuity CHAOS-3219 spent a wave removing.

The fix builds the published resolution from the **same frame the terminal persists**, through the **same projector** `compat` already uses to replay a clarification — extracted as `scope_resolution_from_frame` so there is one producer, not two.

| case | before | after |
|---|---|---|
| not-found ("Nightfall") | `inherited`, 0 candidates | `unresolved` |
| ambiguous ("Atlas") | `inherited`, 0 candidates | `ambiguous`, 2 real candidates |

## Part 1 — `scope.resolved` on every terminal

`OrchestratorResult` carries `scope_resolution`, set in `finish()` (the one funnel every terminal passes through); `streaming` emits the frame from it, immediately **before** the terminal frame on both branches.

Placement was verified against every consumer: before the terminal is safe everywhere (ops `validate_stream`, web `client.ts` `consumeFrame`, web `contractValidation.ts`, all `scripts/acceptance` smoke scripts, the live Playwright spec); **after** it would 502 web. On the answer path the payload is byte-identical to what shipped before, so that path does not move.

No contract fixture or JSON schema changed — nothing pins event order and `stream_fixtures()` is untouched, so there is no `contracts/` re-export and no web mirror sync.

## Part 2 — the widening is said out loud

One sentence is appended to `answer.warnings`, which in a single append reaches both the stream's `warning` frames and the persisted frame's `limitations` (`wrap_legacy_answer_as_frame` copies warnings into limitations). Copy lives beside the other pinned sentences in `no_match_terminal.py` and carries no underscore-bearing token, so it cannot trip the internal-token denylist.

**Deliberately not what the ticket suggested.** The trigger is the preflight's `legacy_guard_required`, *not* `fallbacks == ["organization"]`. That marker has a second producer — `scope_service.resolve`'s `used_org_fallback` — which fires for a question that named **no** subject at all. Keying copy on it would tell an ordinary org-wide asker their subject was missed, which is false. The two predicates agree today only because production passes `allow_organization_fallback=False`; a test pins **both halves** of that reasoning, with failure messages naming which half moved, because the correct response is opposite in each direction.

## Two regressions this change introduced, found by review and fixed

- `router._replayed_result` never set the new field, so an idempotent replay of an **answered** run silently lost its `scope.resolved` frame. No router test asserted on that event, so nothing failed. They do now, on both the live and replay legs. `FakeBoundedRuntime` was mirroring the real producer minus this field and is corrected — otherwise the live leg under-tests the wire.
- A later failed `resolve_scope.v1` lookup overwrote a real narrower commit. `published_resolution()` now applies the same organization-scope guard the answer path already uses, so a miss for one name is not reported as the scope decision of a run that executed under another.

## Evidence

**The ticket's claim is executed, not argued.** Both blocked checkers are run from `scripts.acceptance.corpus.invariants` against a real stream from the real orchestrator, shaped byte-identically to the live corpus runner's `_post_sse`. `no_unauthorized_candidate_surfaces` passes on the real candidate set **and fails on a set that excludes them** — so "passed" means something.

**RED-proof pairs.** Every guard was observed failing on its own, then restored, with each restore verified by content diff against a backup rather than by git state:

| revert | tests that fail |
|---|---|
| `streaming.py` emission | 4 wire tests |
| the disclosure hook in `finish()` | the prose test |
| `preflight_terminal_resolution` | 2 preflight-terminal tests |
| the organization-scope guard | the stale-miss test |
| predicate swapped to `fallbacks` | the two-producer control |
| `router._replayed_result` field | the router replay test |

A test-quality audit caught my *own* negative control being weak — the whole file still passed with the predicate swapped, because that scenario resolves `inherited` with empty `fallbacks` so the swapped predicate never fired. Replaced with a control that puts a run in the one state separating the two predicates, and re-verified by applying the swap.

## Scope discipline

No acceptance corpus case files touched — a separate lane owns re-authoring; this change only makes their invariants satisfiable. No contract fixtures or schemas changed. Web needs no consumer change (`reduceDevConversationStream` has no case for `scope.resolved`; it is ignored, not assumed to imply an answer); a low-priority fixture-fidelity follow-up is filed as CHAOS-3526.

## Known gap, filed rather than papered over

A replayed **no-answer** run publishes no `scope.resolved`: no `dev_scope_resolution.v1` is persisted for that terminal, so there is nothing to replay. Live runs publish it, their replays do not. Documented in-code at the divergence rather than hidden.
