### PR TITLE
CHAOS-3531: one disclosure rule, one implementation — and correct the test that pinned the defect

### DIFF
--- a/src/dev_health_ops/api/dev/no_match_terminal.py
+++ b/src/dev_health_ops/api/dev/no_match_terminal.py
@@ -266,29 +266,54 @@ _MAX_ANSWER_WARNINGS: int = next(
 )
 
 
-def disclose_scope_widening(answer: DevAnswer) -> DevAnswer:
-    """Add the widening disclosure to ``answer.warnings``, once.
+def _disclosed(answer: DevAnswer, sentence: str) -> DevAnswer:
+    """Put one server-owned ``sentence`` into ``answer.warnings``, once.
 
-    Returns ``answer`` unchanged when the sentence is already present or the
-    contract's twenty-warning bound is already spent -- a disclosure that
-    cannot fit must not silently evict a warning the producer chose.
+    The single implementation of "a disclosure survives the bound", shared by
+    every disclosure below so the rule is decided once rather than per
+    caller. CHAOS-3531: the two callers used to disagree here -- one yielded
+    at the bound and one took the slot -- which is a trap for the next reader
+    and made "never silent" true of one disclosure and false of its twin.
 
     ``warnings`` is the right channel rather than a bespoke field: it is what
     ``streaming`` publishes as ``warning`` frames and what
     ``terminal_frames.wrap_legacy_answer_as_frame`` copies into the frame's
-    ``limitations``, so one append reaches both the wire and the rendered
-    answer. ``answered_with_gaps`` (what every wrapped legacy answer is)
+    ``limitations``, so one entry reaches the wire and the rendered answer
+    together. ``answered_with_gaps`` (what every wrapped legacy answer is)
     requires disclosed limitations, so adding one can never invalidate the
     frame.
+
+    At the contract's twenty-warning bound the disclosure DISPLACES the last
+    producer warning rather than yielding to it. That trade is deliberate and
+    it is the whole point of this function: an undisclosed scope decision is
+    a claim the reader cannot check, and a dropped twentieth warning is not.
+    An answer carrying twenty warnings is already degenerate; the disclosure
+    is the one entry whose absence changes what the answer MEANS.
+
+    The sentence goes FIRST so a truncating renderer keeps it, and the
+    function is idempotent -- disclosing twice costs one slot, not two.
     """
 
-    if SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in answer.warnings:
-        return answer
-    if len(answer.warnings) >= _MAX_ANSWER_WARNINGS:
+    if sentence in answer.warnings:
         return answer
     return answer.model_copy(
-        update={"warnings": [*answer.warnings, SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE]}
+        update={"warnings": [sentence, *answer.warnings][:_MAX_ANSWER_WARNINGS]}
     )
+
+
+def disclose_scope_widening(answer: DevAnswer) -> DevAnswer:
+    """Disclose that the run widened to organization scope, once.
+
+    CHAOS-3531 corrects what CHAOS-3497 claimed: this used to return the
+    answer unchanged once the twenty-warning bound was spent, so a widened
+    run could answer organization-wide with no prose disclosure at all --
+    while CHAOS-3497's own write-up said the widening "is said out loud"
+    without qualification. The claim is now true rather than qualified: see
+    ``_disclosed`` for the bound rule and why displacement is the right
+    trade.
+    """
+
+    return _disclosed(answer, SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE)
 
 
 #: CHAOS-3525: the sentence that makes a model-chosen subject visible.
@@ -315,41 +340,20 @@ def subject_matched_disclosure(*, span: str, label: str) -> str:
 
 
 def disclose_subject_match(answer: DevAnswer, *, span: str, label: str) -> DevAnswer:
-    """Add the QUA-match disclosure to ``answer.warnings``, once.
-
-    Same channel and same bound discipline as ``disclose_scope_widening``
-    above -- one append reaches the stream's ``warning`` frames and the
-    frame's ``limitations`` together, so a reader of the rendered answer and
-    a reader of the wire see the same claim.
+    """Disclose which subject a QUA proposal committed, once.
 
     The label is authorized catalog content, so a legitimate entity whose
     name happens to contain a denylisted token must not fail its own answer:
     the caller attests it through ``finish()``'s ``extra_attested`` seam, the
     same trust tier already granted to clarification-candidate labels.
+
+    Bound behaviour is ``_disclosed``'s, shared with the widening disclosure
+    -- a model-chosen subject reaching a reader unannounced is the failure
+    the whole promotion path is gated to prevent, and it must not become
+    reachable just because an answer already carried twenty warnings.
     """
 
