### PR TITLE
CHAOS-3544: stop retaining 0-day conversations forever when they never complete a turn

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -3763,12 +3763,12 @@
       "notes": "Unconditional five-minute refresh for exact coverage projections."
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/ask_dev_retention.py:210",
+      "id": "celery_task:src/dev_health_ops/workers/ask_dev_retention.py:217",
       "surface": "run_ask_dev_retention_cleanup",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/ask_dev_retention.py",
-        "line": 210
+        "line": 217
       },
       "queue_or_cadence": "default",
       "dispatches": "self (Beat)",

--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -3763,12 +3763,12 @@
       "notes": "Unconditional five-minute refresh for exact coverage projections."
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/ask_dev_retention.py:163",
+      "id": "celery_task:src/dev_health_ops/workers/ask_dev_retention.py:188",
       "surface": "run_ask_dev_retention_cleanup",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/ask_dev_retention.py",
-        "line": 163
+        "line": 188
       },
       "queue_or_cadence": "default",
       "dispatches": "self (Beat)",

--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -3763,12 +3763,12 @@
       "notes": "Unconditional five-minute refresh for exact coverage projections."
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/ask_dev_retention.py:188",
+      "id": "celery_task:src/dev_health_ops/workers/ask_dev_retention.py:210",
       "surface": "run_ask_dev_retention_cleanup",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/ask_dev_retention.py",
-        "line": 188
+        "line": 210
       },
       "queue_or_cadence": "default",
       "dispatches": "self (Beat)",

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -3736,7 +3736,20 @@ class DevPersistenceService:
                     .where(
                         DevConversation.retention_days == 0,
                         DevConversation.expires_at.is_(None),
-                        DevConversation.created_at < now - EPHEMERAL_ABANDONED_GRACE,
+                        # Codex adversarial review (HIGH): keyed on
+                        # updated_at, not created_at. The reachable version
+                        # of that finding -- a user resuming a pre-fix row
+                        # and having it stamped out from under a live run --
+                        # is already closed by _touch stamping the NULL
+                        # expiry on admission, and a test proves it. This is
+                        # the belt-and-braces half: "idle for a full grace"
+                        # is the condition that actually matters, and
+                        # updated_at says it directly rather than relying on
+                        # the invariant that every touch also stamps. A
+                        # future path that touches without stamping would
+                        # strand and then purge a live conversation under
+                        # created_at; under updated_at it cannot.
+                        DevConversation.updated_at < now - EPHEMERAL_ABANDONED_GRACE,
                     )
                     .order_by(DevConversation.created_at, DevConversation.id)
                     .limit(limit)
@@ -3944,6 +3957,31 @@ class DevPersistenceService:
         conversation.updated_at = now
         if conversation.retention_days == 30:
             conversation.expires_at = now + timedelta(days=30)
+        else:
+            # CHAOS-3544, Codex adversarial review (HIGH, REPRODUCED): the
+            # ephemeral expiry must track ACTIVITY, not creation.
+            #
+            # Anchoring on creation alone is a data-loss path. Open an
+            # ephemeral conversation, leave it idle 55 minutes, then ask a
+            # question: the run is legitimately in flight, but the expiry set
+            # at T0 falls due at T0+1h and `cleanup_expired` has no run-state
+            # guard -- so the live turn's own conversation is deleted out
+            # from under it, five minutes in. The first in-flight test could
+            # not see this: it starts its run at creation time, with the
+            # whole grace still ahead of it.
+            #
+            # Refreshing here restores the invariant the grace was meant to
+            # provide -- an ephemeral conversation is never collectable until
+            # it has been idle for a full grace period. It also repairs a
+            # pre-fix row (`expires_at IS NULL`) the moment anyone touches
+            # it, which is what stops the age-based backfill from stamping a
+            # conversation somebody just resumed.
+            #
+            # It never DELAYS the completed case:
+            # `_stamp_ephemeral_expiry_if_terminal` still moves the expiry
+            # back to `now` when the run reaches terminal, and runs after
+            # this.
+            conversation.expires_at = now + EPHEMERAL_ABANDONED_GRACE
 
     async def _purge_conversation(
         self,

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, TypeAlias
 
 from pydantic import ValidationError as PydanticValidationError
-from sqlalchemy import and_, case, event, exists, func, or_, select
+from sqlalchemy import and_, case, event, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -107,6 +107,45 @@ def _wire_visible_message_condition():
         .in_(_REAL_ANSWER_SCHEMA_VERSIONS),
     )
 
+
+#: How long a 0-day (ephemeral) conversation that never completes a turn is
+#: kept before the sweep may collect it (CHAOS-3544).
+#:
+#: WHY A GRACE AT ALL, rather than stamping ``now`` at creation. ``cleanup_
+#: expired`` selects purely on ``expires_at IS NOT NULL AND expires_at <=
+#: now``; it has NO in-flight protection of any kind. That is safe only
+#: because a 0-day row is never stamped until its run reaches terminal.
+#: Stamping ``now`` at creation makes every ephemeral conversation deletable
+#: the instant it exists -- purging it while the user is still typing their
+#: first message, and deleting a live run's conversation out from under it.
+#: Observed, not theorised: against that implementation
+#: ``append_user_message_and_run`` raises ``conversation not found`` because
+#: the row is already gone.
+#:
+#: WHY ONE HOUR, derived rather than chosen. A run cannot outlive the grace:
+#: ``DevRunLimits.wall_seconds`` is 45 seconds (80x smaller), and
+#: ``router._STALE_NON_TERMINAL_RUN_THRESHOLD`` is 5 minutes (12x smaller) --
+#: the latter documented in its own comment as "comfortably longer than any
+#: run that is still genuinely in flight could take without something else
+#: already having failed it". Both bounds are asserted against this constant
+#: by ``test_the_grace_is_far_longer_than_any_run_can_live``, so growing
+#: either past the grace fails loudly instead of silently reintroducing the
+#: purged-while-in-use failure mode.
+#:
+#: A module constant rather than configuration, deliberately: a configurable
+#: grace invites being lowered back under the safety bound, and expressing a
+#: floor for it would mean importing two constants from other modules and
+#: silently clamping an operator's value -- a worse surprise than one number
+#: with its derivation written beside it.
+#:
+#: WHAT THIS CHANGES ABOUT THE PRODUCT PROMISE. 0-day retention now means
+#: "deleted at completion, or within an hour if abandoned". It previously
+#: meant "deleted at completion, or NEVER" -- a conversation that never
+#: completed a turn was retained indefinitely in the one tier whose entire
+#: promise is immediate deletion. The grace applies ONLY to conversations
+#: that never complete a turn: a completed one is still stamped to ``now`` at
+#: terminal and collected on the next tick, unchanged.
+EPHEMERAL_ABANDONED_GRACE = timedelta(hours=1)
 
 _TERMINAL_RUN_STATES = frozenset(
     {
@@ -1263,7 +1302,23 @@ class DevPersistenceService:
             retention_days=retention_days,
             created_at=now,
             updated_at=now,
-            expires_at=(now + timedelta(days=30)) if retention_days == 30 else None,
+            # CHAOS-3544: BOTH tiers are stamped at creation now. Creation is
+            # the one event guaranteed to happen -- a conversation exists the
+            # moment it is created, with no message and therefore no run
+            # required -- so it is the only stamp that cannot be missed.
+            #
+            # The 0-day stamp is graced (see EPHEMERAL_ABANDONED_GRACE); the
+            # run-terminal stamp is now a REFRESH that moves it earlier to
+            # `now`, preserving immediate deletion for any conversation that
+            # actually completes a turn. Before this, a 0-day conversation
+            # that never completed one -- abandoned before its first message,
+            # or holding a run left non-terminal by a crash -- was stamped by
+            # nothing and retained forever.
+            expires_at=(
+                now + timedelta(days=30)
+                if retention_days == 30
+                else now + EPHEMERAL_ABANDONED_GRACE
+            ),
         )
         self.session.add(conversation)
         await self.session.flush()
@@ -3632,9 +3687,17 @@ class DevPersistenceService:
         run still non-terminal) and stamps ``expires_at = now()`` on them,
         identically to the synchronous stamp -- the ordinary
         ``cleanup_expired`` sweep then collects them on its next tick, same
