### PR TITLE
ci: fix an unsatisfiable corpus floor and drain the login window (CHAOS-3219 Phase 5)

### DIFF
--- a/.github/workflows/ask-dev-acceptance.yml
+++ b/.github/workflows/ask-dev-acceptance.yml
@@ -206,6 +206,35 @@ jobs:
           ./scripts/acceptance/run_ask_dev_compose.sh --web-root "${WEB_ROOT}" \
             2>&1 | tee "${LOG_DIR}/boot.log"
 
+      # Dispatch run 1 (31146779949): all 91 active cases errored in setup with
+      # `POST /api/v1/auth/login returned HTTP 429: Rate limit exceeded` -- 273
+      # login calls in one run. AUTH_LOGIN_IP_LIMIT is "20/15minutes" and it is
+      # keyed PER IP (src/dev_health_ops/api/middleware/rate_limit.py). A CI job
+      # is one IP, and the boot's per-principal login proof plus
+      # prepare_ask_dev_acceptance.py plus the corpus's own logins exceed 20
+      # inside a single window when they run back to back. Locally they are
+      # minutes apart, which is why this could not surface before a CI run
+      # existed.
+      #
+      # This is the PROVEN local recipe, not a sleep-until-it-works: the Phase 2
+      # exit run script (.p2exit_run.sh) carries exactly this wait, with the
+      # same reasoning -- "Deliberate and stated, not a sleep-until-it-works:
+      # skip it and the run fails loudly on 429 rather than silently
+      # under-measuring." 16 minutes on a nightly is free.
+      #
+      # A WORKAROUND with a known replacement: CHAOS-3529 (session/token reuse
+      # across corpus cases) removes the need for it. DELETE THIS STEP when that
+      # lands -- its acceptance criteria say so explicitly -- and do
+      # not leave a 16-minute sleep in a workflow whose reason has gone away.
+      # Production's limit is deliberately NOT relaxed for CI: it is a security
+      # control, and an acceptance-only override would make this lane stop
+      # proving production's shape.
+      - name: Drain the per-IP login window before the corpus
+        run: |
+          set -euo pipefail
+          echo "waiting 16m for the per-IP login window to drain (AUTH_LOGIN_IP_LIMIT=20/15minutes)"
+          sleep 960
+
       # The corpus runner's QuotaBudget refuses to start un-budgeted: without
       # ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX and
       # ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD in ITS OWN process
@@ -251,13 +280,24 @@ jobs:
           ASK_DEV_ACCEPTANCE_API_URL: http://127.0.0.1:18080
           # A coarse attrition floor, not a registry -- see the long comment on
           # this variable in run_wave4_corpus.sh. run_report's default of 1
-          # means a run executing ONE of ~144 cases exits 0 and this lane goes
-          # green having certified 0.7% of the corpus (reproduced by
-          # adversarial review with a synthetic JUnit report). 100 catches
-          # catastrophic loss while surviving the corpus's own churn; it does
-          # NOT prove every case ran, and this lane must not be read as
-          # claiming that until Lane 5a's expected-case registry lands.
-          ASK_DEV_CORPUS_MIN_EXECUTED: "100"
+          # means a run executing ONE case exits 0 and this lane reports green
+          # having certified a fraction of the corpus.
+          #
+          # 75 is derived from the MEASURED active-case count, not a file count.
+          # Dispatch run 1 (31146779949) failed this guard at 91 < 100: the
+          # first value came from a stale "144 cases" figure in an old run log,
+          # but only 91 of the 143 case-*.json files are status='active' -- the
+          # other 52 are status='declared-blocked', which run_report
+          # deliberately does not count (its own docstring says so). A floor of
+          # 100 was therefore UNSATISFIABLE: it could never pass on any run,
+          # however healthy, and a guard that cannot pass is worse than no guard
+          # because it teaches people to ignore the lane.
+          #
+          # 75 is ~82% of 91 -- catches catastrophic attrition, survives the
+          # corpus's own re-authoring churn. Re-derive it from the count of
+          # status='active' cases when the corpus changes shape, never from the
+          # file count, which is the mistake that produced 100.
+          ASK_DEV_CORPUS_MIN_EXECUTED: "75"
           TEST_SUPERUSER_EMAIL: admin@devhealth.example
           TEST_SUPERUSER_PASSWORD: devhealth123
         run: |
