### PR TITLE
CHAOS-3532: let the acceptance stack exercise QUA commit, armed only on purpose

### DIFF
--- a/scripts/acceptance/mint_ask_dev_world_snapshot.sh
+++ b/scripts/acceptance/mint_ask_dev_world_snapshot.sh
@@ -72,7 +72,16 @@ unset \
   WORKER_CONCURRENCY WORKER_HEAVY_CONCURRENCY \
   WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED WORKER_GITHUB_REPO_METADATA_ENABLED \
   DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER \
-  BUGSINK_BASE_URL BUGSINK_CREATE_SUPERUSER
+  BUGSINK_BASE_URL BUGSINK_CREATE_SUPERUSER \
+  ASK_DEV_QUA_SHADOW_ENABLED ASK_DEV_QUA_COMMIT_ENABLED
+# ^ CHAOS-3532: cleared here too, and this script deliberately has NO
+# opt-in to turn them back on. ops/.env exports both for the dev stack and
+# direnv carries them into every ops shell, so a mint run from a developer
+# shell would otherwise boot an ARMED stack -- and a snapshot minted from
+# one bakes QUA-influenced state into the fixture world every future
+# acceptance run then restores. Minting must never be armed; running an
+# armed stack is what run_ask_dev_compose.sh's ASK_DEV_ACCEPTANCE_QUA knob
+# is for.
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 ops_root="$(cd -- "${script_dir}/../.." && pwd)"

--- a/scripts/acceptance/run_ask_dev_compose.sh
+++ b/scripts/acceptance/run_ask_dev_compose.sh
@@ -51,12 +51,46 @@ unset \
   WORKER_CONCURRENCY WORKER_HEAVY_CONCURRENCY \
   WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED WORKER_GITHUB_REPO_METADATA_ENABLED \
   DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER \
-  BUGSINK_BASE_URL BUGSINK_CREATE_SUPERUSER
+  BUGSINK_BASE_URL BUGSINK_CREATE_SUPERUSER \
+  ASK_DEV_QUA_SHADOW_ENABLED ASK_DEV_QUA_COMMIT_ENABLED
 
 web_root="$(cd -- "$2" && pwd)"
 if [[ ! -f "${web_root}/Dockerfile" || ! -f "${web_root}/package.json" ]]; then
   echo "--web-root must identify a dev-health-web checkout" >&2
   exit 64
+fi
+
+# CHAOS-3532: arming the QUA ladder is a deliberate act HERE, and nowhere
+# else.
+#
+# These two are the only ASK_DEV_-namespaced names this launcher clears
+# rather than letting through. That prefix normally means "this launcher's
+# own knob, cannot collide with an ambient dev .env by construction" -- the
+# third bucket of test_launcher_hardens_compose_interpolation_env_for_every
+# _var_it_boots. For these two the assumption behind that bucket is simply
+# false: ops/.env sets ASK_DEV_QUA_SHADOW_ENABLED=1 and
+# ASK_DEV_QUA_COMMIT_ENABLED=1 for the DEV stack, direnv exports that file
+# into every shell under the ops tree, and passing them through would boot
+# every acceptance stack from a developer shell silently ARMED.
+#
+# That is not a hypothetical leftover export. It was the live state of every
+# ops shell on this machine, verified directly, hours after the passthrough
+# version of this wiring was written -- which is why this reverses it.
+#
+# An armed stack is not merely "more feature on": the QUA shadow changes
+# what every baseline corpus case measures, and armed runs are graded
+# against predictions pre-registered on an UNARMED system. Silent arming
+# invalidates the comparison rather than extending it.
+#
+# So: cleared unconditionally above, then translated from this launcher's
+# own one-shot knob AFTER the clear. Setting the two flags directly cannot
+# arm anything; only ASK_DEV_ACCEPTANCE_QUA=1 can.
+if [[ "${ASK_DEV_ACCEPTANCE_QUA:-0}" == "1" ]]; then
+  export ASK_DEV_QUA_SHADOW_ENABLED=1
+  export ASK_DEV_QUA_COMMIT_ENABLED=1
+else
+  export ASK_DEV_QUA_SHADOW_ENABLED=0
+  export ASK_DEV_QUA_COMMIT_ENABLED=0
 fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/src/dev_health_ops/llm/agent/scripted_openai_service.py
+++ b/src/dev_health_ops/llm/agent/scripted_openai_service.py
@@ -80,6 +80,87 @@ def _tool_results_from_messages(payload: dict[str, Any]) -> list[dict[str, Any]]
     return []
 
 
