### PR TITLE
CHAOS-3219: the scripted fault matrix was never loaded; make that impossible to miss

### DIFF
--- a/scripts/acceptance/corpus/scripted_engine.py
+++ b/scripts/acceptance/corpus/scripted_engine.py
@@ -75,6 +75,7 @@ class ScriptedEngineStatus:
     loaded: bool
     role: str
     cases: int
+    script_digest: str
     reason: str | None
     raw: Mapping[str, Any]
 
@@ -141,10 +142,35 @@ def scripted_engine_status(
             "the scripted provider's health payload carries no "
             f"'scripted_engine' block: {payload!r}"
         )
+    # `cases` is an int in every shape this service emits, but a malformed or
+    # truncated payload must still leave through THIS module's typed error --
+    # the caller (`test_wave4_corpus_runner_live._scripted_engine_precondition`)
+    # catches only ScriptedEngineUnavailableError, so a bare ValueError would
+    # escape as an opaque traceback instead of the diagnostic failure this
+    # module exists to produce. Found by probing the parser, not by review.
+    raw_cases = engine.get("cases")
+    if raw_cases is None:
+        # A degraded payload legitimately omits `cases` -- it never loaded a
+        # script to count. `loaded` is what rejects that shape, not this.
+        cases = 0
+    elif isinstance(raw_cases, bool) or not isinstance(raw_cases, int):
+        # Deliberately strict: `engine.get("cases") or 0` was the first
+        # attempt and it silently coerced falsy junk -- `[]`, `{}` -- into a
+        # perfectly valid 0, turning a malformed payload into a confident
+        # wrong answer. bool is excluded because it is an int subclass, so
+        # `True` would otherwise report one case.
+        raise ScriptedEngineUnavailableError(
+            f"the scripted provider reported a non-numeric case count "
+            f"{raw_cases!r} ({type(raw_cases).__name__})"
+        )
+    else:
+        cases = raw_cases
+
     return ScriptedEngineStatus(
         loaded=bool(engine.get("loaded")),
         role=str(engine.get("role", "")),
-        cases=int(engine.get("cases") or 0),
+        cases=cases,
+        script_digest=str(engine.get("script_digest") or ""),
         reason=(str(engine["reason"]) if engine.get("reason") else None),
         raw=payload,
     )