-    sentence = subject_matched_disclosure(span=span, label=label)
-    if sentence in answer.warnings:
-        return answer
-    # Unlike the widening disclosure above, this one is NOT best-effort: it
-    # takes the last slot rather than yielding it.
-    #
-    # `warnings` is bounded at twenty. Yielding at that bound meant a
-    # QUA-committed subject could reach a reader with no disclosure at all
-    # while the commit still stood -- a silent, model-chosen subject, which
-    # is the precise failure this whole path is gated to prevent, reachable
-    # with no authorization failure anywhere (adversarial review finding,
-    # reproduced before fixing). Displacing a producer warning is the
-    # cheaper loss by a wide margin: an undisclosed subject is a claim the
-    # reader cannot check, and a dropped twentieth warning is not.
-    #
-    # The disclosure goes FIRST so it is the one a truncating renderer keeps,
-    # and the tail is cut to the contract bound.
-    return answer.model_copy(
-        update={
-            "warnings": [sentence, *answer.warnings][:_MAX_ANSWER_WARNINGS],
-        }
-    )
+    return _disclosed(answer, subject_matched_disclosure(span=span, label=label))
 
 
 #: The noun used when the question gave no entity noun of its own. Never

--- a/src/dev_health_ops/api/dev/no_match_terminal.py
+++ b/src/dev_health_ops/api/dev/no_match_terminal.py
@@ -290,6 +290,15 @@ def _disclosed(answer: DevAnswer, sentence: str) -> DevAnswer:
     An answer carrying twenty warnings is already degenerate; the disclosure
     is the one entry whose absence changes what the answer MEANS.
 
+    That judgement rests on a checked property of today's producers, stated
+    so a future change can notice it: every server-authored writer of
+    ``warnings`` emits at MOST one entry (the server-grounded notice, the
+    budget-exhaustion notice, these disclosures), so the only way to reach
+    the bound is model-authored free text -- displacement evicts model prose,
+    never a server safety signal. If a deterministic producer ever starts
+    emitting many machine warnings here, revisit this trade rather than
+    assuming it still holds.
+
     The sentence goes FIRST so a truncating renderer keeps it, and the
     function is idempotent -- disclosing twice costs one slot, not two.
     """

--- a/tests/api/dev/test_chaos_3497_scope_observability.py
+++ b/tests/api/dev/test_chaos_3497_scope_observability.py
@@ -713,17 +713,40 @@ def test_the_disclosure_reaches_the_frame_a_reader_actually_sees() -> None:
     assert frame.public_outcome is PublicOutcome.ANSWERED_WITH_GAPS
 
 
-def test_the_disclosure_is_appended_once_and_never_evicts_a_warning() -> None:
-    """Idempotent, and it refuses to spend a warning slot it does not have."""
+def test_the_disclosure_is_added_once_and_keeps_every_warning_it_can() -> None:
+    """Idempotent, and it costs a producer warning only at the bound.
+
+    CHAOS-3531 CORRECTED this test, and the correction is the point. It used
+    to assert ``disclose_scope_widening(full).warnings == full.warnings`` --
+    that at the twenty-warning bound the answer came back untouched. That
+    pinned the DEFECT as intended behaviour: a run that widened to
+    organization scope could answer organization-wide with no prose
+    disclosure at all, while this ticket's own write-up claimed the widening
+    is "said out loud".
+
+    The half worth keeping is here unchanged (added once, idempotent, nothing
+    else disturbed). The half that encoded the bug is replaced by its
+    opposite: at the bound the disclosure displaces the last producer warning
+    rather than yielding to it. See ``test_chaos_3531_disclosure_bound.py``
+    for the full statement of that rule and why the trade is the right one.
+    """
 
     answer = DevAnswer.model_validate(positive_fixtures()["dev_answer.v1"])
     once = disclose_scope_widening(answer)
     twice = disclose_scope_widening(once)
     assert once.warnings == twice.warnings
-    assert once.warnings[:-1] == list(answer.warnings)
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in once.warnings
+    assert set(answer.warnings) <= set(once.warnings), (
+        "below the bound nothing a producer wrote may be lost"
+    )
 
     full = answer.model_copy(update={"warnings": [f"w{index}" for index in range(20)]})
-    assert disclose_scope_widening(full).warnings == full.warnings
+    disclosed = disclose_scope_widening(full)
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in disclosed.warnings, (
+        "the disclosure must survive a saturated warning list -- an "
+        "undisclosed widening is the defect CHAOS-3531 closed"
+    )
+    assert len(disclosed.warnings) == 20
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3497_scope_observability.py
+++ b/tests/api/dev/test_chaos_3497_scope_observability.py
@@ -731,14 +731,21 @@ def test_the_disclosure_is_added_once_and_keeps_every_warning_it_can() -> None:
     for the full statement of that rule and why the trade is the right one.
     """
 