@@ -384,11 +424,17 @@ jobs:
             "- acceptance-live: ${LIVE_RESULT}" \
             "- acceptance-live-gate: ${GATE_RESULT}" \
             "" \
-            "Read the corpus.log artifact before judging this a regression. The" \
-            "line \"armed run executed N case(s)\" distinguishes a run that" \
-            "executed cases and failed some from one that never reached the" \
-            "corpus at all; its ABSENCE means the step died first and the run is" \
-            "unmeasured, not failing.")"
+            "Read the corpus.log artifact before judging this a regression." \
+            "" \
+            "Exit 66 has TWO meanings; the message text distinguishes them." \
+            "\"executed 0 real corpus case(s)\" is a run that never reached the" \
+            "product. \"executed N ... at least M must execute\" is a run that" \
+            "DID run and fell under the attrition floor. Exit 67 means nothing" \
+            "was measurable at all. Exit 1 WITH an executed-count line is the" \
+            "ordinary case-failure arm." \
+            "" \
+            "Absence of any executed-count line means the step died before the" \
+            "corpus ran: unmeasured, not failing.")"
           # No `|| true` anywhere in here on purpose: this job is the thing
           # that makes a red nightly visible, so a notifier that quietly
           # half-worked is worse than one that fails and turns the run red.

--- a/tests/tooling/test_ask_dev_acceptance_workflow.py
+++ b/tests/tooling/test_ask_dev_acceptance_workflow.py
@@ -26,6 +26,7 @@ reported as INVALID rather than passing quietly.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
@@ -65,6 +66,28 @@ CORPUS_RUNNER = "scripts/acceptance/run_wave4_corpus.sh"
 # dict[Any, Any], not dict[str, Any]: PyYAML resolves the bare key `on` to
 # the BOOLEAN True under YAML 1.1, so a workflow mapping genuinely has a
 # non-str key and claiming otherwise would be a type that lies.
+CORPUS_DIR = ROOT / "tests" / "acceptance" / "world" / "ask-dev-world.v1" / "corpus"
+
+
+def _active_corpus_case_count() -> int:
+    """How many cases run_report will actually count.
+
+    NOT the file count. 143 files, 91 of them status='active' and 52
+    status='declared-blocked' -- and declared-blocked cases execute without
+    touching the product, so run_report deliberately excludes them. Reading the
+    file count instead is what produced an unsatisfiable floor of 100.
+    """
+    active = 0
+    for path in sorted(CORPUS_DIR.glob("case-*.json")):
+        try:
+            case = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:  # pragma: no cover - a malformed case is another test's job
+            continue
+        if case.get("status") == "active":
+            active += 1
+    return active
+
+
 def _load(text: str) -> dict[Any, Any]:
     doc = yaml.safe_load(text)
     assert isinstance(doc, dict)
@@ -412,12 +435,69 @@ def check_corpus_has_an_attrition_floor(text: str) -> list[str]:
             "back to run_report's floor of 1 and a corpus that lost most of its case "
             "files would still report green"
         ]
-    if int(raw) < 2:
+    floor = int(raw)
+    if floor < 2:
         return [
             f"{CORPUS_STEP} pins ASK_DEV_CORPUS_MIN_EXECUTED={raw}, which is the default "
             "floor this check exists to raise"
         ]
+    active = _active_corpus_case_count()
+    if floor > active:
+        return [
+            f"{CORPUS_STEP} pins ASK_DEV_CORPUS_MIN_EXECUTED={floor}, but only {active} "
+            "corpus cases are status='active' and run_report counts no others -- this "
+            "floor is UNSATISFIABLE and would fail every run however healthy. Dispatch "
+            "run 1 failed exactly this way at 91 < 100."
+        ]
     return []