@@ -153,17 +179,33 @@ def scripted_engine_status(
 def require_scripted_engine_loaded(
     context: ComposeContext,
     *,
-    minimum_cases: int = 1,
+    expected_role: str,
+    expected_digest: str,
     service: str = "ask-dev-scripted-openai",
     runner: Any = subprocess.run,
 ) -> ScriptedEngineStatus:
-    """Fail the armed run unless the scripted engine is loaded with scripts.
+    """Fail the armed run unless the container serves EXACTLY the script this
+    run asserts against.
 
-    ``minimum_cases`` guards the second failure shape, which is why a bare
-    ``loaded`` boolean is not enough: a directory that exists but is empty,
-    or a role file naming zero cases, loads "successfully" and still serves
-    nothing. "Loaded with 0 cases" and "loaded with 93 cases" are different
-    kinds of ready, and only one of them can measure a corpus.
+    Identity, not quantity. An earlier revision compared only a case-count
+    floor and claimed in its own comment to catch stale, partial and
+    wrong-role mounts -- codex adversarial review (HIGH, confirmed against
+    source) showed that claim was FALSE: a wrong role, a stale compose
+    project, or an unrelated script with an equal or larger case count all
+    cleared a floor while serving different decisions than the corpus
+    asserts. ``status.role`` was parsed and then never compared at all.
+
+    So both halves are checked here:
+
+    * ``expected_role`` -- the container must be serving the role the host
+      loaded, not merely *a* role;
+    * ``expected_digest`` -- ``role_script_identity_digest`` over
+      ``by_fingerprint``, the map ``ScriptEngine.resolve`` actually routes
+      on, so the check fails if any question routes to a different case id.
+      A question edited by one word moves this digest; a count would not.
+
+    ``loaded`` is still checked first because it produces the far more
+    actionable message for the failure that actually happened in the field.
     """
 
     status = scripted_engine_status(context, service=service, runner=runner)
@@ -177,11 +219,26 @@ def require_scripted_engine_loaded(
             "compose.ask-dev.yml still mounts the provider-scripts directory "
             "and sets ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR."
         )
-    if status.cases < minimum_cases:
+    if status.role != expected_role:
         raise ScriptedEngineUnavailableError(
-            f"the scripted engine in {service!r} loaded role {status.role!r} "
-            f"with only {status.cases} case(s), below the required "
-            f"{minimum_cases} -- an empty or truncated script directory "
-            "serves nothing while reporting itself loaded."
+            f"{service!r} is serving role {status.role!r} but this run "
+            f"asserts against {expected_role!r} -- the container would answer "
+            "with a different decision matrix than the corpus expects."
+        )
+    if not status.script_digest:
+        raise ScriptedEngineUnavailableError(
+            f"{service!r} reported no script_digest, so its script identity "
+            "could not be verified. An unverifiable identity is not a "
+            "matching one -- refusing to proceed."
+        )
+    if status.script_digest != expected_digest:
+        raise ScriptedEngineUnavailableError(
+            f"{service!r} loaded role {status.role!r} with {status.cases} "
+            f"case(s) but its script identity digest {status.script_digest!r} "
+            f"does not match this run's {expected_digest!r}. The container is "
+            "serving a DIFFERENT script than the corpus asserts against -- a "
+            "stale mount, a stale compose project, or an edited question. A "
+            "case count cannot detect this, which is why it is not what is "
+            "compared."
         )
     return status

--- a/scripts/acceptance/corpus/scripted_engine.py
+++ b/scripts/acceptance/corpus/scripted_engine.py
@@ -1,0 +1,187 @@
+"""CHAOS-3219 Phase 3: prove the scripted decision/fault engine is actually
+loaded before an armed corpus run measures anything.
+
+Why this module exists, stated plainly because the cost was real: the
+2026-08-07 04:55 armed run recorded 140 receipts, reported the corpus green,
+and had exercised **no scripted fault or refusal at all**. The
+``ask-dev-scripted-openai`` container could not see its script directory --
+the ``api`` image target ships only the built wheel, no ``tests/`` tree, and
+the compose overlay mounted nothing -- so ``provider_scripts._scripts_dir()``
+resolved a relative path against WORKDIR ``/app``, ``load_registry_ids``
+raised ``scripts_directory_unavailable``, and ``try_load_engine`` swallowed
+it and returned ``None``.
+
+That swallow is CORRECT for organic production traffic (an infra failure must
+not turn an ordinary user question into an error) and catastrophic for an
+acceptance run, where the entire point is that the scripted matrix answers.
+All 19 scripted cases -- 10 faults and 9 decision scripts, including every
+``adv.injection-request.*`` refusal and both ``provider-fail.*`` cases --
+fell through to the unscripted default heuristic, returned an ordinary
+answer, and PASSED.
+
+The wiring is fixed in ``tests/acceptance/compose.ask-dev.yml``. This module
+is the part that keeps it fixed: **a fault matrix that did not load must fail
+the run, loudly, forever.** A mount can rot silently; a missing env var can
+be dropped in a refactor; an image rebuild can change the working directory.
+None of those may ever again be indistinguishable from a green run.
+
+This is deliberately NOT part of ``db_verify``: that module's documented cap
+is three read-only DATABASE concerns, and this is a service-readiness probe,
+not a database read.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .compose_context import ComposeContext
+
+__all__ = [
+    "ScriptedEngineStatus",
+    "ScriptedEngineUnavailableError",
+    "require_scripted_engine_loaded",
+    "scripted_engine_status",
+]
+
+#: Run inside the scripted-provider container. Prints exactly one JSON line.
+#: Imports the SAME helper the service's own ``/healthz`` returns, rather
+#: than re-deriving "is it loaded" here -- a second implementation of that
+#: question could disagree with the one the service actually reports, which
+#: is the class of defect this whole module exists to catch.
+_PROBE = (
+    "import json;"
+    "from dev_health_ops.llm.agent.scripted_openai_service import "
+    "scripted_engine_health;"
+    "print(json.dumps(scripted_engine_health()))"
+)
+
+
+class ScriptedEngineUnavailableError(RuntimeError):
+    """The scripted engine could not be proven loaded.
+
+    Raised for BOTH "the probe could not run" and "the probe ran and said
+    not loaded". Both must stop an armed run: an unmeasurable precondition
+    is not a satisfied one, and treating a failed probe as a pass would
+    reintroduce exactly the silence this module was written to end.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ScriptedEngineStatus:
+    loaded: bool
+    role: str
+    cases: int
+    reason: str | None
+    raw: Mapping[str, Any]
+
+
+def scripted_engine_status(
+    context: ComposeContext,
+    *,
+    service: str = "ask-dev-scripted-openai",
+    runner: Any = subprocess.run,
+    timeout: float = 60.0,
+) -> ScriptedEngineStatus:
+    """Ask the scripted-provider container whether its engine is loaded."""
+
+    command: Sequence[str] = ("python", "-c", _PROBE)
+    args = [*context.base_args(), "exec", "-T", service, *command]
+    try:
+        # stdin=DEVNULL for the same load-bearing reason db_verify documents:
+        # `-T` suppresses the TTY but leaves fd 0 forwarded, so an inherited
+        # open pipe (any shell-script driver) hangs this call forever -- a
+        # silent hang that burns the stack slot rather than failing.
+        result = runner(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except FileNotFoundError as exc:
+        raise ScriptedEngineUnavailableError(
+            f"docker compose is not available on this host: {exc}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ScriptedEngineUnavailableError(
+            f"probing {service} for scripted-engine status timed out after {timeout}s"
+        ) from exc
+    if result.returncode != 0:
+        raise ScriptedEngineUnavailableError(
+            f"probing {service} for scripted-engine status exited "
+            f"{result.returncode}: {result.stderr.strip()}"
+        )
+
+    stripped = result.stdout.strip()
+    if not stripped:
+        raise ScriptedEngineUnavailableError(
+            f"probing {service} produced no output; stderr={result.stderr.strip()!r}"
+        )
+    # The container emits telemetry banners on stdout before our line, so take
+    # the last non-empty line rather than assuming the payload stands alone.
+    last = [line for line in stripped.splitlines() if line.strip()][-1]
+    try:
+        payload = json.loads(last)
+    except json.JSONDecodeError as exc:
+        raise ScriptedEngineUnavailableError(
+            f"probing {service} returned unparseable output {last!r}: {exc}"
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise ScriptedEngineUnavailableError(
+            f"probing {service} returned a non-object payload: {payload!r}"
+        )
+
+    engine = payload.get("scripted_engine")
+    if not isinstance(engine, Mapping):
+        raise ScriptedEngineUnavailableError(
+            "the scripted provider's health payload carries no "
+            f"'scripted_engine' block: {payload!r}"
+        )
+    return ScriptedEngineStatus(
+        loaded=bool(engine.get("loaded")),
+        role=str(engine.get("role", "")),
+        cases=int(engine.get("cases") or 0),
+        reason=(str(engine["reason"]) if engine.get("reason") else None),
+        raw=payload,
+    )
+
+
+def require_scripted_engine_loaded(
+    context: ComposeContext,
+    *,
+    minimum_cases: int = 1,
+    service: str = "ask-dev-scripted-openai",
+    runner: Any = subprocess.run,
+) -> ScriptedEngineStatus:
+    """Fail the armed run unless the scripted engine is loaded with scripts.
+
+    ``minimum_cases`` guards the second failure shape, which is why a bare
+    ``loaded`` boolean is not enough: a directory that exists but is empty,
+    or a role file naming zero cases, loads "successfully" and still serves
+    nothing. "Loaded with 0 cases" and "loaded with 93 cases" are different
+    kinds of ready, and only one of them can measure a corpus.
+    """
+
+    status = scripted_engine_status(context, service=service, runner=runner)
+    if not status.loaded:
+        raise ScriptedEngineUnavailableError(
+            "the scripted decision/fault engine is NOT loaded in "
+            f"{service!r} (role={status.role!r}): {status.reason}. Every "
+            "scripted fault and refusal would silently degrade to the "
+            "unscripted default heuristic and the run would report green "
+            "having measured nothing -- refusing to proceed. Check that "
+            "compose.ask-dev.yml still mounts the provider-scripts directory "
+            "and sets ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR."
+        )
+    if status.cases < minimum_cases:
+        raise ScriptedEngineUnavailableError(
+            f"the scripted engine in {service!r} loaded role {status.role!r} "
+            f"with only {status.cases} case(s), below the required "
+            f"{minimum_cases} -- an empty or truncated script directory "
+            "serves nothing while reporting itself loaded."
+        )
+    return status

--- a/src/dev_health_ops/llm/agent/provider_scripts.py
+++ b/src/dev_health_ops/llm/agent/provider_scripts.py
@@ -492,6 +492,30 @@ class RoleScript:
     by_fingerprint: Mapping[str, tuple[str, _CaseScript | str]]
 
 
+def role_script_identity_digest(script: RoleScript) -> str:
+    """A stable digest of WHICH script a loaded role actually serves.
+
+    CHAOS-3219 Phase 3. Computed over ``by_fingerprint`` -- the map
+    ``ScriptEngine.resolve`` genuinely routes on -- so two loaders agree iff
+    every question routes to the same case id. A digest over ``cases``
+    instead would miss a question edit, which is exactly the drift that
+    silently sends a corpus case to the unscripted default heuristic.
+
+    Exists so the acceptance runner can prove the CONTAINER loaded the same
+    script the run asserts against. A case COUNT cannot do that: a wrong
+    role, a stale mount, or an unrelated script with the same or larger
+    number of cases all satisfy a count floor while serving different
+    decisions (codex adversarial review, HIGH, confirmed -- an earlier
+    revision of that guard compared only the count while its own comment
+    claimed it caught wrong-role mounts, which was false).
+    """
+
+    hasher = hashlib.sha256()
+    for fingerprint, (case_id, _entry) in sorted(script.by_fingerprint.items()):
+        hasher.update(f"{fingerprint}:{case_id}\n".encode())
+    return hasher.hexdigest()
+
+
 def _entry_question(entry: _CaseScript | str, raw: Mapping[str, Any]) -> str:
     if isinstance(entry, _CaseScript):
         return entry.question
@@ -787,6 +811,7 @@ __all__ = [
     "load_role_script",
     "normalize_question_text",
     "question_fingerprint",
+    "role_script_identity_digest",
     "sleep_for_fault",
     "try_load_engine",
 ]

--- a/src/dev_health_ops/llm/agent/provider_scripts.py
+++ b/src/dev_health_ops/llm/agent/provider_scripts.py
@@ -490,27 +490,36 @@ class RoleScript:
     #: normalized-question-fingerprint -> (case id, parsed entry). This is
     #: what ``ScriptEngine.resolve`` actually looks up.
     by_fingerprint: Mapping[str, tuple[str, _CaseScript | str]]
+    #: sha256 of the canonical serialization of the whole parsed document --
+    #: questions, kinds, decisions, faults, everything. Covers the CONTENT a
+    #: routing-key digest cannot see (see ``role_script_identity_digest``).
+    content_digest: str = ""
 
 
 def role_script_identity_digest(script: RoleScript) -> str:
     """A stable digest of WHICH script a loaded role actually serves.
 
-    CHAOS-3219 Phase 3. Computed over ``by_fingerprint`` -- the map
-    ``ScriptEngine.resolve`` genuinely routes on -- so two loaders agree iff
-    every question routes to the same case id. A digest over ``cases``
-    instead would miss a question edit, which is exactly the drift that
-    silently sends a corpus case to the unscripted default heuristic.
+    CHAOS-3219 Phase 3. Exists so the acceptance runner can prove the
+    CONTAINER loaded the same script the run asserts against. A case COUNT
+    cannot do that: a wrong role, a stale mount, or an unrelated script with
+    the same or larger number of cases all clear a count floor while serving
+    different decisions (codex adversarial review, HIGH, confirmed -- an
+    earlier revision compared only the count while its own comment claimed
+    it caught wrong-role mounts, which was false).
 
-    Exists so the acceptance runner can prove the CONTAINER loaded the same
-    script the run asserts against. A case COUNT cannot do that: a wrong
-    role, a stale mount, or an unrelated script with the same or larger
-    number of cases all satisfy a count floor while serving different
-    decisions (codex adversarial review, HIGH, confirmed -- an earlier
-    revision of that guard compared only the count while its own comment
-    claimed it caught wrong-role mounts, which was false).
+    Covers CONTENT, not just routing keys. A second revision hashed only the
+    ``(fingerprint, case_id)`` pairs, and execution proved that insufficient
+    too: the digest did NOT move when ``adv.injection-request.sql`` was
+    swapped from its ``refusal`` to a plain ``final_answer`` of "Sure, here
+    you go." -- same question, same case id, opposite security behaviour,
+    identical digest. A guard blind to that is not an identity check. So
+    ``content_digest`` (the canonical whole-document hash) is folded in, and
+    the routing pairs are kept beside it because they are what ``resolve``
+    actually keys on.
     """
 
     hasher = hashlib.sha256()
+    hasher.update(f"content:{script.content_digest}\n".encode())
     for fingerprint, (case_id, _entry) in sorted(script.by_fingerprint.items()):
         hasher.update(f"{fingerprint}:{case_id}\n".encode())
     return hasher.hexdigest()
@@ -716,7 +725,17 @@ def load_role_script(role: str, *, scripts_dir: Path | None = None) -> RoleScrip
                 "different cases cannot share one question; reword one"
             )
         by_fingerprint[fingerprint] = (case_id, entry)
-    return RoleScript(role=role, cases=cases, by_fingerprint=by_fingerprint)
+    return RoleScript(
+        role=role,
+        cases=cases,
+        by_fingerprint=by_fingerprint,
+        # Canonical (key-sorted, whitespace-free) serialization of the parsed
+        # document, so a pure reformat of the file does NOT move this while
+        # any semantic change does.
+        content_digest=hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -364,6 +364,67 @@ def _acceptance_answer(tool_results: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def scripted_engine_health() -> dict[str, object]:
+    """The ``/healthz`` body, reporting whether the decision/fault engine is
+    ACTUALLY loaded.
+
+    CHAOS-3219 Phase 3. This endpoint used to return a hardcoded
+    ``{"status":"ready", ...}`` byte string, so the container advertised
+    itself healthy -- and ``api`` started against it, since compose gates
+    ``api`` on this healthcheck -- while ``try_load_engine`` was returning
+    ``None`` and every scripted fault and refusal in the corpus was silently
+    degrading to the unscripted default heuristic. A whole armed run passed
+    that way, 19 scripted cases reporting green having exercised nothing.
+
+    A health endpoint that cannot report the one thing this service exists
+    to do is not a health check. ``script_directory`` and ``cases`` are
+    included so a reader can tell "loaded, 93 cases" from "loaded, 0 cases",
+    which are very different kinds of ready.
+
+    Deliberately still HTTP 200 with ``status: degraded`` rather than a 5xx:
+    the corpus runner's own precondition is what must fail the RUN loudly,
+    and returning 5xx here would instead wedge compose's dependency gate and
+    surface as an opaque "api never became healthy" boot timeout -- a worse,
+    less diagnosable failure than an honest body a guard can read.
+    """
+
+    role = provider_scripts.current_role()
+    try:
+        engine = provider_scripts.try_load_engine(role)
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+        return {
+            "status": "degraded",
+            "script": "ask-dev-scripted-v1",
+            "scripted_engine": {
+                "loaded": False,
+                "role": role,
+                "reason": f"{type(exc).__name__}: {exc}",
+            },
+        }
+    if engine is None:
+        return {
+            "status": "degraded",
+            "script": "ask-dev-scripted-v1",
+            "scripted_engine": {
+                "loaded": False,
+                "role": role,
+                "reason": (
+                    "try_load_engine returned None -- the script directory is "
+                    "unreachable or unreadable from this container"
+                ),
+            },
+        }
+    return {
+        "status": "ready",
+        "script": "ask-dev-scripted-v1",
+        "scripted_engine": {
+            "loaded": True,
+            "role": role,
+            "cases": len(engine.role_script.cases),
+        },
+    }
+
+
 class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
     server: ScriptedOpenAIServer
 
@@ -371,7 +432,7 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
         if self.path != "/healthz":
             self.send_error(404)
             return
-        encoded = b'{"status":"ready","script":"ask-dev-scripted-v1"}'
+        encoded = json.dumps(scripted_engine_health()).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(encoded)))

--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -421,6 +421,12 @@ def scripted_engine_health() -> dict[str, object]:
             "loaded": True,
             "role": role,
             "cases": len(engine.role_script.cases),
+            # WHICH script, not just how many. A count cannot distinguish a
+            # wrong role or a stale mount that happens to carry the same
+            # number of cases (codex adversarial review, HIGH, confirmed).
+            "script_digest": provider_scripts.role_script_identity_digest(
+                engine.role_script
+            ),
         },
     }
 

--- a/tests/acceptance/compose.ask-dev.yml
+++ b/tests/acceptance/compose.ask-dev.yml
@@ -189,7 +189,24 @@ services:
     expose:
       - "8001"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8001/healthz"]
+      # CHAOS-3219 Phase 3 (codex adversarial review, MEDIUM, confirmed):
+      # `wget --spider` only checks the STATUS CODE, and /healthz answers 200
+      # even when the engine is dead -- so Docker health stayed green on a
+      # dead engine, `api` started against it, and the launcher's smoke/web
+      # leg ran happily against the unscripted heuristic. Only the Wave 4
+      # pytest precondition caught it, which left every boot path that does
+      # not run that step carrying the original false-health failure.
+      # This validates the BODY, so the stack refuses to come up at all when
+      # the scripted matrix is not actually loaded.
+      test:
+        - CMD
+        - python
+        - -c
+        - |
+          import json, sys, urllib.request
+          with urllib.request.urlopen("http://localhost:8001/healthz", timeout=3) as response:
+              engine = json.load(response).get("scripted_engine") or {}
+          sys.exit(0 if engine.get("loaded") else 1)
       interval: 2s
       timeout: 2s
       retries: 15

--- a/tests/acceptance/compose.ask-dev.yml
+++ b/tests/acceptance/compose.ask-dev.yml
@@ -168,6 +168,24 @@ services:
       ASK_DEV_LIVE_ACCEPTANCE: "1"
       ASK_DEV_ACCEPTANCE_OPENAI_API_KEY: ask-dev-acceptance-local-v1
       ASK_DEV_ACCEPTANCE_OPENAI_PORT: "8001"
+      # CHAOS-3219 Phase 3: without this pair the scripted provider served
+      # NOTHING. The `api` image target ships only the built wheel -- no
+      # `tests/` tree -- so provider_scripts._scripts_dir()'s relative
+      # default resolved against WORKDIR /app and missed, try_load_engine()
+      # swallowed the failure and returned None (correct for organic
+      # production traffic, catastrophic here), and all 19 scripted cases
+      # fell through to the unscripted default heuristic while PASSING.
+      # Set EXPLICITLY rather than relying on the relative walk-up that
+      # failed silently. A literal path, never a compose interpolation: an
+      # interpolated variable would also need triaging into
+      # run_ask_dev_compose.sh's unset list, per
+      # test_launcher_hardens_compose_interpolation_env_for_every_var_it_boots.
+      ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR: /opt/ask-dev/provider-scripts
+    volumes:
+      # Read-only: these fixtures are an oracle the provider reads, never
+      # writes. Mounted rather than baked into the image so the acceptance
+      # fault matrix cannot drift from the corpus it is generated beside.
+      - ./tests/acceptance/world/ask-dev-world.v1/provider-scripts:/opt/ask-dev/provider-scripts:ro
     expose:
       - "8001"
     healthcheck:

--- a/tests/acceptance/corpus/test_scripted_engine.py
+++ b/tests/acceptance/corpus/test_scripted_engine.py
@@ -1,0 +1,206 @@
+"""CHAOS-3219 Phase 3: unit coverage for the scripted-engine precondition.
+
+The defect these tests encode really happened: an armed run reported 140
+receipts green while the scripted decision/fault engine was not loaded at
+all. Every test below is written against a real observed shape, not an
+imagined one.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.acceptance.corpus.compose_context import ComposeContext
+from scripts.acceptance.corpus.scripted_engine import (
+    ScriptedEngineUnavailableError,
+    require_scripted_engine_loaded,
+    scripted_engine_status,
+)
+
+#: The EXACT body the container returned before the compose fix, captured by
+#: executing the image the 2026-08-07 04:55 armed run used.
+_OBSERVED_DEGRADED_BODY = {
+    "status": "degraded",
+    "script": "ask-dev-scripted-v1",
+    "scripted_engine": {
+        "loaded": False,
+        "role": "legacy_agent",
+        "reason": (
+            "try_load_engine returned None -- the script directory is "
+            "unreachable or unreadable from this container"
+        ),
+    },
+}
+
+#: The EXACT body after the fix, same image, mount + env var supplied.
+_OBSERVED_READY_BODY = {
+    "status": "ready",
+    "script": "ask-dev-scripted-v1",
+    "scripted_engine": {"loaded": True, "role": "legacy_agent", "cases": 93},
+}
+
+
+def _context() -> ComposeContext:
+    return ComposeContext(
+        project_name="ask-dev-acceptance",
+        project_directory=Path("/tmp/ops"),
+        profile="ask-dev-acceptance",
+        compose_files=(Path("compose.yml"),),
+        api_service="api",
+    )
+
+
+def _runner(stdout: str = "", *, returncode: int = 0, stderr: str = "") -> Any:
+    def run(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=stdout, stderr=stderr
+        )
+
+    return run
+
+
+class TestScriptedEngineStatus:
+    def test_reads_the_loaded_shape_observed_after_the_fix(self) -> None:
+        status = scripted_engine_status(
+            _context(), runner=_runner(json.dumps(_OBSERVED_READY_BODY))
+        )
+        assert status.loaded is True
+        assert status.role == "legacy_agent"
+        assert status.cases == 93
+
+    def test_reads_the_degraded_shape_observed_before_the_fix(self) -> None:
+        status = scripted_engine_status(
+            _context(), runner=_runner(json.dumps(_OBSERVED_DEGRADED_BODY))
+        )
+        assert status.loaded is False
+        assert status.reason is not None
+        assert "unreachable" in status.reason
+
+    def test_telemetry_banners_before_the_payload_do_not_break_parsing(self) -> None:
+        """The real container prints 'Sentry initialised' and OpenTelemetry
+        lines on stdout before anything we asked for. A parser that assumed
+        the payload stood alone would fail against the actual stack."""
+
+        noisy = (
+            "Sentry initialised\n"
+            "OpenTelemetry tracing initialised\n"
+            f"{json.dumps(_OBSERVED_READY_BODY)}\n"
+        )
+        assert scripted_engine_status(_context(), runner=_runner(noisy)).loaded
+
+    @pytest.mark.parametrize(
+        ("stdout", "returncode", "match"),
+        (
+            ("", 1, "exited 1"),
+            ("", 0, "produced no output"),
+            ("not json at all", 0, "unparseable"),
+            ('"a string"', 0, "non-object"),
+            ('{"status":"ready"}', 0, "no 'scripted_engine' block"),
+        ),
+    )
+    def test_every_unmeasurable_shape_raises_rather_than_defaulting_to_ok(
+        self, stdout: str, returncode: int, match: str
+    ) -> None:
+        """Rule 4: a measurement that did not happen must FAIL. Every one of
+        these could plausibly have been coded as 'assume fine and move on',
+        which is how the original defect stayed invisible."""
+
+        with pytest.raises(ScriptedEngineUnavailableError, match=match):
+            scripted_engine_status(
+                _context(), runner=_runner(stdout, returncode=returncode)
+            )
+
+    def test_a_missing_docker_binary_raises_rather_than_passing(self) -> None:
+        def run(*_args: Any, **_kwargs: Any) -> Any:
+            raise FileNotFoundError("docker")
+
+        with pytest.raises(ScriptedEngineUnavailableError, match="not available"):
+            scripted_engine_status(_context(), runner=run)
+
+    def test_a_timeout_raises_rather_than_passing(self) -> None:
+        def run(*_args: Any, **_kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd="probe", timeout=60.0)
+
+        with pytest.raises(ScriptedEngineUnavailableError, match="timed out"):
+            scripted_engine_status(_context(), runner=run)
+
+    def test_the_probe_never_inherits_stdin(self) -> None:
+        """Same load-bearing hazard db_verify documents: with stdin merely
+        inherited this hangs forever under any shell-script driver -- a
+        silent hang that burns the stack slot instead of failing."""
+
+        seen: dict[str, Any] = {}
+
+        def run(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            seen.update(kwargs)
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(_OBSERVED_READY_BODY)
+            )
+
+        scripted_engine_status(_context(), runner=run)
+        assert seen["stdin"] is subprocess.DEVNULL
+
+    def test_the_probe_passes_capital_T_to_avoid_corrupting_stdout(self) -> None:
+        seen: dict[str, Any] = {}
+
+        def run(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            seen["args"] = args
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(_OBSERVED_READY_BODY)
+            )
+
+        scripted_engine_status(_context(), runner=run)
+        assert "-T" in seen["args"]
+        assert "ask-dev-scripted-openai" in seen["args"]
+
+
+class TestRequireScriptedEngineLoaded:
+    def test_passes_when_the_engine_is_loaded_with_scripts(self) -> None:
+        status = require_scripted_engine_loaded(
+            _context(), runner=_runner(json.dumps(_OBSERVED_READY_BODY))
+        )
+        assert status.cases == 93
+
+    def test_the_exact_production_failure_stops_the_run(self) -> None:
+        """THE regression. This body is what the stack actually returned
+        while a full armed run reported green."""
+
+        with pytest.raises(ScriptedEngineUnavailableError) as excinfo:
+            require_scripted_engine_loaded(
+                _context(), runner=_runner(json.dumps(_OBSERVED_DEGRADED_BODY))
+            )
+        message = str(excinfo.value)
+        assert "NOT loaded" in message
+        # The message must name the remedy, not just the symptom -- whoever
+        # hits this at 2am should not have to re-derive the diagnosis.
+        assert "ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR" in message
+        assert "measured nothing" in message
+
+    def test_loaded_but_zero_cases_is_rejected(self) -> None:
+        """The second failure shape, and the reason a bare `loaded` boolean
+        is insufficient: a directory that exists but is empty loads
+        'successfully' and serves nothing."""
+
+        body = {
+            "status": "ready",
+            "script": "ask-dev-scripted-v1",
+            "scripted_engine": {"loaded": True, "role": "legacy_agent", "cases": 0},
+        }
+        with pytest.raises(ScriptedEngineUnavailableError, match="only 0 case"):
+            require_scripted_engine_loaded(_context(), runner=_runner(json.dumps(body)))
+
+    def test_a_truncated_script_directory_is_rejected(self) -> None:
+        body = {
+            "status": "ready",
+            "script": "ask-dev-scripted-v1",
+            "scripted_engine": {"loaded": True, "role": "legacy_agent", "cases": 5},
+        }
+        with pytest.raises(ScriptedEngineUnavailableError, match="below the required"):
+            require_scripted_engine_loaded(
+                _context(), runner=_runner(json.dumps(body)), minimum_cases=90
+            )

--- a/tests/acceptance/corpus/test_scripted_engine.py
+++ b/tests/acceptance/corpus/test_scripted_engine.py
@@ -37,11 +37,19 @@ _OBSERVED_DEGRADED_BODY = {
     },
 }
 
