### PR TITLE
DO NOT MERGE — CHAOS-3514 RED-proof: docs-only change must turn the gate red

### DIFF
--- a/docs/use/delivery-flow/pr-flow.md
+++ b/docs/use/delivery-flow/pr-flow.md
@@ -91,3 +91,5 @@ Use [Diagnose no or incomplete data](../troubleshooting/no-or-incomplete-data.md
 - [Read Quadrants](quadrants.md)
 - [Investigate review pressure](review-pressure.md)
 - [Follow relationships in Work Graph](../code-and-relationships/work-graph.md)
+
+Use this view to compare review latency across teams and spot the slowest reviewers.


### PR DESCRIPTION
## ⛔ DO NOT MERGE — throwaway proof, closed unmerged once recorded

This PR exists to **fail**. It is the acceptance criterion for CHAOS-3514, which states in terms:

> a PR that changes only a `docs/*` file which `tests/docs` asserts on must produce a RED required check when that assertion is broken. Prove it by breaking one deliberately and observing the gate fail — **a green run is not evidence here**.

## What it changes

Exactly one file, `docs/use/delivery-flow/pr-flow.md`, plus one sentence:

> *"Use this view to compare review latency across teams and spot the slowest reviewers."*

`review latency` is in `PR_FLOW_UNSUPPORTED_CLAIMS`, so it trips `test_canonical_pr_flow_is_source_accurate_and_calibrated`. The sentence is deliberately the kind a well-meaning docs author would actually write — plausible, helpful-sounding, and claiming a capability the product does not measure. That is precisely what the guard exists to catch, and it is a more honest test of the gate than a syntax error would be.

**No test, workflow, or code file is touched** — that is load-bearing. It keeps `code=false`, so this exercises the docs-only path specifically.

## Expected result

- `docs-tests` → **RED**, with `AssertionError: canonical pr-flow.md contains unsupported claim 'review latency'`
- the required `test` check → **RED**, because the aggregator sees a failed gated job

## Why this matters

**Before #1580 this PR would have been GREEN on every required check.** The `code` filter selected on `tests/**` but not `docs/**`, so a docs-content-only change ran none of the 116 docs assertions, and `docs-guards.yml` invokes pytest zero times. The broken claim would have shipped, then surfaced later on an unrelated author's code PR.

A green run on the merged PR proved the job **runs**. Only this proves it **guards**.

Refs CHAOS-3514.