### PR TITLE
CHAOS-3573: reconcile NULL-cost terminals instead of keeping the worst-case reservation

### DIFF
--- a/src/dev_health_ops/api/services/askdev_allowance_counters.py
+++ b/src/dev_health_ops/api/services/askdev_allowance_counters.py
@@ -73,7 +73,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import case, func, select
+from sqlalchemy import and_, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.dev.org_policy import TERMINAL_RUN_STATES, platform_month_window
@@ -185,30 +185,91 @@ async def _recompute_from_dev_runs(
 
     Used for the Valkey-down fallback, lazy cold-key init, breaker-recovery
     recompute, and the explicit operator reconcile. One definition, so the
-    "what counts as charged" logic (terminal -> the real cost, zero if none
-    was ever recorded; non-terminal -> the worst-case reservation, since the
-    run may still bill up to the per-call estimate) cannot drift between call
-    sites the way it had before this module existed (ask_dev.py and
-    persistence/service.py each had their own copy).
+    "what counts as charged" logic cannot drift between call sites the way
+    it had before this module existed (ask_dev.py and persistence/service.py
+    each had their own copy).
 
-    CHAOS-3573: a terminal run's ``estimated_cost_microusd`` is NULL only
-    when it never dispatched a single provider call --
-    ``ProviderBudget.require()`` (``orchestrator.py``) always turns it into a
-    concrete int the instant a call is reserved, before dispatch, and never
-    back to None afterward, so every terminal write's cost column is exactly
-    the real, fully-accounted spend for that run at the moment it reached
-    ``finish()``. A terminal-but-NULL run is therefore a genuine
-    zero-cost run (a preflight rejection, a disabled feature, a
-    provider-unavailable 503 -- never a run that spent and lost the number).
-    Charging it the worst-case reservation here would keep exactly the
-    phantom spend this function exists to heal away, and would silently
-    re-inflate the Valkey counter back to worst-case on the very next
-    cold-key init / breaker recovery / operator reconcile after
-    ``reconcile_terminal_cost`` (below) has already corrected it there --
-    the two call sites must agree, or "fixed" doesn't survive a heal cycle.
+    CHAOS-3573: a terminal run's ``estimated_cost_microusd`` is NULL for one
+    of two structurally distinct reasons, and they must be charged
+    oppositely:
+
+    1. It never dispatched a single provider call.
+       ``ProviderBudget.require()`` (``orchestrator.py``) always turns
+       ``estimated_cost_microusd`` into a concrete int the instant a call is
+       reserved, before dispatch, and never back to None afterward -- every
+       *normal* terminal write's cost column (via ``update_run``'s terminal
+       branch, reached from ``orchestrator_persistence.py``'s ``terminal()``
+       or ``router.py``'s provider-unavailable path) is exactly the real,
+       fully-accounted spend at the moment it reached ``finish()``. Genuinely
+       zero real cost here -> charge 0.
+
+    2. Its terminal write bypassed the normal path entirely.
+       ``DevPersistenceService.force_terminal_fallback`` /
+       ``recover_stale_non_terminal_run`` (persistence/service.py) exist
+       specifically because ``finish()`` may already have dispatched real,
+       billed provider calls before its own terminal ``update_run`` write
+       died (a dropped connection, a poisoned session) -- these force
+       ``state`` terminal directly and never touch ``estimated_cost_microusd``
+       or call ``reconcile_terminal_cost``. Real cost here is UNKNOWN, not
+       zero -- coalescing it to 0 would erase a possibly-real charge on every
+       cold-key heal, which runs routinely (first request of the month, TTL
+       lapse, Valkey restart), not rarely. Worst-case reservation stays
+       charged.
+
+    Discriminator for (2): both recovery paths are the ONLY writers on
+    ``dev_runs`` that set ``safe_error_code`` non-NULL while leaving
+    ``terminal_error_payload`` NULL (pinned by
+    ``test_force_terminal_fallback_forces_a_stuck_run_terminal`` /
+    ``test_recover_stale_non_terminal_run_forces_a_stuck_run_terminal_when_
+    old_enough`` in test_persistence_v2.py). Every normal path derives both
+    columns from the same ``DevError`` object at the same time
+    (``orchestrator_persistence.py.terminal()``:
+    ``safe_error_code=error.code if error else None`` alongside
+    ``terminal_error_payload=(error.model_dump(...) if error is not None
+    else None)``; ``router.py``'s provider-unavailable path passes both
+    together too) -- so a normal write is always both-None or both-set, and
+    only the two forced-recovery paths ever decouple them. This also
+    correctly falls back to worst-case for any pre-``terminal_error_payload``-
+    column legacy row (the column's own docstring: NULL for every run that
+    predates it) -- an ambiguous old row stays conservative by construction,
+    not by a special case.
+
+    Charging (1) at worst-case here would keep exactly the phantom spend
+    CHAOS-3573 exists to heal away, and would silently re-inflate the Valkey
+    counter back to worst-case on the very next heal after
+    ``reconcile_terminal_cost`` (below) already corrected it there -- the two
+    call sites must agree on (1), or "fixed" doesn't survive a heal cycle.
     """
 
+    # NOTE on JSON-column NULL semantics: SQLAlchemy's JSON type defaults to
+    # ``none_as_null=False`` (Python None -> JSON "null", not SQL NULL) for a
+    # column that is EXPLICITLY assigned None as a genuine value change.
+    # ``terminal_error_payload`` never hits that path here: it starts
+    # genuinely unset (omitted from the original INSERT, since
+    # append_user_message_and_run never passes it), every intermediate
+    # bare-state ``update_run`` call re-assigns the SAME None it already
+    # holds (a no-op the ORM excludes from its UPDATE entirely -- verified
+    # directly against this exact code path, not assumed), and
+    # force_terminal_fallback/recover_stale_non_terminal_run's own
+    # ``run.terminal_error_payload = None`` is the identical no-op. It only
+    # ever becomes a real value (dict -> JSON, never back to None) on a
+    # genuine terminal write carrying a real ``DevError``. So this column
+    # reads as true SQL NULL via ``.is_(None)`` on every path this
+    # discriminator cares about, on both SQLite and Postgres (the
+    # unchanged-attribute exclusion is ORM/unit-of-work behavior, not
+    # dialect-specific).
+    recovery_write_with_unknown_cost = and_(
+        DevRun.safe_error_code.is_not(None),
+        DevRun.terminal_error_payload.is_(None),
+    )
     charged_cost = case(
+        (
+            and_(
+                DevRun.state.in_(TERMINAL_RUN_STATES),
+                recovery_write_with_unknown_cost,
+            ),
+            per_run_reservation_microusd,
+        ),
         (
             DevRun.state.in_(TERMINAL_RUN_STATES),
             func.coalesce(DevRun.estimated_cost_microusd, 0),
@@ -459,23 +520,36 @@ async def reconcile_terminal_cost(
     A no-op only when there is no ``provider`` this counter tracks, or the
     state is not terminal. ``estimated_cost_microusd`` being None is NOT a
     no-op (CHAOS-3573 -- reversing CHAOS-3522(b)'s original choice here):
-    every terminal write's cost column comes from
+    every terminal write reaching THIS FUNCTION had its cost column set from
     ``ProviderBudget.usage.estimated_cost_microusd``
     (``orchestrator.py``/``orchestrator_persistence.py``'s ``finish()``),
     which ``require()`` turns into a concrete int the instant a provider
-    call is reserved and never resets to None afterward. NULL at a terminal
-    write therefore means this run never dispatched a single provider call
-    -- a preflight rejection, a disabled feature, a provider-unavailable
-    503 -- genuinely zero spend, never a run that spent and lost the
-    number. (A crash that loses a run's cost entirely bypasses this
-    function altogether: ``force_terminal_fallback`` /
-    ``recover_stale_non_terminal_run`` write ``state`` directly and never
-    call ``update_run``'s terminal branch, so they never reach here --
-    those stay fail-closed by construction, unaffected by this change.)
-    Reconciling NULL to 0 here is what makes this function agree with
-    ``_recompute_from_dev_runs``'s identical ``charged_cost`` rule above --
-    the two must match, or a cold-key heal / breaker recovery / operator
-    reconcile would re-inflate the counter this call just corrected.
+    call is reserved and never resets to None afterward. NULL here therefore
+    means this run never dispatched a single provider call -- a preflight
+    rejection, a disabled feature, a provider-unavailable 503 -- genuinely
+    zero spend, never a run that spent and lost the number.
+
+    CRASH-RECOVERED ROWS NEVER REACH THIS FUNCTION AT ALL -- a narrower
+    claim than "unaffected by this change" would suggest, so spelled out
+    precisely: ``force_terminal_fallback`` / ``recover_stale_non_terminal_
+    run`` (persistence/service.py) write ``run.state`` directly for a run
+    whose ``finish()`` may already have dispatched real, billed provider
+    calls before its own terminal ``update_run`` write died -- their real
+    cost is UNKNOWN, not proven zero, and they never call ``update_run``'s
+    terminal branch, so they structurally cannot call this function either.
+    Nothing here reconciles those rows one way or the other; the Valkey
+    reservation this function would have touched is simply never revisited
+    for them. The overall CHAOS-3573 fix DOES still cover them, at the
+    other call site: ``_recompute_from_dev_runs`` above carries its own
+    explicit discriminator (a decoupled ``safe_error_code``/
+    ``terminal_error_payload`` pair, unique to those two recovery paths)
+    that keeps them charged at worst-case on every cold-key heal / breaker
+    recovery / operator reconcile -- see that function's docstring for the
+    full argument. This function and that one therefore agree on the ONE
+    case both ever see (a normal ``update_run``-reached terminal with NULL
+    cost -> 0), and disagree by construction on the case only the SQL side
+    ever sees (a recovery-forced terminal -> worst-case), because only one
+    of the two functions is ever invoked for the latter.
     """
 
     if provider_source != "platform" or state not in TERMINAL_RUN_STATES:

--- a/src/dev_health_ops/api/services/askdev_allowance_counters.py
+++ b/src/dev_health_ops/api/services/askdev_allowance_counters.py
@@ -73,7 +73,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import and_, case, func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.dev.org_policy import TERMINAL_RUN_STATES, platform_month_window
@@ -185,19 +185,33 @@ async def _recompute_from_dev_runs(
 
     Used for the Valkey-down fallback, lazy cold-key init, breaker-recovery
     recompute, and the explicit operator reconcile. One definition, so the
-    "what counts as charged" logic (terminal + has a real cost -> the real
-    cost; anything else -> the worst-case reservation) cannot drift between
-    call sites the way it had before this module existed (ask_dev.py and
+    "what counts as charged" logic (terminal -> the real cost, zero if none
+    was ever recorded; non-terminal -> the worst-case reservation, since the
+    run may still bill up to the per-call estimate) cannot drift between call
+    sites the way it had before this module existed (ask_dev.py and
     persistence/service.py each had their own copy).
+
+    CHAOS-3573: a terminal run's ``estimated_cost_microusd`` is NULL only
+    when it never dispatched a single provider call --
+    ``ProviderBudget.require()`` (``orchestrator.py``) always turns it into a
+    concrete int the instant a call is reserved, before dispatch, and never
+    back to None afterward, so every terminal write's cost column is exactly
+    the real, fully-accounted spend for that run at the moment it reached
+    ``finish()``. A terminal-but-NULL run is therefore a genuine
+    zero-cost run (a preflight rejection, a disabled feature, a
+    provider-unavailable 503 -- never a run that spent and lost the number).
+    Charging it the worst-case reservation here would keep exactly the
+    phantom spend this function exists to heal away, and would silently
+    re-inflate the Valkey counter back to worst-case on the very next
+    cold-key init / breaker recovery / operator reconcile after
+    ``reconcile_terminal_cost`` (below) has already corrected it there --
+    the two call sites must agree, or "fixed" doesn't survive a heal cycle.
     """
 
     charged_cost = case(
         (
-            and_(
-                DevRun.state.in_(TERMINAL_RUN_STATES),
-                DevRun.estimated_cost_microusd.is_not(None),
-            ),
-            DevRun.estimated_cost_microusd,
+            DevRun.state.in_(TERMINAL_RUN_STATES),
+            func.coalesce(DevRun.estimated_cost_microusd, 0),
         ),
         else_=per_run_reservation_microusd,
     )
@@ -442,23 +456,35 @@ async def reconcile_terminal_cost(
     test_persistence_v2.py's contract test driving a terminal transition
     twice through the real path).
 
-    A no-op when there is no real cost to reconcile with (provider is not
-    "platform", the state is not terminal, or ``estimated_cost_microusd`` is
-    None -- the defensive terminal-without-cost path). Per CHAOS-3522(b):
-    the reservation stays pinned at worst-case in that last case, matching
-    the existing ``test_platform_monthly_allowance_reserves_unknown_cost_
-    fail_closed`` contract -- deliberate fail-closed, not something this
-    ticket revises.
+    A no-op only when there is no ``provider`` this counter tracks, or the
+    state is not terminal. ``estimated_cost_microusd`` being None is NOT a
+    no-op (CHAOS-3573 -- reversing CHAOS-3522(b)'s original choice here):
+    every terminal write's cost column comes from
+    ``ProviderBudget.usage.estimated_cost_microusd``
+    (``orchestrator.py``/``orchestrator_persistence.py``'s ``finish()``),
+    which ``require()`` turns into a concrete int the instant a provider
+    call is reserved and never resets to None afterward. NULL at a terminal
+    write therefore means this run never dispatched a single provider call
+    -- a preflight rejection, a disabled feature, a provider-unavailable
+    503 -- genuinely zero spend, never a run that spent and lost the
+    number. (A crash that loses a run's cost entirely bypasses this
+    function altogether: ``force_terminal_fallback`` /
+    ``recover_stale_non_terminal_run`` write ``state`` directly and never
+    call ``update_run``'s terminal branch, so they never reach here --
+    those stay fail-closed by construction, unaffected by this change.)
+    Reconciling NULL to 0 here is what makes this function agree with
+    ``_recompute_from_dev_runs``'s identical ``charged_cost`` rule above --
+    the two must match, or a cold-key heal / breaker recovery / operator
+    reconcile would re-inflate the counter this call just corrected.
     """
 
     if provider_source != "platform" or state not in TERMINAL_RUN_STATES:
         return
-    if estimated_cost_microusd is None:
-        return
 
     now = now or datetime.now(UTC)
     window_start, _reset_at = platform_month_window(now)
-    delta = estimated_cost_microusd - per_run_reservation_microusd
+    real_cost = estimated_cost_microusd if estimated_cost_microusd is not None else 0
+    delta = real_cost - per_run_reservation_microusd
     if delta == 0:
         return
 

--- a/tests/api/admin/test_ask_dev.py
+++ b/tests/api/admin/test_ask_dev.py
@@ -571,6 +571,12 @@ async def test_usage_is_ask_dev_only_content_free_aggregation(admin_context):
                     state="failed",
                     input_tokens=3,
                     output_tokens=0,
+                    # CHAOS-3573: no estimated_cost_microusd recorded (and no
+                    # safe_error_code/terminal_error_payload set either, so
+                    # this is NOT a force_terminal_fallback/recover_stale_
+                    # non_terminal_run row) -- a genuine zero-cost terminal.
+                    # The platform allowance aggregate now charges it 0, not
+                    # the worst-case reservation.
                     provider_source="platform",
                     started_at=now,
                 ),
@@ -608,8 +614,11 @@ async def test_usage_is_ask_dev_only_content_free_aggregation(admin_context):
     assert allowance["request_used"] == 2
     assert allowance["request_remaining"] == 998
     assert allowance["cost_limit_microusd"] == 100_000_000
-    assert allowance["cost_used_microusd"] == 5_000_025
-    assert allowance["cost_remaining_microusd"] == 94_999_975
+    # CHAOS-3573: the failed platform run's NULL cost reconciles to its
+    # real cost (0), not the $5 worst-case reservation -- 25 (the
+    # completed run's real cost) + 0, not 5_000_025.
+    assert allowance["cost_used_microusd"] == 25
+    assert allowance["cost_remaining_microusd"] == 99_999_975
     assert allowance["warning"] == "none"
     assert allowance["window_start"].endswith("T00:00:00Z")
     assert allowance["reset_at"].endswith("T00:00:00Z")

--- a/tests/api/dev/test_persistence_postgres.py
+++ b/tests/api/dev/test_persistence_postgres.py
@@ -546,11 +546,86 @@ async def test_platform_monthly_allowance_charges_unique_runs_and_replay_is_free
 
 
 @pytest.mark.asyncio
-async def test_platform_monthly_allowance_reserves_unknown_cost_fail_closed(
+async def test_platform_monthly_allowance_reserves_unknown_cost_while_running(
     postgres_persistence: tuple[
         async_sessionmaker[AsyncSession], AsyncEngine, uuid.UUID, uuid.UUID
     ],
 ) -> None:
+    """While a run is still in flight, its cost is genuinely unknown, so
+    admission must reserve the full worst-case cost rather than treat it as
+    zero -- a concurrent second request that would blow the monthly cost
+    ceiling once both worst cases are counted must be rejected.
+
+    CHAOS-3573 note: this is deliberately a NON-terminal in-flight run (no
+    ``update_run`` call at all). Before CHAOS-3573 this test terminated the
+    first run (``state="cancelled"``) with no recorded cost and asserted the
+    reservation stayed pinned forever after termination too -- that was
+    exactly the bug (see
+    ``test_platform_monthly_allowance_releases_unknown_terminal_cost``
+    below, which now pins the corrected behavior for the terminal case).
+    This test keeps the still-valid half of the original contract: an
+    ACTIVE run's unknown cost must still fail closed, because it has not
+    reconciled to anything yet and may still bill up to the full estimate.
+    """
+    maker, _engine, org_id, user_id = postgres_persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id,
+            user_id=user_id,
+            current_scope={},
+        )
+        allowance = DevPlatformAllowance(
+            monthly_request_limit=10,
+            monthly_cost_limit_microusd=5_000_000,
+        )
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="Reserve the full unknown platform cost",
+            scope_snapshot={},
+            provider_source="platform",
+            platform_allowance=allowance,
+        )
+        # First run is left non-terminal (in flight) -- its worst-case
+        # reservation still stands, so a second admission that would exceed
+        # the cost ceiling once both worst cases are counted must reject.
+        with pytest.raises(DevMonthlyCostLimitExceeded):
+            await service.append_user_message_and_run(
+                org_id=org_id,
+                user_id=user_id,
+                conversation_id=conversation.id,
+                client_message_id=uuid.uuid4(),
+                question="An in-flight run's unknown cost is not zero yet",
+                scope_snapshot={},
+                provider_source="platform",
+                platform_allowance=allowance,
+            )
+
+
+@pytest.mark.asyncio
+async def test_platform_monthly_allowance_releases_unknown_terminal_cost(
+    postgres_persistence: tuple[
+        async_sessionmaker[AsyncSession], AsyncEngine, uuid.UUID, uuid.UUID
+    ],
+) -> None:
+    """CHAOS-3573: a TERMINAL run with no recorded cost must reconcile to
+    its real cost -- zero, since ``estimated_cost_microusd`` is NULL at a
+    terminal write only when the run never dispatched a single provider
+    call (see askdev_allowance_counters.reconcile_terminal_cost's
+    docstring). Before this fix, the worst-case admission-time reservation
+    was held forever past termination, which is exactly the phantom-spend
+    defect CHAOS-3573 was filed against (6 of 29 production runs, ~30% of a
+    monthly allowance, held by runs that cost approximately nothing).
+
+    This exercises the SQL-fallback ground truth (``_recompute_from_dev_
+    runs``), not the Valkey HINCRBY path -- REDIS_URL is unset for this
+    module, so ``admit()``/``reconcile_terminal_cost`` both take the
+    SQL-only branch. Both paths must agree (see the module docstring), and
+    this is the contract test for the SQL side.
+    """
     maker, _engine, org_id, user_id = postgres_persistence
     async with maker() as session:
         service = DevPersistenceService(session)
@@ -579,17 +654,20 @@ async def test_platform_monthly_allowance_reserves_unknown_cost_fail_closed(
             run_id=first.run.id,
             state="cancelled",
         )
-        with pytest.raises(DevMonthlyCostLimitExceeded):
-            await service.append_user_message_and_run(
-                org_id=org_id,
-                user_id=user_id,
-                conversation_id=conversation.id,
-                client_message_id=uuid.uuid4(),
-                question="Unknown cost cannot be treated as zero",
-                scope_snapshot={},
-                provider_source="platform",
-                platform_allowance=allowance,
-            )
+        # The first run is now terminal with no recorded cost -- its real
+        # cost is zero, and the second request must be admitted with the
+        # full $5 ceiling available again.
+        second = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="A terminal run's unrecorded cost reconciles to zero",
+            scope_snapshot={},
+            provider_source="platform",
+            platform_allowance=allowance,
+        )
+        assert second.created is True
 
 
 # -- CHAOS-3297 Codex review round 9: the DB trigger closure, production