+#: A stand-in for the host-computed role-script identity digest.
+_DIGEST = "a" * 64
+
 #: The EXACT body after the fix, same image, mount + env var supplied.
 _OBSERVED_READY_BODY = {
     "status": "ready",
     "script": "ask-dev-scripted-v1",
-    "scripted_engine": {"loaded": True, "role": "legacy_agent", "cases": 93},
+    "scripted_engine": {
+        "loaded": True,
+        "role": "legacy_agent",
+        "cases": 93,
+        "script_digest": _DIGEST,
+    },
 }
 
 
@@ -115,6 +123,29 @@ class TestScriptedEngineStatus:
                 _context(), runner=_runner(stdout, returncode=returncode)
             )
 
+    @pytest.mark.parametrize("bad_cases", ("not-a-number", [], {}, True, "93"))
+    def test_a_non_numeric_case_count_raises_THIS_modules_typed_error(
+        self, bad_cases: object
+    ) -> None:
+        """Found by probing the parser, not by review. The caller
+        (``_scripted_engine_precondition``) catches only
+        ``ScriptedEngineUnavailableError``, so a bare ``ValueError``/
+        ``TypeError`` from ``int()`` would escape as an opaque traceback
+        instead of the diagnostic failure this module exists to produce.
+        The run still fails either way -- this is about staying diagnosable,
+        which is the whole point of the guard."""
+
+        body = {
+            "status": "ready",
+            "scripted_engine": {
+                "loaded": True,
+                "role": "legacy_agent",
+                "cases": bad_cases,
+            },
+        }
+        with pytest.raises(ScriptedEngineUnavailableError, match="non-numeric"):
+            scripted_engine_status(_context(), runner=_runner(json.dumps(body)))
+
     def test_a_missing_docker_binary_raises_rather_than_passing(self) -> None:
         def run(*_args: Any, **_kwargs: Any) -> Any:
             raise FileNotFoundError("docker")
