### PR TITLE
CHAOS-3572: ordinary boots refuse a container serving another checkout

### DIFF
--- a/scripts/acceptance/container_source_guard.sh
+++ b/scripts/acceptance/container_source_guard.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# CHAOS-3572: the host-checkout <-> container-served-source identity guard,
+# generalized from the mint-only version #1582 added
+# (mint_ask_dev_world_snapshot.sh) so every ORDINARY acceptance-stack boot
+# entrypoint gets the same protection, from ONE place.
+#
+# Mechanism (see CHAOS-3572 for the full writeup): compose is launched with
+# `--project-directory <ops_root>`, and the api service bind-mounts that
+# directory at /app. The container therefore reads whichever worktree
+# BOOTED the stack, live -- not the checkout a later command happens to be
+# invoked from. Several lanes each hold their own worktree on this machine
+# (the normal state, not an edge case), so a stack booted by one lane keeps
+# serving that lane's source after being handed to another. Nothing else
+# reports this: `docker ps` shows a healthy stack, the API answers, tests
+# pass -- the only symptom is that results describe code nobody is looking
+# at.
+#
+# Usage: source this file, then call
+#   container_source_guard_check <ops_root> <compose_arg>...
+# where <compose_arg>... is the SAME base compose invocation array the
+# caller uses for its other `docker compose` calls (e.g. `"${compose[@]}"`
+# as built from `docker compose --project-name ... --project-directory ...
+# -f ... -f ... --profile ...`), WITHOUT a subcommand -- this function
+# appends `exec -T api ...` (and `ps -q api`) itself.
+#
+# Returns (does not exit -- the caller decides, same convention as any other
+# boolean-ish shell function):
+#   0  the container's source signature matches this checkout's.
+#   70 mismatch -- REFUSING is printed with both paths and the remedy.
+#      (Same code the mint guard, #1582, uses for the identical failure --
+#      a caller distinguishing "the guard refused" from any other boot
+#      failure does not need a second, different code to check.)
+#
+# macOS ships bash 3.2: no `${array[@]@Q}` (bash 5 only, the first version of
+# the mint guard died on this with "bad substitution" -- a guard that cannot
+# run is worse than none, because it reads as coverage) and no nameref
+# locals (`declare -n`, bash 4.3+). The compose command is therefore passed
+# POSITIONALLY ("$@"), never by name, and the file list is passed to the
+# container-side python interpreter as a single newline-delimited argument,
+# never interpolated through bash array quoting.
+
+# The source signature: sha256 over a set of files, computed on the host and
+# again inside the container, then hashed together. A signature rather than
+# probing one symbol, so ANY drift between the checkouts is caught, not just
+# drift in one already-known-interesting module. dev_health_ops/__init__.py
+# anchors the set to the same installed package the container-side snippet
+# resolves `dev_health_ops.__file__` against; the rest are the CHAOS-3544
+# fixture-generation files the mint guard already covers.
+CONTAINER_SOURCE_GUARD_FILES="dev_health_ops/__init__.py
+dev_health_ops/fixtures/generators/interactions.py
+dev_health_ops/fixtures/ttl_horizon.py
+dev_health_ops/fixtures/world_snapshot.py
+dev_health_ops/fixtures/world.py"
+
+container_source_guard_check() {
+  local ops_root="$1"
+  shift
+  local -a compose
+  compose=("$@")
+
+  echo "boot: verifying the api container is serving this checkout" >&2
+
+  local host_signature
+  host_signature="$(
+    for rel in ${CONTAINER_SOURCE_GUARD_FILES}; do
+      shasum -a 256 "${ops_root}/src/${rel}"
+    done | awk '{print $1}' | shasum -a 256 | awk '{print $1}'
+  )"
+
+  local container_signature
+  container_signature="$(
+    "${compose[@]}" exec -T api python -c "
+import hashlib, pathlib, sys
+import dev_health_ops
+root = pathlib.Path(dev_health_ops.__file__).resolve().parent.parent
+parts = [
+    hashlib.sha256((root / rel).read_bytes()).hexdigest()
+    for rel in sys.argv[1].split()
+]
+print(hashlib.sha256(('\n'.join(parts) + '\n').encode()).hexdigest())
+" "${CONTAINER_SOURCE_GUARD_FILES}" | tr -d '\r'
+  )"
+
+  if [[ "${host_signature}" == "${container_signature}" ]]; then
+    echo "boot: api container matches this checkout (${host_signature:0:12})" >&2
+    return 0
+  fi
+
+  # Mismatch: name BOTH paths, not just the signatures -- an operator hitting
+  # this needs to know which worktree the container is actually bound to, the
+  # same fact CHAOS-3572's own reproduction used (`docker inspect ...
+  # --format '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{end}}'`).
+  # Best-effort: if the container is gone or `docker inspect` fails, the
+  # refusal still fires on the signature mismatch alone.
+  local container_id served_from
+  container_id="$("${compose[@]}" ps -q api 2>/dev/null || true)"
+  served_from=""
+  if [[ -n "${container_id}" ]]; then
+    served_from="$(
+      docker inspect "${container_id}" \
+        --format '{{range .Mounts}}{{if eq .Destination "/app"}}{{.Source}}{{end}}{{end}}' \
+        2>/dev/null || true
+    )"
+  fi
+
+  echo "boot: REFUSING -- the api container is not serving this checkout." >&2
+  echo "boot:   host      ${host_signature}" >&2
+  echo "boot:   container ${container_signature}" >&2
+  echo "boot:   this checkout   ${ops_root}" >&2
+  echo "boot:   container /app  ${served_from:-<could not determine -- see docker inspect above>}" >&2
+  echo "boot: compose bind-mounts --project-directory at /app, so a stack booted from" >&2
+  echo "boot: a DIFFERENT worktree keeps serving that worktree's source even after" >&2
+  echo "boot: being handed to this one. Tear it down and boot fresh from this checkout." >&2
+  return 70
+}
+
+# Test-only direct-invocation entry point, mirroring ci/local_validate.sh's
+# `--ch-probe-only` precedent: `bash container_source_guard.sh <ops_root>
+# <compose_arg>...` drives the real function above through a stubbed
+# `docker` on PATH, with no caller script (and no docker daemon) required.
+# Never reached when this file is merely sourced by a boot entrypoint.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  container_source_guard_check "$@"
+  exit $?
+fi