--- a/tests/api/dev/test_persistence_v2.py
+++ b/tests/api/dev/test_persistence_v2.py
@@ -2510,6 +2510,84 @@ async def test_force_terminal_fallback_is_a_noop_for_a_missing_run(persistence) 
         )
 
 
+@pytest.mark.asyncio
+async def test_recompute_from_dev_runs_keeps_worst_case_for_force_terminal_fallback_row(
+    persistence,
+) -> None:
+    """CHAOS-3573 follow-up (adversarial review finding).
+
+    force_terminal_fallback exists precisely because finish() may already
+    have dispatched real, billed provider calls before its own terminal
+    update_run write died -- the row it leaves behind has
+    estimated_cost_microusd == NULL with UNKNOWN real cost, never a proven
+    zero. _recompute_from_dev_runs must not coalesce that NULL to 0 the way
+    it correctly does for a genuine zero-spend terminal (preflight
+    rejection, disabled feature, etc.) -- doing so would erase a
+    possibly-real charge on every cold-key heal (routine: first request of
+    the month, TTL lapse, Valkey restart), not merely a rare event.
+
+    This is the SQL-ground-truth sibling of
+    test_force_terminal_fallback_forces_a_stuck_run_terminal above, which
+    already pins the row shape (safe_error_code set, terminal_error_payload
+    NULL) this discriminator relies on.
+    """
+
+    from dev_health_ops.api.dev.org_policy import (
+        ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+        platform_month_window,
+    )
+    from dev_health_ops.api.services.askdev_allowance_counters import (
+        _recompute_from_dev_runs,
+    )
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="A run that dies mid-flight after real spend",
+            scope_snapshot={},
+            admission_limits=DevAdmissionLimits(),
+            provider_source="platform",
+            platform_allowance=DevPlatformAllowance(
+                monthly_request_limit=10,
+                monthly_cost_limit_microusd=6_000_000,
+            ),
+        )
+        await session.commit()
+
+        await service.force_terminal_fallback(
+            org_id=org_id, user_id=user_id, run_id=accepted.run.id
+        )
+
+        run_after = await session.get(DevRun, accepted.run.id)
+        assert run_after is not None
+        assert run_after.state == "failed"
+        assert run_after.estimated_cost_microusd is None
+        # Sanity: the exact decoupled signature the discriminator keys off.
+        assert run_after.safe_error_code is not None
+        assert run_after.terminal_error_payload is None
+
+        window_start, reset_at = platform_month_window(datetime.now(UTC))
+        counts = await _recompute_from_dev_runs(
+            session,
+            org_id=str(org_id),
+            window_start=window_start,
+            reset_at=reset_at,
+            per_run_reservation_microusd=ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+        )
+        assert counts.cost_microusd == ASK_DEV_RUN_COST_HARD_MAX_MICROUSD, (
+            "a force_terminal_fallback row's unknown cost must stay "
+            "charged at the worst-case reservation, never coalesced to zero"
+        )
+
+
 # -- recover_stale_non_terminal_run (CHAOS-3297 Codex review round 5 HIGH) --
 #
 # force_terminal_fallback is the request's own last-resort write. This is
