### PR TITLE
CHAOS-3576: frame-construction failures must fail tests loudly; fixture generated from the producer

### DIFF
--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -34,10 +34,15 @@ from dev_health_ops.api.dev.contracts import (
     DevScopeResolution,
     DevToolRequest,
     DevToolResult,
+    FreshnessState,
     QuestionClass,
     ToolID,
 )
 from dev_health_ops.api.dev.contracts_v2 import DevInvestigationResult, DevSubjectSet
+from dev_health_ops.api.dev.evidence_service import (
+    EvidenceRecord,
+    EvidenceReferenceSigner,
+)
 from dev_health_ops.api.dev.orchestrator import DevOrchestrator, OrchestratorResult
 from dev_health_ops.api.dev.orchestrator_states import RunState
 from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
@@ -50,6 +55,7 @@ from dev_health_ops.api.dev.scope_service import (
     ScopeResolutionService,
 )
 from dev_health_ops.api.dev.subject_preflight import SubjectPreflight
+from dev_health_ops.api.dev.terminal_frames import is_orchestrator_error_frame
 from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
 from dev_health_ops.llm.agent.contracts import (
     AgentDecisionResult,
@@ -70,6 +76,45 @@ PERMISSION_FINGERPRINT = "permissions_01"
 RUN_ID = "run_01"
 CONVERSATION_ID = "conversation_01"
 ANSWER_ID = "answer_01"
+
+#: CHAOS-3576: a fixed, valid (>=32 byte) test secret for the REAL
+#: ``EvidenceReferenceSigner`` -- the exact class ``production_runtime.py``
+#: wires into ``PlanExecutor``/``EvidenceService`` -- rather than a
+#: hand-typed handle string. Mirrors
+#: ``tests._chaos_3295_plan_executor.TEST_EVIDENCE_SIGNER`` (duplicated, not
+#: imported: that module imports ``Recorder`` from this one, so importing
+#: back would be circular).
+_TEST_EVIDENCE_SIGNER = EvidenceReferenceSigner(
+    b"chaos-3576-preflight-harness-test-secret"
+)
+
+
+def _real_evidence_ref_id(*, org_id: str = ORG_ID) -> str:
+    """Mint a real, ``_TEST_EVIDENCE_SIGNER``-verifiable evidence handle.
+
+    The exact ``EvidenceRecord``/``issue`` call
+    ``EvidenceService._to_ref`` makes for every real evidence handle in
+    production, mirroring the fixture's own ``_evidence()`` shape
+    (``contract_fixtures.py``) so the minted handle stands in for that
+    fixture's ``evidence_ref_id`` without hand-authoring a grammar-valid
+    string that no signer ever actually produced (CHAOS-3576: never
+    hand-author what a producer can generate).
+    """
+
+    record = EvidenceRecord(
+        source_system="work_graph",
+        source_version="work_graph.v1",
+        entity_type="work_item",
+        entity_id="item_01",
+        display_label="Implement contract baseline",
+        observed_at=fixed_now(),
+        freshness=FreshnessState.FRESH,
+        provenance="Canonical work graph projection",
+        confidence=1.0,
+        repository_ids=("repo_dev_health",),
+    )
+    return _TEST_EVIDENCE_SIGNER.issue(org_id, record)
+
 
 #: Seeded subjects, by owning organization. Every catalog method filters on
 #: ``org_id`` exactly as every ``scope_catalog`` query does in SQL, so
@@ -291,6 +336,51 @@ def organization_resolution(scope: DevScope) -> DevScopeResolution:
     )
 
 