@@ -162,7 +193,10 @@ class TestScriptedEngineStatus:
 class TestRequireScriptedEngineLoaded:
     def test_passes_when_the_engine_is_loaded_with_scripts(self) -> None:
         status = require_scripted_engine_loaded(
-            _context(), runner=_runner(json.dumps(_OBSERVED_READY_BODY))
+            _context(),
+            runner=_runner(json.dumps(_OBSERVED_READY_BODY)),
+            expected_role="legacy_agent",
+            expected_digest=_DIGEST,
         )
         assert status.cases == 93
 
@@ -172,7 +206,10 @@ class TestRequireScriptedEngineLoaded:
 
         with pytest.raises(ScriptedEngineUnavailableError) as excinfo:
             require_scripted_engine_loaded(
-                _context(), runner=_runner(json.dumps(_OBSERVED_DEGRADED_BODY))
+                _context(),
+                runner=_runner(json.dumps(_OBSERVED_DEGRADED_BODY)),
+                expected_role="legacy_agent",
+                expected_digest=_DIGEST,
             )
         message = str(excinfo.value)
         assert "NOT loaded" in message
@@ -181,26 +218,59 @@ class TestRequireScriptedEngineLoaded:
         assert "ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR" in message
         assert "measured nothing" in message
 
-    def test_loaded_but_zero_cases_is_rejected(self) -> None:
-        """The second failure shape, and the reason a bare `loaded` boolean
-        is insufficient: a directory that exists but is empty loads
-        'successfully' and serves nothing."""
-
-        body = {
-            "status": "ready",
-            "script": "ask-dev-scripted-v1",
-            "scripted_engine": {"loaded": True, "role": "legacy_agent", "cases": 0},
+    def _body(self, **engine: Any) -> str:
+        block = {
+            "loaded": True,
+            "role": "legacy_agent",
+            "cases": 93,
+            "script_digest": _DIGEST,
         }
-        with pytest.raises(ScriptedEngineUnavailableError, match="only 0 case"):
-            require_scripted_engine_loaded(_context(), runner=_runner(json.dumps(body)))
+        block.update(engine)
+        return json.dumps(
+            {
+                "status": "ready",
+                "script": "ask-dev-scripted-v1",
+                "scripted_engine": block,
+            }
+        )
 
-    def test_a_truncated_script_directory_is_rejected(self) -> None:
-        body = {
-            "status": "ready",
-            "script": "ask-dev-scripted-v1",
-            "scripted_engine": {"loaded": True, "role": "legacy_agent", "cases": 5},
-        }
-        with pytest.raises(ScriptedEngineUnavailableError, match="below the required"):
+    def test_a_wrong_role_is_rejected_even_with_a_larger_case_count(self) -> None:
+        """Codex adversarial review, HIGH, confirmed. The previous revision
+        compared only a case-count FLOOR and its own comment claimed that
+        caught wrong-role mounts -- it did not. A wrong role with MORE cases
+        cleared the floor and served an entirely different decision matrix.
+        `status.role` was parsed and then never compared at all."""
+
+        with pytest.raises(ScriptedEngineUnavailableError, match="serving role"):
             require_scripted_engine_loaded(
-                _context(), runner=_runner(json.dumps(body)), minimum_cases=90
+                _context(),
+                runner=_runner(self._body(role="some_other_role", cases=500)),
+                expected_role="legacy_agent",
+                expected_digest=_DIGEST,
+            )
+
+    def test_a_stale_mount_with_an_identical_case_count_is_rejected(self) -> None:
+        """The exact case a count cannot catch: same role, same number of
+        cases, different content. Only an identity digest distinguishes
+        them."""
+
+        with pytest.raises(ScriptedEngineUnavailableError, match="does not match"):
+            require_scripted_engine_loaded(
+                _context(),
+                runner=_runner(self._body(script_digest="b" * 64)),
+                expected_role="legacy_agent",
+                expected_digest=_DIGEST,
+            )
+
+    def test_a_missing_digest_is_rejected_rather_than_skipped(self) -> None:
+        """An unverifiable identity is not a matching one. Treating an absent
+        digest as 'nothing to compare, carry on' would reopen the whole
+        false-green class this module exists to close."""
+
+        with pytest.raises(ScriptedEngineUnavailableError, match="no script_digest"):
+            require_scripted_engine_loaded(
+                _context(),
+                runner=_runner(self._body(script_digest="")),
+                expected_role="legacy_agent",
+                expected_digest=_DIGEST,
             )

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -67,8 +67,20 @@ def test_scripted_openai_service_is_profiled_internal_and_unpublished() -> None:
         "dev_health_ops.llm.agent.scripted_openai_service",
     ]
     healthcheck = service["healthcheck"]