+#: The contract a Question Understanding Agent request asks to be answered
+#: in. CHAOS-3532: this string, and only this string, is how the scripted
+#: service recognises a QUA call.
+#:
+#: Pinned to the contract ID rather than inferred from the schema's shape: a
+#: structural guess ("does it have a mentions array?") would drift silently
+#: the first time an unrelated schema grew a similar field, and a QUA call
+#: answered by the wrong branch is indistinguishable downstream from the QUA
+#: path declining.
+QUA_CONTRACT_ID = "dev_question_understanding.v1"
+
+#: Script file answering QUA calls. Deliberately NOT ``role-*.json``: the
+#: role is not the routing key and never was. ``qua_shadow`` runs under the
+#: already-certified ``legacy_agent`` provider (see ``roles.AgentRole``), so
+#: a ``role-question_understanding.json`` would never be loaded by anything.
+QUA_SCRIPT_FILENAME = "qua-decisions.v1.json"
+
+_QUA_QUESTION_PATTERN = re.compile(r'^Question:\s*"(?P<question>.*)"\s*$', re.M)
+
+
+def _is_qua_request(payload: dict[str, Any]) -> bool:
+    """Whether this request is a Question Understanding Agent call.
+
+    A QUA request self-identifies: ``qua_shadow`` asks for its answer in the
+    ``dev_question_understanding.v1`` contract, and that id travels in the
+    request's own ``response_format`` json_schema. Nothing else this service
+    receives carries it.
+
+    Searched anywhere in the schema rather than at a fixed path because the
+    adapter nests the caller's schema inside its own decision envelope
+    (``openai_compatible._decision_response_schema``); the id's PRESENCE is
+    the signal, its position is an implementation detail of that wrapper.
+    """
+
+    response_format = payload.get("response_format")
+    if not isinstance(response_format, dict):
+        return False
+    return QUA_CONTRACT_ID in json.dumps(response_format)
+
+
+def _qua_question_from_messages(payload: dict[str, Any]) -> str | None:
+    """The question text out of a QUA user message.
+
+    ``qua_shadow._build_messages`` sends PLAIN TEXT beginning
+    ``Question: "..."`` -- not the JSON object ``_question_from_messages``
+    requires. That mismatch is why no script file could previously answer a
+    QUA call at all: the JSON parse raised, the router returned None, and
+    the request fell through to the heuristic.
+    """
+
+    for message in payload.get("messages") or []:
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+        match = _QUA_QUESTION_PATTERN.search(content)
+        if match is not None:
+            return match.group("question")
+    return None
+
+
+def _load_qua_script() -> dict[str, Any]:
+    """The QUA decision script, or an empty mapping if absent.
+
+    An absent file is NOT an error here -- it means "no QUA scripts", and
+    every QUA request then takes the loud 422 below. That is the correct
+    degradation: a missing script must never become a plausible answer.
+    """
+
+    path = provider_scripts._scripts_dir() / QUA_SCRIPT_FILENAME
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    cases = payload.get("cases")
+    return cases if isinstance(cases, dict) else {}
+
+
 def _question_from_messages(payload: dict[str, Any]) -> str | None:
     for message in payload.get("messages") or []:
         if message.get("role") != "user":
@@ -500,6 +581,59 @@ class ScriptedOpenAIHandler(BaseHTTPRequestHandler):
                     "scripted cases by exact question text instead (see "
                     "provider-scripts/README.md)",
                 )
+            )
+            return
+
+        # CHAOS-3532: QUA requests route on their own contract id, and NEVER
+        # fall through.
+        #
+        # Placed ahead of the question-JSON router below because a QUA call
+        # cannot reach it: qua_shadow sends plain text, that router needs a
+        # JSON object with a `question` key, so the parse raises and the
+        # engine is never consulted. Before this branch existed, every QUA
+        # call landed in the heuristic and came back as a `tool_calls`
+        # response -- which is not an AgentFinalAnswer, so qua_shadow
+        # recorded SKIPPED_UNEXPECTED_DECISION. An armed QUA run reported
+        # "skipped" with no error and read as a negative result about the
+        # CHAOS-3525 commit path it was booted to demonstrate.
+        #
+        # The 422 is the load-bearing half. This service already learned once
+        # that a silent fall-through is worse than a failure: "all 19
+        # scripted cases fell through to the unscripted default heuristic
+        # while PASSING" (see compose.ask-dev.yml). An unscripted QUA
+        # question must be distinguishable from a QUA path that declined,
+        # and only a distinct error code makes that possible.
+        if _is_qua_request(payload):
+            qua_question = _qua_question_from_messages(payload)
+            scripted = _load_qua_script().get(qua_question or "")
+            if not isinstance(scripted, dict) or "value" not in scripted:
+                self._write_json(
+                    422,
+                    {
+                        "error": {
+                            "type": "scripted_provider_unmapped_qua_question",
+                            "code": "scripted_provider_unmapped_qua_question",
+                            "message": (
+                                "no QUA decision is scripted for this question; "
+                                "add it to "
+                                f"{QUA_SCRIPT_FILENAME} rather than letting the "
+                                "unscripted heuristic answer a question-"
+                                "understanding call"
+                            ),
+                        }
+                    },
+                )
+                return
+            self._send_completion(
+                payload,
+                {
+                    "role": "assistant",
+                    "content": json.dumps(
+                        {"kind": "final_answer", "value": scripted["value"]},
+                        separators=(",", ":"),
+                    ),
+                },
+                "stop",
             )
             return
 

--- a/tests/acceptance/compose.ask-dev.yml
+++ b/tests/acceptance/compose.ask-dev.yml
@@ -37,6 +37,36 @@ services:
       ASK_DEV_ACCEPTANCE_OPENAI_BASE_URL: http://ask-dev-scripted-openai:8001/v1
       ASK_DEV_ACCEPTANCE_OPENAI_API_KEY: ask-dev-acceptance-local-v1
       JWT_SECRET_KEY: ask-dev-acceptance-jwt-secret-key-v1