+def _make_payload_v2_frame_valid(payload: dict[str, Any]) -> str:
+    """Mutate ``payload`` in place so it survives
+    ``terminal_frames.wrap_legacy_answer_as_frame`` and returns the minted
+    evidence handle (CHAOS-3576).
+
+    The stock ``dev_answer.v1`` fixture's evidence (``_evidence()``,
+    ``contract_fixtures.py``) carries ``evidence_ref_id: "ev_01"`` and its
+    metric (``_metric()``) carries ``evidence_ref_ids: ["ev_01"]`` -- both
+    valid v1 ``OpaqueID`` shapes, but far short of v2's
+    ``EvidenceHandle`` grammar (``ev1_`` + 40 hex,
+    ``min_length=44``, ``contracts_v2.base.EvidenceHandle``). A completed
+    run's answer is re-validated as its v2 mirror inside
+    ``wrap_legacy_answer_as_frame`` (``DevEvidenceRefV2``/
+    ``DevMetricRefV2``), so construction raised for *every* run through
+    this fixture, and ``orchestrator.finish()``'s broad except silently
+    substituted the ``internal_error`` fallback frame in its place --
+    vacuous coverage for every test asserting on a recorded frame's content
+    (CHAOS-3576).
+
+    Two different fixes for two different fields, because they mean
+    different things:
+
+    * ``evidence[0].evidence_ref_id`` -- a real disclosure channel, so it
+      gets a REAL handle, minted the way ``EvidenceService._to_ref`` mints
+      one in production (see :func:`_real_evidence_ref_id`), never a
+      hand-typed grammar-valid literal.
+    * every ``metrics[*].evidence_ref_ids`` -- cleared to ``()``, matching
+      what ``production_runtime.py``'s ``query_metric.v1`` tool always
+      does to a real metric before a model ever sees it (``item.model_copy
+      (update={"evidence_ref_ids": []})``). ``_wrap_legacy_metric``
+      (``terminal_frames.py``) sets ``evidence_classification`` on every
+      v1-sourced metric UNCONDITIONALLY on that same premise -- a metric
+      carrying both a real handle and that classification is precisely
+      what ``DevMetricRefV2``'s F10 XOR validator exists to reject, so a
+      *minted* handle here would still fail, just on a different clause.
+    """
+
+    handle = _real_evidence_ref_id()
+    for evidence in payload.get("evidence", []):
+        evidence["evidence_ref_id"] = handle
+    for metric in payload.get("metrics", []):
+        metric["evidence_ref_ids"] = []
+    return handle
+
+
 def answer_payload(*, script_id: str) -> dict[str, Any]:
     """The stock answer with claims dropped.
 
@@ -304,6 +394,7 @@ def answer_payload(*, script_id: str) -> dict[str, Any]:
 
     payload = deepcopy(positive_fixtures()["dev_answer.v1"])
     payload["claims"] = []
+    _make_payload_v2_frame_valid(payload)
     payload["model"] = {
         "provider_source": "platform",
         "provider_family": "scripted",
@@ -329,6 +420,14 @@ def grounded_answer_payload(
     payload["direct_summary"] = summary
     payload["claims"][0]["text"] = summary
     payload["claims"][0]["validity_scope"] = deepcopy(validity_scope)
+    # CHAOS-3576: the claim's own evidence_ref_ids must keep pointing at a
+    # real id the answer's `evidence` list actually carries -- `DevAnswer
+    # .validate_answer_invariants` (contracts.py) rejects a claim that cites
+    # an id outside `{item.evidence_ref_id for item in self.evidence}`, so
+    # this has to be the SAME minted handle `_make_payload_v2_frame_valid`
+    # writes onto `payload["evidence"][0]`, not a second, independent one.
+    handle = _make_payload_v2_frame_valid(payload)
+    payload["claims"][0]["evidence_ref_ids"] = [handle]
     payload["model"] = {
         "provider_source": "platform",
         "provider_family": "scripted",
@@ -492,6 +591,18 @@ def stock_executor(
                 "tool_id": request.tool_id.value,
             }
         )
+        # CHAOS-3576: `DevOrchestrator._canonical_answer_data` overwrites a
+        # completed answer's OWN `metrics`/`evidence` with these exact tool-
+        # result values (deduplicated by id) before `wrap_legacy_answer_as_
+        # frame` ever runs -- so this stock success fixture, not
+        # `answer_payload()`'s, is what actually reaches frame construction
+        # for any ordinary grounded run through this executor. `_real_
+        # evidence_ref_id` is deterministic (a fixed HMAC over a fixed
+        # payload), so every call mints the SAME handle -- multiple tool
+        # calls in one run still canonicalize to identical, deduplicable
+        # evidence/metric entries, exactly as this fixture's plain "ev_01"
+        # did before.
+        _make_payload_v2_frame_valid(payload)
         return DevToolResult.model_validate(payload)
 
     return execute
@@ -571,6 +682,58 @@ class RunOutput:
             for _outcome, guard in self.recorder.preflight_diagnostics
             if guard is not None
         )
+
+
+def assert_answered_frame_is_not_construction_fallback(
+    output: Any, *, run_id: str = RUN_ID
+) -> Any:
+    """CHAOS-3576: fail LOUDLY if a completed answer's recorded frame
+    silently degraded to the orchestrator's internal_error construction
+    fallback, instead of returning ``None``/passing quietly.
+
+    ``orchestrator.finish()`` deliberately swallows a
+    ``wrap_legacy_answer_as_frame`` exception and substitutes
+    ``terminal_frames.build_error_frame(code="internal_error", ...)`` so a
+    frame-layer bug in production can never crash or discard an otherwise-
+    successful run (see ``terminal_frames.py``'s module docstring and
+    ``orchestrator.py``'s ``frame_construction_exc`` handler) -- that
+    behavior is correct and this helper does not change it.
+
+    What it closes is the gap one layer up: a test asserting directly on
+    ``output.recorder.frames[-1]`` had no way to tell "this is the real
+    content frame" from "this is the generic stub the swallow produced" --
+    every assertion past that point measured the always-identical stub
+    instead of the run's actual output (vacuous coverage). Call this before
+    reading frame content on any run expected to answer.
+
+    Accepts a duck-typed ``output`` (only ``.result.answer`` and
+    ``.recorder.frames`` are read) so a caller can exercise this against a
+    hand-built double without depending on the full ``RunOutput``/
+    ``OrchestratorResult`` shape (see
+    ``test_chaos_3576_frame_construction_fixture.py``'s own anti-vacuity
+    control for this helper).
+    """
+
+    assert output.result.answer is not None, (
+        "no answer was produced -- nothing to have framed"
+    )
+    recorder = output.recorder
+    assert recorder is not None and recorder.frames, (
+        f"run {run_id!r} produced an answer but recorded no frame at all"
+    )
+    frame = recorder.frames[-1]
+    assert not is_orchestrator_error_frame(
+        frame_id=frame.frame_id, run_id=run_id, code="internal_error"
+    ), (
+        f"frame construction silently fell back to the internal_error frame "
+        f"for run {run_id!r} -- wrap_legacy_answer_as_frame raised inside "
+        f"orchestrator.finish() and its broad except (orchestrator.py, the "
+        f"frame_construction_exc handler) swallowed it instead of failing "
+        f"this test. Check the fixture answer's metrics/evidence shape "
+        f"against DevMetricRefV2/DevEvidenceRefV2 (contracts_v2/embedded.py) "
+        f"-- see _make_payload_v2_frame_valid's docstring above."
+    )
+    return frame
 
 
 async def run_preflight_orchestrator(

--- a/tests/api/dev/test_chaos_3297_s5_guard_cutover.py
+++ b/tests/api/dev/test_chaos_3297_s5_guard_cutover.py
@@ -93,15 +93,23 @@ _NARRATION = "Nightfall completed twelve work items this period."
 #: A v2-shaped evidence handle (``ev1_`` + 40 lowercase hex,
 #: ``contracts_v2.base.EvidenceHandle``).
 #:
-#: The shared harness fixture still mints the pre-v2 ``ev_01`` shape, which
-#: ``terminal_frames.wrap_legacy_answer_as_frame`` cannot project into a
-#: ``DevEvidenceRefV2`` -- so every run through that fixture silently
-#: degrades to an ``internal_error`` frame (CHAOS-3340, filed; two confirmed
-#: instances). These controls are about what the FRAME carries, so they
-#: cannot be asserted on a fixture that never produces a real one. This
-#: registry mints the handle shape production's
-#: ``EvidenceHandleService.issue`` actually returns. Repairing the shared
-#: fixture is CHAOS-3340's blast-radius call, not this stack's.
+#: CHAOS-3576 fixed the shared harness fixture at its source: ``recording_
+#: registry``/``stock_executor`` and ``answer_payload``/``grounded_answer_
+#: payload`` (``tests._chaos_3292_preflight``) now mint a real, v2-valid
+#: evidence handle by construction, so a run through the plain shared
+#: fixture no longer silently degrades to the ``internal_error`` frame
+#: (filed as "CHAOS-3340" in this file's own prior comment; CHAOS-3576 is
+#: that fix). ``_with_v2_handles``/``_V2_EVIDENCE_HANDLE`` stay for
+#: ``_canonical_tool_result`` (a standalone ``DevToolResult`` builder, never
+#: compared against ``grounded_answer_payload``'s own minted handle), but
+#: ``_v2_evidence_registry`` below now delegates to the shared harness's
+#: fixed ``recording_registry`` rather than rewriting to this SEPARATE
+#: literal handle -- keeping two independently-minted "valid" handles in
+#: one run is exactly what broke C1/C3/M1 here once the harness's own
+#: ``grounded_answer_payload`` started minting its own real handle: the
+#: model's answer cited one handle, this registry's tool result carried a
+#: different one, and the run failed answer validation before the guard
+#: this suite tests ever ran.
 _V2_EVIDENCE_HANDLE = "ev1_" + ("a1b2c3d4e5" * 4)
 
 
@@ -178,26 +186,19 @@ def _ungrounded_narrating_script(script_id: str) -> list[ScriptedStep]:
 
 
 def _v2_evidence_registry(calls: list[DevToolRequest]) -> AskDevToolRegistry:
-    """The stock success registry, with v2-projectable evidence handles."""
+    """The stock success registry, with v2-projectable evidence handles.
 
-    async def execute(_context: Any, request: DevToolRequest) -> DevToolResult:
-        calls.append(request)
-        payload = deepcopy(positive_fixtures()["dev_tool_result.v1"])
-        payload.update(
-            {
-                "run_id": request.run_id,
-                "tool_call_id": request.tool_call_id,
-                "tool_id": request.tool_id.value,
-            }
-        )
-        payload = _with_v2_handles(payload)
-        # F10: a v1-sourced metric never carries evidence_ref_ids -- see
-        # terminal_frames._wrap_legacy_metric.
-        for metric in payload.get("metrics", []):
-            metric["evidence_ref_ids"] = []
-        return DevToolResult.model_validate(payload)
+    CHAOS-3576: a thin alias over the shared harness's own ``recording_
+    registry``, which now mints this SAME real evidence handle
+    ``grounded_answer_payload`` puts on the model's answer (both call
+    ``tests._chaos_3292_preflight._real_evidence_ref_id``, a deterministic
+    HMAC, so every caller gets identical output). Kept as a distinct name
+    for call-site continuity in this file rather than a second,
+    independently-minted fixture that could again drift out of step with
+    what the answer actually cites.
+    """
 
-    return AskDevToolRegistry({tool_id: execute for tool_id in ToolID})
+    return recording_registry(calls)
 
 
 def _barren_registry(calls: list[DevToolRequest]) -> AskDevToolRegistry:

--- a/tests/api/dev/test_chaos_3576_frame_construction_fixture.py
+++ b/tests/api/dev/test_chaos_3576_frame_construction_fixture.py
@@ -1,0 +1,119 @@
+"""CHAOS-3576 -- the shared harness's ``answer_payload()``/
+``grounded_answer_payload()`` metrics fixture must produce a real,
+v2-valid ``dev_answer_frame.v1`` for every completed run, and any future
+regression must fail LOUDLY rather than silently degrade.
+
+Defect (pre-fix): ``answer_payload()``'s metric carries
+``evidence_ref_ids: ["ev_01"]`` and its evidence entry carries
+``evidence_ref_id: "ev_01"`` -- both valid v1 ``OpaqueID`` shapes, but far
+short of v2's ``EvidenceHandle`` grammar (``ev1_`` + 40 hex,
+``contracts_v2.base.EvidenceHandle``, ``min_length=44``).
+``terminal_frames.wrap_legacy_answer_as_frame`` re-validates a completed
+run's metrics/evidence as their v2 mirrors
+(``DevMetricRefV2``/``DevEvidenceRefV2``), so construction raises for
+*every* completed run through this fixture -- and ``orchestrator.finish()``
+(``orchestrator.py``, the ``except Exception as frame_construction_exc``
+block) deliberately swallows that failure and substitutes the always-
+registered ``internal_error`` fallback frame, by design, so a frame-layer
+bug can never crash or discard an otherwise-successful run. That
+production behavior is correct and stays untouched here.
+
+The bug this file guards against is one layer up: nothing told a TEST that
+this substitution had happened. A test asserting on
+``output.recorder.frames[-1]`` was silently comparing against the generic
+``internal_error`` stub instead of the real content frame it believed it
+was exercising -- vacuous coverage, the "measurement that did not happen
+must FAIL, loudly" class.
+
+Several other suites independently discovered and locally patched around
+this exact gap before it was filed here (each rewriting the fixture's
+``ev_01`` handles to a v2-valid shape ad hoc): ``test_chaos_3297_frame_e2e
+.py``, ``test_chaos_3297_s5_guard_cutover.py`` (filed as "CHAOS-3340" in
+its own comment), ``test_chaos_3393_portfolio_orchestrator.py``, and
+``test_terminal_frames.py``. This file is the first to fix it at the
+fixture's own source rather than working around it per-suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev import terminal_frames
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from tests._chaos_3292_preflight import (
+    RUN_ID,
+    assert_answered_frame_is_not_construction_fallback,
+    case_a1,
+)
+
+
+@pytest.mark.asyncio
+async def test_case_a1_frame_construction_does_not_silently_fall_back_to_internal_error() -> (
+    None
+):
+    """N0-equivalent for the fake-recorder harness (CHAOS-3576).
+
+    ``case_a1`` is a known real project: a well-behaved script commits a
+    subject, runs one tool, and answers -- the ordinary completed-run shape
+    every acceptance case in this module shares. The recorded frame must be
+    a genuine ``wrap_legacy_answer_as_frame`` projection of that answer, not
+    the orchestrator's own internal_error construction fallback.
+    """
+
+    output = await case_a1()
+
+    assert output.result.state is RunState.COMPLETED
+    assert output.result.answer is not None
+
+    frame = assert_answered_frame_is_not_construction_fallback(output, run_id=RUN_ID)
+
+    # A positive control alongside the negative one above: the frame that
+    # *did* get recorded actually carries this run's content, not merely
+    # "some frame that isn't the fallback" (a frame_id typo in the helper
+    # itself would otherwise pass this test vacuously).
+    assert frame.public_outcome.value == "answered_with_gaps"
+    assert frame.metrics, "the answer's metric never reached the frame"
+    assert frame.metrics[0].metric_id == "items_completed"
+
+
+@pytest.mark.asyncio
+async def test_construction_fallback_detector_is_not_vacuous() -> None:
+    """Anti-vacuity control for the helper itself.
+
+    Proves ``assert_answered_frame_is_not_construction_fallback`` actually
+    discriminates: fed the exact fallback frame
+    ``orchestrator.finish()`` substitutes on a real construction failure,
+    it must raise -- otherwise the positive test above would pass no matter
+    what the detector did.
+    """
+
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    from tests._chaos_3292_preflight import Recorder
+
+    fallback = terminal_frames.build_error_frame(
+        code="internal_error",
+        run_id=RUN_ID,
+        generated_at=datetime.now(UTC),
+    )
+    recorder = Recorder()
+    recorder.frames.append(fallback)
+
+    # Duck-typed: the helper only reads `.result.answer` and `.recorder`, so
+    # a `SimpleNamespace` proves the same contract `RunOutput` does without
+    # coupling this control to every other required `OrchestratorResult`
+    # field.
+    fake_output = SimpleNamespace(
+        result=SimpleNamespace(answer=object()), recorder=recorder
+    )
+
+    try:
+        assert_answered_frame_is_not_construction_fallback(fake_output, run_id=RUN_ID)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError(
+            "the detector must reject the orchestrator's own internal_error "
+            "fallback frame, and it did not"
+        )


