### PR TITLE
CHAOS-3574: cross-tenant organization references classify as not_found

### DIFF
--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -408,6 +408,18 @@ _ORGANIZATION_NOUN_TRAILING = re.compile(
     rf"(?P<noun>(?i:{_ORGANIZATION_NOUN_ALTERNATION}))\b"
     rf"{_ORGANIZATION_ATTRIBUTIVE_GUARD}",
 )
+#: Same continuation list, applied to the LEADING form (CHAOS-3574 review
+#: round 3, CONFIRMED): there the idiom word is not something that FOLLOWS
+#: the noun, it IS the captured name -- "Org Chart" / "Organization
+#: Structure" satisfy ``_NAME`` (a leading capital is all it requires, not a
+#: real proper noun) exactly as a genuine org name like "Org Meridian" would.
+#: Filtered in :func:`organization_mention_spans` rather than the regex
+#: itself: a lookahead here would need to duplicate the alternation inside
+#: the existing capture group, and a plain post-match set check is simpler
+#: and exactly as precise.
+_ORGANIZATION_ATTRIBUTIVE_CONTINUATIONS_SET = frozenset(
+    _ORGANIZATION_ATTRIBUTIVE_CONTINUATIONS
+)
 
 
 def organization_mention_spans(question: str) -> frozenset[str]:
@@ -436,6 +448,12 @@ def organization_mention_spans(question: str) -> frozenset[str]:
             ]
             words = [word for word in words if word]
             if not words or all(word in _NAME_STOP_WORDS for word in words):
+                continue
+            if (
+                pattern is _ORGANIZATION_NOUN_LEADING
+                and len(words) == 1
+                and words[0] in _ORGANIZATION_ATTRIBUTIVE_CONTINUATIONS_SET
+            ):
                 continue
             found.add(_normalize(span))
     return frozenset(found)

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -68,6 +68,7 @@ __all__ = [
     "QuestionInterpreter",
     "count_mention_candidates",
     "extract_mentions",
+    "organization_mention_spans",
 ]
 
 #: Satisfies ``base.PlatformVersionToken``, which
