### PR TITLE
CHAOS-3536: make the schema production actually sends strict-mode valid, and correct the never-widen claim it disproved

### DIFF
--- a/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
@@ -18,9 +18,12 @@ Whether a given index actually falls within the specific shortlist shown for
 that mention is a **per-call** fact this static schema cannot know (two
 different questions show different candidate counts).
 
-**That bound is enforced in exactly ONE place: ``qua_shadow._verify``.**
-This docstring used to list two enforcement points and present them as
-defence in depth. That was wrong, and CHAOS-3536 corrected it:
+**PER-MENTION index authorization is enforced in exactly ONE place:
+``qua_shadow._verify``.** Scope that sentence carefully -- there IS one
+structural bound left (the call-wide zero-candidate encoding, below), so the
+precise claim is that no wire-level rule constrains an index to the mention
+it belongs to. This docstring used to list two enforcement points and present
+them as defence in depth. That was wrong, and CHAOS-3536 corrected it:
 
 1. ``_verify`` re-checks every index against the exact per-mention slice
    after parsing, independent of whether the provider honored anything.

--- a/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
@@ -40,11 +40,19 @@ defence in depth. That was wrong, and CHAOS-3536 corrected it:
    reading it. Tracked as CHAOS-3537.
 
 The one structural bound that DOES survive projection is the zero-candidate
-case: with nothing authorized, ``selected_candidate_index`` is sent as
-``{"type": "null"}``, so no index is expressible at all. ``candidate_indices``
-has no equivalent -- it is a non-optional tuple here, so a null would fail
-parsing -- and is therefore unbounded on the wire and rejected only by
-``_verify``.
+case: when the CALL authorized nothing at all, ``selected_candidate_index``
+is sent as ``{"type": "null"}``, so no SELECTED index is expressible. That
+covers ``selected_candidate_index`` only -- ``candidate_indices`` still goes
+out as ``{"type": "array", "items": {"type": "integer"}}`` even then, so an
+index remains expressible there and is caught only by ``_verify``.
+
+Note the scope of that carefully -- it is call-wide, not per mention.
+``_response_schema`` is built once from the COMBINED shortlist, so all
+mentions share one index space, and a mention whose own slice is empty (past
+``max_total_candidates``) still sees the call's full range in the schema.
+Only ``_verify`` knows about per-mention slices. ``candidate_indices`` gets
+no structural bound either -- it is a non-optional tuple here, so a null
+would fail parsing -- and is likewise rejected only by ``_verify``.
 """
 
 from __future__ import annotations

--- a/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
@@ -16,19 +16,35 @@ class only checks *shape*: is ``selected_candidate_index`` an int or null,
 is ``confidence`` a probability, is ``outcome`` one of three closed values.
 Whether a given index actually falls within the specific shortlist shown for
 that mention is a **per-call** fact this static schema cannot know (two
-different questions show different candidate counts) -- that bound is
-enforced two other ways, both in ``qua_shadow.py``:
+different questions show different candidate counts).
 
-1. The wire-level JSON Schema handed to the provider (``_response_schema``)
-   bounds every index field to ``[0, total_candidates - 1]`` for THIS call,
-   built fresh per call. A provider honoring the schema cannot even
-   *generate* an out-of-range integer, and when there are zero authorized
-   candidates the bound is ``[0, -1]`` -- empty, so no integer satisfies it.
-2. ``_verify`` re-checks every index against the exact per-mention slice
-   after parsing, in case a provider does not honor the schema strictly.
-   A violation there marks that one mention's proposal ``rejected``, never
-   the whole record, and it is never a live-path decision either way --
-   shadow mode never acts on any of this.
+**That bound is enforced in exactly ONE place: ``qua_shadow._verify``.**
+This docstring used to list two enforcement points and present them as
+defence in depth. That was wrong, and CHAOS-3536 corrected it:
+
+1. ``_verify`` re-checks every index against the exact per-mention slice
+   after parsing, independent of whether the provider honored anything.
+   A violation marks that one mention's proposal ``rejected``, never the
+   whole record. CHAOS-3525 additionally hardened the singular commit path
+   to resolve by identity, so this is a strong check -- but it is the only
+   one, and a change that weakens it is not backstopped by anything.
+2. The wire-level JSON Schema was the claimed second enforcement point:
+   ``_response_schema`` bounds every index field to
+   ``[0, total_candidates - 1]``, so a provider honoring the schema could
+   not generate an out-of-range integer. **Those bounds never reached a
+   provider.** ``OpenAICompatibleAgentProvider`` projects every schema
+   through ``_structural_schema``, which keeps only
+   ``_STRUCTURAL_SCHEMA_KEYS`` -- ``minimum``/``maximum``/``minItems``/
+   ``maxItems``/``maxLength`` are not in it and are stripped before
+   dispatch. Verified by executing ``build_completion_request``, not by
+   reading it. Tracked as CHAOS-3537.
+
+The one structural bound that DOES survive projection is the zero-candidate
+case: with nothing authorized, ``selected_candidate_index`` is sent as
+``{"type": "null"}``, so no index is expressible at all. ``candidate_indices``
+has no equivalent -- it is a non-optional tuple here, so a null would fail
+parsing -- and is therefore unbounded on the wire and rejected only by
+``_verify``.
 """
 
 from __future__ import annotations
