### PR TITLE
CHAOS-3537: re-express the never-widen bound as an enum, so it survives the wire

### DIFF
--- a/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
@@ -18,44 +18,38 @@ Whether a given index actually falls within the specific shortlist shown for
 that mention is a **per-call** fact this static schema cannot know (two
 different questions show different candidate counts).
 
-**PER-MENTION index authorization is enforced in exactly ONE place:
-``qua_shadow._verify``.** Scope that sentence carefully -- there IS one
-structural bound left (the call-wide zero-candidate encoding, below), so the
-precise claim is that no wire-level rule constrains an index to the mention
-it belongs to. This docstring used to list two enforcement points and present
-them as defence in depth. That was wrong, and CHAOS-3536 corrected it:
+**That bound is enforced in two places, split by scope.** This paragraph has
+been wrong in both directions -- it once claimed defence in depth that did not
+exist (CHAOS-3536), then, while that was true, understated what came back
+(CHAOS-3537) -- so it now states the boundary precisely rather than a slogan:
 
-1. ``_verify`` re-checks every index against the exact per-mention slice
-   after parsing, independent of whether the provider honored anything.
-   A violation marks that one mention's proposal ``rejected``, never the
-   whole record. CHAOS-3525 additionally hardened the singular commit path
-   to resolve by identity, so this is a strong check -- but it is the only
-   one, and a change that weakens it is not backstopped by anything.
-2. The wire-level JSON Schema was the claimed second enforcement point:
-   ``_response_schema`` bounds every index field to
-   ``[0, total_candidates - 1]``, so a provider honoring the schema could
-   not generate an out-of-range integer. **Those bounds never reached a
-   provider.** ``OpenAICompatibleAgentProvider`` projects every schema
-   through ``_structural_schema``, which keeps only
-   ``_STRUCTURAL_SCHEMA_KEYS`` -- ``minimum``/``maximum``/``minItems``/
-   ``maxItems``/``maxLength`` are not in it and are stripped before
-   dispatch. Verified by executing ``build_completion_request``, not by
-   reading it. Tracked as CHAOS-3537.
+1. **Call-wide, structurally, on the wire.** ``qua_shadow._response_schema``
+   enumerates this call's authorized indices as ``enum``, so a provider cannot
+   express an index the CALL never authorized. The keyword matters:
+   ``OpenAICompatibleAgentProvider`` projects every schema through
+   ``_structural_schema``, which keeps only ``_STRUCTURAL_SCHEMA_KEYS``.
+   ``minimum``/``maximum``/``minItems``/``maxItems``/``maxLength`` are not in
+   it and are stripped in transit; ``enum`` is, and survives. The original
+   claim rested on ``[0, total_candidates - 1]`` range bounds and was false
+   for as long as it stood -- those never reached any provider.
+2. **Per-mention, at runtime.** ``_verify`` re-checks every index against the
+   exact per-mention slice after parsing, independent of whether the provider
+   honored anything. A violation marks that one mention's proposal
+   ``rejected``, never the whole record. CHAOS-3525 additionally hardened the
+   singular commit path to resolve by identity.
 
-The one structural bound that DOES survive projection is the zero-candidate
-case: when the CALL authorized nothing at all, ``selected_candidate_index``
-is sent as ``{"type": "null"}``, so no SELECTED index is expressible. That
-covers ``selected_candidate_index`` only -- ``candidate_indices`` still goes
-out as ``{"type": "array", "items": {"type": "integer"}}`` even then, so an
-index remains expressible there and is caught only by ``_verify``.
+**Neither subsumes the other, which is why both are listed.** The schema is
+built once per call from the COMBINED shortlist, so all mentions share one
+index space: it can stop an index that exists nowhere in the call, and it
+cannot stop an index belonging to a *different mention* of the same call.
+Only ``_verify`` knows about per-mention slices. Treating either as
+redundant would be a real reduction in coverage.
 
-Note the scope of that carefully -- it is call-wide, not per mention.
-``_response_schema`` is built once from the COMBINED shortlist, so all
-mentions share one index space, and a mention whose own slice is empty (past
-``max_total_candidates``) still sees the call's full range in the schema.
-Only ``_verify`` knows about per-mention slices. ``candidate_indices`` gets
-no structural bound either -- it is a non-optional tuple here, so a null
-would fail parsing -- and is likewise rejected only by ``_verify``.
+With zero candidates authorized, both index fields are closed structurally:
+``selected_candidate_index`` is sent as ``{"type": "null"}``, and
+``candidate_indices`` keeps its array type (a null would fail parsing here --
+the field is a non-optional tuple) with an EMPTY item enum, so no element
+value is admissible.
 """
 
 from __future__ import annotations
@@ -78,11 +72,12 @@ QUESTION_UNDERSTANDING_SCHEMA_VERSION = "dev_question_understanding.v1"
 
 #: Bound applied to every candidate-index field regardless of shortlist size.
 #:
-#: CHAOS-3536: this used to call itself the "belt" to the wire schema's
-#: tighter per-call bound. There is no such braces -- the wire bound is
-#: stripped by the provider projection (CHAOS-3537), so for a non-empty
-#: shortlist this ceiling and ``_verify`` are what exist. Kept as the
-#: absolute ceiling a hand-authored ``max_length``/``le`` must never exceed.
+#: CHAOS-3536 found this calling itself the "belt" to a tighter per-call wire
+#: bound that had been stripped in transit and did not exist. CHAOS-3537
+#: restored that bound as an ``enum``, which survives the projection -- so the
+#: braces are real again and this genuinely is the belt. Kept as the absolute
+#: ceiling a hand-authored ``max_length``/``le`` must never exceed, and as the
+#: bound that still applies if the per-call enum is ever widened.
 _MAX_MENTIONS = 25
 _MAX_CANDIDATE_INDICES = 25
 

--- a/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/question_understanding.py
@@ -38,18 +38,22 @@ exist (CHAOS-3536), then, while that was true, understated what came back
    ``rejected``, never the whole record. CHAOS-3525 additionally hardened the
    singular commit path to resolve by identity.
 
-**Neither subsumes the other, which is why both are listed.** The schema is
-built once per call from the COMBINED shortlist, so all mentions share one
-index space: it can stop an index that exists nowhere in the call, and it
-cannot stop an index belonging to a *different mention* of the same call.
-Only ``_verify`` knows about per-mention slices. Treating either as
-redundant would be a real reduction in coverage.
+**These are two STAGES, not two coverages.** Every mention slice is a subset
+of ``[0, len(combined))``, so any index the enum rejects is outside every
+mention's slice and ``_verify`` rejects it too -- ``_verify``'s rejection set
+strictly SUBSUMES the schema's. The enum earns its place by acting before
+generation (an unauthorized index is never produced, so the proposal survives
+rather than being discarded) and by ending ``_verify``'s status as a single
+point of failure. Per-mention ownership is ``_verify``'s alone: the schema is
+built once per call from the COMBINED shortlist and cannot express which
+mention an index belongs to.
 
-With zero candidates authorized, both index fields are closed structurally:
-``selected_candidate_index`` is sent as ``{"type": "null"}``, and
-``candidate_indices`` keeps its array type (a null would fail parsing here --
-the field is a non-optional tuple) with an EMPTY item enum, so no element
-value is admissible.
+With zero candidates authorized, ``selected_candidate_index`` is sent as
+``{"type": "null"}``. ``candidate_indices`` stays a plain integer array --
+a null would fail parsing here (non-optional tuple), and the ``enum: []``
+that would close it structurally is an unsatisfiable choice set that has not
+been certified against the local/ollama/lmstudio decoders. It is bounded by
+``_verify`` alone. See ``qua_shadow._response_schema``.
 """
 
 from __future__ import annotations