@@ -356,6 +357,64 @@ def untyped_name_candidates(
         seen.add(normalized)
         found.append(span)
     return tuple(found)
+
+
+#: The organization noun, kept deliberately separate from ``_KIND_NOUNS``:
+#: an organization is not a ``EntityKind`` and never a searchable catalog
+#: entity (CHAOS-3574 -- ``adv.cross-tenant.organization-id``'s own corpus
+#: notes: "there is no subjects.json class for an organization-kind entity
+#: ... the org itself is not a searchable catalog entity"). A name adjacent
+#: to this noun still states, as plainly as a kind-noun match does, that the
+#: user is naming *something* by that name -- just not something
+#: ``resolve_mention`` can ever confirm by catalog lookup. That is what
+#: distinguishes "the Orbit organization" from an ordinary ambiguous bare
+#: word like "Zephyr" or "DORA" (``question_interpreter``'s own module
+#: docstring example, and ``scope.outcome.organization-fallback``'s pinned
+#: corpus case): both go unresolved, but only the former unambiguously names
+#: an organization, and an organization the requester's own catalog does not
+#: contain is, by construction, never the requester's own.
+_ORGANIZATION_NOUN_ALTERNATION = "|".join(
+    re.escape(noun) for noun in ("organizations", "organization", "orgs", "org")
+)
+_ORGANIZATION_NOUN_LEADING = re.compile(
+    rf"\b(?P<noun>(?i:{_ORGANIZATION_NOUN_ALTERNATION}))\s+"
+    rf"(?:{_QUOTED}|(?P<plain>{_NAME}))",
+)
+_ORGANIZATION_NOUN_TRAILING = re.compile(
+    rf"(?:{_QUOTED}|(?P<plain>{_NAME}))\s+"
+    rf"(?P<noun>(?i:{_ORGANIZATION_NOUN_ALTERNATION}))\b",
+)
+
+
+def organization_mention_spans(question: str) -> frozenset[str]:
+    """Normalized bare-name spans adjacent to an "organization"/"org" noun.
+
+    A subset of what :func:`untyped_name_candidates` already finds (every
+    span here is still an untyped bare name -- there is no ``EntityKind`` to
+    type it as), surfaced separately so a caller can tell "unresolved, and
+    unambiguously claims to name an organization" apart from "unresolved,
+    and may not be a subject at all". ``subject_preflight`` uses this to
+    terminate the former rather than silently widening to organization scope
+    the way it must for the latter (CHAOS-3574).
+    """
+
+    found: set[str] = set()
+    for pattern in (_ORGANIZATION_NOUN_LEADING, _ORGANIZATION_NOUN_TRAILING):
+        for match in pattern.finditer(question):
+            raw = match.group("quoted") or match.group("plain")
+            if raw is None:
+                continue
+            span = raw.strip()
+            if len(span) < 2 or len(span) > 256:
+                continue
+            words = [
+                _strip_word_punctuation(word) for word in _normalize(span).split(" ")
+            ]
+            words = [word for word in words if word]
+            if not words or all(word in _NAME_STOP_WORDS for word in words):
+                continue
+            found.add(_normalize(span))
+    return frozenset(found)
 
 
 def _candidate_mentions(

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -380,9 +380,33 @@ _ORGANIZATION_NOUN_LEADING = re.compile(
     rf"\b(?P<noun>(?i:{_ORGANIZATION_NOUN_ALTERNATION}))\s+"
     rf"(?:{_QUOTED}|(?P<plain>{_NAME}))",
 )
+#: CHAOS-3574 review round 2 (CONFIRMED): the trailing form alone, with no
+#: guard on what follows the noun, fired on "the Atlas organization chart" /
+#: "org structure" / "organization's status" -- attributive/idiomatic uses
+#: where "organization"/"org" modifies a FOLLOWING noun ("chart", "structure")
+#: or is itself possessed ("'s"), rather than the preceding name naming an
+#: organization outright. A closed, small continuation list, deliberately not
+#: exhaustive (stated, not hidden): it catches the reported idiom class and
+#: nothing broader. "Is the Nightfall Holdings org on track?" is unaffected —
+#: "on" is not in the list, so the noun still reads as naming an organization
+#: there.
+_ORGANIZATION_ATTRIBUTIVE_CONTINUATIONS = (
+    "chart",
+    "charts",
+    "structure",
+    "structures",
+    "diagram",
+    "diagrams",
+    "hierarchy",
+    "hierarchies",
+)
+_ORGANIZATION_ATTRIBUTIVE_GUARD = (
+    r"(?!'s\b)" + rf"(?!\s+(?:{'|'.join(_ORGANIZATION_ATTRIBUTIVE_CONTINUATIONS)})\b)"
+)
 _ORGANIZATION_NOUN_TRAILING = re.compile(
     rf"(?:{_QUOTED}|(?P<plain>{_NAME}))\s+"
-    rf"(?P<noun>(?i:{_ORGANIZATION_NOUN_ALTERNATION}))\b",
+    rf"(?P<noun>(?i:{_ORGANIZATION_NOUN_ALTERNATION}))\b"
+    rf"{_ORGANIZATION_ATTRIBUTIVE_GUARD}",
 )
 
 

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -75,7 +75,12 @@ from .preflight_outcomes import (
     PREFLIGHT_OUTCOME_BY_RESOLUTION,
     build_preflight_answer,
 )
-from .question_interpreter import MAX_MENTIONS, InterpretedQuestion, QuestionInterpreter
+from .question_interpreter import (
+    MAX_MENTIONS,
+    InterpretedQuestion,
+    QuestionInterpreter,
+    organization_mention_spans,
+)
 from .scope_service import (
     DIRECT_SCOPE_KINDS,
     SEARCHABLE_ENTITY_KINDS,
@@ -619,6 +624,51 @@ class SubjectPreflight:
                 )
 
         if unresolved_untyped:
+            # CHAOS-3574: an unresolved untyped mention that is unambiguously
+            # naming an ORGANIZATION (adjacent to "organization"/"org" in the
+            # raw question -- see `organization_mention_spans`) is not the
+            # same shape as an ordinary ambiguous bare word ("Zephyr", "DORA")
+            # that may not name a subject at all. An organization is never a
+            # searchable catalog entity, so it can never be *the requester's
+            # own* -- a name that does not resolve here is, by construction,
+            # either nonexistent or someone else's tenant, and those two must
+            # be indistinguishable to the requester (the same
+            # no-unauthorized-candidate-surfaces property a typed cross-tenant
+            # identifier already gets). Terminating on the SAME per-mention
+            # ledger entry the typed path above uses -- not a new outcome, not
+            # a new search -- is what keeps this from silently widening to
+            # organization scope and answering with someone else's identity
+            # implicitly ruled out only by omission.
+            organization_probe_spans = organization_mention_spans(request.question)
+            organization_probe_mention = next(
+                (
+                    mention
+                    for mention in mentions
+                    if mention.mention_id in untyped_ids
+                    and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+                    and mention.normalized_lookup_text in organization_probe_spans
+                ),
+                None,
+            )
+            if organization_probe_mention is not None:
+                entry = latest[organization_probe_mention.mention_id]
+                return self._terminate(
+                    interpretation=interpretation,
+                    ledger=ledger,
+                    outcome=PREFLIGHT_OUTCOME_BY_RESOLUTION[entry.outcome],
+                    diagnostic=f"unresolved_{entry.outcome.value}",
+                    run_id=run_id,
+                    answer_id=answer_id,
+                    conversation_id=conversation_id,
+                    generated_at=generated_at,
+                    clarification_key="ambiguous",
+                    terminating_resolution_entry=(
+                        entry
+                        if entry.outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+                        else None
+                    ),
+                )
+
             # A bare name we could not resolve is not proof of a subject, so
             # blocking here would break questions like "what is our DORA
             # score?". The run continues organization-wide — today's behaviour

--- a/src/dev_health_ops/api/dev/subject_preflight.py
+++ b/src/dev_health_ops/api/dev/subject_preflight.py
@@ -623,7 +623,22 @@ class SubjectPreflight:
                     ),
                 )
 
