### PR TITLE
CHAOS-3490: stop run_report calling two different denominators "case(s)"

### DIFF
--- a/scripts/acceptance/corpus/run_report.py
+++ b/scripts/acceptance/corpus/run_report.py
@@ -255,8 +255,20 @@ def main(argv: list[str] | None = None) -> int:
     except ArmedRunNotExecutedError as exc:
         print(f"NOT EXECUTED: {exc}", file=sys.stderr)
         return EXIT_NOT_EXECUTED
+    # Both counters, explicitly labelled and never both called "case(s)".
+    # Found by the phase5-ci lane comparing two CI runs (2026-08-07): this
+    # success line used to print `summary.executed`, which counts EVERY
+    # non-skipped testcase (real cases + declared-blocked receipts + the
+    # collection guard), while the failure path's message prints
+    # `len(executed_corpus_cases)`, which counts real corpus cases only.
+    # Same word, two denominators: comparing a failed run's line to a
+    # successful one read as the corpus gaining 53 cases when nothing had
+    # changed, and very nearly got a correct prediction filed as a wrong one.
+    # A harness whose whole job is answering "did this run measure anything"
+    # must not be ambiguous about what it counted.
     print(
-        f"armed run executed {summary.executed} case(s) "
+        f"armed run executed {len(summary.executed_corpus_cases)} real corpus "
+        f"case(s) of {summary.executed} executed testcase(s) "
         f"(collected {summary.tests}, skipped {summary.skipped}, "
         f"failed {summary.failures}, errored {summary.errors})"
     )

--- a/tests/acceptance/corpus/test_run_report.py
+++ b/tests/acceptance/corpus/test_run_report.py
@@ -341,3 +341,56 @@ class TestOnlyRealCorpusCasesCount:
         assert summary.executed_corpus_cases == ()
         with pytest.raises(ArmedRunNotExecutedError):
             assert_armed_run_executed(summary)
+
+
+class TestTheSuccessLineNamesWhatItCounted:
+    """The success line must never call two different denominators "case(s)".
+
+    Found by the phase5-ci lane comparing two CI runs (2026-08-07). The
+    failure path reports ``len(executed_corpus_cases)`` -- real corpus cases
+    only -- while the success path reported ``summary.executed``, which
+    counts every non-skipped testcase: real cases PLUS the declared-blocked
+    receipts PLUS the collection guard. Both said "executed ... case(s)".
+
+    Comparing a failed run's line to a successful one therefore read as the
+    corpus gaining 53 cases when nothing had changed, and very nearly got a
+    correct prediction filed as a wrong one. This module's entire purpose is
+    answering "did this run measure anything"; it must not be ambiguous
+    about what it counted.
+    """
+
+    @staticmethod
+    def _mixed_xml() -> str:
+        # 1 collection guard + 2 declared-blocked + 3 real corpus cases.
+        cases = (
+            '<testcase classname="c" name="test_at_least_one_corpus_case_is_collected"/>'
+            '<testcase classname="c" name="test_declared_blocked_case[a]"/>'
+            '<testcase classname="c" name="test_declared_blocked_case[b]"/>'
+            '<testcase classname="c" name="test_corpus_case[one]"/>'
+            '<testcase classname="c" name="test_corpus_case[two]"/>'
+            '<testcase classname="c" name="test_corpus_case[three]"/>'
+        )
+        return (
+            "<testsuites>"
+            f'<testsuite errors="0" failures="0" skipped="0" tests="6">{cases}'
+            "</testsuite></testsuites>"
+        )
+
+    def test_both_denominators_are_reported_and_distinguishable(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from scripts.acceptance.corpus import run_report
+
+        report = tmp_path / "junit.xml"
+        report.write_text(self._mixed_xml(), encoding="utf-8")
+        assert run_report.main([str(report)]) == 0
+        line = capsys.readouterr().out
+
+        # The two counts are genuinely different here (3 vs 6), which is what
+        # makes this test able to fail at all -- a fixture where they matched
+        # would pass against the old wording too.
+        assert "3 real corpus case(s)" in line, line
+        assert "6 executed testcase(s)" in line, line
+        # The specific regression: the headline number must not be the
+        # all-testcase count wearing the word "case(s)".
+        assert "executed 6 case(s)" not in line, line


### PR DESCRIPTION
Found by the phase5-ci lane comparing two CI runs, reported to me as the corpus tooling owner.

`run_report` printed **two different counts under the same word**:

| path | number | what it counts |
|---|---|---|
| failure | `len(executed_corpus_cases)` | real corpus cases only (91) |
| success | `summary.executed` | every non-skipped testcase — real cases + declared-blocked receipts + the collection guard (144) |

Both said `executed ... case(s)`. So comparing a failed run's line against a successful one read as **the corpus gaining 53 cases when nothing had changed**, and very nearly got a correct prediction filed as a wrong one.

This module's entire job is answering *"did this run measure anything"*. Being ambiguous about what it counted is the same class of defect as the false greens it exists to catch, one layer up in the reporting.

The success line now names both numbers and reserves `case(s)` for real corpus cases:

```
armed run executed 3 real corpus case(s) of 6 executed testcase(s)
  (collected 6, skipped 0, failed 0, errored 0)
```

**Guarded RED-first, and the guard was observed failing before it passed.** Against the old wording the new test fails with `armed run executed 6 case(s)` for a fixture holding only 3 real cases. The fixture deliberately uses *different* counts (3 real of 6 executed) — one where they matched would pass against the old wording too and prove nothing.

Gate: `bash ci/local_validate.sh` PASSED, zero failures.