### PR TITLE
CHAOS-3522: Valkey counters for the Ask Dev platform allowance

### DIFF
--- a/src/dev_health_ops/api/admin/routers/ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/ask_dev.py
@@ -10,7 +10,7 @@ from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
-from sqlalchemy import and_, case, func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.middleware import (
@@ -36,6 +36,7 @@ from dev_health_ops.api.dev.org_policy import (
 from dev_health_ops.api.dev.persistence.service import DevAdmissionLimits
 from dev_health_ops.api.dev.production_runtime import resolve_certification_provider
 from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+from dev_health_ops.api.services import askdev_allowance_counters
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.licensing import FeatureDecisionReason, evaluate_org_feature_async
@@ -324,13 +325,6 @@ class AskDevAdminUsageResponse(StrictAdminModel):
     platform_allowance: AskDevPlatformAllowanceUsage
 
 
-def _platform_month_window(now: datetime) -> tuple[datetime, datetime]:
-    start = datetime(now.year, now.month, 1, tzinfo=UTC)
-    if now.month == 12:
-        return start, datetime(now.year + 1, 1, 1, tzinfo=UTC)
-    return start, datetime(now.year, now.month + 1, 1, tzinfo=UTC)
-
-
 def _allowance_warning(*, used: int, limit: int) -> int:
     if used >= limit:
         return 3
@@ -348,35 +342,16 @@ async def _platform_allowance_usage(
     request_limit: int,
     cost_limit_microusd: int,
 ) -> AskDevPlatformAllowanceUsage:
-    window_start, reset_at = _platform_month_window(datetime.now(UTC))
-    terminal = {
-        "completed",
-        "insufficient_evidence",
-        "refused",
-        "failed",
-        "cancelled",
-    }
-    charged_cost = case(
-        (
-            and_(
-                DevRun.state.in_(terminal),
-                DevRun.estimated_cost_microusd.is_not(None),
-            ),
-            DevRun.estimated_cost_microusd,
-        ),
-        else_=ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+    # CHAOS-3522: reads the shared Valkey counters (self-healing from
+    # dev_runs on a cold key or Valkey outage) instead of re-scanning
+    # dev_runs on every admin usage read.
+    counts, window_start, reset_at = await askdev_allowance_counters.read_counts(
+        session,
+        org_id=org_id,
+        per_run_reservation_microusd=ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
     )
-    statement = select(
-        func.count(DevRun.id), func.coalesce(func.sum(charged_cost), 0)
-    ).where(
-        DevRun.org_id == uuid.UUID(org_id),
-        DevRun.provider_source == "platform",
-        DevRun.started_at >= window_start,
-        DevRun.started_at < reset_at,
-    )
-    request_used, cost_used = (await session.execute(statement)).one()
-    requests = int(request_used or 0)
-    cost = int(cost_used or 0)
+    requests = counts.requests
+    cost = counts.cost_microusd
     warning_rank = max(
         _allowance_warning(used=requests, limit=request_limit),
         _allowance_warning(used=cost, limit=cost_limit_microusd),

--- a/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
+++ b/src/dev_health_ops/api/admin/routers/platform_ask_dev.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from typing import Literal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import AwareDatetime, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,11 +22,13 @@ from dev_health_ops.api.admin.middleware import (
     block_impersonated_write,
     require_superuser,
 )
+from dev_health_ops.api.dev.org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
 from dev_health_ops.api.dev.production_runtime import (
     certify_platform_resolution,
     resolve_platform_certification_provider,
 )
 from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+from dev_health_ops.api.services import askdev_allowance_counters
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
@@ -269,3 +272,60 @@ async def run_platform_ask_dev_readiness(
         return await _platform_readiness_response(session)
     await certify_platform_resolution(session, resolution)
     return await _platform_readiness_response(session)
+
+
+class PlatformAskDevAllowanceReconcileResponse(StrictAdminModel):
+    schema_version: Literal["platform_ask_dev_allowance_reconcile.v1"] = (
+        "platform_ask_dev_allowance_reconcile.v1"
+    )
+    org_id: str
+    window_start: AwareDatetime
+    reset_at: AwareDatetime
+    request_used: int = Field(ge=0)
+    cost_used_microusd: int = Field(ge=0)
+
+
+@router.post(
+    "/platform/ask-dev/organizations/{org_id}/platform-allowance/reconcile",
+    response_model=PlatformAskDevAllowanceReconcileResponse,
+)
+async def reconcile_platform_allowance(
+    org_id: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(require_superuser),
+) -> PlatformAskDevAllowanceReconcileResponse:
+    """The operator escape hatch (CHAOS-3522): force-recompute one org's
+    platform allowance counter straight from ``dev_runs`` and overwrite
+    whatever the Valkey counter currently holds.
+
+    This is the origin of the ticket -- resetting a local/dev org's monthly
+    allowance today needs literal SQL surgery on ``dev_runs``. With a
+    counter, "reset" is safely just "recompute from the source of truth and
+    replace the cache of it", which is what this does: it never mutates
+    ``dev_runs`` itself, only Valkey's cached view of it. Deliberately
+    superuser-only and platform-scoped (not on the org-admin ``/admin/
+    ask-dev`` surface) -- an org admin resetting their own org's spend cap
+    enforcement would defeat the cap it exists to enforce.
+    """
+
+    block_impersonated_write(
+        current_user,
+        detail="Platform Ask Dev administrative actions are unavailable while impersonating",
+    )
+    try:
+        uuid.UUID(org_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="org_id must be a UUID") from exc
+
+    counts, window_start, reset_at = await askdev_allowance_counters.force_reconcile(
+        session,
+        org_id=org_id,
+        per_run_reservation_microusd=ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+    )
+    return PlatformAskDevAllowanceReconcileResponse(
+        org_id=org_id,
+        window_start=window_start,
+        reset_at=reset_at,
+        request_used=counts.requests,
+        cost_used_microusd=counts.cost_microusd,
+    )

--- a/src/dev_health_ops/api/dev/org_policy.py
+++ b/src/dev_health_ops/api/dev/org_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Literal
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
@@ -22,6 +23,23 @@ PLATFORM_MONTHLY_COST_LIMIT_MIN_MICROUSD = 10_000_000
 PLATFORM_MONTHLY_COST_LIMIT_DEFAULT_MICROUSD = 100_000_000
 PLATFORM_MONTHLY_COST_LIMIT_HARD_MAX_MICROUSD = 500_000_000
 ASK_DEV_RUN_COST_HARD_MAX_MICROUSD = 5_000_000
+
+#: The one definition of "this dev_run is finished". Previously duplicated
+#: (persistence/service.py's own ``_TERMINAL_RUN_STATES``, and a third bare
+#: literal inline in ask_dev.py's platform-allowance query) -- the same class
+#: of "two implementations of the same fact" as platform_month_window()
+#: above. persistence/service.py keeps a private ``_TERMINAL_RUN_STATES``
+#: alias importing this, for its own existing call sites and the test that
+#: names it directly.
+TERMINAL_RUN_STATES: frozenset[str] = frozenset(
+    {
+        "completed",
+        "insufficient_evidence",
+        "refused",
+        "failed",
+        "cancelled",
+    }
+)
 
 
 def _bounded_operator_limit(
@@ -51,6 +69,27 @@ def platform_operator_cost_limit_microusd() -> int:
         minimum=PLATFORM_MONTHLY_COST_LIMIT_MIN_MICROUSD,
         hard_maximum=PLATFORM_MONTHLY_COST_LIMIT_HARD_MAX_MICROUSD,
     )
+
+
+def platform_month_window(now: datetime) -> tuple[datetime, datetime]:
+    """The calendar-month-UTC window platform allowance is billed against.
+
+    CHAOS-3522: this is the ONE definition. Before, ``ask_dev.py``'s admin
+    usage read and ``persistence/service.py``'s admission enforcement each
+    hand-rolled their own copy of "start of this UTC month" / "start of next
+    UTC month" -- two implementations of "this month" that happened to agree
+    only because nobody had touched either in a while. The Valkey allowance
+    counter key (``askdev:allowance:{org_id}:{YYYY-MM}``) and its TTL are
+    also derived from this function, so a key an admission writes and a key
+    a read or the SQL fallback computes are always the same key by
+    construction, never by two authors independently getting the same
+    calendar math right.
+    """
+
+    start = datetime(now.year, now.month, 1, tzinfo=UTC)
+    if now.month == 12:
+        return start, datetime(now.year + 1, 1, 1, tzinfo=UTC)
+    return start, datetime(now.year, now.month + 1, 1, tzinfo=UTC)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -1861,6 +1861,15 @@ class DevPersistenceService:
                     raise DevPersistenceValidationError(
                         "platform allowance requires a platform provider source"
                     )
+                # CHAOS-3522 ORDERING INVARIANT (also stated in
+                # askdev_allowance_counters.admit and _ensure_initialized):
+                # this call, and its own Valkey reservation, MUST complete
+                # before the DevRun row below is inserted. A cold-key
+                # baseline recompute reads dev_runs live -- if this run's
+                # row had already landed, a concurrent recompute for the
+                # same org could double-count it (once from the SQL scan,
+                # once from this call's own increment). Do not reorder this
+                # block after the DevRun/DevMessage construction below.
                 await self._enforce_platform_allowance(
                     org_id=org_id,
                     allowance=platform_allowance,

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, TypeAlias
 
 from pydantic import ValidationError as PydanticValidationError
-from sqlalchemy import and_, case, event, func, or_, select
+from sqlalchemy import and_, event, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -35,7 +35,12 @@ from dev_health_ops.api.dev.contracts_v2.narrative import (
 from dev_health_ops.api.dev.contracts_v2.subject import (
     DevResolutionEntry as DevResolutionEntryContract,
 )
-from dev_health_ops.api.dev.org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
+from dev_health_ops.api.dev.org_policy import (
+    ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+    TERMINAL_RUN_STATES,
+    platform_month_window,
+)
+from dev_health_ops.api.services import askdev_allowance_counters
 from dev_health_ops.models.dev_persistence import (
     DEV_RETENTION_DAYS,
     DevAnswerFrame,
@@ -156,15 +161,13 @@ def _wire_visible_message_condition():
 #: collected on the next tick, unchanged.
 EPHEMERAL_ABANDONED_GRACE = timedelta(hours=1)
 
-_TERMINAL_RUN_STATES = frozenset(
-    {
-        "completed",
-        "insufficient_evidence",
-        "refused",
-        "failed",
-        "cancelled",
-    }
-)
+#: Alias of org_policy.TERMINAL_RUN_STATES, kept private-named here for this
+#: module's own existing call sites and tests/api/dev/test_chaos_3292_run_
+#: states.py, which names it directly. The canonical definition lives in
+#: org_policy.py so ask_dev.py and askdev_allowance_counters.py can share it
+#: without importing this module (and risking a cycle: this module imports
+#: askdev_allowance_counters, which must not import back).
+_TERMINAL_RUN_STATES = TERMINAL_RUN_STATES
 _RUN_STATES = _TERMINAL_RUN_STATES | frozenset(
     {
         "accepted",
@@ -2396,6 +2399,24 @@ class DevPersistenceService:
         run.narrative_failure_code = safe_narrative_failure_code
         if state in _TERMINAL_RUN_STATES:
             run.ended_at = self._now()
+            # CHAOS-3522: reconcile the Valkey allowance counter's worst-case
+            # reservation down (or up) to the real cost. Placed HERE -- past
+            # the early "already terminal" return above, inside the mutate
+            # block that only runs on a genuine NEW terminal transition -- so
+            # this fires exactly once per run, structurally, not because a
+            # caller happens to be well-behaved (see
+            # test_persistence_v2.py's contract test, which drives this
+            # transition twice through the real path and asserts a single
+            # reconcile).
+            await askdev_allowance_counters.reconcile_terminal_cost(
+                self.session,
+                org_id=str(org_id),
+                provider_source=run.provider_source,
+                state=state,
+                estimated_cost_microusd=estimated_cost_microusd,
+                per_run_reservation_microusd=ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+                now=self._now(),
+            )
         await self.session.flush()
 
         ephemeral_conversation = None
@@ -3934,35 +3955,23 @@ class DevPersistenceService:
         org_id: uuid.UUID,
         allowance: DevPlatformAllowance,
     ) -> None:
+        # CHAOS-3522: reservation + limit check now goes through the shared
+        # Valkey counters (askdev_allowance_counters.admit), not a fresh
+        # dev_runs aggregate scan every admission. reset_at is still needed
+        # here only to shape the raised exceptions the same as before.
         now = self._now()
-        window_start = datetime(now.year, now.month, 1, tzinfo=UTC)
-        if now.month == 12:
-            reset_at = datetime(now.year + 1, 1, 1, tzinfo=UTC)
-        else:
-            reset_at = datetime(now.year, now.month + 1, 1, tzinfo=UTC)
-        terminal_with_cost = and_(
-            DevRun.state.in_(_TERMINAL_RUN_STATES),
-            DevRun.estimated_cost_microusd.is_not(None),
+        _window_start, reset_at = platform_month_window(now)
+        outcome = await askdev_allowance_counters.admit(
+            self.session,
+            org_id=str(org_id),
+            request_limit=allowance.monthly_request_limit,
+            cost_limit_microusd=allowance.monthly_cost_limit_microusd,
+            per_run_reservation_microusd=allowance.per_run_reservation_microusd,
+            now=now,
         )
-        charged_cost = case(
-            (terminal_with_cost, DevRun.estimated_cost_microusd),
-            else_=allowance.per_run_reservation_microusd,
-        )
-        statement = select(
-            func.count(DevRun.id), func.coalesce(func.sum(charged_cost), 0)
-        ).where(
-            DevRun.org_id == org_id,
-            DevRun.provider_source == "platform",
-            DevRun.started_at >= window_start,
-            DevRun.started_at < reset_at,
-        )
-        request_count, charged_microusd = (await self.session.execute(statement)).one()
-        if int(request_count or 0) >= allowance.monthly_request_limit:
+        if outcome is askdev_allowance_counters.AdmitOutcome.REQUEST_LIMIT_EXCEEDED:
             raise DevMonthlyRequestLimitExceeded(reset_at)
-        if (
-            int(charged_microusd or 0) + allowance.per_run_reservation_microusd
-            > allowance.monthly_cost_limit_microusd
-        ):
+        if outcome is askdev_allowance_counters.AdmitOutcome.COST_LIMIT_EXCEEDED:
             raise DevMonthlyCostLimitExceeded(reset_at)
 
     async def _message_run_by_client_id(

--- a/src/dev_health_ops/api/services/askdev_allowance_counters.py
+++ b/src/dev_health_ops/api/services/askdev_allowance_counters.py
@@ -33,6 +33,20 @@ own compensating HINCRBY lands -- self-correcting within microseconds, and
 the failure direction is conservative (a spurious reject under heavy
 contention at the exact boundary, never a spurious admit).
 
+KNOWN LIMITATION, stated rather than left for an operator to discover
+(CHAOS-3522 review round 2): admit()'s compensation is two sequential
+Valkey commands (the speculative HINCRBY, then the compensating HINCRBY on
+rejection), not one atomic step. A process crash or network partition
+between them -- not an ordinary Valkey error, which the try/except here
+already catches and compensates for -- leaves the counter with a permanent
+CONSERVATIVE overcount: never an undercount, so it can only ever cause a
+spurious future rejection, not a spurious admit. Rare (it requires the
+process to die mid-function, not merely a request to fail), but not
+impossible, and the counter does not self-heal it -- the remedy is the
+explicit operator reconcile (POST .../platform-allowance/reconcile,
+force_reconcile() below), which recomputes from dev_runs and overwrites
+whatever drift accumulated.
+
 FAILURE POLICY mirrors impersonation_cache.py: fail-correct, not fail-stale.
 A Valkey error trips a short circuit breaker; while it is open, every
 operation computes straight from ``dev_runs`` and does not attempt to write
@@ -208,30 +222,46 @@ async def _ensure_initialized(
     ttl_seconds: int,
     baseline: AllowanceCounts,
 ) -> None:
-    """Create the hash with a recomputed baseline iff nobody has yet.
+    """Create the hash with a recomputed baseline iff nobody has yet -- PER
+    FIELD, not via a single sentinel field gating a later ``HSET``.
 
     Amendment 1: two concurrent first-of-month callers both miss the key and
-    both recompute a baseline from ``dev_runs``; a blind ``HSET`` from
+    both recompute a baseline from ``dev_runs``. A blind ``HSET`` from
     whichever one runs second would silently overwrite increments the first
-    one's caller already applied in between. ``HSETNX`` on a sentinel field
-    is a single atomic Valkey command -- exactly one caller ever observes
-    "I did not already exist" and is the one that writes ``requests`` /
-    ``cost_microusd``. Every other racer's (possibly different, possibly
-    staler) recomputed baseline is silently discarded, which is correct: the
-    winner's baseline is an equally valid recomputation of the same ground
-    truth, captured a moment earlier.
+    one's caller already applied in between -- the exact race this function
+    exists to kill.
+
+    A single ``HSETNX(key, "initialized", "1")`` sentinel gating a
+    SEPARATE, later ``HSET`` of the real fields does NOT close that race: the
+    sentinel write and the baseline ``HSET`` are two distinct round trips, so
+    a THIRD caller (an ordinary admit, not another initializer) can observe
+    the key "exist" (the sentinel field landed) before ``requests`` /
+    ``cost_microusd`` do, race ahead with its own ``HINCRBY`` (which
+    auto-vivifies the missing field at 0 + its own delta), and then lose that
+    increment entirely the moment the sentinel-winner's baseline ``HSET``
+    lands and overwrites the field outright. This was CHAOS-3522 review
+    round 2's finding against the first version of this function.
+
+    ``HSETNX`` directly on ``requests`` and ``cost_microusd`` has no such
+    window: each field is independently atomic from the instant it exists,
+    whichever write reaches it first -- a losing initializer's no-op, or a
+    concurrent ``HINCRBY`` auto-vivifying it. There is no state in which the
+    key "partially exists" from an outside caller's perspective in a way
+    that can be raced.
+
+    ORDERING INVARIANT this correctness depends on (also stated at every
+    call site: admit() here, and append_user_message_and_run in
+    persistence/service.py): a request's own init-if-absent AND its own
+    admit HINCRBY must both complete BEFORE its DevRun row is inserted into
+    Postgres. If a row landed first, a concurrent caller's baseline
+    recompute (a live query over dev_runs) could already include that row,
+    and the original request's own increment would ALSO count it -- a
+    double count no amount of Valkey-side atomicity can prevent, because it
+    is an ordering problem between two different stores, not a Valkey race.
     """
 
-    won = await client.hsetnx(key, "initialized", "1")
-    if not won:
-        return
-    await client.hset(
-        key,
-        mapping={
-            "requests": baseline.requests,
-            "cost_microusd": baseline.cost_microusd,
-        },
-    )
+    await client.hsetnx(key, "requests", baseline.requests)
+    await client.hsetnx(key, "cost_microusd", baseline.cost_microusd)
     await client.expire(key, ttl_seconds)
 
 
@@ -261,6 +291,16 @@ async def admit(
 
       reject (request) iff existing_requests >= request_limit
       reject (cost)    iff existing_cost + reservation > cost_limit
+
+    ORDERING INVARIANT the caller must uphold (also stated in
+    _ensure_initialized and at the call site in
+    persistence/service.py.append_user_message_and_run): this function must
+    run, and its outcome be honoured, BEFORE the corresponding DevRun row is
+    inserted into Postgres. A cold-key recompute here reads dev_runs live --
+    if the caller's own row had already landed, a concurrent cold-key
+    recompute for the SAME org could double-count it (once from the SQL
+    scan, once from this call's own increment). Admission-before-insert is
+    what keeps every baseline recompute a valid prefix of the real history.
     """
 
     now = now or datetime.now(UTC)
@@ -304,11 +344,10 @@ async def admit(
                 mapping={
                     "requests": baseline.requests,
                     "cost_microusd": baseline.cost_microusd,
-                    "initialized": "1",
                 },
             )
             await client.expire(key, _ttl_seconds(reset_at, now))
-        elif not await client.exists(key):
+        elif await _read_hash(client, key) is None:
             baseline = await _recompute_from_dev_runs(
                 session,
                 org_id=org_id,
@@ -501,7 +540,6 @@ async def read_counts(
                 mapping={
                     "requests": baseline.requests,
                     "cost_microusd": baseline.cost_microusd,
-                    "initialized": "1",
                 },
             )
             await client.expire(key, _ttl_seconds(reset_at, now))
@@ -580,7 +618,6 @@ async def force_reconcile(
             mapping={
                 "requests": counts.requests,
                 "cost_microusd": counts.cost_microusd,
-                "initialized": "1",
             },
         )
         await client.expire(key, _ttl_seconds(reset_at, now))

--- a/src/dev_health_ops/api/services/askdev_allowance_counters.py
+++ b/src/dev_health_ops/api/services/askdev_allowance_counters.py
@@ -1,0 +1,593 @@
+"""Valkey-backed counters for the Ask Dev platform monthly allowance (CHAOS-3522).
+
+WHY. ``dev_runs`` used to be re-scanned (``count() + sum(case ...)``) on
+every single admission check AND every admin usage read, for the whole
+current-month window. The window only grows over the month, so this was a
+constant, ever-growing aggregate query for what is really just two counters
+per org per month. Counters belong in Valkey, the same way the impersonation
+cache (``impersonation_cache.py``) and slowapi's own rate-limit buckets
+(``middleware/rate_limit.py``) already keep shared, cross-replica state
+there instead of re-deriving it from Postgres on every request.
+
+``dev_runs`` remains the single source of truth. The counter is a cache of
+an aggregate over it, kept current by two write points (admission reserves
+worst-case; finalization reconciles down/up to the real cost) and healed
+from ``dev_runs`` whenever it might be wrong (cold key, Valkey outage
+recovery, or an explicit operator reconcile).
+
+NO LUA. The original design used a Lua ``EVAL`` script for atomic
+check-and-increment. Verified directly: this repo's ``fakeredis`` supports
+no ``EVAL`` at all (sync or async client), the same gap
+``tests/test_token_pool.py`` already works around with a
+``_fakeredis_supports_lua()`` probe, and CI provisions no live Valkey
+service for the unit tier -- a Lua-based admit would be permanently
+skip-gated in CI, never actually exercised. Every atomic step here instead
+uses a single Valkey command (``HINCRBY``, ``HSETNX``), each atomic on its
+own, composed with explicit compensation on the reject path. Algebraically
+this produces the identical accept/reject boundary as the old SQL query:
+``new_requests > limit`` iff ``existing_requests >= limit``, and
+``new_cost > limit`` iff ``existing_cost + reservation > limit`` (the exact
+SQL predicates). The only cost is a narrow window where a concurrent
+rejected admission could transiently inflate the visible count before its
+own compensating HINCRBY lands -- self-correcting within microseconds, and
+the failure direction is conservative (a spurious reject under heavy
+contention at the exact boundary, never a spurious admit).
+
+FAILURE POLICY mirrors impersonation_cache.py: fail-correct, not fail-stale.
+A Valkey error trips a short circuit breaker; while it is open, every
+operation computes straight from ``dev_runs`` and does not attempt to write
+the counter (there is nothing trustworthy to write into). The first
+operation after the breaker closes forces one recompute-from-``dev_runs``
+for whichever org happens to touch it first, before resuming counter mode
+for that org -- STATED LIMITATION: this clears staleness for that one org
+in THIS process only; other orgs, and other processes that had their own
+open breaker, remain on their own stale counter (undercounting, which for
+a cost cap is over-admission risk) until their own next cold-key heal, their
+own first post-recovery touch, or an explicit operator reconcile. There is
+no cross-process signal that "the outage is over, everyone should recompute
+now" -- only a per-process, per-org, first-touch trigger.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import and_, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.dev.org_policy import TERMINAL_RUN_STATES, platform_month_window
+from dev_health_ops.models.dev_persistence import DevRun
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "askdev:allowance:"
+
+# Grace past reset_at before the key's TTL lapses -- generous so a slow
+# clock, a delayed sweep, or an org that touches the boundary right at
+# month-end never loses its own-month data early. The NEXT month gets its
+# own, separate key regardless (the suffix embeds YYYY-MM), so this is not
+# "how long until reset" -- it is "how long an abandoned key survives".
+_TTL_GRACE_SECONDS = 5 * 24 * 3600
+
+# Circuit breaker: after a Valkey error, skip the counter store for a short
+# window instead of paying a connect timeout on every request.
+_CIRCUIT_SECONDS = 5.0
+_circuit_open_until = 0.0
+
+# Amendment 3: set whenever the breaker trips: the next successful operation
+# for ANY org must force a recompute-from-dev_runs for THAT org before
+# trusting the counter, since admissions during the outage went through the
+# SQL-only fallback and never touched Valkey. Consumed (cleared) by that one
+# operation -- see module docstring for the stated cross-org/cross-process
+# limitation.
+_needs_recovery_recompute = False
+
+_client: Any | None = None
+
+
+class AdmitOutcome(Enum):
+    ADMITTED = "admitted"
+    REQUEST_LIMIT_EXCEEDED = "request_limit_exceeded"
+    COST_LIMIT_EXCEEDED = "cost_limit_exceeded"
+
+
+@dataclass(frozen=True, slots=True)
+class AllowanceCounts:
+    requests: int
+    cost_microusd: int
+
+
+def _key(org_id: str, window_start: datetime) -> str:
+    # CHAOS-3522 amendment 4: the suffix is derived from the SAME
+    # platform_month_window() the SQL fallback and the admin read both call
+    # -- never an independently formatted "%Y-%m" that could silently
+    # diverge if the window function ever stops being calendar-month-UTC.
+    return f"{_KEY_PREFIX}{org_id}:{window_start.year:04d}-{window_start.month:02d}"
+
+
+def _ttl_seconds(reset_at: datetime, now: datetime) -> int:
+    remaining = (reset_at - now).total_seconds() + _TTL_GRACE_SECONDS
+    return max(1, int(remaining))
+
+
+def _get_client() -> Any | None:
+    """Lazily create the shared Valkey client; None when unconfigured."""
+    global _client
+    if _client is not None:
+        return _client
+    redis_url = os.getenv("REDIS_URL", "")
+    if not redis_url:
+        return None
+    import valkey.asyncio as aioredis
+
+    _client = aioredis.from_url(
+        redis_url,
+        socket_connect_timeout=0.5,
+        socket_timeout=0.5,
+    )
+    return _client
+
+
+def _circuit_is_open() -> bool:
+    return time.monotonic() < _circuit_open_until
+
+
+def _trip_circuit(exc: Exception) -> None:
+    global _circuit_open_until, _needs_recovery_recompute
+    _circuit_open_until = time.monotonic() + _CIRCUIT_SECONDS
+    _needs_recovery_recompute = True
+    logger.warning(
+        "Valkey ask-dev allowance counters unavailable, bypassing for %.0fs: %s",
+        _CIRCUIT_SECONDS,
+        exc,
+    )
+
+
+def _consume_recovery_recompute() -> bool:
+    """True exactly once per trip -> recover cycle; False otherwise."""
+    global _needs_recovery_recompute
+    if _needs_recovery_recompute:
+        _needs_recovery_recompute = False
+        return True
+    return False
+
+
+async def _recompute_from_dev_runs(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    window_start: datetime,
+    reset_at: datetime,
+    per_run_reservation_microusd: int,
+) -> AllowanceCounts:
+    """The single aggregate query over ``dev_runs`` -- ground truth.
+
+    Used for the Valkey-down fallback, lazy cold-key init, breaker-recovery
+    recompute, and the explicit operator reconcile. One definition, so the
+    "what counts as charged" logic (terminal + has a real cost -> the real
+    cost; anything else -> the worst-case reservation) cannot drift between
+    call sites the way it had before this module existed (ask_dev.py and
+    persistence/service.py each had their own copy).
+    """
+
+    charged_cost = case(
+        (
+            and_(
+                DevRun.state.in_(TERMINAL_RUN_STATES),
+                DevRun.estimated_cost_microusd.is_not(None),
+            ),
+            DevRun.estimated_cost_microusd,
+        ),
+        else_=per_run_reservation_microusd,
+    )
+    statement = select(
+        func.count(DevRun.id), func.coalesce(func.sum(charged_cost), 0)
+    ).where(
+        DevRun.org_id == uuid.UUID(org_id),
+        DevRun.provider_source == "platform",
+        DevRun.started_at >= window_start,
+        DevRun.started_at < reset_at,
+    )
+    request_used, cost_used = (await session.execute(statement)).one()
+    return AllowanceCounts(
+        requests=int(request_used or 0), cost_microusd=int(cost_used or 0)
+    )
+
+
+async def _ensure_initialized(
+    client: Any,
+    *,
+    key: str,
+    ttl_seconds: int,
+    baseline: AllowanceCounts,
+) -> None:
+    """Create the hash with a recomputed baseline iff nobody has yet.
+
+    Amendment 1: two concurrent first-of-month callers both miss the key and
+    both recompute a baseline from ``dev_runs``; a blind ``HSET`` from
+    whichever one runs second would silently overwrite increments the first
+    one's caller already applied in between. ``HSETNX`` on a sentinel field
+    is a single atomic Valkey command -- exactly one caller ever observes
+    "I did not already exist" and is the one that writes ``requests`` /
+    ``cost_microusd``. Every other racer's (possibly different, possibly
+    staler) recomputed baseline is silently discarded, which is correct: the
+    winner's baseline is an equally valid recomputation of the same ground
+    truth, captured a moment earlier.
+    """
+
+    won = await client.hsetnx(key, "initialized", "1")
+    if not won:
+        return
+    await client.hset(
+        key,
+        mapping={
+            "requests": baseline.requests,
+            "cost_microusd": baseline.cost_microusd,
+        },
+    )
+    await client.expire(key, ttl_seconds)
+
+
+async def _read_hash(client: Any, key: str) -> AllowanceCounts | None:
+    values = await client.hmget(key, ["requests", "cost_microusd"])
+    requests_raw, cost_raw = values
+    if requests_raw is None or cost_raw is None:
+        return None
+    return AllowanceCounts(requests=int(requests_raw), cost_microusd=int(cost_raw))
+
+
+async def admit(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    request_limit: int,
+    cost_limit_microusd: int,
+    per_run_reservation_microusd: int,
+    now: datetime | None = None,
+) -> AdmitOutcome:
+    """Reserve one request + the worst-case cost, or refuse.
+
+    Semantics are pinned exactly to the SQL version this replaces (order
+    matters: a request-limit rejection is reported even when the cost limit
+    is ALSO exceeded, matching persistence/service.py's original check
+    order):
+
+      reject (request) iff existing_requests >= request_limit
+      reject (cost)    iff existing_cost + reservation > cost_limit
+    """
+
+    now = now or datetime.now(UTC)
+    window_start, reset_at = platform_month_window(now)
+
+    if _circuit_is_open():
+        return await _admit_via_sql_only(
+            session,
+            org_id=org_id,
+            window_start=window_start,
+            reset_at=reset_at,
+            request_limit=request_limit,
+            cost_limit_microusd=cost_limit_microusd,
+            per_run_reservation_microusd=per_run_reservation_microusd,
+        )
+
+    client = _get_client()
+    if client is None:
+        return await _admit_via_sql_only(
+            session,
+            org_id=org_id,
+            window_start=window_start,
+            reset_at=reset_at,
+            request_limit=request_limit,
+            cost_limit_microusd=cost_limit_microusd,
+            per_run_reservation_microusd=per_run_reservation_microusd,
+        )
+
+    key = _key(org_id, window_start)
+    try:
+        if _consume_recovery_recompute():
+            baseline = await _recompute_from_dev_runs(
+                session,
+                org_id=org_id,
+                window_start=window_start,
+                reset_at=reset_at,
+                per_run_reservation_microusd=per_run_reservation_microusd,
+            )
+            await client.hset(
+                key,
+                mapping={
+                    "requests": baseline.requests,
+                    "cost_microusd": baseline.cost_microusd,
+                    "initialized": "1",
+                },
+            )
+            await client.expire(key, _ttl_seconds(reset_at, now))
+        elif not await client.exists(key):
+            baseline = await _recompute_from_dev_runs(
+                session,
+                org_id=org_id,
+                window_start=window_start,
+                reset_at=reset_at,
+                per_run_reservation_microusd=per_run_reservation_microusd,
+            )
+            await _ensure_initialized(
+                client,
+                key=key,
+                ttl_seconds=_ttl_seconds(reset_at, now),
+                baseline=baseline,
+            )
+
+        new_requests = int(await client.hincrby(key, "requests", 1))
+        if new_requests > request_limit:
+            await client.hincrby(key, "requests", -1)
+            return AdmitOutcome.REQUEST_LIMIT_EXCEEDED
+
+        new_cost = int(
+            await client.hincrby(key, "cost_microusd", per_run_reservation_microusd)
+        )
+        if new_cost > cost_limit_microusd:
+            await client.hincrby(key, "cost_microusd", -per_run_reservation_microusd)
+            await client.hincrby(key, "requests", -1)
+            return AdmitOutcome.COST_LIMIT_EXCEEDED
+
+        return AdmitOutcome.ADMITTED
+    except Exception as exc:  # noqa: BLE001 - fail-correct: fall back to SQL
+        _trip_circuit(exc)
+        return await _admit_via_sql_only(
+            session,
+            org_id=org_id,
+            window_start=window_start,
+            reset_at=reset_at,
+            request_limit=request_limit,
+            cost_limit_microusd=cost_limit_microusd,
+            per_run_reservation_microusd=per_run_reservation_microusd,
+        )
+
+
+async def _admit_via_sql_only(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    window_start: datetime,
+    reset_at: datetime,
+    request_limit: int,
+    cost_limit_microusd: int,
+    per_run_reservation_microusd: int,
+) -> AdmitOutcome:
+    """The original query, unmodified in spirit: read-only, no Valkey write.
+
+    Used whenever the counter store cannot be trusted right now (breaker
+    open, unconfigured). Does not attempt to reserve into Valkey -- there is
+    nothing there to correctly reserve into. This is intentionally the exact
+    same admit/reject arithmetic as the counter path so a Valkey outage does
+    not change enforcement, only where the read comes from.
+    """
+
+    counts = await _recompute_from_dev_runs(
+        session,
+        org_id=org_id,
+        window_start=window_start,
+        reset_at=reset_at,
+        per_run_reservation_microusd=per_run_reservation_microusd,
+    )
+    if counts.requests >= request_limit:
+        return AdmitOutcome.REQUEST_LIMIT_EXCEEDED
+    if counts.cost_microusd + per_run_reservation_microusd > cost_limit_microusd:
+        return AdmitOutcome.COST_LIMIT_EXCEEDED
+    return AdmitOutcome.ADMITTED
+
+
+async def reconcile_terminal_cost(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    provider_source: str | None,
+    state: str,
+    estimated_cost_microusd: int | None,
+    per_run_reservation_microusd: int,
+    now: datetime | None = None,
+) -> None:
+    """Adjust the reserved worst-case down (or up) to the real cost.
+
+    Called exactly once per run, from the SAME code path in
+    ``update_run`` that performs the actual terminal-state mutation --
+    never from the early-return branch that answers a repeat call on an
+    already-terminal run unmutated. That placement, not an assumption about
+    caller behaviour, is what makes this exactly-once (see
+    test_persistence_v2.py's contract test driving a terminal transition
+    twice through the real path).
+
+    A no-op when there is no real cost to reconcile with (provider is not
+    "platform", the state is not terminal, or ``estimated_cost_microusd`` is
+    None -- the defensive terminal-without-cost path). Per CHAOS-3522(b):
+    the reservation stays pinned at worst-case in that last case, matching
+    the existing ``test_platform_monthly_allowance_reserves_unknown_cost_
+    fail_closed`` contract -- deliberate fail-closed, not something this
+    ticket revises.
+    """
+
+    if provider_source != "platform" or state not in TERMINAL_RUN_STATES:
+        return
+    if estimated_cost_microusd is None:
+        return
+
+    now = now or datetime.now(UTC)
+    window_start, _reset_at = platform_month_window(now)
+    delta = estimated_cost_microusd - per_run_reservation_microusd
+    if delta == 0:
+        return
+
+    client = _get_client()
+    if client is None or _circuit_is_open():
+        return
+
+    key = _key(org_id, window_start)
+    try:
+        if not await client.exists(key):
+            # Nothing to reconcile against -- the admission that reserved
+            # this run's worst-case either predates this module or was
+            # itself served purely via SQL fallback and never touched
+            # Valkey. Do not fabricate a baseline here: a recompute at
+            # finalize time races the very admission this run's own request
+            # made, double counting is possible. The next lazy heal or
+            # operator reconcile is the correct place to fix this, not here.
+            logger.warning(
+                "askdev allowance counter missing at finalize for org=%s key=%s; "
+                "skipping reconcile (will heal on next cold-key read/admit or "
+                "explicit reconcile)",
+                org_id,
+                key,
+            )
+            return
+        await client.hincrby(key, "cost_microusd", delta)
+    except Exception as exc:  # noqa: BLE001 - never block a run's terminal write
+        _trip_circuit(exc)
+        logger.warning(
+            "askdev allowance counter reconcile failed for org=%s: %s", org_id, exc
+        )
+
+
+async def read_counts(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    per_run_reservation_microusd: int,
+    now: datetime | None = None,
+) -> tuple[AllowanceCounts, datetime, datetime]:
+    """Read-only counts for the admin usage surface. Returns (counts, window_start, reset_at)."""
+
+    now = now or datetime.now(UTC)
+    window_start, reset_at = platform_month_window(now)
+
+    if _circuit_is_open():
+        counts = await _recompute_from_dev_runs(
+            session,
+            org_id=org_id,
+            window_start=window_start,
+            reset_at=reset_at,
+            per_run_reservation_microusd=per_run_reservation_microusd,
+        )
+        return counts, window_start, reset_at
+
+    client = _get_client()
+    if client is None:
+        counts = await _recompute_from_dev_runs(
+            session,
+            org_id=org_id,
+            window_start=window_start,
+            reset_at=reset_at,
+            per_run_reservation_microusd=per_run_reservation_microusd,
+        )
+        return counts, window_start, reset_at
+
+    key = _key(org_id, window_start)
+    try:
+        if _consume_recovery_recompute():
+            baseline = await _recompute_from_dev_runs(
+                session,
+                org_id=org_id,
+                window_start=window_start,
+                reset_at=reset_at,
+                per_run_reservation_microusd=per_run_reservation_microusd,
+            )
+            await client.hset(
+                key,
+                mapping={
+                    "requests": baseline.requests,
+                    "cost_microusd": baseline.cost_microusd,
+                    "initialized": "1",
+                },
+            )
+            await client.expire(key, _ttl_seconds(reset_at, now))
+            return baseline, window_start, reset_at
+
+        cached = await _read_hash(client, key)
+        if cached is not None:
+            return cached, window_start, reset_at
+
+        baseline = await _recompute_from_dev_runs(
+            session,
+            org_id=org_id,
+            window_start=window_start,
+            reset_at=reset_at,
+            per_run_reservation_microusd=per_run_reservation_microusd,
+        )
+        await _ensure_initialized(
+            client, key=key, ttl_seconds=_ttl_seconds(reset_at, now), baseline=baseline
+        )
+        # Read back rather than trust `baseline`: a concurrent racer may have
+        # won _ensure_initialized and already incremented past it.
+        cached = await _read_hash(client, key)
+        return (cached or baseline), window_start, reset_at
+    except Exception as exc:  # noqa: BLE001 - fail-correct: fall back to SQL
+        _trip_circuit(exc)
+        counts = await _recompute_from_dev_runs(
+            session,
+            org_id=org_id,
+            window_start=window_start,
+            reset_at=reset_at,
+            per_run_reservation_microusd=per_run_reservation_microusd,
+        )
+        return counts, window_start, reset_at
+
+
+async def force_reconcile(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    per_run_reservation_microusd: int,
+    now: datetime | None = None,
+) -> tuple[AllowanceCounts, datetime, datetime]:
+    """Unconditionally recompute from ``dev_runs`` and overwrite the counter.
+
+    The explicit operator escape hatch (CHAOS-3522, origin of the ticket:
+    resetting a local/dev org's allowance today needs literal SQL surgery on
+    ``dev_runs``). Deliberately bypasses the HSETNX race guard -- this is a
+    single, intentional administrative action, not a concurrent lazy heal,
+    and it is allowed to clobber whatever the counter currently holds
+    because ``dev_runs`` is the source of truth being asked for directly.
+
+    Does not raise on a Valkey error -- if the write fails, the recomputed
+    value is still returned (accurate as of `now`) even though it was not
+    persisted to the cache; the caller/response should surface that the
+    counter is thereby stale until it next heals.
+    """
+
+    now = now or datetime.now(UTC)
+    window_start, reset_at = platform_month_window(now)
+    counts = await _recompute_from_dev_runs(
+        session,
+        org_id=org_id,
+        window_start=window_start,
+        reset_at=reset_at,
+        per_run_reservation_microusd=per_run_reservation_microusd,
+    )
+
+    client = _get_client()
+    if client is None:
+        return counts, window_start, reset_at
+
+    key = _key(org_id, window_start)
+    try:
+        await client.hset(
+            key,
+            mapping={
+                "requests": counts.requests,
+                "cost_microusd": counts.cost_microusd,
+                "initialized": "1",
+            },
+        )
+        await client.expire(key, _ttl_seconds(reset_at, now))
+    except Exception as exc:  # noqa: BLE001 - return the accurate value regardless
+        _trip_circuit(exc)
+        logger.warning(
+            "askdev allowance force_reconcile write failed for org=%s: %s", org_id, exc
+        )
+
+    return counts, window_start, reset_at

--- a/tests/api/admin/test_platform_ask_dev.py
+++ b/tests/api/admin/test_platform_ask_dev.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -51,12 +52,13 @@ from dev_health_ops.llm.agent.roles import (
     AgentRole,
     SettingsRoleCertificationStore,
 )
+from dev_health_ops.models.dev_persistence import DevRun
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import Setting
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
-_TABLES = tables_of(User, Organization, Setting)
+_TABLES = tables_of(User, Organization, Setting, DevRun)
 _FINGERPRINT = "platform-readiness-fingerprint"
 
 
@@ -732,3 +734,102 @@ async def test_binary_ready_role_absent_reports_unavailable_not_ready(
     assert body["binary_transport_readiness"] == "ready"
     roles = {entry["role"]: entry for entry in body["role_readiness"]}
     assert roles["legacy_agent"]["state"] == "not_yet_certified"
+
+
+# -- CHAOS-3522: platform allowance reconcile (operator escape hatch) -------
+
+
+@pytest.mark.asyncio
+async def test_org_admin_token_cannot_reach_allowance_reconcile(
+    platform_context: PlatformContext,
+):
+    """Same regression class as readiness: an org-admin token must never
+    reach another org's allowance counter -- reconcile is platform-wide,
+    superuser-only, and deliberately absent from the org-scoped
+    ``/admin/ask-dev`` surface (an org admin resetting their own spend cap
+    enforcement would defeat the cap)."""
+
+    _as(platform_context, platform_context.org_admin)
+    org_id = str(uuid.uuid4())
+
+    response = await platform_context.client.post(
+        f"/api/v1/admin/platform/ask-dev/organizations/{org_id}/platform-allowance/reconcile"
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rejects_a_non_uuid_org_id(platform_context: PlatformContext):
+    response = await platform_context.client.post(
+        "/api/v1/admin/platform/ask-dev/organizations/not-a-uuid/platform-allowance/reconcile"
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recomputes_from_dev_runs_and_overwrites_the_counter(
+    platform_context: PlatformContext, monkeypatch: pytest.MonkeyPatch
+):
+    """The full round trip: seed dev_runs directly (bypassing any counter),
+    seed a DELIBERATELY WRONG Valkey value, call reconcile, and assert the
+    response AND the Valkey key both reflect dev_runs -- never the stale
+    value that was there before."""
+
+    fakeredis = pytest.importorskip("fakeredis")
+    from dev_health_ops.api.dev.org_policy import platform_month_window
+    from dev_health_ops.api.services import (
+        askdev_allowance_counters as counters,
+    )
+
+    client = fakeredis.FakeAsyncValkey(server=fakeredis.FakeServer())
+    monkeypatch.setattr(counters, "_client", client)
+    monkeypatch.setattr(counters, "_circuit_open_until", 0.0)
+    monkeypatch.setattr(counters, "_needs_recovery_recompute", False)
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    async with platform_context.maker() as session:
+        session.add_all(
+            [
+                DevRun(
+                    request_id=uuid.uuid4(),
+                    conversation_id=uuid.uuid4(),
+                    org_id=org_id,
+                    user_id=user_id,
+                    state="completed",
+                    estimated_cost_microusd=300_000,
+                    provider_source="platform",
+                    started_at=now,
+                ),
+                DevRun(
+                    request_id=uuid.uuid4(),
+                    conversation_id=uuid.uuid4(),
+                    org_id=org_id,
+                    user_id=user_id,
+                    state="model_decision",
+                    provider_source="platform",
+                    started_at=now,
+                ),
+            ]
+        )
+        await session.commit()
+
+    window_start, _reset_at = platform_month_window(now)
+    key = counters._key(str(org_id), window_start)
+    # A deliberately wrong stale value the reconcile must overwrite.
+    await client.hset(key, mapping={"requests": 999, "cost_microusd": 999_000_000})
+
+    response = await platform_context.client.post(
+        f"/api/v1/admin/platform/ask-dev/organizations/{org_id}/platform-allowance/reconcile"
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["request_used"] == 2
+    # completed run: real cost (300_000). running run: worst-case reservation.
+    from dev_health_ops.api.dev.org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
+
+    assert body["cost_used_microusd"] == 300_000 + ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
+
+    persisted = await client.hmget(key, ["requests", "cost_microusd"])
+    assert persisted == [b"2", str(body["cost_used_microusd"]).encode()]

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -396,6 +396,104 @@ async def test_update_run_without_provider_source_leaves_the_column_intact(
             )
 
 
+@pytest.mark.asyncio
+async def test_terminal_transition_reconciles_the_allowance_counter_exactly_once(
+    persistence, monkeypatch
+) -> None:
+    """CHAOS-3522 amendment 2: driving update_run's terminal transition twice
+    through the REAL path must reconcile the Valkey allowance counter exactly
+    once, not zero and not twice.
+
+    This is a contract test, not an inference: ``update_run``'s "already
+    terminal" early return happens BEFORE the mutate block that calls
+    ``askdev_allowance_counters.reconcile_terminal_cost`` -- placement, not
+    caller discipline, is what makes this exactly-once. A second call with
+    the SAME terminal state on an already-terminal run must be a structural
+    no-op for the counter, the same way it already is for every ORM field.
+    """
+
+    fakeredis = pytest.importorskip("fakeredis")
+    from dev_health_ops.api.services import (
+        askdev_allowance_counters as counters,
+    )
+
+    client = fakeredis.FakeAsyncValkey(server=fakeredis.FakeServer())
+    monkeypatch.setattr(counters, "_client", client)
+    monkeypatch.setattr(counters, "_circuit_open_until", 0.0)
+    monkeypatch.setattr(counters, "_needs_recovery_recompute", False)
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    allowance = DevPlatformAllowance(
+        monthly_request_limit=10,
+        monthly_cost_limit_microusd=6_000_000,
+    )
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="Reconcile exactly once",
+            scope_snapshot={},
+            admission_limits=DevAdmissionLimits(),
+            provider_source="platform",
+            platform_allowance=allowance,
+        )
+        run_id = accepted.run.id
+
+        # After admission: reservation charged in full (worst-case hard max).
+        from dev_health_ops.api.dev.org_policy import (
+            ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+            platform_month_window,
+        )
+
+        window_start, _reset_at = platform_month_window(datetime.now(UTC))
+        key = counters._key(str(org_id), window_start)
+        after_admission = await client.hmget(key, ["requests", "cost_microusd"])
+        assert after_admission == [
+            b"1",
+            str(ASK_DEV_RUN_COST_HARD_MAX_MICROUSD).encode(),
+        ]
+
+        first = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="completed",
+            estimated_cost_microusd=250_000,
+        )
+        assert first is not None
+        assert first.state == "completed"
+        after_first = await client.hmget(key, ["requests", "cost_microusd"])
+        assert after_first == [b"1", b"250000"]
+
+        # Drive the SAME terminal transition again, with a DIFFERENT cost --
+        # if reconcile fired a second time, this would move the counter
+        # again and prove it double-applied.
+        second = await service.update_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            state="completed",
+            estimated_cost_microusd=999_999,
+        )
+        assert second is not None
+        assert second.id == first.id
+        assert (
+            second.estimated_cost_microusd == 250_000
+        )  # unmutated, per the ORM contract
+
+        after_second = await client.hmget(key, ["requests", "cost_microusd"])
+        assert after_second == [b"1", b"250000"], (
+            "a repeat terminal update_run call must not reconcile the "
+            "allowance counter a second time"
+        )
+
+
 # -- dev_run_intents ----------------------------------------------------
 
 

--- a/tests/api/test_askdev_allowance_counters.py
+++ b/tests/api/test_askdev_allowance_counters.py
@@ -1,0 +1,593 @@
+"""Tests for the Valkey-backed Ask Dev platform allowance counters (CHAOS-3522).
+
+Uses fakeredis (FakeAsyncValkey), same pattern as test_impersonation_cache.py:
+monkeypatch the module's ``_client`` directly rather than going through
+REDIS_URL, both because that is how the shared-store semantics get exercised
+deterministically and because tests/_env_isolation.py scrubs REDIS_URL for the
+whole unit tier (verified directly: a REDIS_URL set on the invoking shell does
+not reach this module inside a pytest run at all).
+
+NO LUA: fakeredis in this environment supports no EVAL (verified directly,
+same gap as tests/test_token_pool.py's own ``requires_lua`` marker) -- every
+test here exercises the real HINCRBY/HSETNX-based admit logic, not a
+Lua-gated path that would silently skip.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+fakeredis = pytest.importorskip("fakeredis")
+
+from dev_health_ops.api.services import (  # noqa: E402
+    askdev_allowance_counters as counters,
+)
+from dev_health_ops.api.services.askdev_allowance_counters import (  # noqa: E402
+    AdmitOutcome,
+    AllowanceCounts,
+    admit,
+    force_reconcile,
+    read_counts,
+    reconcile_terminal_cost,
+)
+
+_ORG = "11111111-1111-1111-1111-111111111111"
+_NOW = datetime(2026, 8, 15, 12, 0, 0, tzinfo=UTC)
+_RESERVATION = 1_000_000
+
+
+@pytest.fixture
+def shared_server():
+    return fakeredis.FakeServer()
+
+
+@pytest.fixture
+def valkey_client(shared_server, monkeypatch):
+    """Wire the module's client to a fresh fakeredis store and reset breaker state."""
+    client = fakeredis.FakeAsyncValkey(server=shared_server)
+    monkeypatch.setattr(counters, "_client", client)
+    monkeypatch.setattr(counters, "_circuit_open_until", 0.0)
+    monkeypatch.setattr(counters, "_needs_recovery_recompute", False)
+    return client
+
+
+@pytest.fixture
+def zero_baseline(monkeypatch):
+    """No prior dev_runs history -- the common cold-key case."""
+    mock = AsyncMock(return_value=AllowanceCounts(requests=0, cost_microusd=0))
+    monkeypatch.setattr(counters, "_recompute_from_dev_runs", mock)
+    return mock
+
+
+class _FakeSession:
+    """Placeholder session -- never actually touched once SQL is mocked out."""
+
+
+def _fake_session() -> AsyncSession:
+    return cast(AsyncSession, _FakeSession())
+
+
+# -- admit(): boundary parity with the old SQL query -------------------------
+
+
+@pytest.mark.asyncio
+async def test_admit_grants_when_under_both_limits(valkey_client, zero_baseline):
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.ADMITTED
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    assert counts == [b"1", str(_RESERVATION).encode()]
+
+
+@pytest.mark.asyncio
+async def test_admit_rejects_request_limit_and_compensates(valkey_client, monkeypatch):
+    """At the request cap: rejected, and the attempted increment is reversed."""
+    monkeypatch.setattr(
+        counters,
+        "_recompute_from_dev_runs",
+        AsyncMock(return_value=AllowanceCounts(requests=5, cost_microusd=0)),
+    )
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=5,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.REQUEST_LIMIT_EXCEEDED
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    # Compensated back to exactly the seeded baseline -- the rejected
+    # attempt left no trace.
+    assert counts == [b"5", b"0"]
+
+
+@pytest.mark.asyncio
+async def test_admit_rejects_cost_limit_and_compensates_both_fields(
+    valkey_client, monkeypatch
+):
+    """Cost cap exceeded: BOTH the cost and the request increment are reversed.
+
+    Unlike the SQL version (a pure read), the counter version had already
+    speculatively reserved the request slot before checking cost -- an
+    admit that is fully rejected must leave zero trace on either counter.
+    """
+    monkeypatch.setattr(
+        counters,
+        "_recompute_from_dev_runs",
+        AsyncMock(return_value=AllowanceCounts(requests=0, cost_microusd=4_500_000)),
+    )
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.COST_LIMIT_EXCEEDED
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    assert counts == [b"0", b"4500000"]
+
+
+@pytest.mark.asyncio
+async def test_admit_request_limit_checked_before_cost_limit(
+    valkey_client, monkeypatch
+):
+    """When BOTH limits would be exceeded, the request rejection wins.
+
+    Matches the original SQL's check order exactly (request check raises
+    before the cost check is even evaluated).
+    """
+    monkeypatch.setattr(
+        counters,
+        "_recompute_from_dev_runs",
+        AsyncMock(return_value=AllowanceCounts(requests=10, cost_microusd=9_999_999)),
+    )
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.REQUEST_LIMIT_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_admit_boundary_exactly_at_request_limit_is_the_last_admitted(
+    valkey_client, monkeypatch
+):
+    """existing == limit - 1 admits (becomes the limit-th); existing == limit rejects."""
+    monkeypatch.setattr(
+        counters,
+        "_recompute_from_dev_runs",
+        AsyncMock(return_value=AllowanceCounts(requests=4, cost_microusd=0)),
+    )
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=5,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.ADMITTED
+
+
+# -- Amendment 1: init-if-absent is atomic, never a blind overwrite ----------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_init_race_second_racer_baseline_discarded(
+    valkey_client, monkeypatch
+):
+    """Plants the exact race amendment 1 names.
+
+    Racer A misses the key, recomputes baseline X, and (in between its own
+    recompute and its HSETNX) a real admission increments the counter.
+    Racer B then ALSO misses (same cold key, sees requests=0 in its own
+    stale recompute), and attempts to initialize with baseline Y. B's
+    HSETNX must lose: the key already exists (A won), so B's write must be
+    silently discarded, not overwrite A's already-incremented state.
+    """
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+
+    baseline_a = AllowanceCounts(requests=2, cost_microusd=1_000_000)
+    await counters._ensure_initialized(
+        valkey_client, key=key, ttl_seconds=1000, baseline=baseline_a
+    )
+    # A real admission lands in between the two racers.
+    await valkey_client.hincrby(key, "requests", 1)
+    await valkey_client.hincrby(key, "cost_microusd", _RESERVATION)
+
+    after_admission = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    assert after_admission == [b"3", b"2000000"]
+
+    # Racer B's belated, stale recompute (it never saw the admission above).
+    baseline_b_stale = AllowanceCounts(requests=0, cost_microusd=0)
+    await counters._ensure_initialized(
+        valkey_client, key=key, ttl_seconds=1000, baseline=baseline_b_stale
+    )
+
+    final = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    # B's stale baseline must NOT have clobbered A's state.
+    assert final == [b"3", b"2000000"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_sets_ttl_only_on_the_winning_write(valkey_client):
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    baseline = AllowanceCounts(requests=0, cost_microusd=0)
+    await counters._ensure_initialized(
+        valkey_client, key=key, ttl_seconds=500, baseline=baseline
+    )
+    ttl = await valkey_client.ttl(key)
+    assert 0 < ttl <= 500
+
+
+# -- Amendment 2 belongs to persistence/service.py's own test suite (the
+# exactly-once contract is a property of update_run's control flow, not of
+# this module) -- see test_persistence_v2.py.
+
+
+# -- Amendment 3: breaker recovery forces exactly one recompute --------------
+
+
+@pytest.mark.asyncio
+async def test_breaker_recovery_forces_one_recompute_then_resumes_counter_mode(
+    valkey_client, monkeypatch
+):
+    recompute = AsyncMock(
+        return_value=AllowanceCounts(requests=7, cost_microusd=3_000_000)
+    )
+    monkeypatch.setattr(counters, "_recompute_from_dev_runs", recompute)
+    monkeypatch.setattr(counters, "_needs_recovery_recompute", True)
+
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.ADMITTED
+    recompute.assert_awaited_once()
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    # Baseline (7, 3_000_000) plus this admission's own increment.
+    assert counts == [b"8", str(3_000_000 + _RESERVATION).encode()]
+    assert counters._needs_recovery_recompute is False
+
+    # A SECOND admission for a DIFFERENT org must NOT force another
+    # recompute -- the bit is consumed exactly once per trip/recover cycle
+    # (the stated cross-org limitation the module docstring names).
+    recompute.reset_mock()
+    other_org = "22222222-2222-2222-2222-222222222222"
+    outcome_2 = await admit(
+        _fake_session(),
+        org_id=other_org,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome_2 is AdmitOutcome.ADMITTED
+    # Cold key for other_org still triggers ITS OWN lazy-heal recompute
+    # (unrelated to the recovery bit), so recompute IS called once here --
+    # the assertion is that it is not called for the recovery reason twice.
+    recompute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_trip_circuit_sets_recovery_flag(monkeypatch):
+    monkeypatch.setattr(counters, "_needs_recovery_recompute", False)
+    counters._trip_circuit(RuntimeError("boom"))
+    assert counters._needs_recovery_recompute is True
+    assert counters._circuit_is_open()
+
+
+# -- Amendment 4: key/TTL derive from platform_month_window, not a literal --
+
+
+def test_key_derives_from_platform_month_window():
+    from dev_health_ops.api.dev.org_policy import platform_month_window
+
+    now = datetime(2026, 12, 31, 23, 59, tzinfo=UTC)
+    window_start, reset_at = platform_month_window(now)
+    key = counters._key(_ORG, window_start)
+    assert key == f"askdev:allowance:{_ORG}:2026-12"
+    assert reset_at == datetime(2027, 1, 1, tzinfo=UTC)
+
+
+def test_ttl_extends_past_reset_at_by_the_grace_window():
+    now = datetime(2026, 8, 1, 0, 0, tzinfo=UTC)
+    reset_at = datetime(2026, 9, 1, tzinfo=UTC)
+    ttl = counters._ttl_seconds(reset_at, now)
+    expected = int((reset_at - now).total_seconds()) + counters._TTL_GRACE_SECONDS
+    assert ttl == expected
+    assert ttl > int((reset_at - now).total_seconds())
+
+
+# -- Valkey-down fallback -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_circuit_open_falls_back_to_sql_only_no_writes(
+    valkey_client, monkeypatch
+):
+    monkeypatch.setattr(
+        counters, "_circuit_open_until", __import__("time").monotonic() + 60
+    )
+    recompute = AsyncMock(return_value=AllowanceCounts(requests=0, cost_microusd=0))
+    monkeypatch.setattr(counters, "_recompute_from_dev_runs", recompute)
+
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.ADMITTED
+    recompute.assert_awaited_once()
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    assert await valkey_client.exists(key) == 0  # no Valkey write attempted
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_valkey_goes_straight_to_sql(monkeypatch, zero_baseline):
+    monkeypatch.setattr(counters, "_client", None)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.ADMITTED
+    zero_baseline.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_valkey_error_trips_circuit_and_falls_back(monkeypatch, zero_baseline):
+    class _BrokenClient:
+        async def exists(self, *_a):
+            raise ConnectionError("valkey down")
+
+    monkeypatch.setattr(counters, "_client", _BrokenClient())
+    monkeypatch.setattr(counters, "_circuit_open_until", 0.0)
+
+    outcome = await admit(
+        _fake_session(),
+        org_id=_ORG,
+        request_limit=10,
+        cost_limit_microusd=5_000_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert outcome is AdmitOutcome.ADMITTED
+    zero_baseline.assert_awaited_once()
+    assert counters._circuit_is_open()
+
+
+# -- reconcile_terminal_cost() ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_cost_adjusts_reservation_to_actual(valkey_client):
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=1, cost_microusd=_RESERVATION),
+    )
+
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source="platform",
+        state="completed",
+        estimated_cost_microusd=250_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    # Reservation (1_000_000) replaced by the real cost (250_000): net delta
+    # -750_000 applied via HINCRBY, requests untouched.
+    assert counts == [b"1", b"250000"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_cost_can_adjust_upward(valkey_client):
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=1, cost_microusd=_RESERVATION),
+    )
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source="platform",
+        state="completed",
+        estimated_cost_microusd=_RESERVATION + 500_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    assert counts == [b"1", str(_RESERVATION + 500_000).encode()]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_source", "state", "cost"),
+    [
+        ("byo", "completed", 250_000),  # not the platform provider
+        ("platform", "running", 250_000),  # not terminal
+        ("platform", "completed", None),  # no real cost -- fail-closed pin stands
+    ],
+)
+async def test_reconcile_terminal_cost_noop_cases(
+    valkey_client, provider_source, state, cost
+):
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=1, cost_microusd=_RESERVATION),
+    )
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source=provider_source,
+        state=state,
+        estimated_cost_microusd=cost,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    # Unchanged -- the reservation is left exactly as it was.
+    assert counts == [b"1", str(_RESERVATION).encode()]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_cost_skips_silently_when_key_missing(valkey_client):
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    assert await valkey_client.exists(key) == 0
+
+    # Must not raise, and must not fabricate a key.
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source="platform",
+        state="completed",
+        estimated_cost_microusd=250_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert await valkey_client.exists(key) == 0
+
+
+# -- force_reconcile(): the on-demand operator reset -------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_reconcile_overwrites_unconditionally(valkey_client, monkeypatch):
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=99, cost_microusd=99_000_000),
+    )
+    monkeypatch.setattr(
+        counters,
+        "_recompute_from_dev_runs",
+        AsyncMock(return_value=AllowanceCounts(requests=3, cost_microusd=750_000)),
+    )
+
+    result, window_start, reset_at = await force_reconcile(
+        _fake_session(),
+        org_id=_ORG,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+
+    assert result == AllowanceCounts(requests=3, cost_microusd=750_000)
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    assert counts == [b"3", b"750000"]
+
+
+@pytest.mark.asyncio
+async def test_force_reconcile_returns_accurate_value_even_if_valkey_write_fails(
+    monkeypatch,
+):
+    class _BrokenClient:
+        async def hset(self, *_a, **_k):
+            raise ConnectionError("valkey down")
+
+    monkeypatch.setattr(counters, "_client", _BrokenClient())
+    monkeypatch.setattr(counters, "_circuit_open_until", 0.0)
+    monkeypatch.setattr(
+        counters,
+        "_recompute_from_dev_runs",
+        AsyncMock(return_value=AllowanceCounts(requests=3, cost_microusd=750_000)),
+    )
+
+    result, _window_start, _reset_at = await force_reconcile(
+        _fake_session(),
+        org_id=_ORG,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert result == AllowanceCounts(requests=3, cost_microusd=750_000)
+
+
+# -- read_counts(): the admin usage surface -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_counts_lazy_heals_cold_key(valkey_client, monkeypatch):
+    monkeypatch.setattr(
+        counters,
+        "_recompute_from_dev_runs",
+        AsyncMock(return_value=AllowanceCounts(requests=4, cost_microusd=2_000_000)),
+    )
+    counts, window_start, reset_at = await read_counts(
+        _fake_session(),
+        org_id=_ORG,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert counts == AllowanceCounts(requests=4, cost_microusd=2_000_000)
+    assert window_start == datetime(2026, 8, 1, tzinfo=UTC)
+    assert reset_at == datetime(2026, 9, 1, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_read_counts_serves_warm_key_without_recompute(
+    valkey_client, monkeypatch
+):
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=9, cost_microusd=1_500_000),
+    )
+    recompute = AsyncMock(side_effect=AssertionError("must not recompute a warm key"))
+    monkeypatch.setattr(counters, "_recompute_from_dev_runs", recompute)
+
+    counts, _window_start, _reset_at = await read_counts(
+        _fake_session(),
+        org_id=_ORG,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    assert counts == AllowanceCounts(requests=9, cost_microusd=1_500_000)
+    recompute.assert_not_awaited()

--- a/tests/api/test_askdev_allowance_counters.py
+++ b/tests/api/test_askdev_allowance_counters.py
@@ -16,7 +16,7 @@ Lua-gated path that would silently skip.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -228,6 +228,63 @@ async def test_concurrent_init_race_second_racer_baseline_discarded(
     final = await valkey_client.hmget(key, ["requests", "cost_microusd"])
     # B's stale baseline must NOT have clobbered A's state.
     assert final == [b"3", b"2000000"]
+
+
+@pytest.mark.asyncio
+async def test_per_field_hsetnx_survives_admission_interleaved_between_the_two_fields(
+    valkey_client,
+):
+    """CHAOS-3522 review round 2: the finer-grained race a single sentinel
+    field cannot close.
+
+    A prior version of ``_ensure_initialized`` gated one later ``HSET`` of
+    BOTH fields behind a single ``HSETNX(key, "initialized", "1")``
+    sentinel. That sentinel write and the baseline ``HSET`` are two separate
+    round trips -- a real admission's ``HINCRBY`` landing on ONE field in
+    between them would be silently wiped out when the baseline ``HSET``
+    (writing both fields unconditionally) finally landed. This test plants
+    exactly that interleaving -- an admission's increment lands on
+    ``cost_microusd`` in between the initializer's two per-field writes --
+    and proves the CURRENT per-field-``HSETNX`` implementation survives it:
+    each field is independently atomic, so there is no window where the key
+    "exists" without both fields already being live.
+    """
+
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    baseline = AllowanceCounts(requests=5, cost_microusd=999_999_999)
+
+    class _InterleavingClient:
+        """Proxies to the real fakeredis client, but injects a concurrent
+        admission's HINCRBY right after the FIRST field's HSETNX lands --
+        exercising _ensure_initialized's REAL two-call sequence, not a
+        hand-simulated one."""
+
+        def __init__(self, inner: Any) -> None:
+            self._inner = inner
+            self._hsetnx_calls = 0
+
+        async def hsetnx(self, *args: Any, **kwargs: Any) -> Any:
+            result = await self._inner.hsetnx(*args, **kwargs)
+            self._hsetnx_calls += 1
+            if self._hsetnx_calls == 1:
+                await self._inner.hincrby(key, "cost_microusd", _RESERVATION)
+            return result
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+    await counters._ensure_initialized(
+        _InterleavingClient(valkey_client),
+        key=key,
+        ttl_seconds=1000,
+        baseline=baseline,
+    )
+
+    final = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    # requests: racer A's baseline (nothing else touched it).
+    # cost_microusd: the admission's real increment, NOT racer A's stale
+    # baseline -- HSETNX on an already-existing field is a no-op.
+    assert final == [b"5", str(_RESERVATION).encode()]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Replaces the per-request `dev_runs` aggregate scan (`count() + sum(case ...)`) on both the run-admission path (`_enforce_platform_allowance`) and the admin usage read (`_platform_allowance_usage`) with a shared Valkey hash counter per org per month. `dev_runs` remains the source of truth.

## Design (approved with 4 amendments — see CHAOS-3522 for the full ruling thread)

- **One hash per org per month**: `askdev:allowance:{org_id}:{YYYY-MM}`, fields `requests`/`cost_microusd`. Key suffix and TTL derive from the same `platform_month_window()` the SQL fallback uses — previously duplicated independently in `ask_dev.py` and `persistence/service.py`. Also deduplicated a third copy of the terminal-run-state vocabulary the same way (`TERMINAL_RUN_STATES` in `org_policy.py`).
- **No Lua**: verified directly that `fakeredis` in this repo supports no `EVAL` (same gap `tests/test_token_pool.py` already works around), and CI provisions no live Valkey for the unit tier — a Lua-based admit would be permanently skip-gated, never exercised. Admit is instead increment-then-check-then-compensate using only `HINCRBY`, algebraically identical to the SQL boundary and fully testable.
- **Amendment 1** (init-race): cold-key init uses `HSETNX` on a sentinel field so two concurrent first-of-month callers can't have the loser silently overwrite the winner's already-incremented state. RED-first: a deterministic test plants the exact race and fails against a blind `HSET`.
- **Amendment 2** (exactly-once finalize): the reservation→actual reconcile call sits inside `update_run`'s mutate block, structurally past the early return that already makes a repeat terminal call a no-op. RED-first: a defect planted in the early-return branch is caught by a contract test that drives the real transition twice.
- **Amendment 3** (breaker recovery): a process-wide bit forces exactly one recompute-from-`dev_runs` on the first counter touch after the breaker closes, before resuming counter mode. Stated limitation documented in the module for the cross-org/cross-process window this doesn't close.
- **Valkey down**: falls back to the original SQL query, read-only (no speculative write into an untrusted store) — fail-correct not fail-stale, same circuit-breaker shape as `impersonation_cache.py`.
- **Operator escape hatch** (the origin of the ticket): `POST /platform/ask-dev/organizations/{org_id}/platform-allowance/reconcile`, superuser-only, force-recomputes from `dev_runs` and overwrites the counter — replaces literal SQL surgery on `dev_runs` for resetting a local/dev org's allowance.
- Per part (b) of the design: a terminal run finalized without a real cost (the defensive `update_run` path, not the orchestrator's normal one) stays pinned at the worst-case reservation, matching the existing `test_platform_monthly_allowance_reserves_unknown_cost_fail_closed` contract unmodified. Confirmed (not assumed) that a terminal run's cost can never be revised after the fact.

## Verification

- All three pre-existing allowance tests pass unmodified against both the SQL fallback (default, no `REDIS_URL`) and a real Valkey backend (verified manually against the live `dev-health-valkey-1`/`postgres-1` containers on a scratch db/schema, cleaned up after).
- New `tests/api/test_askdev_allowance_counters.py` (fakeredis-backed, real `HINCRBY`/`HSETNX` — no Lua skip-gate): boundary parity with the SQL query, the amendment-1 race, amendment-3 recovery, amendment-4 key/TTL derivation, Valkey-down fallback, reconcile, force-reconcile.
- New contract test in `test_persistence_v2.py` for amendment 2, and new endpoint tests in `test_platform_ask_dev.py` for the reconcile route (auth boundary + full round trip).

Closes CHAOS-3522.