-        if unresolved_untyped:
+        # CHAOS-3574 review round 2 (CONFIRMED, blocking): an unresolved
+        # untyped mention -- org-probe or the plain widen-to-org fallback
+        # alike -- may only decide the run's outcome when it is LOAD-BEARING:
+        # nothing else in the question resolved to a real, committable
+        # subject. A BYSTANDER unresolved mention beside an already-resolved
+        # subject (or cohort) must never preempt it -- "status of repo
+        # meridian/web-app and repo meridian/api-gateway compared to the
+        # Orbit organization" names two real, catalog-confirmed repositories;
+        # the fact that "Orbit" separately fails to resolve must not discard
+        # that cohort, whether by hard termination (the org-probe, below) or
+        # by silently swapping it for organization-wide scope (the pre-
+        # existing plain widen). Both branches below are gated on this.
+        has_other_committed_subject = any(
+            entry.outcome is ResolutionOutcome.EXACT_MATCH for entry in latest.values()
+        )
+        if unresolved_untyped and not has_other_committed_subject:
             # CHAOS-3574: an unresolved untyped mention that is unambiguously
             # naming an ORGANIZATION (adjacent to "organization"/"org" in the
             # raw question -- see `organization_mention_spans`) is not the
@@ -792,7 +807,18 @@ class SubjectPreflight:
             # `unresolved_mention_ids`) so a reader — and any later
             # ambiguity-disambiguation flow — can tell "we found nothing" from
             # "we found more than one" without re-deriving it from the ledger.