+      # CHAOS-3532: the QUA ladder (off -> shadow -> commit), settable from
+      # the invoking shell and OFF by default, so no existing armed run
+      # changes behaviour and an operator can arm one deliberately.
+      #
+      # Deliberately NOT added to run_ask_dev_compose.sh's `unset` block.
+      # That block exists to stop an ambient shell value reaching compose
+      # interpolation -- but these two ARE the operator's deliberate input,
+      # and unsetting them would strip the very export that arms the run,
+      # leaving a stack that still cannot exercise QUA commit while looking
+      # correctly wired. They need no triage there in any case: they are
+      # ASK_DEV_-namespaced, which is bucket (c) of
+      # test_launcher_hardens_compose_interpolation_env_for_every_var_it_
+      # boots (tests/acceptance/test_ask_dev_compose.py:608-610), where an
+      # ASK_DEV_ prefix is accounted for by construction because it cannot
+      # collide with an unrelated ambient dev `.env`.
+      #
+      # "0" rather than "" as the default only for readability: production
+      # reads both with a strict `os.getenv(...) == "1"`
+      # (production_runtime.py:663,679), so unset, empty, "0" and even
+      # "true" are ALL off. That strictness is what makes these two immune
+      # to the empty-permissive default class (a `:-true` style default) -- an
+      # empty value fails closed here rather than reading as enabled.
+      #
+      # No interlock is needed between them: commit already implies shadow
+      # at production_runtime.py:679
+      # (`_qua_shadow_flag_enabled() and ...COMMIT_ENABLED == "1"`), so
+      # arming commit alone cannot produce a commit without a shadow
+      # evaluation behind it.
+      ASK_DEV_QUA_SHADOW_ENABLED: "${ASK_DEV_QUA_SHADOW_ENABLED:-0}"
+      ASK_DEV_QUA_COMMIT_ENABLED: "${ASK_DEV_QUA_COMMIT_ENABLED:-0}"
       # CHAOS-3219 Wave 4 quota plumbing: these are the ONLY two Ask Dev
       # settings production code actually reads from the environment
       # (org_policy.py platform_operator_request_limit /

--- a/tests/acceptance/compose.ask-dev.yml
+++ b/tests/acceptance/compose.ask-dev.yml
@@ -37,34 +37,31 @@ services:
       ASK_DEV_ACCEPTANCE_OPENAI_BASE_URL: http://ask-dev-scripted-openai:8001/v1
       ASK_DEV_ACCEPTANCE_OPENAI_API_KEY: ask-dev-acceptance-local-v1
       JWT_SECRET_KEY: ask-dev-acceptance-jwt-secret-key-v1
-      # CHAOS-3532: the QUA ladder (off -> shadow -> commit), settable from
-      # the invoking shell and OFF by default, so no existing armed run
-      # changes behaviour and an operator can arm one deliberately.
+      # CHAOS-3532: the QUA ladder (off -> shadow -> commit). Interpolated
+      # here, but NOT from whatever the invoking shell happens to export --
+      # run_ask_dev_compose.sh clears both names unconditionally and then
+      # sets them from its own one-shot ASK_DEV_ACCEPTANCE_QUA knob, AFTER
+      # the clear.
       #
-      # Deliberately NOT added to run_ask_dev_compose.sh's `unset` block.
-      # That block exists to stop an ambient shell value reaching compose
-      # interpolation -- but these two ARE the operator's deliberate input,
-      # and unsetting them would strip the very export that arms the run,
-      # leaving a stack that still cannot exercise QUA commit while looking
-      # correctly wired. They need no triage there in any case: they are
-      # ASK_DEV_-namespaced, which is bucket (c) of
-      # test_launcher_hardens_compose_interpolation_env_for_every_var_it_
-      # boots (tests/acceptance/test_ask_dev_compose.py:608-610), where an
-      # ASK_DEV_ prefix is accounted for by construction because it cannot
-      # collide with an unrelated ambient dev `.env`.
+      # These are the only ASK_DEV_-namespaced vars that launcher clears.
+      # The prefix normally means "cannot collide with an ambient dev .env
+      # by construction" -- for these two that assumption is false: ops/.env
+      # sets both to 1 for the DEV stack and direnv exports it into every
+      # shell under the ops tree. Passing them through booted every
+      # acceptance stack from a developer shell silently ARMED, which does
+      # not merely add a feature: the shadow changes what every baseline
+      # corpus case measures, and armed runs are graded against predictions
+      # registered on an unarmed system.
       #
-      # "0" rather than "" as the default only for readability: production
-      # reads both with a strict `os.getenv(...) == "1"`
-      # (production_runtime.py:663,679), so unset, empty, "0" and even
-      # "true" are ALL off. That strictness is what makes these two immune
-      # to the empty-permissive default class (a `:-true` style default) -- an
-      # empty value fails closed here rather than reading as enabled.
+      # The `:-0` default therefore guards only the case where the launcher
+      # was bypassed entirely (a raw `docker compose` invocation). Off is the
+      # only safe default for that path too.
       #
-      # No interlock is needed between them: commit already implies shadow
-      # at production_runtime.py:679
-      # (`_qua_shadow_flag_enabled() and ...COMMIT_ENABLED == "1"`), so
-      # arming commit alone cannot produce a commit without a shadow
-      # evaluation behind it.
+      # Production reads both with a strict `os.getenv(...) == "1"`
+      # (production_runtime.py:663,679), so unset, empty, "0" and "true" are
+      # ALL off -- an empty value fails closed rather than reading as
+      # enabled. And commit already implies shadow at :679, so no interlock
+      # is needed between them.
       ASK_DEV_QUA_SHADOW_ENABLED: "${ASK_DEV_QUA_SHADOW_ENABLED:-0}"
       ASK_DEV_QUA_COMMIT_ENABLED: "${ASK_DEV_QUA_COMMIT_ENABLED:-0}"
       # CHAOS-3219 Wave 4 quota plumbing: these are the ONLY two Ask Dev

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -1666,18 +1666,28 @@ def test_acceptance_overlay_wires_the_qua_ladder_off_by_default() -> None:
         )
 
 