@@ -49,9 +65,13 @@ __all__ = [
 
 QUESTION_UNDERSTANDING_SCHEMA_VERSION = "dev_question_understanding.v1"
 
-#: Bound applied to every candidate-index field regardless of shortlist size
-#: (belt: the wire schema's own per-call bound is tighter; this is the
-#: absolute ceiling a hand-authored ``max_length``/``le`` must never exceed).
+#: Bound applied to every candidate-index field regardless of shortlist size.
+#:
+#: CHAOS-3536: this used to call itself the "belt" to the wire schema's
+#: tighter per-call bound. There is no such braces -- the wire bound is
+#: stripped by the provider projection (CHAOS-3537), so for a non-empty
+#: shortlist this ceiling and ``_verify`` are what exist. Kept as the
+#: absolute ceiling a hand-authored ``max_length``/``le`` must never exceed.
 _MAX_MENTIONS = 25
 _MAX_CANDIDATE_INDICES = 25
 

--- a/src/dev_health_ops/api/dev/qua_promotion.py
+++ b/src/dev_health_ops/api/dev/qua_promotion.py
@@ -22,11 +22,18 @@ cohort, an uncorroborated organization-wide cardinality -- each returns
 without the seam. There is no branch here that repairs a partial proposal
 into a usable one.
 
-**It re-authorizes at commit time.** The shadow already bounds proposals two
-ways (a per-call JSON Schema that makes an out-of-range index inexpressible,
-and a runtime verifier re-checking each index against that mention's own
-slice). Promotion adds a third check, and on the singular path that third
-check is not redundancy -- it is the ONLY receipt. ``committed_resolution_for``
+**It re-authorizes at commit time.** This paragraph used to say the shadow
+already bounds proposals "two ways" -- a per-call JSON Schema making an
+out-of-range index inexpressible, plus a runtime verifier. CHAOS-3536
+established that the first of those does not exist: the schema's
+``minimum``/``maximum`` bounds are stripped by the provider's
+``_structural_schema`` projection and have never reached a decoder
+(CHAOS-3537). Shadow-time index bounding is ``qua_shadow._verify`` alone,
+re-checking each index against that mention's own slice.
+
+So promotion's ``verify_still_authorized`` is the SECOND check overall, not
+the third -- and on the singular path it is not redundancy either way, it is
+the ONLY receipt. ``committed_resolution_for``
 mints no ``subject_set_fingerprint``, and the executor's fingerprint
 cross-check (``investigation_plans/executor.py``) only covers *set* batches,
 so nothing downstream re-verifies a singular committed entity. See
@@ -141,19 +148,31 @@ def promotable_selection(
     # truncation. So for a question with many mentions, a later mention
     # cannot carry a selection that survives verification.
     #
-    # CHAOS-3536 corrected the mechanism claimed here. This used to say the
-    # per-call JSON Schema bounded such a mention's index range to
-    # ``[0, -1]``, "which no integer satisfies" -- i.e. that the provider
-    # could not express it. It could: ``_structural_schema`` strips
-    # ``minimum``/``maximum`` before dispatch (CHAOS-3537). The empty
-    # zero-candidate slice is now sent as ``{"type": "null"}``, which does
-    # survive projection, so the schema half is real again for THIS shape --
-    # but the guarantee that has always held is ``_verify``'s, which rejects
-    # any index not in the mention's own slice.
+    # CHAOS-3536 corrected the mechanism claimed here, and the claim was
+    # wrong in TWO ways. It used to say the per-call JSON Schema bounded
+    # such a mention's index range to ``[0, -1]``, "which no integer
+    # satisfies".
     #
-    # Either way the direction is fail-closed (no proposal rather than a
-    # proposal over a truncated list), and it is one more reason a
-    # multi-mention question falls through to clarification above.
+    # First: those bounds never reached the provider at all --
+    # ``_structural_schema`` strips ``minimum``/``maximum`` before dispatch
+    # (CHAOS-3537).
+    #
+    # Second, and independent of the stripping: THERE IS NO PER-MENTION
+    # INDEX RANGE IN THE SCHEMA. ``_response_schema`` is built once per call
+    # from ``candidate_count=len(combined)`` -- the COMBINED, call-wide
+    # shortlist -- so every mention shares one index space. A mention past
+    # ``max_total_candidates`` gets an empty SLICE from
+    # ``_combine_shortlists``, but ``candidate_count`` is still 50, so the
+    # schema keeps expressing 0..49 for it. The zero-candidate
+    # ``{"type": "null"}`` encoding fires only when the WHOLE call
+    # authorized nothing, which is not this case.
+    #
+    # So for a truncated mention the schema offers nothing whatsoever, and
+    # ``_verify`` -- which checks each index against that mention's OWN
+    # ``[start, end)`` slice, not the call-wide range -- is the entire
+    # reason a truncated mention cannot carry a selection. That is still
+    # fail-closed, and it is one more reason a multi-mention question falls
+    # through to clarification above.
     # An organization-wide proposal can name no entity to verify, so there is
     # nothing here to commit even when corroborated; a singular commit is the
     # only shape this promotion has. Checked explicitly rather than left to

--- a/src/dev_health_ops/api/dev/qua_promotion.py
+++ b/src/dev_health_ops/api/dev/qua_promotion.py
@@ -138,10 +138,20 @@ def promotable_selection(
     # Stated rather than left to be discovered: the shortlist is capped at
     # ``max_total_candidates`` (50) across the WHOLE call, and a mention past
     # that bound gets an EMPTY slice -- never a partial one straddling the
-    # truncation. So for a question with many mentions, a later mention is
-    # structurally unable to carry a selection: the per-call JSON Schema
-    # bounds its index range to ``[0, -1]``, which no integer satisfies.
-    # That is the correct fail-closed direction (no proposal rather than a
+    # truncation. So for a question with many mentions, a later mention
+    # cannot carry a selection that survives verification.
+    #
+    # CHAOS-3536 corrected the mechanism claimed here. This used to say the
+    # per-call JSON Schema bounded such a mention's index range to
+    # ``[0, -1]``, "which no integer satisfies" -- i.e. that the provider
+    # could not express it. It could: ``_structural_schema`` strips
+    # ``minimum``/``maximum`` before dispatch (CHAOS-3537). The empty
+    # zero-candidate slice is now sent as ``{"type": "null"}``, which does
+    # survive projection, so the schema half is real again for THIS shape --
+    # but the guarantee that has always held is ``_verify``'s, which rejects
+    # any index not in the mention's own slice.
+    #
+    # Either way the direction is fail-closed (no proposal rather than a
     # proposal over a truncated list), and it is one more reason a
     # multi-mention question falls through to clarification above.
     # An organization-wide proposal can name no entity to verify, so there is

--- a/src/dev_health_ops/api/dev/qua_shadow.py
+++ b/src/dev_health_ops/api/dev/qua_shadow.py
@@ -45,10 +45,20 @@ adversarial critique, comment 7d1368d9):
   resolve by identity. That makes it a strong sole guard, but a sole guard.
 
   The one structural bound that DOES survive projection is the
-  zero-candidate encoding: with nothing authorized,
-  ``selected_candidate_index`` is ``{"type": "null"}``, so no index is
-  expressible at all. See ``_response_schema``. CHAOS-3537 tracks restoring
-  a real structural bound for the non-empty case.
+  zero-candidate encoding: when the CALL authorized nothing,
+  ``selected_candidate_index`` is ``{"type": "null"}``. Two limits on that,
+  both stated because the previous version of this bullet is what taught us
+  not to round such claims up:
+
+  - it covers ``selected_candidate_index`` only. ``candidate_indices`` still
+    ships as ``{"type": "array", "items": {"type": "integer"}}``, so an
+    index stays expressible there and ``_verify`` remains its only guard;
+  - it is CALL-wide, not per mention. ``_response_schema`` is built once
+    from the combined shortlist, so a mention whose own slice is empty
+    (past ``max_total_candidates``) still sees the call's full range.
+
+  See ``_response_schema``. CHAOS-3537 tracks restoring a real structural
+  bound for the non-empty case.
 * **LLM unavailable degrades to silent skip, never a block.** Every branch
   of ``evaluate()`` returns a ``QUAShadowRecord`` (never raises); the
   orchestrator's own call site additionally wraps the call and the

--- a/src/dev_health_ops/api/dev/qua_shadow.py
+++ b/src/dev_health_ops/api/dev/qua_shadow.py
@@ -25,14 +25,30 @@ adversarial critique, comment 7d1368d9):
   the same cardinality. This is what stops "how is the Contxt Fabric doing?"
   from reading as a corroborated org-wide proposal just because the model
   found no candidate id to name.
-* **Never-widen holds structurally.** ``_response_schema`` bounds every
-  candidate-index field to ``[0, len(combined) - 1]`` for the exact
-  authorized shortlist THIS call built -- when that shortlist is empty the
-  bound is ``[0, -1]``, which no integer satisfies, so the wire schema
-  itself cannot express a candidate when none were authorized. ``_verify``
-  re-checks every accepted index against its OWN mention's slice (not just
-  the call-wide bound) after parsing, independent of whether the provider
-  honored the schema.
+* **Never-widen is enforced at RUNTIME, not by the wire schema.** This bullet
+  used to claim the opposite -- that ``_response_schema``'s
+  ``[0, len(combined) - 1]`` index bounds made an unauthorized candidate
+  inexpressible on the wire. That was FALSE for as long as it was written
+  (CHAOS-3536). ``OpenAICompatibleAgentProvider`` projects every schema
+  through ``_structural_schema``, which keeps only ``_STRUCTURAL_SCHEMA_KEYS``
+  -- and ``minimum``/``maximum``/``minItems``/``maxItems``/``maxLength`` are
+  not among them. The bounds were stripped before dispatch on every call
+  that ever ran; no provider has seen them. Verified by executing the
+  product's own ``build_completion_request`` and reading the result, not by
+  reasoning about it.
+
+  So ``_verify`` is not a belt-and-braces second check, as this file
+  previously implied -- it is the ONLY check. It re-checks every accepted
+  index against its OWN mention's authorized slice (not just the call-wide
+  bound) after parsing, independent of whether the provider honored
+  anything, and CHAOS-3525 additionally hardened the singular path to
+  resolve by identity. That makes it a strong sole guard, but a sole guard.
+
+  The one structural bound that DOES survive projection is the
+  zero-candidate encoding: with nothing authorized,
+  ``selected_candidate_index`` is ``{"type": "null"}``, so no index is
+  expressible at all. See ``_response_schema``. CHAOS-3537 tracks restoring
+  a real structural bound for the non-empty case.
 * **LLM unavailable degrades to silent skip, never a block.** Every branch
   of ``evaluate()`` returns a ``QUAShadowRecord`` (never raises); the
   orchestrator's own call site additionally wraps the call and the
