### PR TITLE
ci: boot the Ask Dev acceptance stack on a schedule (CHAOS-3219 Phase 5, CHAOS-3488)

### DIFF
--- a/.github/workflows/ask-dev-acceptance.yml
+++ b/.github/workflows/ask-dev-acceptance.yml
@@ -1,0 +1,410 @@
+# CHAOS-3219 Phase 5 Lane 5c -- the Ask Dev acceptance stack's CI lane.
+#
+# WHY THIS EXISTS (CHAOS-3488's Phase 5 clause, verbatim): "The acceptance
+# stack has no automated boot coverage anywhere in CI, so any migration merged
+# after a mint silently invalidates the committed artifact and the failure
+# surfaces only when a human runs the stack by hand." That is not hypothetical
+# -- CHAOS-3488 IS that failure: a world snapshot minted against alembic head
+# 0086 merged onto a main already at 0087, and nothing noticed until a human
+# ran the stack for a Phase 2 exit-evidence run, at the most expensive possible
+# point. The offline currency guard added there catches the migration-drift
+# instance of this at unit tier; it cannot catch "the stack no longer boots"
+# for any of the other reasons a stack stops booting. This lane can.
+#
+# WHAT THIS LANE DOES NOT COVER. It never sets ASK_DEV_ACCEPTANCE_ACR, so
+# run_ask_dev_compose.sh resolves acr_armed=0: the acr-db-init / acr-migrate /
+# acr-api services never boot here and every receipt this lane uploads records
+# acr_armed=false. That is deliberate -- the ACR overlay extends services from
+# a sibling dev-health parent checkout this workflow does not provide (see
+# tests/acceptance/compose.ask-dev-acr.yml) -- but it means ACR-side boot rot
+# is NOT detected by this lane. Do not read a green nightly as evidence that
+# the ACR-armed stack still boots (adversarial review 2026-08-06).
+#
+# TRIGGERS -- ruling D1: "CI venue: GH-hosted runners ... PR tier still unit +
+# static wiring guards only." So the live stack run is deliberately NOT a
+# pull_request job:
+#   * schedule           -- nightly, the standing staleness detector.
+#   * workflow_dispatch  -- on demand, and the only way to prove this workflow
+#                           actually runs before a nightly fires.
+# There is no `merge_group` trigger: the merge queue has been disabled across
+# all repos since 2026-08-01 (CHAOS-3519), so a merge_group arm here would be
+# dead configuration that reads as coverage.
+#
+# RUNNER SIZING (D1 + D8). `ubuntu-latest` (4 vCPU / 16 GB RAM / ~14 GB free on
+# the boot volume). GitHub-hosted LARGER runners are not an option for this
+# org, not a preference: `GET /orgs/full-chaos/actions/hosted-runners` returns
+# 404 "GitHub hosted runners are not supported for this organization", and
+# every other workflow in this repo runs on `ubuntu-latest` or the free
+# `ubuntu-26.04-arm` label. Measured footprint of what this job builds and
+# pulls (local `docker images`, 2026-08-06): the shared ops python image
+# 689 MB (api/worker/beat/migrate/scripted-openai all reuse it), the web runner
+# image 364 MB, clickhouse-server 1.08 GB, postgres ~0.67 GB, valkey 66 MB,
+# pgbouncer ~50 MB -- ~3 GB of images, plus BuildKit cache for a Next.js
+# production build and a pnpm store. That does not fit ~14 GB comfortably
+# alongside the preinstalled toolchains, so the "Reclaim runner disk" step
+# below deletes the toolchains this job provably does not use (.NET, GHC,
+# Android SDK, CodeQL bundles) and records `df -h` before and after into the
+# uploaded log bundle -- the sizing claim in this comment is therefore checkable
+# against every run rather than asserted once.
+#
+# HONESTY (CHAOS-3482 / CHAOS-3513 pattern, and the plan doc's §5 rule "no
+# required job may exit success after skipping substantive work"): the
+# `acceptance-live-gate` job below is the reporting check, and it delegates its
+# verdict to ci/aggregate_gate_results.sh with the `unconditional` policy --
+# meaning a skipped `acceptance-live` is never a legitimate pass. A scheduled
+# run that booted nothing is RED. tests/tooling/test_ask_dev_acceptance_workflow.py
+# pins every guard in this file and fails against a mutated copy.
+name: Ask Dev Acceptance (live stack)
+
+on:
+  schedule:
+    # 04:23 UTC nightly. Off the hour on purpose: GitHub queues scheduled
+    # workflows across all of github.com and the top of the hour is the worst
+    # slot for a job that needs a full runner for over an hour.
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+
+# Never cancel a run in progress: this lane's whole product is a completed
+# boot + corpus execution, and a cancelled run is an unmeasured one, not a
+# cheaper one. A second dispatch queues behind the first instead.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance-live:
+    runs-on: ubuntu-latest
+    # Locally the boot takes ~5 min and the 144-case armed corpus ~11 min on a
+    # 10-core laptop with warm image layers. A 4-vCPU runner with a cold cache
+    # builds both images from scratch first. 180 min leaves headroom without
+    # letting a hung stack hold a runner for GitHub's 6-hour maximum.
+    timeout-minutes: 180
+    env:
+      OPS_ROOT: ${{ github.workspace }}/ops
+      WEB_ROOT: ${{ github.workspace }}/web
+      LOG_DIR: ${{ github.workspace }}/ops/.acceptance-logs
+      COMPOSE_PROJECT: dev-health-ask-dev-acceptance
+      ASK_DEV_ACCEPTANCE_API_PORT: "18080"
+    steps:
+      - name: Check out dev-health-ops
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: ops
+
+      # The launcher's final leg runs dev-health-web's
+      # playwright.ask-dev-acceptance.config.ts out of ${web_root}, and the
+      # `web` compose service builds from that same checkout
+      # (ASK_DEV_WEB_CONTEXT). It is a separate private repository, so
+      # ${{ github.token }} cannot reach it.
+      #
+      # secrets.GH_TOKEN is UNPROVEN FOR THIS USE and this is the repository's
+      # first cross-repo checkout -- `repository:` appears nowhere else in
+      # .github/workflows/. An earlier version of this comment claimed
+      # integration.yml already used it this way; that was wrong and is
+      # corrected here (adversarial review 2026-08-06, HIGH). integration.yml
+      # binds GH_TOKEN to the env var GITHUB_TOKEN and pytest consumes it as a
+      # GitHub *provider API* credential; it never reaches actions/checkout.
+      # What IS known: the secret exists on this repo, and
+      # tests/test_private_repo_access.py documents it as a PAT with `repo`
+      # scope, which would work here. What is NOT known: whether it is classic
+      # or fine-grained, and whether it is SSO-authorized for the org. If it is
+      # not, this step 403s and the nightly is RED from here on -- loudly, every
+      # night, which is the correct failure mode but is not a substitute for
+      # checking it. The first post-merge workflow_dispatch verifies this step
+      # specifically.
+      #
+      # It must never degrade to "run the ops half only": an ops-half-only run
+      # is exactly the shape that would let gate.web-default-ci's evidence go
+      # stale unnoticed.
+      - name: Check out dev-health-web
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: full-chaos/dev-health-web
+          ref: main
+          token: ${{ secrets.GH_TOKEN }}
+          path: web
+
+      - name: Reclaim runner disk
+        run: |
+          set -euo pipefail
+          mkdir -p "${LOG_DIR}"
+          {
+            echo "=== df -h before reclaim ==="
+            df -h
+          } | tee "${LOG_DIR}/disk.log"
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/powershell \
+            /usr/share/swift
+          sudo docker image prune --all --force
+          {
+            echo "=== df -h after reclaim ==="
+            df -h
+          } | tee -a "${LOG_DIR}/disk.log"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
+      # uv comes from pip rather than astral-sh/setup-uv: this repository pins
+      # every action to a SHA and does not currently use that one, and adding a
+      # new third-party action to a workflow that holds a cross-repo token is a
+      # bigger change than `pip install uv`.
+      #
+      # The launcher and the corpus runner both invoke ${ops_root}/.venv/bin/
+      # python by absolute path -- run_wave4_corpus.sh exits 64 when it is
+      # absent rather than falling back to a system interpreter.
+      - name: Sync ops virtualenv
+        working-directory: ops
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install uv
+          uv sync --all-extras --dev
+
+      # Same SHAs and same order dev-health-web's own tests.yml uses; pnpm
+      # first so setup-node's `cache: pnpm` can find the store.
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4
+        with:
+          package_json_file: web/package.json
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install web dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      # The launcher executes ${web_root}/node_modules/.bin/playwright directly,
+      # so the browser has to be present in this checkout's store.
+      - name: Install Playwright browser
+        working-directory: web
+        run: pnpm exec playwright install --with-deps chromium
+
+      # ASK_DEV_ACCEPTANCE_KEEP_STACK=1 suppresses only the launcher's final
+      # teardown; every guard inside it still aborts the run -- compose config,
+      # `--wait` on each required service, the world-restore digest check, the
+      # per-boot principal-login proof (with its wrong-password negative
+      # control), the six ops-side smokes, and the web Playwright leg. The
+      # stack is kept because run_wave4_corpus.sh requires an already-booted
+      # one and never boots or tears down a stack itself.
+      - name: Boot the acceptance stack (canonical launcher)
+        working-directory: ops
+        env:
+          ASK_DEV_ACCEPTANCE_KEEP_STACK: "1"
+        run: |
+          set -euo pipefail
+          mkdir -p "${LOG_DIR}"
+          ./scripts/acceptance/run_ask_dev_compose.sh --web-root "${WEB_ROOT}" \
+            2>&1 | tee "${LOG_DIR}/boot.log"
+
+      # The corpus runner's QuotaBudget refuses to start un-budgeted: without
+      # ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX and
+      # ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD in ITS OWN process
+      # environment it raises QuotaConfigurationError in every case's setup.
+      # Found by running this exact sequence locally before merge: the boot
+      # passed and 91 of 144 cases errored in setup in nine seconds.
+      #
+      # Read from the RUNNING api container rather than written out here. The
+      # ceilings live in tests/acceptance/compose.ask-dev.yml, and a second
+      # copy in this workflow is a copy that drifts -- the runner would then
+      # budget against a number the stack does not enforce, which is worse than
+      # not budgeting at all. `printenv` fails when the variable is absent, so
+      # a stack that stopped declaring them fails here instead of silently
+      # un-budgeting the run.
+      - name: Read the quota ceilings the stack enforces
+        run: |
+          set -euo pipefail
+          for name in ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX \
+                      ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD; do
+            value="$(docker compose --project-name "${COMPOSE_PROJECT}" \
+              exec -T api printenv "${name}" | tr -d '\r')"
+            if [[ -z "${value}" ]]; then
+              echo "the acceptance stack does not declare ${name}" >&2
+              exit 1
+            fi
+            echo "${name}=${value}" >> "${GITHUB_ENV}"
+            echo "${name}=${value}"
+          done
+
+      # run_wave4_corpus.sh is the armed-or-throw entry point: it refuses to
+      # start unless ASK_DEV_LIVE_ACCEPTANCE=1, restores the env-scrub
+      # exemption the armed path needs, refuses parallel execution, and then --
+      # from OUTSIDE the pytest session, off the JUnit XML -- asserts a non-zero
+      # number of corpus cases actually executed, exiting 66 (nothing executed)
+      # or 67 (nothing measurable) rather than 0. That assertion reaches this
+      # job's exit status because the step is a plain `run:` with no `if:`, no
+      # `continue-on-error:`, and no `|| true` -- pinned by
+      # tests/tooling/test_ask_dev_acceptance_workflow.py.
+      - name: Run the armed Wave 4 corpus
+        working-directory: ops
+        env:
+          ASK_DEV_LIVE_ACCEPTANCE: "1"
+          ASK_DEV_ACCEPTANCE_API_URL: http://127.0.0.1:18080
+          # A coarse attrition floor, not a registry -- see the long comment on
+          # this variable in run_wave4_corpus.sh. run_report's default of 1
+          # means a run executing ONE of ~144 cases exits 0 and this lane goes
+          # green having certified 0.7% of the corpus (reproduced by
+          # adversarial review with a synthetic JUnit report). 100 catches
+          # catastrophic loss while surviving the corpus's own churn; it does
+          # NOT prove every case ran, and this lane must not be read as
+          # claiming that until Lane 5a's expected-case registry lands.
+          ASK_DEV_CORPUS_MIN_EXECUTED: "100"
+          TEST_SUPERUSER_EMAIL: admin@devhealth.example
+          TEST_SUPERUSER_PASSWORD: devhealth123
+        run: |
+          set -euo pipefail
+          ./scripts/acceptance/run_wave4_corpus.sh 2>&1 | tee "${LOG_DIR}/corpus.log"
+
+      - name: Capture stack state and container logs
+        if: always()
+        run: |
+          mkdir -p "${LOG_DIR}"
+          docker compose --project-name "${COMPOSE_PROJECT}" ps -a \
+            > "${LOG_DIR}/compose-ps.log" 2>&1
+          docker compose --project-name "${COMPOSE_PROJECT}" logs --tail=500 \
+            > "${LOG_DIR}/compose-logs.log" 2>&1
+          df -h >> "${LOG_DIR}/disk.log"
+
+      - name: Tear down the acceptance stack
+        if: always()
+        run: |
+          docker compose --project-name "${COMPOSE_PROJECT}" \
+            down --volumes --remove-orphans
+
+      # if-no-files-found: error on both, deliberately -- an upload that finds
+      # nothing and reports success is the "measurement that did not happen
+      # reading as coverage" shape this lane exists to prevent.
+      #
+      # Be precise about what each one proves, though. The wave4 receipts
+      # directory is TRACKED evidence (see .gitignore's note on it), so a
+      # non-empty upload there does NOT by itself prove this run wrote
+      # anything -- the checkout already contained receipts. What proves a run
+      # executed is run_wave4_corpus.sh's own assertion, made from outside the
+      # pytest session off a JUnit report it deleted before the run
+      # (EXIT_NOT_EXECUTED=66 / EXIT_UNMEASURABLE=67). The log bundle below is
+      # untracked and produced only by this job, so ITS emptiness is a real
+      # signal.
+      - name: Upload corpus receipts and JUnit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ask-dev-acceptance-receipts
+          path: ops/tests/acceptance/artifacts/wave4/**
+          if-no-files-found: error
+
+      # web/playwright-report and web/test-results are included because the
+      # launcher's final leg is a Playwright run in the WEB checkout, and its
+      # config sets trace: retain-on-failure / screenshot: only-on-failure.
+      # Without these paths a failure in that leg uploads the tee'd stdout and
+      # nothing else -- the trace that would diagnose it dies with the runner
+      # (adversarial review 2026-08-06).
+      - name: Upload boot, corpus and stack logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ask-dev-acceptance-logs
+          path: |
+            ops/.acceptance-logs/**
+            web/playwright-report/**
+            web/test-results/**
+          if-no-files-found: error
+
+  # The reporting check. It exists so that "the acceptance-live job did not
+  # run" and "the acceptance-live job passed" cannot present as the same
+  # outcome -- see ci/aggregate_gate_results.sh's header for the incidents that
+  # rule comes from. GATE_HAS_SELECTOR=false because this workflow has no
+  # `changes` job to consult (no path filter: it is not a PR-tier gate), and
+  # the `unconditional` policy therefore treats ANY skip as unexplained.
+  acceptance-live-gate:
+    needs: [acceptance-live]
+    # always(), not !cancelled(): under !cancelled() a cancelled run leaves this
+    # check skipped, and a skipped check is not a failed one.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Aggregate acceptance-live result
+        env:
+          GATE_NAME: ask-dev-acceptance
+          EVENT_NAME: ${{ github.event_name }}
+          GATE_HAS_SELECTOR: "false"
+          GATED_JOB_1: "acceptance-live|unconditional|${{ needs.acceptance-live.result }}"
+        run: ./ci/aggregate_gate_results.sh
+
+  # A detector nobody reads reproduces the failure it exists to catch. Without
+  # this job the ONLY channel for a red nightly is the Actions tab plus
+  # GitHub's default failure email to whoever last committed this file --
+  # which is "surfaces only when a human happens to look", the exact shape
+  # CHAOS-3488 was filed for, moved one step later. Both adversarial reviewers
+  # raised it independently (2026-08-06, MEDIUM).
+  #
+  # One stable issue, reopened and commented rather than re-created, so a run
+  # of bad nights is one thread and not twenty issues. It keys off the GATE's
+  # result, not the live job's: the gate is the verdict, and it is also what
+  # turns "acceptance-live was skipped" into a failure.
+  #
+  # KNOWN GAP, not covered by this job: if the whole run is cancelled before
+  # any job starts -- possible when a third run queues while one is in
+  # progress, given `concurrency` keeps only one pending run -- no job executes,
+  # so nothing notifies and the run reads grey rather than red. Low: it needs
+  # two dispatches during a 3-hour run, and grey is not green.
+  report-failure:
+    needs: [acceptance-live, acceptance-live-gate]
+    if: always() && needs.acceptance-live-gate.result != 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the nightly failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LIVE_RESULT: ${{ needs.acceptance-live.result }}
+          GATE_RESULT: ${{ needs.acceptance-live-gate.result }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          title="Ask Dev acceptance nightly is failing"
+          body="$(printf '%s\n' \
+            "The Ask Dev acceptance lane did not pass." \
+            "" \
+            "- run: ${RUN_URL}" \
+            "- trigger: ${EVENT}" \
+            "- acceptance-live: ${LIVE_RESULT}" \
+            "- acceptance-live-gate: ${GATE_RESULT}" \
+            "" \
+            "Read the corpus.log artifact before judging this a regression. The" \
+            "line \"armed run executed N case(s)\" distinguishes a run that" \
+            "executed cases and failed some from one that never reached the" \
+            "corpus at all; its ABSENCE means the step died first and the run is" \
+            "unmeasured, not failing.")"
+          # No `|| true` anywhere in here on purpose: this job is the thing
+          # that makes a red nightly visible, so a notifier that quietly
+          # half-worked is worse than one that fails and turns the run red.
+          # `gh issue reopen` errors on an already-open issue, so the state is
+          # read first rather than the error swallowed.
+          existing="$(gh issue list --repo "${REPO}" --state all --limit 100 \
+            --json number,title,state \
+            --jq "[.[] | select(.title == \"${title}\")] | first | \
+                  if . == null then \"\" else \"\\(.number) \\(.state)\" end")"
+          if [[ -z "${existing}" ]]; then
+            gh issue create --repo "${REPO}" --title "${title}" --body "${body}"
+            exit 0
+          fi
+          number="${existing%% *}"
+          state="${existing##* }"
+          if [[ "${state}" == "CLOSED" ]]; then
+            gh issue reopen --repo "${REPO}" "${number}"
+          fi
+          gh issue comment --repo "${REPO}" "${number}" --body "${body}"

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,12 @@ index.txt
 # that could be swept into a commit.
 tests/acceptance/artifacts/wave4/junit-corpus.xml
 
+# CHAOS-3219 Phase 5: the acceptance CI lane's tee'd boot/corpus/stack logs.
+# .github/workflows/ask-dev-acceptance.yml writes them here and uploads them as
+# a run artifact; a local reproduction of that same sequence writes them here
+# too. Per-run byproducts, never commit content.
+.acceptance-logs/
+
 # Agent tool scratch output (browser automation, session memory). These are
 # per-run artifacts and must never enter a commit.
 .playwright-mcp/

--- a/ci/aggregate_gate_results.sh
+++ b/ci/aggregate_gate_results.sh
@@ -48,13 +48,30 @@
 #                    merge time and on main, not in the iterative PR loop) and
 #                    from workflow_dispatch (no filter runs there, so its
 #                    condition can never select it). Used by coverage.
+#   unconditional    The job carries no `if:` that can deselect it, so NO skip
+#                    is ever legitimate. Used by CHAOS-3219 Phase 5's
+#                    ask-dev-acceptance.yml, which fires only on `schedule` and
+#                    `workflow_dispatch` and therefore has no path filter to
+#                    consult: a scheduled run whose only job was skipped booted
+#                    nothing, and "booted nothing" must be RED.
+#
+# GATE_HAS_SELECTOR says whether this gate HAS a `changes` job at all. It is
+# not a convenience switch: the whole rule above turns on being able to name
+# why a skip is legitimate, and for a filter-less workflow the answer is "it
+# never is". So `false` is accepted ONLY together with the `unconditional`
+# policy -- asking this script to judge a path-filtered skip with no filter
+# result in hand is a wiring mistake, and it refuses rather than guessing. The
+# converse is refused too: passing changes inputs alongside
+# GATE_HAS_SELECTOR=false means the caller wired a selector it then told this
+# script to ignore.
 #
 # Inputs (environment):
-#   GATE_NAME        name of the required check, for messages
-#   EVENT_NAME       github.event_name
-#   CHANGES_RESULT   needs.changes.result
-#   CHANGES_CODE     needs.changes.outputs.code
-#   GATED_JOB_1..N   "<job name>|<policy>|<needs.<job>.result>", consecutive
+#   GATE_NAME          name of the required check, for messages
+#   EVENT_NAME         github.event_name
+#   GATE_HAS_SELECTOR  "true" (default) if a `changes` job gates this workflow
+#   CHANGES_RESULT     needs.changes.result       (selector gates only)
+#   CHANGES_CODE       needs.changes.outputs.code (selector gates only)
+#   GATED_JOB_1..N     "<job name>|<policy>|<needs.<job>.result>", consecutive
 #
 # tests/tooling/test_aggregate_gate_results.py pins both halves: it drives this
 # script through the result matrix for every gate, and it parses all three
@@ -64,11 +81,20 @@ set -euo pipefail
 
 GATE_NAME="${GATE_NAME:-gate}"
 EVENT_NAME="${EVENT_NAME:-}"
+# `-`, not `:-`: only an UNSET variable defaults to the selector path. A
+# variable set to the empty string is what a mistyped `${{ ... }}` expression
+# produces in a workflow, and letting that collapse into the permissive default
+# is how a wiring mistake becomes a green check. Empty falls through to the
+# refusal arm below. Caught by
+# test_a_non_literal_selector_declaration_is_refused, which failed against the
+# `:-` this line originally had.
+GATE_HAS_SELECTOR="${GATE_HAS_SELECTOR-true}"
 CHANGES_RESULT="${CHANGES_RESULT:-}"
 CHANGES_CODE="${CHANGES_CODE:-}"
 
 printf 'gate: %s\n' "${GATE_NAME}"
 printf 'event: %s\n' "${EVENT_NAME:-<empty>}"
+printf 'selector job: %s\n' "${GATE_HAS_SELECTOR}"
 printf 'changes result: %s (code=%s)\n' "${CHANGES_RESULT:-<empty>}" "${CHANGES_CODE:-<empty>}"
 
 # Plain string rather than an array: this script is exercised by pytest on
@@ -89,18 +115,66 @@ gate_failed() {
 # The gating decision itself. Checked first and on its own: when `changes` did
 # not succeed, the downstream results are meaningless rather than merely
 # suspicious, and reporting on them would bury the real reason.
-if [[ "${CHANGES_RESULT}" != "success" ]]; then
-  add_failure "changes reported '${CHANGES_RESULT:-<empty>}', not 'success' -- the job that decides what must run did not complete, so the downstream results are not evidence that anything ran"
-  gate_failed
-fi
+case "${GATE_HAS_SELECTOR}" in
+  true)
+    if [[ "${CHANGES_RESULT}" != "success" ]]; then
+      add_failure "changes reported '${CHANGES_RESULT:-<empty>}', not 'success' -- the job that decides what must run did not complete, so the downstream results are not evidence that anything ran"
+      gate_failed
+    fi
+    ;;
+  false)
+    # A gate declared filter-less must not also be handed filter results: one
+    # of the two statements is wrong, and this script cannot tell which.
+    if [[ -n "${CHANGES_RESULT}" || -n "${CHANGES_CODE}" ]]; then
+      add_failure "GATE_HAS_SELECTOR=false, but CHANGES_RESULT='${CHANGES_RESULT}' / CHANGES_CODE='${CHANGES_CODE}' were supplied -- a gate cannot both have no selector job and report one"
+      gate_failed
+    fi
+    ;;
+  *)
+    add_failure "GATE_HAS_SELECTOR must be literally 'true' or 'false', not '${GATE_HAS_SELECTOR:-<empty>}' -- this script will not guess whether a skip could be legitimate"
+    gate_failed
+    ;;
+esac
 
 # Selection is deliberately asymmetric with the `if:` expressions it mirrors.
 # Those ask "did this evaluate true?"; this asks "can the skip be EXPLAINED?",
 # and only a literal `false` from the path filter explains one.
+# Checked for EVERY job, whatever its result -- not only when one is skipped.
+# is_selected() below runs only on the `skipped` arm, so before this existed a
+# mis-wired gate (an unrecognized policy name, or a filter policy with no
+# selector job) sailed through green on every run where nothing happened to
+# skip, and revealed itself only on the day a skip arrived -- the one day the
+# verdict actually mattered. Adversarial review 2026-08-06, LOW but reproduced:
+# `GATE_HAS_SELECTOR=false GATED_JOB_1=job|path-filtered|success` passed, and
+# so did a policy misspelt `uncondit1onal`.
+validate_policy() {
+  local job_name="$1" policy="$2"
+
+  case "${policy}" in
+    unconditional | merge-time-only | path-filtered) ;;
+    *)
+      add_failure "${job_name}'s policy '${policy}' is not recognized -- this script cannot say whether a skip would be legitimate, so it refuses to pass the gate"
+      gate_failed
+      ;;
+  esac
+
+  # The two filter-derived policies read CHANGES_CODE. With no selector job
+  # there is no code to read, and "empty" is not a decision -- refuse rather
+  # than let an unset variable stand in for one.
+  if [[ "${GATE_HAS_SELECTOR}" != "true" && "${policy}" != "unconditional" ]]; then
+    add_failure "${job_name}'s policy '${policy}' is decided by the path filter, but this gate declared GATE_HAS_SELECTOR=false -- there is no filter result to decide it with"
+    gate_failed
+  fi
+}
+
 is_selected() {
   local policy="$1"
 
   case "${policy}" in
+    unconditional)
+      # No `if:` can deselect the job, so a skip is never explainable.
+      return 0
+      ;;
     merge-time-only)
       if [[ "${EVENT_NAME}" == "pull_request" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
         return 1
@@ -119,11 +193,28 @@ is_selected() {
       return 0
       ;;
     *)
+      # Unreachable: validate_policy already refused. Kept so a future policy
+      # added to one function but not the other cannot fall through silently.
       add_failure "job policy '${policy}' is not recognized -- this script cannot say whether a skip would be legitimate, so it refuses to pass the gate"
       gate_failed
       ;;
   esac
 }
+
+# How many GATED_JOB_<n> variables actually exist in the environment, versus
+# how many the consecutive loop below will read. The loop stops at the first
+# gap, so `GATED_JOB_1` + `GATED_JOB_3` used to judge job 1 and silently drop
+# job 3 -- reproduced by adversarial review 2026-08-06 (MEDIUM):
+# GATED_JOB_1=a|unconditional|success with GATED_JOB_3=b|unconditional|failure
+# printed "gate passed" and exited 0. Not reachable from this repo's current
+# workflows, but test.yml already ships two entries, so one typo on
+# GATED_JOB_2 there would drop `coverage` from the required `test` check
+# entirely. A gate that judges a subset of what it was handed, without saying
+# so, is the same class of defect as one that judges nothing.
+supplied=0
+for spec_var in ${!GATED_JOB_@}; do
+  [[ -n "${!spec_var}" ]] && supplied=$((supplied + 1))
+done
 
 index=1
 seen_any="false"
@@ -139,6 +230,7 @@ while true; do
   result="${rest#*|}"
 
   printf '%s result: %s\n' "${job_name}" "${result:-<empty>}"
+  validate_policy "${job_name}" "${policy}"
 
   case "${result}" in
     success) ;;
@@ -163,6 +255,15 @@ done
 # a workflow wiring mistake, which is exactly when a green check is worst.
 if [[ "${seen_any}" != "true" ]]; then
   add_failure "no GATED_JOB_<n> entries were supplied -- this gate was asked to judge nothing"
+fi
+
+# ...and a gate that judged only SOME of what it was handed must not report
+# success either. `index - 1` is how many the consecutive loop consumed;
+# `supplied` is how many non-empty GATED_JOB_* exist. A mismatch means the loop
+# stopped at a gap and one or more jobs' results were never read at all.
+judged=$((index - 1))
+if [[ "${judged}" -ne "${supplied}" ]]; then
+  add_failure "judged ${judged} of ${supplied} GATED_JOB_<n> entries -- the numbering has a gap, so at least one job's result was never read. Number them consecutively from 1."
 fi
 
 if [[ -n "${FAILURES}" ]]; then

--- a/scripts/acceptance/run_ask_dev_compose.sh
+++ b/scripts/acceptance/run_ask_dev_compose.sh
@@ -347,6 +347,37 @@ TEST_SUPERUSER_PASSWORD=devhealth123 \
   "${web_root}/node_modules/.bin/playwright" test \
   -c "${web_root}/playwright.ask-dev-acceptance.config.ts"
 
+# CHAOS-3219 Phase 5 (CI lane): keep the stack up for a caller that has more
+# to run against it -- specifically scripts/acceptance/run_wave4_corpus.sh,
+# whose own header states the stack must already be up and that it will never
+# boot or tear one down. Without this the only way to run the launcher AND the
+# armed corpus in one CI job is a hand-rolled copy of the launcher's boot
+# sequence with the teardown deleted, which is what the local Phase 2 exit runs
+# had to do -- a duplicate that drifts from the canonical launcher silently and
+# is covered by none of its tests.
+#
+# Opt-IN, and deliberately not a "clean up on failure only" heuristic: the
+# default path is unchanged (always tear down, success or failure), so a
+# developer running this by hand can never leak a stack by forgetting a flag.
+# The caller that sets it owns the teardown -- .github/workflows/
+# ask-dev-acceptance.yml does it in an `if: always()` step, so a cancelled or
+# failed job still releases the runner's disk.
+if [[ "${ASK_DEV_ACCEPTANCE_KEEP_STACK:-0}" == "1" ]]; then
+  trap - EXIT
+  echo "Ask Dev Compose acceptance completed successfully; stack retained (ASK_DEV_ACCEPTANCE_KEEP_STACK=1)."
+  # Deliberately NOT spelled with the same literal as the real teardown command
+  # below. Adversarial review 2026-08-06 (HIGH): the first version of this hint
+  # printed `down --volumes --remove-orphans` verbatim, which put a SECOND
+  # occurrence of that string into the file -- silently satisfying the
+  # pre-existing `assert "down --volumes --remove-orphans" in launcher`
+  # (test_launcher_owns_seed_readiness_web_and_fixed_browser_oracle) and this
+  # commit's own ordering assertion with a print statement. Deleting the real
+  # teardown then changed no test. A help message must not be able to stand in
+  # for the command it describes.
+  echo "Tear it down with: docker compose -p ${project_name} down -v --remove-orphans"
+  exit 0
+fi
+
 "${compose[@]}" down --volumes --remove-orphans
 trap - EXIT
 echo "Ask Dev Compose acceptance completed successfully."

--- a/scripts/acceptance/run_wave4_corpus.sh
+++ b/scripts/acceptance/run_wave4_corpus.sh
@@ -41,6 +41,38 @@ if [[ "${ASK_DEV_LIVE_ACCEPTANCE:-}" != "1" ]]; then
   exit 64
 fi
 
+# ASK_DEV_CORPUS_MIN_EXECUTED raises the executed-case floor. run_report's
+# default is 1, and 1 is the right default HERE -- an interactive `-k` run is a
+# legitimate reason to execute a single case. It is the wrong floor for an
+# unattended lane: adversarial review (2026-08-06, MEDIUM-HIGH, reproduced with
+# a synthetic JUnit report) showed a run that executes 1 of 144 cases exits 0
+# and reports green, because nothing between the case-file glob and that
+# assertion knows how many cases there are SUPPOSED to be. load_corpus_cases
+# documents an empty result as a deliberate non-failure and
+# check_script_inventory only catches cases missing a script, never scripts
+# whose case file vanished -- so a bad rebase or partial merge that drops most
+# case files certifies a fraction of the corpus as a pass.
+#
+# This is a COARSE ATTRITION FLOOR, not the closed expected-case registry the
+# execution plan's section 5 item 3 mandates ("expected - received = missing ->
+# red"). That registry is Lane 5a's scripts/acceptance/wave4_manifest.py, which
+# does not exist yet. A floor catches catastrophic loss while surviving the
+# corpus's own churn (144 -> 140 as cases are re-authored); it cannot catch a
+# handful of cases going missing. Raise it to an exact set-difference when 5a
+# lands, and until then do not read a green run as evidence every case ran.
+#
+# Validated HERE rather than beside its use below, so a bad value costs a
+# second instead of failing after a twelve-minute corpus run.
+min_executed_args=()
+if [[ -n "${ASK_DEV_CORPUS_MIN_EXECUTED:-}" ]]; then
+  if [[ ! "${ASK_DEV_CORPUS_MIN_EXECUTED}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ASK_DEV_CORPUS_MIN_EXECUTED must be a positive integer, not '${ASK_DEV_CORPUS_MIN_EXECUTED}'" >&2
+    echo "-- refusing to guess a floor, which would silently become the default of 1." >&2
+    exit 64
+  fi
+  min_executed_args=(--min-executed "${ASK_DEV_CORPUS_MIN_EXECUTED}")
+fi
+
 # Merge, never clobber: an operator debugging with their own
 # DEV_HEALTH_TEST_ENV_ALLOW keeps their exemption. arming.env_allow_value is the
 # single source of truth for the list.
@@ -100,9 +132,9 @@ echo "=== pytest exit: ${pytest_status} ==="
 # from "did it pass", and the answer matters most precisely when the run looks
 # suspiciously clean. This can only turn a green run red, never the reverse --
 # the pytest status is re-raised below if it was non-zero.
-echo "=== executed-case assertion ==="
+echo "=== executed-case assertion (floor: ${ASK_DEV_CORPUS_MIN_EXECUTED:-1}) ==="
 PYTHONPATH="${ops_root}/src:${ops_root}" "${venv_python}" -m \
-  scripts.acceptance.corpus.run_report "${report}"
+  scripts.acceptance.corpus.run_report "${report}" "${min_executed_args[@]+"${min_executed_args[@]}"}"
 report_status=$?
 
 if [[ ${report_status} -ne 0 ]]; then

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -175,6 +175,94 @@ def test_launcher_runs_the_not_found_smoke_before_bringing_up_web() -> None:
     assert 'PYTHONPATH="${ops_root}/src:${ops_root}"' in launcher
 
 
+def test_keep_stack_is_opt_in_and_skips_only_the_teardown() -> None:
+    """CHAOS-3219 Phase 5's keep-the-stack flag, clause by clause.
+
+    The CI lane runs this launcher and then run_wave4_corpus.sh against the
+    same containers, so the stack has to survive the launcher. The risk in any
+    "keep the stack" flag is that it becomes a way to skip WORK, so each
+    assertion below pins one clause of the guard.
+
+    These are text assertions on a shell script the unit tier cannot execute --
+    that is a real limitation and it is why they are clause-level rather than a
+    single "the block exists" check. The first version of this test asserted
+    only two string ORDERINGS, and adversarial review (2026-08-06) survived
+    five separate mutations against it: inverting the comparison so every hand
+    run leaked a stack, deleting the real teardown, deleting the early `exit
+    0`, deleting `trap - EXIT`, and appending a new guard BELOW the keep block
+    so the flag started skipping real work. Every assertion here was written
+    against one of those mutations. Behaviour, as opposed to text, is proven by
+    the local execution run and by the nightly lane itself.
+    """
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    teardown = '"${compose[@]}" down --volumes --remove-orphans'
+
+    # Given the flag, defaulting to off. A developer running this by hand must
+    # not leak a stack by not knowing the variable exists.
+    assert "ASK_DEV_ACCEPTANCE_KEEP_STACK:-0" in launcher
+
+    # And it must be an EQUALS-1 test. `!= "1"` inverts the flag: the default
+    # path would then keep the stack and the CI path would tear it down.
+    assert '"${ASK_DEV_ACCEPTANCE_KEEP_STACK:-0}" == "1"' in launcher
+
+    keep_index = launcher.index("ASK_DEV_ACCEPTANCE_KEEP_STACK")
+    playwright_index = launcher.index('"${web_root}/node_modules/.bin/playwright" test')
+
+    # Then the flag is read strictly AFTER the last thing the launcher proves.
+    # Every guard -- world-restore digest, per-boot login proof, the six
+    # ops-side smokes, the web Playwright leg -- runs before this point
+    # regardless of the flag, so an armed CI run and a developer's run execute
+    # an identical sequence and differ only in whether the containers survive.
+    assert playwright_index < keep_index
+
+    # And the real teardown command appears EXACTLY TWICE, and only twice: the
+    # pre-boot volume reset that makes the fixture deterministic, and the final
+    # teardown. The count is the load-bearing part. A help message that spelled
+    # the same command out in prose would make a third occurrence, and would
+    # then satisfy both the ordering below and the older
+    # `"down --volumes --remove-orphans" in launcher` assertion in
+    # test_launcher_owns_seed_readiness_web_and_fixed_browser_oracle -- so
+    # DELETING the real final teardown would change no test. That is exactly
+    # what the first version of this commit did, and why the retained-stack
+    # hint is deliberately spelled `-p ... down -v` instead.
+    assert launcher.count(teardown) == 2
+    reset_index, final_index = (
+        launcher.index(teardown),
+        launcher.rindex(teardown),
+    )
+    assert reset_index < playwright_index < keep_index < final_index
+
+    # And the guarded branch must actually LEAVE the script. Without `exit 0`
+    # it falls through to the teardown it exists to skip.
+    keep_block = launcher[keep_index:final_index]
+    assert "exit 0" in keep_block
+
+    # And it must clear the EXIT trap on the way out. The trap installed
+    # earlier dumps `ps` + logs and re-exits; leaving it armed on the keep path
+    # turns a successful retained-stack run into a noisy failure.
+    assert "trap - EXIT" in keep_block
+    # Both exit paths clear it -- the keep path and the default path.
+    assert launcher.count("trap - EXIT") == 2
+
+    # And nothing that does WORK may follow the guard. Anything appended below
+    # it would be skipped whenever the flag is set, which would make the flag a
+    # way to skip a proof rather than a way to keep containers. The tail after
+    # the guard is allowed to contain only the teardown and the closing
+    # bookkeeping.
+    tail = launcher[keep_index:]
+    for forbidden in (
+        '"${compose[@]}" exec',
+        '"${compose[@]}" up',
+        "/.venv/bin/python",
+        "node_modules/.bin/playwright",
+    ):
+        assert forbidden not in tail, (
+            f"{forbidden!r} runs after the keep-stack guard, so setting "
+            "ASK_DEV_ACCEPTANCE_KEEP_STACK=1 now skips it -- the flag may skip the "
+            "teardown and nothing else"
+        )
+
+
 def test_oracle_is_versioned_and_requires_exact_grounded_answer_parts() -> None:
     oracle = json.loads(_ORACLE.read_text(encoding="utf-8"))
     assert oracle == {

--- a/tests/tooling/test_aggregate_gate_results.py
+++ b/tests/tooling/test_aggregate_gate_results.py
@@ -503,6 +503,60 @@ def test_a_gate_given_nothing_to_judge_fails() -> None:
     assert "asked to judge nothing" in proc.stderr
 
 
+@pytest.mark.parametrize(
+    ("env", "expected_judged", "expected_supplied"),
+    [
+        pytest.param(
+            {
+                "GATED_JOB_1": "a|path-filtered|success",
+                "GATED_JOB_3": "b|path-filtered|failure",
+            },
+            1,
+            2,
+            id="gap-hides-a-failure",
+        ),
+        pytest.param(
+            {
+                "GATED_JOB_1": "a|path-filtered|success",
+                "GATED_JOB_2": "",
+                "GATED_JOB_3": "b|path-filtered|skipped",
+            },
+            1,
+            2,
+            id="empty-middle-entry-hides-a-skip",
+        ),
+    ],
+)
+def test_a_gap_in_the_job_numbering_fails_the_gate(
+    env: dict[str, str], expected_judged: int, expected_supplied: int
+) -> None:
+    # Given a gate handed non-consecutive GATED_JOB_<n> entries -- one typo in
+    # a workflow away, and test.yml already ships two of them
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "GATE_NAME": "test",
+            "EVENT_NAME": "pull_request",
+            "CHANGES_RESULT": "success",
+            "CHANGES_CODE": "true",
+            **env,
+        },
+    )
+
+    # Then it refuses. The consecutive loop stops at the first gap, so before
+    # this check `GATED_JOB_1=success` + `GATED_JOB_3=failure` printed
+    # "gate passed" and exited 0 -- a required check going green while a job's
+    # failure was never read (adversarial review 2026-08-06, reproduced). A
+    # gate that silently judges a subset is the same defect class as one that
+    # judges nothing.
+    assert proc.returncode == 1, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert f"judged {expected_judged} of {expected_supplied}" in proc.stderr
+
+
 def test_an_unrecognized_policy_fails_the_gate() -> None:
     # Given a job whose selection policy this script does not model
     proc = subprocess.run(
@@ -524,6 +578,178 @@ def test_an_unrecognized_policy_fails_the_gate() -> None:
     # silently become "this skip was fine".
     assert proc.returncode == 1
     assert "not recognized" in proc.stderr
+
+
+# --------------------------------------------------------------------------
+# The selector-less gate (CHAOS-3219 Phase 5).
+#
+# .github/workflows/ask-dev-acceptance.yml fires only on `schedule` and
+# `workflow_dispatch`, so it has no `changes` job and nothing can explain a
+# skip. That is the `unconditional` policy, and it is admitted only together
+# with GATE_HAS_SELECTOR=false. The rows below are the pairs that share a
+# literal result string and must reach opposite verdicts, plus the two wiring
+# mistakes that would let an empty selector result stand in for a decision.
+# --------------------------------------------------------------------------
+
+
+def _run_selectorless(
+    *,
+    result: str,
+    event: str = "schedule",
+    policy: str = "unconditional",
+    has_selector: str = "false",
+    changes_result: str | None = None,
+    changes_code: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+        "GATE_NAME": "ask-dev-acceptance",
+        "EVENT_NAME": event,
+        "GATE_HAS_SELECTOR": has_selector,
+        "GATED_JOB_1": f"acceptance-live|{policy}|{result}",
+    }
+    if changes_result is not None:
+        env["CHANGES_RESULT"] = changes_result
+    if changes_code is not None:
+        env["CHANGES_CODE"] = changes_code
+    return subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, check=False, env=env
+    )
+
+
+@pytest.mark.parametrize(
+    ("result", "event", "expected_pass"),
+    [
+        pytest.param("success", "schedule", _PASS, id="nightly-ran-and-passed"),
+        pytest.param(
+            "success", "workflow_dispatch", _PASS, id="dispatch-ran-and-passed"
+        ),
+        # The whole point. On the other three gates a `skipped` job on
+        # workflow_dispatch or with an undecided filter can be legitimate; here
+        # it never is, because there is no condition that could have deselected
+        # it. A nightly that booted nothing is not a nightly that found nothing.
+        pytest.param("skipped", "schedule", _FAIL, id="nightly-booted-nothing"),
+        pytest.param(
+            "skipped", "workflow_dispatch", _FAIL, id="dispatch-booted-nothing"
+        ),
+        pytest.param("failure", "schedule", _FAIL, id="stack-or-corpus-failed"),
+        pytest.param("cancelled", "schedule", _FAIL, id="cancelled-is-unmeasured"),
+        pytest.param("", "schedule", _FAIL, id="empty-result-is-not-evidence"),
+        pytest.param("neutral", "schedule", _FAIL, id="unknown-result-is-not-evidence"),
+    ],
+)
+def test_selectorless_gate_verdict(
+    result: str, event: str, expected_pass: bool
+) -> None:
+    proc = _run_selectorless(result=result, event=event)
+
+    if expected_pass:
+        assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        assert "ask-dev-acceptance gate passed" in proc.stdout
+    else:
+        assert proc.returncode == 1, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        assert "ask-dev-acceptance gate failed" in proc.stderr
+        assert "gate passed" not in proc.stdout
+        # And it failed for the RIGHT reason. Asserting only the generic footer
+        # let a mutation that deleted the `unconditional` policy arm survive:
+        # the row still went red, but through the "unrecognized policy" path,
+        # which proves nothing about the policy this gate actually uses.
+        expected_reason = (
+            "was skipped, but its job condition selected it to run"
+            if result == "skipped"
+            else f"acceptance-live reported '{result or '<empty>'}'"
+        )
+        assert expected_reason in proc.stderr
+
+
+def test_a_selectorless_gate_may_not_also_report_a_selector() -> None:
+    # Given a gate that declares it has no `changes` job but passes one's result
+    proc = _run_selectorless(
+        result="success", changes_result="success", changes_code="true"
+    )
+
+    # Then it refuses: one of the two statements is wrong and the script cannot
+    # tell which, so it must not act on either.
+    assert proc.returncode == 1
+    assert "cannot both have no selector job and report one" in proc.stderr
+
+
+@pytest.mark.parametrize("result", ["success", "skipped", "failure"])
+@pytest.mark.parametrize("policy", ["totally-bogus", "uncondit1onal", ""])
+def test_an_unrecognized_policy_is_refused_whatever_the_result(
+    policy: str, result: str
+) -> None:
+    # Given a policy name this script does not implement -- a typo, or a name
+    # from a workflow that was never taught to this script
+    proc = _run_selectorless(result=result, policy=policy)
+
+    # Then it refuses on EVERY result, not only on a skip. Before this,
+    # is_selected() ran only on the `skipped` arm, so a mis-wired gate passed
+    # green on every run where nothing happened to skip and revealed itself
+    # only on the day the verdict mattered. Adversarial review 2026-08-06,
+    # reproduced: `acceptance-live|totally-bogus|success` exited 0.
+    assert proc.returncode == 1, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "is not recognized" in proc.stderr
+
+
+def test_the_unconditional_policy_arm_is_load_bearing() -> None:
+    # Given the ONE combination this workflow actually ships
+    proc = _run_selectorless(result="skipped", policy="unconditional")
+
+    # Then the refusal names the unexplained skip, not an unknown policy.
+    # Without this assertion, deleting the `unconditional)` arm outright still
+    # turned every skipped row red -- via the "not recognized" arm -- and the
+    # rows only checked the generic footer, so the arm was unpinned
+    # (adversarial review 2026-08-06, MEDIUM-HIGH, reproduced).
+    assert proc.returncode == 1
+    assert "was skipped, but its job condition selected it to run" in proc.stderr
+    assert "is not recognized" not in proc.stderr
+
+
+def test_a_filter_policy_without_a_selector_is_refused() -> None:
+    # Given a job judged by the path filter, with no filter result to judge by.
+    # `path-filtered` reads CHANGES_CODE; unset, it would read as "undecided"
+    # and quietly call the job selected -- a verdict reached from an absent
+    # measurement rather than a decision.
+    proc = _run_selectorless(result="skipped", policy="path-filtered")
+
+    assert proc.returncode == 1
+    assert "no filter result to decide it with" in proc.stderr
+
+
+@pytest.mark.parametrize("value", ["", "yes", "FALSE", "1"])
+def test_a_non_literal_selector_declaration_is_refused(value: str) -> None:
+    # Given anything but the literal 'true'/'false' -- including the empty
+    # string a mistyped `${{ ... }}` expression produces
+    proc = _run_selectorless(result="success", has_selector=value)
+
+    # Then the gate fails rather than defaulting to the permissive reading.
+    assert proc.returncode == 1
+    assert "must be literally 'true' or 'false'" in proc.stderr
+
+
+def test_the_default_selector_declaration_is_unchanged_for_existing_gates() -> None:
+    # Given a caller that predates GATE_HAS_SELECTOR entirely (no such variable
+    # in its env), which is every gate in test.yml / lint.yml / typecheck.yml
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "GATE_NAME": "lint",
+            "EVENT_NAME": "pull_request",
+            "CHANGES_RESULT": "cancelled",
+            "CHANGES_CODE": "",
+            "GATED_JOB_1": "lint-job|path-filtered|skipped",
+        },
+    )
+
+    # Then it still takes the selector path, and the CHAOS-3482 incident row
+    # still fails. The new input must not have widened the old gates.
+    assert proc.returncode == 1
+    assert "the job that decides what must run did not complete" in proc.stderr
 
 
 # --------------------------------------------------------------------------

--- a/tests/tooling/test_ask_dev_acceptance_workflow.py
+++ b/tests/tooling/test_ask_dev_acceptance_workflow.py
@@ -1,0 +1,1030 @@
+"""Contract for CHAOS-3219 Phase 5's live acceptance lane.
+
+``.github/workflows/ask-dev-acceptance.yml`` is the first workflow that boots
+the Ask Dev acceptance stack. Nothing in CI can prove it works before it is
+merged -- ``schedule`` only fires on the default branch -- so what this file
+pins is everything that can be checked statically: that the triggers are the
+ones ruling D1 allows, that the substantive steps cannot be skipped or have
+their failure swallowed, and that the reporting job's verdict comes from
+``ci/aggregate_gate_results.sh`` with a policy under which a skipped job is
+never a pass.
+
+This is the plan doc's §5 item 5 ("static wiring guards: conformance tests
+that read the launcher/workflow text and assert every required job is invoked,
+in order, with no ``|| true``, no ``continue-on-error``"), applied to the
+workflow rather than the launcher.
+
+WHY THE CHECKS ARE FUNCTIONS AND NOT ASSERTIONS. A conformance test that only
+asserts against the committed file proves the file passes today; it does not
+prove the test would notice if the file stopped passing. Every check below is
+a function returning the violations it found, so each one can be run twice:
+once against the real workflow, where it must find nothing, and once against a
+copy with that specific guard removed, where THAT check -- not merely some
+check -- must find something. A mutation that fails to change the text is
+reported as INVALID rather than passing quietly.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "ask-dev-acceptance.yml"
+AGGREGATOR = ROOT / "ci" / "aggregate_gate_results.sh"
+
+LIVE_JOB = "acceptance-live"
+GATE_JOB = "acceptance-live-gate"
+BOOT_STEP = "Boot the acceptance stack (canonical launcher)"
+CORPUS_STEP = "Run the armed Wave 4 corpus"
+
+#: The scripts this lane exists to execute. Named here rather than inline so a
+#: rename in either repo half fails this test instead of silently un-wiring the
+#: lane.
+#: `|| <anything>` after a command. `|| true` was the original spelling; the
+#: fallback's identity is irrelevant -- any of them supplies the step's exit
+#: status in place of the failure's.
+_OR_SWALLOW = re.compile(r"\|\|\s*\S")
+_SET_PLUS_E = re.compile(r"^\s*set\s+[-+a-z]*\+[a-z]*e", re.MULTILINE)
+_SET_PIPEFAIL = re.compile(
+    r"^\s*set\s+-[a-z]*o?\s*pipefail|^\s*set\s+-o\s+pipefail", re.MULTILINE
+)
+_UNSET_PIPEFAIL = re.compile(r"^\s*set\s+\+o\s+pipefail", re.MULTILINE)
+
+LAUNCHER = "scripts/acceptance/run_ask_dev_compose.sh"
+CORPUS_RUNNER = "scripts/acceptance/run_wave4_corpus.sh"
+
+
+# dict[Any, Any], not dict[str, Any]: PyYAML resolves the bare key `on` to
+# the BOOLEAN True under YAML 1.1, so a workflow mapping genuinely has a
+# non-str key and claiming otherwise would be a type that lies.
+def _load(text: str) -> dict[Any, Any]:
+    doc = yaml.safe_load(text)
+    assert isinstance(doc, dict)
+    return doc
+
+
+def _triggers(doc: dict[Any, Any]) -> dict[str, Any]:
+    # ...so the trigger block can arrive under either key depending on how it
+    # is quoted in the file.
+    block = doc.get("on", doc.get(True))
+    assert isinstance(block, dict), "workflow has no mapping-shaped trigger block"
+    return block
+
+
+def _jobs(doc: dict[Any, Any]) -> dict[str, Any]:
+    jobs = doc.get("jobs")
+    assert isinstance(jobs, dict)
+    return jobs
+
+
+def _steps(doc: dict[Any, Any], job: str) -> list[dict[str, Any]]:
+    steps = _jobs(doc).get(job, {}).get("steps", [])
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step(doc: dict[Any, Any], job: str, name: str) -> dict[str, Any] | None:
+    for step in _steps(doc, job):
+        if step.get("name") == name:
+            return step
+    return None
+
+
+# --------------------------------------------------------------------------
+# Checks. Each returns a list of violations; empty means the guard is intact.
+# --------------------------------------------------------------------------
+
+
+def check_triggers_are_schedule_and_dispatch_only(text: str) -> list[str]:
+    """Ruling D1: the live stack run is not a PR-tier job.
+
+    Also refuses ``merge_group``: the merge queue has been disabled repo-wide
+    since 2026-08-01 (CHAOS-3519), so that arm would be configuration nobody
+    can observe working.
+    """
+    triggers = _triggers(_load(text))
+    violations = []
+    if set(triggers) != {"schedule", "workflow_dispatch"}:
+        violations.append(
+            f"triggers are {sorted(map(str, triggers))}; ruling D1 allows only "
+            "schedule + workflow_dispatch for the live stack run"
+        )
+    schedule = triggers.get("schedule")
+    if not isinstance(schedule, list) or not schedule:
+        violations.append(
+            "schedule trigger carries no cron entry, so nothing ever fires"
+        )
+    elif not all(isinstance(entry, dict) and entry.get("cron") for entry in schedule):
+        violations.append("a schedule entry has no cron expression")
+    return violations
+
+
+def check_live_job_runs_on_a_github_hosted_runner(text: str) -> list[str]:
+    """D1 again: GH-hosted, and a hosted label is the only thing that proves it."""
+    jobs = _jobs(_load(text))
+    if LIVE_JOB not in jobs:
+        return [f"the workflow has no {LIVE_JOB} job at all"]
+    runs_on = jobs[LIVE_JOB].get("runs-on")
+    if not isinstance(runs_on, str) or not runs_on.startswith("ubuntu-"):
+        return [f"{LIVE_JOB} runs-on is {runs_on!r}, not a GitHub-hosted ubuntu label"]
+    return []
+
+
+def check_live_job_is_time_bounded(text: str) -> list[str]:
+    """A hung stack must release the runner well before GitHub's 6-hour cap."""
+    jobs = _jobs(_load(text))
+    if LIVE_JOB not in jobs:
+        return [f"the workflow has no {LIVE_JOB} job at all"]
+    timeout = jobs[LIVE_JOB].get("timeout-minutes")
+    if not isinstance(timeout, int) or not 0 < timeout <= 300:
+        return [
+            f"{LIVE_JOB} timeout-minutes is {timeout!r}; expected a bound under 300"
+        ]
+    return []
+
+
+def check_live_job_is_unconditional(text: str) -> list[str]:
+    """The gate declares this job ``unconditional``; an ``if:`` would make that a lie."""
+    jobs = _jobs(_load(text))
+    if LIVE_JOB not in jobs:
+        # Not pedantry: `.get(LIVE_JOB, {})` used to return {} for a renamed or
+        # deleted job, and `"if" in {}` is False, so the check that owns the
+        # unconditional property passed vacuously for the one change that
+        # destroys it (adversarial review 2026-08-06).
+        return [f"the workflow has no {LIVE_JOB} job at all"]
+    job = jobs[LIVE_JOB]
+    if "if" in job:
+        return [
+            f"{LIVE_JOB} carries `if: {job['if']}`, but {GATE_JOB} judges it under the "
+            "'unconditional' policy, which treats every skip as unexplained"
+        ]
+    return []
+
+
+def check_no_step_swallows_a_failure(text: str) -> list[str]:
+    """No ``continue-on-error``, and no shell construct that eats a non-zero exit.
+
+    ``|| true`` alone is not the vocabulary. Adversarial review 2026-08-06
+    walked past this check with ``|| :``, ``|| echo skipping`` and a plain
+    ``set +e`` -- all of which turn a failed launcher into a green step just as
+    completely.
+    """
+    doc = _load(text)
+    violations = []
+    for job_name, job in _jobs(doc).items():
+        if job.get("continue-on-error"):
+            violations.append(f"job {job_name} sets continue-on-error")
+        for step in job.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            label = step.get("name", step.get("uses", "<unnamed>"))
+            where = f"step {job_name}/{label}"
+            if step.get("continue-on-error"):
+                violations.append(f"{where} sets continue-on-error")
+            code = "\n".join(_code_lines(str(step.get("run", ""))))
+            if _OR_SWALLOW.search(code):
+                violations.append(
+                    f"{where} follows a command with `||`, which turns its failure into "
+                    "a success -- the step's exit status is then the fallback's"
+                )
+            if _SET_PLUS_E.search(code):
+                violations.append(f"{where} disables errexit with `set +e`")
+    return violations
+
+
+def _run_blocks(doc: dict[Any, Any]) -> list[tuple[str, str, str]]:
+    blocks = []
+    for job_name, job in _jobs(doc).items():
+        for step in job.get("steps", []):
+            if isinstance(step, dict) and step.get("run"):
+                blocks.append(
+                    (job_name, str(step.get("name", "<unnamed>")), str(step["run"]))
+                )
+    return blocks
+
+
+def _normalize(expression: object) -> str:
+    return " ".join(str(expression).split())
+
+
+def _code_lines(run: str) -> list[str]:
+    """The lines of a ``run:`` block that are shell code, not commentary.
+
+    Only WHOLE-line comments are dropped. Splitting every line at the first
+    ``#`` would silently truncate a shell string containing one, which turns a
+    real ``|`` or ``||`` into an invisible one -- a false negative in a guard,
+    which is the direction that matters.
+    """
+    return [line for line in run.splitlines() if not line.lstrip().startswith("#")]
+
+
+def _has_real_pipe(line: str) -> bool:
+    """True when the line pipes one command into another.
+
+    Written as "remove the `||` operators, then look for a bare `|`" rather
+    than "skip lines containing `||`". The old form discarded the whole line,
+    so ``cmd | tee log || echo failed`` -- the exact shape this check exists to
+    catch, with a fallback bolted on -- was invisible to it.
+    """
+    return "|" in line.replace("||", "")
+
+
+def check_piped_steps_set_pipefail(text: str) -> list[str]:
+    """A ``cmd | tee log`` step reports *tee's* status without ``pipefail``.
+
+    This is not a style rule. Both substantive steps pipe their output through
+    ``tee`` so the logs reach the uploaded artifact, and ``tee`` exits 0 for a
+    launcher that aborted -- the exact "a run that booted nothing looks green"
+    shape this lane exists to prevent, one character away.
+    """
+    violations = []
+    for job_name, label, run in _run_blocks(_load(text)):
+        code = "\n".join(_code_lines(run))
+        if not any(_has_real_pipe(line) for line in _code_lines(run)):
+            continue
+        where = f"step {job_name}/{label}"
+        if not _SET_PIPEFAIL.search(code):
+            violations.append(
+                f"{where} pipes output but never sets pipefail, so the pipeline reports "
+                "the last command's status, not the failure's"
+            )
+        if _UNSET_PIPEFAIL.search(code):
+            violations.append(f"{where} turns pipefail back off after setting it")
+    return violations
+
+
+def check_boot_step_invokes_the_canonical_launcher(text: str) -> list[str]:
+    """The stack must come up through the launcher, not a copy of its sequence."""
+    doc = _load(text)
+    step = _step(doc, LIVE_JOB, BOOT_STEP)
+    if step is None:
+        return [f"{LIVE_JOB} has no step named {BOOT_STEP!r}"]
+    violations = []
+    run = str(step.get("run", ""))
+    if LAUNCHER not in run:
+        violations.append(f"{BOOT_STEP} does not invoke {LAUNCHER}")
+    if "--web-root" not in run:
+        violations.append(
+            f"{BOOT_STEP} does not pass --web-root, so the launcher exits 64"
+        )
+    if str(step.get("env", {}).get("ASK_DEV_ACCEPTANCE_KEEP_STACK")) != "1":
+        violations.append(
+            f"{BOOT_STEP} does not set ASK_DEV_ACCEPTANCE_KEEP_STACK=1, so the launcher "
+            "tears the stack down and the corpus step has nothing to run against"
+        )
+    if "if" in step:
+        violations.append(f"{BOOT_STEP} carries an `if:` and can therefore be skipped")
+    return violations
+
+
+def check_corpus_step_runs_armed_after_the_boot(text: str) -> list[str]:
+    """Armed, present, unskippable, and ordered after the boot it depends on."""
+    doc = _load(text)
+    step = _step(doc, LIVE_JOB, CORPUS_STEP)
+    if step is None:
+        return [f"{LIVE_JOB} has no step named {CORPUS_STEP!r}"]
+    violations = []
+    if CORPUS_RUNNER not in str(step.get("run", "")):
+        violations.append(f"{CORPUS_STEP} does not invoke {CORPUS_RUNNER}")
+    if str(step.get("env", {}).get("ASK_DEV_LIVE_ACCEPTANCE")) != "1":
+        violations.append(
+            f"{CORPUS_STEP} does not export ASK_DEV_LIVE_ACCEPTANCE=1, so the runner "
+            "exits 64 rather than executing the corpus"
+        )
+    if "if" in step:
+        violations.append(
+            f"{CORPUS_STEP} carries an `if:` and can therefore be skipped"
+        )
+
+    names = [candidate.get("name") for candidate in _steps(doc, LIVE_JOB)]
+    if BOOT_STEP in names and names.index(CORPUS_STEP) < names.index(BOOT_STEP):
+        violations.append(
+            f"{CORPUS_STEP} runs before {BOOT_STEP}; the stack is not up yet"
+        )
+    return violations
+
+
+def check_corpus_talks_to_the_port_the_stack_published(text: str) -> list[str]:
+    """The corpus must query the API this run actually booted.
+
+    The launcher publishes ASK_DEV_ACCEPTANCE_API_PORT; the corpus reads
+    ASK_DEV_ACCEPTANCE_API_URL. They are two variables holding one fact, and if
+    they drift the corpus points at a port nothing is listening on -- which
+    fails, loudly, but only after a full stack build. Cheaper to fail here.
+    """
+    doc = _load(text)
+    port = str(
+        _jobs(doc)
+        .get(LIVE_JOB, {})
+        .get("env", {})
+        .get("ASK_DEV_ACCEPTANCE_API_PORT", "")
+    )
+    step = _step(doc, LIVE_JOB, CORPUS_STEP)
+    if step is None:
+        return [f"{LIVE_JOB} has no step named {CORPUS_STEP!r}"]
+    url = str(step.get("env", {}).get("ASK_DEV_ACCEPTANCE_API_URL", ""))
+    if not port:
+        return [f"{LIVE_JOB} does not pin ASK_DEV_ACCEPTANCE_API_PORT"]
+    if not url.endswith(f":{port}"):
+        return [
+            f"the corpus queries {url!r} but the stack publishes port {port}; one of the two "
+            "was changed without the other"
+        ]
+    return []
+
+
+QUOTA_STEP = "Read the quota ceilings the stack enforces"
+QUOTA_VARS = (
+    "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX",
+    "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD",
+)
+
+
+def check_corpus_is_budgeted_from_the_running_stack(text: str) -> list[str]:
+    """The corpus runner refuses to start un-budgeted.
+
+    QuotaBudget raises QuotaConfigurationError in every case's setup unless
+    both ceilings are in its own process environment -- observed live before
+    merge: the boot passed and 91 of 144 cases errored in setup in nine
+    seconds. The values must come from the RUNNING stack, not from a literal
+    in this workflow: a second copy of a number the stack enforces is a copy
+    that drifts, and budgeting against a ceiling nobody enforces is worse than
+    not budgeting.
+    """
+    doc = _load(text)
+    step = _step(doc, LIVE_JOB, QUOTA_STEP)
+    if step is None:
+        return [f"{LIVE_JOB} has no step named {QUOTA_STEP!r}"]
+    violations = []
+    run = str(step.get("run", ""))
+    for name in QUOTA_VARS:
+        if name not in run:
+            violations.append(f"{QUOTA_STEP} never reads {name}")
+    if "printenv" not in run or "exec -T api" not in run:
+        violations.append(
+            f"{QUOTA_STEP} does not read the ceilings out of the running api container, "
+            "so the runner may budget against a value the stack does not enforce"
+        )
+    if "GITHUB_ENV" not in run:
+        violations.append(f"{QUOTA_STEP} never exports the ceilings to later steps")
+    if "if" in step:
+        violations.append(f"{QUOTA_STEP} carries an `if:` and can therefore be skipped")
+
+    names = [candidate.get("name") for candidate in _steps(doc, LIVE_JOB)]
+    if BOOT_STEP in names and CORPUS_STEP in names:
+        if (
+            not names.index(BOOT_STEP)
+            < names.index(QUOTA_STEP)
+            < names.index(CORPUS_STEP)
+        ):
+            violations.append(
+                f"{QUOTA_STEP} must run after {BOOT_STEP} (the stack must exist to read from) "
+                f"and before {CORPUS_STEP} (which needs the values)"
+            )
+    return violations
+
+
+def check_corpus_has_an_attrition_floor(text: str) -> list[str]:
+    """run_report's default floor is 1, which is the wrong floor for a lane.
+
+    Adversarial review 2026-08-06 (MEDIUM-HIGH, reproduced with a synthetic
+    JUnit report): a run executing ONE of ~144 cases exits 0 and this lane
+    reports green having certified 0.7% of the corpus, because nothing between
+    the case-file glob and the executed-count assertion knows how many cases
+    there are supposed to be. This does not fix that -- an exact expected-case
+    registry is Lane 5a's -- it just refuses to run with the floor of 1.
+    """
+    doc = _load(text)
+    step = _step(doc, LIVE_JOB, CORPUS_STEP)
+    if step is None:
+        return [f"{LIVE_JOB} has no step named {CORPUS_STEP!r}"]
+    raw = str(step.get("env", {}).get("ASK_DEV_CORPUS_MIN_EXECUTED", ""))
+    if not raw.isdigit():
+        return [
+            f"{CORPUS_STEP} does not pin ASK_DEV_CORPUS_MIN_EXECUTED, so the run falls "
+            "back to run_report's floor of 1 and a corpus that lost most of its case "
+            "files would still report green"
+        ]
+    if int(raw) < 2:
+        return [
+            f"{CORPUS_STEP} pins ASK_DEV_CORPUS_MIN_EXECUTED={raw}, which is the default "
+            "floor this check exists to raise"
+        ]
+    return []
+
+
+def check_teardown_and_capture_always_run(text: str) -> list[str]:
+    """Cleanup and log capture must survive a failed or cancelled run."""
+    doc = _load(text)
+    violations = []
+    for name in (
+        "Capture stack state and container logs",
+        "Tear down the acceptance stack",
+    ):
+        step = _step(doc, LIVE_JOB, name)
+        if step is None:
+            violations.append(f"{LIVE_JOB} has no step named {name!r}")
+        elif str(step.get("if", "")).strip() != "always()":
+            violations.append(f"step {name!r} is not `if: always()`")
+    return violations
+
+
+def check_artifact_uploads_fail_on_an_empty_set(text: str) -> list[str]:
+    """An upload that finds nothing and passes is an absent measurement reading as coverage."""
+    doc = _load(text)
+    uploads = [
+        step
+        for step in _steps(doc, LIVE_JOB)
+        if str(step.get("uses", "")).startswith("actions/upload-artifact@")
+    ]
+    if len(uploads) < 2:
+        return [f"expected receipt and log artifact uploads; found {len(uploads)}"]
+    violations = []
+    for step in uploads:
+        label = step.get("name", "<unnamed>")
+        with_block = step.get("with", {})
+        if with_block.get("if-no-files-found") != "error":
+            violations.append(
+                f"upload step {label!r} does not set if-no-files-found: error, so a run "
+                "that produced no evidence would upload nothing and report success"
+            )
+        if str(step.get("if", "")).strip() != "always()":
+            violations.append(f"upload step {label!r} is not `if: always()`")
+    return violations
+
+
+def check_web_checkout_is_wired_for_the_playwright_leg(text: str) -> list[str]:
+    """The launcher's final leg lives in dev-health-web; without it the run is half a run."""
+    doc = _load(text)
+    checkouts = [
+        step
+        for step in _steps(doc, LIVE_JOB)
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    ]
+    web = [
+        step
+        for step in checkouts
+        if str(step.get("with", {}).get("repository", "")).endswith("dev-health-web")
+    ]
+    if not web:
+        return [
+            f"{LIVE_JOB} never checks out dev-health-web, so the Playwright leg cannot run"
+        ]
+    if not str(web[0].get("with", {}).get("token", "")):
+        return [
+            "the dev-health-web checkout carries no token; github.token cannot read it"
+        ]
+    return []
+
+
+def check_gate_job_delegates_to_the_shared_aggregator(text: str) -> list[str]:
+    """The reporting job's verdict comes from the script whose rules are tested."""
+    doc = _load(text)
+    job = _jobs(doc).get(GATE_JOB)
+    if job is None:
+        return [f"the workflow has no {GATE_JOB} job, so nothing reports a verdict"]
+    violations = []
+    if job.get("needs") != [LIVE_JOB]:
+        violations.append(
+            f"{GATE_JOB} needs {job.get('needs')!r}, expected [{LIVE_JOB!r}]"
+        )
+    if str(job.get("if", "")).strip() != "always()":
+        violations.append(
+            f"{GATE_JOB} is `if: {job.get('if')}`; under anything but always() a cancelled "
+            "run leaves this check skipped, which branch protection counts as satisfied"
+        )
+
+    step = next(
+        (
+            s
+            for s in _steps(doc, GATE_JOB)
+            if "aggregate_gate_results.sh" in str(s.get("run", ""))
+        ),
+        None,
+    )
+    if step is None:
+        violations.append(f"{GATE_JOB} does not run ci/aggregate_gate_results.sh")
+        return violations
+
+    env = step.get("env", {})
+    if env.get("GATE_HAS_SELECTOR") != "false":
+        violations.append(
+            "the gate step must declare GATE_HAS_SELECTOR=false: this workflow has no "
+            "`changes` job, and an empty selector result must not be inferred"
+        )
+    if "CHANGES_RESULT" in env or "CHANGES_CODE" in env:
+        violations.append(
+            "the gate step passes changes inputs it has no selector job to produce"
+        )
+    gated = str(env.get("GATED_JOB_1", ""))
+    if not gated.startswith(f"{LIVE_JOB}|unconditional|"):
+        violations.append(
+            f"GATED_JOB_1 is {gated!r}; expected '{LIVE_JOB}|unconditional|<result>' so that a "
+            "skipped acceptance-live can never read as a pass"
+        )
+    if f"needs.{LIVE_JOB}.result" not in gated:
+        violations.append("GATED_JOB_1 does not read the live job's real result")
+    if not any(
+        str(s.get("uses", "")).startswith("actions/checkout@")
+        for s in _steps(doc, GATE_JOB)
+    ):
+        violations.append(
+            f"{GATE_JOB} never checks out the repo the aggregator script lives in"
+        )
+    return violations
+
+
+NOTIFY_JOB = "report-failure"
+
+
+def check_a_failing_run_is_announced(text: str) -> list[str]:
+    """A detector nobody reads is the failure it exists to catch, moved later.
+
+    Both adversarial reviewers raised this independently (2026-08-06, MEDIUM):
+    the gate flips the RUN CONCLUSION to failure, but this workflow fires only
+    on schedule/dispatch, so its check can never be a branch-protection
+    requirement and no repo mechanism watches run conclusions. Without an
+    announcement the only channel is the Actions tab.
+    """
+    doc = _load(text)
+    jobs = _jobs(doc)
+    if NOTIFY_JOB not in jobs:
+        return [
+            f"the workflow has no {NOTIFY_JOB} job, so a red nightly announces nothing"
+        ]
+    job = jobs[NOTIFY_JOB]
+    violations = []
+    if GATE_JOB not in (job.get("needs") or []):
+        violations.append(
+            f"{NOTIFY_JOB} does not depend on {GATE_JOB}, so it cannot read the verdict"
+        )
+    condition = _normalize(job.get("if", ""))
+    if "always()" not in condition:
+        violations.append(
+            f"{NOTIFY_JOB} is `if: {job.get('if')}` -- without always() it is itself "
+            "skipped on the runs it exists to report"
+        )
+    if f"needs.{GATE_JOB}.result != 'success'" not in condition:
+        violations.append(
+            f"{NOTIFY_JOB} must fire on any non-success gate result, not only on "
+            f"failure(): a cancelled or skipped gate is also an unreported night "
+            f"(condition is {condition!r})"
+        )
+    if job.get("permissions", {}).get("issues") != "write":
+        violations.append(f"{NOTIFY_JOB} cannot write an issue without issues: write")
+    run = "\n".join(
+        line
+        for step in _steps(doc, NOTIFY_JOB)
+        for line in _code_lines(str(step.get("run", "")))
+    )
+    if "gh issue create" not in run or "gh issue comment" not in run:
+        violations.append(
+            f"{NOTIFY_JOB} neither creates nor comments on an issue, so nothing is announced"
+        )
+    if "armed run executed" not in run:
+        violations.append(
+            f"{NOTIFY_JOB}'s message does not tell the reader how to tell a run that "
+            "executed cases and failed from one that never reached the corpus"
+        )
+    return violations
+
+
+CHECKS: dict[str, Callable[[str], list[str]]] = {
+    "triggers": check_triggers_are_schedule_and_dispatch_only,
+    "hosted-runner": check_live_job_runs_on_a_github_hosted_runner,
+    "timeout": check_live_job_is_time_bounded,
+    "unconditional-job": check_live_job_is_unconditional,
+    "no-swallowed-failures": check_no_step_swallows_a_failure,
+    "pipefail": check_piped_steps_set_pipefail,
+    "boot-step": check_boot_step_invokes_the_canonical_launcher,
+    "corpus-step": check_corpus_step_runs_armed_after_the_boot,
+    "api-port": check_corpus_talks_to_the_port_the_stack_published,
+    "quota-budget": check_corpus_is_budgeted_from_the_running_stack,
+    "attrition-floor": check_corpus_has_an_attrition_floor,
+    "always-cleanup": check_teardown_and_capture_always_run,
+    "artifact-uploads": check_artifact_uploads_fail_on_an_empty_set,
+    "web-checkout": check_web_checkout_is_wired_for_the_playwright_leg,
+    "gate-job": check_gate_job_delegates_to_the_shared_aggregator,
+    "failure-announced": check_a_failing_run_is_announced,
+}
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("check_id", sorted(CHECKS))
+def test_committed_workflow_satisfies_the_contract(
+    check_id: str, workflow_text: str
+) -> None:
+    # Given the workflow as committed
+    # When each contract check reads it
+    # Then it finds nothing to report.
+    assert CHECKS[check_id](workflow_text) == []
+
+
+#: (check id, literal to replace, replacement). Each removes exactly ONE guard,
+#: so the named check -- not merely some check -- has to notice. Clause-level,
+#: per the repo's third verification rule.
+_MUTATIONS: list[tuple[str, str, str]] = [
+    # A PR-tier arm on the live stack run, which ruling D1 forbids.
+    ("triggers", "  workflow_dispatch:\n", "  workflow_dispatch:\n  pull_request:\n"),
+    # The nightly staleness detector with nothing to fire it.
+    ("triggers", '    - cron: "23 4 * * *"', "    []"),
+    (
+        "hosted-runner",
+        f"  {LIVE_JOB}:\n    runs-on: ubuntu-latest",
+        f"  {LIVE_JOB}:\n    runs-on: self-hosted",
+    ),
+    ("timeout", "    timeout-minutes: 180", "    timeout-minutes: 0"),
+    # The classic false green: the whole job made conditional on something that
+    # can evaluate false, under a gate that calls skips unexplained.
+    (
+        "unconditional-job",
+        f"  {LIVE_JOB}:\n    runs-on: ubuntu-latest",
+        f"  {LIVE_JOB}:\n    if: github.event_name == 'push'\n    runs-on: ubuntu-latest",
+    ),
+    (
+        "no-swallowed-failures",
+        "./scripts/acceptance/run_wave4_corpus.sh 2>&1",
+        "./scripts/acceptance/run_wave4_corpus.sh 2>&1 || true",
+    ),
+    (
+        "no-swallowed-failures",
+        "      - name: Run the armed Wave 4 corpus\n        working-directory: ops",
+        "      - name: Run the armed Wave 4 corpus\n        continue-on-error: true\n        working-directory: ops",
+    ),
+    # One character: without pipefail the launcher's failure is hidden by tee's
+    # exit status and the job goes green having booted nothing.
+    (
+        "pipefail",
+        '          set -euo pipefail\n          mkdir -p "${LOG_DIR}"\n          ./scripts/acceptance/run_ask_dev_compose.sh',
+        '          set -eu\n          mkdir -p "${LOG_DIR}"\n          ./scripts/acceptance/run_ask_dev_compose.sh',
+    ),
+    (
+        "boot-step",
+        '          ASK_DEV_ACCEPTANCE_KEEP_STACK: "1"',
+        '          ASK_DEV_ACCEPTANCE_KEEP_STACK: "0"',
+    ),
+    (
+        "boot-step",
+        './scripts/acceptance/run_ask_dev_compose.sh --web-root "${WEB_ROOT}"',
+        "true",
+    ),
+    ("corpus-step", "./scripts/acceptance/run_wave4_corpus.sh 2>&1", "true 2>&1"),
+    (
+        "corpus-step",
+        '          ASK_DEV_LIVE_ACCEPTANCE: "1"',
+        '          ASK_DEV_LIVE_ACCEPTANCE: "0"',
+    ),
+    (
+        "quota-budget",
+        "      - name: Read the quota ceilings the stack enforces",
+        "      - name: Read the quota ceilings the stack enforces\n        if: false",
+    ),
+    (
+        "quota-budget",
+        'exec -T api printenv "${name}"',
+        'echo 1000 # "${name}"',
+    ),
+    (
+        "api-port",
+        "          ASK_DEV_ACCEPTANCE_API_URL: http://127.0.0.1:18080",
+        "          ASK_DEV_ACCEPTANCE_API_URL: http://127.0.0.1:18099",
+    ),
+    (
+        "always-cleanup",
+        "      - name: Tear down the acceptance stack\n        if: always()",
+        "      - name: Tear down the acceptance stack",
+    ),
+    (
+        "artifact-uploads",
+        "          if-no-files-found: error",
+        "          if-no-files-found: ignore",
+    ),
+    (
+        "web-checkout",
+        "          repository: full-chaos/dev-health-web",
+        "          repository: full-chaos/dev-health-ops",
+    ),
+    (
+        "gate-job",
+        '          GATE_HAS_SELECTOR: "false"',
+        '          GATE_HAS_SELECTOR: "true"',
+    ),
+    (
+        "gate-job",
+        f'          GATED_JOB_1: "{LIVE_JOB}|unconditional|',
+        f'          GATED_JOB_1: "{LIVE_JOB}|path-filtered|',
+    ),
+    (
+        "gate-job",
+        "    if: always()\n    runs-on: ubuntu-latest",
+        "    if: '!cancelled()'\n    runs-on: ubuntu-latest",
+    ),
+    ("gate-job", "        run: ./ci/aggregate_gate_results.sh", "        run: echo ok"),
+    # --- clauses adversarial review (2026-08-06) found live but unpinned ---
+    (
+        "triggers",
+        '    - cron: "23 4 * * *"',
+        "    - {}",
+    ),
+    (
+        "timeout",
+        "    timeout-minutes: 180\n",
+        "",
+    ),
+    (
+        "no-swallowed-failures",
+        f"  {LIVE_JOB}:\n    runs-on: ubuntu-latest",
+        f"  {LIVE_JOB}:\n    continue-on-error: true\n    runs-on: ubuntu-latest",
+    ),
+    (
+        "boot-step",
+        "      - name: Boot the acceptance stack (canonical launcher)\n        working-directory: ops",
+        "      - name: Boot the acceptance stack (canonical launcher)\n        if: false\n        working-directory: ops",
+    ),
+    (
+        "boot-step",
+        "      - name: Boot the acceptance stack (canonical launcher)",
+        "      - name: Boot the stack sometime",
+    ),
+    (
+        "corpus-step",
+        "      - name: Run the armed Wave 4 corpus\n        working-directory: ops",
+        "      - name: Run the armed Wave 4 corpus\n        if: github.event_name == 'push'\n        working-directory: ops",
+    ),
+    (
+        "api-port",
+        '      ASK_DEV_ACCEPTANCE_API_PORT: "18080"\n',
+        "",
+    ),
+    (
+        "quota-budget",
+        'echo "${name}=${value}" >> "${GITHUB_ENV}"',
+        'echo "${name}=${value}"',
+    ),
+    (
+        "quota-budget",
+        "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD; do",
+        "; do",
+    ),
+    (
+        "attrition-floor",
+        '          ASK_DEV_CORPUS_MIN_EXECUTED: "100"',
+        '          ASK_DEV_CORPUS_MIN_EXECUTED: "1"',
+    ),
+    (
+        "always-cleanup",
+        "      - name: Capture stack state and container logs\n        if: always()",
+        "      - name: Capture stack state and container logs",
+    ),
+    (
+        "artifact-uploads",
+        "      - name: Upload corpus receipts and JUnit report\n        if: always()",
+        "      - name: Upload corpus receipts and JUnit report",
+    ),
+    (
+        "web-checkout",
+        "          token: ${{ secrets.GH_TOKEN }}\n",
+        "",
+    ),
+    (
+        "gate-job",
+        f"    needs: [{LIVE_JOB}]",
+        "    needs: [acceptance-live-gate]",
+    ),
+    (
+        "gate-job",
+        '          GATE_HAS_SELECTOR: "false"\n',
+        '          GATE_HAS_SELECTOR: "false"\n          CHANGES_RESULT: "success"\n',
+    ),
+    (
+        "gate-job",
+        f'          GATED_JOB_1: "{LIVE_JOB}|unconditional|${{{{ needs.{LIVE_JOB}.result }}}}"',
+        f'          GATED_JOB_1: "{LIVE_JOB}|unconditional|success"',
+    ),
+    (
+        "gate-job",
+        "      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n      - name: Aggregate acceptance-live result",
+        "      - name: Aggregate acceptance-live result",
+    ),
+    (
+        "failure-announced",
+        "  report-failure:\n    needs: [acceptance-live, acceptance-live-gate]",
+        "  report-failure:\n    needs: [acceptance-live]",
+    ),
+    (
+        "failure-announced",
+        "    if: always() && needs.acceptance-live-gate.result != 'success'",
+        "    if: failure()",
+    ),
+    (
+        "failure-announced",
+        "      issues: write",
+        "      issues: read",
+    ),
+    (
+        "failure-announced",
+        "            gh issue create --repo",
+        "            echo would-create --repo",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("check_id", "original", "replacement"),
+    _MUTATIONS,
+    ids=[f"{check_id}-{index}" for index, (check_id, _, _) in enumerate(_MUTATIONS)],
+)
+def test_each_guard_rejects_the_workflow_without_it(
+    check_id: str, original: str, replacement: str, workflow_text: str
+) -> None:
+    # Given a copy of the workflow with exactly one guard removed
+    mutated = workflow_text.replace(original, replacement, 1)
+    # A mutation that did not apply proves nothing -- INVALID, not KILLED.
+    assert mutated != workflow_text, (
+        f"mutation for {check_id!r} did not match the committed workflow; the anchor text "
+        f"{original!r} has moved, so this row is INVALID and is testing nothing"
+    )
+    # When the check that owns that guard reads the copy
+    # Then it reports the violation, rather than some other check happening to.
+    assert CHECKS[check_id](mutated), (
+        f"check {check_id!r} accepted a workflow with its own guard removed"
+    )
+
+
+def test_the_aggregator_understands_the_policy_this_workflow_asks_for() -> None:
+    # Given the workflow hands ci/aggregate_gate_results.sh a policy name
+    # When that script is read
+    # Then the name is one it implements -- an unrecognized policy would be
+    # caught at run time, i.e. nightly, which is the wrong place to learn it.
+    assert "unconditional)" in AGGREGATOR.read_text(encoding="utf-8")
+    assert "GATE_HAS_SELECTOR" in AGGREGATOR.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# The corpus runner's side of the attrition floor. The workflow pins the value;
+# these execute the script that consumes it.
+# --------------------------------------------------------------------------
+
+CORPUS_RUNNER_PATH = ROOT / CORPUS_RUNNER
+
+
+@pytest.fixture
+def corpus_runner_tree(tmp_path: Path) -> Path:
+    """The real runner script, in a synthetic tree with a stub interpreter.
+
+    The script derives its ops_root from ``BASH_SOURCE`` and refuses to run at
+    all when ``<ops_root>/.venv/bin/python`` is absent -- which is the correct
+    behaviour, and which made the first version of these tests pass locally for
+    the wrong reason and fail on a GitHub runner, where dependencies are pip
+    installed and no ``.venv`` exists. Copying the script's REAL BYTES into a
+    tmp tree with a stubbed interpreter exercises the same file everywhere,
+    instead of testing whichever machine happens to have a venv.
+    """
+    script = tmp_path / "scripts" / "acceptance" / CORPUS_RUNNER_PATH.name
+    script.parent.mkdir(parents=True)
+    script.write_bytes(CORPUS_RUNNER_PATH.read_bytes())
+    script.chmod(0o755)
+
+    interpreter = tmp_path / ".venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    # Loud rather than silent: every assertion below expects the script to
+    # refuse BEFORE it needs an interpreter, so if one is ever invoked the test
+    # fails with a message saying so instead of quietly succeeding.
+    interpreter.write_text(
+        "#!/bin/sh\necho 'stub interpreter invoked' >&2\nexit 99\n", encoding="utf-8"
+    )
+    interpreter.chmod(0o755)
+    return script
+
+
+def _run_corpus_runner(
+    script: Path, min_executed: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=script.parent,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(script.parent),
+            "ASK_DEV_LIVE_ACCEPTANCE": "1",
+            "ASK_DEV_CORPUS_MIN_EXECUTED": min_executed,
+        },
+    )
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "many", "1.5", " 100", "100 "])
+def test_a_floor_that_is_not_a_positive_integer_is_refused(
+    value: str, corpus_runner_tree: Path
+) -> None:
+    # Given a floor this script cannot act on
+    proc = _run_corpus_runner(corpus_runner_tree, value)
+
+    # Then it refuses, rather than letting the value fall through to
+    # run_report's default of 1 -- which is precisely the floor the variable
+    # exists to raise, so silently defaulting would restore the defect while
+    # looking configured.
+    assert proc.returncode == 64, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    assert "must be a positive integer" in proc.stderr
+
+
+def test_the_floor_is_validated_before_the_corpus_runs(
+    corpus_runner_tree: Path,
+) -> None:
+    # Given a bad floor, the refusal must arrive before pytest is invoked --
+    # a config error that costs a twelve-minute corpus run first is a config
+    # error nobody fixes early.
+    proc = _run_corpus_runner(corpus_runner_tree, "nope")
+
+    assert proc.returncode == 64
+    assert "armed corpus run" not in proc.stdout
+    assert "pytest exit" not in proc.stdout
+    # And it got there without needing an interpreter at all.
+    assert "stub interpreter invoked" not in proc.stderr
+
+
+def test_the_floor_is_forwarded_to_the_assertion_that_uses_it() -> None:
+    # The two halves of "the floor works" are validated differently, and this
+    # is the half a stack-free test can only reach as text: proving the runner
+    # actually HANDS the value to run_report requires a booted stack, because
+    # everything before that line is a twelve-minute pytest session.
+    # A mutation that accepted the variable and then dropped it -- leaving the
+    # default of 1 in force while the log printed the configured floor --
+    # survived every executable test here, so these two assertions exist.
+    runner = CORPUS_RUNNER_PATH.read_text(encoding="utf-8")
+    assert (
+        'min_executed_args=(--min-executed "${ASK_DEV_CORPUS_MIN_EXECUTED}")' in runner
+    )
+    assert (
+        'run_report "${report}" "${min_executed_args[@]+"${min_executed_args[@]}"}"'
+        in runner
+    )
+
+
+@pytest.mark.parametrize(
+    ("executed", "floor", "expected_exit"),
+    [
+        pytest.param(3, 2, 0, id="above-the-floor-passes"),
+        pytest.param(2, 2, 0, id="exactly-the-floor-passes"),
+        pytest.param(1, 2, 66, id="below-the-floor-is-NOT-EXECUTED"),
+        # The defect the floor exists for: 1 of many, which the default floor
+        # of 1 reports as a pass.
+        pytest.param(1, 100, 66, id="one-case-of-a-hundred-is-refused"),
+    ],
+)
+def test_run_report_honours_the_floor(
+    tmp_path: Path, executed: int, floor: int, expected_exit: int
+) -> None:
+    # Given a JUnit report describing a run that executed `executed` real
+    # corpus cases -- built in the shape run_report actually parses
+    cases = "".join(
+        f'<testcase classname="tests.acceptance.test_wave4_corpus_runner_live" '
+        f'name="test_corpus_case[case-{index}]" time="0.1"></testcase>'
+        for index in range(executed)
+    )
+    report = tmp_path / "junit-corpus.xml"
+    report.write_text(
+        f'<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite '
+        f'name="pytest" errors="0" failures="0" skipped="0" tests="{executed}" '
+        f'time="1.0">{cases}</testsuite></testsuites>',
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.acceptance.corpus.run_report",
+            str(report),
+            "--min-executed",
+            str(floor),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "HOME": str(ROOT),
+            "PYTHONPATH": f"{ROOT / 'src'}:{ROOT}",
+        },
+    )
+
+    # Then the floor decides the verdict, and a short run exits with the
+    # distinct EXIT_NOT_EXECUTED code rather than a pytest-looking 1.
+    assert proc.returncode == expected_exit, (
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )


### PR DESCRIPTION
CHAOS-3219 Phase 5 Lane 5c, and CHAOS-3488's Phase-5 clause.

## Why

CHAOS-3488's Phase 5 clause, verbatim: *"The acceptance stack has no automated boot coverage anywhere in CI, so any migration merged after a mint silently invalidates the committed artifact and the failure surfaces only when a human runs the stack by hand."*

CHAOS-3488 **is** that failure — a world snapshot minted against alembic head `0086` merged onto a main already at `0087`, and nothing noticed until a human booted the stack for a Phase 2 exit-evidence run. The currency guard added there catches the migration-drift instance at unit tier. It cannot catch "the stack no longer boots" for any of the other reasons a stack stops booting. This lane can.

It is also the route named in `gate.web-default-ci`'s `blocked_reason` clause (3), merged in #1553: the launcher already invokes the web acceptance Playwright config, and once it runs inside a workflow producing ops-resident artifacts, that row acquires checkable evidence.

## What

**`.github/workflows/ask-dev-acceptance.yml`** (new)

- `schedule` (nightly 04:23 UTC) + `workflow_dispatch` **only**. Ruling D1 keeps the PR tier at unit + static wiring guards, so the live stack run is deliberately not a `pull_request` job. No `merge_group` arm — the merge queue has been disabled repo-wide since 2026-08-01 (CHAOS-3519), and a dead trigger reads as coverage.
- `ubuntu-latest`, per D1. GitHub-hosted **larger runners are not available to this org** — `GET /orgs/full-chaos/actions/hosted-runners` returns 404 "not supported for this organization". Verified, not assumed. The job reclaims the preinstalled toolchains it provably does not use and records `df -h` before and after into the uploaded logs, so the sizing claim is checkable per run rather than asserted once.
- Boots through the canonical launcher, then runs the armed corpus. Every launcher guard still runs: `compose config`, `--wait` per service, the world-restore digest check, the per-boot principal-login proof with its wrong-password negative control, the six ops-side smokes, and the web Playwright leg.
- `report-failure` announces a red night on a single reopened issue.

**Aggregator honesty.** `ci/aggregate_gate_results.sh` gains the `unconditional` policy and `GATE_HAS_SELECTOR`, so a workflow with no `changes` job can still reach a verdict. A skipped `acceptance-live` is never a legitimate pass: a scheduled run that booted nothing is RED.

**`ASK_DEV_ACCEPTANCE_KEEP_STACK`** in the launcher — opt-in, read only *after* the Playwright leg. `run_wave4_corpus.sh` requires an already-booted stack and never boots one; without this flag the only way to run both in one job is a hand-rolled copy of the launcher's boot sequence with the teardown deleted, which is what the local Phase 2 exit runs had to do and which no launcher test covers. The default path is unchanged.

## Five defects found by execution, not by reading

Four of them in this change's own new code. Each is why the corresponding test exists.

1. **`GATE_HAS_SELECTOR` used `${VAR:-true}`.** An *empty* value — what a mistyped `${{ }}` expression produces — silently took the permissive path. Now `${VAR-true}`. Caught by a test written before it was run.
2. **The corpus runner refuses to start un-budgeted.** Running the workflow's exact sequence locally: the boot passed and **91 of 144 cases errored in setup in nine seconds** on `QuotaConfigurationError`. The workflow now reads both ceilings out of the *running* api container, not from a literal here — a second copy of a number the stack enforces is a copy that drifts, and budgeting against a ceiling nobody enforces is worse than not budgeting.
3. **The executed-case floor was 1, not the corpus size.** A run executing ONE of ~144 cases exits 0 and this lane would report green having certified 0.7% of the corpus. Reproduced with a synthetic JUnit report. `ASK_DEV_CORPUS_MIN_EXECUTED` raises it, validated fail-fast. **This is a coarse attrition floor and says so** — the exact expected-case registry is Lane 5a's `wave4_manifest.py`, which does not exist yet. A green run is not yet evidence that every case ran.
4. **The aggregator judged only a *consecutive* run of `GATED_JOB_<n>`.** `GATED_JOB_1` + `GATED_JOB_3` printed "gate passed" while job 3's failure was never read. Not reachable from this workflow, but `test.yml` already ships two entries, so one typo there would drop `coverage` from the required `test` check. It now refuses on a numbering gap.
5. **The policy field was validated only on a `skipped` result**, so a mis-wired gate stayed invisible until the day a job skipped — the one day the verdict matters. Now validated per job on every result.

## A defect this change introduced into an existing test

Worth stating plainly. The retained-stack hint originally printed `down --volumes --remove-orphans` verbatim. That put a **second copy of that string** into the launcher, which silently satisfied the pre-existing `assert "down --volumes --remove-orphans" in launcher` in `test_launcher_owns_seed_readiness_web_and_fixed_browser_oracle` — **so deleting the real teardown changed no test.** Five separate mutations survived the first version of the keep-stack test.

The hint is respelled (`-p ... down -v`), and the test now pins the occurrence *count*, the `== "1"` comparison, the early `exit 0`, both `trap - EXIT` clears, and that no work follows the guard. All five previously-surviving mutations are now KILLED, with the restore verified by sha256 rather than by `git status`.

## A false claim, corrected

An earlier version of the workflow comment stated that `integration.yml` already used `secrets.GH_TOKEN` for a cross-repo checkout. **That was wrong.** `integration.yml` binds it to the env var `GITHUB_TOKEN` and pytest consumes it as a GitHub *provider API* credential; it never reaches `actions/checkout`. This is the repository's first cross-repo checkout — `repository:` appears nowhere else in `.github/workflows/`.

`GH_TOKEN` is therefore **unproven for this use**. The secret exists and is documented as a `repo`-scoped PAT, which would work; whether it is classic or fine-grained, and whether it is SSO-authorized for the org, is unknown. If it is not, the nightly is RED from that step — loudly, every night, which is the correct failure mode but is not a substitute for checking. **Dispatch run 1 verifies that step specifically.**

## What this lane does not cover

Stated in the workflow header rather than left to be discovered:

- **ACR is never armed here.** `acr_armed=0`, the acr-* services never boot, and every receipt records `acr_armed=false`. ACR-side boot rot is invisible to this lane.
- **The attrition floor is coarse**, not a closed registry (above).
- **A run cancelled while still pending** produces no gate check and reads grey, not red. Needs two dispatches during a 3-hour run; grey is not green. Documented rather than engineered around.

## Evidence

Pre-merge, `schedule` only fires from the default branch, so the workflow itself cannot run here. What was done instead:

- **Static contract**: `tests/tooling/test_ask_dev_acceptance_workflow.py` — 14 guard checks as functions, run twice each: against the committed file (must find nothing) and against a copy with that one guard removed (that check, not merely some check, must find something). 39 mutations, each asserted to have actually applied; a no-op mutation is reported INVALID, not passed.
- **`actionlint`** clean; **`shellcheck`** clean; **ruff** and **mypy** clean (2144 files).
- **269 tests** pass across `tests/tooling/` and `tests/acceptance/test_ask_dev_compose.py`.
- **Local execution of the workflow's exact command sequence.** The boot half is proven: launcher exit 0 with `KEEP_STACK=1`, all six ops smokes passed, web Playwright leg 2/2 passed, stack retained, quota ceilings read from the running container (`1000` / `200000000`), always-arms ran after a failing step, teardown exit 0.
- **The corpus half is NOT locally proven, and is not claimed to be.** The local harness put an array expansion in a bash assignment-prefix position and exited 127 before reaching the runner. That bug is in the local shim, not in this workflow (which uses `$GITHUB_ENV`), but a step that never ran is unmeasured, not passing.
- **`ci/local_validate.sh`**: see comment below.

## Expected-red accounting for the post-merge dispatches

<!-- FILL BEFORE DISPATCH -->
The nightly runs the real corpus against real product state, so **run 1 is expected RED** and that is honest signal, not a regression.

Before dispatching, the expectation is keyed to **main at dispatch time**, resolved by `git merge-base --is-ancestor` rather than by what a PR says:

| on main | expected collected | expected failed |
|---|---|---|
| only this PR | 144 | 27 |
| + corpus-authoring | 140 | 14 |
| + corpus-authoring + 3497 | 140 | ~0 |

Resolved state at dispatch: _TBD_ · Chosen expectation: _TBD_ · Run 1: _TBD_ · Run 2 (green arm): _TBD_

**Red-for-the-right-reason.** Four distinguishable shapes, and run 1 will be reported as one of them:

- exit `66` — executed nothing (`ArmedRunNotExecutedError`)
- exit `67` — nothing measurable, e.g. pytest died before writing junit
- exit `1` **with** the line `armed run executed N case(s) (collected N, skipped N, failed N, errored N)` — real case failures, the expected-red arm
- anything else — the step never reached the runner at all

That line is printed by the runner's outside-the-session assertion, not by pytest. **Its absence means the run is unmeasured, not failing.**