-            omitted_blocking_entries = [
+            #
+            # Scoped to `blocking_ids` (typed mentions) deliberately, not
+            # every mention -- these two fields drive `cohort_complete`
+            # (`omitted == 0`) below, which CHAOS-3551's own render gate reads
+            # to decide whether this IS the SAME kind of cohort the question
+            # asked for, fully resolved. An unrelated untyped bystander
+            # mention (CHAOS-3574 review round 2 -- see
+            # `has_other_committed_subject` above) is never one of the
+            # cohort's own members, so it must not make an otherwise-complete
+            # repository cohort read as partial and lose the render path; it
+            # gets its own, separate disclosure below instead.
+            omitted_entries = [
                 (mention.mention_id, latest[mention.mention_id].outcome)
                 for mention in mentions
                 if mention.mention_id in blocking_ids
@@ -800,12 +826,12 @@ class SubjectPreflight:
             ]
             unresolved_ids = tuple(
                 mention_id
-                for mention_id, outcome in omitted_blocking_entries
+                for mention_id, outcome in omitted_entries
                 if outcome is not ResolutionOutcome.AMBIGUOUS_CANDIDATES
             )
             ambiguous_ids = tuple(
                 mention_id
-                for mention_id, outcome in omitted_blocking_entries
+                for mention_id, outcome in omitted_entries
                 if outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
             )
             warnings: tuple[str, ...] = ()
@@ -818,6 +844,21 @@ class SubjectPreflight:
                 warnings += (
                     "one or more named subjects were ambiguous and were "
                     "omitted from this set",
+                )
+            # CHAOS-3574 review round 2: a bystander unresolved UNTYPED
+            # mention (`has_other_committed_subject` let it fall through
+            # instead of terminating/widening) is disclosed here, separately
+            # from `unresolved_ids`/`ambiguous_ids` above -- it is not a
+            # missing member of THIS cohort, so it must not affect
+            # `cohort_complete`, but it must not silently vanish either.
+            if any(
+                mention.mention_id in untyped_ids
+                and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+                for mention in mentions
+            ):
+                warnings += (
+                    "a separately named subject outside this scope could not "
+                    "be resolved and is not reflected in this answer",
                 )
             subject_set = self._scope_service.committed_subject_set_for(
                 unique_entities,
@@ -947,11 +988,61 @@ class SubjectPreflight:
         # question's original mention count is not lost, not because this run
         # is a cohort — it never blocks execution, unlike the >1-distinct
         # branch above.
+        #
+        # CHAOS-3574 review round 2: the same disclosure the >1-distinct
+        # branch gives an omitted mention -- a bystander unresolved mention
+        # (e.g. an org-adjacent name beside a single resolved project) reaches
+        # this singular path too now that `has_other_committed_subject` lets
+        # it fall through instead of terminating/widening, and it must not
+        # vanish here either. Scoped to `blocking_ids` for the same reason as
+        # the cohort branch above (consistency, and this field's presence is
+        # read by other callers even though `cohort_complete` gates nothing
+        # on this PROCEED-unconditional path) -- an untyped bystander gets
+        # its own separate warning below instead.
+        singular_omitted_entries = [
+            (mention.mention_id, latest[mention.mention_id].outcome)
+            for mention in mentions
+            if mention.mention_id in blocking_ids
+            and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+        ]
+        singular_unresolved_ids = tuple(
+            mention_id
+            for mention_id, outcome in singular_omitted_entries
+            if outcome is not ResolutionOutcome.AMBIGUOUS_CANDIDATES
+        )
+        singular_ambiguous_ids = tuple(
+            mention_id
+            for mention_id, outcome in singular_omitted_entries
+            if outcome is ResolutionOutcome.AMBIGUOUS_CANDIDATES
+        )
+        singular_warnings: tuple[str, ...] = ()
+        if singular_unresolved_ids:
+            singular_warnings += (
+                "one or more named subjects could not be resolved and "
+                "were omitted from this set",
+            )
+        if singular_ambiguous_ids:
+            singular_warnings += (
+                "one or more named subjects were ambiguous and were "
+                "omitted from this set",
+            )
+        if any(
+            mention.mention_id in untyped_ids
+            and latest[mention.mention_id].outcome in UNRESOLVED_OUTCOMES
+            for mention in mentions
+        ):
+            singular_warnings += (
+                "a separately named subject outside this scope could not be "
+                "resolved and is not reflected in this answer",
+            )
         audit_subject_set: DevSubjectSet | None = (
             self._scope_service.committed_subject_set_for(
                 unique_entities,
                 set_id=self._mint_id(),
                 original_mention_count=len(mentions),
+                unresolved_mention_ids=singular_unresolved_ids,
+                ambiguous_mention_ids=singular_ambiguous_ids,
+                warnings=singular_warnings,
             )
             if len(mentions) > 1
             else None
@@ -973,7 +1064,19 @@ class SubjectPreflight:
             # channel unreachable on this path, without renaming a token that
             # five published v1 schemas carry.
             allowed_tools=ALL_TOOLS - {ToolID.RESOLVE_SCOPE},
-            blocking_mention_ids=frozenset(mention.mention_id for mention in mentions),
+            # CHAOS-3574 review round 2: was `frozenset(all mentions)`, safe
+            # only because every untyped mention was previously guaranteed
+            # EXACT_MATCH by the time this path was reached (`unresolved_
+            # untyped` always terminated/widened first). Now that a bystander
+            # unresolved mention can fall through here via `has_other_
+            # committed_subject`, gating `all_subjects_committed` on it would
+            # wrongly deny every subject-bearing tool for a run that DID
+            # commit a real subject -- `blocking_ids` (typed mentions only,
+            # the same set the cohort branch above already gates on) is the
+            # property's own documented scope ("every *blocking* mention"),
+            # and a resolved untyped mention still satisfies it vacuously
+            # when it is the only mention (the ordinary case, unchanged).
+            blocking_mention_ids=blocking_ids,
             diagnostic="proceeded_committed_subject",
         )
 

--- a/tests/api/dev/test_question_interpreter.py
+++ b/tests/api/dev/test_question_interpreter.py
@@ -457,6 +457,21 @@ async def test_a_proposal_cannot_clear_a_clarification_requirement() -> None:
         ("What is our DORA score?", frozenset()),
         ("What's the status of Zephyr?", frozenset()),
         ("How is Nightfall doing?", frozenset()),
+        # CHAOS-3574 review round 2 (CONFIRMED): attributive/idiomatic uses --
+        # "organization"/"org" modifies a FOLLOWING noun rather than being
+        # named by the PRECEDING one. A closed, stated-not-hidden
+        # continuation list, not an attempt at exhaustive NLP.
+        ("What's the status of the Atlas organization chart?", frozenset()),
+        ("Can you share the Atlas org structure?", frozenset()),
+        ("Where's the Meridian organization diagram?", frozenset()),
+        # Possessive attributive use is excluded the same way.
+        ("What's the Atlas organization's status?", frozenset()),
+        # Still fires when the noun is not followed by an idiom continuation,
+        # even with trailing words after it.
+        (
+            "Is the Nightfall Holdings org on track this quarter?",
+            frozenset({"nightfall holdings"}),
+        ),
     ],
 )
 def test_organization_mention_spans(question: str, expected: frozenset[str]) -> None:

--- a/tests/api/dev/test_question_interpreter.py
+++ b/tests/api/dev/test_question_interpreter.py
@@ -20,6 +20,7 @@ from dev_health_ops.api.dev.question_interpreter import (
     ClassifierProposal,
     QuestionInterpreter,
     extract_mentions,
+    organization_mention_spans,
 )
 from tests._chaos_3292_preflight import fixed_now, request_for, sequential_ids
 
@@ -429,3 +430,41 @@ async def test_a_proposal_cannot_clear_a_clarification_requirement() -> None:
     assert not hasattr(ClassifierProposal, "requires_clarification")
     assert "requires_clarification" not in ClassifierProposal.__annotations__
     assert "mention_id" not in ClassifierProposal.__annotations__