+
+
+DRAIN_STEP = "Drain the per-IP login window before the corpus"
+
+
+def check_the_login_window_is_drained_before_the_corpus(text: str) -> list[str]:
+    """The corpus cannot log in inside the boot's own rate-limit window.
+
+    Dispatch run 1 (31146779949): all 91 active cases errored in setup on
+    ``HTTP 429: Rate limit exceeded``. ``AUTH_LOGIN_IP_LIMIT`` is
+    ``20/15minutes`` and PER IP; a CI job is one IP, and boot + corpus exceed
+    20 logins in one window when they run back to back. Locally they are
+    minutes apart, so no local run could have found this.
+
+    A workaround, pinned so it cannot be quietly shortened into
+    uselessness -- and so its removal is a deliberate act once session reuse
+    lands, not an accident.
+    """
+    doc = _load(text)
+    step = _step(doc, LIVE_JOB, DRAIN_STEP)
+    if step is None:
+        return [f"{LIVE_JOB} has no step named {DRAIN_STEP!r}"]
+    violations = []
+    run = str(step.get("run", ""))
+    match = re.search(r"sleep\s+(\d+)", run)
+    if match is None:
+        violations.append(f"{DRAIN_STEP} does not wait at all")
+    elif int(match.group(1)) < 900:
+        violations.append(
+            f"{DRAIN_STEP} waits {match.group(1)}s, under the 900s the "
+            "20/15minutes window needs -- a partial drain still 429s, and does it "
+            "after paying most of the wait"
+        )
+    if "if" in step:
+        violations.append(f"{DRAIN_STEP} carries an `if:` and can therefore be skipped")
+
+    names = [candidate.get("name") for candidate in _steps(doc, LIVE_JOB)]
+    if BOOT_STEP in names and CORPUS_STEP in names:
+        if (
+            not names.index(BOOT_STEP)
+            < names.index(DRAIN_STEP)
+            < names.index(CORPUS_STEP)
+        ):
+            violations.append(
+                f"{DRAIN_STEP} must run after {BOOT_STEP} (whose logins fill the window) "
+                f"and before {CORPUS_STEP} (which needs it drained)"
+            )
+    return violations
 
 
 def check_teardown_and_capture_always_run(text: str) -> list[str]:
@@ -588,11 +668,17 @@ def check_a_failing_run_is_announced(text: str) -> list[str]:
         violations.append(
             f"{NOTIFY_JOB} neither creates nor comments on an issue, so nothing is announced"
         )
-    if "armed run executed" not in run:
-        violations.append(
-            f"{NOTIFY_JOB}'s message does not tell the reader how to tell a run that "
-            "executed cases and failed from one that never reached the corpus"
-        )
+    # The message must teach the reader to distinguish the failure shapes.
+    # Exit 66 acquired a SECOND meaning when the attrition floor was added --
+    # "executed nothing" and "executed below the floor" are different findings
+    # and dispatch run 1 was the second -- so the message has to name both, not
+    # just the executed-count line.
+    for phrase in ("Exit 66", "attrition floor", "Exit 67", "unmeasured, not failing"):
+        if phrase not in run:
+            violations.append(
+                f"{NOTIFY_JOB}'s message omits {phrase!r}, so a reader cannot tell which "
+                "kind of red this was"
+            )
     return violations
 
 