-        as any other now-due row. Deliberately narrow: a conversation with
-        zero runs (freshly created, no message posted yet) or ANY
-        non-terminal run (genuinely still in flight) is never touched.
+        as any other now-due row.
+
+        CHAOS-3544 WIDENED WHAT COUNTS AS STRANDED. This used to skip a
+        conversation with zero runs ("nothing to retire yet") or with any
+        non-terminal run ("genuinely still in flight"). Both exclusions were
+        wrong in the same way: they assumed something would eventually stamp
+        those rows, and nothing ever would. A 0-day conversation abandoned
+        before its first message, or holding a run left non-terminal by a
+        crash, was unreachable by every path -- retained forever in the tier
+        whose whole promise is immediate deletion. The selection is now by
+        AGE, which covers both and cannot touch anything still in flight.
 
         Bounded and idempotent -- returns the number stamped this call;
         safe to run repeatedly (a resumable one-time operator action, e.g.
@@ -3645,15 +3708,27 @@ class DevPersistenceService:
                 "backfill limit must be between 1 and 500"
             )
         now = self._now()
-        has_a_run = exists(
-            select(DevRun.id).where(DevRun.conversation_id == DevConversation.id)
-        )
-        has_a_non_terminal_run = exists(
-            select(DevRun.id).where(
-                DevRun.conversation_id == DevConversation.id,
-                DevRun.state.not_in(_TERMINAL_RUN_STATES),
-            )
-        )
+        # CHAOS-3544: an AGE predicate replaces the previous
+        # `has_a_run AND ~has_a_non_terminal_run` pair.
+        #
+        # That pair existed for one reason: to avoid stamping a conversation
+        # whose run might still be in flight. But it bought that safety by
+        # excluding BOTH stranded shapes this backfill now has to reach --
+        # a conversation with zero runs (excluded by `has_a_run`) and one
+        # whose run never terminates (excluded by `~has_a_non_terminal_run`).
+        # Neither was repairable by anything, in a tier that promises
+        # immediate deletion.
+        #
+        # Age subsumes the pair rather than joining it: past
+        # EPHEMERAL_ABANDONED_GRACE a live run is impossible by the same two
+        # bounds that justify the grace itself (a 45s wall limit, and a
+        # 5-minute threshold beyond which a non-terminal run is already
+        # considered dead). So this is one predicate, no run-state reasoning,
+        # and strictly more complete than the two it replaces.
+        #
+        # Still narrow in the way that matters: a conversation created within
+        # the grace is never touched, so an in-flight turn cannot be stamped
+        # out from under itself.
         stranded = (
             (
                 await self.session.execute(
@@ -3661,8 +3736,7 @@ class DevPersistenceService:
                     .where(
                         DevConversation.retention_days == 0,
                         DevConversation.expires_at.is_(None),
-                        has_a_run,
-                        ~has_a_non_terminal_run,
+                        DevConversation.created_at < now - EPHEMERAL_ABANDONED_GRACE,
                     )
                     .order_by(DevConversation.created_at, DevConversation.id)
                     .limit(limit)

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -3671,6 +3671,41 @@ class DevPersistenceService:
             or 0
         )
 
+    async def count_stranded_ephemeral(self) -> int:
+        """Count 0-day conversations still awaiting a repair stamp (CHAOS-3544).
+
+        The exact counterpart of ``count_expired``, for the population that
+        one is structurally blind to: a stranded row carries ``expires_at IS
+        NULL``, so no count of DUE expiries can ever see it.
+
+        Non-locking, and that is the whole point (Codex adversarial review
+        round 2). The sweep's stamp loop cannot conclude "backlog cleared"
+        from a short batch: ``backfill_stranded_ephemeral_expiry`` selects
+        ``FOR UPDATE SKIP LOCKED``, so a concurrent stamper -- another tick,
+        or the manual ``dev-hops maintenance`` drain -- holding the remaining
+        rows makes the batch look short while the backlog is untouched. And
+        if that peer then rolls back, the rows it held still need stamping,
+        yet this task would already have reported a healthy "completed".
+
+        Row locks block writers, not readers, so this sees every still-
+        stranded row regardless of who holds it -- exactly the argument
+        ``count_expired`` already makes for the purge half.
+        """
+
+        now = self._now()
+        return int(
+            await self.session.scalar(
+                select(func.count())
+                .select_from(DevConversation)
+                .where(
+                    DevConversation.retention_days == 0,
+                    DevConversation.expires_at.is_(None),
+                    DevConversation.updated_at < now - EPHEMERAL_ABANDONED_GRACE,
+                )
+            )
+            or 0
+        )
+
     async def backfill_stranded_ephemeral_expiry(self, *, limit: int = 500) -> int:
         """One-time repair for 0-day conversations already stranded before
         this fix existed (CHAOS-3404; Codex adversarial-review round 3,

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -139,12 +139,21 @@ def _wire_visible_message_condition():
 #: with its derivation written beside it.
 #:
 #: WHAT THIS CHANGES ABOUT THE PRODUCT PROMISE. 0-day retention now means
-#: "deleted at completion, or within an hour if abandoned". It previously
-#: meant "deleted at completion, or NEVER" -- a conversation that never
-#: completed a turn was retained indefinitely in the one tier whose entire
-#: promise is immediate deletion. The grace applies ONLY to conversations
-#: that never complete a turn: a completed one is still stamped to ``now`` at
-#: terminal and collected on the next tick, unchanged.
+#: **"deleted at completion, or after 1 hour with no activity if abandoned"**.
+#: It previously meant "deleted at completion, or NEVER" -- a conversation
+#: that never completed a turn was retained indefinitely in the one tier
+#: whose entire promise is immediate deletion.
+#:
+#: The invariant is IDLE-anchored, not creation-anchored: an ephemeral
+#: conversation is **never collectable until it has been idle for a full
+#: grace period**. ``_touch`` refreshes this expiry on every activity, which
+#: is what makes that true -- anchoring on creation alone was a data-loss
+#: path, deleting a turn that started late in the window while it was still
+#: in flight.
+#:
+#: The grace therefore only ever affects conversations that go quiet: one
+#: that completes a turn is still stamped to ``now`` at terminal and
+#: collected on the next tick, unchanged.
 EPHEMERAL_ABANDONED_GRACE = timedelta(hours=1)
 
 _TERMINAL_RUN_STATES = frozenset(

--- a/src/dev_health_ops/fixtures/generators/retention_conversations.py
+++ b/src/dev_health_ops/fixtures/generators/retention_conversations.py
@@ -78,11 +78,31 @@ def build_retention_aged_conversation(
     ``retention_days > 0``) and a fresh one for the SAME policy.
     """
 
+    from dev_health_ops.api.dev.persistence.service import (
+        EPHEMERAL_ABANDONED_GRACE,
+    )
     from dev_health_ops.models.dev_persistence import DevConversation
 
     created_at = pinned_now - timedelta(days=age_days)
+    # CHAOS-3544: a 0-day row is stamped here exactly as production stamps
+    # it, and this is a PAIRED fix rather than an optional tidy-up.
+    #
+    # This generator writes DevConversation rows DIRECTLY -- it never goes
+    # through DevPersistenceService.create_conversation -- so fixing the
+    # product does not fix the fixture. It does the opposite: it would leave
+    # the fixture emitting a shape production can no longer produce, which is
+    # the drift-from-the-producer failure this codebase treats as a defect in
+    # its own right. And every 0-day row this generator emits is also a
+    # zero-run row (``runs=()`` below) -- precisely CHAOS-3544's stranded
+    # shape (a) -- so the fixture world was seeding un-purgeable rows.
+    #
+    # The grace is IMPORTED rather than restated: a fixture hardcoding "one
+    # hour" would silently disagree with production the day that constant
+    # moves.
     expires_at = (
-        created_at + timedelta(days=retention_days) if retention_days > 0 else None
+        created_at + timedelta(days=retention_days)
+        if retention_days > 0
+        else created_at + EPHEMERAL_ABANDONED_GRACE
     )
     conversation = DevConversation(
         id=_uuid5("conversation", id_seed),

--- a/src/dev_health_ops/workers/ask_dev_retention.py
+++ b/src/dev_health_ops/workers/ask_dev_retention.py
@@ -96,6 +96,31 @@ async def _run_ask_dev_retention_cleanup(
     batches_run = 0
 
     try:
+        # CHAOS-3544: stamp stranded rows BEFORE sweeping, so anything
+        # repaired on this tick is collected by the same tick rather than
+        # waiting another day.
+        #
+        # This task previously called only `cleanup_expired`, and the
+        # backfill's only caller was a `dev-hops maintenance` command. That
+        # left the repair operator-dependent -- and "the CLI drain can simply
+        # not happen" is exactly the failure mode that let a retained-forever
+        # population stay invisible for the whole life of the defect. A
+        # scheduled repair is self-healing; a documented manual one is a
+        # promise about human behaviour.
+        #
+        # Bounded and idempotent like the purge loop below, and cheap once
+        # drained: the selection is one predicate that returns nothing when
+        # nothing is stranded.
+        for _ in range(max(1, int(max_batches))):
+            async with factory() as session:
+                stamp_service = DevPersistenceService(session)
+                stamped = await stamp_service.backfill_stranded_ephemeral_expiry(
+                    limit=limit
+                )
+                await session.commit()
+            if stamped < limit:
+                break
+
         for _ in range(max(1, int(max_batches))):
             batches_run += 1
             async with factory() as session:

--- a/src/dev_health_ops/workers/ask_dev_retention.py
+++ b/src/dev_health_ops/workers/ask_dev_retention.py
@@ -93,6 +93,7 @@ async def _run_ask_dev_retention_cleanup(
         factory = session_factory
 
     total_purged = 0
+    total_stamped = 0
     batches_run = 0
 
     try:
@@ -111,6 +112,7 @@ async def _run_ask_dev_retention_cleanup(
         # Bounded and idempotent like the purge loop below, and cheap once
         # drained: the selection is one predicate that returns nothing when
         # nothing is stranded.
+        stamp_backlog_cleared = False
         for _ in range(max(1, int(max_batches))):
             async with factory() as session:
                 stamp_service = DevPersistenceService(session)
@@ -118,7 +120,14 @@ async def _run_ask_dev_retention_cleanup(
                     limit=limit
                 )
                 await session.commit()
+            total_stamped += stamped
             if stamped < limit:
+                # A short batch means the selection ran out of stranded rows.
+                # Unlike cleanup_expired's own short batch below this is
+                # conclusive: the backfill's SELECT ... FOR UPDATE SKIP
+                # LOCKED can only skip rows another stamper holds, and a row
+                # another stamper is holding is a row being repaired.
+                stamp_backlog_cleared = True
                 break
 
         for _ in range(max(1, int(max_batches))):
@@ -147,6 +156,18 @@ async def _run_ask_dev_retention_cleanup(
         # uncontended tick actually verifies the backlog is clear.
         async with factory() as session:
             drained = await DevPersistenceService(session).count_expired() == 0
+        # CHAOS-3544, Codex adversarial review (MEDIUM): `count_expired`
+        # counts rows with a DUE expires_at, so it is structurally blind to
+        # the stranded population this task now repairs -- those still carry
+        # expires_at IS NULL. With more stranded rows than
+        # max_batches * limit, the stamp loop hits its cap, the purge loop
+        # finds nothing left, and the task would report "completed" and
+        # advance the last-success gauge while an older backlog remained.
+        # That is the same false-drained claim CHAOS-3404 round 2 closed for
+        # the purge half, reintroduced through the repair half.
+        #
+        # Only a stamp loop that ran out of work may contribute to drained.
+        drained = drained and stamp_backlog_cleared
     except Exception:
         logger.exception(
             "ask_dev_retention_sweep.failed",
@@ -174,6 +195,7 @@ async def _run_ask_dev_retention_cleanup(
             "purged": total_purged,
             "batches": batches_run,
             "drained": drained,
+            "stamped": total_stamped,
         },
     )
     record_ask_dev_retention_sweep(status=status, purged=total_purged)

--- a/src/dev_health_ops/workers/ask_dev_retention.py
+++ b/src/dev_health_ops/workers/ask_dev_retention.py
@@ -112,7 +112,6 @@ async def _run_ask_dev_retention_cleanup(
         # Bounded and idempotent like the purge loop below, and cheap once
         # drained: the selection is one predicate that returns nothing when
         # nothing is stranded.
-        stamp_backlog_cleared = False
         for _ in range(max(1, int(max_batches))):
             async with factory() as session:
                 stamp_service = DevPersistenceService(session)
@@ -122,12 +121,6 @@ async def _run_ask_dev_retention_cleanup(
                 await session.commit()
             total_stamped += stamped
             if stamped < limit:
-                # A short batch means the selection ran out of stranded rows.
-                # Unlike cleanup_expired's own short batch below this is
-                # conclusive: the backfill's SELECT ... FOR UPDATE SKIP
-                # LOCKED can only skip rows another stamper holds, and a row
-                # another stamper is holding is a row being repaired.
-                stamp_backlog_cleared = True
                 break
 
         for _ in range(max(1, int(max_batches))):
@@ -166,8 +159,22 @@ async def _run_ask_dev_retention_cleanup(
         # That is the same false-drained claim CHAOS-3404 round 2 closed for
         # the purge half, reintroduced through the repair half.
         #
-        # Only a stamp loop that ran out of work may contribute to drained.
-        drained = drained and stamp_backlog_cleared
+        # Only a VERIFIED-empty stranded backlog may contribute to drained.
+        #
+        # Codex adversarial review round 2 (MEDIUM, confirmed) corrected the
+        # first version of this, which trusted a short stamp batch. It cannot
+        # be trusted, for exactly the reason CHAOS-3404 round 2 established
+        # for the purge half: backfill_stranded_ephemeral_expiry selects FOR
+        # UPDATE SKIP LOCKED, so a concurrent stamper holding the remaining
+        # rows makes the batch look short while the backlog is untouched --
+        # and if that peer rolls back, those rows still need stamping. The
+        # non-locking count is the same instrument count_expired already is,
+        # pointed at the population count_expired structurally cannot see.
+        async with factory() as session:
+            stranded_cleared = (
+                await DevPersistenceService(session).count_stranded_ephemeral() == 0
+            )
+        drained = drained and stranded_cleared
     except Exception:
         logger.exception(
             "ask_dev_retention_sweep.failed",

--- a/tests/api/dev/test_chaos_3544_ephemeral_retention.py
+++ b/tests/api/dev/test_chaos_3544_ephemeral_retention.py
@@ -63,7 +63,10 @@ import pytest_asyncio
 from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.api.dev.persistence import (
+    DevPersistenceNotFound,
+    DevPersistenceService,
+)
 from dev_health_ops.models.dev_persistence import DevConversation
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.users import Organization, User
@@ -556,3 +559,83 @@ async def test_a_resumed_pre_fix_conversation_is_not_stamped_and_purged(
         "and purged for being old -- age alone is not idleness"
     )
     assert await _exists(maker, conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_a_completed_conversation_cannot_be_written_to_again(
+    retention,
+) -> None:
+    """Why a completed ephemeral conversation cannot be resurrected by a late
+    write -- established by execution, and recorded because I nearly shipped
+    a guard against it.
+
+    ``_touch`` refreshes the ephemeral expiry on activity, so a touch landing
+    AFTER ``_stamp_ephemeral_expiry_if_terminal`` would push a completed
+    conversation an hour into the future, quietly delaying the immediate
+    deletion 0-day promises. Measured directly against the helper: 12:00
+    becomes 13:00.
+
+    I added a parameter to stop that, then found the path is unreachable and
+    removed it again. Two independent mechanisms already close it: ``finish()``
+    writes the answer BEFORE the terminal transition, so the terminal stamp is
+    last; and once stamped, the conversation is due, and every append path
+    resolves through ``get_conversation``, which excludes expired rows. The
+    append does not extend retention -- it fails closed.
+
+    A guard I could not exercise through a reachable path would have been
+    complexity that reads as protection. This test asserts the mechanism that
+    actually does the work instead, so if either half ever changes, something
+    fails.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="A turn that completes.",
+            scope_snapshot={},
+        )
+        accepted.run.state = "completed"
+        await session.flush()
+        assert (
+            await service._stamp_ephemeral_expiry_if_terminal(
+                org_id=org_id, user_id=user_id, conversation_id=conversation.id
+            )
+            is not None
+        )
+        await session.commit()
+
+    # A late assistant write cannot even find it -- so it cannot extend it.
+    answer_id = uuid.uuid4()
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        with pytest.raises(DevPersistenceNotFound):
+            await service.append_assistant_answer(
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation.id,
+                answer_payload={
+                    "schema_version": "dev_answer.v1",
+                    "answer_id": str(answer_id),
+                    "conversation_id": str(conversation.id),
+                    "summary": "An answer written after the terminal stamp.",
+                    "claims": [],
+                    "metrics": [],
+                    "evidence": [],
+                },
+                validator=lambda payload: payload,
+                scope_snapshot={},
+            )
+
+    # And it is still due NOW, with no grace added.
+    assert await _sweep(maker, clock) == 1
+    assert not await _exists(maker, conversation.id)

--- a/tests/api/dev/test_chaos_3544_ephemeral_retention.py
+++ b/tests/api/dev/test_chaos_3544_ephemeral_retention.py
@@ -45,9 +45,23 @@ stamped to ``now`` at terminal and purged immediately, exactly as before --
 the grace only ever affects conversations that never complete one, which is
 precisely the stranded population.
 
-``test_an_active_conversation_is_not_purged_while_in_flight`` is the test
-that kills the literal stamp-at-creation. It was watched failing against
-that implementation before this one was written.
+THE INVARIANT IS IDLE-ANCHORED, NOT CREATION-ANCHORED. Anchoring on
+creation alone was itself a data-loss path, found in review: a turn started
+55 minutes after the conversation was opened is legitimately in flight when
+the creation stamp falls due, and gets its conversation deleted out from
+under it. ``_touch`` therefore refreshes the expiry on every activity, so
+the real rule is: an ephemeral conversation is never collectable until it
+has been idle for a full grace period.
+
+So the promise this suite defends is **"deleted at completion, or after 1
+hour with no activity if abandoned"** -- previously "deleted at completion,
+or never".
+
+``test_an_active_conversation_is_not_purged_while_in_flight`` kills the
+literal stamp-at-creation, and
+``test_a_turn_started_late_in_the_grace_is_not_purged_under_it`` kills the
+creation-anchored one. Both were watched failing against the implementation
+they exist to reject, before it was replaced.
 """
 
 from __future__ import annotations

--- a/tests/api/dev/test_chaos_3544_ephemeral_retention.py
+++ b/tests/api/dev/test_chaos_3544_ephemeral_retention.py
@@ -436,3 +436,123 @@ async def test_the_grace_is_far_longer_than_any_run_can_live(retention) -> None:
     assert (
         EPHEMERAL_ABANDONED_GRACE.total_seconds() >= 50 * DevRunLimits().wall_seconds
     ), "and far beyond a single run's own wall-clock limit"
+
+
+@pytest.mark.asyncio
+async def test_a_turn_started_late_in_the_grace_is_not_purged_under_it(
+    retention,
+) -> None:
+    """Codex adversarial review, HIGH: the creation stamp is anchored to
+    CREATION, but a turn can start at any point afterwards.
+
+    Open an ephemeral conversation, leave it idle 55 minutes, then ask a
+    question. The run is legitimately in flight -- but the expiry was set at
+    T0 and comes due at T0+1h, and ``cleanup_expired`` has no run-state
+    guard. The live run's own conversation is deleted out from under it,
+    five minutes into a turn.
+
+    This is the same purged-while-in-use failure the grace exists to
+    prevent, arriving through a door the original in-flight test could not
+    see: that test starts its run at creation time, so the whole grace is
+    still ahead of it. Anchoring on creation was the mistake -- the stamp has
+    to track ACTIVITY.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await session.commit()
+
+    # 55 minutes later the user finally asks something.
+    clock.value = _START + timedelta(minutes=55)
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="Asked 55 minutes after opening the panel.",
+            scope_snapshot={},
+        )
+        await session.commit()
+
+    # Five minutes into that turn, the original creation-anchored expiry is
+    # due. The run is still in flight.
+    clock.value = _START + timedelta(minutes=60)
+    assert await _sweep(maker, clock) == 0, (
+        "a conversation whose turn started late in the grace must not be "
+        "purged while that turn is in flight -- the expiry has to track "
+        "activity, not creation"
+    )
+    assert await _exists(maker, conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_pre_fix_conversation_is_not_stamped_and_purged(
+    retention,
+) -> None:
+    """Codex adversarial review, HIGH: the backfill must not stamp a
+    conversation somebody has just resumed.
+
+    A row created before this fix still carries ``expires_at IS NULL`` and
+    stays perfectly readable, so a user can come back to it after deploy and
+    ask something. If the repair selects purely on how OLD the conversation
+    is, it stamps that row to ``now`` for no reason but its age, and the same
+    sweep tick purges it with a live run attached -- reintroducing precisely
+    the in-flight protection the replaced run-state pair used to provide.
+
+    The conversation here is days old and NULL-stamped: unambiguously a
+    pre-fix stranded row by age alone. The only thing that makes it
+    ineligible is that someone is using it right now.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await session.commit()
+
+    # Rewrite it into the genuine pre-fix shape: NULL expiry, days old.
+    async with maker() as session:
+        row = await session.get(DevConversation, conversation.id)
+        assert row is not None
+        row.expires_at = None
+        row.created_at = _START - timedelta(days=3)
+        row.updated_at = _START - timedelta(days=3)
+        await session.commit()
+
+    # The user resumes it and asks a question.
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="Resumed an old ephemeral conversation.",
+            scope_snapshot={},
+        )
+        await session.commit()
+
+    # A beat tick fires while that turn is in flight: stamp, then sweep.
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        await service.backfill_stranded_ephemeral_expiry(limit=100)
+        await session.commit()
+    purged = await _sweep(maker, clock)
+
+    assert purged == 0, (
+        "a resumed pre-fix conversation with a live run must not be stamped "
+        "and purged for being old -- age alone is not idleness"
+    )
+    assert await _exists(maker, conversation.id)

--- a/tests/api/dev/test_chaos_3544_ephemeral_retention.py
+++ b/tests/api/dev/test_chaos_3544_ephemeral_retention.py
@@ -1,0 +1,438 @@
+"""RED-first coverage for CHAOS-3544: 0-day conversations that never complete
+a run are retained forever.
+
+An organisation on the 0-day retention tier has chosen immediate deletion.
+Two reachable shapes are retained indefinitely instead:
+
+* **(a) zero runs** -- ``POST /conversations`` is standalone
+  (``router.py``), so a conversation exists the moment it is created and no
+  message, and therefore no ``DevRun``, is required. Opened and abandoned
+  without asking anything is ordinary use of an assistant panel, not an edge
+  case.
+* **(b) a run that never terminates** -- crash, cancellation, or an orphaned
+  non-terminal run.
+
+Why nothing collects either today:
+
+* ``create_conversation`` stamps ``expires_at = NULL`` for ``retention_days
+  == 0``; only the 30-day tier gets a creation stamp.
+* ``_stamp_ephemeral_expiry_if_terminal`` is the only 0-day stamp, and it
+  fires exclusively on a run reaching terminal.
+* ``cleanup_expired`` selects on ``expires_at IS NOT NULL``.
+* ``backfill_stranded_ephemeral_expiry`` requires ``has_a_run AND
+  ~has_a_non_terminal_run`` -- excluding (a) by the first condition and (b)
+  by the second.
+* ``recover_stale_non_terminal_run`` cannot rescue (b): its own docstring
+  says it fires "from the replay path itself, at the moment a caller
+  actually asks for this run again, rather than a background sweep". A
+  crashed run nobody re-requests is never recovered.
+
+THE FIX, AND THE TRAP IT HAS TO AVOID. The obvious remedy -- stamp
+``expires_at`` at creation, the one guaranteed event -- cannot be taken
+literally. ``cleanup_expired`` has NO in-flight protection whatsoever; it is
+safe today only because a 0-day row is never stamped before its run is
+terminal. Stamping ``now`` at creation would make every 0-day conversation
+deletable the instant it exists, purging conversations while the user is
+still typing their first message. That is strictly worse than the defect.
+
+So the creation stamp is GRACED, and the grace is derived rather than
+guessed: ``DevRunLimits.wall_seconds`` is 45 seconds and
+``_STALE_NON_TERMINAL_RUN_THRESHOLD`` is 5 minutes, the latter documented as
+"comfortably longer than any run that is still genuinely in flight could
+take without something else already having failed it". An hour is 80x the
+first and 12x the second. A conversation that DOES complete a turn is still
+stamped to ``now`` at terminal and purged immediately, exactly as before --
+the grace only ever affects conversations that never complete one, which is
+precisely the stranded population.
+
+``test_an_active_conversation_is_not_purged_while_in_flight`` is the test
+that kills the literal stamp-at-creation. It was watched failing against
+that implementation before this one was written.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.dev.persistence import DevPersistenceService
+from dev_health_ops.models.dev_persistence import DevConversation
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+
+@dataclass
+class Clock:
+    """A controllable ``now`` -- the grace is an hour, and no test sleeps."""
+
+    value: datetime
+
+    def __call__(self) -> datetime:
+        return self.value
+
+
+@pytest_asyncio.fixture
+async def retention(tmp_path: Path):
+    database = tmp_path / "chaos-3544-retention.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    from dev_health_ops.models.dev_persistence import (
+        DevAnswerFrame,
+        DevConversationTombstone,
+        DevFeedback,
+        DevMessage,
+        DevRun,
+        DevRunIntent,
+        DevRunNarrative,
+        DevRunQuaShadow,
+        DevRunResolution,
+        DevRunSourceObservation,
+        DevRunStageDiagnostic,
+        DevRunSubjectSet,
+        DevToolCall,
+    )
+
+    tables = tables_of(
+        User,
+        Organization,
+        DevConversation,
+        DevMessage,
+        DevRun,
+        DevToolCall,
+        DevFeedback,
+        DevConversationTombstone,
+        DevAnswerFrame,
+        DevRunResolution,
+        DevRunNarrative,
+        DevRunSubjectSet,
+        DevRunIntent,
+        DevRunSourceObservation,
+        DevRunStageDiagnostic,
+        DevRunQuaShadow,
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=tables
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    async with maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="ask-dev", name="Ask Dev"),
+                User(id=user_id, email="ask-dev@example.com"),
+            ]
+        )
+        await session.commit()
+    try:
+        yield maker, org_id, user_id
+    finally:
+        await engine.dispose()
+
+
+_START = datetime(2026, 8, 7, 12, 0, tzinfo=UTC)
+
+
+async def _exists(maker, conversation_id: uuid.UUID) -> bool:
+    async with maker() as session:
+        return await session.get(DevConversation, conversation_id) is not None
+
+
+async def _sweep(maker, clock: Clock) -> int:
+    """One real ``cleanup_expired`` tick, committed, as the beat task runs it."""
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        result = await service.cleanup_expired(limit=100)
+        await session.commit()
+    return result.purged
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_zero_run_conversation_is_eventually_purged(
+    retention,
+) -> None:
+    """Stranded shape (a): created and abandoned before any message.
+
+    The org selected immediate deletion; today this row is retained forever,
+    because every purge path keys off an ``expires_at`` that nothing will
+    ever set for it.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await session.commit()
+
+    clock.value = _START + timedelta(days=1)
+    purged = await _sweep(maker, clock)
+
+    assert purged == 1, (
+        "CHAOS-3544: a 0-day conversation abandoned before any message must "
+        "eventually be purged. The organisation chose immediate deletion; "
+        "retaining it forever is a retention-policy violation in the tier "
+        "whose entire promise is deletion."
+    )
+    assert not await _exists(maker, conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_a_conversation_whose_run_never_terminates_is_eventually_purged(
+    retention,
+) -> None:
+    """Stranded shape (b): a run left non-terminal by a crash or cancellation.
+
+    ``recover_stale_non_terminal_run`` cannot save this one -- it fires only
+    from the replay path, when a caller asks for the run again. A run nobody
+    re-requests is never recovered, so the conversation is retained forever.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="This run never reaches a terminal state.",
+            scope_snapshot={},
+        )
+        await session.commit()
+
+    clock.value = _START + timedelta(days=1)
+    purged = await _sweep(maker, clock)
+
+    assert purged == 1, (
+        "CHAOS-3544: a 0-day conversation whose run never terminated must "
+        "eventually be purged -- no existing path can rescue it, so today it "
+        "is retained forever."
+    )
+    assert not await _exists(maker, conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_an_active_conversation_is_not_purged_while_in_flight(
+    retention,
+) -> None:
+    """THE guard against the obvious-but-wrong fix, and the reason the
+    creation stamp is graced.
+
+    ``cleanup_expired`` selects purely on ``expires_at <= now`` and has no
+    in-flight protection at all. A literal ``expires_at = now`` at creation
+    would make every 0-day conversation deletable the instant it exists --
+    purging it while the user is still typing their first message, and
+    deleting a live run's own conversation out from under it.
+
+    That is strictly worse than the defect being fixed: it converts
+    "retained forever" into "destroyed while in use". This test was watched
+    FAILING against the literal implementation before the graced one was
+    written.
+
+    Asserted at two points inside the grace -- immediately, and just before
+    it elapses -- so a grace accidentally set to zero or to a few seconds is
+    caught rather than only a grace of exactly zero.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="A genuinely in-flight turn.",
+            scope_snapshot={},
+        )
+        await session.commit()
+
+    # Immediately: the run has not even started producing output yet.
+    assert await _sweep(maker, clock) == 0, (
+        "a 0-day conversation must NOT be purged the moment it is created -- "
+        "cleanup_expired has no in-flight protection, so a literal "
+        "stamp-at-creation deletes live conversations"
+    )
+    assert await _exists(maker, conversation.id)
+
+    # And still safe near the end of the grace, which is an order of
+    # magnitude beyond any run that could still be genuinely in flight.
+    clock.value = _START + timedelta(minutes=55)
+    assert await _sweep(maker, clock) == 0
+    assert await _exists(maker, conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_a_completed_conversation_is_still_purged_immediately(
+    retention,
+) -> None:
+    """Preserved behaviour: the grace must not delay the case that already
+    worked.
+
+    A 0-day conversation whose run reaches terminal is stamped to ``now`` and
+    collected on the very next sweep tick -- no grace, exactly as today. If
+    this ever starts waiting an hour, the fix has quietly downgraded the
+    promise for the common path instead of only the abandoned one.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="A turn that completes normally.",
+            scope_snapshot={},
+        )
+        # Raw terminal mutation rather than update_run: update_run also
+        # attempts the synchronous purge, and this test is about the
+        # STAMP + sweep half, which is what must survive a failed or skipped
+        # inline purge.
+        accepted.run.state = "completed"
+        await session.flush()
+        stamped = await service._stamp_ephemeral_expiry_if_terminal(
+            org_id=org_id, user_id=user_id, conversation_id=conversation.id
+        )
+        await session.commit()
+
+    assert stamped is not None
+    # No clock advance at all: the terminal stamp is `now`, not `now + grace`.
+    assert await _sweep(maker, clock) == 1, (
+        "a completed 0-day conversation must still be purged on the next "
+        "tick with no grace -- the creation grace exists only for "
+        "conversations that never complete a turn"
+    )
+    assert not await _exists(maker, conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_a_30_day_conversation_is_untouched_by_any_of_this(
+    retention,
+) -> None:
+    """The 30-day tier's semantics are correct and must not move.
+
+    It already stamps at creation (``now + 30d``); nothing here changes that
+    path, and a 30-day conversation must be unaffected by the ephemeral
+    grace at every point the 0-day rows above are purged.
+    """
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=30
+        )
+        await session.commit()
+
+    # Well past the ephemeral grace, nowhere near 30 days.
+    clock.value = _START + timedelta(days=2)
+    assert await _sweep(maker, clock) == 0
+    assert await _exists(maker, conversation.id)
+
+    # And still collected on its own schedule.
+    clock.value = _START + timedelta(days=31)
+    assert await _sweep(maker, clock) == 1
+    assert not await _exists(maker, conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_the_creation_stamp_is_the_graced_one_not_now(retention) -> None:
+    """Pins the stamp itself, not only its downstream effect.
+
+    The sweep tests above would all pass for a grace of one second or one
+    year. This asserts the actual persisted value against the constant, so a
+    change to the grace is a deliberate edit to a named number rather than a
+    silent drift nothing measures.
+    """
+
+    from dev_health_ops.api.dev.persistence.service import (
+        EPHEMERAL_ABANDONED_GRACE,
+    )
+
+    maker, org_id, user_id = retention
+    clock = Clock(_START)
+
+    async with maker() as session:
+        service = DevPersistenceService(session, now=clock)
+        ephemeral = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}, retention_days=0
+        )
+        await session.commit()
+
+    async with maker() as session:
+        row = await session.get(DevConversation, ephemeral.id)
+        assert row is not None
+        assert row.expires_at is not None, (
+            "a 0-day conversation must carry an expiry from the moment it "
+            "exists -- creation is the one event guaranteed to happen"
+        )
+        stored = row.expires_at
+        if stored.tzinfo is None:
+            stored = stored.replace(tzinfo=UTC)
+        assert stored == _START + EPHEMERAL_ABANDONED_GRACE
+
+
+@pytest.mark.asyncio
+async def test_the_grace_is_far_longer_than_any_run_can_live(retention) -> None:
+    """The derivation, asserted rather than left in a comment.
+
+    The grace is only safe because it is far beyond any run that could still
+    be genuinely in flight. Both bounds are imported from where they are
+    actually defined, so if either grows past the grace this fails instead of
+    silently reintroducing the "purged while in use" failure mode.
+    """
+
+    from dev_health_ops.api.dev.orchestrator import DevRunLimits
+    from dev_health_ops.api.dev.persistence.service import (
+        EPHEMERAL_ABANDONED_GRACE,
+    )
+    from dev_health_ops.api.dev.router import _STALE_NON_TERMINAL_RUN_THRESHOLD
+
+    assert EPHEMERAL_ABANDONED_GRACE >= 10 * _STALE_NON_TERMINAL_RUN_THRESHOLD, (
+        "the grace must stay an order of magnitude above the threshold at "
+        "which a non-terminal run is considered impossible-to-still-be-live"
+    )
+    assert (
+        EPHEMERAL_ABANDONED_GRACE.total_seconds() >= 50 * DevRunLimits().wall_seconds
+    ), "and far beyond a single run's own wall-clock limit"

--- a/tests/api/dev/test_persistence.py
+++ b/tests/api/dev/test_persistence.py
@@ -1027,13 +1027,26 @@ async def test_backfill_stranded_ephemeral_expiry_repairs_pre_fix_rows(persisten
     it does nothing for rows already left with every run terminal and
     expires_at=NULL by the pre-fix force_terminal_fallback/
     recover_stale_non_terminal_run in production before this deploys.
-    Simulates exactly that pre-fix state directly (a raw state mutation,
-    bypassing update_run/force_terminal_fallback entirely -- those all
-    stamp now, so this is the only way to construct the stranded shape a
-    backfill needs to repair), then proves backfill_stranded_ephemeral_expiry
-    stamps it and the ordinary sweep collects it -- while leaving a
-    still-in-flight (non-terminal run) or run-less (freshly created,
-    nothing to retire) 0-day conversation untouched.
+    Simulates exactly that pre-fix state directly (a raw mutation, bypassing
+    update_run/force_terminal_fallback entirely -- those all stamp now, so
+    this is the only way to construct the stranded shape a backfill needs to
+    repair), then proves backfill_stranded_ephemeral_expiry stamps it and the
+    ordinary sweep collects it.
+
+    CHAOS-3544 REWROTE TWO ASSERTIONS HERE, deliberately and under an
+    explicit ruling. This test used to assert that a run-less 0-day
+    conversation and one with a non-terminal run were left untouched, and
+    that the run-less one still EXISTED after a sweep. Read today that looks
+    like a guarantee being deleted; it is not. Those assertions encoded
+    "nothing to retire YET" under the old model, where the only stamp was
+    run-terminal and a creation stamp did not exist. They were never a
+    decision that a 0-day conversation should be kept forever -- which is
+    exactly what they had come to certify, since neither row could ever be
+    stamped by anything.
+
+    Both are now stamped at creation (graced), so the shapes this test
+    constructs must set expires_at=None explicitly to simulate a pre-fix row
+    at all, and the backfill's own selection is by age rather than run state.
     """
     maker, org_id, _other_org_id, user_id, _other_user_id = persistence
     async with maker() as session:
@@ -1051,8 +1064,17 @@ async def test_backfill_stranded_ephemeral_expiry_repairs_pre_fix_rows(persisten
             scope_snapshot={},
         )
         # Raw mutation -- simulates the pre-fix force_terminal_fallback
-        # shape directly: terminal run, expires_at never stamped.
+        # shape directly: terminal run, expires_at never stamped. Since
+        # CHAOS-3544 stamps at creation, the stamp has to be cleared here too
+        # or this is no longer a pre-fix row.
         stranded_accepted.run.state = "failed"
+        stranded.expires_at = None
+        # ...and aged past the grace. A row genuinely stranded in production
+        # by the pre-fix code has been sitting there since before the deploy;
+        # a row created moments ago is indistinguishable from one whose turn
+        # is still starting, which is exactly what the age predicate refuses
+        # to touch.
+        stranded.created_at = datetime.now(UTC) - timedelta(days=2)
         await session.flush()
 
         still_in_flight = await service.create_conversation(
@@ -1094,11 +1116,27 @@ async def test_backfill_stranded_ephemeral_expiry_repairs_pre_fix_rows(persisten
             expires_at = expires_at.replace(tzinfo=UTC)
         assert expires_at <= datetime.now(UTC)
 
-        # Untouched: still in flight, and never had a run at all.
-        assert (
+        # CHAOS-3544: these two used to be asserted as expires_at IS NULL --
+        # i.e. as permanently unpurgeable, which is the defect. Both are now
+        # stamped at CREATION (graced), so they carry a real expiry and will
+        # be collected once it elapses. What must still hold is that the
+        # backfill did not touch them: their stamp is the creation one, still
+        # in the future, not a backfill stamp of `now`.
+        in_flight_expiry = (
             await session3.get(DevConversation, still_in_flight.id)
-        ).expires_at is None
-        assert (await session3.get(DevConversation, run_less.id)).expires_at is None
+        ).expires_at
+        run_less_expiry = (await session3.get(DevConversation, run_less.id)).expires_at
+        for expiry in (in_flight_expiry, run_less_expiry):
+            assert expiry is not None, (
+                "a 0-day conversation must carry an expiry from creation -- "
+                "a NULL here is the CHAOS-3544 retained-forever shape"
+            )
+            # sqlite hands back naive datetimes; normalise before comparing.
+            aware = expiry if expiry.tzinfo is not None else expiry.replace(tzinfo=UTC)
+            assert aware > datetime.now(UTC), (
+                "and it must still be the graced creation stamp, not a "
+                "backfill stamp of now: neither row is old enough to repair"
+            )
 
     # Idempotent: a second call finds nothing left to stamp.
     async with maker() as session4:
@@ -1113,6 +1151,9 @@ async def test_backfill_stranded_ephemeral_expiry_repairs_pre_fix_rows(persisten
     assert result.purged == 1
     async with maker() as session6:
         assert await session6.get(DevConversation, stranded.id) is None
+        # Still present: its graced creation stamp has not elapsed, so the
+        # sweep has nothing to collect yet. Previously this row was retained
+        # forever; now it is retained until its expiry, which is the point.
         assert await session6.get(DevConversation, still_in_flight.id) is not None
         assert await session6.get(DevConversation, run_less.id) is not None
 

--- a/tests/api/dev/test_persistence.py
+++ b/tests/api/dev/test_persistence.py
@@ -1075,6 +1075,10 @@ async def test_backfill_stranded_ephemeral_expiry_repairs_pre_fix_rows(persisten
         # is still starting, which is exactly what the age predicate refuses
         # to touch.
         stranded.created_at = datetime.now(UTC) - timedelta(days=2)
+        # ...and untouched since. The repair keys on updated_at, because
+        # "idle for a full grace" is the real condition -- a row someone
+        # resumed minutes ago is not stranded no matter how old it is.
+        stranded.updated_at = datetime.now(UTC) - timedelta(days=2)
         await session.flush()
 
         still_in_flight = await service.create_conversation(

--- a/tests/test_fixtures_world_generators.py
+++ b/tests/test_fixtures_world_generators.py
@@ -215,7 +215,26 @@ class TestRetentionConversations:
             == bundle.conversation.created_at + timedelta(days=30)
         )
 
-    def test_retention_zero_days_has_no_expiry(self) -> None:
+    def test_retention_zero_days_carries_the_graced_creation_expiry(self) -> None:
+        """CHAOS-3544 rewrote this assertion, deliberately and under ruling.
+
+        It previously asserted ``expires_at is None`` for a 0-day row. That
+        matched production at the time -- and production was wrong: a NULL
+        expiry is exactly the shape no purge path can ever collect, so the
+        fixture world was seeding conversations that are retained forever in
+        the tier whose entire promise is immediate deletion. Every row this
+        generator emits is also run-less, which is CHAOS-3544's stranded
+        shape (a) precisely.
+
+        The assertion now tracks the producer instead of the old bug. It is
+        computed from the imported constant rather than a literal, so the
+        fixture cannot drift from production the day the grace changes.
+        """
+
+        from dev_health_ops.api.dev.persistence.service import (
+            EPHEMERAL_ABANDONED_GRACE,
+        )
+
         bundle = conv_gen.build_retention_aged_conversation(
             org_id=uuid.uuid4(),
             user_id=uuid.uuid4(),
@@ -225,8 +244,15 @@ class TestRetentionConversations:
             pinned_now=_NOW,
             title="probe",
         )
-        assert bundle.conversation.expires_at is None
         assert bundle.conversation.retention_days == 0
+        assert bundle.conversation.expires_at is not None, (
+            "a 0-day fixture row with no expiry is un-purgeable by every "
+            "code path -- the CHAOS-3544 defect, seeded"
+        )
+        assert (
+            bundle.conversation.expires_at
+            == bundle.conversation.created_at + EPHEMERAL_ABANDONED_GRACE
+        )
 
     def test_deterministic_ids_across_calls(self) -> None:
         org_id = uuid.uuid4()

--- a/tests/workers/test_ask_dev_retention_sweep.py
+++ b/tests/workers/test_ask_dev_retention_sweep.py
@@ -532,3 +532,87 @@ class TestRecordAskDevRetentionSweepGaugeContract:
 
         mock_total.assert_called_once_with(status="failed")
         mock_gauge_set.assert_not_called()
+
+
+class TestSweepRepairsStrandedEphemeralRows:
+    """CHAOS-3544: the scheduled sweep must repair stranded 0-day rows, not
+    merely purge already-stamped ones.
+
+    Before this, ``backfill_stranded_ephemeral_expiry``'s only caller was a
+    ``dev-hops maintenance`` command. A repair that depends on an operator
+    remembering to run a CLI is a promise about human behaviour, and "the
+    drain simply never happened" is the failure mode that let a
+    retained-forever population stay invisible for the whole life of the
+    defect. The beat tick already runs daily; it now stamps before it sweeps,
+    so anything repaired is collected by the same tick.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_sweep_stamps_and_then_purges_a_stranded_row(
+        self, persistence
+    ) -> None:
+        """Seeds the pre-fix shape -- a 0-day conversation with a NULL expiry,
+        old enough that no run could still be in flight -- and asserts one
+        ordinary beat tick removes it.
+
+        RED before CHAOS-3544: the task called only ``cleanup_expired``,
+        which cannot see a NULL expiry, so the row survived every tick
+        forever.
+        """
+
+        maker, org_id, user_id = persistence
+        conversation_id = await _seed_conversation(
+            maker, org_id=org_id, user_id=user_id, retention_days=0
+        )
+        # The pre-fix shape: NULL expiry, aged well past the grace.
+        async with maker() as session:
+            await session.execute(
+                update(DevConversation)
+                .where(DevConversation.id == conversation_id)
+                .values(
+                    expires_at=None,
+                    created_at=datetime.now(UTC) - timedelta(days=3),
+                )
+            )
+            await session.commit()
+
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        with patch("dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"):
+            await _run_ask_dev_retention_cleanup(session_factory=maker)
+
+        async with maker() as session:
+            assert await session.get(DevConversation, conversation_id) is None, (
+                "one beat tick must stamp and then collect a stranded 0-day "
+                "row -- leaving it for a manual CLI drain is what made this "
+                "defect survive"
+            )
+
+    @pytest.mark.asyncio
+    async def test_the_sweep_leaves_a_recent_ephemeral_row_alone(
+        self, persistence
+    ) -> None:
+        """The other arm: a 0-day conversation created moments ago is inside
+        its grace and may be mid-turn. A sweep that collected it would be the
+        purged-while-in-use failure the grace exists to prevent, arriving by
+        the back door of the backfill rather than the creation stamp."""
+
+        maker, org_id, user_id = persistence
+        conversation_id = await _seed_conversation(
+            maker, org_id=org_id, user_id=user_id, retention_days=0
+        )
+
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        with patch("dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"):
+            await _run_ask_dev_retention_cleanup(session_factory=maker)
+
+        async with maker() as session:
+            assert await session.get(DevConversation, conversation_id) is not None, (
+                "a freshly created 0-day conversation is inside its grace and "
+                "must survive the sweep"
+            )

--- a/tests/workers/test_ask_dev_retention_sweep.py
+++ b/tests/workers/test_ask_dev_retention_sweep.py
@@ -572,6 +572,8 @@ class TestSweepRepairsStrandedEphemeralRows:
                 .values(
                     expires_at=None,
                     created_at=datetime.now(UTC) - timedelta(days=3),
+                    # Untouched since: the repair keys on idleness, not age.
+                    updated_at=datetime.now(UTC) - timedelta(days=3),
                 )
             )
             await session.commit()
@@ -616,3 +618,54 @@ class TestSweepRepairsStrandedEphemeralRows:
                 "a freshly created 0-day conversation is inside its grace and "
                 "must survive the sweep"
             )
+
+    @pytest.mark.asyncio
+    async def test_a_capped_stamp_loop_reports_partial_not_completed(
+        self, persistence
+    ) -> None:
+        """CHAOS-3544, Codex adversarial review (MEDIUM): the sweep must not
+        claim it drained while stranded rows remain.
+
+        ``count_expired`` counts rows with a DUE ``expires_at``, so it is
+        structurally blind to the stranded population -- those still carry
+        ``expires_at IS NULL``. With more stranded rows than
+        ``max_batches * limit`` the stamp loop hits its cap, the purge loop
+        then finds nothing left to do, and the task would report "completed"
+        and advance the last-success gauge over an untouched older backlog.
+        That is the same false-drained claim CHAOS-3404 round 2 closed for
+        the purge half, reintroduced through the repair half.
+
+        Three stranded rows, a batch limit of one, and one batch allowed: the
+        stamp loop can only reach one of them.
+        """
+
+        from dev_health_ops.workers.ask_dev_retention import (
+            _run_ask_dev_retention_cleanup,
+        )
+
+        maker, org_id, user_id = persistence
+        aged = datetime.now(UTC) - timedelta(days=3)
+        for _ in range(3):
+            conversation_id = await _seed_conversation(
+                maker, org_id=org_id, user_id=user_id, retention_days=0
+            )
+            async with maker() as session:
+                await session.execute(
+                    update(DevConversation)
+                    .where(DevConversation.id == conversation_id)
+                    .values(expires_at=None, created_at=aged, updated_at=aged)
+                )
+                await session.commit()
+
+        with patch("dev_health_ops.metrics.prometheus.record_ask_dev_retention_sweep"):
+            result = await _run_ask_dev_retention_cleanup(
+                session_factory=maker, limit=1, max_batches=1
+            )
+
+        assert result["status"] == "partial", (
+            "the stamp loop hit its cap with stranded rows still unrepaired, "
+            "so this tick did NOT drain the backlog -- reporting 'completed' "
+            "here advances the last-success gauge over work that never "
+            f"happened. Got {result!r}."
+        )
+        assert result["drained"] is False


### PR DESCRIPTION
Closes CHAOS-3544 (Urgent). **PR1 of 2** — see "What lands in PR2" below; this one does not unblock the corpus case.

## The defect

An organisation on the 0-day retention tier has chosen **immediate deletion**. Two reachable shapes were retained **forever**:

- **zero runs** — `POST /conversations` is standalone, so a conversation exists the moment it is created; opened and abandoned before asking anything is ordinary use of an assistant panel.
- **a run that never terminates** — crash or cancellation.

Nothing could collect either: `create_conversation` stamped `NULL` for 0-day, the only 0-day stamp fired on run-terminal, `cleanup_expired` requires a non-null expiry, and the backfill required `has_a_run AND ~has_a_non_terminal_run` — excluding the first shape by one condition and the second by the other. `recover_stale_non_terminal_run` cannot rescue either: its own docstring says it fires "from the replay path itself… rather than a background sweep", so a crashed run nobody re-requests is never recovered.

## The promise change

> **0-day now means: deleted at completion, or after 1 hour with no activity if abandoned.** It previously meant: deleted at completion, **or never**.

The invariant is **idle-anchored**: an ephemeral conversation is never collectable until it has been idle for a full grace period. If a different grace is wanted it is one named constant.

## Two designs were rejected, both by watching them fail

**1. Stamping `now` at creation** — the literal reading of "stamp at creation" — is *worse than the defect*. `cleanup_expired` selects purely on `expires_at <= now` and has **no in-flight protection whatsoever**; it is safe today only because 0-day rows are never stamped before terminal. Measured against that implementation: `append_user_message_and_run` raises **`conversation not found`**, because the row is deleted before the first message can be appended. It converts "retained forever" into "destroyed while the user types".

**2. Anchoring the grace to creation** — my first working version, and a data-loss path found in review. Open a conversation, idle 55 minutes, then ask: the run is legitimately in flight, the expiry set at T0 falls due at T0+1h, and the live turn's conversation is deleted out from under it. My own in-flight test could not see it, because that test starts its run at creation with the whole grace still ahead. `_touch` now refreshes the expiry on every activity.

Both rejected designs have a test that kills them.

## Why one hour, derived rather than chosen

`DevRunLimits.wall_seconds` is 45 seconds (80×) and `_STALE_NON_TERMINAL_RUN_THRESHOLD` is 5 minutes (12×), the latter already documented as *"comfortably longer than any run that is still genuinely in flight could take"*. A test asserts the grace against **both bounds, imported from where they are defined**, so growing either past the grace fails loudly rather than silently reintroducing the purged-while-in-use mode.

A module constant, not config: a configurable grace invites being lowered back under the safety bound, and a floor for it would mean importing two other modules' constants and silently clamping an operator's value.

## The backfill predicate collapses

`has_a_run AND ~has_a_non_terminal_run` existed only to avoid stamping something in flight — and bought that by excluding **both** stranded shapes. Past the grace a live run is impossible by the same two bounds, so a single `updated_at < now - GRACE` predicate subsumes the pair while reaching strictly more.

## The sweep is now self-healing, and honest about it

The backfill's only caller was a `dev-hops maintenance` command. "The drain simply never happened" is the failure mode that let this stay invisible for the defect's entire life, so the daily beat tick now stamps before it purges.

That introduced a false-drained claim, which review caught: `count_expired` only counts **due** expiries and is structurally blind to stranded rows (`expires_at IS NULL`). With more stranded rows than `max_batches × limit` the task would report `completed` over an untouched backlog — the same failure CHAOS-3404 round 2 closed for the purge half, reintroduced through the repair half. Fixed with that half's own instrument: a new non-locking `count_stranded_ephemeral()`, and `drained` now requires a **verified** empty count rather than an inference from batch size. (My first attempt inferred it from a short batch, on the reasoning that `SKIP LOCKED` only skips rows another stamper holds — wrong, because that peer can roll back.)

## Two existing tests asserted the defect, and are rewritten under an explicit ruling

- `test_persistence.py` asserted a run-less 0-day conversation kept `expires_at IS NULL` **and still existed after a sweep**.
- `test_fixtures_world_generators.py` asserted the generator emits a NULL expiry.

Both encoded *"nothing to retire **yet**"* under the old stamp model, where a creation stamp did not exist. Neither was ever a decision to keep 0-day conversations forever — which is exactly what they had come to certify. Each rewrite states what the old assertion actually encoded. **Flagging prominently because from a diff these read as protections being deleted; they were reviewed and ruled.**

## A guard of mine was removed

I measured a real effect — a `_touch` after the terminal stamp moves a completed conversation's expiry 12:00 → 13:00 — and added a parameter to prevent it. Then I tried to exercise it through the real `append_assistant_answer` path and got `DevPersistenceNotFound`: once stamped the conversation is due, and every append resolves through `get_conversation`, which excludes expired rows. Two mechanisms already close it.

The guard protected an unreachable path and **could not be tested non-vacuously** — proven by mutating it and watching my own test stay green, because that test called `_touch` directly rather than the production path. Removed, and replaced by a test of the mechanism that actually does the work.

## What lands in PR2 (this PR does **not** unblock the corpus case)

The generator fix here is a **paired** fix — it writes `DevConversation` rows directly, never through `create_conversation`, so fixing the product alone would leave it emitting a shape production can no longer produce.

But the acceptance stack restores a **committed snapshot**, not live generator output, and that snapshot's `sibling` 0-day rows still carry `expires_at: None`. So the fixture half is **inert until the snapshot is re-minted**, and `pers.retention.0-day` stays blocked. PR2 carries the regenerated snapshot rows, the `WORLD_DIGEST` re-pin, and a unit guard for generator-vs-snapshot divergence — atomically, so the guard is green in-PR and the digest never disagrees with the snapshot across a merge boundary. The committed snapshot is untouched here, so the current digest pin and any pending armed run are unaffected.

## Verification

- Local gate **PASSED** — all 7 stages ✔, zero failures.
- `tests/api tests/workers tests/acceptance tests/models` → 5473 passed; only the 2 known `pytest.mark.clickhouse` graphql reds (gate deselects them).
- ruff clean, mypy clean.
- Mutations killed: literal stamp, grace→0, `<=`→`<`, sweep-without-backfill, `_touch` refresh removed, `drained` ignoring the stranded count.
- Codex adversarial review, 2 rounds, all findings reproduced before fixing.

The `transitional-inventory.json` row for `run_ask_dev_retention_cleanup` was re-anchored **three times** by this change (163→188→210→217) — same surface each time. A contract keyed to line numbers will do this to every edit in that file.