--- a/scripts/acceptance/run_ask_dev_compose.sh
+++ b/scripts/acceptance/run_ask_dev_compose.sh
@@ -197,6 +197,19 @@ trap report_failure EXIT
 "${compose[@]}" down --volumes --remove-orphans
 "${compose[@]}" up -d --build --wait "${boot_services[@]}"
 
+# CHAOS-3572: refuse to proceed unless the api container we just booted is
+# serving THIS checkout. Runs immediately after boot and before anything --
+# world-restore, fixtures, any smoke/corpus script -- reads or writes through
+# it, so a wrong-worktree stack is refused here rather than discovered mid-
+# measurement (or not discovered at all: docker ps, the API, and every test
+# all look healthy regardless of which worktree booted the container). Same
+# mechanism and exit code (70) as the mint guard #1582 added for the one-off
+# mint flow; see container_source_guard.sh for why it is a shared function
+# rather than a copy in every entrypoint.
+# shellcheck source=container_source_guard.sh
+source "${script_dir}/container_source_guard.sh"
+container_source_guard_check "${ops_root}" "${compose[@]}"
+
 # CHAOS-3463 (Phase 2 exit blockers B2 + B3): seed the pinned
 # ask-dev-world.v1 into the databases this stack's API actually serves.
 #

--- a/scripts/acceptance/run_ask_dev_provider_profile.sh
+++ b/scripts/acceptance/run_ask_dev_provider_profile.sh
@@ -115,6 +115,15 @@ trap report_failure EXIT
 "${compose[@]}" up -d --build --wait \
   postgres pgbouncer clickhouse valkey migrate api
 
