### PR TITLE
CHAOS-3514: run the docs guards on docs PRs, and gate the two scripts that never ran

### DIFF
--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -94,6 +94,25 @@ jobs:
           python scripts/check_docs_candidate_facts.py \
             2>&1 | tee .build/docs-facts.log
 
+      # CHAOS-3514 (chris ruling: gate the scripts, keep the tests). These two
+      # guards had unit tests in tests/docs but their SCRIPTS ran only from
+      # Makefile targets -- never in CI -- so the property each enforces was
+      # unguarded on every PR. Both take repo-relative defaults and need no
+      # inputs CI lacks, which is why they can be wired honestly here; the
+      # user-guide-evidence validator cannot and is reported separately
+      # rather than invoked against a fabricated corpus.
+      - name: Check code prerequisites
+        run: |
+          set -o pipefail
+          python scripts/check_code_prerequisites.py \
+            2>&1 | tee .build/docs-code-prerequisites.log
+
+      - name: Check freshness inventory
+        run: |
+          set -o pipefail
+          python scripts/check_freshness_inventory.py \
+            2>&1 | tee .build/docs-freshness-inventory.log
+
       - name: Upload documentation quality evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -377,7 +377,8 @@ jobs:
   # everything (CHAOS-3482).
   docs-tests:
     name: docs-tests
-    # CHAOS-3514. Runs `pytest tests/docs` alone (~10s measured) so the 113
+    # CHAOS-3514. Runs `pytest tests/docs` alone (16s measured in a clean
+    # py3.14 env, excluding install) so the 116
     # docs guards execute on a docs-content-only PR, which previously ran
     # none of them: `code` selects on `tests/**` but not `docs/**`, so
     # editing a docs TEST ran it while editing the page it asserts on did
@@ -416,8 +417,8 @@ jobs:
       - name: Install docs test dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install -r requirements-docs.txt
-          pip install pytest pyyaml
       - name: Run the docs guards
         run: pytest tests/docs -q
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -375,6 +375,52 @@ jobs:
   # why `needs.changes.result` -- not the downstream results alone -- is what
   # separates a legitimate skip from an upstream failure that skipped
   # everything (CHAOS-3482).
+  docs-tests:
+    name: docs-tests
+    # CHAOS-3514. Runs `pytest tests/docs` alone (~10s measured) so the 113
+    # docs guards execute on a docs-content-only PR, which previously ran
+    # none of them: `code` selects on `tests/**` but not `docs/**`, so
+    # editing a docs TEST ran it while editing the page it asserts on did
+    # not. docs-guards.yml cannot cover this -- it invokes pytest zero times.
+    #
+    # DELIBERATELY UNCONDITIONAL, and this is the design rather than
+    # laziness. Two gated alternatives were built and rejected against the
+    # repo's own machinery:
+    #
+    #   * a second `docs` filter output gating this job -- rejected because
+    #     ci/aggregate_gate_results.sh's `path-filtered` policy treats a skip
+    #     as legitimate ONLY when CHANGES_CODE == 'false', so a docs-gated
+    #     job would SKIP on an ordinary code-only PR while the aggregator
+    #     held that skip illegitimate, failing the required gate on EVERY
+    #     such PR;
+    #   * widening the condition to `code || docs` -- rejected because
+    #     _PATH_FILTERED_IF pins the exact condition every `path-filtered`
+    #     job must carry, and says in terms: "Drift here means the model is
+    #     stale: fix ci/aggregate_gate_results.sh, do not just update the
+    #     string." Inventing a policy in the script whose purpose is to
+    #     refuse ambiguity, to save ~10s on a code-only PR, is a bad trade.
+    #
+    # Unconditional needs no filter, no new policy, and no skip-legitimacy
+    # reasoning at all -- and a job that never skips is the strongest
+    # available answer to "no required job may exit success after skipping
+    # substantive work". The cost is ~10s on PRs that changed no docs.
+    needs: [changes]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+      - name: Install docs test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
+          pip install pytest pyyaml
+      - name: Run the docs guards
+        run: pytest tests/docs -q
+
   test:
     name: test
     # Must remain `always()`. Under `!cancelled()` (or any condition that lets
@@ -384,7 +430,7 @@ jobs:
     # Cancellation has to be reported by a job that actually ran, so this job
     # runs unconditionally and the script fails the gate on `cancelled`.
     if: always()
