### PR TITLE
CHAOS-3552: an unmeterable platform model must never be booked silently

### DIFF
--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -1126,7 +1126,10 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
         model=candidate.model,
         base_url=candidate.credentials.base_url,
     )
-    if metering is PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR:
+    if metering in (
+        PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR,
+        PlatformCostMetering.UNKNOWN_BILLABILITY,
+    ):
         # LOUD, not fatal (team-lead ruling, revising an earlier fail-loud
         # ruling on measured availability evidence). Refusing construction
         # would have taken Ask Dev away from every organization running an
@@ -1152,16 +1155,29 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
             extra={
                 "model": candidate.model,
                 "provider": candidate.provider,
+                "reason": metering.value,
+                # Two different operators, two different remedies: a typo'd
+                # or new OpenAI model needs a price entry; an Azure/OpenRouter
+                # /gateway deployment needs its endpoint priced (CHAOS-3560),
+                # and telling them the same thing sends one of them chasing
+                # the wrong fix.
                 "remedy": (
                     "price the model in _PLATFORM_MODEL_PRICES or set "
                     "LLM_MODEL to a priced model"
+                    if metering is PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR
+                    else "this endpoint is not api.openai.com, so its billing "
+                    "rates are unknown and runs book the conservative "
+                    "reservation; pricing known gateways is CHAOS-3560"
                 ),
             },
         )