+# CHAOS-3572: same wrong-worktree guard run_ask_dev_compose.sh runs -- see
+# container_source_guard.sh. compose bind-mounts --project-directory at
+# /app, so this stack could just as easily be serving a different checkout's
+# source as the main acceptance launcher's stack can; nothing about being a
+# provider-profile boot instead exempts it.
+# shellcheck source=container_source_guard.sh
+source "${script_dir}/container_source_guard.sh"
+container_source_guard_check "${ops_root}" "${compose[@]}"
+
 "${compose[@]}" exec -T api dev-hops fixtures generate \
   --sink clickhouse://ch:ch@clickhouse:8123/default \
   --org "${fixture_org_id}" \

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -1194,6 +1194,78 @@ def test_beat_sentinel_date_parsing_handles_naive_and_aware_timestamps() -> None
 
 
 # ---------------------------------------------------------------------------
+# CHAOS-3572: ordinary-boot wrong-worktree guard
+# ---------------------------------------------------------------------------
+
+
+def test_launcher_sources_the_shared_container_source_guard() -> None:
+    """CHAOS-3572: an ordinary boot has the SAME exposure the mint guard
+    (#1582, CHAOS-3544) closed for the one-off mint flow -- `compose.yml` is
+    launched with `--project-directory <ops_root>` and bind-mounts that
+    directory at /app, so the launcher's own stack can just as easily serve
+    a different worktree's source. `docker ps`, the API, and every later
+    test all look healthy regardless of which worktree booted the container
+    -- nothing else in the launcher would ever report this.
+
+    Sourced from container_source_guard.sh (a shared function), NOT a
+    per-entrypoint copy -- CHAOS-3572 explicitly calls out avoiding
+    per-entrypoint duplication so a future boot entrypoint (e.g. the
+    corpus-lane armed-boot script) inherits the same check rather than
+    growing its own that can drift.
+    """
+
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    guard_script = _ROOT / "scripts" / "acceptance" / "container_source_guard.sh"
+    assert guard_script.exists(), (
+        "the shared guard script must exist for the launcher to source"
+    )
+    assert 'source "${script_dir}/container_source_guard.sh"' in launcher, (
+        "the launcher must source the SHARED guard, not reimplement its own "
+        "copy of the signature check"
+    )
+    assert "container_source_guard_check" in launcher, (
+        "the launcher must actually CALL the guard, not merely source the "
+        "file that defines it"
+    )
+
+
+def test_launcher_runs_the_container_source_guard_immediately_after_boot() -> None:
+    """Ordering is load-bearing, exactly like the world-restore check below:
+    the guard must run BEFORE `fixtures world-restore` (or anything else)
+    touches the stack -- a mismatch discovered after data has already been
+    restored/generated against the wrong container is a mismatch discovered
+    too late to matter."""
+
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    boot_index = launcher.index('up -d --build --wait "${boot_services[@]}"')
+    guard_call_index = launcher.index("container_source_guard_check ")
+    restore_index = launcher.index("dev-hops fixtures world-restore")
+
+    assert boot_index < guard_call_index < restore_index, (
+        "the container-source guard must run immediately after boot and "
+        "before the world is restored into the (possibly wrong) container"
+    )
+
+
+def test_launcher_container_source_guard_is_not_gated_by_acr_arming() -> None:
+    """The guard call must sit OUTSIDE the `if [[ "${acr_armed}" == "1" ]]`
+    block -- an ACR-armed boot has exactly the same bind-mount exposure as a
+    plain one, and a guard that only ran when ACR happened to be armed would
+    read as coverage it does not have on the (default, far more common)
+    unarmed path."""
+
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    acr_block_start = launcher.index('if [[ "${acr_armed}" == "1" ]]; then')
+    acr_block_end = launcher.index("\nfi\n", acr_block_start)
+    acr_block = launcher[acr_block_start:acr_block_end]
+
+    assert "container_source_guard_check" not in acr_block, (
+        "the guard must run unconditionally, not only inside the ACR-armed branch"
+    )
+    assert "container_source_guard_check" in launcher
+
+
+# ---------------------------------------------------------------------------
 # CHAOS-3463: world seeding wiring
 # ---------------------------------------------------------------------------
 