--- a/src/dev_health_ops/api/dev/qua_promotion.py
+++ b/src/dev_health_ops/api/dev/qua_promotion.py
@@ -30,7 +30,9 @@ bound stripped in transit (``minimum``/``maximum`` are not in
 ``_STRUCTURAL_SCHEMA_KEYS``); CHAOS-3537 restored it as an ``enum``, which
 survives the projection. So today the wire schema bounds indices to what the
 CALL authorized, and ``qua_shadow._verify`` bounds them to what the MENTION
-authorized -- different scopes, neither redundant.
+authorized. Those are different STAGES rather than different coverage --
+``_verify``'s rejection set subsumes the schema's, and the schema's value is
+that an unauthorized index is never generated in the first place.
 
 Promotion's ``verify_still_authorized`` is the third check, and on the
 singular path it is not redundancy -- it is the ONLY receipt.

--- a/src/dev_health_ops/api/dev/qua_promotion.py
+++ b/src/dev_health_ops/api/dev/qua_promotion.py
@@ -22,18 +22,19 @@ cohort, an uncorroborated organization-wide cardinality -- each returns
 without the seam. There is no branch here that repairs a partial proposal
 into a usable one.
 
-**It re-authorizes at commit time.** This paragraph used to say the shadow
-already bounds proposals "two ways" -- a per-call JSON Schema making an
-out-of-range index inexpressible, plus a runtime verifier. CHAOS-3536
-established that the first of those does not exist: the schema's
-``minimum``/``maximum`` bounds are stripped by the provider's
-``_structural_schema`` projection and have never reached a decoder
-(CHAOS-3537). Shadow-time index bounding is ``qua_shadow._verify`` alone,
-re-checking each index against that mention's own slice.
+**It re-authorizes at commit time.** The shadow does bound proposals two ways
+before promotion sees them -- but read ``qua_shadow``'s module docstring for
+what each one covers, because this paragraph once asserted the pair
+uncritically while one of them was absent. CHAOS-3536 found the wire-level
+bound stripped in transit (``minimum``/``maximum`` are not in
+``_STRUCTURAL_SCHEMA_KEYS``); CHAOS-3537 restored it as an ``enum``, which
+survives the projection. So today the wire schema bounds indices to what the
+CALL authorized, and ``qua_shadow._verify`` bounds them to what the MENTION
+authorized -- different scopes, neither redundant.
 
-So promotion's ``verify_still_authorized`` is the SECOND check overall, not
-the third -- and on the singular path it is not redundancy either way, it is
-the ONLY receipt. ``committed_resolution_for``
+Promotion's ``verify_still_authorized`` is the third check, and on the
+singular path it is not redundancy -- it is the ONLY receipt.
+``committed_resolution_for``
 mints no ``subject_set_fingerprint``, and the executor's fingerprint
 cross-check (``investigation_plans/executor.py``) only covers *set* batches,
 so nothing downstream re-verifies a singular committed entity. See
@@ -153,19 +154,22 @@ def promotable_selection(
     # such a mention's index range to ``[0, -1]``, "which no integer
     # satisfies".
     #
-    # First: those bounds never reached the provider at all --
-    # ``_structural_schema`` strips ``minimum``/``maximum`` before dispatch
-    # (CHAOS-3537).
+    # First: as written, those bounds never reached the provider at all --
+    # ``_structural_schema`` strips ``minimum``/``maximum`` before dispatch.
+    # CHAOS-3537 fixed that by re-expressing the bound as an ``enum``, which
+    # survives, so a call-wide bound now genuinely reaches the decoder. That
+    # repair does NOT rescue the claim below.
     #
-    # Second, and independent of the stripping: THERE IS NO PER-MENTION
+    # Second, and the reason CHAOS-3537 changes nothing here: THERE IS NO
+    # PER-MENTION
     # INDEX RANGE IN THE SCHEMA. ``_response_schema`` is built once per call
     # from ``candidate_count=len(combined)`` -- the COMBINED, call-wide
     # shortlist -- so every mention shares one index space. A mention past
     # ``max_total_candidates`` gets an empty SLICE from
     # ``_combine_shortlists``, but ``candidate_count`` is still 50, so the
-    # schema keeps expressing 0..49 for it. The zero-candidate
-    # ``{"type": "null"}`` encoding fires only when the WHOLE call
-    # authorized nothing, which is not this case.
+    # schema's enum keeps admitting 0..49 for it. The zero-candidate encoding
+    # fires only when the WHOLE call authorized nothing, which is not this
+    # case.
     #
     # So for a truncated mention the schema offers nothing whatsoever, and
     # ``_verify`` -- which checks each index against that mention's OWN

--- a/src/dev_health_ops/api/dev/qua_shadow.py
+++ b/src/dev_health_ops/api/dev/qua_shadow.py
@@ -54,11 +54,16 @@ adversarial critique, comment 7d1368d9):
   bullet claimed the latter and was wrong. Every mention slice is a subset of
   ``[0, len(combined))``, so any index the enum rejects is also outside every
   mention's slice: ``_verify``'s rejection set strictly SUBSUMES the enum's.
-  The enum is worth having because it acts BEFORE generation (an unauthorized
-  index is never produced, rather than produced and then rejected, which also
-  means the proposal survives instead of being discarded) and because it ends
-  ``_verify``'s status as a single point of failure. Per-mention ownership is
-  ``_verify``'s alone and always will be: the schema cannot express it.
+
+  What the enum buys, scoped to what is actually true: **for a decoder that
+  honors the schema**, a call-wide-out-of-range index is not generated in the
+  first place, so the proposal arrives usable instead of arriving and being
+  rejected. It is a generation-time constraint that reduces malformed
+  proposals -- NOT an authorization control and NOT a backstop. A
+  non-compliant decoder can still emit anything (and a decoder that dislikes
+  the schema can reject the request outright), and ``_verify`` remains the
+  sole enforcement point for per-mention ownership, which the schema cannot
+  express at all. If ``_verify`` regresses, the enum does not save you.
 
   With zero candidates authorized, ``selected_candidate_index`` is
   ``{"type": "null"}``. ``candidate_indices`` stays a plain integer array and
@@ -677,17 +682,32 @@ class QuestionUnderstandingShadow:
         than the residual it closes. Adopt it only with per-endpoint
         certification evidence (CHAOS-3538 is the natural home).
 