-def test_the_qua_flags_are_not_stripped_by_the_launcher() -> None:
-    """The other half, and the one that is easy to get backwards.
+def test_ambient_qua_flags_cannot_arm_the_acceptance_stack() -> None:
+    """CHAOS-3532: the QUA flags are CLEARED by the launcher, and armed only
+    by its own one-shot opt-in.
 
-    The launcher's `unset` block exists to stop an ambient shell value
-    reaching compose interpolation. These two are the exception that proves
-    the rule: they ARE the operator's deliberate input, so unsetting them
-    would strip the export that arms the run and leave a stack that cannot
-    exercise QUA commit while looking correctly wired.
+    THIS ASSERTION IS THE REVERSE OF THE ONE IT REPLACES, and the reversal was
+    forced by reality within the hour. The first version passed the flags
+    through from the invoking shell (`${VAR:-0}`) so an operator could arm a
+    run, and asserted they must NOT be in the unset list. Then `ops/.env`
+    gained `ASK_DEV_QUA_SHADOW_ENABLED=1` / `ASK_DEV_QUA_COMMIT_ENABLED=1`
+    for the dev stack, direnv exports that file into every shell under the
+    ops tree, and passthrough would therefore have booted EVERY future
+    acceptance stack silently ARMED -- changing what every baseline corpus
+    case measures, against predictions registered on an unarmed system.
 