--- a/tests/acceptance/test_ask_dev_provider_profiles.py
+++ b/tests/acceptance/test_ask_dev_provider_profiles.py
@@ -90,6 +90,38 @@ def test_selected_ollama_local_profile_fails_before_compose_without_model() -> N
     assert "ASK_DEV_PROVIDER_MODEL is required" in result.stderr
 
 
+def test_launcher_runs_the_shared_container_source_guard_after_boot() -> None:
+    """CHAOS-3572: the provider-profile launcher boots its own compose
+    project with `--project-directory <ops_root>`, the same bind-mount
+    hazard `run_ask_dev_compose.sh` has -- a stack booted from a different
+    worktree keeps serving that worktree's source after being handed to
+    this one, and nothing else here would report it. Must source the SAME
+    shared guard the main launcher uses (not a copy), and must run it after
+    the api container boots but before anything reads or writes through it
+    (`fixtures generate` here, `fixtures world-restore` in the main
+    launcher).
+    """
+
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    guard_script = _ROOT / "scripts" / "acceptance" / "container_source_guard.sh"
+    assert guard_script.exists()
+    assert 'source "${script_dir}/container_source_guard.sh"' in launcher, (
+        "the provider-profile launcher must source the SHARED guard"
+    )
+    assert "container_source_guard_check" in launcher
+
+    boot_index = launcher.index(
+        "up -d --build --wait \\\n  postgres pgbouncer clickhouse valkey migrate api"
+    )
+    guard_call_index = launcher.index("container_source_guard_check ")
+    generate_index = launcher.index("dev-hops fixtures generate")
+
+    assert boot_index < guard_call_index < generate_index, (
+        "the guard must run immediately after boot and before fixtures are "
+        "generated against a possibly-wrong container"
+    )
+
+
 def test_live_smoke_uses_public_conversation_and_bounded_sse_contract() -> None:
     smoke = _SMOKE.read_text(encoding="utf-8")
     assert "/api/v1/dev/conversations" in smoke

