### PR TITLE
CHAOS-3528, CHAOS-3530: two small ops fixes (preflight diagnostics tuple, budget_guard flake)

### DIFF
--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -149,6 +149,10 @@ PREFLIGHT_DIAGNOSTICS: tuple[str, ...] = (
     # PROCEED diagnostics -- see the two call sites' own comments.
     "committed_cohort_portfolio_v1",
     "committed_portfolio_org_wide",
+    # CHAOS-3528: the CHAOS-3393 portfolio catalog-outage branch's own
+    # diagnostic, emitted at a real call site but never added here -- the
+    # exact CHAOS-3292 class this tuple exists to prevent.
+    "portfolio_catalog_unavailable",
     # CHAOS-3525: a subject the deterministic layer declined, committed from
     # a verified QUA proposal. Lives in this closed tuple like every other
     # branch's diagnostic even though the branch that sets it is in the

--- a/tests/api/dev/test_chaos_3366_not_found_fallback.py
+++ b/tests/api/dev/test_chaos_3366_not_found_fallback.py
@@ -15,11 +15,13 @@ equals the name outright.
 
 from __future__ import annotations
 
+import inspect
 import re
 from typing import Any
 
 import pytest
 
+from dev_health_ops.api.dev import subject_preflight as subject_preflight_module
 from dev_health_ops.api.dev.contracts_v2 import (
     PublicOutcome,
     ResolutionOutcome,
@@ -877,3 +879,36 @@ def test_every_preflight_diagnostic_fits_the_persisted_column() -> None:
     assert len(set(PREFLIGHT_DIAGNOSTICS)) == len(PREFLIGHT_DIAGNOSTICS)
     oversized = [name for name in PREFLIGHT_DIAGNOSTICS if len(name) > 32]
     assert oversized == []
+
+
+def test_every_emitted_diagnostic_literal_is_declared_in_the_closed_tuple() -> None:
+    """CHAOS-3528: a ``diagnostic="..."`` literal emitted somewhere in this
+    module but never added to :data:`PREFLIGHT_DIAGNOSTICS` widens
+    ``dev_runs.preflight_outcome`` past its own closed vocabulary silently --
+    the tuple's length guard above cannot see a value it never lists, and
+    nothing else in this test module reads the module's source to check.
+
+    ``portfolio_catalog_unavailable`` (the CHAOS-3393 catalog-outage branch)
+    was exactly that: emitted at a real call site, absent from the tuple, and
+    invisible to every other test because none of them persist a run against
+    the real ``String(32)`` column. Grep-based, per the ticket's own
+    suggested fix: it inspects the literal ``diagnostic="..."`` call-site
+    strings actually compiled into the module, not test expectations of them,
+    so a future branch that emits a new undeclared diagnostic fails HERE
+    rather than relying on a reviewer to notice.
+
+    Deliberately blind to a diagnostic assembled at runtime (an f-string) --
+    the closed tuple's own docstring requires diagnostics to be kept literal
+    for exactly this reason, so a dynamically built diagnostic is already a
+    violation the length guard and this guard both are entitled to miss.
+    """
+
+    source = inspect.getsource(subject_preflight_module)
+    emitted = set(re.findall(r'diagnostic="([a-z_]+)"', source))
+
+    assert emitted, 'no literal diagnostic="..." call sites found in the module'
+    undeclared = emitted - set(PREFLIGHT_DIAGNOSTICS)
+    assert undeclared == set(), (
+        f'{sorted(undeclared)} emitted via a literal diagnostic="..." but '
+        "missing from PREFLIGHT_DIAGNOSTICS"
+    )

--- a/tests/test_budget_guard_cooldown.py
+++ b/tests/test_budget_guard_cooldown.py
@@ -1610,6 +1610,7 @@ def test_budget_wall_clock_cap_exhausts_below_the_count_cap(db_session, monkeypa
     it is actually admissible -- which is the defect F1 fixed, not the cap
     this test is about.
     """
+    from dev_health_ops.providers.github import budget as github_budget
     from dev_health_ops.sync.budget_guard import (
         BUDGET_DEFERRAL_WALL_CLOCK_SECONDS_DEFAULT,
         BUDGET_MAX_DEFERRALS_DEFAULT,
@@ -1645,6 +1646,9 @@ def test_budget_wall_clock_cap_exhausts_below_the_count_cap(db_session, monkeypa
     # unit must genuinely not fit for exhaustion to be considered at all.
     monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
     monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    monkeypatch.setattr(
+        github_budget, "_credential_fingerprint", lambda *_a, **_k: "ca360fbc"
+    )
 
     sync_units.dispatch_sync_run(str(run.id))
 
@@ -1658,8 +1662,19 @@ def test_budget_wall_clock_cap_exhausts_below_the_count_cap(db_session, monkeypa
     # units against a cap of 100). Review round 2, F1: the explanation has to
     # come from the same evaluation that made the decision, or an operator is
     # handed numbers from a bucket state that no longer exists.
+    #
+    # CHAOS-3530: asserted against the NUMERIC evidence field, not a bare
+    # "360" substring of the whole message. The credential fingerprint above
+    # is pinned to a digest that itself contains "360" (github.com/... run
+    # 31160919212 hit an unpinned digest with the same collision) -- a
+    # substring check over the full error text fires on that hex noise
+    # whether or not the stale count leaked, and used to flake whenever an
+    # unpinned random digest happened to contain the same three digits.
+    # Checking the field the number actually lives in is immune to what the
+    # fingerprint hashes to.
     assert unit.error is not None
-    assert "360" not in unit.error, unit.error
+    assert unit.result["estimated_units"] == 2, unit.result
+    assert unit.result["estimated_units"] != 360, unit.result
     assert "estimates 2 units" in unit.error
     assert "cap is 0" in unit.error
     assert "rest_core" in unit.error


### PR DESCRIPTION
Two small, independent ops fixes.

## CHAOS-3528 — Ask Dev preflight: `portfolio_catalog_unavailable` missing from `PREFLIGHT_DIAGNOSTICS`

`subject_preflight.py`'s portfolio catalog-outage branch emits `diagnostic="portfolio_catalog_unavailable"`, which was not a member of the closed `PREFLIGHT_DIAGNOSTICS` tuple every other branch's diagnostic belongs to — the exact CHAOS-3292 class the tuple exists to prevent (`dev_runs.preflight_outcome` is a `String(32)` with no CHECK constraint).

Fix: added the missing entry, plus a totality guard (`test_every_emitted_diagnostic_literal_is_declared_in_the_closed_tuple`) that greps the module's compiled `diagnostic="..."` literals against the tuple, so a future undeclared diagnostic fails here instead of relying on a reviewer noticing.

RED-first: observed the new guard fail against the undeclared string before adding it to the tuple.

## CHAOS-3530 — budget_guard flake: bare `'360'` substring collides with random hex digests

`test_budget_wall_clock_cap_exhausts_below_the_count_cap` asserted `"360" not in unit.error` against the whole error message, which embeds a credential-fingerprint sha256 hex digest built from a random per-test org/integration id. Whenever the digest happened to contain `"360"`, the assertion fired on hex noise instead of measuring anything about the stale seeded payload the test is actually about. Reproduced in both the local gate and CI (comment-only PR #1565, run 31160919212, digest `...ca360fbc...`).

Fix: assert the live numeric field (`unit.result["estimated_units"]`) directly instead of scanning the rendered message.

RED-first: pinned the credential fingerprint to a digest deliberately containing `"360"`, observed the old substring assertion fail deterministically on the collision, then confirmed the fix passes with the same forced collision still in place — so it's immune to whatever the fingerprint hashes to, not merely lucky this run. The pin also makes the test itself deterministic instead of a coin flip.

## CHAOS-3535 — not included

Already fixed on `main` by commit `0749c0953` (PR #1563) before this branch was cut — same defect (run_report's ambiguous "executed" counter), same fix. Closed as duplicate on the Linear ticket with the evidence; nothing to change here.

Closes CHAOS-3528, CHAOS-3530. References CHAOS-3535 (duplicate, already resolved on main).