+        Decoder compatibility, since the live evidence is one endpoint
+        (OpenAI/gpt-5-nano) and ``CERTIFIED_PLATFORM_AGENT_PROVIDERS`` also
+        holds ``local``/``ollama``/``lmstudio``: ``enum`` itself is NOT a new
+        dependency for them. Every Ask Dev call already ships enums to every
+        provider family -- ``_decision_response_schema``'s mandatory ``kind``
+        field is one, and this schema's own ``intent_id``/``cardinality``/
+        ``outcome`` were enums before this change. The untested delta is
+        narrow: integer-valued enums rather than string, and a list up to 50
+        long. That is why the EMPTY enum was withdrawn while these were kept
+        -- an unsatisfiable choice set is a genuinely novel construct, a
+        50-element integer enum is a variation on something already in every
+        request. Fold the remaining delta into CHAOS-3538's certification.
+
         What the enum does NOT do, stated because the first version of this
         docstring got it wrong: it does not add coverage ``_verify`` lacks.
         Every mention's slice is a subset of ``[0, len(combined))``, so an
         index the enum would reject is outside every mention's slice and
         ``_verify`` rejects it too -- ``_verify``'s rejection set strictly
         SUBSUMES the enum's. The enum earns its place by acting at a
-        different STAGE, not over a different set: it constrains generation,
-        so an unauthorized index is never produced rather than produced and
-        then rejected, and a ``_verify`` regression is no longer a
-        single point of failure. Per-mention ownership remains ``_verify``'s
-        alone -- the schema is built once per call from the COMBINED
+        different STAGE, not over a different set: for a decoder that honors
+        the schema it constrains generation, so a call-wide-out-of-range
+        index is not produced rather than produced and then rejected, and the
+        proposal survives instead of being discarded. It is not an
+        authorization control and not a backstop -- a non-compliant decoder
+        can emit anything, and per-mention ownership remains ``_verify``'s
+        alone, since the schema is built once per call from the COMBINED
         shortlist and cannot express it.
 
         ``maxItems``/``maxLength`` below are stripped in transit and are kept

--- a/src/dev_health_ops/api/dev/qua_shadow.py
+++ b/src/dev_health_ops/api/dev/qua_shadow.py
@@ -25,40 +25,39 @@ adversarial critique, comment 7d1368d9):
   the same cardinality. This is what stops "how is the Contxt Fabric doing?"
   from reading as a corroborated org-wide proposal just because the model
   found no candidate id to name.
-* **Never-widen is enforced at RUNTIME, not by the wire schema.** This bullet
-  used to claim the opposite -- that ``_response_schema``'s
-  ``[0, len(combined) - 1]`` index bounds made an unauthorized candidate
-  inexpressible on the wire. That was FALSE for as long as it was written
-  (CHAOS-3536). ``OpenAICompatibleAgentProvider`` projects every schema
-  through ``_structural_schema``, which keeps only ``_STRUCTURAL_SCHEMA_KEYS``
-  -- and ``minimum``/``maximum``/``minItems``/``maxItems``/``maxLength`` are
-  not among them. The bounds were stripped before dispatch on every call
-  that ever ran; no provider has seen them. Verified by executing the
-  product's own ``build_completion_request`` and reading the result, not by
-  reasoning about it.
+* **Never-widen is enforced in TWO places, and the split is exact.** This
+  bullet has now been wrong in both directions, so it states the boundary
+  rather than a slogan.
 
-  So ``_verify`` is not a belt-and-braces second check, as this file
-  previously implied -- it is the ONLY check. It re-checks every accepted
-  index against its OWN mention's authorized slice (not just the call-wide
-  bound) after parsing, independent of whether the provider honored
-  anything, and CHAOS-3525 additionally hardened the singular path to
-  resolve by identity. That makes it a strong sole guard, but a sole guard.
+  *Call-wide, structurally, on the wire.* ``_response_schema`` enumerates the
+  authorized indices as ``enum``, rebuilt per call, so a provider cannot
+  express an index this CALL did not authorize. Read the mechanism, because
+  the keyword choice is the whole point: ``OpenAICompatibleAgentProvider``
+  projects every schema through ``_structural_schema``, which keeps only
+  ``_STRUCTURAL_SCHEMA_KEYS``. ``minimum``/``maximum``/``minItems``/
+  ``maxItems``/``maxLength`` are NOT in that set; ``enum`` is. The original
+  bullet claimed this guarantee on the strength of ``[0, len(combined) - 1]``
+  range bounds, and was FALSE for as long as it was written (CHAOS-3536) --
+  those bounds were stripped before dispatch on every call that ever ran.
+  CHAOS-3537 re-expressed the bound in a keyword that survives, which is also
+  strictly stronger: a range admits every integer between its ends, an enum
+  admits exactly the shortlist.
 
-  The one structural bound that DOES survive projection is the
-  zero-candidate encoding: when the CALL authorized nothing,
-  ``selected_candidate_index`` is ``{"type": "null"}``. Two limits on that,
-  both stated because the previous version of this bullet is what taught us
-  not to round such claims up:
+  *Per-mention, at runtime.* ``_verify`` re-checks every accepted index
+  against its OWN mention's authorized slice, which the wire schema cannot
+  express at all -- the schema is built once per call from the COMBINED
+  shortlist, so a mention whose own slice is empty (past
+  ``max_total_candidates``) still sees the call's full range. CHAOS-3525
+  additionally hardened the singular path to resolve by identity.
 
-  - it covers ``selected_candidate_index`` only. ``candidate_indices`` still
-    ships as ``{"type": "array", "items": {"type": "integer"}}``, so an
-    index stays expressible there and ``_verify`` remains its only guard;
-  - it is CALL-wide, not per mention. ``_response_schema`` is built once
-    from the combined shortlist, so a mention whose own slice is empty
-    (past ``max_total_candidates``) still sees the call's full range.
+  **Neither subsumes the other.** The schema stops "an index that exists
+  nowhere in this call"; ``_verify`` stops "an index that belongs to a
+  different mention". Weakening either is a real reduction in coverage, not
+  the removal of a redundancy.
 
-  See ``_response_schema``. CHAOS-3537 tracks restoring a real structural
-  bound for the non-empty case.
+  With zero candidates authorized, both index fields are closed structurally:
+  ``selected_candidate_index`` is ``{"type": "null"}`` and
+  ``candidate_indices`` carries an empty item enum. See ``_response_schema``.
 * **LLM unavailable degrades to silent skip, never a block.** Every branch
   of ``evaluate()`` returns a ``QUAShadowRecord`` (never raises); the
   orchestrator's own call site additionally wraps the call and the