-    CHAOS-3532's own scope text originally instructed the opposite. This
-    asserts the correct behaviour so the instruction cannot be followed by a
-    later reader.
+    That is not a hypothetical leftover export. It was the live state of
+    every ops shell on this machine, verified directly, while the
+    passthrough version of this file was already committed.
+
+    So arming is now a deliberate act at the launcher boundary and nowhere
+    else: both names are cleared unconditionally, and only
+    `ASK_DEV_ACCEPTANCE_QUA=1` -- the launcher's own knob, translated AFTER
+    the clear -- turns them on.
     """
 
     launcher = _LAUNCHER.read_text(encoding="utf-8")
@@ -1686,11 +1696,20 @@ def test_the_qua_flags_are_not_stripped_by_the_launcher() -> None:
     unset_vars = set(re.findall(r"[A-Z_][A-Z0-9_]*", unset_match.group(1)))
 
     for flag in ("ASK_DEV_QUA_SHADOW_ENABLED", "ASK_DEV_QUA_COMMIT_ENABLED"):
-        assert flag not in unset_vars, (
-            f"{flag} must NOT be in the launcher's unset list -- unsetting it "
-            "strips the operator's own export and makes an armed QUA run "
-            "impossible. It needs no triage there regardless: ASK_DEV_-"
-            "namespaced vars are bucket (c) of "
-            "test_launcher_hardens_compose_interpolation_env_for_every_var_"
-            "it_boots."
+        assert flag in unset_vars, (
+            f"{flag} must be CLEARED by the launcher. It is exported by "
+            "ops/.env and reaches every shell under the ops tree via direnv, "
+            "so leaving it to pass through arms every acceptance stack "
+            "booted from a developer shell."
         )
+
+    assert "ASK_DEV_ACCEPTANCE_QUA" in launcher, (
+        "the launcher must own a one-shot opt-in; clearing the flags without "
+        "one leaves no way to arm a QUA run at all"
+    )
+
+    # Ordering is the whole guarantee: translated AFTER the clear, or the
+    # clear removes what the translation just set.
+    assert launcher.index("\nunset \\\n") < launcher.index(
+        "export ASK_DEV_QUA_SHADOW_ENABLED="
+    ), "the opt-in translation must run AFTER the unset block, not before"

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -168,6 +168,15 @@ def test_api_acceptance_configuration_is_exact_and_network_scoped() -> None:
         # just that case, not this shared default.
         "ASK_DEV_PLATFORM_MONTHLY_REQUEST_MAX": "1000",
         "ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD": "200000000",
+        # CHAOS-3532: the QUA ladder, off by default and overridable from the
+        # invoking shell. The DEFAULT is the load-bearing half -- an armed
+        # corpus run that silently gained a QUA shadow evaluation would
+        # change what every existing case measures, and the pre-registered
+        # predictions those runs are graded against would be comparing to a
+        # different system. Exact-set here on purpose: flipping either
+        # default has to be a deliberate edit to this assertion.
+        "ASK_DEV_QUA_SHADOW_ENABLED": "${ASK_DEV_QUA_SHADOW_ENABLED:-0}",
+        "ASK_DEV_QUA_COMMIT_ENABLED": "${ASK_DEV_QUA_COMMIT_ENABLED:-0}",
     }
     assert api["networks"] == ["default", "ask-dev-acceptance"]
     assert api["depends_on"]["ask-dev-scripted-openai"] == {
@@ -1628,3 +1637,60 @@ def test_mint_script_refuses_a_container_serving_another_checkout() -> None:
     assert mint.index("verifying the api container is serving") < mint.index(
         "dev-hops fixtures world "
     ), "the container-currency check must precede world generation"
+
+
+def test_acceptance_overlay_wires_the_qua_ladder_off_by_default() -> None:
+    """CHAOS-3532: the stack must be ABLE to exercise QUA commit, and must
+    not do so unless someone asked for it.
+
+    Before this, neither flag appeared anywhere in the acceptance tooling, so
+    the shadow never evaluated and the promotion never engaged -- the stack
+    demonstrated pre-CHAOS-3525 behaviour by construction, whatever the code
+    did. A live probe against it would have faithfully reproduced the old
+    dead-end and been read as a negative result about the fix.
+
+    Both halves are asserted, and the default matters as much as the
+    presence: an armed corpus run that silently gained a QUA shadow
+    evaluation would change what every existing case measures, and the
+    pre-registered predictions those runs are graded against would be
+    comparing to a different system.
+    """
+
+    overlay = _OVERLAY.read_text(encoding="utf-8")
+
+    for flag in ("ASK_DEV_QUA_SHADOW_ENABLED", "ASK_DEV_QUA_COMMIT_ENABLED"):
+        assert f'{flag}: "${{{flag}:-0}}"' in overlay, (
+            f"{flag} must be wired into the acceptance overlay, defaulting "
+            "OFF and overridable from the invoking shell -- without it the "
+            "stack cannot exercise the QUA path at all"
+        )
+
+
+def test_the_qua_flags_are_not_stripped_by_the_launcher() -> None:
+    """The other half, and the one that is easy to get backwards.
+
+    The launcher's `unset` block exists to stop an ambient shell value
+    reaching compose interpolation. These two are the exception that proves
+    the rule: they ARE the operator's deliberate input, so unsetting them
+    would strip the export that arms the run and leave a stack that cannot
+    exercise QUA commit while looking correctly wired.
+
+    CHAOS-3532's own scope text originally instructed the opposite. This
+    asserts the correct behaviour so the instruction cannot be followed by a
+    later reader.
+    """
+
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    unset_match = re.search(r"\nunset \\\n(.*?)\n\nweb_root=", launcher, re.S)
+    assert unset_match is not None
+    unset_vars = set(re.findall(r"[A-Z_][A-Z0-9_]*", unset_match.group(1)))
+
+    for flag in ("ASK_DEV_QUA_SHADOW_ENABLED", "ASK_DEV_QUA_COMMIT_ENABLED"):
+        assert flag not in unset_vars, (
+            f"{flag} must NOT be in the launcher's unset list -- unsetting it "
+            "strips the operator's own export and makes an armed QUA run "
+            "impossible. It needs no triage there regardless: ASK_DEV_-"
+            "namespaced vars are bucket (c) of "
+            "test_launcher_hardens_compose_interpolation_env_for_every_var_"
+            "it_boots."
+        )

--- a/tests/acceptance/world/ask-dev-world.v1/provider-scripts/qua-decisions.v1.json
+++ b/tests/acceptance/world/ask-dev-world.v1/provider-scripts/qua-decisions.v1.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "ask_dev_qua_script.v1",
+  "answers_contract": "dev_question_understanding.v1",
+  "note": "CHAOS-3532. Deterministic Question Understanding Agent decisions for the acceptance stack. NOT named role-*.json on purpose: the role is not the routing key. qua_shadow runs under the already-certified legacy_agent provider (see llm/agent/roles.py AgentRole.QUESTION_UNDERSTANDING, which is a reserved probe-less member), so a role-question_understanding.json would never be loaded by anything. The scripted service recognises a QUA call by the answers_contract id above appearing in the request's own response_format json_schema, and matches on the exact question text. A question with no entry here returns HTTP 422 scripted_provider_unmapped_qua_question -- never a heuristic answer, because a guessed QUA decision is indistinguishable downstream from the QUA path declining.",
+  "cases": {
+    "What's the status of the ACR project?": {
+      "$comment": "chris's original complaint: this question dead-ends before CHAOS-3525. With the QUA ladder armed it should resolve the mention and commit the subject, which is what an armed run has to be able to demonstrate. Confidence is above qua_promotion.QUA_COMMIT_MIN_CONFIDENCE (0.85) so the promotion actually engages; a value below it would exercise the shadow and silently decline to commit.",
+      "value": {
+        "schema_version": "dev_question_understanding.v1",
+        "intent_id": "entity_status",
+        "cardinality": "singular",
+        "mentions": [
+          {
+            "text_span": "ACR",
+            "outcome": "resolved",
+            "selected_candidate_index": 0,
+            "candidate_indices": [0],
+            "confidence": 0.95
+          }
+        ],
+        "requires_clarification": false
+      }
+    }
+  }
+}

--- a/tests/api/dev/test_chaos_3532_qua_scripted_routing.py
+++ b/tests/api/dev/test_chaos_3532_qua_scripted_routing.py
@@ -1,0 +1,223 @@
+"""CHAOS-3532: the acceptance stack must be able to answer a QUA call, and
+must refuse to guess at one.
+
+THE GAP. The scripted OpenAI service routes on question text, and it gets
+that text by parsing the user message as JSON:
+``scripted_openai_service._question_from_messages`` does
+``json.loads(content)["question"]``. But ``qua_shadow._build_messages``
+sends PLAIN TEXT (``Question: "..."`` followed by the named mentions). The
+parse raises, the router returns ``None``, and the scripted engine is never
+consulted -- so no script file of any name could answer a QUA call.
+
+WHY THAT IS WORSE THAN A MISSING FEATURE. With no script consulted the
+request falls through to the pre-CHAOS-3219 heuristic and comes back as a
+``tool_calls`` response. That is not an ``AgentFinalAnswer``, so
+``qua_shadow.evaluate`` records ``SKIPPED_UNEXPECTED_DECISION`` -- quietly,
+with no error. An armed QUA run would report "skipped" and read as a
+negative result about CHAOS-3525's commit path. CHAOS-3532 exists precisely
+because "the boot would have faithfully reproduced the old dead-end and been
+mistaken for a negative result about the fix"; a silent fall-through is that
+same trap through a different door.
+
+The compose overlay already records the last time this class bit: "all 19
+scripted cases fell through to the unscripted default heuristic while
+PASSING."
+
+THE FIX. A QUA request self-identifies -- its ``response_format.json_schema``
+carries the ``dev_question_understanding.v1`` contract. Detection pins that
+contract ID string rather than guessing at structure, and needs no
+production change. An identified QUA request is answered from
+``qua-decisions.v1.json``, and one with no matching entry returns a loud
+422 rather than a plausible guess.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import threading
+import urllib.request
+from collections.abc import Iterator
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.question_understanding import (
+    QUESTION_UNDERSTANDING_SCHEMA_VERSION,
+)
+from dev_health_ops.llm.agent.scripted_openai_service import ScriptedOpenAIServer
+
+_ACCEPTANCE_KEY = secrets.token_hex(16)
+
+#: A question the QUA script answers. Kept in one place so the script file
+#: and these tests cannot drift.
+_SCRIPTED_QUESTION = "What's the status of the ACR project?"
+
+
+@pytest.fixture
+def scripted_openai_server() -> Iterator[ScriptedOpenAIServer]:
+    server = ScriptedOpenAIServer(_ACCEPTANCE_KEY)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _qua_request(question: str, *, mention_count: int = 1) -> dict[str, Any]:
+    """A request shaped exactly as ``qua_shadow`` sends one.
+
+    The user content is PLAIN TEXT, not JSON -- that is the whole point. If
+    this helper ever starts sending a JSON object with a ``question`` key it
+    stops reproducing the real call and these tests go vacuous.
+    """
+
+    return {
+        "model": "ask-dev-scripted-v1",
+        "messages": [
+            {"role": "system", "content": "You are a question understanding agent."},
+            {
+                "role": "user",
+                "content": (
+                    f'Question: "{question}"\n'
+                    "\n"
+                    "Named mentions:\n"
+                    '- "ACR" (requested kind: project):\n'
+                    "    [0] project: ACR"
+                ),
+            },
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "ask_dev_decision",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "object",
+                            "properties": {
+                                "schema_version": {
+                                    "const": QUESTION_UNDERSTANDING_SCHEMA_VERSION
+                                },
+                                "mentions": {
+                                    "type": "array",
+                                    "minItems": mention_count,
+                                    "maxItems": mention_count,
+                                },
+                            },
+                        }
+                    },
+                },
+            },
+        },
+    }
+
+
+def _post(server: ScriptedOpenAIServer, body: dict[str, Any]) -> tuple[int, Any]:
+    host, port = cast(tuple[str, int], server.server_address)
+    request = urllib.request.Request(
+        f"http://{host}:{port}/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={
+            "Authorization": f"Bearer {_ACCEPTANCE_KEY}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as error:  # noqa: PERF203 - the assertion surface
+        return error.code, json.loads(error.read())
+
+
+def test_a_scripted_qua_question_is_answered_deterministically(
+    scripted_openai_server: ScriptedOpenAIServer,
+) -> None:
+    """The capability this ticket exists to create.
+
+    Asserts the shape the QUA adapter actually consumes: a ``final_answer``
+    decision whose ``value`` validates as ``dev_question_understanding.v1``.
+    Anything else -- notably the heuristic's ``tool_calls`` response -- makes
+    ``qua_shadow.evaluate`` record SKIPPED_UNEXPECTED_DECISION instead.
+    """
+
+    status, body = _post(scripted_openai_server, _qua_request(_SCRIPTED_QUESTION))
+
+    assert status == 200, body
+    content = json.loads(body["choices"][0]["message"]["content"])
+    assert content["kind"] == "final_answer", (
+        "a QUA call must be answered with a final_answer decision -- a "
+        "tool_calls response is what the unscripted heuristic returns, and "
+        "it is recorded as SKIPPED_UNEXPECTED_DECISION rather than a result"
+    )
+    value = content["value"]
+    assert value["schema_version"] == QUESTION_UNDERSTANDING_SCHEMA_VERSION
+    assert len(value["mentions"]) == 1, (
+        "the mention count must match the request's own schema bound -- "
+        "qua_shadow rejects a response whose mention count differs"
+    )
+
+
+def test_an_unscripted_qua_question_fails_loudly_rather_than_guessing(
+    scripted_openai_server: ScriptedOpenAIServer,
+) -> None:
+    """THE negative control, and the reason this ticket is not just a script
+    file.
+
+    A QUA-shaped request with no matching script must return a distinct 422.
+    It must NOT fall through to the heuristic, which would answer with a
+    plausible ``tool_calls`` response that reads downstream as "the QUA path
+    declined" rather than "the harness has no script for this".
+
+    That distinction is the entire finding behind this ticket. Watch this
+    test fail if anyone re-adds a fall-through for QUA-shaped requests.
+    """
+
+    status, body = _post(
+        scripted_openai_server, _qua_request("A question no QUA script answers at all")
+    )
+
+    assert status == 422, (
+        "an unscripted QUA request must fail loudly. Falling through to the "
+        "heuristic is the '19 scripted cases passed while serving nothing' "
+        f"incident with a new door. Got {status}: {body}"
+    )
+    assert body["error"]["type"] == "scripted_provider_unmapped_qua_question", (
+        "and with its own error type, so a runner can tell 'no QUA script "
+        "for this question' apart from a wire-protocol error or a scripted "
+        f"fault. Got {body['error']!r}."
+    )
+
+
+def test_a_non_qua_request_is_untouched_by_the_qua_branch(
+    scripted_openai_server: ScriptedOpenAIServer,
+) -> None:
+    """Preserved-behaviour control.
+
+    Every existing corpus case flows through the ordinary question-JSON
+    router and the heuristic behind it. If QUA detection ever widened to
+    match those, the whole corpus would start 422ing -- so this asserts an
+    ordinary request still gets its ordinary answer.
+    """
+
+    status, body = _post(
+        scripted_openai_server,
+        {
+            "model": "ask-dev-scripted-v1",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": json.dumps({"question": "How is meridian/web-app?"}),
+                }
+            ],
+        },
+    )
+
+    assert status == 200, body
+    assert "choices" in body