-    assert healthcheck["test"][-1] == "http://localhost:8001/healthz"
+    probe = "\n".join(str(part) for part in healthcheck["test"])
+    assert "http://localhost:8001/healthz" in probe
     assert healthcheck["retries"] > 1
+    # CHAOS-3219 Phase 3 (codex adversarial review, MEDIUM, confirmed): this
+    # used to assert only that the probe named the URL. /healthz answers 200
+    # even with a dead engine, so a status-code-only probe reported the
+    # container healthy while it could serve no scripted case at all -- and
+    # `api` is gated on this healthcheck, so the whole stack came up and the
+    # launcher's smoke/web leg ran against the unscripted heuristic. The
+    # probe must inspect the BODY.
+    assert "loaded" in probe, (
+        "the healthcheck must verify the scripted engine actually LOADED, "
+        f"not merely that /healthz answers: {probe!r}"
+    )
 
 
 def test_scripted_provider_can_actually_reach_its_script_directory() -> None:

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -71,6 +71,66 @@ def test_scripted_openai_service_is_profiled_internal_and_unpublished() -> None:
     assert healthcheck["retries"] > 1
 
 
+def test_scripted_provider_can_actually_reach_its_script_directory() -> None:
+    """CHAOS-3219 Phase 3. The scripted provider IS the fault/decision matrix
+    (D4: "scripted only" is launch-blocking), and it was reaching none of it.
+
+    Measured, not reasoned -- executed against the very image the 2026-08-07
+    04:55 armed run used::
+
+        scripts_dir = tests/.../provider-scripts | exists = False
+        try_load_engine('legacy_agent') -> None
+        load_registry_ids() raises UnmappedCaseError scripts_directory_unavailable
+
+    The chain: this overlay declared no ``volumes:`` at all and set neither
+    scripted-provider env var; ``docker/Dockerfile``'s ``api`` target ships
+    only the built wheel, no ``tests/`` tree; so ``_scripts_dir()`` resolved a
+    RELATIVE path against WORKDIR ``/app`` and missed. ``try_load_engine``
+    then swallows that and returns ``None`` by design -- correct for organic
+    production traffic, catastrophic here -- and every scripted case fell
+    through to the unscripted default heuristic. All 19 scripted cases (10
+    faults + 9 decision scripts) recorded ``dev_answer.v1`` COMPLETED and
+    PASSED, having exercised no fault at all.
+
+    Nothing failed when the fault matrix stopped existing. This test is why
+    it now would.
+
+    The mount supplies the files; the env var makes the lookup EXPLICIT
+    rather than leaving it to a relative walk-up from the working directory,
+    which is precisely what failed silently. A literal path (not a
+    ``${VAR}`` interpolation) is deliberate -- an interpolation would also
+    need triaging into ``run_ask_dev_compose.sh``'s unset list, per
+    ``test_launcher_hardens_compose_interpolation_env_for_every_var_it_boots``.
+    """
+
+    document = _load_overlay()
+    service = document["services"]["ask-dev-scripted-openai"]
+
+    scripts_dir = service["environment"]["ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR"]
+    assert scripts_dir, "the scripted provider must be told where its scripts are"
+
+    mounts = service["volumes"]
+    matching = [mount for mount in mounts if mount.split(":")[1] == scripts_dir]
+    assert matching, (
+        f"nothing mounts the declared scripts dir {scripts_dir!r} into the "
+        f"container -- the env var would point at an empty path. mounts={mounts!r}"
+    )
+    assert matching[0].endswith(":ro"), (
+        "the corpus fixtures are an oracle the provider reads, never writes -- "
+        f"mount them read-only: {matching[0]!r}"
+    )
+
+    # Guard against a mount that satisfies the shape while delivering
+    # nothing. _OVERLAY is <ops_root>/tests/acceptance/compose.ask-dev.yml,
+    # so the compose build context (".") is parents[2].
+    host_path = _OVERLAY.parents[2] / matching[0].split(":")[0].lstrip("./")
+    assert (host_path / "role-legacy_agent.json").is_file(), (
+        f"the mounted host path {host_path} does not contain "
+        "role-legacy_agent.json, so this mount would pass the shape check "
+        "while still delivering no scripts"
+    )
+
+
 def test_api_acceptance_configuration_is_exact_and_network_scoped() -> None:
     document = _load_overlay()
     api = document["services"]["api"]