@@ -638,37 +637,54 @@ class QuestionUnderstandingShadow:
     ) -> dict[str, Any]:
         """The response schema for THIS call's authorized shortlist.
 
-        CHAOS-3536, read this before trusting the bounds below: ``minimum``,
-        ``maximum``, ``minItems``, ``maxItems`` and ``maxLength`` DO NOT
-        REACH THE PROVIDER. ``OpenAICompatibleAgentProvider`` projects every
-        schema through ``_structural_schema``, which keeps only the keys in
-        ``_STRUCTURAL_SCHEMA_KEYS`` -- and none of those five are in it. They
-        are dropped before dispatch. Keeping them here is still worthwhile
-        (they document intent, and they bound the schema for any future
-        provider that does not project), but nothing may be claimed on their
-        strength. ``_verify`` is the guard that actually holds. See
-        CHAOS-3537 for restoring a structural bound to the wire.
+        Index bounds are expressed as ``enum``, not as ``minimum``/
+        ``maximum``, and that is load-bearing rather than stylistic.
+        ``OpenAICompatibleAgentProvider`` projects every schema through
+        ``_structural_schema``, which keeps only ``_STRUCTURAL_SCHEMA_KEYS``.
+        ``minimum``/``maximum``/``minItems``/``maxItems``/``maxLength`` are
+        NOT in that set and are stripped before dispatch; ``enum`` IS, and
+        survives untouched. CHAOS-3536 found the range bounds had therefore
+        never reached any provider, leaving ``_verify`` as the sole guard;
+        CHAOS-3537 is this repair.
 
-        The zero-candidate case is the one bound that DOES survive, and it
-        is encoded to survive deliberately. It used to be the empty integer
-        range ``[0, -1]``, which projection erased down to
-        ``{"type": ["integer", "null"]}`` -- any integer expressible with
-        nothing authorized. It is now ``{"type": "null"}``: the same
-        never-widen intent, expressed with a keyword the projection keeps,
-        and parseable because the contract field is ``_StrictIndex | None``.
+        An enumeration is also strictly STRONGER than the range it replaces:
+        ``[0, n-1]`` admits every integer between the ends, while the enum
+        admits exactly the indices this call authorized, rebuilt per call.
 
-        ``candidate_indices`` gets no equivalent treatment and is bounded
-        only at runtime: its contract field is a non-optional tuple, so a
-        null would fail parsing on every zero-candidate call, and
-        ``maxItems: 0`` would be stripped like the rest. An out-of-range
-        entry there is expressible on the wire and rejected by ``_verify``.
+        Measured live before adopting (CHAOS-3537, gpt-5-nano): strict mode
+        accepts an integer enum at 3 and at 50 candidates and accepts the
+        empty enum below; and given a prompt instructing it to return
+        out-of-range index 7, the pre-fix schema returned
+        ``selected_candidate_index: 7`` at confidence 0.92 in 3 runs of 3,
+        while the enum-bound schema could not express it in any of 3.
+
+        Zero candidates gets both fields closed, which the previous encoding
+        could not manage. ``selected_candidate_index`` is ``{"type": "null"}``
+        (parseable -- the contract field is ``_StrictIndex | None``), and
+        ``candidate_indices`` keeps its array type, so it still parses as the
+        empty tuple, but with an EMPTY item enum so no element value is
+        admissible. That closes the residual CHAOS-3536 had to leave open,
+        where ``maxItems: 0`` was stripped and any integer stayed expressible.
+
+        Still NOT closed here, and still ``_verify``'s job: the schema is
+        built once per call from the COMBINED shortlist, so the enum bounds
+        indices to what the CALL authorized, never to what the MENTION
+        authorized. A mention whose own slice is empty still sees the call's
+        full range. Neither guard subsumes the other.
+
+        ``maxItems``/``maxLength`` below are stripped in transit and are kept
+        only as intent, and as a real bound for any future provider that does
+        not project. Nothing may be claimed on their strength.
         """
 
-        max_index = candidate_count - 1
+        authorized_indices = list(range(candidate_count))
         index_schema: dict[str, Any] = (
             {"type": "null"}
             if candidate_count == 0
-            else {"type": ["integer", "null"], "minimum": 0, "maximum": max_index}
+            else {
+                "type": ["integer", "null"],
+                "enum": [*authorized_indices, None],
+            }
         )
         mention_schema = {
             "type": "object",
@@ -684,7 +700,11 @@ class QuestionUnderstandingShadow:
                 "candidate_indices": {
                     "type": "array",
                     "maxItems": 25,
-                    "items": {"type": "integer", "minimum": 0, "maximum": max_index},
+                    # Empty enum when nothing was authorized: the array still
+                    # parses as the empty tuple, but no element value is
+                    # admissible. See the docstring -- this is the half
+                    # CHAOS-3536 could not close.
+                    "items": {"type": "integer", "enum": authorized_indices},
                 },
                 "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
             },

--- a/src/dev_health_ops/api/dev/qua_shadow.py
+++ b/src/dev_health_ops/api/dev/qua_shadow.py
@@ -50,14 +50,20 @@ adversarial critique, comment 7d1368d9):
   ``max_total_candidates``) still sees the call's full range. CHAOS-3525
   additionally hardened the singular path to resolve by identity.
 
-  **Neither subsumes the other.** The schema stops "an index that exists
-  nowhere in this call"; ``_verify`` stops "an index that belongs to a
-  different mention". Weakening either is a real reduction in coverage, not
-  the removal of a redundancy.
+  **These are two STAGES, not two coverages** -- the first version of this
+  bullet claimed the latter and was wrong. Every mention slice is a subset of
+  ``[0, len(combined))``, so any index the enum rejects is also outside every
+  mention's slice: ``_verify``'s rejection set strictly SUBSUMES the enum's.
+  The enum is worth having because it acts BEFORE generation (an unauthorized
+  index is never produced, rather than produced and then rejected, which also
+  means the proposal survives instead of being discarded) and because it ends
+  ``_verify``'s status as a single point of failure. Per-mention ownership is
+  ``_verify``'s alone and always will be: the schema cannot express it.
 
-  With zero candidates authorized, both index fields are closed structurally:
-  ``selected_candidate_index`` is ``{"type": "null"}`` and
-  ``candidate_indices`` carries an empty item enum. See ``_response_schema``.
+  With zero candidates authorized, ``selected_candidate_index`` is
+  ``{"type": "null"}``. ``candidate_indices`` stays a plain integer array and
+  is bounded only by ``_verify`` -- see ``_response_schema`` for the
+  empty-enum option that was measured and deliberately not adopted.
 * **LLM unavailable degrades to silent skip, never a block.** Every branch
   of ``evaluate()`` returns a ``QUAShadowRecord`` (never raises); the
   orchestrator's own call site additionally wraps the call and the
@@ -658,19 +664,31 @@ class QuestionUnderstandingShadow:
         ``selected_candidate_index: 7`` at confidence 0.92 in 3 runs of 3,
         while the enum-bound schema could not express it in any of 3.
 