-    answer = DevAnswer.model_validate(positive_fixtures()["dev_answer.v1"])
+    # A REAL producer warning, not the fixture's empty list: asserting
+    # `set(answer.warnings) <= set(once.warnings)` against `[]` is vacuously
+    # true and would pass even if the helper discarded everything below the
+    # bound (adversarial review, LOW).
+    answer = DevAnswer.model_validate(positive_fixtures()["dev_answer.v1"]).model_copy(
+        update={"warnings": ["a warning the producer chose"]}
+    )
     once = disclose_scope_widening(answer)
     twice = disclose_scope_widening(once)
     assert once.warnings == twice.warnings
     assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in once.warnings
-    assert set(answer.warnings) <= set(once.warnings), (
+    assert "a warning the producer chose" in once.warnings, (
         "below the bound nothing a producer wrote may be lost"
     )
+    assert len(once.warnings) == 2
 
     full = answer.model_copy(update={"warnings": [f"w{index}" for index in range(20)]})
     disclosed = disclose_scope_widening(full)

--- a/tests/api/dev/test_chaos_3525_qua_commit.py
+++ b/tests/api/dev/test_chaos_3525_qua_commit.py
@@ -48,6 +48,7 @@ from dev_health_ops.api.dev.scope_service import (
 from dev_health_ops.llm.agent.contracts import AgentFinalAnswer
 from dev_health_ops.llm.agent.scripted import ScriptedAgentProvider, ScriptedStep
 from tests._chaos_3292_preflight import (
+    CHAOS_3388_ACR_PROJECT,
     ORG_ID,
     SeededCatalog,
     run_preflight_orchestrator,
@@ -56,17 +57,17 @@ from tests._chaos_3292_preflight import (
 pytestmark = pytest.mark.asyncio
 
 
-#: The acceptance world's own project row, verbatim
-#: (``tests/acceptance/world/ask-dev-world.v1/subjects.json``'s
-#: ``subject.exact.context-fabric``). Reused rather than re-worded so this
-#: unit proof and the acceptance corpus point at the same real label shape:
-#: >=5 capitalized words AND a parenthetical qualifier, with an acronym
-#: ("ACR") that matches the INNER words only.
-ACR_PROJECT = AuthorizedEntity(
-    EntityKind.PROJECT,
-    "project-context-fabric",
-    "Dev Health Agent Context Runtime (Context Fabric)",
-)
+#: The CHAOS-3388 live-repro fixture, reused rather than re-declared.
+#:
+#: It is the REAL production catalog row read live from ClickHouse during
+#: that incident, and its display label is exactly the shape this ticket is
+#: about: >=5 capitalized words with a parenthetical qualifier, and an
+#: acronym ("ACR") over the label's INNER words only. An earlier revision of
+#: this module declared its own copy with an invented canonical id -- two
+#: fixtures for one real subject, which is how they drift apart. Sharing it
+#: also makes the ticket chain visible in the fixtures themselves: CHAOS-3388
+#: correctly declines to auto-commit this row, CHAOS-3525 commits it.
+ACR_PROJECT = CHAOS_3388_ACR_PROJECT
 
 ACR_QUESTION = "What's the status of the ACR project"
 

--- a/tests/api/dev/test_chaos_3531_disclosure_bound.py
+++ b/tests/api/dev/test_chaos_3531_disclosure_bound.py
@@ -186,3 +186,60 @@ def test_an_unsaturated_answer_loses_nothing(disclose, sentence: str) -> None:
     assert sentence in disclosed.warnings
     assert "one real warning" in disclosed.warnings
     assert len(disclosed.warnings) == 2
+
+
+@pytest.mark.asyncio
+async def test_the_two_disclosures_can_never_both_fire_on_one_run() -> None:
+    """Mutual exclusion, pinned rather than left to a code reading.
+
+    Adversarial review traced that these two can never both apply -- the QUA
+    promotion sets ``legacy_guard_required=False`` and commits an EXACT
+    resolution, and the widening disclosure requires that flag true AND an
+    ``organization_fallback`` outcome -- but nothing tested it. Two
+    independent guards holding today is exactly the kind of property that
+    quietly stops holding when someone touches one of them.
+
+    It matters because the two sentences contradict each other: one says the
+    named subject could not be matched and the answer went organization-wide,
+    the other says it WAS matched to a specific entity. A reader shown both
+    learns nothing except that the system is unsure.
+
+    Asserted end to end through the real promotion path rather than by
+    re-checking the guards in isolation.
+
+    What this test does and does NOT catch, measured rather than assumed:
+    removing EITHER guard alone leaves it green, because the other still
+    holds -- verified by mutating each in turn. It fails when BOTH go
+    (verified). That is the honest scope of a test over a double-guarded
+    property: it is a regression guard on the observable outcome, not a
+    proof that each guard individually matters. Stated here so nobody reads
+    a green run as evidence that both guards are still load-bearing.
+    """
+
+    from dev_health_ops.api.dev.contracts import ScopeResolutionOutcome
+    from tests._chaos_3292_preflight import ORG_ID, run_preflight_orchestrator
+    from tests.api.dev.test_chaos_3525_qua_commit import (
+        ACR_PROJECT,
+        ACR_QUESTION,
+        _selecting_shadow,
+    )
+
+    output = await run_preflight_orchestrator(
+        question=ACR_QUESTION,
+        entities=[(ORG_ID, ACR_PROJECT)],
+        script_id="3531-mutual-exclusion",
+        qua_shadow=_selecting_shadow(text_span="ACR", script_id="3531-mx"),
+    )
+
+    answer = output.result.answer
+    assert answer is not None, "the promotion must have produced an answer"
+    assert answer.resolved_scope.outcome is ScopeResolutionOutcome.EXACT
+
+    assert (
+        subject_matched_disclosure(span="ACR", label=ACR_PROJECT.label)
+        in answer.warnings
+    )
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE not in answer.warnings, (
+        "a run that committed a specific subject must not also claim it "
+        "could not match one -- the two disclosures contradict each other"
+    )

--- a/tests/api/dev/test_chaos_3531_disclosure_bound.py
+++ b/tests/api/dev/test_chaos_3531_disclosure_bound.py
@@ -1,0 +1,188 @@
+"""CHAOS-3531: a disclosure must survive the warnings bound, whichever one it is.
+
+``DevAnswer.warnings`` is capped at twenty. Both server-owned disclosures
+ride that list -- it is what ``streaming`` publishes as ``warning`` frames
+and what ``terminal_frames.wrap_legacy_answer_as_frame`` copies into the
+frame's ``limitations`` -- so one append reaches the wire and the rendered
+answer together.
+
+CHAOS-3525's adversarial review found that yielding at the bound lets a
+model-chosen subject reach a reader with no disclosure at all, and fixed
+``disclose_subject_match`` to take the last slot instead. This module is the
+same proof for its sibling: ``disclose_scope_widening`` (CHAOS-3497) had the
+identical hole, and CHAOS-3497's own write-up claimed the widening "is said
+out loud" without qualification -- a claim that was false at the bound.
+
+The rule is now one rule with one implementation. Two disclosure helpers
+behaving oppositely at the same bound is a trap for the next reader, and the
+third disclosure someone adds should inherit the behaviour rather than
+re-decide it.
+
+Why displacing a producer warning is the right trade, stated once here
+because it is the judgement the whole module rests on: an undisclosed scope
+decision is a claim the reader cannot check, and a dropped twentieth warning
+is not. The answer is already degenerate at twenty warnings; the disclosure
+is the one entry whose absence changes what the answer MEANS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import DevAnswer
+from dev_health_ops.api.dev.no_match_terminal import (
+    SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE,
+    disclose_scope_widening,
+    disclose_subject_match,
+    subject_matched_disclosure,
+)
+
+_MATCHED_SPAN = "ACR"
+_MATCHED_LABEL = "Dev Health Agent Context Runtime (Context Fabric)"
+
+
+def _answer(warnings: list[str]) -> DevAnswer:
+    base = DevAnswer.model_validate(positive_fixtures()["dev_answer.v1"])
+    return base.model_copy(update={"warnings": warnings})
+
+
+def _saturated() -> DevAnswer:
+    """An answer whose warning list is exactly at the contract bound."""
+
+    return _answer([f"producer warning {index}" for index in range(20)])
+
+
+def test_the_widening_disclosure_survives_a_full_warning_list() -> None:
+    """The CHAOS-3497 hole, stated as the state the answer must reach.
+
+    Before this fix the helper returned the answer unchanged at the bound, so
+    a run that widened to organization scope could answer organization-wide
+    with no prose disclosure of the widening -- exactly the human-reader gap
+    CHAOS-3497 part 2 existed to close.
+    """
+
+    disclosed = disclose_scope_widening(_saturated())
+
+    assert SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE in disclosed.warnings
+    assert len(disclosed.warnings) == 20, "the contract bound still holds"
+
+
+def test_the_subject_match_disclosure_survives_a_full_warning_list() -> None:
+    """The sibling, kept green so the two cannot drift apart again.
+
+    This one was fixed in CHAOS-3525; the assertion lives here beside its
+    twin so a future change to the shared helper is caught for BOTH callers
+    rather than only whichever module the author happened to open.
+    """
+
+    disclosed = disclose_subject_match(
+        _saturated(), span=_MATCHED_SPAN, label=_MATCHED_LABEL
+    )
+
+    assert (
+        subject_matched_disclosure(span=_MATCHED_SPAN, label=_MATCHED_LABEL)
+        in disclosed.warnings
+    )
+    assert len(disclosed.warnings) == 20
+
+
+@pytest.mark.parametrize(
+    ("disclose", "sentence"),
+    [
+        (
+            lambda answer: disclose_scope_widening(answer),
+            SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE,
+        ),
+        (
+            lambda answer: disclose_subject_match(
+                answer, span=_MATCHED_SPAN, label=_MATCHED_LABEL
+            ),
+            subject_matched_disclosure(span=_MATCHED_SPAN, label=_MATCHED_LABEL),
+        ),
+    ],
+    ids=["widening", "subject-match"],
+)
+def test_a_disclosure_displaces_exactly_one_producer_warning(
+    disclose, sentence: str
+) -> None:
+    """The cost of the trade is bounded and identical for both.
+
+    Exactly one producer warning is lost, it is the LAST one, and every other
+    producer warning survives in its original order. A helper that dropped
+    more than it needed -- or reordered what it kept -- would be a quieter
+    kind of data loss than the one being fixed.
+    """
+
+    saturated = _saturated()
+    disclosed = disclose(saturated)
+
+    assert disclosed.warnings[0] == sentence, (
+        "the disclosure goes first so a truncating renderer keeps it"
+    )
+    assert disclosed.warnings[1:] == list(saturated.warnings)[:-1]
+    assert saturated.warnings[-1] not in disclosed.warnings
+
+
+@pytest.mark.parametrize(
+    ("disclose", "sentence"),
+    [
+        (
+            lambda answer: disclose_scope_widening(answer),
+            SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE,
+        ),
+        (
+            lambda answer: disclose_subject_match(
+                answer, span=_MATCHED_SPAN, label=_MATCHED_LABEL
+            ),
+            subject_matched_disclosure(span=_MATCHED_SPAN, label=_MATCHED_LABEL),
+        ),
+    ],
+    ids=["widening", "subject-match"],
+)
+def test_disclosing_twice_costs_only_one_slot(disclose, sentence: str) -> None:
+    """Idempotent at the bound, where a non-idempotent helper would be worst.
+
+    ``finish()`` is the one funnel every terminal passes through, and nothing
+    structurally forbids a future path from disclosing twice. If each call
+    displaced another producer warning, repeated disclosure would quietly eat
+    the list.
+    """
+
+    once = disclose(_saturated())
+    twice = disclose(once)
+
+    assert list(twice.warnings) == list(once.warnings)
+    assert once.warnings.count(sentence) == 1
+
+
+@pytest.mark.parametrize(
+    ("disclose", "sentence"),
+    [
+        (
+            lambda answer: disclose_scope_widening(answer),
+            SCOPE_WIDENED_TO_ORGANIZATION_SENTENCE,
+        ),
+        (
+            lambda answer: disclose_subject_match(
+                answer, span=_MATCHED_SPAN, label=_MATCHED_LABEL
+            ),
+            subject_matched_disclosure(span=_MATCHED_SPAN, label=_MATCHED_LABEL),
+        ),
+    ],
+    ids=["widening", "subject-match"],
+)
+def test_an_unsaturated_answer_loses_nothing(disclose, sentence: str) -> None:
+    """The ordinary case: below the bound nothing is displaced at all.
+
+    The control for the tests above -- if displacement happened on every
+    answer rather than only at the bound, they would still pass while the
+    helper quietly dropped a warning from every disclosed run.
+    """
+
+    answer = _answer(["one real warning"])
+    disclosed = disclose(answer)
+
+    assert sentence in disclosed.warnings
+    assert "one real warning" in disclosed.warnings
+    assert len(disclosed.warnings) == 2


### PR DESCRIPTION
## The defect was protected by a passing test I wrote

CHAOS-3497 shipped a test named `test_the_disclosure_is_appended_once_and_never_evicts_a_warning`, and its final assertion was:

```python
full = answer.model_copy(update={"warnings": [f"w{index}" for index in range(20)]})
assert disclose_scope_widening(full).warnings == full.warnings
```

That is not a test of the disclosure. It is a test that the disclosure **does not happen** — and it was green, so nothing ever questioned it.

What it pinned as intended behaviour: a run that widened to organization scope could answer organization-wide with **no prose disclosure of the widening at all**, whenever the answer already carried twenty warnings. CHAOS-3497's own write-up said the widening "is said out loud", unqualified. At the bound that sentence was false, and the test made the falsehood look deliberate.

This is the failure mode where a test is worse than no test: a reader who greps for coverage of the bound finds a green assertion and stops. The fix had to correct the test *and* the claim, not just the code.

## One rule, one implementation

The two server-owned disclosures rode the same twenty-entry `warnings` list and **disagreed at the bound**:

| | at the bound |
|---|---|
| `disclose_scope_widening` (CHAOS-3497) | yielded — no disclosure |
| `disclose_subject_match` (CHAOS-3525) | took the last slot |

CHAOS-3525's adversarial review had already found and fixed the subject-match half. Nobody checked the twin. Two helpers behaving oppositely at the same bound is a trap for the next reader, and the third disclosure someone adds would have had to re-decide it from scratch.

Both now delegate to a single `_disclosed(answer, sentence)` helper. The rule is decided once.

## Why displacement is the right trade

At the bound the disclosure **displaces the last producer warning** rather than yielding to it. The disclosure goes first (so a truncating renderer keeps it) and the tail is cut to the contract bound.

An undisclosed scope decision is a claim the reader cannot check. A dropped twentieth warning is not. An answer already carrying twenty warnings is degenerate; the disclosure is the one entry whose absence changes what the answer *means*.

That judgement rests on a **checked property of today's producers**, and `_disclosed` now says so in as many words: every server-authored writer of `warnings` emits at most one entry, so the only way to reach the bound is model-authored free text. Displacement therefore evicts model prose, never a server safety signal. Review enumerated the writers to confirm it. It is a property of today's producers, not a law — the docstring tells a future change to revisit the trade rather than inherit it silently.

## Tests

`tests/api/dev/test_chaos_3531_disclosure_bound.py`, parameterized over **both** helpers so a change to the shared implementation is caught for both callers rather than whichever module the author happened to open:

- each disclosure survives a saturated warning list, bound still holds
- displacement costs **exactly one** warning, it is the **last** one, and the survivors keep their order — a helper that dropped more than it needed, or reordered what it kept, would be a quieter data loss than the one being fixed
- disclosing twice costs one slot, not two (`finish()` is the one funnel every terminal passes through; nothing structurally forbids a future path from disclosing twice)
- the control: below the bound **nothing** is displaced — without it, a helper that displaced on *every* answer would pass everything above

Plus an end-to-end test that the two disclosures can never both fire on one run. They contradict each other: one says the subject could not be matched and the answer went organization-wide, the other says it *was* matched to a specific entity. A reader shown both learns only that the system is unsure.

**Measured honestly, and written into the test:** removing either guard alone leaves that test GREEN, because the other still holds. It fails only when both go. Both facts verified by mutation. A double-guarded property is what it is — the useful thing is saying so rather than letting a green run imply each guard is individually load-bearing.

## Also

- Corrects CHAOS-3497's unqualified "said out loud" claims to match what the code now actually does.
- Dedupes the ACR fixture onto the shared project constant instead of a third local copy.
- The corrected CHAOS-3497 test had a *second* vacuous assertion found in review: `set(answer.warnings) <= set(once.warnings)` against a fixture whose `warnings` is `[]` reduces to `set() <= anything`, and would have passed even if the helper discarded every producer warning below the bound. It now uses a real producer warning and asserts it survives by name.

## Verification

Local gate: **PASSED, zero failures** — 13051 passed, 245 skipped, 1 xfailed. Lint, typecheck, ch-migrate and the argMax live-exec proof all green.