@@ -608,6 +694,7 @@ CHECKS: dict[str, Callable[[str], list[str]]] = {
     "api-port": check_corpus_talks_to_the_port_the_stack_published,
     "quota-budget": check_corpus_is_budgeted_from_the_running_stack,
     "attrition-floor": check_corpus_has_an_attrition_floor,
+    "login-drain": check_the_login_window_is_drained_before_the_corpus,
     "always-cleanup": check_teardown_and_capture_always_run,
     "artifact-uploads": check_artifact_uploads_fail_on_an_empty_set,
     "web-checkout": check_web_checkout_is_wired_for_the_playwright_leg,
@@ -779,7 +866,7 @@ _MUTATIONS: list[tuple[str, str, str]] = [
     ),
     (
         "attrition-floor",
-        '          ASK_DEV_CORPUS_MIN_EXECUTED: "100"',
+        '          ASK_DEV_CORPUS_MIN_EXECUTED: "75"',
         '          ASK_DEV_CORPUS_MIN_EXECUTED: "1"',
     ),
     (
@@ -836,6 +923,26 @@ _MUTATIONS: list[tuple[str, str, str]] = [
         "failure-announced",
         "            gh issue create --repo",
         "            echo would-create --repo",
+    ),
+    (
+        "failure-announced",
+        '            "Exit 66 has TWO meanings; the message text distinguishes them." \\',
+        '            "Something went wrong." \\',
+    ),
+    (
+        "login-drain",
+        "          sleep 960",
+        "          sleep 5",
+    ),
+    (
+        "login-drain",
+        "      - name: Drain the per-IP login window before the corpus\n        run: |",
+        "      - name: Drain the per-IP login window before the corpus\n        if: false\n        run: |",
+    ),
+    (
+        "attrition-floor",
+        '          ASK_DEV_CORPUS_MIN_EXECUTED: "75"',
+        '          ASK_DEV_CORPUS_MIN_EXECUTED: "100"',
     ),
 ]
 


### PR DESCRIPTION
Both defects were found by **dispatch run 1** ([31146779949](https://github.com/full-chaos/dev-health-ops/actions/runs/31146779949)) — the first real execution of the lane merged in #1557. Neither was findable before a CI run existed.

## 1. The attrition floor was unsatisfiable

`ASK_DEV_CORPUS_MIN_EXECUTED` was **100**. The maximum achievable executed count is **91**.

Of the 143 `case-*.json` files, 91 are `status='active'` and **52 are `status='declared-blocked'`** — and `run_report` deliberately does not count declared-blocked cases (its own docstring says so). So the guard could never pass, on any run, however healthy.

**A guard that cannot pass is worse than no guard**, because it teaches people to ignore the lane. The bad value came from a stale "144 cases" figure in an old run log instead of from measuring the corpus — I predicted 143 in the pre-registration and was wrong for the same reason.

Now **75** — ~82% of the measured 91 — catching catastrophic attrition while surviving the corpus's re-authoring churn.

Rather than only correcting the constant, `check_corpus_has_an_attrition_floor` now **computes the active-case count from the corpus JSON** and rejects any floor above it, so this class of mistake is structurally impossible rather than a comment someone has to read. Observed failing on the literal run-1 value:

```
pins ASK_DEV_CORPUS_MIN_EXECUTED=100, but only 91 corpus cases are
status='active' and run_report counts no others -- this floor is
UNSATISFIABLE and would fail every run however healthy.
```

## 2. The corpus cannot log in inside the boot's rate-limit window

All 91 active cases errored in setup with `HTTP 429: Rate limit exceeded` — **273 login calls** in one run.

`AUTH_LOGIN_IP_LIMIT` is `"20/15minutes"` and keyed **per IP** (`src/dev_health_ops/api/middleware/rate_limit.py`). A CI job is one IP, and the boot's per-principal login proof + `prepare_ask_dev_acceptance.py` + the corpus's own logins exceed 20 in a single window when they run back to back. **Local runs separate them by minutes, so no local run could have found this.**

Added the drain step between boot and corpus. This is the **proven local recipe**, not a sleep-until-it-works: `.p2exit_run.sh` carries exactly this wait with the same stated reasoning — *"Deliberate and stated, not a sleep-until-it-works: skip it and the run fails loudly on 429 rather than silently under-measuring."* 16 minutes on a nightly is free.

Pinned by a contract test that rejects any wait under 900s — a partial drain still 429s **and** pays most of the wait — and rejects an `if:` on the step.

**It is a workaround and says so.** [CHAOS-3529](https://linear.app/fullchaos/issue/CHAOS-3529) (session/token reuse per principal) is the real fix, and its acceptance criteria require deleting this step in the same change. The step's comment names the ticket, so the sleep and its removal condition point at each other from both ends.

**Production's rate limit is deliberately NOT relaxed for CI.** It is a security control, and an acceptance-only override would make this lane stop proving production's shape — the opposite of what it exists for.

## 3. Exit 66 had acquired a second meaning

Adding the floor made exit 66 mean both *"executed nothing"* and *"executed below the floor"*. Run 1 was the second. The failure-notification message would have led a reader to diagnose it as "never reached the corpus" — false. The message now names all four shapes, and the contract check pins that vocabulary rather than a single phrase.

## Gate

`bash ci/local_validate.sh`, plain, single-flight: **GATE PASSED**, all 7 stages, 13030 passed / 249 skipped / 1 xfailed.

The first run reddened on `test_budget_guard_cooldown.py::test_budget_wall_clock_cap_exhausts_below_the_count_cap`. Diagnosed rather than re-rolled: the assertion tests the bare substring `"360"` against a message containing a random 64-char hex digest, which that run rendered as `api.github.com:360b8725...`. A substring collision, unreachable from this diff (which touches one workflow and one tooling test), passing 3/3 in isolation. Filed as CHAOS-3530.