-        Zero candidates gets both fields closed, which the previous encoding
-        could not manage. ``selected_candidate_index`` is ``{"type": "null"}``
-        (parseable -- the contract field is ``_StrictIndex | None``), and
-        ``candidate_indices`` keeps its array type, so it still parses as the
-        empty tuple, but with an EMPTY item enum so no element value is
-        admissible. That closes the residual CHAOS-3536 had to leave open,
-        where ``maxItems: 0`` was stripped and any integer stayed expressible.
+        With zero candidates, ``selected_candidate_index`` is
+        ``{"type": "null"}`` (parseable -- the contract field is
+        ``_StrictIndex | None``). ``candidate_indices`` deliberately stays a
+        plain integer array. An EMPTY item enum would close it structurally,
+        and was measured working against OpenAI -- but ``enum: []`` is an
+        unsatisfiable choice set, and ``CERTIFIED_PLATFORM_AGENT_PROVIDERS``
+        also includes ``local``/``ollama``/``lmstudio``, whose constrained
+        decoders were NOT probed. A decoder that rejects it would turn every
+        zero-candidate call into a provider error and silently lose exactly
+        the no-match evidence the shadow exists to collect -- a worse failure
+        than the residual it closes. Adopt it only with per-endpoint
+        certification evidence (CHAOS-3538 is the natural home).
 
-        Still NOT closed here, and still ``_verify``'s job: the schema is
-        built once per call from the COMBINED shortlist, so the enum bounds
-        indices to what the CALL authorized, never to what the MENTION
-        authorized. A mention whose own slice is empty still sees the call's
-        full range. Neither guard subsumes the other.
+        What the enum does NOT do, stated because the first version of this
+        docstring got it wrong: it does not add coverage ``_verify`` lacks.
+        Every mention's slice is a subset of ``[0, len(combined))``, so an
+        index the enum would reject is outside every mention's slice and
+        ``_verify`` rejects it too -- ``_verify``'s rejection set strictly
+        SUBSUMES the enum's. The enum earns its place by acting at a
+        different STAGE, not over a different set: it constrains generation,
+        so an unauthorized index is never produced rather than produced and
+        then rejected, and a ``_verify`` regression is no longer a
+        single point of failure. Per-mention ownership remains ``_verify``'s
+        alone -- the schema is built once per call from the COMBINED
+        shortlist and cannot express it.
 
         ``maxItems``/``maxLength`` below are stripped in transit and are kept
         only as intent, and as a real bound for any future provider that does
@@ -700,11 +718,15 @@ class QuestionUnderstandingShadow:
                 "candidate_indices": {
                     "type": "array",
                     "maxItems": 25,
-                    # Empty enum when nothing was authorized: the array still
-                    # parses as the empty tuple, but no element value is
-                    # admissible. See the docstring -- this is the half
-                    # CHAOS-3536 could not close.
-                    "items": {"type": "integer", "enum": authorized_indices},
+                    # Enumerated when there is anything to enumerate. With
+                    # NOTHING authorized this stays a plain integer array
+                    # rather than carrying an empty enum -- see the docstring
+                    # for why that exotic shape was measured, then dropped.
+                    "items": (
+                        {"type": "integer", "enum": authorized_indices}
+                        if authorized_indices
+                        else {"type": "integer"}
+                    ),
                 },
                 "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
             },

--- a/tests/api/dev/test_chaos_3389_qua_shadow.py
+++ b/tests/api/dev/test_chaos_3389_qua_shadow.py
@@ -336,14 +336,22 @@ async def test_a_shadow_component_that_raises_outright_still_never_affects_the_r
 # ---------------------------------------------------------------------------
 # Never-widen holds AT RUNTIME, against a malicious/buggy provider
 #
-# CHAOS-3536 corrected this heading. It used to say "structurally", on the
-# strength of _response_schema's per-call index bounds -- but those bounds
-# are stripped by the provider's _structural_schema projection and have
-# never reached a decoder (CHAOS-3537). Every test below drives a scripted
-# provider that ignores the schema entirely, which is exactly the right
-# shape for the guarantee that actually exists: _verify is the sole guard,
-# and these are its proofs. Nothing here ever demonstrated a wire-level
-# bound, so nothing below changes -- only the claim above it.
+# This heading has been corrected twice; the assertions below have never
+# changed, because they only ever tested one thing and tested it correctly.
+#
+# It first said "structurally", on the strength of _response_schema's
+# minimum/maximum index bounds. CHAOS-3536 found those stripped in transit by
+# _structural_schema -- they reached no decoder, leaving _verify the sole
+# guard. CHAOS-3537 then restored a real wire-level bound as an `enum`, which
+# does survive the projection, so a structural half exists again (see
+# test_chaos_3537_enum_bound.py, which asserts it on the PROJECTED schema).
+#
+# The heading still says RUNTIME because that is what THIS block proves.
+# Every test below drives a scripted provider that ignores the schema
+# entirely -- the correct shape for _verify's guarantee, and silent about the
+# wire either way. Note also that _verify's rejection set SUBSUMES the
+# enum's: every mention slice is a subset of the call-wide index space, so
+# these tests cover the strictly larger property.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/api/dev/test_chaos_3536_qua_strict_schema.py
+++ b/tests/api/dev/test_chaos_3536_qua_strict_schema.py
@@ -446,26 +446,26 @@ def test_the_range_keywords_still_do_not_survive_the_projection() -> None:
         assert keyword not in wire_mention["selected_candidate_index"]
 
 
-def test_candidate_indices_are_now_bounded_on_the_wire() -> None:
-    """The residual CHAOS-3536 documented is CLOSED, by a different keyword.
+def test_candidate_indices_stay_unbounded_when_nothing_was_authorized() -> None:
+    """The residual CHAOS-3536 documented is still open, on purpose.
 
-    This test previously asserted the OPPOSITE, and the reversal is the
-    record worth keeping. CHAOS-3536 could not bound ``candidate_indices``:
-    the contract field is a non-optional ``tuple[_StrictIndex, ...]`` so
-    ``{"type": "null"}`` would fail parsing, and ``maxItems: 0`` is stripped.
-    The conclusion drawn then -- "``_verify`` is the only thing that rejects
-    an out-of-range entry here" -- was right for the encodings considered at
-    the time and wrong as a permanent property of the field.
+    CHAOS-3537 bounded every index field with an ``enum`` for the non-empty
+    case, and could have closed this one too with an EMPTY item enum --
+    measured live against OpenAI and accepted. It was dropped on review:
+    ``enum: []`` is unsatisfiable, and ``local``/``ollama``/``lmstudio`` are
+    certified platform providers whose decoders were never probed. One that
+    rejects it turns every zero-candidate call into a provider error, losing
+    the no-match evidence the shadow exists to gather.
 