@@ -2762,6 +2840,80 @@ async def test_recover_stale_non_terminal_run_refreshes_a_stale_identity_map_ent
         assert run_after.safe_error_code != "internal_error"
         assert run_after.ended_at is not None
         assert run_after.ended_at.replace(tzinfo=UTC) == completed_at
+
+
+@pytest.mark.asyncio
+async def test_recompute_from_dev_runs_keeps_worst_case_for_recover_stale_row(
+    persistence,
+) -> None:
+    """CHAOS-3573 follow-up (adversarial review finding): the
+    recover_stale_non_terminal_run sibling of
+    test_recompute_from_dev_runs_keeps_worst_case_for_force_terminal_fallback_row
+    above -- same unknown-real-cost hazard, reached via the SECOND recovery
+    path instead of the first."""
+
+    from dev_health_ops.api.dev.org_policy import (
+        ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+        platform_month_window,
+    )
+    from dev_health_ops.api.services.askdev_allowance_counters import (
+        _recompute_from_dev_runs,
+    )
+
+    maker, org_id, _other_org, user_id, _other_user = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        accepted = await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="A run stuck non-terminal after real spend",
+            scope_snapshot={},
+            admission_limits=DevAdmissionLimits(),
+            provider_source="platform",
+            platform_allowance=DevPlatformAllowance(
+                monthly_request_limit=10,
+                monthly_cost_limit_microusd=6_000_000,
+            ),
+        )
+        run_id = accepted.run.id
+        await service.update_run(
+            org_id=org_id, user_id=user_id, run_id=run_id, state="resolving_scope"
+        )
+        run = await session.get(DevRun, run_id)
+        assert run is not None
+        run.started_at = datetime.now(UTC) - timedelta(minutes=10)
+        await session.commit()
+
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        recovered = await service.recover_stale_non_terminal_run(
+            org_id=org_id,
+            user_id=user_id,
+            run_id=run_id,
+            stale_after=timedelta(minutes=5),
+        )
+        assert recovered is not None
+        assert recovered.estimated_cost_microusd is None
+        assert recovered.safe_error_code is not None
+        assert recovered.terminal_error_payload is None
+
+        window_start, reset_at = platform_month_window(datetime.now(UTC))
+        counts = await _recompute_from_dev_runs(
+            session,
+            org_id=str(org_id),
+            window_start=window_start,
+            reset_at=reset_at,
+            per_run_reservation_microusd=ASK_DEV_RUN_COST_HARD_MAX_MICROUSD,
+        )
+        assert counts.cost_microusd == ASK_DEV_RUN_COST_HARD_MAX_MICROUSD, (
+            "a recover_stale_non_terminal_run row's unknown cost must stay "
+            "charged at the worst-case reservation, never coalesced to zero"
+        )
 
 
 # -- dev_run_stage_diagnostics ---------------------------------------------