@@ -610,15 +626,40 @@ class QuestionUnderstandingShadow:
     def _response_schema(
         self, *, mention_count: int, candidate_count: int
     ) -> dict[str, Any]:
-        """A JSON Schema whose index bounds make an out-of-authorization
-        candidate literally inexpressible for THIS call. When
-        ``candidate_count`` is zero the bound is ``[0, -1]`` -- an empty
-        range no integer satisfies, so a provider honoring the schema
-        cannot select any candidate at all when none were authorized.
+        """The response schema for THIS call's authorized shortlist.
+
+        CHAOS-3536, read this before trusting the bounds below: ``minimum``,
+        ``maximum``, ``minItems``, ``maxItems`` and ``maxLength`` DO NOT
+        REACH THE PROVIDER. ``OpenAICompatibleAgentProvider`` projects every
+        schema through ``_structural_schema``, which keeps only the keys in
+        ``_STRUCTURAL_SCHEMA_KEYS`` -- and none of those five are in it. They
+        are dropped before dispatch. Keeping them here is still worthwhile
+        (they document intent, and they bound the schema for any future
+        provider that does not project), but nothing may be claimed on their
+        strength. ``_verify`` is the guard that actually holds. See
+        CHAOS-3537 for restoring a structural bound to the wire.
+
+        The zero-candidate case is the one bound that DOES survive, and it
+        is encoded to survive deliberately. It used to be the empty integer
+        range ``[0, -1]``, which projection erased down to
+        ``{"type": ["integer", "null"]}`` -- any integer expressible with
+        nothing authorized. It is now ``{"type": "null"}``: the same
+        never-widen intent, expressed with a keyword the projection keeps,
+        and parseable because the contract field is ``_StrictIndex | None``.
+
+        ``candidate_indices`` gets no equivalent treatment and is bounded
+        only at runtime: its contract field is a non-optional tuple, so a
+        null would fail parsing on every zero-candidate call, and
+        ``maxItems: 0`` would be stripped like the rest. An out-of-range
+        entry there is expressible on the wire and rejected by ``_verify``.
         """
 
         max_index = candidate_count - 1
-        index_schema = {"type": ["integer", "null"], "minimum": 0, "maximum": max_index}
+        index_schema: dict[str, Any] = (
+            {"type": "null"}
+            if candidate_count == 0
+            else {"type": ["integer", "null"], "minimum": 0, "maximum": max_index}
+        )
         mention_schema = {
             "type": "object",
             "additionalProperties": False,
@@ -649,7 +690,17 @@ class QuestionUnderstandingShadow:
                 "requires_clarification",
             ],
             "properties": {
-                "schema_version": {"const": QUESTION_UNDERSTANDING_SCHEMA_VERSION},
+                # CHAOS-3536: ``type`` is REQUIRED here, and its absence took
+                # the whole QUA path down against every real provider --
+                # strict structured-output mode rejects the request with
+                # "In context=('properties', 'schema_version'), schema must
+                # have a 'type' key". ``const`` alone is not a type
+                # declaration. The pin stays: the field must still be v1 by
+                # VALUE, not merely a string.
+                "schema_version": {
+                    "type": "string",
+                    "const": QUESTION_UNDERSTANDING_SCHEMA_VERSION,
+                },
                 "intent_id": {
                     "type": "string",
                     "enum": [intent.value for intent in QuestionIntentID],

--- a/tests/api/dev/test_chaos_3389_qua_shadow.py
+++ b/tests/api/dev/test_chaos_3389_qua_shadow.py
@@ -334,7 +334,16 @@ async def test_a_shadow_component_that_raises_outright_still_never_affects_the_r
 
 
 # ---------------------------------------------------------------------------
-# Never-widen holds structurally, even against a malicious/buggy provider
+# Never-widen holds AT RUNTIME, against a malicious/buggy provider
+#
+# CHAOS-3536 corrected this heading. It used to say "structurally", on the
+# strength of _response_schema's per-call index bounds -- but those bounds
+# are stripped by the provider's _structural_schema projection and have
+# never reached a decoder (CHAOS-3537). Every test below drives a scripted
+# provider that ignores the schema entirely, which is exactly the right
+# shape for the guarantee that actually exists: _verify is the sole guard,
+# and these are its proofs. Nothing here ever demonstrated a wire-level
+# bound, so nothing below changes -- only the claim above it.
 # ---------------------------------------------------------------------------
 
 
@@ -421,10 +430,22 @@ async def test_an_index_outside_the_mentions_own_shortlist_is_rejected_not_trust
 async def test_zero_authorized_candidates_makes_every_index_structurally_inexpressible() -> (
     None
 ):
-    """When a mention has no authorized candidates at all, the wire schema's
-    own bound is [0, -1] -- no integer satisfies it. A provider that ignores
-    the schema and returns index 0 anyway is still caught by the runtime
-    verifier."""
+    """A provider that returns index 0 with nothing authorized is rejected.
+
+    The name is accurate, but CHAOS-3536 changed WHY. This docstring used to
+    say the wire schema's bound was ``[0, -1]``, an empty range no integer
+    satisfies. That range never reached a provider -- ``_structural_schema``
+    strips ``minimum``/``maximum`` before dispatch, so the wire said
+    ``{"type": ["integer", "null"]}`` and any integer was expressible
+    (CHAOS-3537). The zero-candidate case is now encoded as
+    ``{"type": "null"}``, which survives the projection, so the index really
+    is structurally inexpressible -- see
+    ``test_chaos_3536_qua_strict_schema.py``, which asserts that on the
+    PROJECTED schema rather than the generator's output.
+
+    What THIS test proves is the runtime half, and it is the half that has
+    always been load-bearing: the scripted provider ignores the schema
+    completely and returns index 0 anyway, and ``_verify`` rejects it."""
 
     catalog = _catalog([])  # nothing authorized in this org at all
     scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())

--- a/tests/api/dev/test_chaos_3389_qua_shadow.py
+++ b/tests/api/dev/test_chaos_3389_qua_shadow.py
@@ -427,25 +427,30 @@ async def test_an_index_outside_the_mentions_own_shortlist_is_rejected_not_trust
     assert second.rejected_reason is None
 
 
-async def test_zero_authorized_candidates_makes_every_index_structurally_inexpressible() -> (
-    None
-):
+async def test_zero_authorized_candidates_gets_an_index_rejected_at_runtime() -> None:
     """A provider that returns index 0 with nothing authorized is rejected.
 