-        ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL.labels(model=candidate.model).inc()
+        ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL.labels(
+            model=candidate.model, reason=metering.value
+        ).inc()
     return OpenAICompatibleAgentProvider(
         api_key=candidate.credentials.api_key or "platform-openai-compatible",
         model=candidate.model,
+        cost_provider=candidate.provider,
         base_url=candidate.credentials.base_url or None,
         disclosure_key=(
             _ACCEPTANCE_OPENAI_DISCLOSURE_KEY

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -66,6 +66,9 @@ from dev_health_ops.llm.providers import (
 )
 from dev_health_ops.llm.providers.base import DEFAULT_MODEL_BY_PROVIDER
 from dev_health_ops.llm.qua_shadow_budget import attach_qua_shadow_budget_guard
+from dev_health_ops.metrics.prometheus import (
+    ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL,
+)
 from dev_health_ops.models.settings import SettingCategory
 
 from .contracts import (
@@ -1124,15 +1127,38 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
         base_url=candidate.credentials.base_url,
     )
     if metering is PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR:
-        logger.error(
+        # LOUD, not fatal (team-lead ruling, revising an earlier fail-loud
+        # ruling on measured availability evidence). Refusing construction
+        # would have taken Ask Dev away from every organization running an
+        # OpenAI model outside this build's three-entry price book --
+        # gpt-4o, gpt-5, o3 and the rest -- which is a far larger harm than
+        # an overstated allowance.
+        #
+        # So the run proceeds and books the worst-case reservation exactly as
+        # it does today, because a platform run spends real operator dollars
+        # on the platform key and unmetered openai spend bounded only by the
+        # request cap is not an acceptable posture. What changes is that it is
+        # never SILENT: the invariant survives as written -- "must never
+        # SILENTLY book the reservation as its cost" -- and loud booking
+        # satisfies it. Under chris's request-primary ruling the request cap
+        # is the control anyway, so a conservative charge against the cost
+        # backstop is defensible once it is attributed.
+        #
+        # Emitted at CONSTRUCTION rather than per call: once per provider
+        # build is enough to tell an operator, and per-call would be log spam
+        # on the exact deployments already paying for the defect.
+        logger.warning(
             "ask_dev.platform_model_unpriced",
-            extra={"model": candidate.model, "provider": candidate.provider},
+            extra={
+                "model": candidate.model,
+                "provider": candidate.provider,
+                "remedy": (
+                    "price the model in _PLATFORM_MODEL_PRICES or set "
+                    "LLM_MODEL to a priced model"
+                ),
+            },
         )
-        raise DevRuntimeUnavailable(
-            "model_not_supported",
-            "The configured Ask Dev model has no price entry, so run cost "
-            "cannot be metered. Configure a priced model or add its price.",
-        )
+        ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL.labels(model=candidate.model).inc()
     return OpenAICompatibleAgentProvider(
         api_key=candidate.credentials.api_key or "platform-openai-compatible",
         model=candidate.model,

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -1102,7 +1102,7 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
         raise DevRuntimeUnavailable(
             "model_not_supported", "The configured Ask Dev model is not supported."
         )
-    # CHAOS-3552: an unpriced model must not reach the runtime.
+    # CHAOS-3552: an unmeterable model must never be booked SILENTLY.
     #
     # ProviderBudget reserves US$1 per model call and reconciles it down to the
     # real cost afterwards -- but ONLY when a real cost exists.
@@ -1114,13 +1114,17 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
     # allowance after 25 runs, against a 1,000-run request cap. That is what
     # CHAOS-3523's "bounds sized for BYO are gating platform runs" actually was.
     #
-    # Refused HERE, at construction, rather than left to surface as wrong
-    # numbers at runtime: it is an operator configuration fault, and a fault
-    # that reports itself as plausible cost data is worse than one that stops
-    # the process. Only the genuine misconfiguration raises -- self-hosted
-    # deployments are unpriceable by design and pass through unmetered, and the
-    # deterministic acceptance fixture is carved out. See
-    # ``platform_cost_metering``.
+    # Reported HERE, at construction, rather than per call: once per provider
+    # build is enough to tell an operator, and per-call would be log spam on
+    # exactly the deployments already paying for the defect.
+    #
+    # NOTHING RAISES. An earlier revision refused construction; measured
+    # availability evidence retired that (see the branch history): with a
+    # three-entry price book, refusing would have removed Ask Dev from every
+    # organization running gpt-4o, gpt-5, o3 or any other unlisted model --
+    # far larger harm than an overstated allowance. Self-hosted providers pass
+    # through genuinely unmetered, and the acceptance fixture is carved out.
+    # See ``platform_cost_metering``.
     metering = platform_cost_metering(
         provider=candidate.provider,
         model=candidate.model,

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -30,7 +30,9 @@ from dev_health_ops.llm.agent.errors import AgentProviderError, AgentProviderErr
 from dev_health_ops.llm.agent.openai_compatible import (
     READINESS_VERSION,
     OpenAICompatibleAgentProvider,
+    PlatformCostMetering,
     build_completion_request,
+    platform_cost_metering,
 )
 from dev_health_ops.llm.agent.policy import (
     CERTIFIED_PLATFORM_AGENT_PROVIDERS,
@@ -1096,6 +1098,40 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
     if candidate.provider not in CERTIFIED_PLATFORM_AGENT_PROVIDERS:
         raise DevRuntimeUnavailable(
             "model_not_supported", "The configured Ask Dev model is not supported."
+        )
+    # CHAOS-3552: an unpriced model must not reach the runtime.
+    #
+    # ProviderBudget reserves US$1 per model call and reconciles it down to the
+    # real cost afterwards -- but ONLY when a real cost exists.
+    # ``_estimated_cost_microusd`` returns None for an unpriced model and the
+    # reconciliation branch leaves the reservation standing, so every call
+    # permanently books US$1 against the org's monthly allowance. Measured on
+    # the dev stack's own ``gpt-5-nano``: US$4.00 booked per run against
+    # US$0.018 real -- a 222x overcharge that exhausted the default US$100
+    # allowance after 25 runs, against a 1,000-run request cap. That is what
+    # CHAOS-3523's "bounds sized for BYO are gating platform runs" actually was.
+    #
+    # Refused HERE, at construction, rather than left to surface as wrong
+    # numbers at runtime: it is an operator configuration fault, and a fault
+    # that reports itself as plausible cost data is worse than one that stops
+    # the process. Only the genuine misconfiguration raises -- self-hosted
+    # deployments are unpriceable by design and pass through unmetered, and the
+    # deterministic acceptance fixture is carved out. See
+    # ``platform_cost_metering``.
+    metering = platform_cost_metering(
+        provider=candidate.provider,
+        model=candidate.model,
+        base_url=candidate.credentials.base_url,
+    )
+    if metering is PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR:
+        logger.error(
+            "ask_dev.platform_model_unpriced",
+            extra={"model": candidate.model, "provider": candidate.provider},
+        )
+        raise DevRuntimeUnavailable(
+            "model_not_supported",
+            "The configured Ask Dev model has no price entry, so run cost "
+            "cannot be metered. Configure a priced model or add its price.",
         )
     return OpenAICompatibleAgentProvider(
         api_key=candidate.credentials.api_key or "platform-openai-compatible",

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -260,8 +260,29 @@ def _fingerprint(*parts: str) -> str:
 
 
 def _estimated_cost_microusd(
-    *, model: str, input_tokens: int, output_tokens: int
+    *, model: str, input_tokens: int, output_tokens: int, base_url: str | None = None
 ) -> int | None:
+    """Cost for one call, or ``None`` when it genuinely cannot be known.
+
+    CHAOS-3552. The two "no price" cases return DIFFERENT values, and that is
+    the whole point -- ``ProviderBudget.add`` reconciles a numeric cost down
+    from the US$1 admission reservation and leaves the reservation standing on
+    ``None``, so returning ``None`` for both meant self-hosted deployments
+    booked US$4/run for infrastructure the operator already owns.
+
+    * Self-hosted (any non-official endpoint) -> explicit **0**. Unmetered, and
+      unmetered is the honest answer: the run costs the operator nothing on our
+      platform key. Zero reconciles, so no reservation is booked.
+    * OpenAI-official with an unpriced model -> ``None``. The reservation
+      deliberately stands, because a platform run spends real operator dollars
+      and unmetered openai spend bounded only by the request cap is not an
+      acceptable posture. It is never SILENT: ``production_runtime._provider``
+      warns and increments ``ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL`` at
+      construction, naming the model and the remedy.
+    """
+
+    if not _official_openai_endpoint(base_url):
+        return 0
     canonical_model = _canonical_priced_model(model)
     if canonical_model is None:
         return None
@@ -521,6 +542,7 @@ class OpenAICompatibleAgentProvider:
                 model=self.model,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
+                base_url=self.base_url,
             ),
         )
 

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -216,6 +216,21 @@ def _official_openai_endpoint(base_url: str | None) -> bool:
     return parsed.scheme == "https" and parsed.hostname == "api.openai.com"
 
 
+def _normalized_model_id(model: str) -> str:
+    """The one normalization both classification and pricing must share.
+
+    CHAOS-3552, adversarial review MEDIUM: the carve-out check stripped the
+    model id and the price lookup did not, so ``LLM_MODEL="ask-dev-scripted-v1 "``
+    (a trailing space in an env var -- entirely ordinary) classified as
+    ``FIXTURE`` while ``_estimated_cost_microusd`` returned ``None``. The
+    classifier said "carved out, proceed" and the pricer left the reservation
+    standing on every call. Two paths that must agree, normalizing differently
+    -- the same class of defect as the two price books this ticket is about.
+    """
+
+    return model.strip()
+
+
 def _canonical_priced_model(model: str) -> str | None:
     """The price-book key ``model`` resolves to, honouring dated variants.
 
@@ -231,6 +246,7 @@ def _canonical_priced_model(model: str) -> str | None:
     honour: an id that is not exactly the fixture is not the fixture.
     """
 
+    model = _normalized_model_id(model)
     return next(
         (
             known
@@ -265,7 +281,7 @@ def platform_cost_metering(
     near-zero price that keeps its reservation reconciled.
     """
 
-    if model.strip() in _CARVE_OUT_MODELS:
+    if _normalized_model_id(model) in _CARVE_OUT_MODELS:
         return PlatformCostMetering.FIXTURE
     if provider.strip().lower() in _SELF_HOSTED_PROVIDERS:
         return PlatformCostMetering.UNMETERED_SELF_HOSTED

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -153,6 +153,12 @@ SCRIPTED_FIXTURE_MODEL = "ask-dev-scripted-v1"
 #: each such neighbour still fails loud.
 _CARVE_OUT_MODELS = frozenset({SCRIPTED_FIXTURE_MODEL})
 
+#: Providers that run on the operator's OWN hardware, so a call genuinely
+#: costs nothing on our platform key. Mirrors
+#: ``policy._LOCAL_PLATFORM_PROVIDERS``. This -- not the endpoint URL -- is
+#: what licenses reporting a cost of zero.
+_SELF_HOSTED_PROVIDERS = frozenset({"local", "ollama", "lmstudio"})
+
 
 class PlatformCostMetering(StrEnum):
     """Whether a platform provider's cost can be metered, and if not, why not.
@@ -172,8 +178,21 @@ class PlatformCostMetering(StrEnum):
     #: error -- the run proceeds unmetered.
     UNMETERED_SELF_HOSTED = "unmetered_self_hosted"
     #: A real OpenAI model on the official endpoint that this build has no
-    #: price for. Operator misconfiguration, and the only case that fails.
+    #: price for. Operator misconfiguration; books the reservation, loudly.
     UNPRICED_CONFIGURATION_ERROR = "unpriced_configuration_error"
+    #: An openai-compatible endpoint that is NOT OpenAI's own -- Azure OpenAI,
+    #: OpenRouter, a corporate gateway, a forwarding proxy. Billability is
+    #: UNKNOWN, so it books the reservation loudly rather than reporting zero.
+    #:
+    #: Distinct from ``UNMETERED_SELF_HOSTED`` and the distinction is the whole
+    #: point. An earlier revision classified by URL -- "not api.openai.com"
+    #: implied "free" -- and reported Azure, OpenRouter and every paid gateway
+    #: at cost 0. That is fail-OPEN: real spend accrues against an allowance
+    #: that never moves and nobody is throttled or told, which is strictly
+    #: worse than the stuck-reservation overcharge it replaced. Only the
+    #: PROVIDER NAME can say "this is the operator's own hardware"; a URL
+    #: cannot.
+    UNKNOWN_BILLABILITY = "unknown_billability"
 
 
 def _official_openai_endpoint(base_url: str | None) -> bool:
@@ -248,8 +267,10 @@ def platform_cost_metering(
 
     if model.strip() in _CARVE_OUT_MODELS:
         return PlatformCostMetering.FIXTURE
-    if provider.strip().lower() != "openai" or not _official_openai_endpoint(base_url):
+    if provider.strip().lower() in _SELF_HOSTED_PROVIDERS:
         return PlatformCostMetering.UNMETERED_SELF_HOSTED
+    if not _official_openai_endpoint(base_url):
+        return PlatformCostMetering.UNKNOWN_BILLABILITY
     if _canonical_priced_model(model) is None:
         return PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR
     return PlatformCostMetering.PRICED
@@ -260,7 +281,12 @@ def _fingerprint(*parts: str) -> str:
 
 
 def _estimated_cost_microusd(
-    *, model: str, input_tokens: int, output_tokens: int, base_url: str | None = None
+    *,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    base_url: str | None = None,
+    provider: str = "openai",
 ) -> int | None:
     """Cost for one call, or ``None`` when it genuinely cannot be known.
 
@@ -270,7 +296,8 @@ def _estimated_cost_microusd(
     ``None``, so returning ``None`` for both meant self-hosted deployments
     booked US$4/run for infrastructure the operator already owns.
 
-    * Self-hosted (any non-official endpoint) -> explicit **0**. Unmetered, and
+    * Self-hosted BY PROVIDER (``local``/``ollama``/``lmstudio``) -> explicit
+      **0**. Unmetered, and
       unmetered is the honest answer: the run costs the operator nothing on our
       platform key. Zero reconciles, so no reservation is booked.
     * OpenAI-official with an unpriced model -> ``None``. The reservation
@@ -281,8 +308,13 @@ def _estimated_cost_microusd(
       construction, naming the model and the remedy.
     """
 
-    if not _official_openai_endpoint(base_url):
+    if provider.strip().lower() in _SELF_HOSTED_PROVIDERS:
         return 0
+    if not _official_openai_endpoint(base_url):
+        # Billable-or-not is UNKNOWN here (Azure, OpenRouter, a paid gateway).
+        # Unknown fails CLOSED: the reservation stands, loudly. Returning 0
+        # would report real spend as free -- see UNKNOWN_BILLABILITY.
+        return None
     canonical_model = _canonical_priced_model(model)
     if canonical_model is None:
         return None
@@ -303,12 +335,17 @@ class OpenAICompatibleAgentProvider:
         client: Any | None = None,
         disclosure_key: str = "openai_compatible",
         context_window_tokens: int | None = None,
+        cost_provider: str = "openai",
         organization: str = "",
         project: str = "",
         custom_headers: tuple[tuple[str, str], ...] = (),
     ) -> None:
         self.model = model
         self.base_url = base_url or ""
+        #: CHAOS-3552: which PROVIDER this instance speaks for, so cost
+        #: reporting can tell the operator's own hardware from a paid gateway.
+        #: A URL cannot answer that; only the configured provider name can.
+        self.cost_provider = cost_provider
         self.organization = organization
         self.project = project
         self.custom_headers = custom_headers
@@ -543,6 +580,7 @@ class OpenAICompatibleAgentProvider:
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 base_url=self.base_url,
+                provider=self.cost_provider,
             ),
         )
 

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -182,7 +182,7 @@ def _official_openai_endpoint(base_url: str | None) -> bool:
     Mirrors ``llm.budget._official_openai_endpoint``. Duplicated deliberately
     and temporarily: importing ``llm.budget`` here would pull SQLAlchemy, the
     session factory and the licensing models into this provider's import graph
-    for one predicate. Stage 2 (CHAOS-3559) deletes this module's price book in
+    for one predicate. Stage 2 (CHAOS-3560) deletes this module's price book in
     favour of ``budget.reliable_price`` and takes the duplication with it;
     until then a differential test pins the two equal rather than letting them
     drift -- which is the failure this whole ticket is about.

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -7,7 +7,9 @@ import hashlib
 import json
 import time
 from collections.abc import Mapping, Sequence
+from enum import StrEnum
 from typing import Any, cast
+from urllib.parse import urlsplit
 
 from dev_health_ops.llm.providers._http import make_hardened_async_httpx_client
 from dev_health_ops.llm.providers.openai_capabilities import (
@@ -116,10 +118,141 @@ _STRUCTURAL_SCHEMA_KEYS = frozenset(
 # small, non-None cost, so ProviderBudget.add's reconciliation branch
 # replaces the reservation with the true (near-zero) figure instead of
 # leaving it stuck.
+# CHAOS-3552: "gpt-5-nano" had no entry either, and it is what the dev stack
+# actually configures (ops/.env LLM_MODEL). The same defect as the scripted
+# model above, one level more serious because it is a REAL model on a real
+# endpoint: measured at 4 rounds x the US$1 reservation, a run booked US$4.00
+# against a real cost of US$0.018 -- a 222x overcharge that exhausted the
+# default US$100 monthly allowance after 25 runs, against a request cap of
+# 1,000. That is what CHAOS-3523's "the allowance is gating platform runs"
+# turned out to be.
+# Source snapshot: https://developers.openai.com/api/docs/models/gpt-5-nano
 _PLATFORM_MODEL_PRICES: dict[str, tuple[int, int]] = {
     "gpt-5-mini": (250_000, 2_000_000),
+    "gpt-5-nano": (50_000, 400_000),
     "ask-dev-scripted-v1": (1_000, 1_000),
 }
+
+#: The deterministic acceptance provider's model id
+#: (``scripted_openai_service.SCRIPTED_OPENAI_MODEL``), named so the carve-out
+#: keys on it exactly rather than on a bare literal.
+SCRIPTED_FIXTURE_MODEL = "ask-dev-scripted-v1"
+
+#: Models exempt from the unpriced-model configuration error, by EXACT id.
+#:
+#: Exactly one entry, and a test pins the count. A test double is not an
+#: unpriced production model: it has no inference cost to get wrong, and the
+#: acceptance stack runs on it, so failing construction here would take that
+#: stack down for a fault it cannot have.
+#:
+#: Membership is exact -- deliberately NOT the prefix match
+#: ``_estimated_cost_microusd`` uses for real models below. A carve-out in that
+#: style would admit ``ask-dev-scripted-v1-v2`` and every other stem-sharer,
+#: which is how a deliberate exception becomes an accidental default. The
+#: anti-widening control in ``test_chaos_3552_platform_price_book.py`` asserts
+#: each such neighbour still fails loud.
+_CARVE_OUT_MODELS = frozenset({SCRIPTED_FIXTURE_MODEL})
+
+
+class PlatformCostMetering(StrEnum):
+    """Whether a platform provider's cost can be metered, and if not, why not.
+
+    CHAOS-3552. The distinction is load-bearing because the two "no price"
+    cases want OPPOSITE handling, and collapsing them is precisely the bug: a
+    model nobody priced is today indistinguishable from a deployment that
+    cannot be priced, so both silently book the US$1 reservation as the cost.
+    """
+
+    #: A real price exists for this provider/model/endpoint.
+    PRICED = "priced"
+    #: The deterministic acceptance fixture -- see ``_CARVE_OUT_MODELS``.
+    FIXTURE = "fixture"
+    #: Self-hosted, or any non-official endpoint. Genuinely has no dollar cost
+    #: to report, and pricing it at OpenAI's rates would FABRICATE one. Not an
+    #: error -- the run proceeds unmetered.
+    UNMETERED_SELF_HOSTED = "unmetered_self_hosted"
+    #: A real OpenAI model on the official endpoint that this build has no
+    #: price for. Operator misconfiguration, and the only case that fails.
+    UNPRICED_CONFIGURATION_ERROR = "unpriced_configuration_error"
+
+
+def _official_openai_endpoint(base_url: str | None) -> bool:
+    """Whether ``base_url`` is OpenAI's own API.
+
+    Mirrors ``llm.budget._official_openai_endpoint``. Duplicated deliberately
+    and temporarily: importing ``llm.budget`` here would pull SQLAlchemy, the
+    session factory and the licensing models into this provider's import graph
+    for one predicate. Stage 2 (CHAOS-3559) deletes this module's price book in
+    favour of ``budget.reliable_price`` and takes the duplication with it;
+    until then a differential test pins the two equal rather than letting them
+    drift -- which is the failure this whole ticket is about.
+    """
+
+    if not (base_url or "").strip():
+        return True
+    try:
+        parsed = urlsplit(str(base_url))
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and parsed.hostname == "api.openai.com"
+
+
+def _canonical_priced_model(model: str) -> str | None:
+    """The price-book key ``model`` resolves to, honouring dated variants.
+
+    Prefix matching exists for real models, which providers pin as dated
+    snapshots (``gpt-5-nano-2026-01-01`` is the same model at the same rates).
+
+    It is switched OFF for carve-out entries, and that exception is not
+    cosmetic -- the anti-widening test caught this exact hole in the first
+    revision of this change. The fixture is IN the price book, so prefix
+    matching resolved ``ask-dev-scripted-v1-v2`` to it and reported the
+    stranger as PRICED, widening the carve-out through the price book rather
+    than through ``_CARVE_OUT_MODELS``. A test double has no dated variants to
+    honour: an id that is not exactly the fixture is not the fixture.
+    """
+
+    return next(
+        (
+            known
+            for known in _PLATFORM_MODEL_PRICES
+            if model == known
+            or (known not in _CARVE_OUT_MODELS and model.startswith(f"{known}-"))
+        ),
+        None,
+    )
+
+
+def platform_cost_metering(
+    *, provider: str, model: str, base_url: str | None
+) -> PlatformCostMetering:
+    """Classify how -- or whether -- this platform provider's cost can be metered.
+
+    CHAOS-3552. This REPLACES the invariant the ticket proposed ("assert every
+    certified model is priced"), which is not implementable:
+    ``CERTIFIED_PLATFORM_AGENT_PROVIDERS`` lists PROVIDERS, not models; the
+    model is operator-configured at runtime; and self-hosted providers are
+    unpriced BY DESIGN (``budget.py``: "An absent pair is unavailable, never
+    zero"). Requiring a price for every certified provider would break every
+    self-hosted deployment.
+
+    Enforced instead: *a platform provider whose cost cannot be priced must
+    never silently book the reservation as its cost.* Only
+    ``UNPRICED_CONFIGURATION_ERROR`` is a fault; the other three are answers.
+
+    Order matters. The fixture is checked FIRST, before the endpoint test,
+    because the acceptance stack serves it from its own scripted endpoint --
+    classifying it as self-hosted would be true but useless, and would lose the
+    near-zero price that keeps its reservation reconciled.
+    """
+
+    if model.strip() in _CARVE_OUT_MODELS:
+        return PlatformCostMetering.FIXTURE
+    if provider.strip().lower() != "openai" or not _official_openai_endpoint(base_url):
+        return PlatformCostMetering.UNMETERED_SELF_HOSTED
+    if _canonical_priced_model(model) is None:
+        return PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR
+    return PlatformCostMetering.PRICED
 
 
 def _fingerprint(*parts: str) -> str:
@@ -129,14 +262,7 @@ def _fingerprint(*parts: str) -> str:
 def _estimated_cost_microusd(
     *, model: str, input_tokens: int, output_tokens: int
 ) -> int | None:
-    canonical_model = next(
-        (
-            known
-            for known in _PLATFORM_MODEL_PRICES
-            if model == known or model.startswith(f"{known}-")
-        ),
-        None,
-    )
+    canonical_model = _canonical_priced_model(model)
     if canonical_model is None:
         return None
     input_rate, output_rate = _PLATFORM_MODEL_PRICES[canonical_model]

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -258,6 +258,17 @@ if _PROMETHEUS_AVAILABLE:
         buckets=(0.1, 0.25, 0.5, 1.0, 1.5, 2.0, 2.5, 5.0),
     )
 
+    ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_ask_dev_platform_model_unpriced_total",
+        "Ask Dev platform providers constructed with an OpenAI model that has "
+        "no entry in _PLATFORM_MODEL_PRICES. Every such run books the "
+        "worst-case admission reservation as its cost instead of a real "
+        "figure, so allowance usage for this organization is an overstatement "
+        "-- CHAOS-3552 measured 222x on gpt-5-nano. Non-zero means an operator "
+        "must price the model or change LLM_MODEL; it is a configuration "
+        "defect, not a provider fault.",
+        ["model"],
+    )
     ASK_DEV_QUA_SHADOW_FAULT_TOTAL = _prometheus_client_module.Counter(
         "devhealth_ask_dev_qua_shadow_fault_total",
         "Ask Dev QUA shadow evaluations or shadow-record writes that raised "
@@ -341,6 +352,7 @@ else:
     ASK_DEV_QUA_SHADOW_TOTAL = _noop_counter()
     ASK_DEV_QUA_COMMIT_TOTAL = _noop_counter()
     ASK_DEV_QUA_SHADOW_LATENCY_SECONDS = _noop_histogram()
+    ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL = _noop_counter()
     ASK_DEV_QUA_SHADOW_FAULT_TOTAL = _noop_counter()
     ASK_DEV_QUA_SHADOW_CARDINALITY_UNCORROBORATED_TOTAL = _noop_counter()
     ASK_DEV_RETENTION_SWEEP_TOTAL = _noop_counter()

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -267,7 +267,7 @@ if _PROMETHEUS_AVAILABLE:
         "-- CHAOS-3552 measured 222x on gpt-5-nano. Non-zero means an operator "
         "must price the model or change LLM_MODEL; it is a configuration "
         "defect, not a provider fault.",
-        ["model"],
+        ["model", "reason"],
     )
     ASK_DEV_QUA_SHADOW_FAULT_TOTAL = _prometheus_client_module.Counter(
         "devhealth_ask_dev_qua_shadow_fault_total",

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -37,11 +37,20 @@ The correct invariant, which replaces it:
 It splits by WHY the price is missing, and the two halves want opposite
 treatment:
 
-* ``openai`` on an official endpoint with an unpriced model -- a genuine
-  operator misconfiguration. **Fail loud at construction.**
-* anything self-hosted (``local``/``ollama``/``lmstudio``, or a non-official
-  endpoint) -- genuinely unpriceable in dollars, and correctly so. Must **not**
-  fail construction, and must **not** book the reservation either.
+* ``openai`` on an official endpoint with an unpriced model -- an operator
+  misconfiguration. Books the conservative reservation, **loudly** (warning
+  with model + remedy, and a metric). It does NOT refuse construction: with a
+  three-entry price book, refusing would have removed Ask Dev from every
+  organization running gpt-4o, gpt-5 or o3, which is far larger harm than an
+  overstated allowance.
+* ``openai`` on a NON-official endpoint (Azure, OpenRouter, a corporate
+  gateway) -- billability **unknown**, so it also books the reservation
+  loudly, and never reports zero. Reporting these as free was a fail-OPEN
+  defect an earlier revision shipped; see
+  ``test_a_billable_gateway_is_never_reported_as_free``.
+* self-hosted BY PROVIDER (``local``/``ollama``/``lmstudio``) -- the
+  operator's own hardware, genuinely free. Cost is an explicit **0**, so the
+  reservation reconciles away and no charge is booked.
 * ``ask-dev-scripted-v1`` -- a deterministic test double, not a production
   model. Carved out explicitly, keyed to the exact id, and guarded below
   against widening.
@@ -545,4 +554,32 @@ def test_only_a_self_hosted_PROVIDER_earns_a_zero_cost() -> None:
                 provider=provider,
             )
             == 0
+        )
+
+
+def test_the_classifier_and_the_pricer_agree_on_a_whitespace_model_id() -> None:
+    """Two paths that must agree, normalizing differently.
+
+    ``LLM_MODEL="ask-dev-scripted-v1 "`` -- a trailing space in an env var,
+    entirely ordinary -- classified as FIXTURE (the carve-out stripped) while
+    the price lookup returned None (it did not). The classifier said "carved
+    out, proceed" and the pricer left the US$1 reservation standing on every
+    call, so the acceptance stack would have drained an allowance while
+    reporting itself carved out.
+
+    Found by adversarial review. It is the same defect class as the two price
+    books this ticket exists to unify: not a wrong answer, but two answers.
+    """
+
+    from dev_health_ops.llm.agent.openai_compatible import _estimated_cost_microusd
+
+    for raw in ("ask-dev-scripted-v1 ", " ask-dev-scripted-v1", "  gpt-5-nano  "):
+        classified = platform_cost_metering(provider="openai", model=raw, base_url=None)
+        priced = _estimated_cost_microusd(
+            model=raw, input_tokens=10_000, output_tokens=1_000
+        )
+        assert classified is not PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR
+        assert priced is not None, (
+            f"{raw!r} classified {classified.value} but priced None -- the "
+            "reservation would stand on a model the classifier admitted"
         )

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -1,0 +1,362 @@
+"""CHAOS-3552: an unpriced platform model must fail loudly, not book the reservation.
+
+``ProviderBudget.require`` reserves US$1 per model call. ``ProviderBudget.add``
+reconciles that reservation down to the real cost -- but only when a real cost
+exists. ``_estimated_cost_microusd`` returns ``None`` for any model outside
+``_PLATFORM_MODEL_PRICES``, and the reconciliation branch leaves the reservation
+standing:
+
+    if usage.estimated_cost_microusd is None:
+        reconciled_cost = prior_cost      # reservation stands, unreconciled
+
+The dev stack sets ``LLM_MODEL="gpt-5-nano"``, which is not in the price book.
+Measured consequence, with the request cap at 1,000/month:
+
+    booked per run        US$4.00   (4 rounds x the US$1 reservation)
+    real per run          US$0.018  (were it priced)
+    overcharge            222x
+    runs before the US$100 cost cap    25   -- 40x tighter than the request cap
+
+That is what CHAOS-3523's "the allowance is gating platform runs" actually was.
+
+**The invariant this module enforces is NOT the one the ticket proposed.**
+CHAOS-3552 suggested "assert every certified model is priced", which is not
+implementable: ``CERTIFIED_PLATFORM_AGENT_PROVIDERS`` lists PROVIDERS
+(``openai``, ``local``, ``ollama``, ``lmstudio``), not models, and the model is
+operator-configured at runtime. Self-hosted providers are *deliberately*
+unpriced -- ``budget.py`` states it outright: "Only exact, server-certified
+provider/model pairs are present. An absent pair is unavailable, never zero."
+Requiring a price for every certified provider would break every self-hosted
+deployment.
+
+The correct invariant, which replaces it:
+
+    A platform provider whose cost cannot be priced must never silently book
+    the reservation as its cost.
+
+It splits by WHY the price is missing, and the two halves want opposite
+treatment:
+
+* ``openai`` on an official endpoint with an unpriced model -- a genuine
+  operator misconfiguration. **Fail loud at construction.**
+* anything self-hosted (``local``/``ollama``/``lmstudio``, or a non-official
+  endpoint) -- genuinely unpriceable in dollars, and correctly so. Must **not**
+  fail construction, and must **not** book the reservation either.
+* ``ask-dev-scripted-v1`` -- a deterministic test double, not a production
+  model. Carved out explicitly, keyed to the exact id, and guarded below
+  against widening.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.llm.agent.openai_compatible import (
+    SCRIPTED_FIXTURE_MODEL,
+    PlatformCostMetering,
+    platform_cost_metering,
+)
+
+#: The model the dev stack actually configures (`ops/.env`: LLM_MODEL).
+DEV_STACK_MODEL = "gpt-5-nano"
+
+#: An endpoint that is NOT api.openai.com. Pricing an OpenAI model name served
+#: from here at OpenAI rates would be a fabricated cost.
+SELF_HOSTED_URL = "https://llm.internal.example/v1"
+
+
+# --------------------------------------------------------------------------
+# The gap this ticket exists to close.
+# --------------------------------------------------------------------------
+
+
+def test_the_configured_dev_stack_model_is_priced() -> None:
+    """RED on today's gap: `gpt-5-nano` has no price entry.
+
+    This is the whole defect in one assertion. Observed failing before the
+    price was added -- the ordering matters, because a price added first and
+    a test written after proves only that the dict contains what the dict
+    contains.
+    """
+
+    assert (
+        platform_cost_metering(provider="openai", model=DEV_STACK_MODEL, base_url=None)
+        is PlatformCostMetering.PRICED
+    )
+
+
+def test_a_dated_variant_of_a_priced_model_is_still_priced() -> None:
+    """Providers pin dated snapshots; the price book must follow them.
+
+    `gpt-5-nano-2026-01-01` is the same model at the same rates. Without this
+    a routine provider-side pin silently reopens the whole defect.
+    """
+
+    assert (
+        platform_cost_metering(
+            provider="openai", model=f"{DEV_STACK_MODEL}-2026-01-01", base_url=None
+        )
+        is PlatformCostMetering.PRICED
+    )
+
+
+# --------------------------------------------------------------------------
+# The loud failure, and the two things it must NOT do.
+# --------------------------------------------------------------------------
+
+
+def test_an_unpriced_openai_model_on_the_official_endpoint_is_a_config_error() -> None:
+    """The fail-loud half of the invariant.
+
+    An operator who points `LLM_MODEL` at a real OpenAI model this build has
+    no price for gets a configuration error, not a run that reports costs
+    wrong by two orders of magnitude.
+    """
+
+    assert (
+        platform_cost_metering(
+            provider="openai", model="gpt-6-imaginary", base_url=None
+        )
+        is PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url"),
+    [
+        ("local", SELF_HOSTED_URL),
+        ("ollama", SELF_HOSTED_URL),
+        ("lmstudio", SELF_HOSTED_URL),
+        # openai-the-client-library pointed at someone else's endpoint is
+        # still self-hosted for pricing purposes -- the rates are not ours to
+        # assume. This is the case `budget.reliable_price` already refuses and
+        # the agent price book does not.
+        ("openai", SELF_HOSTED_URL),
+    ],
+)
+def test_self_hosted_is_unmetered_rather_than_a_config_error(
+    provider: str, base_url: str
+) -> None:
+    """The no-meter half. Self-hosted must not fail construction.
+
+    These deployments have no dollar cost to report and pricing them at
+    OpenAI's rates would fabricate one. They are unmetered by design --
+    distinct from "we forgot to price it", which is the case above.
+    """
+
+    assert (
+        platform_cost_metering(
+            provider=provider, model="llama-3.1-70b", base_url=base_url
+        )
+        is PlatformCostMetering.UNMETERED_SELF_HOSTED
+    )
+
+
+def test_a_self_hosted_endpoint_claiming_an_openai_model_name_is_not_priced() -> None:
+    """Endpoint blindness, asserted at the classifier.
+
+    The agent price book keys on model name alone, so a self-hosted endpoint
+    serving something it calls `gpt-5-mini` is billed at OpenAI's rates today
+    while `budget.reliable_price` correctly declines. Stage 2 removes the
+    duplicate book; this pins the classifier's answer meanwhile.
+    """
+
+    assert (
+        platform_cost_metering(
+            provider="openai", model="gpt-5-mini", base_url=SELF_HOSTED_URL
+        )
+        is PlatformCostMetering.UNMETERED_SELF_HOSTED
+    )
+
+
+# --------------------------------------------------------------------------
+# The carve-out, and the control that stops it widening.
+# --------------------------------------------------------------------------
+
+
+def test_the_scripted_fixture_model_is_carved_out() -> None:
+    """`ask-dev-scripted-v1` is a test double, not an unpriced production model.
+
+    It must not fail construction: the acceptance stack runs on it, and a
+    naive loud failure would take that stack down.
+    """
+
+    assert (
+        platform_cost_metering(
+            provider="openai", model=SCRIPTED_FIXTURE_MODEL, base_url=None
+        )
+        is PlatformCostMetering.FIXTURE
+    )
+
+
+def test_the_carve_out_cannot_widen_by_prefix() -> None:
+    """THE anti-widening control (team-lead condition).
+
+    The carve-out is keyed to the exact model id. Every other unpriced
+    openai-official model must still fail loud WITH the carve-out present --
+    otherwise the escape hatch quietly becomes the rule, which is how a
+    deliberate exception turns into an accidental default.
+
+    Prefix and suffix neighbours are included because the surrounding price
+    lookup DOES match on prefix (`model.startswith(f"{known}-")`), so a
+    carve-out written in the same style would silently admit all of these.
+    """
+
+    for impostor in (
+        f"{SCRIPTED_FIXTURE_MODEL}-v2",
+        f"{SCRIPTED_FIXTURE_MODEL}-",
+        f"not-{SCRIPTED_FIXTURE_MODEL}",
+        SCRIPTED_FIXTURE_MODEL.rstrip("1") + "2",
+        SCRIPTED_FIXTURE_MODEL.upper(),
+    ):
+        assert (
+            platform_cost_metering(provider="openai", model=impostor, base_url=None)
+            is PlatformCostMetering.UNPRICED_CONFIGURATION_ERROR
+        ), f"carve-out widened to admit {impostor!r}"
+
+
+def test_the_carve_out_is_exactly_one_model() -> None:
+    """Stated as a count, so adding a second fixture is a deliberate edit.
+
+    A carve-out that can grow without anyone noticing is not an exception, it
+    is a second price book.
+    """
+
+    from dev_health_ops.llm.agent.openai_compatible import _CARVE_OUT_MODELS
+
+    assert _CARVE_OUT_MODELS == frozenset({SCRIPTED_FIXTURE_MODEL})
+
+
+# --------------------------------------------------------------------------
+# Claims this change makes in prose, asserted so they cannot rot.
+# --------------------------------------------------------------------------
+
+
+def test_the_carve_out_id_matches_its_actual_producer() -> None:
+    """`SCRIPTED_FIXTURE_MODEL` must equal the scripted service's own constant.
+
+    The carve-out comment says it names
+    ``scripted_openai_service.SCRIPTED_OPENAI_MODEL`` "rather than a bare
+    literal". It IS a bare literal today (importing the scripted service into
+    the provider module for one string is not worth the import edge), so this
+    is what makes the claim true: if the producer ever renames its model id,
+    the carve-out stops matching and the acceptance stack starts failing loud
+    -- and this test says so first, at the rename, instead of at 3am.
+    """
+
+    from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
+
+    assert SCRIPTED_FIXTURE_MODEL == SCRIPTED_OPENAI_MODEL
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        None,
+        "",
+        "   ",
+        "https://api.openai.com",
+        "https://api.openai.com/v1",
+        "http://api.openai.com/v1",
+        "https://api.openai.com.evil.example/v1",
+        "https://not-api.openai.com/v1",
+        SELF_HOSTED_URL,
+        "not a url at all",
+        "https://",
+    ],
+)
+def test_the_duplicated_endpoint_predicate_matches_budgets(
+    base_url: str | None,
+) -> None:
+    """The differential oracle the duplication docstring promises.
+
+    ``openai_compatible._official_openai_endpoint`` is a deliberate, temporary
+    copy of ``budget._official_openai_endpoint`` -- taken because importing
+    ``llm.budget`` here would drag SQLAlchemy and the licensing models into the
+    provider's import graph for one predicate. A copy with no oracle comparing
+    it to its original is exactly the defect this whole ticket is about, so the
+    two are executed side by side rather than assumed equal.
+
+    Stage 2 (CHAOS-3559) deletes the copy; until then this is what stops them
+    drifting. Note the ``https://api.openai.com.evil.example`` case: a
+    hostname-suffix impostor must be refused by BOTH, and a naive
+    ``endswith`` re-implementation of either would admit it.
+    """
+
+    from dev_health_ops.llm.agent.openai_compatible import (
+        _official_openai_endpoint as agent_predicate,
+    )
+    from dev_health_ops.llm.budget import _official_openai_endpoint as budget_predicate
+
+    assert agent_predicate(base_url) == budget_predicate(base_url), (
+        f"endpoint predicates disagree on {base_url!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The guard at the construction site, observed refusing.
+# --------------------------------------------------------------------------
+
+
+def _candidate(model: str, *, provider: str = "openai", base_url: str = ""):
+    from dev_health_ops.llm.agent.policy import (
+        AgentProviderCandidate,
+        AgentProviderSource,
+    )
+    from dev_health_ops.llm.credentials import LLMCredentials
+
+    return AgentProviderCandidate(
+        provider=provider,
+        model=model,
+        credentials=LLMCredentials(api_key="test-key", base_url=base_url),
+        source=AgentProviderSource.PLATFORM,
+    )
+
+
+def test_construction_refuses_an_unpriced_model() -> None:
+    """The classifier is only advice until something acts on it.
+
+    Asserted against the real ``production_runtime._provider`` -- the single
+    place a platform provider is built -- because a test that only exercises
+    ``platform_cost_metering`` would pass just as happily with the guard
+    deleted from the call site.
+    """
+
+    from dev_health_ops.api.dev.production_runtime import _provider
+    from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+
+    with pytest.raises(DevRuntimeUnavailable) as excinfo:
+        _provider(_candidate("gpt-6-imaginary"))
+
+    assert excinfo.value.code == "model_not_supported"
+    # The operator has to be able to tell this apart from an uncertified
+    # provider, which raises the same code from the branch above it.
+    assert "price" in excinfo.value.safe_message.lower()
+
+
+@pytest.mark.parametrize(
+    ("model", "provider", "base_url"),
+    [
+        # priced production model
+        (DEV_STACK_MODEL, "openai", ""),
+        # the acceptance fixture -- the stack this must not take down
+        (SCRIPTED_FIXTURE_MODEL, "openai", ""),
+        # self-hosted, unpriceable by design
+        ("llama-3.1-70b", "ollama", SELF_HOSTED_URL),
+    ],
+)
+def test_construction_admits_everything_that_is_not_a_misconfiguration(
+    model: str, provider: str, base_url: str
+) -> None:
+    """The guard must be narrow: only the genuine fault raises.
+
+    A guard that also refused the fixture or self-hosted would be worse than
+    no guard -- it would trade a wrong number for an outage, and it would take
+    the acceptance stack with it.
+    """
+
+    from dev_health_ops.api.dev.production_runtime import _provider
+
+    assert (
+        _provider(_candidate(model, provider=provider, base_url=base_url)) is not None
+    )

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -129,11 +129,6 @@ def test_an_unpriced_openai_model_on_the_official_endpoint_is_a_config_error() -
         ("local", SELF_HOSTED_URL),
         ("ollama", SELF_HOSTED_URL),
         ("lmstudio", SELF_HOSTED_URL),
-        # openai-the-client-library pointed at someone else's endpoint is
-        # still self-hosted for pricing purposes -- the rates are not ours to
-        # assume. This is the case `budget.reliable_price` already refuses and
-        # the agent price book does not.
-        ("openai", SELF_HOSTED_URL),
     ],
 )
 def test_self_hosted_is_unmetered_rather_than_a_config_error(
@@ -167,7 +162,7 @@ def test_a_self_hosted_endpoint_claiming_an_openai_model_name_is_not_priced() ->
         platform_cost_metering(
             provider="openai", model="gpt-5-mini", base_url=SELF_HOSTED_URL
         )
-        is PlatformCostMetering.UNMETERED_SELF_HOSTED
+        is PlatformCostMetering.UNKNOWN_BILLABILITY
     )
 
 
@@ -374,6 +369,7 @@ def test_self_hosted_books_no_reservation_at_all() -> None:
         input_tokens=10_000,
         output_tokens=1_000,
         base_url=SELF_HOSTED_URL,
+        provider="ollama",
     )
     assert cost == 0, "self-hosted must be unmetered, not unknown"
     assert cost is not None, "None would leave the US$1 reservation booked"
@@ -476,7 +472,11 @@ def test_the_provider_threads_its_own_endpoint_into_the_cost_lookup() -> None:
     response = SimpleNamespace(usage=usage)
 
     self_hosted = OpenAICompatibleAgentProvider(
-        api_key="k", model="gpt-5-nano", base_url=SELF_HOSTED_URL, client=object()
+        api_key="k",
+        model="gpt-5-nano",
+        base_url=SELF_HOSTED_URL,
+        cost_provider="ollama",
+        client=object(),
     )
     official = OpenAICompatibleAgentProvider(
         api_key="k", model="gpt-5-nano", base_url=None, client=object()
@@ -484,3 +484,65 @@ def test_the_provider_threads_its_own_endpoint_into_the_cost_lookup() -> None:
 
     assert self_hosted._normalize_usage(response).estimated_cost_microusd == 0
     assert official._normalize_usage(response).estimated_cost_microusd == 900
+
+
+@pytest.mark.parametrize(
+    ("label", "base_url"),
+    [
+        ("Azure OpenAI", "https://myco.openai.azure.com/openai/deployments/gpt-5"),
+        ("OpenRouter", "https://openrouter.ai/api/v1"),
+        ("corporate gateway", "https://llm-gateway.corp.example/v1"),
+        ("forwarding proxy", "https://openai-proxy.corp.example/v1"),
+    ],
+)
+def test_a_billable_gateway_is_never_reported_as_free(
+    label: str, base_url: str
+) -> None:
+    """THE fail-open regression control.
+
+    An earlier revision classified self-hosted by URL -- "not api.openai.com"
+    implied "free" -- and reported every one of these BILLABLE endpoints at
+    cost 0. That is strictly worse than the stuck-reservation overcharge it
+    replaced: the overcharge is fail-closed (the org gets throttled early and
+    complains), zero is fail-open (real spend accrues against an allowance
+    that never moves, and nobody is throttled or told).
+
+    Only the PROVIDER NAME can say "the operator's own hardware". A URL cannot,
+    and `openai` + a custom base_url is exactly how Azure and every proxy are
+    wired.
+    """
+
+    from dev_health_ops.llm.agent.openai_compatible import _estimated_cost_microusd
+
+    assert (
+        platform_cost_metering(provider="openai", model="gpt-5-mini", base_url=base_url)
+        is PlatformCostMetering.UNKNOWN_BILLABILITY
+    ), f"{label} classified as free"
+    assert (
+        _estimated_cost_microusd(
+            model="gpt-5-mini",
+            input_tokens=10_000,
+            output_tokens=1_000,
+            base_url=base_url,
+            provider="openai",
+        )
+        is None
+    ), f"{label} reported a cost of zero -- real spend would go unbilled"
+
+
+def test_only_a_self_hosted_PROVIDER_earns_a_zero_cost() -> None:
+    """Zero is licensed by the provider name, never by the URL."""
+
+    from dev_health_ops.llm.agent.openai_compatible import _estimated_cost_microusd
+
+    for provider in ("local", "ollama", "lmstudio"):
+        assert (
+            _estimated_cost_microusd(
+                model="llama-3.1-70b",
+                input_tokens=10_000,
+                output_tokens=1_000,
+                base_url="http://localhost:11434/v1",
+                provider=provider,
+            )
+            == 0
+        )

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -313,25 +313,81 @@ def _candidate(model: str, *, provider: str = "openai", base_url: str = ""):
     )
 
 
-def test_construction_refuses_an_unpriced_model() -> None:
-    """The classifier is only advice until something acts on it.
+def test_an_unpriced_openai_model_is_booked_LOUDLY_not_refused(caplog) -> None:
+    """The invariant is "never SILENTLY book the reservation" -- loud booking satisfies it.
 
-    Asserted against the real ``production_runtime._provider`` -- the single
-    place a platform provider is built -- because a test that only exercises
-    ``platform_cost_metering`` would pass just as happily with the guard
-    deleted from the call site.
+    An earlier revision refused construction. Measured availability evidence
+    revised that (team-lead ruling): the price book has three entries, so
+    refusing would have taken Ask Dev away from every organization running
+    gpt-4o, gpt-5, o3 or anything else unlisted -- a far larger harm than an
+    overstated allowance. Platform runs spend real operator dollars, so the
+    conservative charge stays; what changes is that it is attributed.
+
+    THE LOUDNESS IS THE GUARD, so it is what this asserts. Both signals are
+    checked: a warning naming the model and the remedy, and the metric an
+    operator would actually alert on.
     """
 
+    import logging
+
     from dev_health_ops.api.dev.production_runtime import _provider
-    from dev_health_ops.api.dev.runtime import DevRuntimeUnavailable
+    from dev_health_ops.llm.agent.openai_compatible import _estimated_cost_microusd
 
-    with pytest.raises(DevRuntimeUnavailable) as excinfo:
-        _provider(_candidate("gpt-6-imaginary"))
+    with caplog.at_level(logging.WARNING):
+        assert _provider(_candidate("gpt-6-imaginary")) is not None
 
-    assert excinfo.value.code == "model_not_supported"
-    # The operator has to be able to tell this apart from an uncertified
-    # provider, which raises the same code from the branch above it.
-    assert "price" in excinfo.value.safe_message.lower()
+    records = [
+        r for r in caplog.records if r.message == "ask_dev.platform_model_unpriced"
+    ]
+    assert len(records) == 1, "the unpriced model was booked SILENTLY"
+    assert getattr(records[0], "model", None) == "gpt-6-imaginary"
+    assert "LLM_MODEL" in getattr(records[0], "remedy", "")
+
+    # And the cost really is unknown, so the worst-case reservation stands --
+    # the charge this warning is telling the operator about.
+    assert (
+        _estimated_cost_microusd(
+            model="gpt-6-imaginary", input_tokens=10_000, output_tokens=1_000
+        )
+        is None
+    )
+
+
+def test_self_hosted_books_no_reservation_at_all() -> None:
+    """The other half of the invariant, which an earlier revision only claimed.
+
+    ``UNMETERED_SELF_HOSTED`` previously just declined to raise --
+    ``_estimated_cost_microusd`` still returned ``None``, so self-hosted
+    deployments kept booking US$4/run for hardware the operator already owns.
+    The docstring said "must not book the reservation either" and the code did
+    not do it. Explicit **0** now, not ``None``: zero reconciles the admission
+    reservation away, ``None`` leaves it standing, and that difference is the
+    entire defect.
+    """
+
+    from dev_health_ops.llm.agent.openai_compatible import _estimated_cost_microusd
+
+    cost = _estimated_cost_microusd(
+        model="llama-3.1-70b",
+        input_tokens=10_000,
+        output_tokens=1_000,
+        base_url=SELF_HOSTED_URL,
+    )
+    assert cost == 0, "self-hosted must be unmetered, not unknown"
+    assert cost is not None, "None would leave the US$1 reservation booked"
+
+
+def test_a_priced_model_still_reports_a_real_cost() -> None:
+    """Control: making self-hosted zero must not zero out real metering."""
+
+    from dev_health_ops.llm.agent.openai_compatible import _estimated_cost_microusd
+
+    assert (
+        _estimated_cost_microusd(
+            model=DEV_STACK_MODEL, input_tokens=10_000, output_tokens=1_000
+        )
+        == 900
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -277,7 +277,7 @@ def test_the_duplicated_endpoint_predicate_matches_budgets(
     it to its original is exactly the defect this whole ticket is about, so the
     two are executed side by side rather than assumed equal.
 
-    Stage 2 (CHAOS-3559) deletes the copy; until then this is what stops them
+    Stage 2 (CHAOS-3560) deletes the copy; until then this is what stops them
     drifting. Note the ``https://api.openai.com.evil.example`` case: a
     hostname-suffix impostor must be refused by BOTH, and a naive
     ``endswith`` re-implementation of either would admit it.

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -1,4 +1,4 @@
-"""CHAOS-3552: an unpriced platform model must fail loudly, not book the reservation.
+"""CHAOS-3552: an unmeterable platform model must never be booked SILENTLY.
 
 ``ProviderBudget.require`` reserves US$1 per model call. ``ProviderBudget.add``
 reconciles that reservation down to the real cost -- but only when a real cost

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -583,3 +583,72 @@ def test_the_classifier_and_the_pricer_agree_on_a_whitespace_model_id() -> None:
             f"{raw!r} classified {classified.value} but priced None -- the "
             "reservation would stand on a model the classifier admitted"
         )
+
+
+def test_the_provider_threads_base_url_so_a_gateway_is_not_priced_as_openai() -> None:
+    """Dropping ``base_url`` reintroduces the fail-open in a subtler form.
+
+    The provider-identity test above passes ``cost_provider="ollama"``, whose
+    zero is licensed by the PROVIDER, so it never exercises ``base_url`` at
+    all. A mutation sweep caught that: hard-coding ``base_url=None`` at the
+    call site survived every test.
+
+    It matters most for the case the fail-open fix exists for. An Azure or
+    gateway deployment is ``cost_provider="openai"`` with a **priced** model
+    name; if the endpoint is dropped, it looks official, the price book hits,
+    and we report OpenAI's rates for infrastructure billed by someone else --
+    a fabricated cost, and low rather than high.
+    """
+
+    from dev_health_ops.llm.agent.openai_compatible import (
+        OpenAICompatibleAgentProvider,
+    )
+
+    response = SimpleNamespace(
+        usage=SimpleNamespace(prompt_tokens=10_000, completion_tokens=1_000)
+    )
+    gateway = OpenAICompatibleAgentProvider(
+        api_key="k",
+        model="gpt-5-mini",
+        base_url="https://myco.openai.azure.com/openai/deployments/gpt-5",
+        cost_provider="openai",
+        client=object(),
+    )
+
+    assert gateway._normalize_usage(response).estimated_cost_microusd is None, (
+        "a paid gateway was priced at OpenAI's rates -- base_url was not "
+        "threaded into the cost lookup"
+    )
+
+
+def test_the_two_loud_cases_carry_DIFFERENT_remedies(caplog) -> None:
+    """One remedy for both would send an operator chasing the wrong fix.
+
+    Also caught by the sweep: collapsing the conditional so both cases emit
+    the price-entry remedy left every test green. A typo'd model needs a price
+    added; an Azure/OpenRouter deployment needs its gateway priced
+    (CHAOS-3560) and cannot act on "add it to _PLATFORM_MODEL_PRICES" at all.
+    """
+
+    import logging
+
+    from dev_health_ops.api.dev.production_runtime import _provider
+
+    def _remedy_and_reason(model: str, base_url: str) -> tuple[str, str]:
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            _provider(_candidate(model, base_url=base_url))
+        record = next(
+            r for r in caplog.records if r.message == "ask_dev.platform_model_unpriced"
+        )
+        return getattr(record, "remedy", ""), getattr(record, "reason", "")
+
+    unpriced_remedy, unpriced_reason = _remedy_and_reason("gpt-6-imaginary", "")
+    gateway_remedy, gateway_reason = _remedy_and_reason(
+        "gpt-5-mini", "https://openrouter.ai/api/v1"
+    )
+
+    assert unpriced_reason != gateway_reason
+    assert unpriced_remedy != gateway_remedy, "both loud cases emitted the same remedy"
+    assert "LLM_MODEL" in unpriced_remedy
+    assert "3560" in gateway_remedy or "endpoint" in gateway_remedy

--- a/tests/api/dev/test_chaos_3552_platform_price_book.py
+++ b/tests/api/dev/test_chaos_3552_platform_price_book.py
@@ -49,6 +49,8 @@ treatment:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from dev_health_ops.llm.agent.openai_compatible import (
@@ -416,3 +418,69 @@ def test_construction_admits_everything_that_is_not_a_misconfiguration(
     assert (
         _provider(_candidate(model, provider=provider, base_url=base_url)) is not None
     )
+
+
+def test_the_unpriced_warning_also_increments_the_operator_metric(monkeypatch) -> None:
+    """The metric is a separate signal from the log, so it needs its own assertion.
+
+    Caught by the mutation sweep: replacing the ``.inc()`` with ``pass`` left
+    every test green, because the loudness test above only read the log. An
+    operator alerts on the counter, not on grepping warnings, so a dropped
+    metric is a dropped guard -- and the commit message claimed this was
+    covered when it was not.
+    """
+
+    from dev_health_ops.api.dev import production_runtime
+
+    seen: list[str] = []
+
+    class _Spy:
+        def labels(self, **kwargs: str) -> _Spy:
+            seen.append(kwargs["model"])
+            return self
+
+        def inc(self) -> None:
+            seen.append("inc")
+
+    monkeypatch.setattr(
+        production_runtime, "ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL", _Spy()
+    )
+    production_runtime._provider(_candidate("gpt-6-imaginary"))
+
+    assert seen == ["gpt-6-imaginary", "inc"]
+
+
+def test_the_provider_threads_its_own_endpoint_into_the_cost_lookup() -> None:
+    """The classification is worthless if the call site drops ``base_url``.
+
+    Also caught by the sweep: hard-coding ``base_url=None`` at the call site
+    survived every test, because the self-hosted assertions all called
+    ``_estimated_cost_microusd`` directly. Driven through the real provider
+    instance here, so the wiring itself is covered rather than the function
+    it wires to.
+
+    A self-hosted provider must report 0 (unmetered); the same usage payload
+    on an official-endpoint provider running a priced model must report a real
+    cost. If the call site stops passing the endpoint, the first becomes a
+    priced figure for infrastructure we do not bill.
+    """
+
+    from dev_health_ops.llm.agent.openai_compatible import (
+        OpenAICompatibleAgentProvider,
+    )
+
+    # `_normalize_usage` reads ATTRIBUTES off the SDK's usage object, not dict
+    # keys -- a dict silently yields zero tokens and a meaningless zero cost,
+    # which would have made this test pass for the wrong reason.
+    usage = SimpleNamespace(prompt_tokens=10_000, completion_tokens=1_000)
+    response = SimpleNamespace(usage=usage)
+
+    self_hosted = OpenAICompatibleAgentProvider(
+        api_key="k", model="gpt-5-nano", base_url=SELF_HOSTED_URL, client=object()
+    )
+    official = OpenAICompatibleAgentProvider(
+        api_key="k", model="gpt-5-nano", base_url=None, client=object()
+    )
+
+    assert self_hosted._normalize_usage(response).estimated_cost_microusd == 0
+    assert official._normalize_usage(response).estimated_cost_microusd == 900


### PR DESCRIPTION
## CHAOS-3552 — an unmeterable model must never be booked silently

`ProviderBudget` reserves **US$1 per model call** and reconciles it down to the real cost — but only when a real cost exists. `_estimated_cost_microusd` returned `None` for any model outside a three-entry price book, and the reconcile branch leaves the reservation standing. The dev stack configures `LLM_MODEL="gpt-5-nano"`, which was not in the book.

Measured, against a 1,000/month request cap:

```
booked per run   US$4.00   (4 rounds x the US$1 reservation)
real per run     US$0.018
overcharge       222x
runs before the US$100 cost cap   25   -- 40x tighter than the request cap
```

**That is what CHAOS-3523's "bounds sized for BYO are gating platform runs" actually was** — a broken meter, not a mis-sized bound. chris's re-band decision (request-primary) is sequenced after this so the bands are chosen against a working meter.

## The invariant is not the one the ticket proposed

3552 suggested *"assert every certified model is priced"*. Not implementable: `CERTIFIED_PLATFORM_AGENT_PROVIDERS` lists **providers** (`openai`, `local`, `ollama`, `lmstudio`), not models; the model is operator-configured at runtime; and self-hosted providers are unpriced **by design** (`budget.py`: *"An absent pair is unavailable, never zero"*). Requiring a price per certified provider would break every self-hosted deployment.

Enforced instead:

> **A platform provider whose cost cannot be priced must never *silently* book the reservation as its cost.**

| condition | behaviour |
|---|---|
| `local` / `ollama` / `lmstudio` (by **provider name**) | unmetered, cost **0** — reservation reconciles away |
| `openai` + official endpoint + priced | real cost |
| `openai` + official endpoint + unpriced | conservative reservation, **loud** (`unpriced_model`) |
| `openai` + **non-official** endpoint (Azure, OpenRouter, gateway) | conservative reservation, **loud** (`unknown_billability`) |
| `ask-dev-scripted-v1` | carved out, exact id |

Loud = `logger.warning` with the model and a **case-specific remedy**, plus `ASK_DEV_PLATFORM_MODEL_UNPRICED_TOTAL{model,reason}`, once per provider construction (per-call would spam exactly the deployments already paying for the defect).

## Two rulings this revised, both on evidence

**Fail-loud → loud booking.** An earlier revision *refused construction*. The suite went red, and chasing it showed the price book has **three entries** — so refusing would have removed Ask Dev from every org running `gpt-4o`, `gpt-5`, `o3`. Far larger harm than an overstated allowance. Rejected on the way: widening the price book to common models, because there is no cited source for their rates and **fabricating prices is worse than refusing to price**.

*The tell:* the two failing tests are green in this PR **without being edited**. They pass because the policy changed — evidence the guard was wrong, not the tests.

**A fail-open defect caught before review.** The first "self-hosted returns 0" classified by **URL** — "not `api.openai.com`" implied "free" — and reported Azure OpenAI, OpenRouter, corporate gateways and forwarding proxies at cost **0**. Strictly worse than the bug being fixed: a stuck reservation over-reports and fails **closed**; zero under-reports and fails **open**.

Root cause is this ticket's own thesis: `budget.reliable_price` uses the identical endpoint predicate **safely**, because its `None` is a typed refusal. Returning `0` asserts a fact. **Same predicate, opposite meaning — `0` and `None` are different words in a budget path**, and no type checker sees it. Fixed by classifying on provider name; `OpenAICompatibleAgentProvider` gained `cost_provider` because the instance previously could not answer that at all.

## Verification

- **Mutation sweep: 16/16 killed** — 0 survivors, 0 invalid anchors. Across three rounds it found **four real gaps in tests I had written and believed covered**: the carve-out widening through the *price book's* prefix match, an unasserted metric, an unthreaded `base_url` (twice, in two disguises), and collapsed remedies. None would have surfaced from reading.
- **Full suite: 3110 passed, 0 failed.** Lint/format/mypy clean.
- Adversarial review converged; all four findings closed. Its HIGH was the paid-gateway fail-open — independent confirmation of the self-caught defect.

## Reviewer: two claims to check rather than take on my word

Both are the class this ticket is about:
- `SCRIPTED_FIXTURE_MODEL` is asserted equal to `scripted_openai_service.SCRIPTED_OPENAI_MODEL`, so a producer rename fails loudly instead of silently un-carving the fixture.
- `_official_openai_endpoint` is a **deliberate temporary duplicate** of `budget`'s, asserted equal across 11 inputs including the `api.openai.com.evil.example` suffix impostor. **CHAOS-3560** deletes it.

## Scope

Stage 1 only. **CHAOS-3560** unifies the two price books (endpoint blindness; cached-input dropped, overstating cache-heavy calls 1.7×) and is where Azure/OpenRouter rates belong — today they pay the conservative reservation loudly, which is correct-but-crude and **over**-reports.

No flag: this path is always on, which is why the availability evidence was decisive.
