### PR TITLE
CHAOS-3586: run the Wave 4 access matrix from the Compose launcher

### DIFF
--- a/scripts/acceptance/run_ask_dev_compose.sh
+++ b/scripts/acceptance/run_ask_dev_compose.sh
@@ -394,6 +394,41 @@ TEST_SUPERUSER_PASSWORD=devhealth123 \
   "${web_root}/node_modules/.bin/playwright" test \
   -c "${web_root}/playwright.ask-dev-acceptance.config.ts"
 
+# CHAOS-3586 (unblocks CHAOS-3510 / Phase 4 Lane 4d): the Wave 4 access
+# matrix. A SECOND playwright invocation rather than more env on the one
+# above, because the two configs arm on different contracts and must be able
+# to fail independently -- folding them together would let a Phase 1 oracle
+# change take the access matrix down with it, and vice versa.
+#
+# ASK_DEV_WAVE4_ACCESS_MATRIX is deliberately its own knob, not implied by
+# ASK_DEV_LIVE_ACCEPTANCE. A launcher predating this lane sets the latter but
+# not the former, so it cannot appear to have run a matrix that did not exist
+# yet -- the web config throws instead of silently proving nothing.
+#
+# ASK_DEV_ACCEPTANCE_ACR is forwarded rather than defaulted: the entitlement
+# non-coupling rows assert against the DECLARED arming state, and the web
+# config rejects anything that is not exactly "0" or "1". Forwarding
+# ${acr_armed} (already normalized above) keeps that contract honest whether
+# or not this run armed ACR.
+if [[ ! -s "${org_ids_output}" ]]; then
+  echo "Wave 4 access matrix cannot run: ${org_ids_output} is missing or empty." >&2
+  echo "prepare_ask_dev_acceptance.py must have written the org-ids artifact" >&2
+  echo "(schema ask_dev_acceptance_org_ids.v1) before this point. Refusing to" >&2
+  echo "run the matrix against unknown tenants rather than skipping it." >&2
+  exit 1
+fi
+ASK_DEV_LIVE_ACCEPTANCE=1 \
+ASK_DEV_COMPOSE_WEB_READY=1 \
+ASK_DEV_WAVE4_ACCESS_MATRIX=1 \
+ASK_DEV_ACCEPTANCE_WEB_URL=http://127.0.0.1:3002 \
+ASK_DEV_ACCEPTANCE_ORG_IDS="${org_ids_output}" \
+ASK_DEV_ACCEPTANCE_ACR="${acr_armed}" \
+PLAYWRIGHT_LIVE_BACKEND_URL="${acceptance_api_url}" \
+TEST_SUPERUSER_EMAIL=admin@devhealth.example \
+TEST_SUPERUSER_PASSWORD=devhealth123 \
+  "${web_root}/node_modules/.bin/playwright" test \
+  -c "${web_root}/playwright.ask-dev-wave4.config.ts"
+
 # CHAOS-3219 Phase 5 (CI lane): keep the stack up for a caller that has more
 # to run against it -- specifically scripts/acceptance/run_wave4_corpus.sh,
 # whose own header states the stack must already be up and that it will never

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -1785,3 +1785,58 @@ def test_ambient_qua_flags_cannot_arm_the_acceptance_stack() -> None:
     assert launcher.index("\nunset \\\n") < launcher.index(
         "export ASK_DEV_QUA_SHADOW_ENABLED="
     ), "the opt-in translation must run AFTER the unset block, not before"
+
+
+def test_launcher_runs_the_wave4_access_matrix_with_its_own_arming_contract() -> None:
+    """CHAOS-3586 (unblocks CHAOS-3510 / Phase 4 Lane 4d).
+
+    The Wave 4 access matrix is a SECOND playwright invocation with its own
+    arming contract. Every assertion here exists because the corresponding
+    omission would produce a silently weaker run rather than a failure:
+
+    - a missing config reference means the matrix never runs at all, and the
+      launcher still exits 0;
+    - a missing ASK_DEV_WAVE4_ACCESS_MATRIX means a launcher predating this
+      lane looks like it ran the matrix;
+    - a missing ASK_DEV_ACCEPTANCE_ORG_IDS means the entitlement rows cannot
+      find the disabled-entitlement tenant;
+    - a missing ASK_DEV_ACCEPTANCE_ACR means the non-coupling rows assert
+      against an undeclared toggle state.
+    """
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+
+    assert "playwright.ask-dev-wave4.config.ts" in launcher
+    assert "ASK_DEV_WAVE4_ACCESS_MATRIX=1" in launcher
+    assert 'ASK_DEV_ACCEPTANCE_ORG_IDS="${org_ids_output}"' in launcher
+    assert 'ASK_DEV_ACCEPTANCE_ACR="${acr_armed}"' in launcher
+
+    # Two SEPARATE invocations, not one with more env. Folding them together
+    # would couple the Phase 1 oracle to the access matrix so either could
+    # take the other down.
+    assert launcher.count('"${web_root}/node_modules/.bin/playwright" test') == 2
+
+    # Ordering: the matrix runs after web is up and after the Phase 1 spec,
+    # so a Phase 1 regression is reported against Phase 1 rather than
+    # surfacing as a confusing access-matrix failure.
+    web_up_index = launcher.index("up -d --build --wait web")
+    acceptance_config_index = launcher.index("playwright.ask-dev-acceptance.config.ts")
+    wave4_config_index = launcher.index("playwright.ask-dev-wave4.config.ts")
+    assert web_up_index < acceptance_config_index < wave4_config_index
+
+    # The org-ids artifact must be written before it is forwarded. index()
+    # raises rather than passing vacuously if either anchor disappears.
+    org_ids_written_index = launcher.index(
+        'ASK_DEV_ACCEPTANCE_ORG_IDS_OUTPUT="${org_ids_output}"'
+    )
+    org_ids_forwarded_index = launcher.index(
+        'ASK_DEV_ACCEPTANCE_ORG_IDS="${org_ids_output}"'
+    )
+    assert org_ids_written_index < org_ids_forwarded_index
+
+    # A missing/empty artifact must ABORT, never skip. The matrix asserting
+    # nothing about tenants it could not identify is the false green this
+    # whole lane exists to prevent.
+    assert '[[ ! -s "${org_ids_output}" ]]' in launcher
+    preflight_index = launcher.index('[[ ! -s "${org_ids_output}" ]]')
+    assert preflight_index < wave4_config_index
+    assert "|| true" not in launcher[preflight_index:wave4_config_index]