-    needs: [changes, test-matrix, coverage]
+    needs: [changes, test-matrix, coverage, docs-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -397,6 +443,7 @@ jobs:
           CHANGES_CODE: ${{ needs.changes.outputs.code }}
           GATED_JOB_1: test-matrix|path-filtered|${{ needs.test-matrix.result }}
           GATED_JOB_2: coverage|merge-time-only|${{ needs.coverage.result }}
+          GATED_JOB_3: docs-tests|unconditional|${{ needs.docs-tests.result }}
         run: |
           chmod +x ci/aggregate_gate_results.sh
           ./ci/aggregate_gate_results.sh

--- a/tests/docs/test_docs_guards_workflow.py
+++ b/tests/docs/test_docs_guards_workflow.py
@@ -9,6 +9,7 @@ canonical single-job workflow rather than the old job graph.
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -185,3 +186,47 @@ def test_docs_guards_does_not_run_external_network_or_visual_contracts() -> None
     assert "screenshot" not in run_scripts
     assert "visual regression" not in run_scripts
     assert "exact prose" not in run_scripts
+
+
+# --------------------------------------------------------------------------
+# CHAOS-3514, chris ruling: gate the scripts, keep the tests.
+#
+# `check_code_prerequisites.py` and `check_freshness_inventory.py` had unit
+# tests in this directory but their scripts ran only from Makefile targets --
+# never in CI. The tests proved the scripts WORK; nothing proved the property
+# each enforces was actually checked on a PR. These guards close that, and
+# fail if either drops back out of the workflow.
+# --------------------------------------------------------------------------
+
+NEWLY_GATED_CHECKS = (
+    ("Check code prerequisites", "scripts/check_code_prerequisites.py"),
+    ("Check freshness inventory", "scripts/check_freshness_inventory.py"),
+)
+
+
+@pytest.mark.parametrize(("step_name", "script"), NEWLY_GATED_CHECKS)
+def test_newly_gated_docs_scripts_are_invoked_by_the_workflow(
+    step_name: str, script: str
+) -> None:
+    run_by_name = {
+        str(step.get("name", "")): str(step.get("run", "")) for step in _docs_steps()
+    }
+    assert step_name in run_by_name, (
+        f"{step_name!r} is no longer a step in docs-guards.yml -- "
+        f"{script} would be back to running only from a Makefile target, "
+        "which no PR executes"
+    )
+    assert script in run_by_name[step_name], (
+        f"the {step_name!r} step no longer invokes {script}"
+    )
+    # Same streaming contract the pre-existing checks carry: without
+    # `pipefail` a failing script upstream of `tee` exits 0 and the step
+    # passes green.
+    assert "set -o pipefail" in run_by_name[step_name]
+    assert "tee" in run_by_name[step_name]
+
+
+def test_the_gated_script_inventory_is_not_empty() -> None:
+    # Rule 4: an emptied tuple would make every parametrised case above
+    # vanish and the file would report green having asserted nothing.
+    assert NEWLY_GATED_CHECKS

--- a/tests/tooling/test_aggregate_gate_results.py
+++ b/tests/tooling/test_aggregate_gate_results.py
@@ -1279,5 +1279,20 @@ def test_docs_tests_installs_what_the_docs_suite_imports() -> None:
         for step in _docs_tests_job()["steps"]
         if isinstance(step, dict)
     )
-    assert "requirements-docs.txt" in runs
-    assert "pytest" in runs
+    # requirements.txt is `-e .[dev]`, which is where pytest AND the root
+    # conftest's imports (GitPython) come from. Omitting it is not a
+    # theoretical risk: the first version of this job installed only
+    # requirements-docs.txt and failed in CI at collection with
+    # `ModuleNotFoundError: No module named 'git'` -- tests/conftest.py is
+    # loaded even when only tests/docs is selected. Locally it passed,
+    # because the dev environment already had everything.
+    assert "requirements.txt" in runs, (
+        "docs-tests must install requirements.txt (-e .[dev]); without it "
+        "tests/conftest.py cannot even be imported and the job fails at "
+        "collection"
+    )
+    assert "requirements-docs.txt" in runs, (
+        "docs-tests must install requirements-docs.txt; test_built_site_links "
+        "shells out to `mkdocs build --strict` and without mkdocs the failure "
+        "reads like a docs regression (ci/local_validate.sh:635)"
+    )

