### PR TITLE
CHAOS-3571: gate must fail loudly when a stage cannot run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,10 @@ It mirrors the PR-time CI gates of the ops repo and MUST be green before `git pu
    `get_clickhouse_uri()` and need a reachable, migrated ClickHouse — the gate provisions
    an isolated **scratch db**, migrates it, and points `CLICKHOUSE_URI` at it before
    running the suite, exactly as CI provides one (a locked dev `default` user makes them
-   false-red otherwise). Without docker, the gate deselects that one module so the
-   pure-Python guards still run.
+   false-red otherwise). Without docker AND without `SKIP_CLICKHOUSE=1`, the gate now
+   hard-fails before the unit suite ever runs at all (see CHAOS-3571 below) — the
+   module-deselect behavior only fires under the explicit `SKIP_CLICKHOUSE=1` opt-out,
+   where the pure-Python guards still run but that one CH-dependent module is skipped.
 4. A **live-ClickHouse argMax proof** that CI's unit/ci tiers never run: after migrating
    the scratch db, it builds a real `ClickHouseDataLoader` and `await`s
    `load_team_attribution_context`, forcing the real engine to parse + EXECUTE every
@@ -121,9 +123,10 @@ itself failing/timing out, the container confirmed absent, a missing dev-hops CL
 is now a **hard failure** with a message naming the true mechanism. The **only**
 sanctioned way to run without the CH-dependent stages is the explicit, logged
 `SKIP_CLICKHOUSE=1` opt-out — a caller decision made up front, not a runtime probe
-result the gate trusts on its own. The verdict line and a machine-readable
-`GATE_STAGE_MANIFEST …` log line both carry `declared=<N> executed=<N>` and the
-exact stage ids that ran (`GATE PASSED. [8/8: lint_format,…,ch_argmax_proof] safe
+result the gate trusts on its own. A machine-readable `GATE_STAGE_MANIFEST …` log
+line carries the literal `declared=<N> executed=<N>` counts plus the exact stage
+ids that ran, and the verdict line carries the same information formatted as
+`[executed/declared: ids]` (`GATE PASSED. [8/8: lint_format,…,ch_argmax_proof] safe
 to push.`, or `[4/4: …]` under `SKIP_CLICKHOUSE=1`), and a self-check fails the
 gate on any declared-but-not-executed gap even if every stage that did run passed.
 See the "STAGE MANIFEST" header comment in `ci/local_validate.sh` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,23 @@ a scratch db (default `ci_local_validate`) via `CLICKHOUSE_URI=…/ci_local_vali
 and **drops that scratch db on exit (trap cleanup)**. `CLICKHOUSE_URI` must never
 default to `…/default` for any `-m clickhouse` run, migrate, or `ensure_schema(force=True)`
 call. If you must run CH tests by hand, always export the scratch DSN first and unset
-it after. When docker / the CH container is unavailable, the CH stage cleanly SKIPs
-(or pass `SKIP_CLICKHOUSE=1`) — but the pure-Python gates 1–3 are always required.
+it after.
+
+**CHAOS-3571 (stage manifest — reversed a prior statement in this doc):** without
+`SKIP_CLICKHOUSE=1`, the gate no longer "cleanly SKIPs" when docker / the CH
+container is unavailable — that exact behavior let a FAILED docker probe read as
+"container not running" and silently drop 3 of 8 stages while still printing
+`GATE PASSED`. Every reason the CH stages might not run (docker missing, the probe
+itself failing/timing out, the container confirmed absent, a missing dev-hops CLI)
+is now a **hard failure** with a message naming the true mechanism. The **only**
+sanctioned way to run without the CH-dependent stages is the explicit, logged
+`SKIP_CLICKHOUSE=1` opt-out — a caller decision made up front, not a runtime probe
+result the gate trusts on its own. The verdict line and a machine-readable
+`GATE_STAGE_MANIFEST …` log line both carry `declared=<N> executed=<N>` and the
+exact stage ids that ran (`GATE PASSED. [8/8: lint_format,…,ch_argmax_proof] safe
+to push.`, or `[4/4: …]` under `SKIP_CLICKHOUSE=1`), and a self-check fails the
+gate on any declared-but-not-executed gap even if every stage that did run passed.
+See the "STAGE MANIFEST" header comment in `ci/local_validate.sh` and
+`tests/tooling/test_local_validate_stage_manifest.py`.
 
 Do not push if `ci/local_validate.sh` prints `GATE FAILED`.

--- a/ci/local_validate.sh
+++ b/ci/local_validate.sh
@@ -63,7 +63,8 @@
 # USAGE:
 #   Run from the worktree ROOT (the dir containing ci/run_tests.sh) using its .venv:
 #     bash ci/local_validate.sh
-#   Skip the live-ClickHouse stage (pure-Python gates only, e.g. no docker):
+#   Skip the live-ClickHouse stage (pure-Python gates only, e.g. no docker) --
+#   this is now the ONLY way to run without them; see STAGE MANIFEST below:
 #     SKIP_CLICKHOUSE=1 bash ci/local_validate.sh
 #   Force a specific scratch db name (rarely needed — the default is already
 #   unique per worktree):
@@ -72,6 +73,36 @@
 #   concurrent gate to release the lock, then fails with an actionable message.
 #   Fail fast instead of waiting if another gate already holds the lock:
 #     LOCK_WAIT_SECS=0 bash ci/local_validate.sh
+#
+# *** STAGE MANIFEST (CHAOS-3571) ***
+#   Observed 2026-08-07: a `docker ps` probe failure inside the ClickHouse
+#   provisioning step was rendered as "container not running" and the gate
+#   `skip`'d 3 of 8 stages (ch-scratch-create, ch-migrate, the argMax live-exec
+#   proof) while still printing `GATE PASSED. safe to push.` -- the container
+#   had been up and healthy the entire time. A degraded run was indistinguishable
+#   from a full one unless a human counted the ✔ lines.
+#
+#   Since that fix: without SKIP_CLICKHOUSE=1, EVERY reason the ClickHouse stages
+#   might not run -- docker missing, the probe itself failing/timing out
+#   (indeterminate container state), the container confirmed not running, or a
+#   missing dev-hops CLI -- is a HARD FAILURE with a distinct diagnostic message
+#   naming the true mechanism, never a silent skip. SKIP_CLICKHOUSE=1 is the
+#   ONLY sanctioned way to run without the CH-dependent stages: it is an
+#   explicit, logged, caller-initiated decision that shrinks the gate's
+#   DECLARED stage set up front, not a runtime probe result the gate decided on
+#   its own to trust.
+#
+#   The verdict line and a machine-readable `GATE_STAGE_MANIFEST ...` log line
+#   both carry `declared=<N> executed=<N>` plus the exact stage ids that ran
+#   (`GATE PASSED. [8/8: lint_format,lint_check,typecheck,ch_probe,
+#   ch_scratch_create,ch_migrate,unit_suite,ch_argmax_proof] safe to push.`,
+#   or `[4/4: ...]` under SKIP_CLICKHOUSE=1) -- a degraded run cannot produce a
+#   verdict line indistinguishable from a full one, even in a copy-pasted PR
+#   quote. `verify_stage_manifest()` additionally self-checks that the set of
+#   stages that actually ran equals the declared set and fails the gate on ANY
+#   mismatch, even if every stage that did run passed -- an independent
+#   backstop against this exact class of bug recurring, not just a fix for this
+#   one instance of it. See tests/tooling/test_local_validate_stage_manifest.py.
 #
 set -uo pipefail
 
@@ -116,7 +147,11 @@ SCRATCH_URI="clickhouse://${CH_USER}:${CH_PASS}@${CH_HOST}:${CH_HTTP_PORT}/${SCR
 PYBIN="${ROOT}/.venv/bin/python"
 RUFF="${ROOT}/.venv/bin/ruff"
 MYPY="${ROOT}/.venv/bin/mypy"
-DEVHOPS="${ROOT}/.venv/bin/dev-hops"
+# Overridable (CHAOS-3571): every real caller gets the identical computed
+# default (env unset), so this changes no production behavior. It lets a test
+# point DEVHOPS at a deliberately-missing path to exercise ch_probe_docker()'s
+# "dev-hops CLI missing" branch without touching the real, shared venv.
+DEVHOPS="${DEVHOPS:-${ROOT}/.venv/bin/dev-hops}"
 
 # Neutralize the local socks5h proxy for every pytest/python invocation. Without
 # this, httpx-based tests fail with 'socksio not installed' — false negatives, not
@@ -554,6 +589,59 @@ declare -a RESULTS=()
 FAILED=0
 CH_READY=0 # set to 1 by ch_provision() once the scratch CH is migrated
 
+# --- Stage manifest (CHAOS-3571). ---------------------------------------------------
+# CHAOS-3571 root cause: ch_provision() rendered a FAILED docker probe as
+# "container not running" and quietly `skip`'d every ClickHouse-dependent stage,
+# and nothing else in the script noticed 3 of 8 declared stages never ran --
+# GATE PASSED still printed. RESULTS/print_summary above only show what a human
+# scrolling the log happens to count; they are not a machine-checkable
+# assertion that the full declared stage set actually executed.
+#
+# DECLARED_STAGE_IDS is the full set of stage ids this run is committed to
+# executing, decided ONCE up front (see run_declared_stages) -- never narrowed
+# later by a stage's own runtime discovery that it "can't" run. The only
+# sanctioned way to shrink it is the explicit, caller-supplied SKIP_CLICKHOUSE=1
+# opt-out, which removes the CH-dependent ids from the declaration itself
+# BEFORE anything runs, rather than letting a stage quietly not show up after
+# the fact. EXECUTED_STAGE_IDS is appended to ONLY by run_stage() and the two
+# manual ch_provision() call sites that record a result outside of run_stage
+# (see ch_provision below) -- i.e. it reflects what actually ran, regardless of
+# pass/fail. verify_stage_manifest() (near main()) diffs the two sets and fails
+# the gate on ANY mismatch, even if every stage that did run passed -- the
+# structural, can't-be-fooled-by-a-single-branch-bug version of "don't silently
+# do less than declared".
+declare -a DECLARED_STAGE_IDS=()
+declare -a EXECUTED_STAGE_IDS=()
+
+# bash 3.2 (stock macOS /bin/bash) treats `"${arr[@]}"` on a DECLARED-BUT-EMPTY
+# array as an unbound-variable error under `set -u` -- confirmed directly on
+# this host, not assumed (see ci/aggregate_gate_results.sh's header comment for
+# the same finding against its own array-avoidance choice). Every expansion of
+# DECLARED_STAGE_IDS/EXECUTED_STAGE_IDS elsewhere in this script goes through
+# these two helpers so that landmine is closed in exactly one place rather than
+# re-solved (or missed) at every call site.
+array_contains() {
+  local needle="$1"
+  shift
+  local candidate
+  for candidate in "$@"; do
+    [ "${candidate}" = "${needle}" ] && return 0
+  done
+  return 1
+}
+
+join_commas() {
+  local out="" item
+  for item in "$@"; do
+    if [ -z "${out}" ]; then
+      out="${item}"
+    else
+      out="${out},${item}"
+    fi
+  done
+  printf '%s' "${out}"
+}
+
 c_red() { printf '\033[31m%s\033[0m' "$1"; }
 c_green() { printf '\033[32m%s\033[0m' "$1"; }
 c_yellow() { printf '\033[33m%s\033[0m' "$1"; }
@@ -589,19 +677,43 @@ die() {
   exit 2
 }
 
+# Shared fail-fast tail (CHAOS-3571): print the summary, the machine-readable
+# stage manifest (so a FAILED run is just as auditable as a PASSED one -- see
+# the stage manifest header comment above), and exit 1. Used both by run_stage
+# below and by ch_provision()'s own call sites that record a result without
+# going through run_stage (docker-probe failure, scratch-create failure) --
+# those are stage failures too and must get the identical fail-fast contract,
+# not a bespoke shorter one that a future reader could believe is less serious.
+fail_fast() {
+  local name="$1"
+  print_summary
+  printf 'GATE_STAGE_MANIFEST result=FAILED declared=%d executed=%d declared_ids=%s executed_ids=%s failed_at=%s\n' \
+    "${#DECLARED_STAGE_IDS[@]}" "${#EXECUTED_STAGE_IDS[@]}" \
+    "$(join_commas "${DECLARED_STAGE_IDS[@]+"${DECLARED_STAGE_IDS[@]}"}")" \
+    "$(join_commas "${EXECUTED_STAGE_IDS[@]+"${EXECUTED_STAGE_IDS[@]}"}")" \
+    "${name}"
+  printf '\n%s first failing stage: %s — fix it, then re-run before pushing.\n' "$(c_red 'GATE FAILED.')" "${name}"
+  exit 1
+}
+
 # Run a stage; on failure print an actionable hint and STOP (fail fast) unless the
 # caller passes KEEP_GOING=1. We fail fast by default so the first red is the signal.
+#
+# stage_id (CHAOS-3571) is the stable, human-name-independent key this stage is
+# tracked under in EXECUTED_STAGE_IDS / DECLARED_STAGE_IDS -- appended
+# regardless of pass/fail, because "executed" means "ran", not "ran and
+# passed" (a failing stage still ran; failing to run at all is the distinct,
+# worse condition this whole mechanism exists to catch).
 run_stage() {
-  local name="$1"
-  shift
+  local name="$1" stage_id="$2"
+  shift 2
   banner "${name}"
   "$@"
   local rc=$?
   record "${name}" "${rc}"
+  EXECUTED_STAGE_IDS+=("${stage_id}")
   if [ "$rc" -ne 0 ] && [ "${KEEP_GOING:-0}" != "1" ]; then
-    print_summary
-    printf '\n%s first failing stage: %s — fix it, then re-run before pushing.\n' "$(c_red 'GATE FAILED.')" "${name}"
-    exit 1
+    fail_fast "${name}"
   fi
   return "$rc"
 }
@@ -699,10 +811,85 @@ gate_unit_suite() {
 }
 
 # --- Live-ClickHouse stage, ISOLATED to a scratch db (dropped on exit). ------------
-ch_available() {
-  command -v docker >/dev/null 2>&1 || return 1
-  docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "${CH_CONTAINER}" || return 1
-  [ -x "${DEVHOPS}" ] || return 2
+#
+# ch_probe_docker() (CHAOS-3571 fix). The predecessor of this function,
+# ch_available(), collapsed four DIFFERENT facts into one `return 1`: docker not
+# installed, `docker ps` itself failing (daemon unreachable, timeout, permission
+# error), and the container genuinely not running all looked identical to the
+# caller. ch_provision() then printed the ONE fact it assumed -- "container
+# '...' not running" -- no matter which of the three actually happened, and
+# `skip`'d the CH-dependent stages. Observed for real 2026-08-07 (CHAOS-3571):
+# `docker ps` failed transiently under host load (most likely — the exact
+# invocation was never captured, see the ticket), the container was up and
+# healthy the whole time, and the gate printed "container ... not running" and
+# GATE PASSED with 3 of 8 stages silently missing.
+#
+# This function returns a DISTINCT code for each cause and sets CH_PROBE_DETAIL
+# to a message that names the ACTUAL mechanism rather than a guessed
+# interpretation of it -- "probe FAILED, state UNKNOWN" is not the same claim
+# as "confirmed not running", and only ch_provision() (not this function)
+# decides what to do with that distinction. Every branch here logs docker's own
+# exit code and stderr verbatim (the ticket's own first diagnostic step),
+# rather than swallowing them the way `2>/dev/null` did before.
+#
+#   0  available: docker present, `docker ps` succeeded, container present,
+#      dev-hops present.
+#   1  docker CLI missing from PATH.
+#   2  `docker ps` ITSELF failed (nonzero exit) -- INDETERMINATE. This is the
+#      exact CHAOS-3571 mechanism: the probe could not get an answer at all,
+#      so "not running" would be a fabricated claim, not a measurement.
+#   3  `docker ps` succeeded and the container is confirmed ABSENT from the
+#      running-container list -- a real, provable "not running" fact.
+#   4  docker + container confirmed present, but the dev-hops CLI the CH
+#      stages shell out to is missing from this venv.
+#
+# CHAOS-3571 policy (decided in ch_provision(), not here): ONLY an explicit,
+# caller-supplied SKIP_CLICKHOUSE=1 may turn "CH stages did not run" into a
+# clean, gate-passing SKIP. Every code below (1-4) is a HARD FAILURE of the
+# gate when SKIP_CLICKHOUSE is not set -- including case 3, which the
+# CHAOS-3571 ticket's own proposed direction treats as legitimate to skip.
+# This script deliberately does NOT take that half of the proposal: a merge
+# gate that trusts an unattended runtime probe's "confirmed not running" enough
+# to silently pass is exactly the shape of tool this ticket was filed against,
+# and the whole point of (a)/(c) below is that NOTHING short of the caller's
+# own explicit, logged opt-in may shrink what "PASSED" claims to have run.
+# CH_PROBE_DETAIL still names case 3 distinctly from case 2 in the failure
+# message, so a human fixing this after a HARD FAIL is told the true
+# mechanism, not a fabricated one -- that half of the ticket's ask is honored.
+CH_PROBE_DETAIL=""
+
+ch_probe_docker() {
+  CH_PROBE_DETAIL=""
+  if ! command -v docker >/dev/null 2>&1; then
+    CH_PROBE_DETAIL="docker CLI not found on PATH"
+    return 1
+  fi
+  # Capture docker ps's exit code AND stderr unconditionally (CHAOS-3571's own
+  # first diagnostic step) instead of the old `2>/dev/null` that threw the
+  # actual error away before anyone could see it. A private mktemp file, not a
+  # pipe: this is a single small command, not the CHAOS-3362/3489 large-payload
+  # here-document hazard, but there is no reason to introduce a pipe here either.
+  local ps_err_file ps_out ps_rc
+  ps_err_file="$(mktemp "${TMPDIR:-/tmp}/local-validate-docker-ps-stderr.XXXXXX")" || {
+    CH_PROBE_DETAIL="could not create a temp file to capture the docker ps probe's stderr"
+    return 2
+  }
+  ps_out="$(docker ps --format '{{.Names}}' 2>"${ps_err_file}")"
+  ps_rc=$?
+  if [ "${ps_rc}" -ne 0 ]; then
+    CH_PROBE_DETAIL="docker ps probe FAILED (exit ${ps_rc}): $(tr '\n' ' ' <"${ps_err_file}" | sed -e 's/ *$//') — container state UNKNOWN, NOT confirmed absent"
+    rm -f "${ps_err_file}"
+    return 2
+  fi
+  rm -f "${ps_err_file}"
+  if ! printf '%s\n' "${ps_out}" | grep -qx "${CH_CONTAINER}"; then
+    CH_PROBE_DETAIL="container '${CH_CONTAINER}' confirmed NOT running (docker ps succeeded; name absent from the running-container list)"
+    return 3
+  fi
+  if [ ! -x "${DEVHOPS}" ]; then
+    CH_PROBE_DETAIL="dev-hops CLI missing at ${DEVHOPS} — install the [dev] extra: uv sync --all-extras --dev"
+    return 4
+  fi
   return 0
 }
 
@@ -879,29 +1066,39 @@ ch_argmax_proof() {
 # Provision the isolated scratch db + apply THIS branch's migrations BEFORE the
 # unit suite, then export CLICKHOUSE_URI=<scratch> so the CH-dependent unit tests
 # run faithfully and the CH-marked tests + argMax proof reuse the same schema.
+#
+# CHAOS-3571: every failure branch below now goes through `record` (so it
+# appears in RESULTS / the summary) and `fail_fast` (so it stops the gate
+# immediately, the same contract run_stage gives every other stage) instead of
+# the old `skip ...; return 0`, which is the exact mechanism that let a FAILED
+# docker probe read as a clean, gate-passing result. The ONLY remaining `skip`
+# path left in this function is the top one: an explicit, caller-supplied
+# SKIP_CLICKHOUSE=1. That is a loud, logged, opt-in decision the caller made on
+# purpose -- categorically different from the gate silently deciding on its own
+# that it "can't" run these stages, which is what CHAOS-3571 was filed against.
 ch_provision() {
   if [ "${SKIP_CLICKHOUSE:-0}" = "1" ]; then
-    skip "clickhouse provisioning (scratch db)" "SKIP_CLICKHOUSE=1 — CH stages skipped"
+    skip "clickhouse provisioning (scratch db)" "SKIP_CLICKHOUSE=1 — CH stages explicitly excluded by caller (see DECLARED_STAGE_IDS)"
     return 0
   fi
   banner "clickhouse provisioning (isolated scratch db: ${SCRATCH_DB})"
-  ch_available
-  case $? in
-  1)
-    skip "clickhouse provisioning" "container '${CH_CONTAINER}' not running (start the dev stack, or SKIP_CLICKHOUSE=1)"
-    return 0
-    ;;
-  2)
-    skip "clickhouse provisioning" "missing ${DEVHOPS} (install [dev] extra into .venv)"
-    return 0
-    ;;
-  esac
+  if ! ch_probe_docker; then
+    record "clickhouse: docker probe (${CH_PROBE_DETAIL})" 1
+    EXECUTED_STAGE_IDS+=("ch_probe")
+    fail_fast "clickhouse: docker probe"
+  fi
+  record "clickhouse: docker probe (container '${CH_CONTAINER}' reachable, dev-hops present)" 0
+  EXECUTED_STAGE_IDS+=("ch_probe")
+
   if ! ch_create_scratch; then
-    skip "clickhouse provisioning" "could not create scratch db ${SCRATCH_DB}"
-    return 0
+    record "ch-scratch-create (${SCRATCH_DB})" 1
+    EXECUTED_STAGE_IDS+=("ch_scratch_create")
+    fail_fast "ch-scratch-create (${SCRATCH_DB})"
   fi
   record "ch-scratch-create (${SCRATCH_DB})" 0
-  run_stage "ch-migrate (upgrade + status --check)" ch_migrate
+  EXECUTED_STAGE_IDS+=("ch_scratch_create")
+
+  run_stage "ch-migrate (upgrade + status --check)" ch_migrate ch_migrate
   CH_READY=1
   export CLICKHOUSE_URI="${SCRATCH_URI}"
   printf '   %s -> %s\n' "$(c_green 'CLICKHOUSE_URI')" "${SCRATCH_URI} (scratch)"
@@ -911,10 +1108,17 @@ ch_provision() {
 # Runs AFTER the unit suite, reusing the provisioned scratch db.
 ch_tests() {
   if [ "${CH_READY:-0}" != "1" ]; then
-    skip "argMax live-exec proof" "scratch CH not provisioned"
+    # CHAOS-3571: this branch is reachable ONLY via the explicit
+    # SKIP_CLICKHOUSE=1 opt-out now -- ch_provision() fail_fast's the whole
+    # gate on every other reason CH_READY could be unset, so CH_READY=0
+    # reaching here with no opt-out set would itself be a bug in ch_provision,
+    # not a legitimate runtime state. DECLARED_STAGE_IDS already excludes
+    # ch_argmax_proof under SKIP_CLICKHOUSE=1 (see run_declared_stages), so
+    # this skip does not need its own EXECUTED_STAGE_IDS entry.
+    skip "argMax live-exec proof" "scratch CH not provisioned (SKIP_CLICKHOUSE=1)"
     return 0
   fi
-  run_stage "argMax live-exec proof (real engine)" ch_argmax_proof
+  run_stage "argMax live-exec proof (real engine)" ch_argmax_proof ch_argmax_proof
 }
 
 print_summary() {
@@ -930,27 +1134,96 @@ print_summary() {
   hr
 }
 
+# verify_stage_manifest() (CHAOS-3571): the structural, independent backstop.
+# Every individual stage above already fails fast on its own bad outcome; this
+# does not re-check any of them. It checks something no single stage's own
+# logic can: that the SET of stages which actually ran (EXECUTED_STAGE_IDS) is
+# exactly the set this run committed to up front (DECLARED_STAGE_IDS) --
+# neither short (something declared never ran) nor long (something ran that
+# was never declared, e.g. a copy-paste stage_id typo hiding a duplicate). A
+# mismatch fails the gate even if every stage that DID run passed, which is
+# exactly the CHAOS-3571 shape: a docker-probe-failure branch that quietly
+# `return`s 0 without ever calling record()/fail_fast is a bug this backstop
+# still catches, because it never touches EXECUTED_STAGE_IDS -- independent of
+# whether whoever wrote that hypothetical future bug also got the RESULTS/
+# FAILED bookkeeping right.
+verify_stage_manifest() {
+  local id missing="" extra=""
+  for id in "${DECLARED_STAGE_IDS[@]+"${DECLARED_STAGE_IDS[@]}"}"; do
+    array_contains "${id}" "${EXECUTED_STAGE_IDS[@]+"${EXECUTED_STAGE_IDS[@]}"}" ||
+      missing="${missing:+${missing} }${id}"
+  done
+  for id in "${EXECUTED_STAGE_IDS[@]+"${EXECUTED_STAGE_IDS[@]}"}"; do
+    array_contains "${id}" "${DECLARED_STAGE_IDS[@]+"${DECLARED_STAGE_IDS[@]}"}" ||
+      extra="${extra:+${extra} }${id}"
+  done
+  if [ -n "${missing}" ] || [ -n "${extra}" ]; then
+    record "stage-manifest self-check (declared-but-not-executed=[${missing:-none}] executed-but-not-declared=[${extra:-none}])" 1
+    fail_fast "stage-manifest self-check"
+  fi
+  record "stage-manifest self-check (${#EXECUTED_STAGE_IDS[@]}/${#DECLARED_STAGE_IDS[@]} declared stages executed)" 0
+}
+
+# run_declared_stages() (CHAOS-3571): DECLARED_STAGE_IDS is decided HERE, in
+# full, BEFORE any stage runs -- not derived after the fact from whatever
+# happened to execute. The only branch is the explicit SKIP_CLICKHOUSE=1
+# opt-out; every other reason a CH stage might not run (docker missing, the
+# probe failing, the container confirmed absent, dev-hops missing) is a
+# ch_provision() hard failure against the FULL 8-id declaration, never a
+# reason to shrink it at runtime. Factored out of main() so the CHAOS-3571
+# `--stage-manifest-probe` test-only hook near the bottom of this file can
+# exercise this exact sequencing (with the expensive leaf stages stubbed) --
+# same precedent as `--lock-probe` exercising the real acquire_lock/
+# release_lock without paying for preflight/lint/mypy/the unit suite.
+run_declared_stages() {
+  if [ "${SKIP_CLICKHOUSE:-0}" = "1" ]; then
+    DECLARED_STAGE_IDS=(lint_format lint_check typecheck unit_suite)
+  else
+    DECLARED_STAGE_IDS=(lint_format lint_check typecheck ch_probe ch_scratch_create ch_migrate unit_suite ch_argmax_proof)
+  fi
+
+  run_stage "lint: ruff format --check" lint_format gate_lint_format
+  run_stage "lint: ruff check" lint_check gate_lint_check
+  run_stage "typecheck: mypy" typecheck gate_typecheck
+  # run_stage "go: format + vet + test"     go_fast    gate_go_fast
+  # run_stage "river: static compatibility harness" river_compat gate_river_compat_static
+  ch_provision # scratch db + migrations; exports CLICKHOUSE_URI when available
+  run_stage "unit suite (FULL, not subset)" unit_suite gate_unit_suite
+  ch_tests # argMax live-exec proof on the real engine (reuses the scratch db)
+
+  verify_stage_manifest
+
+  print_summary
+  if [ "${FAILED}" -ne 0 ]; then
+    printf 'GATE_STAGE_MANIFEST result=FAILED declared=%d executed=%d declared_ids=%s executed_ids=%s\n' \
+      "${#DECLARED_STAGE_IDS[@]}" "${#EXECUTED_STAGE_IDS[@]}" \
+      "$(join_commas "${DECLARED_STAGE_IDS[@]+"${DECLARED_STAGE_IDS[@]}"}")" \
+      "$(join_commas "${EXECUTED_STAGE_IDS[@]+"${EXECUTED_STAGE_IDS[@]}"}")"
+    printf '\n%s do NOT push. Fix the failures above.\n' "$(c_red 'GATE FAILED.')"
+    exit 1
+  fi
+  # The verdict line itself now carries the stage count and the exact ids that
+  # ran (CHAOS-3571 (b)): "GATE PASSED [8/8: ...]" cannot be produced by a run
+  # that executed fewer stages than it declared -- verify_stage_manifest above
+  # already exited 1 before this line if it had. A degraded run can no longer
+  # print an indistinguishable "GATE PASSED. safe to push." — the bracketed
+  # count is unconditionally part of the same line a human or a PR quote would
+  # copy, not a separate line easy to omit when pasting.
+  printf 'GATE_STAGE_MANIFEST result=PASSED declared=%d executed=%d declared_ids=%s executed_ids=%s\n' \
+    "${#DECLARED_STAGE_IDS[@]}" "${#EXECUTED_STAGE_IDS[@]}" \
+    "$(join_commas "${DECLARED_STAGE_IDS[@]+"${DECLARED_STAGE_IDS[@]}"}")" \
+    "$(join_commas "${EXECUTED_STAGE_IDS[@]+"${EXECUTED_STAGE_IDS[@]}"}")"
+  printf '\n%s [%d/%d: %s] safe to push.\n' \
+    "$(c_green 'GATE PASSED.')" "${#EXECUTED_STAGE_IDS[@]}" "${#DECLARED_STAGE_IDS[@]}" \
+    "$(join_commas "${EXECUTED_STAGE_IDS[@]+"${EXECUTED_STAGE_IDS[@]}"}")"
+  exit 0
+}
+
 # ===================================================================================
 main() {
   acquire_lock # CHAOS-3403 single-flight mutex — before any work is done
   preflight
-
-  run_stage "lint: ruff format --check" gate_lint_format
-  run_stage "lint: ruff check" gate_lint_check
-  run_stage "typecheck: mypy" gate_typecheck
-  # run_stage "go: format + vet + test"     gate_go_fast
-  # run_stage "river: static compatibility harness" gate_river_compat_static
-  ch_provision # scratch db + migrations; exports CLICKHOUSE_URI when available
-  run_stage "unit suite (FULL, not subset)" gate_unit_suite
-  ch_tests # argMax live-exec proof on the real engine (reuses the scratch db)
-
-  print_summary
-  if [ "${FAILED}" -ne 0 ]; then
-    printf '\n%s do NOT push. Fix the failures above.\n' "$(c_red 'GATE FAILED.')"
-    exit 1
-  fi
-  printf '\n%s safe to push.\n' "$(c_green 'GATE PASSED.')"
-  exit 0
+  run_declared_stages
 }
 
 # High-resolution timestamp for --lock-probe, in order of preference: bash's
@@ -1061,6 +1334,80 @@ if [ "${1:-}" = "--lock-probe-exit-order" ]; then
   # exactly that flaky non-observation during this hook's own development.
   # hold_secs makes the window a real, controllable duration to poll for.
   sleep "${hold_secs}"
+  exit 0
+fi
+
+# Test-only harness hook (CHAOS-3571): exercises the REAL ch_probe_docker()
+# function in isolation -- no lock, no preflight, no lint/mypy/unit suite, no
+# scratch db. Prints its return code and CH_PROBE_DETAIL so a test can plant a
+# specific docker failure mode (missing binary, `docker ps` erroring, a clean
+# "container absent" result) via a PATH-shadowing stub `docker` binary, and
+# assert the exact distinguishing message CHAOS-3571 was filed over -- a probe
+# FAILURE reported as a confirmed "not running" fact. Never invoked by main();
+# only by tests/tooling/test_local_validate_stage_manifest.py.
+if [ "${1:-}" = "--ch-probe-only" ]; then
+  shift
+  ch_probe_docker
+  ch_probe_rc=$?
+  printf 'ch-probe-result: rc=%s detail=%s\n' "${ch_probe_rc}" "${CH_PROBE_DETAIL}"
+  exit "${ch_probe_rc}"
+fi
+
+# Test-only harness hook (CHAOS-3571): exercises the REAL stage-declaration /
+# stage-execution / verify_stage_manifest / verdict-line bookkeeping in
+# run_declared_stages() end-to-end, with every expensive or environment-
+# dependent LEAF stage swapped for a trivial stand-in -- same technique as
+# --lock-probe-exit-order's cleanup_scratch() override above, applied to seven
+# functions instead of one. This is deliberately NOT a test of any individual
+# gate's correctness (lint/mypy/pytest are not being exercised here at all);
+# it is a test that the manifest machinery itself -- the part CHAOS-3571 was
+# actually about -- correctly declares, tracks, diffs, and reports, without
+# paying for the ~15-minute real gate or touching a real docker/ClickHouse.
+# Never invoked by main(); only by
+# tests/tooling/test_local_validate_stage_manifest.py.
+if [ "${1:-}" = "--stage-manifest-probe" ]; then
+  shift
+  gate_lint_format() { return 0; }
+  gate_lint_check() { return 0; }
+  gate_typecheck() { return 0; }
+  gate_unit_suite() { return 0; }
+  ch_probe_docker() {
+    CH_PROBE_DETAIL="stubbed: available"
+    return 0
+  }
+  # NOTE: does NOT set SCRATCH_CREATED=1 -- the real cleanup_scratch() (run
+  # unconditionally by the on_exit EXIT trap registered near the top of this
+  # script, which this hook does not disable) gates its `docker exec ...
+  # DROP DATABASE` on that flag. Leaving it unset means on_exit's real
+  # cleanup_scratch() call is a guaranteed no-op here, so this hook makes
+  # zero docker calls end to end -- consistent with "no docker commands
+  # against real containers" for a probe whose whole point is to test the
+  # manifest bookkeeping, not ClickHouse.
+  ch_create_scratch() { return 0; }
+  ch_migrate() { return 0; }
+  ch_argmax_proof() { return 0; }
+  run_declared_stages
+fi
+
+# Test-only harness hook (CHAOS-3571): exercises verify_stage_manifest() in
+# total isolation from run_declared_stages -- feeds it a DECLARED_STAGE_IDS /
+# EXECUTED_STAGE_IDS pair with a deliberate gap (something declared that never
+# "ran") and confirms it fails loudly by name, rather than trusting that a
+# normal gate run can ever actually produce a mismatch to test against (under
+# the CHAOS-3571 fix it structurally can't -- run_stage/ch_provision append to
+# EXECUTED_STAGE_IDS unconditionally on every path, so the only way to observe
+# this function's own refusal logic is to hand it a gap directly). Reads the
+# fake declared/executed id lists from argv so a test can vary them freely.
+# Never invoked by main(); only by
+# tests/tooling/test_local_validate_stage_manifest.py.
+if [ "${1:-}" = "--stage-manifest-mismatch-probe" ]; then
+  shift
+  declared_csv="${1:?declared csv required}"
+  executed_csv="${2:?executed csv required}"
+  IFS=',' read -r -a DECLARED_STAGE_IDS <<<"${declared_csv}"
+  IFS=',' read -r -a EXECUTED_STAGE_IDS <<<"${executed_csv}"
+  verify_stage_manifest
+  printf 'stage-manifest-mismatch-probe: no mismatch detected (unexpected)\n'
   exit 0
 fi
 

--- a/ci/local_validate.sh
+++ b/ci/local_validate.sh
@@ -92,15 +92,16 @@
 #   DECLARED stage set up front, not a runtime probe result the gate decided on
 #   its own to trust.
 #
-#   The verdict line and a machine-readable `GATE_STAGE_MANIFEST ...` log line
-#   both carry `declared=<N> executed=<N>` plus the exact stage ids that ran
-#   (`GATE PASSED. [8/8: lint_format,lint_check,typecheck,ch_probe,
-#   ch_scratch_create,ch_migrate,unit_suite,ch_argmax_proof] safe to push.`,
-#   or `[4/4: ...]` under SKIP_CLICKHOUSE=1) -- a degraded run cannot produce a
-#   verdict line indistinguishable from a full one, even in a copy-pasted PR
-#   quote. `verify_stage_manifest()` additionally self-checks that the set of
-#   stages that actually ran equals the declared set and fails the gate on ANY
-#   mismatch, even if every stage that did run passed -- an independent
+#   A machine-readable `GATE_STAGE_MANIFEST ... declared=<N> executed=<N>
+#   declared_ids=... executed_ids=...` log line carries the literal counts and
+#   ids, and the human verdict line carries the same information formatted as
+#   `[executed/declared: ids]` (`GATE PASSED. [8/8: lint_format,lint_check,
+#   typecheck,ch_probe,ch_scratch_create,ch_migrate,unit_suite,ch_argmax_proof]
+#   safe to push.`, or `[4/4: ...]` under SKIP_CLICKHOUSE=1) -- a degraded run
+#   cannot produce a verdict line indistinguishable from a full one, even in a
+#   copy-pasted PR quote. `verify_stage_manifest()` additionally self-checks
+#   that the set of stages that actually ran equals the declared set and fails
+#   the gate on ANY mismatch, even if every stage that did run passed -- an independent
 #   backstop against this exact class of bug recurring, not just a fix for this
 #   one instance of it. See tests/tooling/test_local_validate_stage_manifest.py.
 #
@@ -1357,7 +1358,7 @@ fi
 # stage-execution / verify_stage_manifest / verdict-line bookkeeping in
 # run_declared_stages() end-to-end, with every expensive or environment-
 # dependent LEAF stage swapped for a trivial stand-in -- same technique as
-# --lock-probe-exit-order's cleanup_scratch() override above, applied to seven
+# --lock-probe-exit-order's cleanup_scratch() override above, applied to eight
 # functions instead of one. This is deliberately NOT a test of any individual
 # gate's correctness (lint/mypy/pytest are not being exercised here at all);
 # it is a test that the manifest machinery itself -- the part CHAOS-3571 was

--- a/tests/tooling/test_local_validate_stage_manifest.py
+++ b/tests/tooling/test_local_validate_stage_manifest.py
@@ -1,0 +1,317 @@
+"""Regression coverage for CHAOS-3571: a degraded ``ci/local_validate.sh`` run
+must never print ``GATE PASSED``.
+
+Observed 2026-08-07 while gating CHAOS-3552 (PR #1579), machine load ~27: the
+docker probe inside ``ch_provision()`` failed (most likely ``docker ps`` timing
+out under load -- the exact invocation was never captured), and the old code
+rendered that FAILURE as the claim "container 'dev-health-clickhouse-1' not
+running" and ``skip``'d ch-scratch-create, ch-migrate, and the argMax live-exec
+proof. The gate still printed ``GATE PASSED. safe to push.`` with 3 of 8 real
+stages silently missing -- the container had been up and healthy the entire
+time, verified independently by two people minutes later.
+
+This file proves two independent things now hold, matching the family rule "a
+measurement that did not happen must FAIL loudly":
+
+  (i)  A docker probe FAILURE (``docker ps`` itself erroring -- indeterminate
+       container state) is a HARD gate failure with a message that names the
+       true mechanism ("probe FAILED ... UNKNOWN"), never the old fabricated
+       "not running" claim, and never a ``skip``.
+  (ii) The stage manifest (declared vs. executed) is enforced structurally:
+       a full run's executed-stage-id set equals its declared set, a
+       SKIP_CLICKHOUSE=1 run's reduced declared set is met exactly, and
+       ``verify_stage_manifest()`` itself refuses ANY declared-but-not-executed
+       gap even when handed a scenario the current fix can no longer produce
+       through normal execution.
+
+Every test here drives the REAL functions in ``ci/local_validate.sh`` through
+its `--ch-probe-only` / `--stage-manifest-probe` / `--stage-manifest-mismatch-
+probe` test-only harness hooks (same precedent as `--lock-probe` in
+test_local_validate_lock.py) -- never a reimplementation, and never the real
+`bash ci/local_validate.sh` with no hook (which would run the full ~15-minute
+gate, including a real docker probe against the shared, single-flight-locked
+ClickHouse container these tests must not touch). No test here issues a single
+real ``docker`` command: docker is always a PATH-shadowing stub script, or, for
+the manifest-only tests, `ch_probe_docker` itself is stubbed by the harness
+hook.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "ci" / "local_validate.sh"
+_BASE_PATH = "/usr/bin:/bin"
+_TIMEOUT = 30
+
+
+def _write_fake_docker(
+    bin_dir: Path, *, ps_exit: int, ps_stdout: str, ps_stderr: str
+) -> None:
+    """A PATH-shadowing ``docker`` stub: only ``docker ps ...`` is faked."""
+    script = bin_dir / "docker"
+    script.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = "ps" ]; then\n'
+        f"  printf %s {_sh_quote(ps_stdout)}\n"
+        f"  printf %s {_sh_quote(ps_stderr)} >&2\n"
+        f"  exit {ps_exit}\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    script.chmod(0o755)
+
+
+def _sh_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def _run_ch_probe_only(
+    tmp_path: Path, *, extra_env: dict[str, str]
+) -> subprocess.CompletedProcess:
+    env = {"PATH": f"{tmp_path}:{_BASE_PATH}"}
+    env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--ch-probe-only"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+
+
+# --- (i) The exact CHAOS-3571 defect: a FAILED probe must never read as ------------
+#         "not running", and must never let the gate pass. --------------------------
+
+
+def test_docker_ps_failure_is_reported_as_a_failed_probe_not_a_confirmed_absence(
+    tmp_path,
+):
+    """Plant the exact CHAOS-3571 mechanism: ``docker`` is on PATH and
+    ``command -v docker`` succeeds, but ``docker ps`` itself exits nonzero
+    (simulating the daemon being unreachable/overloaded, exactly as the ticket
+    describes -- "most likely a docker CLI call timing out under load"). This
+    must be reported as an INDETERMINATE probe failure, distinctly worded from
+    "not running", and must be a hard failure (nonzero exit), never rc=0/skip.
+
+    RED proof against the pre-fix code (not re-asserted here, see the PR body):
+    sourcing origin/main's ``ch_provision()`` directly against this identical
+    stub prints "container '...' not running" and returns rc=0 with FAILED=0
+    -- the fabricated claim this test exists to forbid.
+    """
+    _write_fake_docker(
+        tmp_path,
+        ps_exit=1,
+        ps_stdout="",
+        ps_stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n",
+    )
+    result = _run_ch_probe_only(
+        tmp_path, extra_env={"CH_CONTAINER": "dev-health-clickhouse-1"}
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 2, combined
+    assert "rc=2" in combined, combined
+    assert "probe FAILED" in combined, combined
+    assert "UNKNOWN" in combined, combined
+    assert "not running" not in combined, (
+        f"the FABRICATED claim from the CHAOS-3571 defect must never appear when "
+        f"the probe itself failed.\n{combined}"
+    )
+    assert "Cannot connect to the Docker daemon" in combined, (
+        f"the probe's real stderr must be surfaced verbatim, not swallowed.\n{combined}"
+    )
+
+
+def test_docker_absent_from_path_is_a_distinct_hard_failure(tmp_path):
+    """No ``docker`` binary at all is its own, differently-worded case --
+    never confused with a probe that ran and failed."""
+    result = _run_ch_probe_only(
+        tmp_path, extra_env={}
+    )  # empty tmp_path: no docker stub written
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 1, combined
+    assert "docker CLI not found on PATH" in combined, combined
+    assert "probe FAILED" not in combined, combined
+
+
+def test_container_confirmed_absent_is_still_a_hard_failure_not_a_silent_skip(
+    tmp_path,
+):
+    """CHAOS-3571 (a): 'docker down' must HARD FAIL, never fall back to a
+    silent skip -- even when ``docker ps`` genuinely, cleanly confirms the
+    container is absent (as opposed to the probe itself failing, covered
+    above). The only sanctioned escape hatch is the explicit SKIP_CLICKHOUSE=1
+    opt-out (covered by test_skip_clickhouse_reduces_the_declared_set_exactly
+    below), not a runtime probe result, however clean.
+    """
+    _write_fake_docker(
+        tmp_path, ps_exit=0, ps_stdout="some-unrelated-container\n", ps_stderr=""
+    )
+    result = _run_ch_probe_only(
+        tmp_path, extra_env={"CH_CONTAINER": "dev-health-clickhouse-1"}
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 3, combined
+    assert "confirmed NOT running" in combined, combined
+    # Distinct from the probe-failure wording -- a human reading this must be
+    # told the true mechanism, not a guess.
+    assert "probe FAILED" not in combined, combined
+
+
+def test_devhops_missing_is_a_distinct_hard_failure(tmp_path):
+    """Container reachable, but the dev-hops CLI this stage shells out to is
+    missing from the venv -- also a hard failure (CHAOS-3571 (a): 'missing
+    dependency'), with its own distinguishing message."""
+    _write_fake_docker(
+        tmp_path, ps_exit=0, ps_stdout="dev-health-clickhouse-1\n", ps_stderr=""
+    )
+    result = _run_ch_probe_only(
+        tmp_path,
+        extra_env={
+            "CH_CONTAINER": "dev-health-clickhouse-1",
+            "DEVHOPS": str(tmp_path / "no-such-dev-hops"),
+        },
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 4, combined
+    assert "dev-hops CLI missing" in combined, combined
+
+
+def test_container_reachable_probe_succeeds(tmp_path):
+    """Sanity check for the tests above: a genuinely healthy probe (container
+    present, dev-hops present) returns 0 -- the stub harness itself is not
+    what is forcing every other test's failure."""
+    _write_fake_docker(
+        tmp_path, ps_exit=0, ps_stdout="dev-health-clickhouse-1\n", ps_stderr=""
+    )
+    devhops = tmp_path / "dev-hops"
+    devhops.write_text("#!/bin/bash\nexit 0\n")
+    devhops.chmod(0o755)
+    result = _run_ch_probe_only(
+        tmp_path,
+        extra_env={"CH_CONTAINER": "dev-health-clickhouse-1", "DEVHOPS": str(devhops)},
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+    assert "rc=0" in combined, combined
+
+
+# --- (ii) The stage manifest: executed must equal declared, structurally. ----------
+
+
+def test_full_run_executed_stages_equal_the_full_declared_set(tmp_path):
+    """With every leaf gate stubbed to pass instantly (no lint/mypy/pytest/
+    docker/ClickHouse actually run -- see the `--stage-manifest-probe` hook's
+    own header comment in local_validate.sh), a clean run's executed-stage-id
+    set must equal the full 8-stage declared set, and the verdict line +
+    machine-readable manifest line must say so explicitly.
+    """
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--stage-manifest-probe"],
+        cwd=ROOT,
+        env={"PATH": _BASE_PATH},
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 0, combined
+    assert "GATE PASSED." in combined, combined
+    assert "GATE_STAGE_MANIFEST result=PASSED declared=8 executed=8" in combined, (
+        combined
+    )
+    assert "[8/8:" in combined, combined
+    for stage_id in (
+        "lint_format",
+        "lint_check",
+        "typecheck",
+        "ch_probe",
+        "ch_scratch_create",
+        "ch_migrate",
+        "unit_suite",
+        "ch_argmax_proof",
+    ):
+        assert stage_id in combined, (
+            f"missing declared stage id {stage_id!r}.\n{combined}"
+        )
+
+
+def test_skip_clickhouse_reduces_the_declared_set_exactly(tmp_path):
+    """SKIP_CLICKHOUSE=1 is the ONLY sanctioned way to shrink the declared set
+    -- it must do so exactly (4/4, the 4 non-CH stage ids), never silently
+    leaving a CH-dependent id in the declaration with nothing to execute it."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--stage-manifest-probe"],
+        cwd=ROOT,
+        env={"PATH": _BASE_PATH, "SKIP_CLICKHOUSE": "1"},
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 0, combined
+    assert "GATE_STAGE_MANIFEST result=PASSED declared=4 executed=4" in combined, (
+        combined
+    )
+    assert "[4/4:" in combined, combined
+    for stage_id in ("ch_probe", "ch_scratch_create", "ch_migrate", "ch_argmax_proof"):
+        assert stage_id not in combined, (
+            f"CH stage id {stage_id!r} must not appear in a SKIP_CLICKHOUSE=1 "
+            f"manifest.\n{combined}"
+        )
+
+
+def test_verify_stage_manifest_refuses_a_declared_but_not_executed_gap(tmp_path):
+    """The structural backstop itself: hand verify_stage_manifest() a declared
+    set with one id that never made it into the executed set, and confirm it
+    fails loudly by name -- even though nothing about run_stage()/
+    ch_provision()'s pass/fail bookkeeping is exercised here at all. This is
+    what actually makes "mismatch fails even if every executed stage passed"
+    true, independent of every individual stage's own correctness.
+    """
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--stage-manifest-mismatch-probe", "a,b,c", "a,b"],
+        cwd=ROOT,
+        env={"PATH": _BASE_PATH},
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 1, combined
+    assert "GATE FAILED." in combined, combined
+    assert "stage-manifest self-check" in combined, combined
+    assert "declared-but-not-executed=[c]" in combined, combined
+    assert "GATE_STAGE_MANIFEST result=FAILED declared=3 executed=2" in combined, (
+        combined
+    )
+    assert "no mismatch detected" not in combined, (
+        f"the probe's own 'unexpected' fallback message must never print -- "
+        f"verify_stage_manifest must have exited the process first.\n{combined}"
+    )
+
+
+def test_verify_stage_manifest_accepts_an_exact_match(tmp_path):
+    """Sanity check for the mismatch test above: an exactly-matching
+    declared/executed pair must NOT be flagged."""
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--stage-manifest-mismatch-probe", "a,b,c", "a,b,c"],
+        cwd=ROOT,
+        env={"PATH": _BASE_PATH},
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+    assert "no mismatch detected" in combined, combined

--- a/tests/tooling/test_local_validate_stage_manifest.py
+++ b/tests/tooling/test_local_validate_stage_manifest.py
@@ -38,6 +38,7 @@ hook.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -45,6 +46,54 @@ ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "ci" / "local_validate.sh"
 _BASE_PATH = "/usr/bin:/bin"
 _TIMEOUT = 30
+
+# Every external command local_validate.sh's startup + ch_probe_docker() path
+# can reach, EXCLUDING docker itself. Used only by the "docker absent" test
+# below -- see its docstring for why `_BASE_PATH` alone is not safe for that
+# one case.
+_NON_DOCKER_TOOLS = (
+    "bash",
+    "dirname",
+    "mktemp",
+    "sed",
+    "tr",
+    "grep",
+    "cat",
+    "rm",
+    "sha256sum",
+    "shasum",
+    "openssl",
+    "cksum",
+    "awk",
+)
+
+
+def _path_guaranteed_docker_free(bin_dir: Path) -> str:
+    """A PATH that resolves every tool `local_validate.sh` needs up to and
+    including `ch_probe_docker()`'s "docker missing" branch -- EXCEPT
+    `docker` itself, which is guaranteed absent regardless of the host.
+
+    `_BASE_PATH` ("/usr/bin:/bin") is NOT reliably docker-free: GitHub's
+    `ubuntu-latest` Actions runners ship docker preinstalled at
+    `/usr/bin/docker`, so a test that reused `_BASE_PATH` here (as an earlier
+    version of this file did) found a REAL docker on that PATH and got
+    rc=3 ("container confirmed NOT running") instead of the intended rc=1
+    ("docker CLI not found") -- exactly what happened the first time this
+    test ran in CI. This builds the allowed toolset by resolving each name in
+    `_NON_DOCKER_TOOLS` via the REAL, live `PATH` (whatever it is on this
+    host) and symlinking only those into an isolated directory, so the
+    result is portable across hosts that do and do not ship docker in a
+    standard location, without guessing at a fixed exclusion list.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for tool in _NON_DOCKER_TOOLS:
+        found = shutil.which(tool)
+        if found:
+            (bin_dir / tool).symlink_to(found)
+    assert shutil.which("docker", path=str(bin_dir)) is None, (
+        "docker leaked into the supposedly docker-free PATH"
+    )
+    return str(bin_dir)
 
 
 def _write_fake_docker(
@@ -128,10 +177,22 @@ def test_docker_ps_failure_is_reported_as_a_failed_probe_not_a_confirmed_absence
 
 def test_docker_absent_from_path_is_a_distinct_hard_failure(tmp_path):
     """No ``docker`` binary at all is its own, differently-worded case --
-    never confused with a probe that ran and failed."""
-    result = _run_ch_probe_only(
-        tmp_path, extra_env={}
-    )  # empty tmp_path: no docker stub written
+    never confused with a probe that ran and failed.
+
+    Uses `_path_guaranteed_docker_free`, NOT the `_BASE_PATH`-based
+    `_run_ch_probe_only` helper every other test in this file uses: this is
+    the one case that specifically needs docker to be verifiably absent, and
+    `_BASE_PATH` alone does not guarantee that on every host (see that
+    helper's docstring).
+    """
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--ch-probe-only"],
+        cwd=ROOT,
+        env={"PATH": _path_guaranteed_docker_free(tmp_path / "no-docker-bin")},
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
     combined = result.stdout + result.stderr
 
     assert result.returncode == 1, combined


### PR DESCRIPTION
## Summary

Fixes CHAOS-3571 (High): `ci/local_validate.sh` silently degraded 7 (now 8, counting the previously-unrecorded docker probe as its own stage) stages down to 4 and still printed `GATE PASSED. safe to push.`

**Quoted defect path (pre-fix, origin/main):** `ci/local_validate.sh`, `ch_provision()` (was lines 882–908), specifically:

```sh
ch_available
case $? in
1)
  skip "clickhouse provisioning" "container '${CH_CONTAINER}' not running (start the dev stack, or SKIP_CLICKHOUSE=1)"
  return 0
  ;;
2)
  skip "clickhouse provisioning" "missing ${DEVHOPS} (install [dev] extra into .venv)"
  return 0
  ;;
esac
```

`ch_available()` (was lines 702–707) collapsed "docker not installed", "`docker ps` itself failed", and "container genuinely not running" into a single `return 1`. Observed 2026-08-07 gating CHAOS-3552 (PR #1579), machine load ~27: `docker ps` failed (most likely a transient timeout under load — the exact invocation was never captured), and this code rendered that FAILURE as the FABRICATED claim `"container 'dev-health-clickhouse-1' not running"`, then `skip`'d ch-scratch-create, ch-migrate, and the argMax live-exec proof while leaving `FAILED=0`. The gate printed `GATE PASSED. safe to push.` The container had been up and healthy the whole time (verified independently by two people minutes later).

## Fix

- `ch_probe_docker()` (replaces `ch_available()`) returns a **distinct** code + `CH_PROBE_DETAIL` message for: docker missing from PATH, `docker ps` itself failing (**indeterminate** — the exact CHAOS-3571 mechanism, worded "probe FAILED ... UNKNOWN", never "not running"), the container **confirmed** absent (a real, provable fact), and dev-hops missing. Docker's own exit code + stderr are captured and surfaced unconditionally (previously `2>/dev/null`'d away).
- Every one of those is now a **hard failure** (`fail_fast`), never a `skip`. The **only** sanctioned way to run without the ClickHouse-dependent stages is the explicit, caller-supplied `SKIP_CLICKHOUSE=1` — it shrinks the *declared* stage set up front, rather than the gate discovering at runtime that it "can't" run something and quietly doing less.
  - Note on scope: CHAOS-3571's own "Proposed fix direction" suggested a confirmed "container not running" could still legitimately skip. This PR deliberately does **not** take that half of the proposal — a merge gate that trusts an unattended runtime probe's "confirmed absent" enough to pass silently is the same shape of tool this ticket was filed against. `SKIP_CLICKHOUSE=1` is the only escape hatch; `CH_PROBE_DETAIL` still names the confirmed-absent case distinctly from the indeterminate-probe case in the failure message, so the diagnostic honesty half of the ticket's ask is preserved even though the "still skip" half is not implemented.
- The verdict line and a new machine-readable `GATE_STAGE_MANIFEST result=PASSED|FAILED declared=<N> executed=<N> declared_ids=... executed_ids=...` log line both carry stage counts and the exact ids that ran: `GATE PASSED. [8/8: lint_format,lint_check,typecheck,ch_probe,ch_scratch_create,ch_migrate,unit_suite,ch_argmax_proof] safe to push.` (or `[4/4: ...]` under `SKIP_CLICKHOUSE=1`).
- `verify_stage_manifest()`: an independent structural backstop. Diffs `EXECUTED_STAGE_IDS` (appended to unconditionally by `run_stage()`/`ch_provision()`, on every pass **and** fail) against `DECLARED_STAGE_IDS` (fixed up front, before any stage runs) and fails the gate on **any** mismatch — even if every stage that did run passed. This guards against a *future* reintroduction of a silent-skip bug, not just this one instance.

## RED-first proof

Sourced origin/main's `ch_provision()` directly (function definitions only, `main "$@"` stripped — never ran the real gate) against a stub `docker` whose `ps` subcommand exits 1:

```
old ch_provision() rc=0 -- RESULTS: SKIP  clickhouse provisioning — container 'dev-health-clickhouse-1' not running (start the dev stack, or SKIP_CLICKHOUSE=1) -- FAILED=0
```

Against the fixed code, the same stub via the new `--ch-probe-only` test hook: `rc=2`, message `docker ps probe FAILED (exit 1): Cannot connect to the Docker daemon ... — container state UNKNOWN, NOT confirmed absent`.

## Tests

`tests/tooling/test_local_validate_stage_manifest.py` (9 new tests, all passing) drives the *real* script functions through three new test-only harness hooks (`--ch-probe-only`, `--stage-manifest-probe`, `--stage-manifest-mismatch-probe` — same precedent as the existing `--lock-probe`/`--lock-probe-exit-order` hooks). No test issues a real `docker` command; `docker` is always a PATH-shadowing stub, or `ch_probe_docker` itself is stubbed for the manifest-only tests. Covers: probe-failure → hard fail with the distinguishing message; docker-absent, container-confirmed-absent, and dev-hops-missing as their own distinctly-worded hard failures; a full run's executed set equalling the 8-id declared set; `SKIP_CLICKHOUSE=1`'s reduced 4-id set; and `verify_stage_manifest()`'s own mismatch-detection logic in isolation.

`DEVHOPS` was made env-overridable (`DEVHOPS="${DEVHOPS:-${ROOT}/.venv/bin/dev-hops}"`) — identical computed default for every real caller — solely so the dev-hops-missing branch is testable without mutating the shared venv.

## Consumers audited (external contract)

Grepped for consumers of `GATE PASSED` and the lock/scratch-db naming conventions before changing the verdict format:
- `AGENTS.md` — documentation only (not parsed); updated to describe the new hard-fail-by-default behavior and stage-manifest format, and to correct its previous "the CH stage cleanly SKIPs" statement.
- `.github/workflows/go.yml` — only a commented-out path-filter entry referencing the filename, not the string.
- `.github/pr-bodies/*.md` — historical PR body archives, not live consumers.
- No script/workflow/test parses `"GATE PASSED"` programmatically. `SCRATCH_DB`/`LOCK_DIR` naming conventions (`ci_local_validate_<hash>`, `/tmp/dev-health-ops-local-validate.<container>.lock`) are unchanged — several test files and `src/dev_health_ops/fixtures/world.py`'s `_SCRATCH_MARKERS` depend on the `ci_local_validate` substring, untouched by this PR.

## Verification run (this PR, not the full gate)

- `ruff format --check .` / `ruff check .` — clean, full repo.
- `mypy --install-types --non-interactive .` — clean, 2165 source files.
- `tests/tooling/` (244 tests, includes the 9 new ones) — all pass.
- Full unit suite, byte-for-byte CI's invocation (`pytest tests -m "not benchmark and not clickhouse" ... -n 4 --dist loadscope`) — 13343 passed, 245 skipped, 1 xfailed. (One `tests/docs/test_built_site_links.py` failure was a pre-existing `uv sync`-doesn't-pull-mkdocs environment gap in this freshly created worktree, unrelated to this change — fixed by installing `requirements-docs.txt`, then reran green.)

**The real `bash ci/local_validate.sh` gate has NOT been executed by me.** Per the assignment, that slot is machine-wide single-flight and reserved for the orchestrator's armed acceptance run, which will gate this PR.

## Test plan
- [x] `ruff format --check .` / `ruff check .` — clean
- [x] `mypy --install-types --non-interactive .` — clean
- [x] `tests/tooling/` — 244 passed
- [x] Full unit suite (CI-parity invocation) — 13343 passed, 0 unexpected failures
- [ ] Orchestrator's armed `ci/local_validate.sh` acceptance run (not run here — reserved slot)