### PR DESCRIPTION
Unblocks **CHAOS-3510** (CHAOS-3219 Phase 4 Lane 4d). Paired web PR: **full-chaos/dev-health-web#858**.

## Why

dev-health-web#858 adds `playwright.ask-dev-wave4.config.ts`, which throws during configuration unless this launcher supplies its arming contract. Nothing set those variables, so the matrix could never execute — the config was correct and completely inert. Arming discipline and invocation are two separate properties; this PR supplies the second.

## What

A **second** Playwright invocation, not more environment on the existing one. The two configs arm on different contracts and must be able to fail independently — folding them together would let a Phase 1 oracle change take the access matrix down with it, and vice versa.

Three variables carry the contract, each deliberate:

| Variable | Why not the obvious simpler thing |
|---|---|
| `ASK_DEV_WAVE4_ACCESS_MATRIX=1` | Its own knob, **not** implied by `ASK_DEV_LIVE_ACCEPTANCE`. A launcher predating this lane sets the latter but not the former, so it cannot appear to have run a matrix that didn't exist yet — the web config throws instead of silently proving nothing. |
| `ASK_DEV_ACCEPTANCE_ORG_IDS` | Forwards the artifact `provision_multi_org()` already writes (`ask_dev_acceptance_org_ids.v1`), so entitlement rows find the deliberately-unentitled tenant instead of inferring entitlement from the primary org's `emergency_disabled` switch — a different mechanism that would prove a different thing. |
| `ASK_DEV_ACCEPTANCE_ACR` | Forwarded, never defaulted. The non-coupling rows assert against the **declared** arming state, and the web config rejects anything that isn't exactly `"0"` or `"1"`. A run that doesn't know which side of the toggle it's on would "prove" non-coupling while never varying the variable. |

A missing or empty org-ids artifact **aborts**. Running the matrix against tenants it couldn't identify, and quietly not running it, are both the false green this lane exists to prevent.

## CI invocation comes free

The launcher already runs inside `.github/workflows/ask-dev-acceptance.yml` (Lane 5c, since landed), so the matrix acquires CI invocation with this change — no separate workflow edit needed. Worth noting for the record: **CHAOS-3510's premise that Lane 5c is an unmet prerequisite is now stale.**

**Honest limitation:** that workflow never sets `ASK_DEV_ACCEPTANCE_ACR` (stated explicitly at `ask-dev-acceptance.yml:14-15`), so `acr_armed` resolves to `0` and **CI exercises only one side of the non-coupling contract.** The `ASK_DEV_ACCEPTANCE_ACR=1` path is reachable by hand but is not covered by any automated run today.

## Verification

RED-first, observed rather than asserted: with the launcher reverted to `main` and the new guard in place, `test_launcher_runs_the_wave4_access_matrix_with_its_own_arming_contract` fails on the missing config reference. Restored → all **50** tests in `tests/acceptance/test_ask_dev_compose.py` pass. Restore verified by content diff, not by git status.

The guard also pins the ordering (`web up` → Phase 1 spec → matrix) and asserts the invocation **count** is exactly 2, so collapsing the two invocations or reordering them fails rather than silently degrading. Anchors use `.index()`, which raises if an anchor disappears, so a rename cannot make this test pass vacuously.

`bash -n` clean; ruff-format/ruff-fix/mypy clean via pre-commit (2177 source files).

**Not run:** no Compose stack booted — the ops acceptance stack is owned by the in-flight Phase 3 armed run. This change is therefore proven at the contract/source tier, not by an executed acceptance run. Requesting the ops gate slot separately.