-    The name is accurate, but CHAOS-3536 changed WHY. This docstring used to
-    say the wire schema's bound was ``[0, -1]``, an empty range no integer
-    satisfies. That range never reached a provider -- ``_structural_schema``
-    strips ``minimum``/``maximum`` before dispatch, so the wire said
-    ``{"type": ["integer", "null"]}`` and any integer was expressible
-    (CHAOS-3537). The zero-candidate case is now encoded as
-    ``{"type": "null"}``, which survives the projection, so the index really
-    is structurally inexpressible -- see
-    ``test_chaos_3536_qua_strict_schema.py``, which asserts that on the
-    PROJECTED schema rather than the generator's output.
+    CHAOS-3536 RENAMED this test, because the old name
+    (``..._makes_every_index_structurally_inexpressible``) claimed two things
+    that are not true, and a test name is read far more often than a
+    docstring.
 
-    What THIS test proves is the runtime half, and it is the half that has
-    always been load-bearing: the scripted provider ignores the schema
-    completely and returns index 0 anyway, and ``_verify`` rejects it."""
+    "Structurally" was false: the old docstring said the wire schema's bound
+    was ``[0, -1]``, an empty range no integer satisfies. That range never
+    reached a provider -- ``_structural_schema`` strips ``minimum``/
+    ``maximum`` before dispatch, so the wire said
+    ``{"type": ["integer", "null"]}`` (CHAOS-3537).
+
+    "Every index" is still false even after the fix. The zero-candidate case
+    now sends ``{"type": "null"}`` for ``selected_candidate_index`` only;
+    ``candidate_indices`` still ships as an integer array, and this test's
+    own payload puts ``[0]`` in it. So an index IS expressible here and
+    ``_verify`` is what rejects it -- which is precisely what the assertions
+    below check, and always were.
+
+    The structural half that DOES exist is asserted in
+    ``test_chaos_3536_qua_strict_schema.py``, against the PROJECTED schema
+    rather than the generator's output."""
 
     catalog = _catalog([])  # nothing authorized in this org at all
     scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())

--- a/tests/api/dev/test_chaos_3536_qua_strict_schema.py
+++ b/tests/api/dev/test_chaos_3536_qua_strict_schema.py
@@ -113,23 +113,33 @@ _TYPE_DECLARING_KEYS = frozenset({"type", "anyOf", "allOf", "oneOf", "$ref"})
 def strict_mode_violations(schema: Any, path: str = "$") -> list[str]:
     """Every OpenAI strict-mode STRUCTURAL rule this schema breaks.
 
-    The three rules, which are the ones the live 400 was raised against:
+    The rules:
 
     1. every object node declares ``type: "object"``;
     2. every object node sets ``additionalProperties: false``;
     3. every object node's ``required`` names EVERY property -- strict mode
        has no optional properties, so optionality is expressed as a nullable
        type, never by omission from ``required``;
+    4. every SCHEMA NODE declares a type (or defers to a combinator).
+       ``const`` alone is not a type declaration, which is the entire bug.
 
-    plus the rule the production failure actually tripped: every property
-    schema must declare a type (or defer to a combinator). ``const`` alone
-    is not a type declaration, which is the entire bug.
+    Review round 3 (medium, reproduced before fixing): rule 4 used to be
+    applied only to entries under ``properties``. A node reached through
+    ``items`` was recursed into but never checked itself, so deleting
+    ``type`` from ``candidate_indices.items`` left this function returning
+    ``[]`` -- the validator had a false-pass path of exactly the kind it
+    exists to catch. It now checks every position a schema can occupy, and
+    ``test_the_validator_detects_each_rule_it_claims_to_check`` plants a
+    defect in an array item specifically.
     """
 
     violations: list[str] = []
     if not isinstance(schema, dict):
         return violations
 
+    # Rule 4, applied to THIS node. The caller decides whether this position
+    # requires a type at all -- only the positions visited below do, and the
+    # root is entered via the object rules rather than as a bare value.
     properties = schema.get("properties")
     if isinstance(properties, dict):
         if schema.get("type") != "object":
@@ -145,32 +155,45 @@ def strict_mode_violations(schema: Any, path: str = "$") -> list[str]:
                 f"unknown={sorted(required - declared)}"
             )
         for name, definition in properties.items():
-            child = f"{path}.properties.{name}"
-            if isinstance(definition, dict) and not (
-                _TYPE_DECLARING_KEYS & set(definition)
-            ):
-                violations.append(
-                    f"{child}: no type key (has {sorted(definition)}) -- "
-                    "strict mode requires one on every property"
-                )
-            violations.extend(strict_mode_violations(definition, child))
+            violations.extend(
+                _schema_position_violations(definition, f"{path}.properties.{name}")
+            )
 