--- a/tests/api/test_askdev_allowance_counters.py
+++ b/tests/api/test_askdev_allowance_counters.py
@@ -505,7 +505,6 @@ async def test_reconcile_terminal_cost_can_adjust_upward(valkey_client):
     [
         ("byo", "completed", 250_000),  # not the platform provider
         ("platform", "running", 250_000),  # not terminal
-        ("platform", "completed", None),  # no real cost -- fail-closed pin stands
     ],
 )
 async def test_reconcile_terminal_cost_noop_cases(
@@ -530,6 +529,118 @@ async def test_reconcile_terminal_cost_noop_cases(
     counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
     # Unchanged -- the reservation is left exactly as it was.
     assert counts == [b"1", str(_RESERVATION).encode()]
+
+
+# -- reconcile_terminal_cost(): CHAOS-3573 NULL-cost release ------------------
+#
+# RED-first pin: a terminal run whose real cost was never recorded (NULL)
+# must have its worst-case admission-time reservation released down to 0,
+# not held forever. Before the CHAOS-3573 fix, reconcile_terminal_cost
+# returned early on `estimated_cost_microusd is None` and these three
+# assertions failed (counts stayed at the full `_RESERVATION` instead of
+# dropping to 0) -- pinning exactly the retention CHAOS-3573's evidence
+# measured in production (6 of 29 runs, 2 failed + 4 insufficient_evidence,
+# each permanently holding the $5 worst-case reservation).
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["failed", "insufficient_evidence"])
+async def test_reconcile_terminal_cost_releases_reservation_on_null_cost(
+    valkey_client, state
+):
+    """A terminal run with NULL cost never dispatched a provider call
+
+    (ProviderBudget.require() in orchestrator.py is the only writer of a
+    non-None estimated_cost_microusd, and it never resets back to None) --
+    so its real cost is 0, and the worst-case reservation held since
+    admission must be released in full.
+    """
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=1, cost_microusd=_RESERVATION),
+    )
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source="platform",
+        state=state,
+        estimated_cost_microusd=None,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    assert counts == [b"1", b"0"], (
+        "a NULL-cost terminal run must reconcile the reservation down to "
+        "its real cost (0), not keep the worst-case reservation forever"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_cost_null_cost_only_releases_that_runs_share(
+    valkey_client,
+):
+    """Two runs share the org/month key; only the NULL-cost run's own
+    reservation portion is released -- the other run's real cost stands."""
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=2, cost_microusd=_RESERVATION * 2),
+    )
+    # First run already reconciled up/down to a real, non-null cost.
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source="platform",
+        state="completed",
+        estimated_cost_microusd=300_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    # Second run terminates with no recorded cost at all.
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source="platform",
+        state="failed",
+        estimated_cost_microusd=None,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    # Total charged: run 1's real 300_000 + run 2's real 0.
+    assert counts == [b"2", b"300000"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_terminal_cost_regression_recorded_cost_still_reconciles(
+    valkey_client,
+):
+    """Regression guard: a terminal run WITH a recorded cost must keep
+    reconciling to that recorded value -- the NULL-cost fix must not touch
+    this path at all."""
+    key = counters._key(_ORG, datetime(2026, 8, 1, tzinfo=UTC))
+    await counters._ensure_initialized(
+        valkey_client,
+        key=key,
+        ttl_seconds=1000,
+        baseline=AllowanceCounts(requests=1, cost_microusd=_RESERVATION),
+    )
+    await reconcile_terminal_cost(
+        _fake_session(),
+        org_id=_ORG,
+        provider_source="platform",
+        state="insufficient_evidence",
+        estimated_cost_microusd=42_000,
+        per_run_reservation_microusd=_RESERVATION,
+        now=_NOW,
+    )
+    counts = await valkey_client.hmget(key, ["requests", "cost_microusd"])
+    assert counts == [b"1", b"42000"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`reconcile_terminal_cost` returned early whenever a terminal run's `estimated_cost_microusd` was NULL, so the admission-time worst-case reservation (5,000,000 microusd / $5) was never released or corrected. Production evidence (CHAOS-3573): 6 of 29 runs (2 `failed`, 4 `insufficient_evidence`) each held the full reservation forever — 30% of a $100 monthly allowance consumed by runs that cost approximately nothing. Combined with the request-primary allowance control (CHAOS-3552), this inflates perceived spend and can lock an org out of the platform allowance early.

**Revision note:** the first pass of this PR fixed `reconcile_terminal_cost` and made `_recompute_from_dev_runs` unconditionally coalesce NULL to 0 for every terminal row. Two independent adversarial reviews caught a blocking gap in that second part: it also zeroed out rows written by the crash-recovery paths (`force_terminal_fallback` / `recover_stale_non_terminal_run`), whose real cost is genuinely *unknown*, not zero. That gap is now closed — see the discriminator below.

## Per-terminal-state decision table

Traced `ProviderBudget.require()`/`add()` in `orchestrator.py`: `require()` is the *only* writer of a non-`None` `estimated_cost_microusd`, and it turns the field into a concrete int the instant a provider call is reserved — **before** dispatch, and never back to `None` afterward (even a failed/costless provider response keeps the pre-reserved worst case via `add()`'s `reconciled_cost = prior_cost` branch). Every *normal* terminal write reaches `update_run` through the same `finish()` closure using the same `budget.usage`, for all five terminal states.

| Terminal state (reached via `update_run`) | What NULL reconciles to | Direction | Why |
|---|---|---|---|
| `completed` | 0 (real cost) | fail-open (justified) | Same `finish()` path; NULL only occurs pre-dispatch |
| `failed` | 0 (real cost) | fail-open (justified) | Matches production evidence directly (2 of 29) |
| `insufficient_evidence` | 0 (real cost) | fail-open (justified) | Matches production evidence directly (4 of 29) |
| `refused` | 0 (real cost) | fail-open (justified) | A refusal after a real LLM round always carries non-NULL cost, so this case only fires pre-dispatch |
| `cancelled` | 0 (real cost) | fail-open (justified) | Same `finish()` path |
| **Any state, reached via `force_terminal_fallback` / `recover_stale_non_terminal_run`** | **worst-case reservation (unchanged)** | **fail-closed** | **These paths exist precisely because `finish()` may already have dispatched real, billed provider calls before its own terminal `update_run` write died. Real cost is UNKNOWN, not proven zero.** |

**Discriminator for the crash-recovery row (no schema change, no new stamp):** both recovery paths are the *only* writers on `dev_runs` that set `safe_error_code` non-NULL while leaving `terminal_error_payload` NULL. Every normal path derives both columns from the same `DevError` object at the same time (`orchestrator_persistence.py`'s `terminal()`, `router.py`'s provider-unavailable path) — so a normal write is always both-None or both-set, and only the two forced-recovery paths ever decouple them (already pinned by existing tests `test_force_terminal_fallback_forces_a_stuck_run_terminal` / `test_recover_stale_non_terminal_run_forces_a_stuck_run_terminal_when_old_enough`). `_recompute_from_dev_runs` now checks `safe_error_code IS NOT NULL AND terminal_error_payload IS NULL` and keeps those rows at worst-case. This also correctly falls back to worst-case for any pre-`terminal_error_payload`-column legacy row (ambiguous old data stays conservative by construction, not a special case).

Verified directly (not assumed) that this discriminator's `.is_(None)` check reads a true SQL NULL on the real code path, not a JSON `"null"` literal: `terminal_error_payload` starts genuinely unset (omitted from the original INSERT), every intermediate bare-state `update_run` call re-assigns the same `None` it already holds (a no-op the ORM excludes from its UPDATE entirely), and the recovery paths' own `run.terminal_error_payload = None` is the identical no-op — so SQLAlchemy's JSON `none_as_null=False` bind processor never fires for it. This is ORM/unit-of-work behavior, not dialect-specific, so it holds on Postgres too.

`reconcile_terminal_cost` itself (the Valkey HINCRBY path) is untouched by this discriminator — it structurally can never be invoked for a crash-recovered row, since those paths write `state` directly and never call `update_run`'s terminal branch. The two functions therefore agree on the one case both ever see (a normal NULL-cost terminal → 0) and intentionally disagree on the case only the SQL side ever sees (a recovery-forced terminal → worst-case).

## Scope note: also fixed `_recompute_from_dev_runs`

`_recompute_from_dev_runs` (the SQL ground-truth aggregate used for Valkey-down fallback, cold-key init, breaker-recovery, and the explicit operator reconcile) had the **identical** "terminal + NULL cost → worst-case reservation" rule baked into its `charged_cost` CASE expression, under the same "what counts as charged" docstring contract the module documents as shared between call sites. Fixing only `reconcile_terminal_cost` would have been silently undone on the very next cold-key heal / breaker recovery / operator reconcile, which recomputes from this SQL query and overwrites the Valkey counter. Both are fixed together, consistently.

This required updating an existing Postgres contract test, `test_platform_monthly_allowance_reserves_unknown_cost_fail_closed`, which pinned the *old* behavior for a `cancelled` run with no recorded cost. Split into two: `test_platform_monthly_allowance_reserves_unknown_cost_while_running` (keeps the still-valid half — an **in-flight** run's unknown cost must still fail closed) and `test_platform_monthly_allowance_releases_unknown_terminal_cost` (pins the corrected **terminal** behavior).

## Tests

- RED-first (first pass): 3 new unit tests in `tests/api/test_askdev_allowance_counters.py`, run against the unfixed source (git-stashed) — confirmed fail for the traced reason.
- RED-first (adversarial-review follow-up): 2 new contract tests in `tests/api/dev/test_persistence_v2.py` drive a row through `force_terminal_fallback` and `recover_stale_non_terminal_run` respectively and assert `_recompute_from_dev_runs` still reserves worst-case — confirmed both **failed** (cost wrongly coalesced to 0) against the prior fix, before this discriminator was added.
- `tests/api/test_askdev_allowance_counters.py`: **28 passed, 0 failed, 0 skipped**
- `tests/api/dev/test_persistence_v2.py` (full file): **87 passed, 1 xfailed** (pre-existing, unrelated), 0 failed
- CI-parity unit selection (`ci/run_tests.sh`'s `unit_tests()` marker set) over `tests/api/test_askdev_allowance_counters.py tests/api/dev/`: **2442 passed, 22 skipped, 1 xfailed, 0 failed/errors**
- `tests/api/dev/test_persistence_postgres.py -k "platform_monthly_allowance"`: **3 skipped cleanly** (`requires DEV_HEALTH_POSTGRES_TEST_URI`, no live Postgres available in this environment per task scope — source-verified and `py_compile`-clean, not exercised against live infra)
- Empirically verified (ad hoc script against the real code path, not assumed) that `terminal_error_payload` reads as true SQL NULL, not JSON `"null"`, for both the normal and recovery write paths.

## Out of scope (per task)

No gate run, no docker, no merge, no Linear status change, no allowance LIMIT value changes — mechanics only.