-    An EMPTY item enum closes it: the field stays an array, so it still
-    parses as the empty tuple, and no element value is admissible. Verified
-    live -- strict mode accepts the empty enum and the model returned ``[]``.
+    ``_verify`` covers this case regardless -- with nothing authorized every
+    mention slice is empty, so any index at all is rejected.
     """
 
     items = _qua_branch(_wire_schema(candidate_count=0))["properties"]["mentions"][
         "items"
     ]["properties"]["candidate_indices"]["items"]
 
-    assert items == {"type": "integer", "enum": []}, (
-        "with nothing authorized, no element value may be admissible"
+    assert items == {"type": "integer"}, (
+        "if this becomes structurally bounded, the certification evidence "
+        "for every supported decoder must land with it"
     )

--- a/tests/api/dev/test_chaos_3536_qua_strict_schema.py
+++ b/tests/api/dev/test_chaos_3536_qua_strict_schema.py
@@ -414,57 +414,58 @@ def test_the_null_encoding_is_call_wide_and_not_per_mention() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_the_bounding_keywords_do_not_survive_the_projection() -> None:
-    """Pins the fact CHAOS-3536 corrected in ``qua_shadow``'s docstring.
+def test_the_range_keywords_still_do_not_survive_the_projection() -> None:
+    """Unchanged fact, and the reason CHAOS-3537 had to use ``enum``.
 
-    ``qua_shadow.py`` claimed "never-widen holds structurally" on the
-    strength of ``minimum``/``maximum`` on every index field. Those keywords
-    are not in ``_STRUCTURAL_SCHEMA_KEYS``, so the provider projection drops
-    them before dispatch and they have never constrained any real decoder.
+    ``minimum``/``maximum``/``minItems``/``maxItems``/``maxLength`` are still
+    absent from ``_STRUCTURAL_SCHEMA_KEYS`` and still stripped before
+    dispatch. CHAOS-3537 did not change that -- it changed which keyword the
+    bound is written in.
 
-    This is asserted rather than merely documented so that the docstring
-    cannot quietly drift back to the stronger claim: if someone adds the
-    bounding keywords to the allowlist (CHAOS-3537), this test fails and
-    points at the docs that must change with it.
+    ``maxItems`` is still emitted by the generator as intent, so this asserts
+    the round trip: written by the generator, gone on the wire. If someone
+    later widens the allowlist instead, this fails and sends them to
+    ``qua_shadow``'s docstring, which says why the enum was chosen over
+    exactly that.
     """
 