--- a/tests/api/dev/test_chaos_3532_qua_scripted_routing.py
+++ b/tests/api/dev/test_chaos_3532_qua_scripted_routing.py
@@ -118,6 +118,23 @@ def _qua_request(question: str, *, mention_count: int = 1) -> dict[str, Any]:
     }
 
 
+def _qua_messages(question: str) -> tuple[Any, ...]:
+    """The message pair qua_shadow._build_messages produces, plain text and all."""
+
+    from dev_health_ops.llm.agent.contracts import AgentMessage, AgentMessageRole
+
+    return (
+        AgentMessage(role=AgentMessageRole.SYSTEM, content="Question understanding."),
+        AgentMessage(
+            role=AgentMessageRole.USER,
+            content=(
+                f'Question: "{question}"\n\nNamed mentions:\n'
+                '- "ACR" (requested kind: project):\n    [0] project: ACR'
+            ),
+        ),
+    )
+
+
 def _post(server: ScriptedOpenAIServer, body: dict[str, Any]) -> tuple[int, Any]:
     host, port = cast(tuple[str, int], server.server_address)
     request = urllib.request.Request(
@@ -221,3 +238,134 @@ def test_a_non_qua_request_is_untouched_by_the_qua_branch(
 
     assert status == 200, body
     assert "choices" in body
+
+
+def test_an_ordinary_corpus_request_with_a_response_format_is_not_seen_as_qua(
+    scripted_openai_server: ScriptedOpenAIServer,
+) -> None:
+    """The false-positive control that actually matches production traffic.
+
+    Every real corpus case sends a ``response_format`` --
+    ``openai_compatible._chat_completion_request`` attaches one whenever
+    ``allow_final_answer`` is set, which is the normal path. So the control
+    above (which sends none) does not exercise the risk that matters: QUA
+    detection reading an ordinary decision schema as a QUA call.
+
+    If that ever happened the blast radius is the whole corpus: every case
+    would take the QUA branch, find no scripted QUA question, and 422. This
+    sends the ordinary envelope -- same wrapper name, same strict flag, a
+    decision schema WITHOUT the QUA contract id -- and asserts it is
+    answered normally.
+    """
+
+    status, body = _post(
+        scripted_openai_server,
+        {
+            "model": "ask-dev-scripted-v1",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": json.dumps({"question": "How is meridian/web-app?"}),
+                }
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ask_dev_decision",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "kind": {
+                                "enum": ["final_answer", "disambiguation", "refusal"]
+                            },
+                            "value": {
+                                "type": "object",
+                                "properties": {
+                                    "schema_version": {"const": "dev_answer.v1"}
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    assert status == 200, (
+        "an ordinary decision request carries a response_format too -- QUA "
+        "detection must key on the CONTRACT ID, not on the presence of a "
+        f"schema, or every corpus case 422s. Got {status}: {body}"
+    )
+    assert "choices" in body
+
+
+@pytest.mark.asyncio
+async def test_what_an_unscripted_qua_question_actually_looks_like_end_to_end(
+    scripted_openai_server: ScriptedOpenAIServer,
+) -> None:
+    """Codex adversarial review (HIGH): the 422 does NOT reach the run as a
+    distinct signal, and this pins what does.
+
+    The distinct error exists only at the HTTP boundary.
+    ``OpenAICompatibleAgentProvider`` normalises a 4xx into an
+    ``AgentProviderError``, and ``QuestionUnderstandingShadow.evaluate``
+    catches that and records a generic status. So at the stack level, "the
+    harness has no QUA script for this question" is **indistinguishable from
+    "the provider failed"** -- and the run continues either way.
+
+    That soft failure is DELIBERATE and must not be changed here: CHAOS-3389's
+    whole contract is that a shadow-mode bug never fails or rolls back the
+    run it shadows, certified by byte-identity tests. Making the shadow raise
+    would retire those proofs by redefinition.
+
+    So this test does not assert a fix. It pins the real behaviour, through
+    the real provider against the real service, so the residual is recorded
+    as a measured fact rather than an assumption -- and so anyone who later
+    makes an armed run assert on this has the exact status to key on.
+
+    The 422 is still worth having: it stops the heuristic from answering a
+    question-understanding call with a plausible ``tool_calls`` response,
+    which is a fabricated result rather than an absent one. This test marks
+    where that guarantee stops.
+    """
+
+    from dev_health_ops.api.dev.qua_shadow import QUAShadowStatus
+    from dev_health_ops.llm.agent.openai_compatible import OpenAICompatibleAgentProvider
+
+    host, port = cast(tuple[str, int], scripted_openai_server.server_address)
+    provider = OpenAICompatibleAgentProvider(
+        api_key=_ACCEPTANCE_KEY,
+        model="ask-dev-scripted-v1",
+        base_url=f"http://{host}:{port}/v1",
+    )
+
+    # Drive the provider exactly as qua_shadow does: a QUA response schema,
+    # and a plain-text user message for a question no script answers.
+    with pytest.raises(Exception) as raised:  # noqa: B017 - the type IS the finding
+        await provider.decide(
+            messages=_qua_messages("A question no QUA script answers at all"),
+            tools=(),
+            response_schema={
+                "type": "object",
+                "properties": {
+                    "schema_version": {"const": QUESTION_UNDERSTANDING_SCHEMA_VERSION}
+                },
+            },
+            timeout_seconds=10.0,
+            max_output_tokens=512,
+            signal=None,
+        )
+
+    # The specific scripted_provider_unmapped_qua_question type is gone by
+    # here -- normalised into a provider error. That IS the residual.
+    assert "AgentProviderError" in type(raised.value).__name__, (
+        "the 422 reaches the caller as a generic provider error; if this "
+        "ever becomes a distinct type, the residual below can be closed"
+    )
+    assert QUAShadowStatus.SKIPPED_PROVIDER_ERROR.value == "skipped_provider_error", (
+        "the status an armed run would record for a missing QUA script -- "
+        "identical to a genuine provider failure. A runner-side assertion "
+        "keying on this is what would make the harness gap loud, and that "
+        "lives in files this change does not own."
+    )


### PR DESCRIPTION
Closes the wiring half of CHAOS-3532. **The live verify against an armed stack is NOT done and is listed as outstanding below — this PR does not claim it.**

## The gap

The acceptance stack could not exercise the CHAOS-3525 QUA commit path at all. Neither `ASK_DEV_QUA_SHADOW_ENABLED` nor `ASK_DEV_QUA_COMMIT_ENABLED` appeared anywhere in the acceptance tooling, so the shadow never evaluated and the promotion never engaged. **The stack demonstrated pre-3525 behaviour by construction, whatever the code did** — a live probe against it would have faithfully reproduced the old dead-end and been read as a negative result about the fix.

## The ticket's proposed fix could not have worked

Scope item 2 asked for a `role-question_understanding.json` provider script. That would have been dead weight, and the RED run *printed* why:

```
HTTP 200  {"tool_calls":[{"function":{"name":"status_snapshot_v1"}}], "content": null}
```

The scripted service routes on question text obtained via `json.loads(content)["question"]` — but `qua_shadow._build_messages` sends **plain text**. The parse raises, the router returns `None`, and the scripted engine is **never consulted**, whatever files exist on disk. A `question_understanding` role would not be reached either: `roles.py` states the shadow deliberately calls the certified `legacy_agent` provider, and no other role is enabled.

So every QUA call fell through to the pre-CHAOS-3219 heuristic and came back as a `tool_calls` response — not an `AgentFinalAnswer`, so `qua_shadow` recorded `SKIPPED_UNEXPECTED_DECISION`. An armed run would have reported **"skipped"**, quietly, and read as a negative result about the commit path it was booted to demonstrate. *Both corrections are posted on the ticket with clause evidence.*

## What this does

**Routes on the request's own contract id.** A QUA call self-identifies — its `response_format.json_schema` carries `dev_question_understanding.v1`. Detection pins that **string**, not a structural guess, and needs no production change. Answers come from `qua-decisions.v1.json`; the name avoids `role-` because the role is not the routing key and never was.

**An unscripted QUA question returns 422, never a heuristic answer.** This service already learned that lesson once — `compose.ask-dev.yml` records *"all 19 scripted cases fell through to the unscripted default heuristic while PASSING."* A guessed QUA decision is indistinguishable downstream from the QUA path declining; only a distinct error separates them.

**The QUA ladder is wired off by default, and armed only at the launcher.** Both flags are **cleared unconditionally** and set solely from the launcher's own one-shot `ASK_DEV_ACCEPTANCE_QUA=1`, translated *after* the clear. They are the only `ASK_DEV_`-namespaced vars the launcher clears — that prefix normally means "cannot collide with an ambient dev `.env` by construction", and for these two the premise is false: `ops/.env` sets both to `1` for the dev stack and direnv carries them into every ops shell. Verified directly: this machine's shells already export one. Passthrough would have booted **every** acceptance stack from a developer shell silently ARMED — and an armed run is graded against predictions registered on an unarmed system, so that invalidates the comparison rather than extending it.

The mint script gets the same clear and **deliberately no opt-in**: a snapshot minted from an armed stack would bake QUA-influenced state into the fixture world every future run restores.

## Outstanding — the live verify

**Not done, and not implied.** No armed run has exercised this end to end. It queues after phase3's armed run, booting from this worktree — per the bind-mount finding in #1582, a stack must be bound to the tree whose code it is meant to grade.

Also outstanding and filed rather than fixed: **CHAOS-3559**. The 422 is normalised into a generic `AgentProviderError` before any runner sees it, and `QuestionUnderstandingShadow.evaluate` records `skipped_provider_error` — so at stack level "no QUA script" is still indistinguishable from "the provider failed". Making the shadow raise would retire CHAOS-3389's byte-identity proofs by redefinition, and the runner-side assertion lives in files this PR does not own. `test_what_an_unscripted_qua_question_actually_looks_like_end_to_end` **pins that residual as a measured fact** so whoever closes it has the status to key on.

## Verification

- **Local gate PASSED** — all 7 stages, zero failures.
- 5465 passed; only the 2 known `pytest.mark.clickhouse` graphql reds.
- **Mutations killed**: removing the QUA branch (both QUA tests fail); widening detection to match every request (the false-positive control fails); removing the launcher clear (the ambient-arming guard fails); moving the opt-in before the clear (ordering guard fails).

Two findings recorded in the commits because both are cheap to repeat: my explanatory comment quoting a literal `${VAR}` broke the interpolation-hardening test, **and my insertion point silently weakened that same guard** by letting its regex swallow my comment — a permissive hole in the guard whose job is catching unaccounted `${VAR}`s. Anything grepping these files cannot tell prose from wiring. Also: my first mutation of the detection was *ineffective rather than survived* (it sat below an early return); an ineffective mutation is not evidence, and it was re-applied where it bites.
