### PR TITLE
CHAOS-3551: render committed-cohort answers instead of refusing

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -2570,8 +2570,35 @@ class DevOrchestrator:
                     # is nothing to batch over without a committed
                     # DevSubjectSet, mirroring the SINGULAR branch's
                     # has_committed_subject gate one line up.
+                    #
+                    # CHAOS-3551: and the committed subject set's own KIND
+                    # must be one `plan` actually supports. Before this
+                    # ticket every intent whose vocabulary could classify as
+                    # PORTFOLIO_STATUS only ever reached here with a PROJECT
+                    # subject_set -- subject_preflight's own homogeneous-
+                    # cohort gate committed nothing else under that intent.
+                    # CHAOS-3551 adds a second PROCEED source for the SAME
+                    # (PORTFOLIO_STATUS-classified, PLURAL_COHORT) shape: a
+                    # REPOSITORY cohort, which intent classification alone
+                    # cannot rule out (it is lexical, not kind-aware -- see
+                    # subject_preflight's own PORTFOLIO_STATUS branch
+                    # comment). Without this check, a repository cohort
+                    # phrased like a status question would reach
+                    # `_project_scope_from_ref` -- documented as relying on
+                    # ITS CALLER to restrict `ref.entity_kind` to PROJECT --
+                    # and misrepresent each repository as a same-named
+                    # "project" scope to `PortfolioStatusService.
+                    # evaluate_portfolio`, exactly the "answer about one
+                    # entity under another's name" this module's own
+                    # docstring says it never does. `plan.
+                    # supported_subject_kinds` already declares the right
+                    # answer for every plan; nothing previously read it.
                     plan_eligible = (
-                        plan_eligible and preflight_result.subject_set is not None
+                        plan_eligible
+                        and plan is not None
+                        and preflight_result.subject_set is not None
+                        and preflight_result.subject_set.entity_kind
+                        in plan.supported_subject_kinds
                     )
                 if plan_eligible:
                     assert plan is not None

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -42,6 +42,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 
 from .contracts import (
+    V1_SCOPE_LIST_LIMIT,
     DevContractVersions,
     DevScope,
     DevScopeResolution,
@@ -149,6 +150,12 @@ PREFLIGHT_DIAGNOSTICS: tuple[str, ...] = (
     # PROCEED diagnostics -- see the two call sites' own comments.
     "committed_cohort_portfolio_v1",
     "committed_portfolio_org_wide",
+    # CHAOS-3551: a homogeneous, complete, v1-sized REPOSITORY cohort
+    # PROCEEDs and renders over the multi-repository scope
+    # `committed_cohort_resolution_for` (CHAOS-3534) already built --
+    # the render half of D1, mirroring `committed_cohort_portfolio_v1`
+    # for every non-portfolio intent.
+    "committed_cohort_v1_render",
     # CHAOS-3528: the CHAOS-3393 portfolio catalog-outage branch's own
     # diagnostic, emitted at a real call site but never added here -- the
     # exact CHAOS-3292 class this tuple exists to prevent.
@@ -194,11 +201,19 @@ class CommittedSubjects:
     """What the preflight committed for one run: a scope, a subject set, or both.
 
     CHAOS-3301. Exactly one of ``resolution``/``subject_set`` is set for a
-    singular commit or a cohort respectively, except the "duplicate aliases
-    collapse to one subject" case (N4), where both are set: the run proceeds
-    on ``resolution`` (there is only one *distinct* committed entity), and
-    ``subject_set`` still records that the question named it more than once
-    (``original_mention_count`` on the persisted ``dev_subject_set.v1``).
+    singular commit or a cohort respectively, with two exceptions where both
+    are set:
+
+    * the "duplicate aliases collapse to one subject" case (N4): the run
+      proceeds on ``resolution`` (there is only one *distinct* committed
+      entity), and ``subject_set`` still records that the question named it
+      more than once (``original_mention_count`` on the persisted
+      ``dev_subject_set.v1``).
+    * a homogeneous, complete REPOSITORY cohort (CHAOS-3551): more than one
+      distinct entity committed, and ``resolution`` is a real multi-
+      repository scope (``committed_cohort_resolution_for``) the run
+      proceeds on directly -- unlike N4, ``resolution`` here is NOT
+      audit-only.
     """
 
     resolution: DevScopeResolution | None
@@ -788,6 +803,74 @@ class SubjectPreflight:
                     allowed_tools=ALL_TOOLS,
                     blocking_mention_ids=blocking_ids,
                     diagnostic="committed_cohort_portfolio_v1",
+                )
+            # CHAOS-3551: a homogeneous, COMPLETE repository cohort has a
+            # faithful v1 direct-scope representation -- `DevScope.
+            # repositories` is a list, unlike every other kind's single
+            # `entity_ref` (see `committed_cohort_resolution_for`'s own
+            # docstring, CHAOS-3534). That function already built this
+            # resolution; until now it was only ever used to publish an
+            # honest scope outcome on a terminal that still refused to
+            # answer. Reusing it here to PROCEED, exactly like a singular
+            # commit but over N repositories, is the render half of the
+            # same fix: the model gets the multi-repository scope in its
+            # prompt and answers over it through the ordinary status-
+            # snapshot path, instead of terminating unsupported.
+            #
+            # Gated on `cohort_complete` (never for a partial cohort): a
+            # partial cohort did not resolve everything the question named,
+            # and `committed_cohort_resolution_for` unconditionally reports
+            # EXACT -- proceeding on a partial commit would render an
+            # answer while claiming a scope outcome the run does not
+            # actually have. Partial repository cohorts keep terminating
+            # UNSUPPORTED below, same as before this ticket.
+            #
+            # Gated on V1_SCOPE_LIST_LIMIT because DevScope.repositories and
+            # DevScopeResolution.authorized_repository_ids both cap at 20,
+            # while a DevSubjectSet may commit up to 25 -- see
+            # orchestrator.py's own oversized-cohort comment for the
+            # identical bound on the terminal-observability call site. An
+            # oversized cohort keeps terminating UNSUPPORTED: under-
+            # disclosure, never a truncated scope.
+            #
+            # Every other kind (a project or team cohort under an ordinary
+            # question) still has no v1 scope representation and keeps
+            # terminating below -- `committed_cohort_resolution_for` itself
+            # refuses any kind but REPOSITORY, so this is a structural
+            # guarantee, not a policy call made twice. In particular this
+            # can never open person-level output: no SEARCHABLE_ENTITY_KINDS
+            # member is a person, and the only kind this branch ever
+            # proceeds on is REPOSITORY.
+            if (
+                next(iter(unique_kinds)) is EntityKind.REPOSITORY
+                and subject_set.cohort_complete
+                and len(unique_entities) <= V1_SCOPE_LIST_LIMIT
+            ):
+                cohort_resolution = self._scope_service.committed_cohort_resolution_for(
+                    subject_set,
+                    org_id=org_id,
+                    base_scope=authorized_scope,
+                    resolved_at=generated_at,
+                )
+                return SubjectPreflightResult(
+                    decision=PreflightDecision.PROCEED,
+                    interpretation=interpretation,
+                    ledger=ledger,
+                    committed_resolution=cohort_resolution,
+                    committed_subjects=CommittedSubjects(
+                        resolution=cohort_resolution, subject_set=subject_set
+                    ),
+                    subject_set=subject_set,
+                    answer=None,
+                    outcome=None,
+                    # Mirrors the singular commit below: the subject is
+                    # already committed, so resolve_scope.v1 has nothing
+                    # left to do, and withholding it closes the same
+                    # forbidden_or_not_found leak channel that branch's own
+                    # comment describes.
+                    allowed_tools=ALL_TOOLS - {ToolID.RESOLVE_SCOPE},
+                    blocking_mention_ids=blocking_ids,
+                    diagnostic="committed_cohort_v1_render",
                 )
             return self._terminate(
                 interpretation=interpretation,

--- a/tests/api/dev/test_chaos_3533_terminate_ledger.py
+++ b/tests/api/dev/test_chaos_3533_terminate_ledger.py
@@ -90,6 +90,20 @@ API_GATEWAY = AuthorizedEntity(
     EntityKind.REPOSITORY, "meridian/api-gateway", "meridian/api-gateway"
 )
 
+#: CHAOS-3551: a homogeneous, complete PROJECT cohort -- unlike the two
+#: repositories above, PROJECT has no v1 multi-entity scope representation
+#: (``committed_cohort_resolution_for`` refuses any kind but REPOSITORY), so
+#: this pair still terminates as ``committed_cohort_v1_only`` after CHAOS-3551
+#: renders repository cohorts. Distinct labels (unlike the shared-label
+#: ``ATLAS_PROJECT_ONE``/``ATLAS_PROJECT_TWO`` pair, which exists to test
+#: ambiguity) so both mentions resolve exactly rather than ambiguously.
+STILL_UNSUPPORTED_PROJECT_ONE = AuthorizedEntity(
+    EntityKind.PROJECT, "project-atlas-1", "Atlas One"
+)
+STILL_UNSUPPORTED_PROJECT_TWO = AuthorizedEntity(
+    EntityKind.PROJECT, "project-atlas-2", "Atlas Two"
+)
+
 
 def _recorder_factory(
     service: DevPersistenceService,
@@ -256,8 +270,8 @@ async def test_chaos_3533_committed_cohort_terminate_persists_every_entry(
     """CHAOS-3534's ledger half, and the reason that ticket's stated premise
     was wrong.
 
-    A question naming two real repositories resolves BOTH exactly and commits
-    a real ``dev_subject_set.v1``; D2 is never consulted, because D2 exists for
+    A question naming two real projects resolves BOTH exactly and commits a
+    real ``dev_subject_set.v1``; D2 is never consulted, because D2 exists for
     PARTIAL cohorts. The run then terminates on D1 -- ``committed_cohort_v1_
     only``, "we committed every resolvable member and the v1 surface cannot
     render it" -- and, on today's code, persists none of the two exact matches
@@ -273,19 +287,26 @@ async def test_chaos_3533_committed_cohort_terminate_persists_every_entry(
     ``exact_match`` entries must stay alongside the rest exactly as the ledger
     recorded them, or the persisted history is a different story from the one
     the preflight actually decided.
+
+    CHAOS-3551: a REPOSITORY cohort in this exact shape now PROCEEDs and
+    renders instead of terminating -- see ``test_chaos_3551_cohort_render``.
+    This test moved to a PROJECT cohort, which has no v1 multi-entity scope
+    representation and so still terminates on D1; the TERMINATE-ledger
+    mechanism under test here is unchanged and kind-independent.
     """
 
     maker, org_id, user_id = seeded
-    question = (
-        'What\'s the status of repo "meridian/web-app" and repo "meridian/api-gateway"?'
-    )
+    question = "Compare project Atlas One and project Atlas Two"
     conversation_id, run_id = await _seed_run(maker, org_id, user_id, question=question)
 
     async with maker() as session:
         service = DevPersistenceService(session)
         output = await run_preflight_orchestrator(
             question=question,
-            entities=[(str(org_id), WEB_APP), (str(org_id), API_GATEWAY)],
+            entities=[
+                (str(org_id), STILL_UNSUPPORTED_PROJECT_ONE),
+                (str(org_id), STILL_UNSUPPORTED_PROJECT_TWO),
+            ],
             org_id=str(org_id),
             user_id=str(user_id),
             conversation_id=str(conversation_id),
@@ -314,7 +335,7 @@ async def test_chaos_3533_committed_cohort_terminate_persists_every_entry(
         assert [row.outcome for row in rows] == ["exact_match", "exact_match"], (
             "CHAOS-3533/3534: a committed-cohort TERMINATE must persist every "
             "entry of the ledger it built, in ordinal order -- both named "
-            "repositories resolved exactly and the run must be able to say so. "
+            "projects resolved exactly and the run must be able to say so. "
             f"Got {[row.outcome for row in rows]!r}."
         )
         assert [row.entry_ordinal for row in rows] == [0, 1]
@@ -334,7 +355,7 @@ async def test_chaos_3533_committed_cohort_terminate_persists_every_entry(
         await _corpus_resolution_path(
             maker,
             run_id,
-            mention_texts=("meridian/web-app", "meridian/api-gateway"),
+            mention_texts=("Atlas One", "Atlas Two"),
         )
         == "deterministic-exact"
     )
@@ -621,12 +642,16 @@ async def test_chaos_3533_a_failed_ledger_write_does_not_discard_the_subject_set
     ``dev_subject_set.v1``, and could not render it on the v1 surface. Losing
     that set to an unrelated ledger fault would erase the only record that
     the cohort resolved at all, which is the same forensic hole one layer up.
+
+    CHAOS-3551: a REPOSITORY cohort in this exact shape now PROCEEDs and
+    renders instead of terminating. This test moved to a PROJECT cohort,
+    which still terminates on D1 (no v1 multi-entity scope representation for
+    that kind) -- the TERMINATE-branch ledger-fault handling under test here
+    is unchanged and kind-independent.
     """
 
     maker, org_id, user_id = seeded
-    question = (
-        'What\'s the status of repo "meridian/web-app" and repo "meridian/api-gateway"?'
-    )
+    question = "Compare project Atlas One and project Atlas Two"
     conversation_id, run_id = await _seed_run(maker, org_id, user_id, question=question)
 
     async with maker() as session:
@@ -644,7 +669,10 @@ async def test_chaos_3533_a_failed_ledger_write_does_not_discard_the_subject_set
 
         output = await run_preflight_orchestrator(
             question=question,
-            entities=[(str(org_id), WEB_APP), (str(org_id), API_GATEWAY)],
+            entities=[
+                (str(org_id), STILL_UNSUPPORTED_PROJECT_ONE),
+                (str(org_id), STILL_UNSUPPORTED_PROJECT_TWO),
+            ],
             org_id=str(org_id),
             user_id=str(user_id),
             conversation_id=str(conversation_id),

--- a/tests/api/dev/test_chaos_3534_cohort_scope_outcome.py
+++ b/tests/api/dev/test_chaos_3534_cohort_scope_outcome.py
@@ -76,6 +76,13 @@ async def test_a_fully_resolved_cohort_publishes_exact_not_unresolved() -> None:
     Asserts the state an auditor reads -- the resolution this run publishes on
     the wire -- not that a branch executed. ``unresolved`` here is a false
     statement about a run that committed both named subjects.
+
+    CHAOS-3551: this exact question now PROCEEDs and answers rather than
+    terminating (see ``test_chaos_3551_cohort_render.py`` for that half, RED-
+    first). The setup control below moved from the old TERMINATE diagnostic
+    to the new render one; every assertion after it is the CHAOS-3534 claim
+    this test still owns -- the published resolution stays EXACT, naming
+    both repositories -- unchanged by which branch produced it.
     """
 
     output = await run_preflight_orchestrator(
@@ -84,11 +91,13 @@ async def test_a_fully_resolved_cohort_publishes_exact_not_unresolved() -> None:
         script_id="chaos-3534-cohort",
     )
 
-    # Setup control: this really is the committed-cohort terminate. Without
-    # it a change that made the run fail earlier would satisfy the assertion
-    # below for entirely the wrong reason.
+    # Setup control: this really is the committed-cohort render path, not
+    # some other path that happens to also publish an EXACT resolution.
     assert output.recorder is not None
-    assert output.recorder.preflight_diagnostics == [("committed_cohort_v1_only", None)]
+    assert output.recorder.preflight_diagnostics == [
+        ("committed_cohort_v1_render", None)
+    ]
+    assert output.result.answer is not None
 
     resolution = output.result.scope_resolution
     assert resolution is not None, (
@@ -410,6 +419,11 @@ async def test_a_cohort_at_exactly_the_v1_limit_still_publishes_exact() -> None:
     sides of the bound are asserted, and the values were confirmed by
     execution rather than reasoning: 19 and 20 publish ``exact`` carrying
     every id, 21 falls back.
+
+    CHAOS-3551: a 20-repository cohort now PROCEEDs and renders (the same
+    V1_SCOPE_LIST_LIMIT bound gates the new render branch, not just the old
+    terminal-observability one) -- the setup control moved to the render
+    diagnostic; the published-resolution claim below is unchanged.
     """
 
     repositories = [
@@ -429,7 +443,10 @@ async def test_a_cohort_at_exactly_the_v1_limit_still_publishes_exact() -> None:
     )
 
     assert output.recorder is not None
-    assert output.recorder.preflight_diagnostics == [("committed_cohort_v1_only", None)]
+    assert output.recorder.preflight_diagnostics == [
+        ("committed_cohort_v1_render", None)
+    ]
+    assert output.result.answer is not None
 
     resolution = output.result.scope_resolution
     assert resolution is not None

--- a/tests/api/dev/test_chaos_3551_cohort_render.py
+++ b/tests/api/dev/test_chaos_3551_cohort_render.py
@@ -1,0 +1,337 @@
+"""RED-first coverage for CHAOS-3551: a committed cohort answers instead of
+refusing.
+
+The defect, in the terms CHAOS-3534 already established:
+
+A question naming a bounded, homogeneous set of real subjects resolves every
+member exactly and commits a real ``dev_subject_set.v1`` -- CHAOS-3534's own
+``committed_cohort_resolution_for`` even builds a faithful multi-repository
+``DevScopeResolution`` for it. But until this ticket, ``subject_preflight``
+only ever used that resolution to describe an honest TERMINATE
+(``committed_cohort_v1_only``, ``feature_not_enabled``) -- the render half of
+D1 was never wired. The corpus case ``scope.bounded-subject-set`` measures
+exactly this shape and stays red on ``public_outcome_in`` because of it.
+
+THE FIX, and why it is scoped to REPOSITORY only: v1's ``DevScope`` has no
+multi-entity representation for any other kind (``DevScope.
+validate_direct_scope`` requires exactly one ``entity_ref`` for project/
+team/work-unit/issue/pull-request, while ``repositories`` is a list) --
+``committed_cohort_resolution_for`` itself refuses any other kind, so a
+project or team cohort still terminates unsupported exactly as before. This
+is also why the fix can never open person-level output: there is no
+``EntityKind.PERSON`` anywhere in this catalog (``EntityKind`` is
+organization/repository/project/work_unit/issue/pull_request/team) -- a
+committed subject is never a person, cohort or not, so there is no
+"person-level" branch to weaken here at all. The closest analog, a TEAM
+cohort, is pinned below to keep refusing.
+
+Driving the REAL ``DevOrchestrator.run()`` end to end (not just
+``SubjectPreflight`` in isolation) for the primary case, because "does this
+answer" is an orchestration-level claim, not just a preflight decision --
+``committed_resolution`` alone does not prove the legacy model round loop
+actually executes a subject-bearing tool against the committed scope and
+returns an answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts import ToolID
+from dev_health_ops.api.dev.investigation_plans.executor import PlanExecutor
+from dev_health_ops.api.dev.investigation_plans.steps import StepRegistry
+from dev_health_ops.api.dev.investigation_plans.wave_3_1_plans import (
+    WAVE_3_1_PLANS_BY_INTENT,
+    register_wave_3_1_steps,
+)
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
+from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
+    ScopeRequestCache,
+    ScopeResolutionService,
+)
+from dev_health_ops.api.dev.subject_preflight import (
+    SUBJECT_BEARING_TOOLS,
+    PreflightDecision,
+    SubjectPreflight,
+)
+from tests._chaos_3292_preflight import (
+    ORG_ID,
+    PLATFORM_TEAM,
+    SeededCatalog,
+    fixed_now,
+    request_for,
+    run_preflight_orchestrator,
+    sequential_ids,
+    versions,
+)
+
+#: CHAOS-3534's own corpus case, verbatim from
+#: ``case-scope.bounded-subject-set.json``: both real, both individually
+#: resolvable, named together in one question.
+WEB_APP = AuthorizedEntity(
+    EntityKind.REPOSITORY, "meridian/web-app", "meridian/web-app"
+)
+API_GATEWAY = AuthorizedEntity(
+    EntityKind.REPOSITORY, "meridian/api-gateway", "meridian/api-gateway"
+)
+COHORT_QUESTION = (
+    'What\'s the status of repo "meridian/web-app" and repo "meridian/api-gateway"?'
+)
+
+#: A second TEAM, distinct-labelled from PLATFORM_TEAM, for the still-refuses
+#: control below -- two same-label teams would resolve ambiguously instead of
+#: committing a cohort at all, proving nothing about the kind gate.
+ROCKET_TEAM = AuthorizedEntity(EntityKind.TEAM, "team-rocket", "Rocket")
+
+
+def _preflight(entities, **catalog_kwargs) -> SubjectPreflight:
+    mint = sequential_ids()
+    return SubjectPreflight(
+        interpreter=QuestionInterpreter(mint_id=mint, now=fixed_now),
+        scope_service=ScopeResolutionService(
+            SeededCatalog(entities, **catalog_kwargs), cache=ScopeRequestCache()
+        ),
+        versions=versions(),
+        mint_id=mint,
+        now=fixed_now,
+    )
+
+
+async def _run(preflight: SubjectPreflight, request, **kwargs):
+    return await preflight.run(
+        request=request,
+        org_id=kwargs.pop("org_id", ORG_ID),
+        permission_fingerprint="permissions_01",
+        authorized_scope=kwargs.pop("authorized_scope", request.scope),
+        run_id="run_01",
+        answer_id="answer_01",
+        conversation_id="conversation_01",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_committed_repository_cohort_answers_instead_of_refusing() -> None:
+    """The defect, in its exact corpus shape, driven end to end.
+
+    Before this fix: ``output.result.error.code == "feature_not_enabled"``,
+    ``output.result.answer is None``, and the model round loop never runs --
+    ``output.calls == []``. That is the RED this test replaces: a fully-
+    resolved, two-repository cohort refuses to say anything about either
+    repository. Confirmed by reverting the ``subject_preflight.py`` hunk
+    locally and re-running this test, which fails exactly that way.
+
+    After: the run PROCEEDs, the model executes ``status_snapshot.v1``
+    against the committed multi-repository scope, and the run completes with
+    a real answer -- the render half of D1.
+    """
+
+    output = await run_preflight_orchestrator(
+        question=COHORT_QUESTION,
+        entities=[(ORG_ID, WEB_APP), (ORG_ID, API_GATEWAY)],
+        script_id="chaos-3551-cohort-render",
+    )
+
+    assert output.recorder is not None
+    assert output.recorder.preflight_diagnostics == [
+        ("committed_cohort_v1_render", None)
+    ], (
+        "setup control: this must be the new render branch, not some other "
+        "path that happens to also produce an answer"
+    )
+
+    # The claim CHAOS-3551 exists to close: a committed cohort ANSWERS.
+    assert output.result.state is RunState.COMPLETED
+    assert output.result.error is None, (
+        f"a committed, fully-resolved cohort must not refuse -- got "
+        f"{output.result.error!r}"
+    )
+    assert output.result.answer is not None
+
+    # Not merely "no error" -- the model round loop actually ran a
+    # subject-bearing tool against the committed scope, rather than the
+    # commit being decorative.
+    assert [call.tool_id for call in output.calls] == [ToolID.STATUS_SNAPSHOT]
+
+    # The scope the run answered under names exactly the two committed
+    # repositories -- never a widened or narrowed substitute.
+    resolution = output.result.scope_resolution
+    assert resolution is not None
+    assert resolution.outcome.value == "exact"
+    assert sorted(resolution.authorized_repository_ids) == [
+        "meridian/api-gateway",
+        "meridian/web-app",
+    ]
+    assert resolution.resolved_scope is not None
+    assert sorted(resolution.resolved_scope.repositories) == [
+        "meridian/api-gateway",
+        "meridian/web-app",
+    ]
+    executed_scope = output.calls[0].scope
+    assert sorted(executed_scope.repositories) == [
+        "meridian/api-gateway",
+        "meridian/web-app",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_committed_repository_cohort_withholds_resolve_scope() -> None:
+    """Mirrors the singular commit's own rationale: nothing is left for the
+    model to resolve, so ``resolve_scope.v1`` is withheld -- the same leak
+    channel that branch's own comment closes.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, WEB_APP), (ORG_ID, API_GATEWAY)]),
+        request_for(COHORT_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.diagnostic == "committed_cohort_v1_render"
+    assert result.committed_resolution is not None
+    assert result.allowed_tools == frozenset(ToolID) - {ToolID.RESOLVE_SCOPE}
+    assert SUBJECT_BEARING_TOOLS <= result.allowed_tools
+    assert result.all_subjects_committed is True
+
+
+@pytest.mark.asyncio
+async def test_a_team_cohort_still_refuses_after_the_render_fix() -> None:
+    """Pin: the fix is REPOSITORY-only. A team cohort -- the closest thing
+    to a "who" cohort this catalog has, since there is no ``EntityKind.
+    PERSON`` at all -- must keep refusing exactly as before CHAOS-3551.
+
+    Not a person-level regression by construction (no person-kind subject
+    exists to leak), but this is the one kind whose committed members are
+    named individuals rather than code artifacts, so it is the sharpest
+    available proxy for "did bounded-cohort answering quietly widen past
+    what the PRD allows" -- and it must not have.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, PLATFORM_TEAM), (ORG_ID, ROCKET_TEAM)]),
+        request_for("What is the status of team Platform and team Rocket?"),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.diagnostic == "committed_cohort_v1_only"
+    assert result.committed_resolution is None
+    assert result.subject_set is not None
+    assert result.subject_set.cohort_complete is True
+    committed_ids = {ref.entity_id for ref in result.subject_set.committed_entity_refs}
+    assert committed_ids == {PLATFORM_TEAM.canonical_id, ROCKET_TEAM.canonical_id}
+
+
+@pytest.mark.asyncio
+async def test_a_partial_repository_cohort_still_refuses() -> None:
+    """Pin: the render fix is gated on ``cohort_complete``. A repository
+    cohort that omitted a named member did not resolve everything the
+    question named, so it must keep terminating unsupported rather than
+    rendering an answer over a silently-narrowed set.
+
+    ``meridian/never-seeded`` is never seeded, so it is omitted; the other
+    two repositories resolve exactly. Phrased as "Compare ... and ... and
+    ..." rather than "What's the status of" deliberately: the latter
+    classifies as ``PORTFOLIO_STATUS``, whose own D2 carve-out (CHAOS-3393)
+    terminates on the FIRST unresolved mention rather than committing a
+    partial cohort at all -- a real, different-diagnosis termination this
+    test is not about. "Compare" classifies as ``BOUNDED_INVESTIGATION``,
+    where D2 lets >=2 distinct exact matches commit a partial cohort, which
+    is the shape this test needs to pin ``cohort_complete`` against.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, WEB_APP), (ORG_ID, API_GATEWAY)]),
+        request_for(
+            'Compare repo "meridian/web-app" and repo "meridian/api-gateway" '
+            'and repo "meridian/never-seeded"'
+        ),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.diagnostic == "committed_cohort_v1_only"
+    assert result.committed_resolution is None
+    assert result.subject_set is not None
+    assert result.subject_set.cohort_complete is False
+
+
+class _NeverCalled:
+    """A stand-in for every wave_3_1 evaluator this suite must not touch."""
+
+    async def evaluate_project(self, **_kwargs: Any) -> Any:
+        raise AssertionError("no wave_3_1 evaluator should run for a repository cohort")
+
+    async def evaluate_team(self, **_kwargs: Any) -> Any:
+        raise AssertionError("no wave_3_1 evaluator should run for a repository cohort")
+
+    async def evaluate_workload(self, **_kwargs: Any) -> Any:
+        raise AssertionError("no wave_3_1 evaluator should run for a repository cohort")
+
+    async def evaluate_portfolio(self, **_kwargs: Any) -> Any:
+        raise AssertionError(
+            "status.portfolio.v1 must never run for a REPOSITORY subject set -- "
+            "it only ever supports PROJECT (WAVE_3_1_PLANS_BY_INTENT's own "
+            "supported_subject_kinds), and _project_scope_from_ref would "
+            "misrepresent each repository as a same-named PROJECT scope"
+        )
+
+
+def _real_wave_3_1_plan_executor() -> PlanExecutor:
+    registry = StepRegistry()
+    register_wave_3_1_steps(
+        registry,
+        project_health=_NeverCalled(),
+        team_health=_NeverCalled(),
+        team_workload=_NeverCalled(),
+        operational_deficiency=_NeverCalled(),
+        portfolio_status=_NeverCalled(),
+    )
+    return PlanExecutor(registry=registry, now=fixed_now)
+
+
+@pytest.mark.asyncio
+async def test_a_repository_cohort_never_reaches_the_portfolio_plan() -> None:
+    """Regression pin for a defect CHAOS-3551 found while wiring the render
+    fix, not the render fix itself.
+
+    ``COHORT_QUESTION`` classifies as ``PORTFOLIO_STATUS`` (its vocabulary
+    is kind-blind -- see ``subject_preflight``'s own PORTFOLIO_STATUS
+    comment), exactly like the project-cohort case ``status.portfolio.v1``
+    is built for. With a REAL ``plan_registry``/``plan_executor`` wired (the
+    production shape this suite's other tests use only a fake ``Recorder``
+    for), the orchestrator's PLURAL_COHORT plan-eligibility gate used to
+    check only "is there a plan for this intent, and a committed subject
+    set" -- never the committed subject set's OWN kind against the plan's
+    declared ``supported_subject_kinds``. A REPOSITORY cohort would have
+    satisfied both existing checks and been handed to ``status.
+    portfolio.v1``'s step, which builds each batch entry via
+    ``_project_scope_from_ref`` -- documented as trusting ITS CALLER to
+    restrict entries to PROJECT -- misrepresenting a repository as a
+    same-named project.
+
+    This proves the fix instead: the plan-eligibility gate now also checks
+    kind, so ``evaluate_portfolio`` (the ``_NeverCalled`` fake above) is
+    never invoked, and the run still answers -- through the ordinary
+    status-snapshot path, exactly like the isolated ``SubjectPreflight``
+    tests above already prove for the fake-recorder shape.
+    """
+
+    output = await run_preflight_orchestrator(
+        question=COHORT_QUESTION,
+        entities=[(ORG_ID, WEB_APP), (ORG_ID, API_GATEWAY)],
+        script_id="chaos-3551-cohort-render-plan-gate",
+        plan_registry=WAVE_3_1_PLANS_BY_INTENT,
+        plan_executor=_real_wave_3_1_plan_executor(),
+    )
+
+    assert output.recorder is not None
+    assert output.recorder.preflight_diagnostics == [
+        ("committed_cohort_v1_render", None)
+    ]
+    assert output.result.error is None
+    assert output.result.answer is not None
+    assert [call.tool_id for call in output.calls] == [ToolID.STATUS_SNAPSHOT]


### PR DESCRIPTION
## Summary

- A bounded, homogeneous, **complete** `REPOSITORY` cohort now `PROCEED`s and answers instead of terminating `feature_not_enabled` (D1). `subject_preflight`'s homogeneous-cohort branch reuses `committed_cohort_resolution_for` (CHAOS-3534) — previously wired only to disclose the correct scope outcome on an honest `TERMINATE` — to commit a real multi-repository `DevScopeResolution` and `PROCEED` with it, exactly like a singular commit. No new rendering machinery was needed: the ordinary legacy model round loop answers over the committed multi-repository scope through the ordinary `status_snapshot.v1` path (`DevScope.repositories` is already list-typed and the tool layer already handles it).
- Scope is deliberately narrow: only `EntityKind.REPOSITORY` has a v1 multi-entity `DevScope` representation (`committed_cohort_resolution_for` itself refuses every other kind — a structural guarantee, not a policy check made twice), so project/team cohorts keep terminating unsupported exactly as before. Gated on `cohort_complete` (a partial cohort keeps refusing) and `V1_SCOPE_LIST_LIMIT` (an oversized cohort keeps refusing).
- **Person-level output**: there is no `EntityKind.PERSON` anywhere in this catalog (`EntityKind` is organization/repository/project/work_unit/issue/pull_request/team), so this fix cannot open person-level output — there's no person-kind subject to leak. A `TEAM` cohort (the closest available proxy — a "who" cohort) is pinned to keep refusing.
- **Also fixes a latent bug this change made reachable**: the orchestrator's `PLURAL_COHORT`/`ORGANIZATION_WIDE` plan-eligibility gate checked only "is there a plan for this intent" and "is a subject set committed" — never the committed subject set's own *kind* against the plan's declared `supported_subject_kinds` (a field that existed but was never read). A repository cohort under a question whose vocabulary classifies as `PORTFOLIO_STATUS` (intent classification is lexical, not kind-aware) would otherwise have been handed to `status.portfolio.v1`'s step, which builds each batch entry via `_project_scope_from_ref` — documented as trusting its *caller* to restrict entries to `PROJECT` — misrepresenting a repository as a same-named project. The plan executor's own defensive fingerprint check turns that into a loud `internal_error` rather than a silent misattribution (verified — see below), but a crash is still not "render an answer". The gate now checks kind too.

## The exact seam changed

- `src/dev_health_ops/api/dev/subject_preflight.py` — new `PROCEED` branch in `SubjectPreflight.run()`'s homogeneous-cohort handling (right after the existing `committed_cohort_portfolio_v1` special case, before the `committed_cohort_v1_only` terminate), diagnostic `committed_cohort_v1_render`.
- `src/dev_health_ops/api/dev/orchestrator.py` — `plan_eligible` computation for `PLURAL_COHORT`/`ORGANIZATION_WIDE` now also checks `preflight_result.subject_set.entity_kind in plan.supported_subject_kinds`.

## RED-first proof

`tests/api/dev/test_chaos_3551_cohort_render.py` is new. Reverting just the `subject_preflight.py` hunk (`git stash` locally) reproduces RED exactly as described:
- `test_a_committed_repository_cohort_answers_instead_of_refusing`: fails — `preflight_diagnostics == [("committed_cohort_v1_only", None)]` instead of the new render diagnostic (old code still terminates).
- `test_a_committed_repository_cohort_withholds_resolve_scope`: fails — `decision is TERMINATE`, not `PROCEED`.
- The two negative-control pins (`test_a_team_cohort_still_refuses_after_the_render_fix`, `test_a_partial_repository_cohort_still_refuses`) already pass on old code — proving they're not vacuous.

Reverting just the `orchestrator.py` hunk (with the `subject_preflight.py` fix still applied) reproduces the *second*, latent-bug RED: `test_a_repository_cohort_never_reaches_the_portfolio_plan` fails with `RunState.FAILED` / `internal_error`, raised from `PlanExecutor.run()`'s own `subject_set_scopes do not match the caller's authorized subject_set_fingerprint` guard — confirming the plan executor's own defensive check prevents *silent* misattribution, but the run still crashes instead of answering, until the `orchestrator.py` gate is fixed too.

Also updated two pre-existing tests whose literal expectations this change *correctly* flips (both explicitly reference CHAOS-3551 in an updated docstring/comment):
- `test_chaos_3534_cohort_scope_outcome.py::test_a_fully_resolved_cohort_publishes_exact_not_unresolved` and `::test_a_cohort_at_exactly_the_v1_limit_still_publishes_exact` — same exact corpus question now `PROCEED`s+answers rather than terminating; the resolution-outcome assertions those tests actually exist for (`EXACT`, both repo ids) are unchanged and still pass.
- `test_chaos_3533_terminate_ledger.py`'s two DB-backed tests that drove the *exact* two-repository corpus question through a real Postgres-shaped ledger-persistence TERMINATE — retargeted to an equivalent PROJECT cohort (still terminates, since only REPOSITORY renders), preserving the persistence mechanism under test.

## Test counts

Targeted files (`test_chaos_3551_cohort_render.py`, `test_chaos_3534_cohort_scope_outcome.py`, `test_chaos_3533_terminate_ledger.py`, `test_subject_preflight.py`, `test_chaos_3393_portfolio_preflight.py`, `test_chaos_3393_portfolio_orchestrator.py`, `test_chaos_3301_controls.py`, `test_chaos_3301_review_findings.py`, `test_chaos_3366_not_found_fallback.py`, `test_chaos_3292_mutations.py`, plus the plan-registry suites): **189/189 passed, 0 skipped, 0 failed**.

Full `ci/run_tests.sh unit` (real command, `-m "not benchmark and not clickhouse"`, xdist `-n auto`): **13343 passed, 245 skipped, 1 xfailed, 12 failed**. The 12 failures are pre-existing and unrelated — confirmed via an identical run on the unmodified branch (same 12: 11× `tests/api/admin/test_org_deletion.py` needing a live Postgres, 1× `tests/docs/test_built_site_links.py` needing `mkdocs`, not installed in this venv). Passed count is baseline (13338) + exactly the 5 new tests this PR adds.

`ruff check`/`ruff format --check`/`mypy` clean on every changed file (also enforced by the repo's own pre-commit hooks, which ran clean on this commit).

## Not covered here

- The live acceptance-corpus flip for `scope.bounded-subject-set`'s `public_outcome_in` invariant happens on the phase3-corpus lane's branch (a separate, unmerged lane per the ticket), not here — this PR is the product fix the corpus case measures, not the corpus run itself.
- `subject_set_ref` on the resulting `DevAnswerFrame` stays unset for this render path (as it already is for every non-portfolio `PROCEED` today) — CHAOS-3551's own text calls this a `wrap_legacy_answer_as_frame` touch point, but wiring it up would mean threading a new free variable through the orchestrator's ~35 `finish()` call sites for a disclosure improvement, not the render/terminate defect itself. Flagging as a real, deliberately-deferred gap rather than fixing it under this ticket's narrower scope.
- The `SINGULAR` cardinality branch's `plan_eligible` gate has the same *theoretical* missing-kind-check shape the `PLURAL_COHORT` branch had — but nothing in this change adds a new way to reach it with a mismatched kind (only pre-existing singular-commit paths reach it, unchanged by this PR), so it's left alone rather than spec-creeping a second, unrelated hardening fix into this diff.
- A pre-existing, unrelated fixture-shape gap: the shared test harness's stock `answer_payload()` fixture's `metrics[0].evidence_ref_ids` is too short for `DevMetricRefV2`'s stricter v2 validation, so `wrap_legacy_answer_as_frame` silently falls back to an `internal_error` *frame* (never affecting `result.answer`/`result.error`) for **any** completed run using that fixture — reproduced on `case_a1` (a pre-existing, currently-passing singular-commit test), so it predates and is unrelated to this change. Not fixed here.

## Gate status

**The local/CI gate has NOT been run** (`ci/local_validate.sh`) — machine-wide single-flight, reserved; queued for the orchestrator's slot per instructions. No merge attempted.