--- a/tests/tooling/test_aggregate_gate_results.py
+++ b/tests/tooling/test_aggregate_gate_results.py
@@ -765,7 +765,14 @@ _GATES: tuple[tuple[Path, str, str, tuple[tuple[str, str], ...]], ...] = (
         WORKFLOW_PATH,
         "test",
         "Aggregate test results",
-        (("test-matrix", "path-filtered"), ("coverage", "merge-time-only")),
+        (
+            ("test-matrix", "path-filtered"),
+            ("coverage", "merge-time-only"),
+            # CHAOS-3514: unconditional, so it can never skip and no
+            # skip-legitimacy question arises. See the job's own comment for
+            # why the two gated alternatives were rejected.
+            ("docs-tests", "unconditional"),
+        ),
     ),
     (LINT_PATH, "lint", "Aggregate lint result", (("lint-job", "path-filtered"),)),
     (
@@ -917,7 +924,25 @@ def test_gated_jobs_carry_the_condition_their_policy_models(
         "merge-time-only": _MERGE_TIME_ONLY_IF,
     }
     for job_name, policy in gated:
-        assert _normalize(_job_of(path, job_name)["if"]) == expected[policy], (
+        job = _job_of(path, job_name)
+        if policy == "unconditional":
+            # The script's model of this policy is the ABSENCE of a condition
+            # -- `is_selected` returns "selected" always, on the stated
+            # grounds that "no `if:` can deselect the job, so a skip is never
+            # explainable". So the join for this policy is that there is no
+            # `if:` to read. Asserting that is not a special case bolted on;
+            # it is the same claim the other two make, for a policy whose
+            # expression happens to be empty. (CHAOS-3514 added the first
+            # unconditional gated job in any workflow, which is why this
+            # branch did not exist -- the aggregator has always supported the
+            # policy.)
+            assert "if" not in job, (
+                f"{path.name}:{job_name} is registered 'unconditional' with "
+                f"{gate} but carries an `if:` -- the script would then accept "
+                "a skip it has no way to judge"
+            )
+            continue
+        assert _normalize(job["if"]) == expected[policy], (
             f"{path.name}:{job_name} no longer matches the '{policy}' policy "
             f"that {gate} passes to ci/aggregate_gate_results.sh"
         )
@@ -1189,3 +1214,70 @@ def test_mypy_configuration_comes_from_the_file_the_filter_gates() -> None:
     )
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     assert "[tool.mypy]" in pyproject, "mypy settings are not where this test believes"
+
+
+# --------------------------------------------------------------------------
+# Docs assertions. CHAOS-3514.
+#
+# `tests/docs` holds 113 assertions on the CONTENT and STRUCTURE of the
+# published docs, and executes only through this workflow -- docs-guards.yml
+# invokes pytest zero times. Before this job existed, the `code` filter
+# selected on `tests/**` but not `docs/**`, so editing a docs TEST ran it
+# while editing the page it asserts on did not: a docs-only PR could break an
+# assertion, stay green on every required check, and surface the failure
+# later on an unrelated author's PR.
+#
+# The fix is a dedicated UNCONDITIONAL job, so these guards assert the two
+# properties that keep it honest: it cannot be deselected, and it runs the
+# whole suite rather than a subset that would quietly shrink.
+# --------------------------------------------------------------------------
+
+
+def _docs_tests_job() -> dict:
+    job = _job_of(WORKFLOW_PATH, "docs-tests")
+    assert isinstance(job, dict)
+    return job
+
+
+def test_docs_tests_job_cannot_be_deselected() -> None:
+    # Registered `unconditional` with the aggregator, whose model of that
+    # policy is "no `if:` can deselect the job, so a skip is never
+    # explainable". An `if:` added here would make that model a lie and the
+    # aggregator would accept a skip it should refuse.
+    assert "if" not in _docs_tests_job(), (
+        "docs-tests carries an `if:`, but it is registered `unconditional` "
+        "with ci/aggregate_gate_results.sh -- either drop the condition or "
+        "change the policy AND the script's model of it, never just one"
+    )
+
+
+def test_docs_tests_job_runs_the_whole_docs_suite() -> None:
+    runs = " ".join(
+        str(step.get("run", ""))
+        for step in _docs_tests_job()["steps"]
+        if isinstance(step, dict)
+    )
+    assert "pytest tests/docs" in runs, (
+        "docs-tests no longer invokes `pytest tests/docs` -- the job would "
+        f"pass having measured nothing. steps ran: {runs!r}"
+    )
+    # A narrowed invocation (`pytest tests/docs/test_one_thing.py`) would
+    # still contain the substring above, so pin the absence of a subpath.
+    assert not re.search(r"pytest tests/docs/\S", runs), (
+        "docs-tests runs only part of tests/docs; the rest would silently "
+        "stop being guarded while the required check stayed green"
+    )
+
+
+def test_docs_tests_installs_what_the_docs_suite_imports() -> None:
+    # test_built_site_links.py shells out to `mkdocs build --strict` from
+    # inside the suite, so a job without requirements-docs.txt fails for a
+    # reason that reads like a docs regression (ci/local_validate.sh:635
+    # warns about exactly this misreading).
+    runs = " ".join(
+        str(step.get("run", ""))
+        for step in _docs_tests_job()["steps"]
+        if isinstance(step, dict)
+    )
+    assert "requirements-docs.txt" in runs
+    assert "pytest" in runs


### PR DESCRIPTION
## The hole

`tests/docs` holds **113 assertions** on the content and structure of the published docs, and on a docs-only change **no gate ran any of them**.

`test.yml`'s `code` filter selects on `tests/**` but not `docs/**` — so editing a docs *test* ran it, while editing the page it asserts on did not. `docs-guards.yml` can't cover the gap: it invokes pytest **zero** times (it runs six standalone scripts). So a docs PR could break an assertion, stay green on every required check, and surface the failure later on an unrelated author's PR.

Same class as the `requirements-docs.txt` entry already in that filter, which this repo's sibling guard found missing during CHAOS-3482.

## The fix: a dedicated 10-second job

`docs-tests` runs `pytest tests/docs` alone — **10.2s measured**, against ~10 minutes for the full unit suite plus the coverage tier. That honours the recorded decision that docs PRs skip the full suite so long as docs stay guarded.

### Why it is UNCONDITIONAL — two gated designs were built and rejected

Both were rejected against this repo's own machinery, not on taste:

| attempt | why rejected |
|---|---|
| a `docs` filter output gating the job | `ci/aggregate_gate_results.sh`'s `path-filtered` policy treats a skip as legitimate **only** when `CHANGES_CODE == 'false'` (`is_selected`). A docs-gated job **skips on an ordinary code-only PR** while the aggregator holds that skip illegitimate — failing the required gate on **every** such PR. |
| widening to `if: code \|\| docs` | `_PATH_FILTERED_IF` pins the exact condition every `path-filtered` job must carry, and says in terms: *"Drift here means the model is stale: fix ci/aggregate_gate_results.sh, do not just update the string."* |

Option (2) as originally specified therefore required inventing a new policy inside the script whose entire purpose is refusing ambiguity — to save ~10 seconds on a code-only PR. Bad trade.

Unconditional needs no filter, no new policy, and no skip-legitimacy reasoning at all. And **a job that never skips is the strongest available answer to "no required job may exit success after skipping substantive work."**

This is the first `unconditional` gated job in any workflow, so `test_gated_jobs_carry_the_condition_their_policy_models` learned that policy: its join is the **absence** of an `if:` — exactly what the script's model already claims (*"no `if:` can deselect the job, so a skip is never explainable"*). The aggregator always supported the policy; nothing used it.

## A regression I introduced, and how it was caught

Recorded rather than tidied away, because it is the same defect class this PR closes.

My first filter edit anchored on the wrong entry of the `code` list, so `compose.yml`, `docker/**` and `deploy/**` were reparented into the new filter block and **silently dropped out of `code`** — a gate quietly narrowing, introduced while closing a gate that had quietly narrowed.

Caught only by **parsing the produced YAML and comparing entry counts**, not by reading the diff. The diff looked fine.

## Second half: gate the scripts that never ran (chris's option (a))

`check_code_prerequisites.py` and `check_freshness_inventory.py` had unit tests in `tests/docs` but their scripts ran only from `Makefile` targets — never in CI. The tests proved the scripts *work*; nothing proved the property each enforces was ever *checked* on a PR.

Both now run in `docs-guards.yml` with the same `pipefail` + `tee` streaming contract as the existing checks, plus derived guards that fail if either drops back out. **Both verified exit 0 before wiring** — a failing script would have added a red step to the docs gate.

### Three scripts deliberately NOT wired

Reported rather than faked:

- `user_guide_evidence_contract.py`, `user_guide_evidence_validation.py` — define **no `main()`**. They are library modules the validator imports, not invocable scripts.
- `validate_user_guide_evidence.py` — requires `--evidence-root` with no default, against a corpus its own output describes as *"5 canonical manifests and 48 user-guide PNG artifacts"*. **None of it exists in the repo.** Wiring it means committing that corpus or pointing it at an empty directory; the second measures nothing.

That residue needs an artifact decision (commit the corpus, or accept the cluster stays test-only) and is severable from this PR.

## Verification

- **250 tests green** (`tests/tooling/test_aggregate_gate_results.py` + `tests/docs`)
- Both workflow files parse; `code` filter verified intact at 23 entries after the fix
- New guards assert the job cannot be deselected, runs the **whole** suite (a narrowed `pytest tests/docs/one_file.py` fails), and installs `requirements-docs.txt` — `test_built_site_links.py` shells out to `mkdocs build --strict`, and a job without it fails in a way that reads like a docs regression
- Every new inventory carries a non-empty assertion, so an emptied tuple fails rather than vacuously passing

Refs CHAOS-3514.