### PR DESCRIPTION
## Summary

Trace: `tests._chaos_3292_preflight.answer_payload()`/`grounded_answer_payload()` and `stock_executor()` build on `positive_fixtures()["dev_answer.v1"]`/`["dev_tool_result.v1"]` (`contract_fixtures.py`), whose `_evidence()`/`_metric()` carry `evidence_ref_id(s): "ev_01"` — a valid v1 `OpaqueID` but far short of v2's `EvidenceHandle` grammar (`ev1_` + 40 hex, `min_length=44`, `contracts_v2/base.py`).

`terminal_frames.wrap_legacy_answer_as_frame` re-validates a completed run's metrics/evidence as their v2 mirrors (`DevMetricRefV2`/`DevEvidenceRefV2`), so construction raised a `pydantic.ValidationError` for **every** completed run through this fixture. The **swallow point** is `orchestrator.py`'s `finish()`, the `except Exception as frame_construction_exc:` block (around line 1456) — a deliberate, documented design (a frame-layer bug must never discard an otherwise-successful run) that logs `ask_dev.orchestrator.frame_construction_failed` and substitutes `terminal_frames.build_error_frame(code="internal_error", ...)` in place of the real content frame. That production behavior is correct and is untouched by this PR.

The bug is one layer up: nothing told a **test** this substitution had happened. Any test asserting on `output.recorder.frames[-1]` was silently comparing against the generic `internal_error` stub instead of the run's real output — vacuous coverage.

