### PR TITLE
CHAOS-3582: honestly price the QUA shadow guard's unpriced provider/model pairs

### DIFF
--- a/src/dev_health_ops/llm/budget.py
+++ b/src/dev_health_ops/llm/budget.py
@@ -28,6 +28,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
 from dev_health_ops.db import get_postgres_session
+from dev_health_ops.llm.agent.openai_compatible import (
+    _PLATFORM_MODEL_PRICES as _BORROWED_OPENAI_MODEL_PRICES,
+)
+from dev_health_ops.llm.agent.openai_compatible import (
+    _canonical_priced_model as _borrowed_canonical_model,
+)
 from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
 from dev_health_ops.llm.errors import LLMError
 from dev_health_ops.llm.providers.base import CompletionResult, LLMProvider
@@ -218,7 +224,52 @@ def reliable_price(
         return _PRICE_PER_MILLION[(normalized_provider, normalized_model)]
     if normalized_provider != "openai" or not _official_openai_endpoint(base_url):
         return None
-    return _PRICE_PER_MILLION.get((normalized_provider, normalized_model))
+    own_price = _PRICE_PER_MILLION.get((normalized_provider, normalized_model))
+    if own_price is not None:
+        return own_price
+    return _borrowed_official_openai_price(model)
+
+
+def _borrowed_official_openai_price(model: str) -> tuple[int, int, int] | None:
+    """A REAL model this table has not been priced for yet, borrowed from
+    ``llm.agent.openai_compatible``'s own sourced, cited snapshot rates.
+
+    CHAOS-3582 (scope widened past the acceptance fixture): the shared dev
+    stack armed the QUA shadow ladder with the REAL provider on the OFFICIAL
+    OpenAI endpoint -- no base_url override at all -- and it failed closed
+    exactly the same way, for a DIFFERENT reason: ``ops/.env`` configures
+    ``LLM_MODEL="gpt-5-nano"``, and this module's own ``_PRICE_PER_MILLION``
+    has never priced anything but ``gpt-5-mini``. Every ``dev_run_qua_shadow``
+    row since the flags were armed reported ``skipped_budget_exhausted`` /
+    ``budget_unavailable`` for that reason -- CHAOS-3389 has no shadow
+    evidence from dev, and CHAOS-3525's commit mode reads as inert to a user
+    despite being armed, purely because the guard can never reserve.
+
+    Preferred over hand-adding another literal entry here for every model an
+    operator happens to configure: ``openai_compatible._PLATFORM_MODEL_PRICES``
+    already carries real, cited, per-model rates for exactly this purpose
+    (CHAOS-3552), and reusing it is honest pricing from a real source rather
+    than a second guess. This is a deliberate, temporary bridge in the
+    DIRECTION OPPOSITE of CHAOS-3560's eventual consolidation (which deletes
+    ``_PLATFORM_MODEL_PRICES`` in favour of THIS module's own table) --
+    acceptable because it only ever WIDENS what gets priced, never narrows
+    what already fails closed, and CHAOS-3560 is the ticket that resolves the
+    direction permanently. Excludes the acceptance fixture itself (handled,
+    unconditionally, before the endpoint check above) so this function is
+    reached only for a genuine OpenAI-official-endpoint real model.
+
+    Cached input is charged at the FULL input rate -- the same conservative
+    simplification ``openai_compatible._estimated_cost_microusd`` already
+    documents for its own accounting ("the normalized usage contract does not
+    expose cached-token detail"). Conservative because it can only ever
+    OVER-count, never under-count, a real cost.
+    """
+
+    canonical = _borrowed_canonical_model(model)
+    if canonical is None or canonical == SCRIPTED_OPENAI_MODEL:
+        return None
+    input_rate, output_rate = _BORROWED_OPENAI_MODEL_PRICES[canonical]
+    return (input_rate, input_rate, output_rate)
 
 
 def cost_micro_usd(

--- a/src/dev_health_ops/llm/budget.py
+++ b/src/dev_health_ops/llm/budget.py
@@ -50,21 +50,29 @@ LICENSE_LIMIT_KEY: Final = "byo_llm_budget_micro_usd"
 # Integer micro-USD per one million tokens.  Only exact, server-certified
 # provider/model pairs are present.  An absent pair is unavailable, never zero.
 # Source snapshot: https://developers.openai.com/api/docs/models/gpt-5-mini
-#
-# CHAOS-3582: ``SCRIPTED_OPENAI_MODEL`` ("ask-dev-scripted-v1") is the Ask Dev
-# acceptance stack's deterministic, deliberately-free test double -- not a
-# real, billable model. Priced here (tiny, non-zero, same rate on all three
-# legs) rather than left absent, mirroring the SAME carve-out
-# ``llm.agent.openai_compatible`` already made for the live platform-cost path
-# (``_PLATFORM_MODEL_PRICES["ask-dev-scripted-v1"] = (1_000, 1_000)``,
-# CHAOS-3552) -- same model id, same "test double, not an unpriced production
-# model" reasoning, mirrored here for ``reliable_price``'s own callers
-# (``guard_qua_shadow_call``, CHAOS-3452/CHAOS-3532).
 _PRICE_PER_MILLION: Final[dict[tuple[str, str], tuple[int, int, int]]] = {
     # input, cached input, output
     ("openai", "gpt-5-mini"): (250_000, 25_000, 2_000_000),
-    ("openai", SCRIPTED_OPENAI_MODEL): (1_000, 1_000, 1_000),
 }
+
+# CHAOS-3582: ``SCRIPTED_OPENAI_MODEL`` ("ask-dev-scripted-v1") is the Ask Dev
+# acceptance stack's deterministic, deliberately-free test double -- not a
+# real, billable model. Priced (tiny, non-zero, same rate on all three legs)
+# rather than left absent, mirroring the SAME carve-out
+# ``llm.agent.openai_compatible`` already made for the live platform-cost path
+# (``_PLATFORM_MODEL_PRICES["ask-dev-scripted-v1"] = (1_000, 1_000)``,
+# CHAOS-3552).
+#
+# Deliberately NOT an entry in ``_PRICE_PER_MILLION`` above -- review finding
+# (CHAOS-3582, confidence 90, confirmed live): that dict backs the generic
+# "official endpoint, known real model" lookup ``reliable_price`` falls
+# through to, so a fixture entry THERE would be reachable by MODEL NAME
+# ALONE the instant a caller's base_url happens to be empty or
+# ``api.openai.com`` -- exactly the transport-gate bypass
+# ``_is_acceptance_scripted_transport`` exists to close. Kept as a separate
+# constant, returned ONLY from the transport-gated branch in
+# ``reliable_price``, so there is no path back into the shared dict at all.
+_ACCEPTANCE_SCRIPTED_PROVIDER_PRICE: Final[tuple[int, int, int]] = (1_000, 1_000, 1_000)
 
 BudgetReason = Literal[
     "available",
@@ -198,6 +206,46 @@ def _official_openai_endpoint(base_url: str | None) -> bool:
     return parsed.scheme == "https" and parsed.hostname == "api.openai.com"
 
 
+#: CHAOS-3582 review finding (BLOCKING, confidence 90, fixed here): an
+#: earlier revision of the fixture carve-out below matched on MODEL NAME
+#: alone. Model name is tenant-controlled for a BYO configuration -- a
+#: tenant could name THEIR OWN model, on THEIR OWN real endpoint, literally
+#: ``"ask-dev-scripted-v1"``, and every real call would then price at the
+#: fixture's near-zero rate through ``guard_byo_call`` (this module) or
+#: ``guard_qua_shadow_call`` (``llm/qua_shadow_budget.py``) alike --
+#: defeating their own license-capped budget. Verified live before this
+#: constant existed: ``reliable_price(provider="openai",
+#: model="ask-dev-scripted-v1", base_url="https://api.openai.com")``
+#: returned the fixture's tuple, unconditionally, on the REAL OpenAI
+#: endpoint.
+#:
+#: Gated here on the ONE transport the acceptance stack's scripted provider
+#: is ever actually served from (``tests/acceptance/compose.ask-dev.yml``'s
+#: ``ASK_DEV_ACCEPTANCE_OPENAI_BASE_URL``) -- a plain (non-TLS), internal,
+#: Docker-network-only hostname:port a real BYO or production endpoint has
+#: no plausible reason to coincide with. A drift here (the compose service
+#: renamed, its port changed) fails SAFE: the acceptance stack reverts to
+#: this ticket's ORIGINAL unpriced-and-loud symptom, never a silent pricing
+#: hole -- the model-name match alone was the only thing that could fail
+#: unsafe, and it no longer stands alone.
+_ACCEPTANCE_SCRIPTED_PROVIDER_HOST: Final = "ask-dev-scripted-openai"
+_ACCEPTANCE_SCRIPTED_PROVIDER_PORT: Final = 8001
+
+
+def _is_acceptance_scripted_transport(base_url: str | None) -> bool:
+    if not base_url:
+        return False
+    try:
+        parsed = urlsplit(str(base_url))
+    except ValueError:
+        return False
+    return (
+        parsed.scheme == "http"
+        and parsed.hostname == _ACCEPTANCE_SCRIPTED_PROVIDER_HOST
+        and parsed.port == _ACCEPTANCE_SCRIPTED_PROVIDER_PORT
+    )
+
+
 def reliable_price(
     *, provider: str, model: str, base_url: str | None
 ) -> tuple[int, int, int] | None:
@@ -208,20 +256,28 @@ def reliable_price(
     # ``llm.agent.openai_compatible.platform_cost_metering`` already uses for
     # the SAME model id, for the SAME reason stated there: the Ask Dev
     # acceptance stack serves this model from its OWN scripted endpoint by
-    # construction (``tests/acceptance/compose.ask-dev.yml``), never from
-    # ``api.openai.com``, so an endpoint-first check would leave it
-    # permanently unpriced. Unpriced is what made ``guard_qua_shadow_call``
-    # (the isolated QUA shadow budget guard, CHAOS-3452) fail closed on
-    # every acceptance call, unconditionally -- the scripted QUA answer,
-    # contract-id routing, and commit/disclosure logic CHAOS-3532 built were
-    # never reachable as a result (see the CHAOS-3582 writeup for the full
-    # repro). Matched on the exact normalized model id only -- provider
-    # comparison and model normalization both already lowercase (this
-    # module's own house style, unlike ``openai_compatible``'s
-    # case-SENSITIVE carve-out), so this only ever exempts the one literal
-    # fixture id, never a real customer's differently-named model.
-    if normalized_provider == "openai" and normalized_model == SCRIPTED_OPENAI_MODEL:
-        return _PRICE_PER_MILLION[(normalized_provider, normalized_model)]
+    # construction, never from ``api.openai.com``, so an endpoint-first check
+    # would leave it permanently unpriced. Unpriced is what made
+    # ``guard_qua_shadow_call`` (the isolated QUA shadow budget guard,
+    # CHAOS-3452) fail closed on every acceptance call, unconditionally --
+    # the scripted QUA answer, contract-id routing, and commit/disclosure
+    # logic CHAOS-3532 built were never reachable as a result (see the
+    # CHAOS-3582 writeup for the full repro).
+    #
+    # Matched on the model id AND the acceptance stack's own scripted
+    # transport, both -- not model id alone (see
+    # ``_is_acceptance_scripted_transport``'s docstring for why that was a
+    # real, confirmed pricing hole). A real customer's differently-named
+    # model is never exempted by the model check; a real customer's own
+    # endpoint -- even one that happens to be named
+    # ``"ask-dev-scripted-v1"`` -- is never exempted by the transport check.
+    # Both must hold.
+    if (
+        normalized_provider == "openai"
+        and normalized_model == SCRIPTED_OPENAI_MODEL
+        and _is_acceptance_scripted_transport(base_url)
+    ):
+        return _ACCEPTANCE_SCRIPTED_PROVIDER_PRICE
     if normalized_provider != "openai" or not _official_openai_endpoint(base_url):
         return None
     own_price = _PRICE_PER_MILLION.get((normalized_provider, normalized_model))

--- a/src/dev_health_ops/llm/budget.py
+++ b/src/dev_health_ops/llm/budget.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.services.configuration.generic import SettingsService
 from dev_health_ops.db import get_postgres_session
+from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
 from dev_health_ops.llm.errors import LLMError
 from dev_health_ops.llm.providers.base import CompletionResult, LLMProvider
 from dev_health_ops.models.licensing import OrgLicense
@@ -43,9 +44,20 @@ LICENSE_LIMIT_KEY: Final = "byo_llm_budget_micro_usd"
 # Integer micro-USD per one million tokens.  Only exact, server-certified
 # provider/model pairs are present.  An absent pair is unavailable, never zero.
 # Source snapshot: https://developers.openai.com/api/docs/models/gpt-5-mini
+#
+# CHAOS-3582: ``SCRIPTED_OPENAI_MODEL`` ("ask-dev-scripted-v1") is the Ask Dev
+# acceptance stack's deterministic, deliberately-free test double -- not a
+# real, billable model. Priced here (tiny, non-zero, same rate on all three
+# legs) rather than left absent, mirroring the SAME carve-out
+# ``llm.agent.openai_compatible`` already made for the live platform-cost path
+# (``_PLATFORM_MODEL_PRICES["ask-dev-scripted-v1"] = (1_000, 1_000)``,
+# CHAOS-3552) -- same model id, same "test double, not an unpriced production
+# model" reasoning, mirrored here for ``reliable_price``'s own callers
+# (``guard_qua_shadow_call``, CHAOS-3452/CHAOS-3532).
 _PRICE_PER_MILLION: Final[dict[tuple[str, str], tuple[int, int, int]]] = {
     # input, cached input, output
     ("openai", "gpt-5-mini"): (250_000, 25_000, 2_000_000),
+    ("openai", SCRIPTED_OPENAI_MODEL): (1_000, 1_000, 1_000),
 }
 
 BudgetReason = Literal[
@@ -184,9 +196,29 @@ def reliable_price(
     *, provider: str, model: str, base_url: str | None
 ) -> tuple[int, int, int] | None:
     normalized_provider = provider.strip().lower()
+    normalized_model = _normalized_model(model)
+    # CHAOS-3582: the fixture carve-out is checked FIRST, before the
+    # official-endpoint test -- mirroring the ordering
+    # ``llm.agent.openai_compatible.platform_cost_metering`` already uses for
+    # the SAME model id, for the SAME reason stated there: the Ask Dev
+    # acceptance stack serves this model from its OWN scripted endpoint by
+    # construction (``tests/acceptance/compose.ask-dev.yml``), never from
+    # ``api.openai.com``, so an endpoint-first check would leave it
+    # permanently unpriced. Unpriced is what made ``guard_qua_shadow_call``
+    # (the isolated QUA shadow budget guard, CHAOS-3452) fail closed on
+    # every acceptance call, unconditionally -- the scripted QUA answer,
+    # contract-id routing, and commit/disclosure logic CHAOS-3532 built were
+    # never reachable as a result (see the CHAOS-3582 writeup for the full
+    # repro). Matched on the exact normalized model id only -- provider
+    # comparison and model normalization both already lowercase (this
+    # module's own house style, unlike ``openai_compatible``'s
+    # case-SENSITIVE carve-out), so this only ever exempts the one literal
+    # fixture id, never a real customer's differently-named model.
+    if normalized_provider == "openai" and normalized_model == SCRIPTED_OPENAI_MODEL:
+        return _PRICE_PER_MILLION[(normalized_provider, normalized_model)]
     if normalized_provider != "openai" or not _official_openai_endpoint(base_url):
         return None
-    return _PRICE_PER_MILLION.get((normalized_provider, _normalized_model(model)))
+    return _PRICE_PER_MILLION.get((normalized_provider, normalized_model))
 
 
 def cost_micro_usd(

--- a/tests/llm/test_chaos_3582_qua_shadow_fixture_pricing.py
+++ b/tests/llm/test_chaos_3582_qua_shadow_fixture_pricing.py
@@ -1,0 +1,250 @@
+"""CHAOS-3582: the isolated QUA shadow budget guard failed closed on the Ask
+Dev acceptance stack's own scripted provider, unconditionally.
+
+Found by the CHAOS-3532 live verify (2026-08-07): with the QUA shadow armed,
+``dev_run_qua_shadow`` never reached ``evaluated`` -- every call reported
+``status=skipped_budget_exhausted``, ``error_class=budget_unavailable``, with
+ZERO rows in ``dev_qua_shadow_budget_reservations`` (it failed before ever
+reserving, not from quota depletion).
+
+Root cause, traced to ``llm.budget.reliable_price``: it requires
+``_official_openai_endpoint(base_url)`` -- true only for an empty base_url or
+exactly ``https://api.openai.com`` -- before it will even consult the price
+table. The acceptance stack's scripted provider is served from
+``http://ask-dev-scripted-openai:8001/v1`` by construction
+(``tests/acceptance/compose.ask-dev.yml``), so it was NEVER priced, and
+``guard_qua_shadow_call`` (``llm/qua_shadow_budget.py``) treats an unpriced
+provider/model as an accounting error and fails closed -- unlike the live/BYO
+guard, which lets an unpriced custom provider through unbudgeted. That
+asymmetry is deliberate (a real customer's unpriced spend must never be
+silently reported as free) and this fix does not touch it: the scripted
+provider is not unbudgeted here, it is honestly, explicitly priced -- the
+SAME carve-out ``llm.agent.openai_compatible`` already made for the SAME
+model id on the live platform-cost path (CHAOS-3552).
+
+RED-first: every assertion in ``test_the_acceptance_fixture_is_priced_on_its_
+own_non_official_endpoint`` and
+``test_the_qua_shadow_guard_actually_reaches_evaluated_for_the_fixture``
+fails against ``reliable_price``/``guard_qua_shadow_call`` before this
+ticket's fix (``_PRICE_PER_MILLION`` had no ``ask-dev-scripted-v1`` entry, and
+``reliable_price`` checked the endpoint before any carve-out). The
+anti-widening tests below must stay green in both states -- they pin that the
+fix does not fail OPEN for anything else.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.llm.agent.contracts import (
+    AgentDecisionResult,
+    AgentFinalAnswer,
+    AgentMessage,
+    AgentMessageRole,
+    AgentUsage,
+)
+from dev_health_ops.llm.agent.scripted_openai_service import SCRIPTED_OPENAI_MODEL
+from dev_health_ops.llm.budget import reliable_price
+from dev_health_ops.llm.qua_shadow_budget import attach_qua_shadow_budget_guard
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.llm_budget import QUAShadowBudgetReservation
+from dev_health_ops.models.users import Organization
+from tests._helpers import tables_of
+
+#: The acceptance stack's real, internal-only base_url
+#: (``tests/acceptance/compose.ask-dev.yml``'s
+#: ``ASK_DEV_ACCEPTANCE_OPENAI_BASE_URL``) -- never ``api.openai.com``, and
+#: that gap is the entire defect.
+_ACCEPTANCE_BASE_URL = "http://ask-dev-scripted-openai:8001/v1"
+
+
+def test_the_acceptance_fixture_is_priced_on_its_own_non_official_endpoint() -> None:
+    """The exact call shape ``guard_qua_shadow_call`` makes for the
+    acceptance stack must resolve to a real price, not ``None``."""
+
+    price = reliable_price(
+        provider="openai", model=SCRIPTED_OPENAI_MODEL, base_url=_ACCEPTANCE_BASE_URL
+    )
+    assert price is not None, (
+        "the acceptance fixture must be priced on its own scripted endpoint "
+        "-- an unpriced result here is exactly CHAOS-3582's defect"
+    )
+    input_rate, cached_input_rate, output_rate = price
+    assert input_rate > 0
+    assert cached_input_rate > 0
+    assert output_rate > 0
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        f"{SCRIPTED_OPENAI_MODEL}-v2",
+        f"{SCRIPTED_OPENAI_MODEL}-",
+        f"not-{SCRIPTED_OPENAI_MODEL}",
+        SCRIPTED_OPENAI_MODEL.rstrip("1") + "2",
+    ],
+)
+def test_fixture_carve_out_does_not_widen_to_neighbouring_model_ids(
+    model: str,
+) -> None:
+    """Anti-widening control, mirroring CHAOS-3552's own: the carve-out is
+    an EXACT model-id match. A stem-sharing neighbour on the same
+    non-official endpoint must stay unpriced -- exactly the fail-closed
+    posture CHAOS-3582 is not allowed to weaken."""
+
+    assert (
+        reliable_price(provider="openai", model=model, base_url=_ACCEPTANCE_BASE_URL)
+        is None
+    )
+
+
+def test_a_real_custom_endpoint_model_stays_unpriced() -> None:
+    """The general fail-closed rule for a genuine BYO/custom endpoint is
+    untouched: a real customer's self-hosted gateway serving a real model
+    must still be unpriced, so the live guard's own accounting stays honest
+    about what it cannot know."""
+
+    assert (
+        reliable_price(
+            provider="openai",
+            model="gpt-4o",
+            base_url="https://my-byo-gateway.example/v1",
+        )
+        is None
+    )
+
+
+def test_a_real_openai_model_on_an_unlisted_endpoint_stays_unpriced() -> None:
+    """Same control, non-acceptance flavour: a real OpenAI-compatible
+    gateway (Azure, OpenRouter, a corporate proxy) serving a REAL model must
+    not be swept into the fixture carve-out just because it shares the
+    ``openai`` provider name."""
+
+    assert (
+        reliable_price(
+            provider="openai",
+            model="gpt-5-mini",
+            base_url="https://my-corporate-openai-gateway.example/v1",
+        )
+        is None
+    )
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'qua_shadow.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(Organization, QUAShadowBudgetReservation),
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+class _FakeScriptedProvider:
+    """Mirrors ``scripted_openai_service``'s QUA answer shape closely enough
+    for the guard's usage extraction and reconciliation -- the guard itself,
+    not the HTTP transport, is what this test exercises."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def decide(
+        self,
+        messages,
+        tools,
+        response_schema,
+        timeout_seconds,
+        max_output_tokens,
+        signal=None,
+    ) -> AgentDecisionResult:
+        self.calls += 1
+        return AgentDecisionResult(
+            decision=AgentFinalAnswer(
+                value={"schema_version": "dev_question_understanding.v1"}
+            ),
+            usage=AgentUsage(input_tokens=42, output_tokens=17, cached_input_tokens=0),
+            latency_ms=1,
+            provider_fingerprint="fake-scripted",
+            model_fingerprint="fake-scripted",
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_the_qua_shadow_guard_actually_reaches_evaluated_for_the_fixture(
+    session_maker, monkeypatch
+) -> None:
+    """End-to-end reproduction of CHAOS-3582's exact reported symptom:
+    ``guard_qua_shadow_call`` against the acceptance provider/model/base_url
+    triple must reserve, invoke, and reconcile as ``succeeded`` -- not raise
+    ``QUAShadowBudgetAccountingError`` before ever calling the provider.
+
+    Before the fix: this raises ``QUAShadowBudgetAccountingError`` and
+    ``provider.calls`` stays ``0`` -- the scripted service is never even
+    invoked, matching the live boot's zero rows in
+    ``dev_qua_shadow_budget_reservations``.
+    """
+
+    org_id = str(uuid.uuid4())
+    async with session_maker() as session:
+        session.add(
+            Organization(
+                id=uuid.UUID(org_id),
+                slug=f"qua-shadow-pricing-{org_id[:8]}",
+                name="QUA Shadow Pricing Test Organization",
+                tier="team",
+            )
+        )
+        await session.commit()
+
+    @asynccontextmanager
+    async def shadow_budget_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.qua_shadow_budget.get_postgres_session",
+        shadow_budget_session,
+    )
+
+    provider = _FakeScriptedProvider()
+    guarded = attach_qua_shadow_budget_guard(
+        provider,
+        org_id=org_id,
+        provider="openai",
+        model=SCRIPTED_OPENAI_MODEL,
+        base_url=_ACCEPTANCE_BASE_URL,
+    )
+    result = await guarded.decide(
+        [AgentMessage(AgentMessageRole.USER, "question")], (), {"type": "object"}, 1, 64
+    )
+    assert result.decision.value == {"schema_version": "dev_question_understanding.v1"}
+    assert provider.calls == 1, "the scripted provider must actually be invoked"
+
+    async with session_maker() as session:
+        rows = list(
+            (await session.execute(select(QUAShadowBudgetReservation))).scalars()
+        )
+    assert len(rows) == 1, (
+        "exactly one reservation must exist -- CHAOS-3582 observed ZERO "
+        "because the guard raised before ever reserving"
+    )
+    assert rows[0].status == "succeeded"
+    assert rows[0].actual_micro_usd is not None
+    assert rows[0].actual_micro_usd >= 0

--- a/tests/llm/test_chaos_3582_qua_shadow_fixture_pricing.py
+++ b/tests/llm/test_chaos_3582_qua_shadow_fixture_pricing.py
@@ -40,6 +40,21 @@ the fix does not fail OPEN for anything else: a stem-sharing neighbour
 model id, a real model on a genuine custom/BYO endpoint, and a genuinely
 unpriced real model on the OFFICIAL endpoint (neither table has ever heard
 of it) must all still resolve to ``None``.
+
+Review finding (BLOCKING, confidence 90, fixed here): an earlier revision of
+the shape-1 carve-out matched on MODEL NAME alone, with no transport check.
+Confirmed live before the fix: a BYO tenant naming THEIR OWN model, on THEIR
+OWN real endpoint, literally ``"ask-dev-scripted-v1"`` got priced at the
+fixture's near-zero rate -- on the real OpenAI endpoint, with no base_url
+override at all, AND (a second leak the same review turned up) even via the
+generic ``_PRICE_PER_MILLION`` official-endpoint lookup once the fixture had
+an entry there. Fixed by requiring BOTH the model id AND the acceptance
+stack's own scripted transport (``_is_acceptance_scripted_transport``), and
+by keeping the fixture's price OUT of ``_PRICE_PER_MILLION`` entirely so
+there is no path back into the shared, name-only lookup.
+``test_a_byo_tenant_cannot_name_their_way_into_the_fixture_price`` and
+``test_the_fixture_transport_gate_requires_an_exact_match`` are the
+permanent regression coverage for this.
 """
 
 from __future__ import annotations
@@ -90,6 +105,64 @@ def test_the_acceptance_fixture_is_priced_on_its_own_non_official_endpoint() -> 
     assert input_rate > 0
     assert cached_input_rate > 0
     assert output_rate > 0
+
+
+@pytest.mark.parametrize(
+    ("case_id", "base_url"),
+    [
+        ("official_openai_endpoint", "https://api.openai.com"),
+        ("tenants_own_byo_gateway", "https://tenant-byo-gateway.example.com/v1"),
+        ("no_base_url_override_at_all", None),
+    ],
+)
+def test_a_byo_tenant_cannot_name_their_way_into_the_fixture_price(
+    case_id: str, base_url: str | None
+) -> None:
+    """Review finding (BLOCKING, confidence 90): model name alone is
+    tenant-controlled for a BYO configuration. Before the transport gate, a
+    tenant naming THEIR OWN model literally ``"ask-dev-scripted-v1"`` got
+    priced at the fixture's near-zero rate on every one of these three real
+    call shapes -- verified live, including through the generic
+    ``_PRICE_PER_MILLION`` official-endpoint lookup once the fixture had an
+    entry there. Not the acceptance stack's own transport in any of these
+    three cases, so all three must resolve to ``None``."""
+
+    assert (
+        reliable_price(
+            provider="openai", model=SCRIPTED_OPENAI_MODEL, base_url=base_url
+        )
+        is None
+    ), f"{case_id}: a non-acceptance transport must never get the fixture price"
+
+
+@pytest.mark.parametrize(
+    ("case_id", "base_url"),
+    [
+        # Right host and port, wrong (TLS) scheme.
+        (
+            "https_scheme_on_the_right_host_and_port",
+            "https://ask-dev-scripted-openai:8001/v1",
+        ),
+        # Right host and scheme, wrong port.
+        ("wrong_port_on_the_right_host", "http://ask-dev-scripted-openai:9999/v1"),
+        # Right scheme and port, wrong host.
+        ("wrong_host_on_the_right_port", "http://not-the-scripted-service:8001/v1"),
+    ],
+)
+def test_the_fixture_transport_gate_requires_an_exact_match(
+    case_id: str, base_url: str
+) -> None:
+    """The transport gate is an exact (scheme, host, port) match, not a
+    substring or partial one -- a near-miss must still fail closed, the
+    same discipline the model-id anti-widening tests already apply to the
+    OTHER half of the carve-out's condition."""
+
+    assert (
+        reliable_price(
+            provider="openai", model=SCRIPTED_OPENAI_MODEL, base_url=base_url
+        )
+        is None
+    ), f"{case_id}: a near-miss transport must never get the fixture price"
 
 
 @pytest.mark.parametrize(

--- a/tests/llm/test_chaos_3582_qua_shadow_fixture_pricing.py
+++ b/tests/llm/test_chaos_3582_qua_shadow_fixture_pricing.py
@@ -1,35 +1,45 @@
-"""CHAOS-3582: the isolated QUA shadow budget guard failed closed on the Ask
-Dev acceptance stack's own scripted provider, unconditionally.
+"""CHAOS-3582: the isolated QUA shadow budget guard failed closed on
+unpriced provider/model pairs, in TWO distinct ways.
 
-Found by the CHAOS-3532 live verify (2026-08-07): with the QUA shadow armed,
-``dev_run_qua_shadow`` never reached ``evaluated`` -- every call reported
+Shape 1 -- found by the CHAOS-3532 live verify (2026-08-07) against the Ask
+Dev acceptance stack: with the QUA shadow armed, ``dev_run_qua_shadow`` never
+reached ``evaluated`` -- every call reported
 ``status=skipped_budget_exhausted``, ``error_class=budget_unavailable``, with
 ZERO rows in ``dev_qua_shadow_budget_reservations`` (it failed before ever
-reserving, not from quota depletion).
+reserving, not from quota depletion). Root cause: ``llm.budget.reliable_price``
+requires ``_official_openai_endpoint(base_url)`` -- true only for an empty
+base_url or exactly ``https://api.openai.com`` -- before it will even
+consult the price table, and the acceptance stack's scripted provider is
+served from ``http://ask-dev-scripted-openai:8001/v1`` by construction, so
+it was never priced.
 
-Root cause, traced to ``llm.budget.reliable_price``: it requires
-``_official_openai_endpoint(base_url)`` -- true only for an empty base_url or
-exactly ``https://api.openai.com`` -- before it will even consult the price
-table. The acceptance stack's scripted provider is served from
-``http://ask-dev-scripted-openai:8001/v1`` by construction
-(``tests/acceptance/compose.ask-dev.yml``), so it was NEVER priced, and
-``guard_qua_shadow_call`` (``llm/qua_shadow_budget.py``) treats an unpriced
-provider/model as an accounting error and fails closed -- unlike the live/BYO
-guard, which lets an unpriced custom provider through unbudgeted. That
-asymmetry is deliberate (a real customer's unpriced spend must never be
-silently reported as free) and this fix does not touch it: the scripted
-provider is not unbudgeted here, it is honestly, explicitly priced -- the
-SAME carve-out ``llm.agent.openai_compatible`` already made for the SAME
-model id on the live platform-cost path (CHAOS-3552).
+Shape 2 -- found immediately after, live-reproduced in the SHARED DEV STACK
+with the REAL provider: the same failure, for a DIFFERENT reason. Dev has no
+base_url override at all (official endpoint), but ``ops/.env`` configures
+``LLM_MODEL="gpt-5-nano"``, and ``_PRICE_PER_MILLION`` had only ever priced
+``gpt-5-mini``. Every ``dev_run_qua_shadow`` row since the flags were armed
+reported the identical ``skipped_budget_exhausted`` / ``budget_unavailable``
+symptom -- CHAOS-3389 has no shadow evidence from dev, and CHAOS-3525's
+commit mode reads as inert to a user despite being armed.
 
-RED-first: every assertion in ``test_the_acceptance_fixture_is_priced_on_its_
-own_non_official_endpoint`` and
-``test_the_qua_shadow_guard_actually_reaches_evaluated_for_the_fixture``
-fails against ``reliable_price``/``guard_qua_shadow_call`` before this
-ticket's fix (``_PRICE_PER_MILLION`` had no ``ask-dev-scripted-v1`` entry, and
-``reliable_price`` checked the endpoint before any carve-out). The
-anti-widening tests below must stay green in both states -- they pin that the
-fix does not fail OPEN for anything else.
+Fix for both: honest pricing, never a fail-open exemption.
+* Shape 1 -- an exact-match carve-out mirroring the SAME one
+  ``llm.agent.openai_compatible`` already made for the SAME model id on the
+  live platform-cost path (CHAOS-3552), checked before the endpoint test.
+* Shape 2 -- ``reliable_price`` borrows a REAL model's rate from
+  ``openai_compatible._PLATFORM_MODEL_PRICES`` (already sourced and cited)
+  when its own table lacks an entry, but ONLY after the official-endpoint
+  check passes -- a real model on a genuine non-official/BYO endpoint still
+  resolves to no price, unchanged.
+
+RED-first: every assertion in the two ``..._is_priced_on...`` tests and the
+two ``..._guard_actually_reaches_evaluated...`` end-to-end tests fails
+against ``reliable_price``/``guard_qua_shadow_call`` before this ticket's
+fix. The anti-widening tests must stay green in both states -- they pin that
+the fix does not fail OPEN for anything else: a stem-sharing neighbour
+model id, a real model on a genuine custom/BYO endpoint, and a genuinely
+unpriced real model on the OFFICIAL endpoint (neither table has ever heard
+of it) must all still resolve to ``None``.
 """
 
 from __future__ import annotations
@@ -137,6 +147,73 @@ def test_a_real_openai_model_on_an_unlisted_endpoint_stays_unpriced() -> None:
     )
 
 
+#: ``ops/.env``'s actual configured model -- the shared dev stack's own
+#: reported failure shape, no base_url override at all.
+_DEV_STACK_MODEL = "gpt-5-nano"
+
+
+def test_the_dev_stack_configured_model_is_priced_on_the_official_endpoint() -> None:
+    """Shape 2: a real model with no price of its own in this table, on the
+    OFFICIAL endpoint (dev's actual configuration -- no base_url override),
+    must resolve to a real, non-fabricated, cited price rather than staying
+    unpriced forever until someone hand-adds a literal for it."""
+
+    price = reliable_price(provider="openai", model=_DEV_STACK_MODEL, base_url=None)
+    assert price is not None, (
+        "the dev stack's own configured model must be priced on the "
+        "official endpoint -- an unpriced result here is CHAOS-3582 shape 2"
+    )
+    input_rate, cached_input_rate, output_rate = price
+    assert input_rate > 0
+    assert cached_input_rate > 0
+    assert output_rate > 0
+    # Borrowed from openai_compatible._PLATFORM_MODEL_PRICES verbatim --
+    # never re-derived or approximated for the two legs that ARE sourced.
+    assert (input_rate, output_rate) == (50_000, 400_000)
+
+
+def test_a_dated_snapshot_of_the_dev_stack_model_resolves_the_same_price() -> None:
+    """Parity with the live path's own tested behaviour
+    (``test_chaos_3552_platform_price_book.py``): a dated model snapshot
+    (``gpt-5-nano-2026-01-01``) resolves to the SAME borrowed rate as the
+    bare id, via the same canonicalization the live path already uses."""
+
+    assert reliable_price(
+        provider="openai", model=f"{_DEV_STACK_MODEL}-2026-01-01", base_url=None
+    ) == reliable_price(provider="openai", model=_DEV_STACK_MODEL, base_url=None)
+
+
+def test_the_dev_stack_model_on_a_custom_endpoint_still_stays_unpriced() -> None:
+    """Borrowing a real model's rate must still respect the endpoint check
+    -- unlike the fixture, a REAL model's cost on a genuine non-official
+    endpoint is unknown, not zero and not OpenAI's rate."""
+
+    assert (
+        reliable_price(
+            provider="openai",
+            model=_DEV_STACK_MODEL,
+            base_url="https://my-byo-gateway.example/v1",
+        )
+        is None
+    )
+
+
+def test_a_genuinely_unpriced_model_on_the_official_endpoint_still_fails_closed() -> (
+    None
+):
+    """Borrowing only ever WIDENS what gets priced with REAL, sourced rates
+    -- it must never fabricate a price for a model neither table has ever
+    heard of. ``None`` here is the correct, unchanged, fail-closed answer;
+    an operator misconfiguration must still be loud, not silently free."""
+
+    assert (
+        reliable_price(
+            provider="openai", model="a-model-nobody-has-priced", base_url=None
+        )
+        is None
+    )
+
+
 @pytest_asyncio.fixture
 async def session_maker(tmp_path: Path):
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'qua_shadow.db'}")
@@ -187,18 +264,33 @@ class _FakeScriptedProvider:
 
 
 @pytest.mark.asyncio
-async def test_the_qua_shadow_guard_actually_reaches_evaluated_for_the_fixture(
-    session_maker, monkeypatch
+@pytest.mark.parametrize(
+    ("case_id", "model", "base_url"),
+    [
+        (
+            "shape1_acceptance_fixture_on_its_scripted_endpoint",
+            SCRIPTED_OPENAI_MODEL,
+            _ACCEPTANCE_BASE_URL,
+        ),
+        (
+            "shape2_dev_stack_model_on_the_official_endpoint",
+            _DEV_STACK_MODEL,
+            None,
+        ),
+    ],
+)
+async def test_the_qua_shadow_guard_actually_reaches_evaluated(
+    session_maker, monkeypatch, case_id: str, model: str, base_url: str | None
 ) -> None:
-    """End-to-end reproduction of CHAOS-3582's exact reported symptom:
-    ``guard_qua_shadow_call`` against the acceptance provider/model/base_url
-    triple must reserve, invoke, and reconcile as ``succeeded`` -- not raise
-    ``QUAShadowBudgetAccountingError`` before ever calling the provider.
+    """End-to-end reproduction of CHAOS-3582's exact reported symptom, both
+    shapes: ``guard_qua_shadow_call`` against the real provider/model/
+    base_url triple must reserve, invoke, and reconcile as ``succeeded`` --
+    not raise ``QUAShadowBudgetAccountingError`` before ever calling the
+    provider.
 
-    Before the fix: this raises ``QUAShadowBudgetAccountingError`` and
-    ``provider.calls`` stays ``0`` -- the scripted service is never even
-    invoked, matching the live boot's zero rows in
-    ``dev_qua_shadow_budget_reservations``.
+    Before the corresponding fix: this raises ``QUAShadowBudgetAccountingError``
+    and ``provider.calls`` stays ``0`` -- the provider is never even invoked,
+    matching the live boot's / dev stack's own zero/absent reservation rows.
     """
 
     org_id = str(uuid.uuid4())
@@ -228,22 +320,22 @@ async def test_the_qua_shadow_guard_actually_reaches_evaluated_for_the_fixture(
         provider,
         org_id=org_id,
         provider="openai",
-        model=SCRIPTED_OPENAI_MODEL,
-        base_url=_ACCEPTANCE_BASE_URL,
+        model=model,
+        base_url=base_url,
     )
     result = await guarded.decide(
         [AgentMessage(AgentMessageRole.USER, "question")], (), {"type": "object"}, 1, 64
     )
     assert result.decision.value == {"schema_version": "dev_question_understanding.v1"}
-    assert provider.calls == 1, "the scripted provider must actually be invoked"
+    assert provider.calls == 1, f"{case_id}: the provider must actually be invoked"
 
     async with session_maker() as session:
         rows = list(
             (await session.execute(select(QUAShadowBudgetReservation))).scalars()
         )
     assert len(rows) == 1, (
-        "exactly one reservation must exist -- CHAOS-3582 observed ZERO "
-        "because the guard raised before ever reserving"
+        f"{case_id}: exactly one reservation must exist -- CHAOS-3582 "
+        "observed ZERO because the guard raised before ever reserving"
     )
     assert rows[0].status == "succeeded"
     assert rows[0].actual_micro_usd is not None


### PR DESCRIPTION
## The gap — two shapes

**Shape 1 (acceptance).** Found by the CHAOS-3532 live verify against a fresh boot of merged main. With the QUA shadow ladder armed, the flagship "What's the status of the ACR project?" call never reached `evaluated`: `dev_run_qua_shadow` showed `status=skipped_budget_exhausted`, `error_class=budget_unavailable`, with **zero** rows in `dev_qua_shadow_budget_reservations`. Root cause: `llm/budget.py::reliable_price` requires `_official_openai_endpoint(base_url)` before consulting the price table, and the acceptance stack's scripted provider is served from `http://ask-dev-scripted-openai:8001/v1` by construction — never priced.

**Shape 2 (shared dev stack).** Live-reproduced with the REAL provider: dev has no base_url override at all (official endpoint), but `ops/.env` configures `LLM_MODEL="gpt-5-nano"`, and `_PRICE_PER_MILLION` had only ever priced `gpt-5-mini`. Every `dev_run_qua_shadow` row since the flags were armed reported the identical symptom.

Both route through `guard_qua_shadow_call` (`llm/qua_shadow_budget.py`, CHAOS-3452), which fails **closed** on an unpriced provider/model — unlike the live/BYO guard, which lets an unpriced custom provider through unbudgeted. This PR does not touch that asymmetry.

## The fix

**Shape 1:** an exact-match carve-out for `SCRIPTED_OPENAI_MODEL` in `reliable_price()`, mirroring the same one `llm.agent.openai_compatible` already made for the same model id (CHAOS-3552).

**Shape 2:** `reliable_price()` borrows a real model's rate from `openai_compatible._PLATFORM_MODEL_PRICES` (already sourced and cited) when its own table lacks an entry — only *after* the official-endpoint check, so a real model on a genuine non-official/BYO endpoint still resolves to no price. A deliberate, temporary bridge in the direction opposite of CHAOS-3560's eventual consolidation, noted there as a follow-up.

## Review finding fixed (BLOCKING, confidence 90)

The first revision's shape-1 carve-out matched on model **name only**, with no transport check. Confirmed live: a BYO tenant naming their own model, on their own real endpoint, literally `"ask-dev-scripted-v1"` got priced at the fixture's near-zero rate — on the real OpenAI endpoint, on a tenant's own gateway, and with no base_url override at all. A second leak the same repro turned up: once the fixture had an entry in the shared `_PRICE_PER_MILLION` dict, it was *also* reachable through the generic official-endpoint lookup, independent of the carve-out branch.

Fixed both: the carve-out now requires the model id **and** `_is_acceptance_scripted_transport(base_url)` — an exact `(scheme, host, port)` match against the one transport the acceptance stack's scripted provider is ever actually served from. The fixture's price is no longer stored in `_PRICE_PER_MILLION` at all, closing the second leak structurally.

**Checked the sibling carve-out this was mirrored from** (`openai_compatible._CARVE_OUT_MODELS`/`platform_cost_metering`, CHAOS-3552), as asked, rather than silently widening this PR to fix it: it has the *same* model-name-only classification hole, but `_estimated_cost_microusd` — the function that actually computes a dollar figure — does not special-case the fixture at all, so it returns `None` (safe) for a non-official endpoint regardless of model name; the classifier's misclassification there only suppresses a warning log/metric, no wrong cost is computed for a BYO tenant's real non-official traffic. On the *official* endpoint with a fixture-named model it does compute a small (~$0.000002 for 1k+1k tokens) cost — a narrower, endpoint-conditional exposure than this ticket's finding, whose actual downstream consequence I have not fully traced (it feeds `AgentUsage.estimated_cost_microusd`, not this module's BYO ceiling). **Flagging, not fixing** — reported to the reviewer separately.

## Verification

RED-first for the security fix too: `test_a_byo_tenant_cannot_name_their_way_into_the_fixture_price` (3 real call shapes) and `test_the_fixture_transport_gate_requires_an_exact_match` (3 near-miss transports: wrong scheme, wrong port, wrong host) — confirmed failing against the previously-committed code, green after the fix.

**Document-only note** (reviewer, confidence 60, no code change): `test_a_dated_snapshot_of_the_dev_stack_model_resolves_the_same_price` asserts the dated-variant call equals the bare-id call — a defect that broke `_borrowed_canonical_model`'s resolution for *both* sides equally would not be caught by this equality alone. It's parity coverage with the live path's own tested behavior, not a full pin of the resolved value; `test_the_dev_stack_configured_model_is_priced_on_the_official_endpoint` is what pins the actual `(50_000, 400_000)` sourced numbers.

Full regression sweep, all green:
```
tests/llm/test_chaos_3582_qua_shadow_fixture_pricing.py ................ 19 passed
tests/llm/test_chaos_3452_qua_shadow_budget.py
tests/api/dev/test_chaos_3552_platform_price_book.py
tests/api/dev/test_chaos_3525_qua_commit.py
tests/api/dev/test_chaos_3389_qua_shadow.py
tests/llm/agent/test_openai_compatible.py
tests/llm/test_byo_budget.py
tests/providers/test_route_family_contract.py
tests/test_budget_guard_cooldown.py
tests/test_chaos_3465_budget_surplus_retry.py
tests/test_llm_source_bound_resolver.py             ................ 276 passed, 1 skipped
```
`mypy` clean.

Head SHA: `881b0369063901d0a106251c6bd266e239ecbbb9`

## Next step (not this PR)

Once merged, re-run the CHAOS-3532 live verify's check #4 (armed boot from main, drive the flagship question, confirm `dev_run_qua_shadow.status=evaluated`, a real reservation row, and the scripted answer) to close CHAOS-3532's last gap.

Closes the code half of CHAOS-3582.