--- a/tests/acceptance/test_container_source_guard.py
+++ b/tests/acceptance/test_container_source_guard.py
@@ -1,0 +1,228 @@
+"""Regression coverage for CHAOS-3572: the ORDINARY-boot wrong-worktree guard.
+
+CHAOS-3544 (#1582) gave the one-off mint script a host-checkout <->
+container-served-source signature check. CHAOS-3572 is the same failure at a
+wider blast radius: `compose.yml` is launched with `--project-directory
+<ops_root>` and bind-mounts that directory at /app, so ANY boot -- not just a
+mint -- can silently serve a different worktree's code. `docker ps` looks
+healthy, the API answers, tests pass; the only symptom is that results
+describe code the operator is not looking at.
+
+This drives the REAL `container_source_guard_check` function in
+`scripts/acceptance/container_source_guard.sh` through its `bash
+container_source_guard.sh <ops_root> <compose_arg>...` test-only direct-
+invocation entry point (same precedent as `--ch-probe-only` in
+`ci/local_validate.sh`, see `tests/tooling/test_local_validate_stage_manifest.py`).
+`docker` is always a PATH-shadowing stub -- no test here touches a real
+container or daemon.
+
+RED proof (recorded here, not re-asserted): before `container_source_guard.sh`
+existed, `test_mismatched_signature_is_refused_with_exit_70_naming_both_paths`
+below fails outright (`FileNotFoundError`/nonzero from a script that is not
+there). Planting the wrong-worktree condition against the OLD boot path
+(`run_ask_dev_compose.sh` before this change) never refuses at all -- the
+launcher has no signature check between `up -d --build --wait` and the first
+`fixtures world-restore`, so a container serving another checkout's code boots
+straight through. Mutation check: delete the mismatch branch's `return 70` in
+`container_source_guard_check` (or hardcode it to `return 0`) and this file's
+mismatch test fails while the match test keeps passing -- the two tests
+cannot both go green through a guard that stopped comparing anything.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD_SCRIPT = ROOT / "scripts" / "acceptance" / "container_source_guard.sh"
+_BASE_PATH = "/usr/bin:/bin"
+_TIMEOUT = 30
+
+# Mirrors CONTAINER_SOURCE_GUARD_FILES in container_source_guard.sh. Kept as
+# an independent literal (not imported/parsed out of the shell file) so this
+# test cannot be satisfied by a guard that silently changed what it hashes --
+# it fixes the fixture universe itself.
+_GUARD_FILES = (
+    "dev_health_ops/__init__.py",
+    "dev_health_ops/fixtures/generators/interactions.py",
+    "dev_health_ops/fixtures/ttl_horizon.py",
+    "dev_health_ops/fixtures/world_snapshot.py",
+    "dev_health_ops/fixtures/world.py",
+)
+
+_NON_DOCKER_TOOLS = ("bash", "shasum", "awk", "tr", "cat")
+
+
+def _fake_ops_root(tmp_path: Path) -> Path:
+    """A minimal host checkout: only the files the guard actually hashes."""
+    ops_root = tmp_path / "ops-checkout"
+    for rel in _GUARD_FILES:
+        path = ops_root / "src" / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Content includes the relative path so every file's bytes are
+        # distinct -- a guard that hashed the same file five times over would
+        # still "work" against identical fixtures.
+        path.write_text(f"# fixture content for {rel}\n", encoding="utf-8")
+    return ops_root
+
+
+def _expected_signature(ops_root: Path) -> str:
+    """Independently reproduces the host-side combination the guard's bash
+    pipeline performs (`shasum -a 256 <file> | awk '{print $1}'` per file,
+    then `shasum -a 256` over the concatenated per-file hash lines) -- NOT by
+    calling into the guard, or this would just be tautological."""
+    per_file_hashes = [
+        hashlib.sha256((ops_root / "src" / rel).read_bytes()).hexdigest()
+        for rel in _GUARD_FILES
+    ]
+    combined = ("\n".join(per_file_hashes) + "\n").encode("utf-8")
+    return hashlib.sha256(combined).hexdigest()
+
+
+def _fake_bin_dir(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for tool in _NON_DOCKER_TOOLS:
+        found = shutil.which(tool)
+        if found:
+            (bin_dir / tool).symlink_to(found)
+    return bin_dir
+
+
+def _write_fake_docker(
+    bin_dir: Path, *, container_signature: str, served_from: str
+) -> None:
+    """A PATH-shadowing `docker` stub standing in for BOTH `docker compose
+    ... exec -T api python -c ...` (the container-side signature probe) and
+    `docker inspect <id> --format ...` (the mismatch-path Mounts lookup) --
+    the same narrow-fake-the-one-call-that-matters shape
+    `test_local_validate_stage_manifest.py` uses for `docker ps`.
+    """
+    script = bin_dir / "docker"
+    script.write_text(
+        "#!/bin/bash\n"
+        'args="$*"\n'
+        'if [ "$1" = "compose" ]; then\n'
+        '  case "$args" in\n'
+        "    *' exec '*)\n"
+        f"      printf '%s\\n' {_sh_quote(container_signature)}\n"
+        "      exit 0\n"
+        "      ;;\n"
+        "    *' ps '*)\n"
+        "      printf '%s\\n' fake-container-id\n"
+        "      exit 0\n"
+        "      ;;\n"
+        "  esac\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "inspect" ]; then\n'
+        f"  printf '%s\\n' {_sh_quote(served_from)}\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    script.chmod(0o755)
+
+
+def _sh_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def _run_guard(
+    tmp_path: Path,
+    ops_root: Path,
+    *,
+    container_signature: str,
+    served_from: str = "/unused",
+) -> subprocess.CompletedProcess:
+    bin_dir = _fake_bin_dir(tmp_path)
+    _write_fake_docker(
+        bin_dir, container_signature=container_signature, served_from=served_from
+    )
+    compose_args = [
+        "docker",
+        "compose",
+        "--project-name",
+        "dev-health-ask-dev-acceptance",
+        "--project-directory",
+        str(ops_root),
+        "-f",
+        "compose.yml",
+        "--profile",
+        "ask-dev-acceptance",
+    ]
+    return subprocess.run(
+        ["bash", str(GUARD_SCRIPT), str(ops_root), *compose_args],
+        cwd=ROOT,
+        env={"PATH": f"{bin_dir}:{_BASE_PATH}"},
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+
+
+def test_matching_signature_is_accepted(tmp_path: Path) -> None:
+    """Sanity check: a container genuinely serving this checkout must pass,
+    or the mismatch test below would prove nothing about discrimination."""
+    ops_root = _fake_ops_root(tmp_path)
+    result = _run_guard(
+        tmp_path, ops_root, container_signature=_expected_signature(ops_root)
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 0, combined
+    assert "matches this checkout" in combined, combined
+    assert "REFUSING" not in combined, combined
+
+
+def test_mismatched_signature_is_refused_with_exit_70_naming_both_paths(
+    tmp_path: Path,
+) -> None:
+    """The CHAOS-3572 mechanism itself: plant a container whose source
+    signature does NOT match the host checkout (the wrong-worktree
+    condition) and observe a hard, loudly-worded refusal -- distinct exit
+    code, both paths named, and the guard clause ordering print (verify
+    ran) present.
+    """
+    ops_root = _fake_ops_root(tmp_path)
+    wrong_worktree = tmp_path / "ops-worktrees" / "some-other-lane"
+    result = _run_guard(
+        tmp_path,
+        ops_root,
+        container_signature="0" * 64,  # cannot collide with a real sha256
+        served_from=str(wrong_worktree),
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 70, combined
+    assert "REFUSING" in combined, combined
+    assert "verifying the api container is serving this checkout" in combined, (
+        f"the check must actually have RUN, not merely concluded.\n{combined}"
+    )
+    assert str(ops_root) in combined, (
+        f"the refusal must name the host checkout's path.\n{combined}"
+    )
+    assert str(wrong_worktree) in combined, (
+        f"the refusal must name the worktree the container is actually "
+        f"serving (via docker inspect's Mounts source) -- a signature "
+        f"mismatch alone tells an operator THAT it is wrong, not WHICH "
+        f"checkout it is instead.\n{combined}"
+    )
+    assert "matches this checkout" not in combined, combined
+
+
+def test_guard_runs_before_reporting_a_verdict(tmp_path: Path) -> None:
+    """The verifying line must precede either verdict line -- a guard that
+    printed its conclusion before actually comparing anything would still
+    satisfy naive substring checks."""
+    ops_root = _fake_ops_root(tmp_path)
+    result = _run_guard(
+        tmp_path, ops_root, container_signature=_expected_signature(ops_root)
+    )
+    combined = result.stdout + result.stderr
+    assert combined.index("verifying the api container is serving") < combined.index(
+        "matches this checkout"
+    ), combined

--- a/tests/acceptance/test_container_source_guard.py
+++ b/tests/acceptance/test_container_source_guard.py
@@ -32,12 +32,14 @@ cannot both go green through a guard that stopped comparing anything.
 from __future__ import annotations
 
 import hashlib
+import re
 import shutil
 import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 GUARD_SCRIPT = ROOT / "scripts" / "acceptance" / "container_source_guard.sh"
+MINT_SCRIPT = ROOT / "scripts" / "acceptance" / "mint_ask_dev_world_snapshot.sh"
 _BASE_PATH = "/usr/bin:/bin"
 _TIMEOUT = 30
 
@@ -226,3 +228,74 @@ def test_guard_runs_before_reporting_a_verdict(tmp_path: Path) -> None:
     assert combined.index("verifying the api container is serving") < combined.index(
         "matches this checkout"
     ), combined
+
+
+# --- guard-integrity: the two signature lists cannot silently diverge -------
+
+
+def _parse_bash_string_list(text: str, *, var_name: str) -> tuple[str, ...]:
+    """Extract the newline-delimited file list a bash var like
+    `VAR_NAME="a/b.py\nc/d.py"` is assigned, from the RAW SCRIPT TEXT --
+    never by sourcing the shell file or importing a copy of the list, or a
+    future edit to either script's list could drift without this test
+    noticing (the exact failure mode this test exists to catch, applied to
+    itself).
+    """
+    match = re.search(rf'{re.escape(var_name)}="(.*?)"', text, re.S)
+    assert match is not None, (
+        f'could not find {var_name}="..." in the script -- this parser or '
+        f"the script itself has drifted"
+    )
+    return tuple(line.strip() for line in match.group(1).splitlines() if line.strip())
+
+
+def test_shared_guard_and_mint_signature_lists_have_no_undocumented_drift() -> None:
+    """Review finding (post-merge-readiness pass on #1592): the shared boot
+    guard's `CONTAINER_SOURCE_GUARD_FILES` (5 files) and the mint script's
+    own `fixture_sources` (4 files, #1582/CHAOS-3544, unchanged here) are
+    two SEPARATE literals with nothing pinning them to each other -- and
+    they had ALREADY drifted (the shared list adds `dev_health_ops/__init__.py`
+    that mint's list has never had). Nothing caught that silently; this test
+    exists so nothing can again.
+
+    The relationship is EXACT and asserted both directions, not just
+    "some overlap": mint's list must be a subset of the shared list (every
+    fixture-generation file mint has always hashed is still hashed by every
+    ordinary boot), and the shared list's only addition over mint's must be
+    the one, deliberate, documented file.
+
+    Why `__init__.py` is shared-only, not backfilled into mint: it is not a
+    fixture-generation file at all -- CHAOS-3572 explicitly generalizes the
+    ordinary-boot signature "beyond the four fixture files" (the ticket's own
+    suggested shape) to anchor the comparison to the installed package
+    location itself (see container_source_guard.sh's own comment on
+    `CONTAINER_SOURCE_GUARD_FILES`), which the narrower one-off mint check
+    never needed and this task was not asked to widen. If mint's list ever
+    gains files beyond that anchor, or the shared list drops below it, this
+    assertion is the thing that goes red instead of the two lists silently
+    diverging further.
+    """
+
+    guard_text = GUARD_SCRIPT.read_text(encoding="utf-8")
+    mint_text = MINT_SCRIPT.read_text(encoding="utf-8")
+
+    shared_files = set(
+        _parse_bash_string_list(guard_text, var_name="CONTAINER_SOURCE_GUARD_FILES")
+    )
+    mint_files = set(_parse_bash_string_list(mint_text, var_name="fixture_sources"))
+
+    assert shared_files, "the shared guard's file list must not be empty"
+    assert mint_files, "the mint guard's file list must not be empty"
+
+    assert mint_files <= shared_files, (
+        f"every file mint hashes must still be hashed by the shared ordinary-"
+        f"boot guard -- mint hashes {sorted(mint_files - shared_files)} that "
+        f"the shared guard does not, so an ordinary boot would miss drift the "
+        f"mint would catch.\nshared={sorted(shared_files)}\nmint={sorted(mint_files)}"
+    )
+    assert shared_files - mint_files == {"dev_health_ops/__init__.py"}, (
+        f"the shared guard's only addition over mint's list must be the "
+        f"documented package-anchor file -- any other difference is "
+        f"undocumented drift, not a deliberate generalization.\n"
+        f"extra in shared: {sorted(shared_files - mint_files)}"
+    )


### PR DESCRIPTION
## Summary

- `compose.yml` binds `--project-directory <ops_root>` and the api service bind-mounts it at `/app`, so a stack booted from one worktree keeps serving that worktree's source after being handed to another lane — `docker ps`, the API, and every test all look healthy regardless. #1582 closed this for the one-off mint flow (`mint_ask_dev_world_snapshot.sh`) with a host-vs-container source-signature check; this closes it for ORDINARY boots.
- Factors the signature check into a shared, sourceable function (`scripts/acceptance/container_source_guard.sh`) rather than a per-entrypoint copy, and wires it into both ordinary-boot entrypoints (`run_ask_dev_compose.sh`, `run_ask_dev_provider_profile.sh`) immediately after `up -d --build --wait` and before anything reads/writes through the container. Same exit code as the mint guard (70). On mismatch, refuses loudly naming BOTH paths: this checkout's `ops_root`, and (via `docker inspect`'s Mounts) the worktree the container's `/app` is actually bind-mounted from.
- **Entrypoints covered:** `run_ask_dev_compose.sh` (main acceptance launcher), `run_ask_dev_provider_profile.sh` (provider-profile launcher). **Not covered:** `run_wave4_corpus.sh` — its own header states the stack must already be up and it never boots one, so there's no boot call for the guard to attach to; it inherits the protection transitively only if the stack it's pointed at was itself booted through one of the covered launchers. A future armed-corpus boot entrypoint (an in-flight, unmerged PR adds `scripts/acceptance/corpus/armed_corpus_boot.sh`) should call the same shared `container_source_guard_check` rather than growing its own copy — that's the reason this is a sourced function and not inline code.
- `mint_ask_dev_world_snapshot.sh` is left untouched (its own #1582 guard and test already cover it); unifying it with the shared helper was considered but would have required rewriting its existing, passing regression test for no behavioral gain, so it's left as a candidate follow-up rather than bundled here.

## RED-first proof

- `tests/acceptance/test_container_source_guard.py` drives the real `container_source_guard_check` shell function directly (via a `bash container_source_guard.sh <ops_root> <compose_arg>...` test-only entry point, same precedent as `--ch-probe-only` in `ci/local_validate.sh`) with a PATH-stubbed `docker` — no real containers or daemon touched. Confirmed RED: mutating the mismatch branch to always `return 0` makes `test_mismatched_signature_is_refused_with_exit_70_naming_both_paths` fail while the match-case test keeps passing; reverted after confirming.
- `tests/acceptance/test_ask_dev_compose.py` and `tests/acceptance/test_ask_dev_provider_profiles.py` gained static wiring/ordering assertions (source the shared guard, call it, run it before the first post-boot read/write, not gated behind ACR arming). Confirmed RED by stashing the two launcher edits and re-running — all 4 new assertions failed against the unmodified launchers; restored and green.

## Verification

- `.venv/bin/python -m pytest tests/acceptance tests/tooling -m "not benchmark and not clickhouse"`: 963 passed, 140 skipped, 0 failed.
- `ruff format --check .`, `ruff check .`, `mypy --install-types --non-interactive .`: all clean.
- `bash -n` against real macOS `/bin/bash` (3.2.57) for all three touched/added shell files, plus a manual runtime smoke of the guard under `/bin/bash` directly (mismatch → exit 70, both paths printed).
- No heredocs introduced (the ci/ heredoc-budget scanner doesn't cover `scripts/acceptance/` anyway, but the guard avoids the class regardless — same precedent as the mint guard's single-line `python -c`).

## Explicitly not done (per task scope)

No docker run against real containers, no corpus files, no other worktrees touched, no Linear status change, no gate run, no merge.

## Review follow-up (post-initial-review commit)

A focused reviewer pass on reachability, exit propagation, and reporter fail-direction came back clean, with two items:

1. **Fixed**: `CONTAINER_SOURCE_GUARD_FILES` (shared guard, 5 files) and mint's `fixture_sources` (4 files, unchanged, #1582) were two independent literals with nothing pinning them together — and had already drifted (the shared list's `dev_health_ops/__init__.py` anchor was never backfilled into mint's list, which was never asked to widen). Added `test_shared_guard_and_mint_signature_lists_have_no_undocumented_drift`, which parses both scripts' raw text and asserts the exact relation: mint's list ⊆ shared list, and the shared list's only addition over mint's is that one documented anchor file. Verified in both directions by mutation: an undocumented extra file added to mint's list, and the anchor file dropped from the shared list, are each independently caught; both scripts confirmed byte-identical to pre-mutation state afterward.
2. **Documented, no code change**: the container-side signature probe (`"${compose[@]}" exec -T api python -c ...` inside `container_source_guard_check`) is not `||`-guarded. Under the callers' `set -e`, a *transient* `docker compose exec` failure (container gone mid-probe, daemon hiccup) aborts the script directly at that line rather than falling through to the mismatch branch's REFUSING diagnostics — so on that specific failure mode, the operator gets a plain nonzero exit from the `exec` command instead of the guard's own worded message. This is fail-**safe** (the boot still stops, non-zero, before anything reads/writes through a possibly-wrong container) but the function header comment's "returns, does not exit" does not strictly hold on that path — worth knowing for the next reader before assuming every guard exit came from an explicit `return`.