Directly observed today's silent swallow before fixing anything:
```
result.state: completed
result.answer is not None: True
frame is internal_error fallback: True
frame.public_outcome: failed
```
(full traceback in the PR — `_wrap_legacy_metric` → `DevMetricRefV2.model_validate` → `evidence_ref_ids.0: String should have at least 44 characters`)

## Consumers (blast radius) — every file importing `answer_payload`/`grounded_answer_payload` from the shared harness

- `tests/_chaos_3301_subjects.py`
- `tests/api/dev/test_chaos_3292_preflight_acceptance.py`
- `tests/api/dev/test_chaos_3292_review_findings.py`
- `tests/api/dev/test_chaos_3297_frame_e2e.py`
- `tests/api/dev/test_chaos_3297_narrative_e2e.py`
- `tests/api/dev/test_chaos_3297_s5_guard_cutover.py`
- `tests/api/dev/test_chaos_3332_tool_executor_faults.py`
- `tests/api/dev/test_chaos_3334_plan_coverage_merge.py`
- `tests/api/dev/test_chaos_3421_leak_graceful_terminal.py`
- `tests/api/dev/test_chaos_3423_3424_persistence_prerequisites.py`

Plus indirect frame-content consumers via `run_preflight_orchestrator`/`case_aN` (not a direct import): `test_chaos_3393_portfolio_orchestrator.py`, `test_chaos_3388_candidate_label_leak.py`.