-    for key in ("items", "not"):
-        if key in schema:
-            violations.extend(strict_mode_violations(schema[key], f"{path}.{key}"))
+    if "items" in schema:
+        violations.extend(_schema_position_violations(schema["items"], f"{path}.items"))
     for key in ("anyOf", "allOf", "oneOf"):
         branches = schema.get(key)
         if isinstance(branches, list):
             for index, branch in enumerate(branches):
                 violations.extend(
-                    strict_mode_violations(branch, f"{path}.{key}[{index}]")
+                    _schema_position_violations(branch, f"{path}.{key}[{index}]")
                 )
     defs = schema.get("$defs")
     if isinstance(defs, dict):
         for name, definition in defs.items():
             violations.extend(
-                strict_mode_violations(definition, f"{path}.$defs.{name}")
+                _schema_position_violations(definition, f"{path}.$defs.{name}")
             )
+    return violations
+
+
+def _schema_position_violations(node: Any, path: str) -> list[str]:
+    """Check a node that occupies a schema position, then recurse into it.
+
+    Every such position must declare a type. Split out from
+    ``strict_mode_violations`` so that ``properties`` entries, array
+    ``items`` and combinator branches are all held to the same rule --
+    keeping the check inline for properties only is what let a typeless
+    array item through.
+    """
+
+    violations: list[str] = []
+    if isinstance(node, dict) and not (_TYPE_DECLARING_KEYS & set(node)):
+        violations.append(
+            f"{path}: no type key (has {sorted(node)}) -- "
+            "strict mode requires one on every schema node"
+        )
+    violations.extend(strict_mode_violations(node, path))
     return violations
 
 
@@ -202,6 +225,18 @@ def strict_mode_violations(schema: Any, path: str = "$") -> list[str]:
             "no type key",
             id="property-without-type",
         ),