-    generated = _generated_schema(candidate_count=3)
-    generated_mention = generated["properties"]["mentions"]["items"]["properties"]
-    assert generated_mention["selected_candidate_index"]["maximum"] == 2, (
-        "the generator still expresses the bound..."
+    generated_mention = _generated_schema(candidate_count=3)["properties"]["mentions"][
+        "items"
+    ]["properties"]
+    assert generated_mention["candidate_indices"]["maxItems"] == 25, (
+        "the generator still states the intent..."
     )
 
     wire_mention = _qua_branch(_wire_schema(candidate_count=3))["properties"][
         "mentions"
     ]["items"]["properties"]
-    assert "maximum" not in wire_mention["selected_candidate_index"], (
-        "...but it does not reach the wire, so it guarantees nothing"
+    assert "maxItems" not in wire_mention["candidate_indices"], (
+        "...but it does not reach the wire, so nothing may be claimed on it"
     )
-    assert "minimum" not in wire_mention["selected_candidate_index"]
+    for keyword in ("minimum", "maximum"):
+        assert keyword not in wire_mention["selected_candidate_index"]
 
 
-def test_candidate_indices_remain_unbounded_on_the_wire() -> None:
-    """An honest residual, not an oversight.
+def test_candidate_indices_are_now_bounded_on_the_wire() -> None:
+    """The residual CHAOS-3536 documented is CLOSED, by a different keyword.
 
-    ``candidate_indices`` cannot get the ``{"type": "null"}`` treatment: the
-    contract field is a non-optional ``tuple[_StrictIndex, ...]``, so a null
-    would fail parsing as SKIPPED_INVALID_OUTPUT on every zero-candidate
-    call. ``maxItems: 0`` would express "must be empty" but is stripped by
-    the projection like every other bounding keyword.
+    This test previously asserted the OPPOSITE, and the reversal is the
+    record worth keeping. CHAOS-3536 could not bound ``candidate_indices``:
+    the contract field is a non-optional ``tuple[_StrictIndex, ...]`` so
+    ``{"type": "null"}`` would fail parsing, and ``maxItems: 0`` is stripped.
+    The conclusion drawn then -- "``_verify`` is the only thing that rejects
+    an out-of-range entry here" -- was right for the encodings considered at
+    the time and wrong as a permanent property of the field.
 
-    So at zero candidates an out-of-range entry in ``candidate_indices`` is
-    still EXPRESSIBLE on the wire, and ``_verify`` -- which re-checks every
-    accepted index against its own mention's authorized slice -- is the only
-    thing that rejects it. That is a real guard, not a gap, but it is a
-    RUNTIME guard, and this test exists so nobody records the schema as
-    doing work it does not do.
+    An EMPTY item enum closes it: the field stays an array, so it still
+    parses as the empty tuple, and no element value is admissible. Verified
+    live -- strict mode accepts the empty enum and the model returned ``[]``.
     """
 
     items = _qua_branch(_wire_schema(candidate_count=0))["properties"]["mentions"][
         "items"
     ]["properties"]["candidate_indices"]["items"]
 
-    assert items == {"type": "integer"}, (
-        "if this becomes structurally bounded, the residual documented in "
-        "qua_shadow's module docstring and in _verify must be revisited"
+    assert items == {"type": "integer", "enum": []}, (
+        "with nothing authorized, no element value may be admissible"
     )

--- a/tests/api/dev/test_chaos_3537_enum_bound.py
+++ b/tests/api/dev/test_chaos_3537_enum_bound.py
@@ -1,0 +1,172 @@
+"""CHAOS-3537: the never-widen bound, re-expressed so it survives the wire.
+
+CHAOS-3536 established that ``minimum``/``maximum`` never reached a provider:
+``_structural_schema`` keeps only ``_STRUCTURAL_SCHEMA_KEYS``, and the
+bounding keywords are not in it. The schema half of CHAOS-3389's never-widen
+guarantee did not exist, and ``_verify`` was the sole guard.
+
+This closes it WITHOUT touching the shared allowlist. ``enum`` is already on
+it, so the bound is re-expressed as an explicit enumeration of the authorized
+indices, which survives projection untouched and is strictly STRONGER than a
+range: ``[0, n-1]`` admits every integer between the ends, while the enum
+admits exactly the indices this call authorized.
+
+Measured live against gpt-5-nano before implementing (CHAOS-3537 probe, 15
+calls):
+
+* strict mode ACCEPTS an integer enum, at 3 and at 50 candidates, and accepts
+  the EMPTY enum used for the zero-candidate case;
+* given a prompt that explicitly instructs it to return out-of-range index 7,
+  the shipped (enum-less) schema returned ``selected_candidate_index: 7`` and
+  ``candidate_indices: [7]`` at confidence 0.92, **3 runs out of 3**;
+* the same prompt against the enum-bound schema could not express 7 in any of
+  3 runs -- it returned null or an in-range index.
+
+That is the whole case for this change, and note what it is NOT: ``_verify``
+rejects index 7 either way, so this was never an authorization bypass. What
+it was is a documented structural guarantee that did not exist, and a real
+model demonstrably reaching for an unauthorized index when asked to.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.dev.qua_shadow import (
+    QUAShadowConfig,
+    QuestionUnderstandingShadow,
+)
+from dev_health_ops.llm.agent.openai_compatible import build_completion_request
+
+
+def _shadow() -> QuestionUnderstandingShadow:
+    return QuestionUnderstandingShadow(
+        provider=None, scope_service=cast(Any, None), config=QUAShadowConfig()
+    )
+
+
+def _wire_mention_properties(
+    *, candidate_count: int, mention_count: int = 1
+) -> dict[str, Any]:
+    """The mention schema as PRODUCTION sends it, after the projection."""
+
+    generated = _shadow()._response_schema(
+        mention_count=mention_count, candidate_count=candidate_count
+    )
+    request = build_completion_request(
+        model="gpt-5-nano",
+        messages=(),
+        tools=(),
+        response_schema=generated,
+        max_output_tokens=6000,
+    )
+    schema = request["response_format"]["json_schema"]["schema"]
+    qua = schema["properties"]["value"]["anyOf"][0]
+    return cast(dict[str, Any], qua["properties"]["mentions"]["items"]["properties"])
+
+
+@pytest.mark.parametrize("candidate_count", (1, 3, 25, 50))
+def test_only_authorized_indices_are_expressible_on_the_wire(
+    candidate_count: int,
+) -> None:
+    """The guarantee CHAOS-3389 documented, now actually true of the wire.
+
+    Asserted on the PROJECTED schema, because the generator's output is not
+    what production sends -- that distinction is the whole of CHAOS-3536.
+    """
+
+    properties = _wire_mention_properties(candidate_count=candidate_count)
+    authorized = list(range(candidate_count))
+
+    selected = properties["selected_candidate_index"]
+    assert selected["enum"] == [*authorized, None], (
+        "exactly the authorized indices, plus null for no_match"
+    )
+    assert properties["candidate_indices"]["items"]["enum"] == authorized
+
+
+@pytest.mark.parametrize("candidate_count", (1, 3, 25, 50))
+def test_the_index_after_the_last_authorized_one_is_not_expressible(
+    candidate_count: int,
+) -> None:
+    """Stated as the attack rather than as the shape.
+
+    The live probe's out-of-range index was reachable in the shipped schema
+    3 runs out of 3. Whatever the enum's shape, the property that matters is
+    that the next index up cannot be named.
+    """
+
+    properties = _wire_mention_properties(candidate_count=candidate_count)
+
+    assert candidate_count not in properties["selected_candidate_index"]["enum"]
+    assert candidate_count not in properties["candidate_indices"]["items"]["enum"]
+
+
+def test_no_index_at_all_is_expressible_when_nothing_was_authorized() -> None:
+    """The zero-candidate case, now closed on BOTH fields.
+
+    CHAOS-3536 could only close ``selected_candidate_index`` (via
+    ``{"type": "null"}``) and had to leave ``candidate_indices`` unbounded,
+    because it is a non-optional tuple that a null would fail to parse and
+    ``maxItems: 0`` is stripped by the projection.
+
+    An EMPTY enum solves it: the array stays an array (so it parses as the
+    empty tuple), and no element value is admissible. Verified live -- strict
+    mode accepts the empty enum and the model returned ``[]`` on both runs.
+    """
+
+    properties = _wire_mention_properties(candidate_count=0)
+
+    assert properties["selected_candidate_index"] == {"type": "null"}
+    assert properties["candidate_indices"]["items"]["enum"] == [], (
+        "with nothing authorized, no index may be admissible in the array "
+        "either -- this is the residual CHAOS-3536 had to leave open"
+    )
+
+
+def test_no_match_stays_expressible() -> None:
+    """The control: bounding must not remove the ability to decline.
+
+    An enum of exactly the authorized indices, with no null, would force the
+    model to select SOMETHING -- converting a never-widen fix into a
+    must-always-guess bug, which is worse than what it replaced.
+    """
+
+    properties = _wire_mention_properties(candidate_count=3)
+
+    assert None in properties["selected_candidate_index"]["enum"]
+    assert "null" in properties["selected_candidate_index"]["type"]
+
+
+def test_the_bound_is_per_call_and_tracks_the_shortlist() -> None:
+    """Two different calls must not share a bound.
+
+    The enum is rebuilt per call from that call's combined shortlist, so a
+    smaller shortlist really is a tighter schema rather than a cached one.
+    """
+
+    small = _wire_mention_properties(candidate_count=2)
+    large = _wire_mention_properties(candidate_count=9)
+
+    assert small["selected_candidate_index"]["enum"] == [0, 1, None]
+    assert large["selected_candidate_index"]["enum"] == [*range(9), None]
+
+
+def test_the_bound_is_call_wide_not_per_mention() -> None:
+    """Unchanged from CHAOS-3536, restated because enum does not fix it.
+
+    ``_response_schema`` is still built once per call from the COMBINED
+    shortlist, so a mention whose own slice is empty still sees every
+    authorized index of the call. The enum narrows the call's index space to
+    what the CALL authorized; only ``_verify`` narrows it to what the MENTION
+    authorized. Both guards are needed and neither subsumes the other.
+    """
+
+    properties = _wire_mention_properties(candidate_count=50, mention_count=3)
+
+    assert properties["selected_candidate_index"]["enum"] == [*range(50), None], (
+        "a multi-mention call is bounded by the combined shortlist, not by "
+        "any single mention's slice"
+    )

--- a/tests/api/dev/test_chaos_3537_enum_bound.py
+++ b/tests/api/dev/test_chaos_3537_enum_bound.py
@@ -169,7 +169,13 @@ def test_the_bound_is_call_wide_not_per_mention() -> None:
     shortlist, so a mention whose own slice is empty still sees every
     authorized index of the call. The enum narrows the call's index space to
     what the CALL authorized; only ``_verify`` narrows it to what the MENTION
-    authorized. Both guards are needed and neither subsumes the other.
+    authorized.
+
+    Precisely: every mention slice is a subset of ``[0, len(combined))``, so
+    ``_verify``'s rejection set strictly SUBSUMES the enum's -- the two are
+    useful at different STAGES, not over different sets. An earlier version
+    of this docstring said "neither subsumes the other", which was wrong and
+    is the claim this file exists to keep honest.
     """
 
     properties = _wire_mention_properties(candidate_count=50, mention_count=3)

--- a/tests/api/dev/test_chaos_3537_enum_bound.py
+++ b/tests/api/dev/test_chaos_3537_enum_bound.py
@@ -104,25 +104,33 @@ def test_the_index_after_the_last_authorized_one_is_not_expressible(
     assert candidate_count not in properties["candidate_indices"]["items"]["enum"]
 
 
-def test_no_index_at_all_is_expressible_when_nothing_was_authorized() -> None:
-    """The zero-candidate case, now closed on BOTH fields.
+def test_no_selected_index_is_expressible_when_nothing_was_authorized() -> None:
+    """The zero-candidate case, and the residual deliberately left open.
 
-    CHAOS-3536 could only close ``selected_candidate_index`` (via
-    ``{"type": "null"}``) and had to leave ``candidate_indices`` unbounded,
-    because it is a non-optional tuple that a null would fail to parse and
-    ``maxItems: 0`` is stripped by the projection.
+    ``selected_candidate_index`` is closed structurally, unchanged from
+    CHAOS-3536.
 
-    An EMPTY enum solves it: the array stays an array (so it parses as the
-    empty tuple), and no element value is admissible. Verified live -- strict
-    mode accepts the empty enum and the model returned ``[]`` on both runs.
+    ``candidate_indices`` is NOT, and that is a decision rather than an
+    oversight. An empty item enum (``{"type": "integer", "enum": []}``) would
+    close it -- measured live against OpenAI, accepted, model returned ``[]``
+    on both runs. It was dropped anyway on review: ``enum: []`` is an
+    unsatisfiable choice set, and ``CERTIFIED_PLATFORM_AGENT_PROVIDERS`` also
+    contains ``local``, ``ollama`` and ``lmstudio``, whose constrained
+    decoders were never probed. One that rejects it would turn every
+    zero-candidate call into a provider error and silently lose exactly the
+    no-match evidence the shadow exists to collect -- strictly worse than the
+    residual, which ``_verify`` already covers.
+
+    So this asserts the SHIPPED shape, including the open half, and is the
+    thing to change first if per-endpoint certification is ever obtained.
     """
 
     properties = _wire_mention_properties(candidate_count=0)
 
     assert properties["selected_candidate_index"] == {"type": "null"}
-    assert properties["candidate_indices"]["items"]["enum"] == [], (
-        "with nothing authorized, no index may be admissible in the array "
-        "either -- this is the residual CHAOS-3536 had to leave open"
+    assert properties["candidate_indices"]["items"] == {"type": "integer"}, (
+        "the empty-enum closure is NOT shipped -- see the docstring; adopting "
+        "it needs certification evidence for the local/ollama/lmstudio decoders"
     )
 
 


### PR DESCRIPTION
## The bound CHAOS-3389 documented never reached a provider

CHAOS-3536 established that `_response_schema`'s `minimum`/`maximum` index bounds were stripped in transit: `OpenAICompatibleAgentProvider` projects every schema through `_structural_schema`, which keeps only `_STRUCTURAL_SCHEMA_KEYS`, and the bounding keywords are not in it. The schema half of the never-widen guarantee did not exist; `_verify` was the sole guard.

This closes it **without touching the shared allowlist**. `enum` is already on it, so the bound is re-expressed as an enumeration of the authorized indices — which survives projection untouched and is strictly *stronger* than the range it replaces: `[0, n-1]` admits every integer between its ends, the enum admits exactly the shortlist this call built.

## Measured live before implementing, not after

15 `gpt-5-nano` calls, well under US$0.01. Strict mode accepts an integer enum at 3 and at 50 candidates. Then the differential that justifies the change:

| schema | prompt instructing "return index 7" | result |
|---|---|---|
| **shipped** (no enum) | same | `selected_candidate_index: 7`, `candidate_indices: [7]`, confidence **0.92** — **3 runs of 3** |
| **enum-bound** | same | could not express 7 — **3 runs of 3** |

Stated in the code as precisely what it is and is not: `_verify` rejects index 7 either way, so this was **never an authorization bypass**. What it was is a documented structural guarantee that did not exist, and a real model reaching for an unauthorized index when instructed to.

## Two things withdrawn or corrected under review

**"Neither guard subsumes the other" was false — and it was mine.** Every mention slice is a subset of `[0, len(combined))`, so any index the enum rejects is also outside every mention's slice: `_verify`'s rejection set strictly **subsumes** the enum's. I wrote the wrong version in four places while explicitly warning myself not to overstate corrections.

What the enum actually buys, now scoped to what is true: for a decoder that *honors* the schema, a call-wide-out-of-range index is never generated, so the proposal arrives usable instead of arriving and being rejected. It is a generation-time constraint that reduces malformed proposals — **not** an authorization control and **not** a backstop. A non-compliant decoder can emit anything, and per-mention ownership stays `_verify`'s alone, which the schema cannot express at all.

**The empty enum is withdrawn.** `{"type": "integer", "enum": []}` would have closed CHAOS-3536's zero-candidate `candidate_indices` residual, and was measured working against OpenAI. But it is an unsatisfiable choice set, and `CERTIFIED_PLATFORM_AGENT_PROVIDERS` is `{openai, local, ollama, lmstudio}` — one of four probed. A decoder that rejects it would turn every zero-candidate call into a provider error and silently lose exactly the no-match evidence the shadow exists to collect: strictly worse than a residual `_verify` already covers.

Review asked the same compatibility question of the **non-empty** enum. Tested rather than accepted: `enum` is not a new dependency for those endpoints — every Ask Dev call already ships enums to every provider family (`_decision_response_schema`'s mandatory `kind`), and this schema's own `intent_id` / `cardinality` / `outcome` were enums before this change. The untested delta is narrow — integer-valued rather than string, up to 50 long — and is folded into CHAOS-3538's certification. That is what makes the asymmetry with the empty-enum withdrawal principled rather than arbitrary.

## Tests

`tests/api/dev/test_chaos_3537_enum_bound.py`, asserted on the **projected** wire schema (a raw-generator assertion proves nothing about what production sends — the whole of CHAOS-3536). RED first: 12 failures. Covers only-authorized-indices-expressible, the next index up being inexpressible, `no_match` staying expressible (the control — an enum without `null` would force the model to always guess), per-call tightening, and the call-wide-not-per-mention scope.

**CHAOS-3536's two tripwires fired exactly as designed.** They were written to fail the moment a bound started surviving projection and to point at the docs that must change with it. Both rewritten rather than deleted, so they now pin *which* mechanism carries the bound and an edit back to `minimum`/`maximum` fails loudly instead of silently un-bounding the wire.

Mutations: dropping `null` from the enum (kills the no-match control) and widening the enum by one (kills the out-of-range assertion) both die at the intended sites; restores verified by content hash.

## Blast radius

No change to `_STRUCTURAL_SCHEMA_KEYS` — so no other caller's request shape moves, and the readiness wire-request fingerprint is untouched. The allowlist-widening alternative recorded on CHAOS-3537 is **not needed**.

## Verification

Local gate: **PASSED**, zero failures, first run — lint, ruff-format, mypy, ch-scratch-create, ch-migrate, full unit suite and the argMax live-exec proof all green. 2880 passed across `tests/api/dev` + `tests/llm` + `tests/acceptance/corpus` on the rebased tree before gating.

Rebased onto `f0e07c014` (CHAOS-3533 B1) after confirming zero file overlap — my files are `qua_shadow`/`contracts_v2`/`qua_promotion` plus tests; theirs are orchestrator/persistence/compose.