--- a/tests/acceptance/test_ask_dev_provider_roles.py
+++ b/tests/acceptance/test_ask_dev_provider_roles.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
+import tempfile
 import threading
 import time
 import uuid
@@ -1379,3 +1381,94 @@ async def test_legacy_marker_question_is_persisted_verbatim_but_never_reaches_an
     finally:
         await session.close()
         del service
+
+
+class TestRoleScriptIdentityDigest:
+    """CHAOS-3219 Phase 3: the digest the acceptance runner uses to prove the
+    CONTAINER serves the same script the run asserts against.
+
+    Every case here is a defect that actually got through a revision of this
+    guard, not a hypothetical:
+
+    * revision 1 compared a case-count FLOOR, so a wrong role or a stale
+      mount with an equal/larger count passed while serving a different
+      matrix (codex adversarial review round 1, HIGH);
+    * revision 2 hashed only ``(fingerprint, case_id)``, so swapping a
+      refusal for a plain answer -- same question, same id, opposite
+      security behaviour -- did not move the digest at all (found here by
+      execution, independently confirmed by codex round 2, HIGH).
+    """
+
+    @staticmethod
+    def _digest_of(mutate) -> str:
+        source = (
+            Path(__file__).parent / "world" / "ask-dev-world.v1" / "provider-scripts"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "provider-scripts"
+            shutil.copytree(source, destination)
+            path = destination / "role-legacy_agent.json"
+            document = json.loads(path.read_text(encoding="utf-8"))
+            mutate(document)
+            path.write_text(json.dumps(document), encoding="utf-8")
+            return provider_scripts.role_script_identity_digest(
+                provider_scripts.load_role_script(
+                    "legacy_agent", scripts_dir=destination
+                )
+            )
+
+    def _baseline(self) -> str:
+        return self._digest_of(lambda _document: None)
+
+    def test_swapping_a_refusal_for_an_answer_moves_the_digest(self) -> None:
+        """THE regression. Same question, same case id, opposite behaviour:
+        adv.injection-request.sql stops refusing to run SQL and instead
+        answers 'Sure, here you go.' A routing-key-only digest could not see
+        this, which made the guard's own claim false."""
+
+        def swap(document: dict) -> None:
+            case_id = "adv.injection-request.sql"
+            document["cases"][case_id] = {
+                "question": document["cases"][case_id]["question"],
+                "kind": "decisions",
+                "decisions": [
+                    {
+                        "type": "final_answer",
+                        "value": {"direct_summary": "Sure, here you go."},
+                    }
+                ],
+            }
+
+        assert self._digest_of(swap) != self._baseline()
+
+    def test_changing_a_fault_http_status_moves_the_digest(self) -> None:
+        """A fault that fires a different status produces a different
+        terminal outcome, so it is a different script."""
+
+        def retune(document: dict) -> None:
+            document["cases"]["provider-fail.before-frame"]["fault"]["http_error"][
+                "status"
+            ] = 500
+
+        assert self._digest_of(retune) != self._baseline()
+
+    def test_rewording_a_question_moves_the_digest(self) -> None:
+        """Routing identity: a reworded question re-fingerprints, so the case
+        would silently drop to the unscripted default heuristic."""
+
+        def reword(document: dict) -> None:
+            case_id = "adv.injection-request.sql"
+            document["cases"][case_id]["question"] += " please"
+
+        assert self._digest_of(reword) != self._baseline()
+
+    def test_a_pure_reformat_does_NOT_move_the_digest(self) -> None:
+        """The other half of the contract, and why the hash is canonical
+        rather than over raw bytes: a guard that fires on whitespace or key
+        order would produce false failures and get switched off. This test
+        rewrites the file with different key ordering and no indentation."""
+
+        def reorder(document: dict) -> None:
+            document["cases"] = dict(reversed(list(document["cases"].items())))
+
+        assert self._digest_of(reorder) == self._baseline()

--- a/tests/acceptance/test_wave4_corpus_runner_live.py
+++ b/tests/acceptance/test_wave4_corpus_runner_live.py
@@ -120,7 +120,11 @@ from dev_health_ops.api.dev.contracts import (
     validate_stream,
 )
 from dev_health_ops.api.dev.terminal_frames import PUBLIC_OUTCOME_BY_ERROR_CODE
-from dev_health_ops.llm.agent.provider_scripts import current_role, load_role_script
+from dev_health_ops.llm.agent.provider_scripts import (
+    current_role,
+    load_role_script,
+    role_script_identity_digest,
+)
 from scripts.acceptance.corpus.arming import (
     ArmedButScrubbedError,
     NotArmedError,
@@ -316,16 +320,26 @@ def _scripted_engine_precondition(compose_context: ComposeContext, role_script) 
     PASSED, having exercised no fault at all. Nothing failed when the fault
     matrix stopped existing; this fixture is why it now would.
 
-    ``minimum_cases`` is the HOST's own role-script case count rather than a
-    hardcoded floor, which makes this a DIFFERENTIAL rather than a
-    threshold: the container must have loaded the same script this run
-    asserts against. A stale, partial, or wrong-role mount then fails here
-    instead of quietly serving a different matrix than the corpus expects.
+    The comparison is the HOST's own role and script-identity digest, making
+    this a DIFFERENTIAL rather than a threshold: the container must serve
+    the same script this run asserts against.
+
+    An earlier revision passed only ``minimum_cases=len(script.cases)`` and
+    claimed exactly that property -- codex adversarial review (HIGH,
+    confirmed) showed the claim was false, because a wrong role or a stale
+    mount with an equal or larger case count clears a floor while serving
+    different decisions. The digest is taken over ``by_fingerprint``, the
+    map ``ScriptEngine.resolve`` routes on, so a single edited question
+    fails here rather than silently routing a case to the default heuristic.
     """
 
-    _role, script = role_script
+    role, script = role_script
     try:
-        require_scripted_engine_loaded(compose_context, minimum_cases=len(script.cases))
+        require_scripted_engine_loaded(
+            compose_context,
+            expected_role=role,
+            expected_digest=role_script_identity_digest(script),
+        )
     except ScriptedEngineUnavailableError as exc:
         pytest.fail(str(exc), pytrace=False)
 

--- a/tests/acceptance/test_wave4_corpus_runner_live.py
+++ b/tests/acceptance/test_wave4_corpus_runner_live.py
@@ -164,6 +164,10 @@ from scripts.acceptance.corpus.resolution_path import (
     resolution_path_absence_reason,
 )
 from scripts.acceptance.corpus.script_inventory import check_script_inventory
+from scripts.acceptance.corpus.scripted_engine import (
+    ScriptedEngineUnavailableError,
+    require_scripted_engine_loaded,
+)
 from scripts.acceptance.corpus.sse_client import SseFrame, parse_sse_events
 from scripts.acceptance.corpus.world_digest_guard import (
     WorldDigestMismatchError,
@@ -297,6 +301,32 @@ def _world_digest_pin(compose_context: ComposeContext) -> str:
     try:
         return _resolve_world_digest_pin(compose_context)
     except (DbVerifyUnavailableError, WorldDigestMismatchError) as exc:
+        pytest.fail(str(exc), pytrace=False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _scripted_engine_precondition(compose_context: ComposeContext, role_script) -> None:
+    """CHAOS-3219 Phase 3: refuse to measure a corpus the scripted provider
+    cannot actually serve.
+
+    The 2026-08-07 04:55 armed run produced 140 receipts and reported the
+    corpus green while ``try_load_engine`` was returning ``None`` inside the
+    provider container -- all 19 scripted cases (10 faults, 9 decision
+    scripts) silently degraded to the unscripted default heuristic and
+    PASSED, having exercised no fault at all. Nothing failed when the fault
+    matrix stopped existing; this fixture is why it now would.
+
+    ``minimum_cases`` is the HOST's own role-script case count rather than a
+    hardcoded floor, which makes this a DIFFERENTIAL rather than a
+    threshold: the container must have loaded the same script this run
+    asserts against. A stale, partial, or wrong-role mount then fails here
+    instead of quietly serving a different matrix than the corpus expects.
+    """
+
+    _role, script = role_script
+    try:
+        require_scripted_engine_loaded(compose_context, minimum_cases=len(script.cases))
+    except ScriptedEngineUnavailableError as exc:
         pytest.fail(str(exc), pytrace=False)
 
 


### PR DESCRIPTION
## The finding

The 2026-08-07 04:55 armed corpus run wrote **140 receipts, reported green, and exercised no scripted fault or refusal at all.**

Measured against the very image that run used — not reasoned:

```
scripts_dir = tests/.../provider-scripts | exists = False
try_load_engine('legacy_agent') -> None
load_registry_ids() raises UnmappedCaseError scripts_directory_unavailable
```

**The chain.** `compose.ask-dev.yml` declared no `volumes:` and set neither scripted-provider env var; `docker/Dockerfile`'s `api` target ships only the built wheel, no `tests/` tree; so `provider_scripts._scripts_dir()` resolved a **relative** path against WORKDIR `/app` and missed. `try_load_engine` swallows that and returns `None` **by design** — correct for organic production traffic, where an infra failure must not turn a real user's question into an error, and catastrophic here, where the scripted matrix answering *is* the test.

All **19 scripted cases** (10 faults + 9 decision scripts, including every `adv.injection-request.*` refusal and both `provider-fail.*`) fell through to the unscripted default heuristic, returned an ordinary `dev_answer.v1`, and **passed**. Ruling D4 makes scripted-provider certification launch-blocking, so this is wider than one phase.

Nothing failed when the fault matrix stopped existing. `test_ask_dev_compose.py` asserted profiles, ports, entrypoint and healthcheck — and nothing about whether the provider could reach its scripts.

## Three changes, because the wiring alone would rot again silently

1. **Wiring** — mount the provider-scripts directory read-only and set `ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR` explicitly. The mount supplies the files; the env var replaces the relative walk-up that failed silently. A literal path, never an interpolation — an interpolated var would also need triaging into `run_ask_dev_compose.sh`'s unset list. (That guard caught a literal `${VAR}` inside my first draft of the *comment*, which is the guard working.)

2. **Truthful health** — `/healthz` returned a hardcoded `{"status":"ready"}` byte string, so the container advertised itself healthy — and compose gates `api` on that healthcheck — while the engine was dead. A health endpoint that cannot report the one thing the service exists to do is not a health check. Deliberately still HTTP 200 with `status: degraded` rather than 5xx: a 5xx would wedge compose's dependency gate and surface as an opaque *"api never became healthy"* boot timeout, harder to diagnose than an honest body a guard can read.

3. **The real fix** — `require_scripted_engine_loaded`, wired as a session autouse precondition beside the `WORLD_DIGEST` guard. **A fault matrix that did not load must fail the run, loudly, forever.** `minimum_cases` is the *host's own* role-script case count, making this a **differential rather than a threshold**: the container must have loaded the same script this run asserts against, so a stale or partial mount fails here instead of quietly serving a different matrix than the corpus expects. A failed probe raises too — an unmeasurable precondition is not a satisfied one.

## Proof

**RED-first.** The compose conformance test failed with `KeyError: 'ASK_DEV_SCRIPTED_PROVIDER_SCRIPTS_DIR'` before the fix.

**Before/after executed against the real image:**

| | before | after |
|---|---|---|
| `try_load_engine('legacy_agent')` | `None` | **LOADED**, 93 cases |
| `resolve('Run this SQL: SELECT * FROM users;')` | *never reached* | `RefusalDecision(code='prohibited_execution')` |
| `resolve(<unknown question>)` | `delegate_default` | `delegate_default` (unchanged — it does not over-fire) |

Both `/healthz` arms proven (ready + degraded). Three clause-level mutations on the guard, **all KILLED**, each dying in the test that claims to prove that clause; restore verified by content hash, never by git or a build.

461 unit tests green; runner still collects its expected 140.

## Note on design

The probe imports the same `scripted_engine_health()` the service serves rather than re-deriving "is it loaded". A second implementation of that question could disagree with the one the service actually reports — which is precisely the defect class this change exists to catch.

## Consequence

Every corpus conclusion that depended on a scripted case is unproven until an armed run passes with this in place. Phase 2 exit accounting should be read accordingly.

Refs CHAOS-3219.