+        pytest.param(
+            lambda node: node["properties"]["mentions"]["items"]["properties"][
+                "candidate_indices"
+            ]["items"].pop("type"),
+            "no type key",
+            id="array-item-without-type",
+        ),
+        # Deliberately NOT a case: popping ``items`` from ``mentions``. That
+        # leaves ``{"type": "array"}``, which breaks no rule this validator
+        # claims to check (arrays-must-declare-items is a real strict-mode
+        # rule, but not one of the four documented above). Asserting a
+        # violation there would record an INVALID mutation as a kill.
     ],
 )
 def test_the_validator_detects_each_rule_it_claims_to_check(

--- a/tests/api/dev/test_chaos_3536_qua_strict_schema.py
+++ b/tests/api/dev/test_chaos_3536_qua_strict_schema.py
@@ -1,0 +1,403 @@
+"""CHAOS-3536: the QUA schema PRODUCTION SENDS must satisfy OpenAI strict mode.
+
+The QUA path was non-functional against every real OpenAI-compatible provider:
+``schema_version`` was declared with ``const`` and no ``type``, and strict
+structured-output mode rejects the request outright::
+
+    BadRequestError: 400 - Invalid schema for response_format
+    'dev_question_understanding': In context=('properties', 'schema_version'),
+    schema must have a 'type' key.
+
+CHAOS-3389's shadow therefore collected ZERO real proposal evidence (every
+run recorded ``SKIPPED_PROVIDER_ERROR``/``invalid_request``), and
+CHAOS-3525's commit mode could never fire. It fails closed, so the shipped
+capability was inert rather than dangerous -- but inert.
+
+WHY NO TEST CAUGHT IT, AND WHY THIS MODULE TESTS WHAT IT TESTS
+--------------------------------------------------------------
+``ScriptedAgentProvider`` accepts any ``response_schema`` without validating
+it, so every QUA test -- including CHAOS-3389's never-widen proofs and
+CHAOS-3525's commit tests -- passed against a schema no real provider would
+accept. The schema's correctness was asserted nowhere.
+
+The obvious repair is to assert on ``_response_schema``'s return value. That
+would be the SAME MISTAKE ONE LEVEL UP, because **the generator's output is
+not what production sends.** ``OpenAICompatibleAgentProvider.decide()``
+nests our schema under ``properties.value`` via ``_decision_response_schema``
+and then projects the whole tree through ``_structural_schema``, which drops
+every key outside ``_STRUCTURAL_SCHEMA_KEYS`` and synthesizes
+``additionalProperties``/``required``. A raw-dict assertion proves nothing
+about the bytes that reach the provider.
+
+So every test here goes through ``build_completion_request`` -- the single
+producer ``decide()`` dispatches wholesale -- and asserts on the projected
+result. That is the artifact strict mode judges.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.dev.qua_shadow import (
+    QUAShadowConfig,
+    QuestionUnderstandingShadow,
+)
+from dev_health_ops.llm.agent.openai_compatible import build_completion_request
+
+#: Counts that bracket the interesting behaviour: none authorized (the
+#: never-widen edge), one, a typical shortlist, and the per-mention cap.
+_CANDIDATE_COUNTS = (0, 1, 3, 25)
+
+_MODEL = "gpt-5-nano"
+
+
+def _shadow() -> QuestionUnderstandingShadow:
+    """A shadow built only to reach ``_response_schema``.
+
+    The schema builder reads nothing off ``self``; the provider and scope
+    service are never touched on this path, so passing ``None`` keeps the
+    test honest about what it exercises rather than standing up a scope
+    service that plays no part in the result.
+    """
+
+    return QuestionUnderstandingShadow(
+        provider=None,
+        scope_service=cast(Any, None),
+        config=QUAShadowConfig(enabled=True),
+    )
+
+
+def _generated_schema(
+    *, candidate_count: int, mention_count: int = 1
+) -> dict[str, Any]:
+    """What the QUA generator produces, BEFORE the provider projects it."""
+
+    return _shadow()._response_schema(
+        mention_count=mention_count, candidate_count=candidate_count
+    )
+
+
+def _wire_schema(*, candidate_count: int, mention_count: int = 1) -> dict[str, Any]:
+    """The complete schema production puts on the wire for a QUA call.
+
+    Assembled by the product's own request builder, not reconstructed here --
+    a hand-built approximation could drift from the real one in exactly the
+    way that would hide the next instance of this bug.
+    """
+
+    request = build_completion_request(
+        model=_MODEL,
+        messages=(),
+        tools=(),
+        response_schema=_generated_schema(
+            candidate_count=candidate_count, mention_count=mention_count
+        ),
+        max_output_tokens=6000,
+    )
+    return cast(dict[str, Any], request["response_format"]["json_schema"]["schema"])
+
+
+def _qua_branch(wire: dict[str, Any]) -> dict[str, Any]:
+    """The QUA schema's own subtree inside the decision envelope."""
+
+    return cast(dict[str, Any], wire["properties"]["value"]["anyOf"][0])
+
+
+#: A node declares its type when it has ``type`` or defers via a combinator.
+_TYPE_DECLARING_KEYS = frozenset({"type", "anyOf", "allOf", "oneOf", "$ref"})
+
+
+def strict_mode_violations(schema: Any, path: str = "$") -> list[str]:
+    """Every OpenAI strict-mode STRUCTURAL rule this schema breaks.
+
+    The three rules, which are the ones the live 400 was raised against:
+
+    1. every object node declares ``type: "object"``;
+    2. every object node sets ``additionalProperties: false``;
+    3. every object node's ``required`` names EVERY property -- strict mode
+       has no optional properties, so optionality is expressed as a nullable
+       type, never by omission from ``required``;
+
+    plus the rule the production failure actually tripped: every property
+    schema must declare a type (or defer to a combinator). ``const`` alone
+    is not a type declaration, which is the entire bug.
+    """
+
+    violations: list[str] = []
+    if not isinstance(schema, dict):
+        return violations
+
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        if schema.get("type") != "object":
+            violations.append(f"{path}: has 'properties' but type is not 'object'")
+        if schema.get("additionalProperties") is not False:
+            violations.append(f"{path}: 'additionalProperties' is not false")
+        declared = set(properties)
+        required = set(schema.get("required") or ())
+        if declared != required:
+            violations.append(
+                f"{path}: 'required' must name every property; "
+                f"missing={sorted(declared - required)} "
+                f"unknown={sorted(required - declared)}"
+            )
+        for name, definition in properties.items():
+            child = f"{path}.properties.{name}"
+            if isinstance(definition, dict) and not (
+                _TYPE_DECLARING_KEYS & set(definition)
+            ):
+                violations.append(
+                    f"{child}: no type key (has {sorted(definition)}) -- "
+                    "strict mode requires one on every property"
+                )
+            violations.extend(strict_mode_violations(definition, child))
+
+    for key in ("items", "not"):
+        if key in schema:
+            violations.extend(strict_mode_violations(schema[key], f"{path}.{key}"))
+    for key in ("anyOf", "allOf", "oneOf"):
+        branches = schema.get(key)
+        if isinstance(branches, list):
+            for index, branch in enumerate(branches):
+                violations.extend(
+                    strict_mode_violations(branch, f"{path}.{key}[{index}]")
+                )
+    defs = schema.get("$defs")
+    if isinstance(defs, dict):
+        for name, definition in defs.items():
+            violations.extend(
+                strict_mode_violations(definition, f"{path}.$defs.{name}")
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# The validator must be able to fail. Proven before it is trusted.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_fragment"),
+    [
+        pytest.param(
+            lambda node: node.pop("type"),
+            "type is not 'object'",
+            id="object-without-type",
+        ),
+        pytest.param(
+            lambda node: node.update({"additionalProperties": True}),
+            "'additionalProperties' is not false",
+            id="additional-properties-allowed",
+        ),
+        pytest.param(
+            lambda node: node.update({"required": ["schema_version"]}),
+            "must name every property",
+            id="required-omits-a-property",
+        ),
+        pytest.param(
+            lambda node: node["properties"]["intent_id"].pop("type"),
+            "no type key",
+            id="property-without-type",
+        ),
+    ],
+)
+def test_the_validator_detects_each_rule_it_claims_to_check(
+    mutate, expected_fragment: str
+) -> None:
+    """A validator that cannot fail would certify the bug as fixed.
+
+    Each strict-mode rule is planted as a defect in an otherwise-valid wire
+    schema, and the validator must name it. Without this, a typo in
+    ``strict_mode_violations`` (an unreachable branch, a wrong key) would
+    make every other test in this module vacuously green -- which is the
+    precise failure mode CHAOS-3536 exists to correct, so repeating it here
+    would be indefensible.
+    """
+
+    wire = _wire_schema(candidate_count=3)
+    assert strict_mode_violations(wire) == [], (
+        "the fixture must start clean or the mutation proves nothing"
+    )
+
+    mutated = copy.deepcopy(wire)
+    mutate(_qua_branch(mutated))
+
+    found = strict_mode_violations(mutated)
+    assert found, f"the validator missed a planted {expected_fragment!r} defect"
+    assert any(expected_fragment in violation for violation in found), (
+        f"expected a {expected_fragment!r} violation, got {found}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The defect itself.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("candidate_count", _CANDIDATE_COUNTS)
+def test_the_schema_production_sends_satisfies_strict_mode(
+    candidate_count: int,
+) -> None:
+    """The class, not the instance.
+
+    RED before the fix at every candidate count with exactly one violation::
+
+        $.properties.value.anyOf[0].properties.schema_version: no type key
+        (has ['const']) -- strict mode requires one on every property
+
+    Note the path: the violation is NESTED under ``value``, because that is
+    where the provider puts our schema. The ticket's live reproduction
+    reported a ROOT-level ``('properties', 'schema_version')`` context, which
+    is how we know that probe sent the raw generated schema directly rather
+    than going through ``decide()``.
+    """
+
+    violations = strict_mode_violations(_wire_schema(candidate_count=candidate_count))
+
+    assert violations == [], (
+        "the schema production sends must satisfy strict mode, or every QUA "
+        f"call fails invalid_request: {violations}"
+    )
+
+
+@pytest.mark.parametrize("mention_count", (1, 2, 5))
+def test_strict_mode_holds_across_mention_counts_too(mention_count: int) -> None:
+    """The schema is generated per call from BOTH counts; vary the other one.
+
+    A fix verified at a single shape is a fix verified by coincidence.
+    """
+
+    violations = strict_mode_violations(
+        _wire_schema(candidate_count=3, mention_count=mention_count)
+    )
+
+    assert violations == [], str(violations)
+
+
+def test_schema_version_is_pinned_by_value_and_not_merely_typed() -> None:
+    """The fix must not weaken what the field means.
+
+    Adding ``type`` to satisfy strict mode is trivially achievable by
+    dropping ``const`` for a bare ``{"type": "string"}``, which would satisfy
+    the validator above while silently letting any version string through.
+    The version pin is what makes a parsed proposal a v1 proposal.
+    """
+
+    schema_version = _qua_branch(_wire_schema(candidate_count=3))["properties"][
+        "schema_version"
+    ]
+
+    assert schema_version.get("type") == "string"
+    assert schema_version.get("const") == "dev_question_understanding.v1", (
+        "the version must still be pinned by value, not merely typed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Never-widen, as it survives the projection.
+# ---------------------------------------------------------------------------
+
+
+def test_no_candidate_index_is_expressible_when_none_were_authorized() -> None:
+    """The zero-candidate re-encoding, and the reason it had to change.
+
+    The generator expressed "no candidate may be selected" as the empty
+    integer range ``{"minimum": 0, "maximum": -1}``. That never reached a
+    provider: ``_structural_schema`` drops both keywords, so the wire schema
+    said ``{"type": ["integer", "null"]}`` -- **any** integer expressible,
+    with nothing authorized.
+
+    ``{"type": "null"}`` carries the same never-widen intent through the
+    projection, and stays parseable because the contract field is
+    ``_StrictIndex | None``.
+    """
+
+    selected = _qua_branch(_wire_schema(candidate_count=0))["properties"]["mentions"][
+        "items"
+    ]["properties"]["selected_candidate_index"]
+
+    assert selected == {"type": "null"}, (
+        "with nothing authorized, no integer index may be expressible on the "
+        f"wire; got {selected}"
+    )
+
+
+def test_a_selectable_index_is_still_expressible_when_candidates_exist() -> None:
+    """The control: the zero-candidate encoding must not leak into real calls.
+
+    A change that returned ``{"type": "null"}`` unconditionally would pass
+    the test above while making every QUA proposal impossible -- a quieter
+    version of the outage being fixed.
+    """
+
+    selected = _qua_branch(_wire_schema(candidate_count=3))["properties"]["mentions"][
+        "items"
+    ]["properties"]["selected_candidate_index"]
+
+    assert "integer" in selected["type"]
+    assert "null" in selected["type"], "no_match must remain expressible"
+
+
+# ---------------------------------------------------------------------------
+# What this schema does NOT guarantee. Stated, because the module docstring
+# used to claim the opposite.
+# ---------------------------------------------------------------------------
+
+
+def test_the_bounding_keywords_do_not_survive_the_projection() -> None:
+    """Pins the fact CHAOS-3536 corrected in ``qua_shadow``'s docstring.
+
+    ``qua_shadow.py`` claimed "never-widen holds structurally" on the
+    strength of ``minimum``/``maximum`` on every index field. Those keywords
+    are not in ``_STRUCTURAL_SCHEMA_KEYS``, so the provider projection drops
+    them before dispatch and they have never constrained any real decoder.
+
+    This is asserted rather than merely documented so that the docstring
+    cannot quietly drift back to the stronger claim: if someone adds the
+    bounding keywords to the allowlist (CHAOS-3537), this test fails and
+    points at the docs that must change with it.
+    """
+
+    generated = _generated_schema(candidate_count=3)
+    generated_mention = generated["properties"]["mentions"]["items"]["properties"]
+    assert generated_mention["selected_candidate_index"]["maximum"] == 2, (
+        "the generator still expresses the bound..."
+    )
+
+    wire_mention = _qua_branch(_wire_schema(candidate_count=3))["properties"][
+        "mentions"
+    ]["items"]["properties"]
+    assert "maximum" not in wire_mention["selected_candidate_index"], (
+        "...but it does not reach the wire, so it guarantees nothing"
+    )
+    assert "minimum" not in wire_mention["selected_candidate_index"]
+
+
+def test_candidate_indices_remain_unbounded_on_the_wire() -> None:
+    """An honest residual, not an oversight.
+
+    ``candidate_indices`` cannot get the ``{"type": "null"}`` treatment: the
+    contract field is a non-optional ``tuple[_StrictIndex, ...]``, so a null
+    would fail parsing as SKIPPED_INVALID_OUTPUT on every zero-candidate
+    call. ``maxItems: 0`` would express "must be empty" but is stripped by
+    the projection like every other bounding keyword.
+
+    So at zero candidates an out-of-range entry in ``candidate_indices`` is
+    still EXPRESSIBLE on the wire, and ``_verify`` -- which re-checks every
+    accepted index against its own mention's authorized slice -- is the only
+    thing that rejects it. That is a real guard, not a gap, but it is a
+    RUNTIME guard, and this test exists so nobody records the schema as
+    doing work it does not do.
+    """
+
+    items = _qua_branch(_wire_schema(candidate_count=0))["properties"]["mentions"][
+        "items"
+    ]["properties"]["candidate_indices"]["items"]
+
+    assert items == {"type": "integer"}, (
+        "if this becomes structurally bounded, the residual documented in "
+        "qua_shadow's module docstring and in _verify must be revisited"
+    )

--- a/tests/api/dev/test_chaos_3536_qua_strict_schema.py
+++ b/tests/api/dev/test_chaos_3536_qua_strict_schema.py
@@ -341,6 +341,38 @@ def test_a_selectable_index_is_still_expressible_when_candidates_exist() -> None
     assert "null" in selected["type"], "no_match must remain expressible"
 
 
+def test_the_null_encoding_is_call_wide_and_not_per_mention() -> None:
+    """The trap this encoding sets, pinned so the next reader does not fall in.
+
+    ``_response_schema`` is built ONCE per call from the COMBINED shortlist,
+    so every mention shares one index space. ``candidate_count == 0`` means
+    "this CALL authorized nothing", not "this mention's slice is empty".
+
+    A mention past ``max_total_candidates`` gets an empty ``[start, end)``
+    slice from ``_combine_shortlists`` while the call-wide count stays
+    non-zero -- so it still sees the full range in the schema, and ONLY
+    ``_verify``'s per-mention check stops it selecting another mention's
+    candidate.
+
+    Written after review caught the author claiming the opposite in
+    ``qua_promotion``'s truncation comment. The pre-existing comment there
+    made the same error, so this is a mistake the code invites rather than
+    one anybody made carelessly, which is exactly why it is worth a test.
+    """
+
+    wire = _qua_branch(_wire_schema(candidate_count=50, mention_count=3))
+    selected = wire["properties"]["mentions"]["items"]["properties"][
+        "selected_candidate_index"
+    ]
+
+    assert selected != {"type": "null"}, (
+        "a multi-mention call with a non-empty combined shortlist must NOT "
+        "get the zero-candidate encoding, however empty an individual "
+        "mention's own slice may be"
+    )
+    assert "integer" in selected["type"]
+
+
 # ---------------------------------------------------------------------------
 # What this schema does NOT guarantee. Stated, because the module docstring
 # used to claim the opposite.


### PR DESCRIPTION
## The QUA path has never worked against a real provider

`qua_shadow._response_schema` declared `schema_version` with `const` and no `type`. OpenAI's strict structured-output mode rejects the whole request for it:

```
BadRequestError: 400 - Invalid schema for response_format 'dev_question_understanding':
In context=('properties', 'schema_version'), schema must have a 'type' key.
```

**Production impact.** CHAOS-3389's shadow, whenever enabled with a real provider, recorded nothing but `SKIPPED_PROVIDER_ERROR` / `invalid_request` — it has **never collected a single real proposal**. CHAOS-3525's commit mode could never fire; it fails closed, so the shipped capability was inert rather than dangerous, but inert.

## Why no test caught it — and why the obvious test wouldn't have either

`ScriptedAgentProvider` accepts any `response_schema` without validating it, so every QUA test — including CHAOS-3389's never-widen proofs and CHAOS-3525's commit tests — passed against a schema no provider would accept.

The obvious repair is to assert on `_response_schema`'s return value. **That is the same mistake one level up.** The generator's output is not what production sends: `OpenAICompatibleAgentProvider.decide()` nests our schema under `properties.value` via `_decision_response_schema`, then projects the whole tree through `_structural_schema`, which drops every key outside `_STRUCTURAL_SCHEMA_KEYS` and synthesizes `additionalProperties`/`required`.

So every test here goes through `build_completion_request` — the single producer `decide()` dispatches wholesale — and asserts on the projected result. RED-first: **13 failures** against the old generator, the headline one naming the nested path `$.properties.value.anyOf[0].properties.schema_version`.

## The bigger finding: never-widen never had a schema half

`qua_shadow.py` documented, as a bullet on the module's invariants, that *"never-widen holds structurally"* — that per-call index bounds made an unauthorized candidate inexpressible on the wire.

That was false for as long as it was written. `minimum`, `maximum`, `minItems`, `maxItems` and `maxLength` are not in `_STRUCTURAL_SCHEMA_KEYS`, so the projection strips them before dispatch. Measured by executing the product's own request builder:

```
candidate_count=3: STRIPPED = ['maxItems','maxLength','maximum','minItems','minimum']
   generated selected_candidate_index = {"type":["integer","null"], "minimum":0, "maximum":2}
   wire      selected_candidate_index = {"type":["integer","null"]}
```

With three candidates authorized, the wire schema permitted **any** integer. `_verify` is, and always has been, the sole guard — a strong one (CHAOS-3525 hardened the singular path to resolve by identity), but a sole one.

The claim is corrected everywhere it appeared, not only where it was found: `qua_shadow.py`, `contracts_v2/question_understanding.py` (which stated it as one of *two* enforcement points and called it defence in depth — the most load-bearing form of the error), `qua_promotion.py` (module docstring *and* truncation comment), and the CHAOS-3389 test heading and zero-candidate test name. **Not one assertion changed** — those tests drive a scripted provider that ignores the schema entirely, so they only ever proved `_verify`'s runtime guarantee. The claim above them was wrong; the tests under it were right.

Restoring a real structural bound is **CHAOS-3537** (High), deliberately not bundled: `_STRUCTURAL_SCHEMA_KEYS` is shared by every agent call and feeds the readiness wire-request fingerprint, so it is a different review and a different risk class.

## Zero candidates

`[0, -1]` was the one bound doing real work, and the projection erased it to `{"type": ["integer","null"]}` — any integer expressible with nothing authorized. Re-encoded as `{"type": "null"}`: same never-widen intent, expressed with a keyword the projection keeps, and parseable because the contract field is `_StrictIndex | None`.

Two limits, both stated in the docstrings and pinned by tests rather than left to be discovered:
- it covers `selected_candidate_index` only — `candidate_indices` is a non-optional tuple, so a null would fail parsing, and it stays unbounded on the wire;
- it is **call-wide, not per mention**. `_response_schema` is built once from the combined shortlist, so a mention past `max_total_candidates` still sees the call's full range. Only `_verify` knows about per-mention slices.

That second point is a trap the code invites — the pre-existing comment in `qua_promotion` made the error, and so did my first correction of it. It now has a test.

## Review: three rounds, eight findings

Rounds 2 and 3 were mostly my own corrections being wrong, which is the part worth recording:

- I fixed `qua_promotion`'s inline comment and missed the module docstring above it selling the same missing defence.
- I wrote *"no index is expressible at all"* — a sweeping claim, in a change whose entire point was that the previous sweeping claim was false.
- **The validator itself had a false-pass path.** Rule 4 (every schema node declares a type) was applied only to entries under `properties`; a node reached through `items` was recursed into but never checked. Deleting `type` from `candidate_indices.items` made `strict_mode_violations` return `[]` — a validator with a hole of exactly the class it exists to catch, which would have certified the next instance of this bug as fixed. Reproduced, fixed, and planted as a self-test case.

The validator is now proven able to fail before it is trusted: each rule is planted as a defect in an otherwise-valid wire schema and must be named. One mutation I tried (popping `items` from `mentions`) is recorded as **INVALID, not a kill** — it leaves `{"type": "array"}`, violating no rule this validator claims.

Mutations: 5 run, 4 killed at the intended site, 1 invalid. Restores verified by content hash, never by `git`.

## Live verification

12 `gpt-5-nano` calls, all sub-1k output tokens, well under US$0.01. Credential process-scoped only — never printed, logged, or stored.

- **Control** — OLD schema through `decide()` → `INVALID_REQUEST`. The defect reproduces on the production path, not just against a hand-assembled request.
- **Fixed, 3 candidates** → OK, valid parseable proposal.
- **Fixed, zero candidates** → OK, returns immediately with `selected_candidate_index: null`, `candidate_indices: []`. No budget burn.
- **Full `evaluate()`**, product's own prompt/schema/verifier → `status=evaluated`, `model_fingerprint` set, `intent_id=project_health`, `cardinality=singular` (corroborated), mention `'ACR'` → `resolved` → `Dev Health Agent Context Runtime (Context Fabric)`. **The first real proposal this path has ever produced**, and CHAOS-3525's outstanding acceptance evidence.

Two calibration findings surfaced by six repeat runs, filed as **CHAOS-3539** — confidence 0.65–0.78 against the 0.85 commit floor (**6/6 below**, so commit mode resolves correctly and still promotes nothing), and latency 1613–2680ms against the 2.5s hard cap (1/6 over, plus a genuine `skipped_timeout`). Neither blocks this fix.

## Tickets filed

**CHAOS-3537** (High) projection strips bounding keywords · **CHAOS-3538** readiness certification never hashes the QUA schema, which is why this outage stayed green · **CHAOS-3539** commit-floor and latency calibration.

## Verification

Local gate: **PASSED**, 13069 passed / 245 skipped / 1 xfailed. Lint, ruff-format, mypy, ch-migrate and argMax live-exec all green.

First gate run showed one failure in `test_compatibility_process_cancellation_terminates_and_reaps_child` — diagnosed, not waved through: it passes 3/3 in isolation, the re-run on the **identical frozen tree and SHA** was fully green, and its `_assert_process_reaped` helper polls for only 100 × 10ms = **1 second total** while the suite spawns real subprocesses under 13k-test load. This change touches five QUA/schema files, none imported by that test. Filed separately rather than left as folklore.