Several of these had already independently discovered and locally patched around this exact gap (each rewriting `"ev_01"` to a v2-valid literal ad hoc): `test_chaos_3297_frame_e2e.py`, `test_chaos_3297_s5_guard_cutover.py` (filed as "CHAOS-3340" in its own comment), `test_chaos_3393_portfolio_orchestrator.py`, `test_terminal_frames.py`. `test_chaos_3332_tool_executor_faults.py` even has a docstring noting `frame_construction_failed` as "pre-existing... unrelated to this fix."

## Fix

- `tests/_chaos_3292_preflight.py`: mint a **real, producer-verifiable** evidence handle via `EvidenceReferenceSigner` (`evidence_service.py` — the exact class `production_runtime.py` wires into `EvidenceService`), never a hand-typed grammar-valid literal. Clear metric `evidence_ref_ids` to `()`, matching what `production_runtime.py`'s `query_metric.v1` tool always does to a real metric before a model ever sees it (`item.model_copy(update={"evidence_ref_ids": []})`) — `_wrap_legacy_metric` sets `evidence_classification` on every v1-sourced metric UNCONDITIONALLY on that same premise, so a metric carrying both a real handle and that classification would still fail, just on F10's XOR clause instead.
- Applied at **both** fixture sources that matter: `answer_payload()`/`grounded_answer_payload()` (the model's own claimed answer) **and** `stock_executor()` (the tool-result fixture) — `DevOrchestrator._canonical_answer_data` overwrites a completed answer's own `metrics`/`evidence` with the tool-result-derived canonical tuples before frame construction ever runs, so the tool-result fixture is what actually reaches `wrap_legacy_answer_as_frame` for any ordinary grounded run.
- Added `assert_answered_frame_is_not_construction_fallback()` to the shared harness: fails loudly (with the file:line of the swallow and what to check) if a completed answer's recorded frame is the orchestrator's own `internal_error` fallback, instead of a test silently reading the stub.
- New `tests/api/dev/test_chaos_3576_frame_construction_fixture.py`: a regression test proving `case_a1`'s frame is real content (not the fallback), verified RED against the unfixed harness first (see PR description above), plus an anti-vacuity control for the detector helper itself.
- `test_chaos_3297_s5_guard_cutover.py`: its own `_v2_evidence_registry` minted a *different* hardcoded literal handle than what the harness's now-fixed `grounded_answer_payload()` puts on the model's answer — this mismatch made 5 tests (C1/C1b/C1c/C3/M1) go newly RED (answer validation failing before the guard under test ever ran). Fix was mechanical and unambiguous: delegate to the shared harness's `recording_registry` (now correct) instead of maintaining a second, independently-minted fixture.

## Newly-red findings (all fixed, mechanism confirmed)

| Test | Mechanism | Fix |
|---|---|---|
| `test_c1_the_guard_fires_and_the_run_still_ships_a_grounded_result` | Model's answer cited the harness's real minted handle; this file's own tool registry carried a different hardcoded literal handle → claim-references-unknown-evidence / grounding mismatch → run failed before the guard ran | Delegate `_v2_evidence_registry` to shared `recording_registry` |
| `test_c1b_the_rejected_prose_reaches_no_shipped_artifact` | same | same |
| `test_c1c_the_guard_verdict_is_recorded_as_a_run_diagnostic` | same | same |
| `test_c3_the_flag_off_path_keeps_every_guard_reason_terminal` | same | same |
| `test_m1_defeating_the_flag_gate_restores_the_pre_cutover_outcome` | same | same |

No consumer test required a non-mechanical fix; no test was dropped or its assertions weakened.

## Test counts

- `tests/api/dev/test_chaos_3576_frame_construction_fixture.py` (new): 2 passed
- Full `tests/api/dev/` + `tests/_chaos_3301_subjects.py` + `tests/_chaos_3295_plan_executor.py` (`-m "not benchmark and not clickhouse"`, includes the 3 Postgres-backed consumer files — a local Postgres/ClickHouse happened to already be running, not started by this session): **2414 passed, 21 skipped, 40 deselected, 1 xfailed, 0 failed**
- `ruff format --check`, `ruff check`, `mypy` (pre-commit hooks): all pass

## Gate

Not run — no docker, no merge, per lane instructions. This PR is ready for review only.