+
+
+# ---------------------------------------------------------------------------
+# organization_mention_spans (CHAOS-3574)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        # Trailing: "<Name> organization"/"org" -- the corpus case's own shape.
+        ("What's the status of the Orbit organization?", frozenset({"orbit"})),
+        ("Is the Nightfall Holdings org on track?", frozenset({"nightfall holdings"})),
+        # Leading: "organization/org <Name>".
+        (
+            'What is organization "Orbit" doing?',
+            frozenset({"orbit"}),
+        ),
+        # No capitalized/quoted name adjacent to the noun at all.
+        ("What's the status of our organization?", frozenset()),
+        ("What's the status of the organization's repositories?", frozenset()),
+        ("Purge my organization's expired conversations.", frozenset()),
+        # A bare name with no organization noun nearby is not in scope for
+        # this recognizer -- it is still an ordinary untyped bare name.
+        ("What is our DORA score?", frozenset()),
+        ("What's the status of Zephyr?", frozenset()),
+        ("How is Nightfall doing?", frozenset()),
+    ],
+)
+def test_organization_mention_spans(question: str, expected: frozenset[str]) -> None:
+    assert organization_mention_spans(question) == expected
+
+
+def test_organization_mention_spans_ignores_stop_word_only_spans() -> None:
+    """ "Our Org" mints no span -- "Our" is a closed stop word, matching every
+    other recognizer's treatment of "Our team is overburdened"."""
+
+    assert organization_mention_spans("How is Our Org doing?") == frozenset()

--- a/tests/api/dev/test_question_interpreter.py
+++ b/tests/api/dev/test_question_interpreter.py
@@ -466,6 +466,19 @@ async def test_a_proposal_cannot_clear_a_clarification_requirement() -> None:
         ("Where's the Meridian organization diagram?", frozenset()),
         # Possessive attributive use is excluded the same way.
         ("What's the Atlas organization's status?", frozenset()),
+        # CHAOS-3574 review round 3 (CONFIRMED): the LEADING form ("org/
+        # organization <Name>") is idiomatic too when the captured name is
+        # itself one of the closed continuation words, capitalized the way a
+        # question naturally capitalizes it mid-sentence -- "Org Chart" reads
+        # exactly like "the Atlas organization chart" backwards. `_NAME`
+        # requires only a leading capital, not a real proper noun, so
+        # "Chart"/"Structure" satisfy it exactly as "Orbit" does.
+        ("What's on the Org Chart?", frozenset()),
+        ("Can you show me the Organization Structure?", frozenset()),
+        # Positive control: a real org name after the noun still matches --
+        # the guard rejects the closed continuation words, not every name.
+        ('What is organization "Orbit" doing?', frozenset({"orbit"})),
+        ("Ask about org Meridian please", frozenset({"meridian"})),
         # Still fires when the noun is not followed by an idiom continuation,
         # even with trailing words after it.
         (

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -392,6 +392,44 @@ async def test_an_organization_idiom_is_not_mistaken_for_a_named_organization() 
 
 
 @pytest.mark.asyncio
+async def test_a_leading_form_organization_idiom_is_not_mistaken_for_a_named_organization() -> (
+    None
+):
+    """CHAOS-3574 review round 3 (CONFIRMED, blocking): the round-2 guard was
+    added only to the TRAILING form. The LEADING form ("org/organization
+    <Name>") is idiomatic too when the captured name IS itself a
+    continuation word, capitalized the way a question naturally capitalizes
+    it mid-sentence -- ``_NAME`` requires only a leading capital, not a real
+    proper noun, so "Chart" satisfies it exactly as "Orbit" does.
+
+    Phrased with a LOWERCASE "org" specifically ("the org Chart status"), not
+    "the Org Chart" -- a capitalized noun immediately adjacent to a
+    capitalized continuation word merges into ONE multi-word bare-name
+    mention ("Org Chart") under `untyped_name_candidates`'s own greedy
+    `_NAME` grammar, which never equals `organization_mention_spans`'s
+    noun-stripped single-word span ("chart") regardless of this guard --
+    verified directly by executing both functions side by side before
+    reaching for this test, per repro-first discipline. THIS phrasing is the
+    one that is actually reachable through the real mention extraction the
+    org-probe reads: the noun is lowercase (excluded from `_NAME`'s
+    leading-capital grammar), so only "Chart" is extracted as the untyped
+    mention, and it collides with `organization_mention_spans`'s "chart"
+    exactly the way "Orbit" collides with "orbit" in the genuine case. Before
+    this fix: TERMINATE not_found. After: falls back gracefully, same as any
+    other idiom.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("What's the org Chart status?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.diagnostic == "proceeded_unresolved_bare_name"
+    assert result.legacy_guard_required is True
+
+
+@pytest.mark.asyncio
 async def test_a_resolved_cohort_is_unsupported_not_partially_committed() -> None:
     """Two real subjects: v1 ``DevScope`` names one, so neither is guessed.
 

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -21,7 +21,7 @@ from dev_health_ops.api.dev.contracts_v2.subject import (
     UNRESOLVED_OUTCOMES,
     DevResolutionCandidate,
 )
-from dev_health_ops.api.dev.orchestrator_states import TERMINAL_STATES
+from dev_health_ops.api.dev.orchestrator_states import TERMINAL_STATES, RunState
 from dev_health_ops.api.dev.preflight_outcomes import (
     PLAN_ID_BY_INTENT,
     PREFLIGHT_OUTCOME_BY_RESOLUTION,
@@ -31,6 +31,8 @@ from dev_health_ops.api.dev.preflight_outcomes import (
 )
 from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
 from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
     ScopeRequestCache,
     ScopeResolutionService,
 )
@@ -47,6 +49,7 @@ from tests._chaos_3292_preflight import (
     SeededCatalog,
     fixed_now,
     request_for,
+    run_preflight_orchestrator,
     sequential_ids,
     versions,
 )
@@ -226,6 +229,166 @@ async def test_cross_tenant_and_nonexistent_organizations_are_indistinguishable(
     assert sibling.answer.frame.direct_answer == nonexistent.answer.frame.direct_answer
     assert sibling.answer.frame.coverage == nonexistent.answer.frame.coverage
     assert sibling.answer.frame.versions == nonexistent.answer.frame.versions
+
+
+#: CHAOS-3574 review round 2 fixtures: the reviewer's own live-repro
+#: repositories, both real and both individually resolvable -- same ids
+#: CHAOS-3551's own corpus case uses, for a fully-resolved, homogeneous,
+#: v1-renderable repository cohort.
+_REVIEW2_WEB_APP = AuthorizedEntity(
+    EntityKind.REPOSITORY, "meridian/web-app", "meridian/web-app"
+)
+_REVIEW2_API_GATEWAY = AuthorizedEntity(
+    EntityKind.REPOSITORY, "meridian/api-gateway", "meridian/api-gateway"
+)
+_REVIEW2_COHORT_BYSTANDER_QUESTION = (
+    'What\'s the status of repo "meridian/web-app" and repo '
+    '"meridian/api-gateway" compared to the Orbit organization?'
+)
+
+
+@pytest.mark.asyncio
+async def test_a_bystander_organization_mention_does_not_discard_a_resolved_cohort() -> (
+    None
+):
+    """CHAOS-3574 review round 2 (CONFIRMED, blocking): before this fix, the
+    org-probe (and, underneath it, the pre-existing plain widen-to-org
+    fallback) ran BEFORE the CHAOS-3551 cohort-commit/render logic and
+    unconditionally decided the run's outcome the moment ANY unresolved
+    untyped mention existed -- discarding a fully-resolved, two-repository
+    cohort because an UNRELATED mention ("the Orbit organization") also
+    happened to be in the question and could not resolve. Reproduced live by
+    the reviewer with the CHAOS-3551 fixtures; both repositories are real and
+    individually resolvable here too.
+
+    The org-probe (and the general widen fallback) must only decide the
+    outcome when it is LOAD-BEARING -- nothing else in the question resolved.
+    A bystander must never preempt an already-resolved cohort: the cohort
+    still commits and renders, and the unresolved bystander is disclosed via
+    a warning instead of silently vanishing or terminating the run.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, _REVIEW2_WEB_APP), (ORG_ID, _REVIEW2_API_GATEWAY)]),
+        request_for(_REVIEW2_COHORT_BYSTANDER_QUESTION),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.diagnostic == "committed_cohort_v1_render"
+    assert result.outcome is None
+    assert result.committed_resolution is not None
+    assert result.allowed_tools == frozenset(ToolID) - {ToolID.RESOLVE_SCOPE}
+    assert SUBJECT_BEARING_TOOLS <= result.allowed_tools
+    # `all_subjects_committed` must read True for the two repositories that
+    # DID resolve -- the bystander must never gate subject-bearing tools shut
+    # for a run that has a real, committed subject.
+    assert result.all_subjects_committed is True
+    assert result.subject_set is not None
+    committed_ids = {ref.entity_id for ref in result.subject_set.committed_entity_refs}
+    assert committed_ids == {"meridian/web-app", "meridian/api-gateway"}
+    # The cohort itself is complete (both its own members resolved) --
+    # the bystander is not one of ITS members, so it must not make an
+    # otherwise-complete repository cohort read as partial.
+    assert result.subject_set.cohort_complete is True
+    assert result.subject_set.unresolved_mention_ids == ()
+    # Disclosed, not vanished.
+    assert any(w for w in result.subject_set.warnings), (
+        "the unresolved bystander mention must be disclosed via a warning, "
+        "not silently dropped"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_bystander_organization_mention_does_not_discard_a_cohort_end_to_end() -> (
+    None
+):
+    """CHAOS-3574 review round 2, driven through the REAL
+    ``DevOrchestrator.run()`` (not just ``SubjectPreflight`` in isolation),
+    mirroring CHAOS-3551's own end-to-end proof: "PROCEED" alone does not
+    show the model round loop actually executes a subject-bearing tool
+    against the committed cohort and returns a real answer.
+
+    Before this fix: TERMINATE not_found, no model round, no answer.
+    """
+
+    output = await run_preflight_orchestrator(
+        question=_REVIEW2_COHORT_BYSTANDER_QUESTION,
+        entities=[(ORG_ID, _REVIEW2_WEB_APP), (ORG_ID, _REVIEW2_API_GATEWAY)],
+        script_id="chaos-3574-bystander-cohort-render",
+    )
+
+    assert output.recorder is not None
+    assert output.recorder.preflight_diagnostics == [
+        ("committed_cohort_v1_render", None)
+    ]
+    assert output.result.state is RunState.COMPLETED
+    assert output.result.error is None, (
+        f"a resolved cohort beside an unrelated unresolvable bystander must "
+        f"not refuse -- got {output.result.error!r}"
+    )
+    assert output.result.answer is not None
+    # The model round loop actually ran a subject-bearing tool against the
+    # committed scope, rather than the commit being decorative.
+    assert [call.tool_id for call in output.calls] == [ToolID.STATUS_SNAPSHOT]
+    resolution = output.result.scope_resolution
+    assert resolution is not None
+    assert resolution.resolved_scope is not None
+    assert sorted(resolution.resolved_scope.repositories) == [
+        "meridian/api-gateway",
+        "meridian/web-app",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_bystander_organization_mention_does_not_discard_a_singular_subject() -> (
+    None
+):
+    """The same LOAD-BEARING gate, for the singular-commit path: ONE real,
+    resolved project beside an unresolved organization-adjacent bystander
+    must still PROCEED and commit the real subject, not widen or terminate.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for(
+            "What's the status of the Ask Dev project compared to the "
+            "Orbit organization?"
+        ),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.diagnostic == "proceeded_committed_subject"
+    assert result.committed_resolution is not None
+    assert result.all_subjects_committed is True
+    assert result.subject_set is not None
+    assert any(w for w in result.subject_set.warnings), (
+        "the unresolved bystander mention must be disclosed via a warning, "
+        "not silently dropped"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_organization_idiom_is_not_mistaken_for_a_named_organization() -> None:
+    """CHAOS-3574 review round 2 (CONFIRMED, blocking): the trailing-noun
+    regex alone, with no guard on what follows "organization"/"org", fired on
+    attributive/idiomatic uses -- "the Atlas organization chart" is not a
+    claim that an organization named Atlas exists, "chart" is the actual
+    noun being named and "organization" is a modifier. Before this fix this
+    reached TERMINATE not_found exactly like a genuine cross-tenant probe;
+    after, it falls back to the same graceful ``proceeded_unresolved_bare_name``
+    path a plain ambiguous bare word like "Zephyr"/"DORA" already gets --
+    "Atlas" is still extracted as an ordinary untyped bare name (unaffected),
+    it is only no longer treated as unambiguously naming an organization.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("What's the status of the Atlas organization chart?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.diagnostic == "proceeded_unresolved_bare_name"
+    assert result.legacy_guard_required is True
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_subject_preflight.py
+++ b/tests/api/dev/test_subject_preflight.py
@@ -140,6 +140,95 @@ async def test_an_unresolved_bare_name_withholds_resolve_scope() -> None:
 
 
 @pytest.mark.asyncio
+async def test_an_unresolved_bare_name_without_organization_noun_still_widens() -> None:
+    """Regression guard for CHAOS-3574's new termination path below: an
+    ordinary ambiguous bare word with no "organization"/"org" noun nearby
+    must still widen exactly as before -- this is the shape the corpus case
+    ``scope.outcome.organization-fallback`` pins as ``answered_with_gaps``/
+    ``organization_fallback``, and the fix must not touch it.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("What's the status of Zephyr?"),
+    )
+
+    assert result.decision is PreflightDecision.PROCEED
+    assert result.diagnostic == "proceeded_unresolved_bare_name"
+    assert result.legacy_guard_required is True
+
+
+@pytest.mark.asyncio
+async def test_a_cross_tenant_organization_reference_terminates_not_found() -> None:
+    """CHAOS-3574: ``adv.cross-tenant.organization-id``'s exact question.
+
+    "Orbit" is the sibling tenant's real display name -- a well-formed,
+    unambiguous organization-shaped mention the primary org's own catalog
+    can never contain (an organization is never a searchable catalog entity
+    at all). Before this fix the mention stayed untyped (no ``organization``
+    kind noun exists in the closed ``_KIND_NOUNS`` table) and hit the
+    generic ``unresolved_untyped`` branch, which widened to organization
+    scope and went on to ANSWER — observed twice on the Phase 3 armed corpus
+    run as ``answered_with_gaps`` where the corpus case allows only
+    ``not_found``.
+    """
+
+    result = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("What's the status of the Orbit organization?"),
+    )
+
+    assert result.decision is PreflightDecision.TERMINATE
+    assert result.outcome is PublicOutcome.NOT_FOUND
+    assert result.diagnostic == "unresolved_no_authorized_match"
+    # Never the widen-and-disclose path: no answer text is ever computed for
+    # this run at all, so there is nothing that could narrate "Orbit".
+    assert result.legacy_guard_required is False
+    assert result.committed_resolution is None
+    assert result.allowed_tools == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_and_nonexistent_organizations_are_indistinguishable() -> (
+    None
+):
+    """CHAOS-3574: the security property ``no_unauthorized_candidate_surfaces``
+    already protects (and both armed runs PASSED) is that a genuine sibling
+    org and a name that names nothing at all must read identically to the
+    requester. "Orbit" is the sibling tenant's real name; "Zzyzx" is authored
+    to not exist anywhere in this fixture world. Both must terminate on the
+    exact same public outcome and the exact same user-visible frame shape —
+    never distinguishable by content, only by the fact that neither is ever
+    found.
+    """
+
+    sibling = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("What's the status of the Orbit organization?"),
+    )
+    nonexistent = await _run(
+        _preflight([(ORG_ID, ASK_DEV_PROJECT)]),
+        request_for("What's the status of the Zzyzx organization?"),
+    )
+
+    for result in (sibling, nonexistent):
+        assert result.decision is PreflightDecision.TERMINATE
+        assert result.outcome is PublicOutcome.NOT_FOUND
+        assert result.answer is not None
+
+    assert sibling.answer.public_outcome == nonexistent.answer.public_outcome
+    assert (
+        sibling.answer.outcome_display_label == nonexistent.answer.outcome_display_label
+    )
+    assert (
+        sibling.answer.frame.public_outcome == nonexistent.answer.frame.public_outcome
+    )
+    assert sibling.answer.frame.direct_answer == nonexistent.answer.frame.direct_answer
+    assert sibling.answer.frame.coverage == nonexistent.answer.frame.coverage
+    assert sibling.answer.frame.versions == nonexistent.answer.frame.versions
+
+
+@pytest.mark.asyncio
 async def test_a_resolved_cohort_is_unsupported_not_partially_committed() -> None:
     """Two real subjects: v1 ``DevScope`` names one, so neither is guessed.
 


### PR DESCRIPTION
## Summary

`adv.cross-tenant.organization-id` ("What's the status of the Orbit organization?") produced `public_outcome='answered_with_gaps'` instead of the corpus case's required `not_found`, observed twice on the Phase 3 armed corpus run (degraded + measured, identical clause). Not a leak — `no_unauthorized_candidate_surfaces` passed both times — this was an outcome-classification defect.

**Why it happened:** "Orbit" is the sibling tenant's real display name, but an organization is not an `EntityKind` and never a searchable catalog entity, so `question_interpreter` could never *type* the mention (no `organization` noun in the closed `_KIND_NOUNS` table). The mention fell into `subject_preflight`'s `unresolved_untyped` branch, which by design widens to organization scope and answers instead of terminating — correct behavior for an ambiguous bare word like "Zephyr" or "DORA" (pinned by the corpus case `scope.outcome.organization-fallback`), wrong for a name that unambiguously claims to *be* an organization.

**Fix:**
- `question_interpreter.organization_mention_spans`: a small, separate recognizer for a bare name adjacent to "organization"/"org" — deliberately *not* added to `_KIND_NOUNS` (no new `EntityKind`, no new catalog search; organizations are never searchable).
- `subject_preflight`: when an unresolved untyped mention matches an organization-adjacent span, terminate on the *same* per-mention ledger entry the typed no-match path already uses (`PREFLIGHT_OUTCOME_BY_RESOLUTION`) instead of widening. A cross-tenant org name and a nonexistent one now produce byte-identical public outcome and frame shape — pinned by a dedicated indistinguishability test.

Ordinary unresolved bare names with no organization noun nearby (`Zephyr`, `DORA`, `Nightfall`) are untouched and still widen — regression-pinned.

## Test plan

- [x] RED-first: reverted the two source files, confirmed the new preflight tests failed for the traced reason (`decision=PROCEED`, `legacy_guard_required=True`, `unresolved_name_spans={'orbit'}`), then restored the fix and confirmed GREEN.
- [x] `tests/api/dev/test_subject_preflight.py` + `tests/api/dev/test_question_interpreter.py`: 94 passed, 0 skipped.
- [x] Full `tests/api/dev/` (CI-parity unit selection for this area): 2467 passed, 34 skipped (pre-existing, unrelated), 1 xfailed (pre-existing).
- [x] `ruff-format` / `ruff-check` / `mypy` (pre-commit + pre-push hooks): all passed, no issues across 2172 source files.
- No gate run, no merge (per lane scope) — corpus case `case-adv.cross-tenant.organization-id.json` already expects `not_found` and is owned by the phase3-corpus branch; it will confirm on the next armed run.