### PR TITLE
CHAOS-3219 Phase 3 close: armed-run grade, recipe fixes, and the span-declaration correction

### DIFF
--- a/scripts/acceptance/armed_corpus_boot.sh
+++ b/scripts/acceptance/armed_corpus_boot.sh
@@ -120,6 +120,43 @@ echo "=== down --volumes --remove-orphans (THIS project only) ==="
 echo "=== up -d --build --wait (boot services, no jobs fleet) ==="
 "${compose[@]}" up -d --build --wait "${boot_services[@]}"
 
+# CHAOS-3575: pin the api container's IDENTITY so a competing boot is named,
+# not merely suffered. On 2026-08-07 a second lane ran run_ask_dev_compose.sh
+# against this same project while this boot was in its jobs-fleet stage; compose
+# recreated the api out from under it and the run died four stages later with
+# `service "api" is not running`. That message names a symptom, and identifying
+# the real cause took cross-lane forensics over docker events.
+#
+# The container id is recorded here and re-checked at each stage boundary below.
+# A CHANGED id means someone else recreated it; an EMPTY id means someone tore it
+# down. Both are reported as what they are.
+api_cid_at_boot="$("${compose[@]}" ps -q api 2>/dev/null | head -1)"
+if [[ -z "${api_cid_at_boot}" ]]; then
+  echo "the api container is not running immediately after 'up --wait'." >&2
+  exit 75
+fi
+echo "API_CONTAINER_PINNED=${api_cid_at_boot:0:12}"
+
+assert_api_is_the_one_we_booted() {
+  local where="$1" now
+  now="$("${compose[@]}" ps -q api 2>/dev/null | head -1)"
+  if [[ -z "${now}" ]]; then
+    echo "STACK STOLEN (${where}): the api container this boot started is GONE." >&2
+    echo "Expected ${api_cid_at_boot:0:12}; nothing is running now." >&2
+    echo "Another process ran 'compose down' against project '${project_name}'." >&2
+    exit 75
+  fi
+  if [[ "${now}" != "${api_cid_at_boot}" ]]; then
+    echo "STACK STOLEN (${where}): the api container was RECREATED mid-boot." >&2
+    echo "Expected ${api_cid_at_boot:0:12}, found ${now:0:12}." >&2
+    echo "Another process ran 'compose up' against project '${project_name}' --" >&2
+    echo "typically run_ask_dev_compose.sh from a different checkout. This run's" >&2
+    echo "earlier preconditions were verified against a container that no longer" >&2
+    echo "exists, so nothing measured after this point could be trusted." >&2
+    exit 75
+  fi
+}
+
 echo "=== PRECONDITION A: QUA flags UNSET/OFF inside the api container's own env ==="
 # `printenv NAME` exits 1 when unset, so the ${VAR:-<unset>} form is expanded
 # INSIDE the container by sh -c -- not interpolated by this shell, which would
@@ -183,6 +220,7 @@ echo "=== PROOF 2: assert_world_principals_can_log_in.py ==="
 echo "=== up -d --build --wait (jobs fleet) ==="
 "${compose[@]}" up -d --build --wait "${jobs_services[@]}"
 
+assert_api_is_the_one_we_booted "after the jobs-fleet build"
 echo "=== fixtures generate (--overwrite-real-users) ==="
 "${compose[@]}" exec -T api dev-hops fixtures generate \
   --sink clickhouse://ch:ch@clickhouse:8123/default \
@@ -198,6 +236,7 @@ echo "=== fixtures generate (--overwrite-real-users) ==="
   --with-metrics \
   --with-work-graph
 
+assert_api_is_the_one_we_booted "before readiness preparation"
 echo "=== prepare_ask_dev_acceptance.py ==="
 ASK_DEV_LIVE_ACCEPTANCE=1 \
 ASK_DEV_ACCEPTANCE_API_URL="${acceptance_api_url}" \
@@ -237,5 +276,6 @@ if [[ -n "${counter_dump}" ]]; then
 fi
 echo "ALLOWANCE_COUNTER_VERIFIED=absent (fresh window, nothing spent)"
 
+assert_api_is_the_one_we_booted "at STACK READY"
 echo "=== STACK READY ==="
 "${compose[@]}" ps

--- a/scripts/acceptance/armed_corpus_boot.sh
+++ b/scripts/acceptance/armed_corpus_boot.sh
@@ -47,10 +47,28 @@ unset \
 # a DIFFERENT checkout than the one under test -- the compose
 # --project-directory decides the /app bind mount.
 ops_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
-web_root="${ASK_DEV_WEB_CONTEXT:-$(cd -- "${ops_root}/../web" 2>/dev/null && pwd || true)}"
+# Locating the web checkout has TWO layouts to satisfy, and the obvious one is
+# wrong for the case this script is actually used in. `${ops_root}/../web` holds
+# for the main checkout (ops/../web), but a git WORKTREE lives at
+# ops-worktrees/<name>/, so the same expression resolves to the non-existent
+# ops-worktrees/web -- and the armed run is normally driven FROM a worktree.
+# Found by running it: the first boot on 2026-08-07 died exit 64 here.
+#
+# So fall back to the repo's COMMON dir, which points at the main checkout's
+# .git regardless of which worktree is running: <common>/../../web.
+web_root="${ASK_DEV_WEB_CONTEXT:-}"
+if [[ -z "${web_root}" ]]; then
+  web_root="$(cd -- "${ops_root}/../web" 2>/dev/null && pwd || true)"
+fi
 if [[ -z "${web_root}" || ! -d "${web_root}" ]]; then
-  echo "cannot locate the web checkout (looked for ${ops_root}/../web);" >&2
-  echo "set ASK_DEV_WEB_CONTEXT to its path." >&2
+  _common="$(git -C "${ops_root}" rev-parse --git-common-dir 2>/dev/null || true)"
+  if [[ -n "${_common}" ]]; then
+    web_root="$(cd -- "${_common}/../../web" 2>/dev/null && pwd || true)"
+  fi
+fi
+if [[ -z "${web_root}" || ! -d "${web_root}" ]]; then
+  echo "cannot locate the web checkout (tried ${ops_root}/../web and the" >&2
+  echo "git common-dir sibling); set ASK_DEV_WEB_CONTEXT to its path." >&2
   exit 64
 fi
 project_name="${ASK_DEV_ACCEPTANCE_PROJECT_NAME:-dev-health-ask-dev-acceptance}"

--- a/tests/acceptance/PRE-REGISTRATION.phase3.v2.md
+++ b/tests/acceptance/PRE-REGISTRATION.phase3.v2.md
@@ -24,7 +24,59 @@ Assumed **NOT** merged, checked at time of writing:
 
 * **CHAOS-3546** — `provider_profile_override` still has **zero readers in `src/`**, so the
   readiness gate still cannot fire. (Checked by grep, not assumed.)
-* **CHAOS-3574** — not on `main`, no open PR found.
+
+### AMENDMENT 1 — merge-set changed before the run (2026-08-07, pre-run)
+
+The document's own rule ("if the assumed merge-set differs at run time, re-derive
+before grading") fired. Four more PRs merged; `main` is now `3e4e24650`:
+
+| merged since v2 was written | effect on predictions |
+|---|---|
+| **CHAOS-3574** `9efd3f309` (#1593) cross-tenant → `not_found` | **Section E's conditional now resolves to its GREEN branch.** |
+| CHAOS-3573 (#1589) reconcile NULL-cost terminals | allowance internals; still predicted non-interfering |
+| CHAOS-3572 (#1592) boot guard | boot-time guard; non-interfering |
+| CHAOS-3582 (#1594) QUA shadow pricing | see AMENDMENT 3 |
+
+**CHAOS-3546 re-checked and still unmerged**, so Section D is unchanged.
+
+### AMENDMENT 2 — the identity literal is NOT stale (correction)
+
+It was suggested pre-run that `12b96199…` had gone stale because #1593/#1594 "touched
+engine files". **Verified false, by checking rather than accepting:** neither merge
+touches `provider-scripts/role-legacy_agent.json`, and
+`role_script_identity_digest` is computed over that document (content digest +
+routing pairs), **not** over `src/`. Recomputed on the synced tree: still
+`12b961997a122ff6e7a711db0a3a5724bdb668a28c262f2fdf94c88be3675e59`, role
+`legacy_agent`, 96 cases.
+
+The operative invariant remains **host == container**, which the boot's precondition B
+checks differentially. The literal is recorded as a tripwire, not as the check: if the
+container reports something else, that is a stale mount — and if the HOST value itself
+has moved, the role script changed and the corpus must be re-derived before grading.
+
+### AMENDMENT 3 — QUA shadow is OUT OF SCOPE for this run, deliberately
+
+CHAOS-3582 (#1594) makes QUA shadow evaluation priceable, and it was suggested this run
+should observe `status=evaluated` with real reservations, treating `budget_unavailable`
+as a MISS. **This run cannot test that, and arming it would invalidate the run:**
+
+* QUA shadow is gated on `ASK_DEV_QUA_SHADOW_ENABLED == "1"`
+  (`production_runtime.py:668`); with the flag unset, construction is **skipped
+  entirely** and no QUA rows of any status are produced.
+* **"QUA flags unset" is a run-validity precondition of THIS document** (above), and the
+  boot hard-aborts (exit 75) if either flag is armed. Arming QUA would void the run
+  against the pre-registration it is being graded by.
+* **Zero corpus cases reference the QUA feature.** Verified: every `qua` substring match
+  across the 133 case files is `quals` / `qualification` / `quality` / `quad`, not the
+  feature. Nothing in the graded set depends on it.
+* Arming it would introduce **real reservations against the platform allowance during a
+  measured corpus run** — the precise mechanism that degraded the 10:03 run to
+  UNMEASURED, and which this document elsewhere declares makes ANY 429 a MISS.
+
+So: QUA stays **disarmed**, no QUA row of any status is expected, and the
+`budget_unavailable` clause is **NOT MEASURED by this run** rather than passed. It needs
+its own verification on a non-corpus stack. Recorded here so a reader cannot mistake the
+absence of QUA rows for evidence that QUA shadow works.
 
 Expected non-interfering, and this is itself a prediction:
 
@@ -128,6 +180,22 @@ Written as two explicit branches so **neither outcome can be folded in**:
 * **If it does NOT merge** → predicted RED on `public_outcome_in`
   (`answered_with_gaps` vs allowed `['not_found']`), a **third** identical reproduction.
 
+**RESOLVED PRE-RUN (Amendment 1): CHAOS-3574 MERGED as `9efd3f309`. The GREEN branch
+applies — `adv.cross-tenant.organization-id` is predicted GREEN on `not_found`.**
+
+**And the two bystanders are now the thing to watch.** #1593 changed the resolution
+route itself (`question_interpreter.py`, `subject_preflight.py`), not just the one
+case's outcome. The family is 7 cases: **four are declared-blocked and execute nothing**,
+so they cannot move. The other two active cases —
+`adv.cross-tenant.project-id` and `adv.cross-tenant.repository-id` — **already reached
+`not_found` in the measured run via the PRE-3574 route**, and all three now share
+`expected_scope_resolution_outcome='unresolved'` / `resolution_path='miss-clarification'`.
+
+Both are predicted to **stay GREEN**. If `organization-id` goes green while either
+bystander goes red, that is a MISS and specifically a **route regression**: the fix
+reached its target by changing a path other cases depended on. Checking only the named
+case would read that as "the fix worked".
+
 Either way this is **not a leak**: `no_unauthorized_candidate_surfaces` passed in both
 prior runs and is predicted to pass again. A failure of THAT check would be a new and far
 more serious finding than the outcome classification.
@@ -151,10 +219,13 @@ These are different observations and must not be conflated.
 
 ```
 134 collected · 0 skipped · 90 executed · 90 receipts · missing: 0
-expected RED: 1   (deg.provider.unsupported)
-              +1  conditionally (adv.cross-tenant.organization-id, if CHAOS-3574 unmerged)
-expected GREEN: everything else, including all 6 flips
+expected RED: 1   (deg.provider.unsupported -- CHAOS-3546 still unmerged)
+              (cross-tenant conditional RESOLVED GREEN: CHAOS-3574 merged 9efd3f309)
+expected GREEN: everything else, including all 6 flips and adv.cross-tenant.organization-id
 discriminator: adv.injection-request.url + scope.unsupported-request stay `unsupported`
+bystander watch: adv.cross-tenant.project-id + .repository-id must STAY green
+                 (#1593 changed the resolution route, not just the one outcome)
+NOT MEASURED:  QUA shadow (disarmed by validity precondition) -- see Amendment 3
 ```
 
 Anything else red, any 429, any count delta, or `missing: 0` failing = **MISS or

--- a/tests/acceptance/corpus/test_corpus_invariants_are_satisfiable.py
+++ b/tests/acceptance/corpus/test_corpus_invariants_are_satisfiable.py
@@ -430,6 +430,37 @@ class TestEveryResolutionPathDeclarerTreatsAnEmptyLedgerAsBroken:
         )
 
 
+#: Cases whose question extracts mentions but whose REQUEST IS REJECTED BEFORE
+#: subject resolution ever runs, so their resolution ledger is empty by
+#: construction -- permanently, not incidentally.
+#:
+#: These are exempt from the span requirement below, and the exemption is
+#: EARNED BY MEASUREMENT rather than assumed. CHAOS-3578 declared
+#: producer-derived spans on both, on the reasoning that covering a case beats
+#: exempting it ("an exemption list is the thing that rots"). The armed run of
+#: 2026-08-07 16:22 falsified that: both went from passed to FAILED on
+#: ``resolution_path_measured`` with absence reason
+#: ``empty-resolution-ledger-despite-mentions``.
+#:
+#: The mechanism is in ``resolution_path.py``'s own docstring: an empty ledger
+#: is HONEST as ``empty-resolution-ledger`` and BROKEN as
+#: ``empty-resolution-ledger-despite-mentions``, and the ONLY thing separating
+#: them is whether the case declares spans. Declaring spans on a case that
+#: cannot reach resolution asserts something false about it.
+#:
+#: Evidence, the same two cases measured both ways on the same day:
+#:   11:11 run -- no spans -- absence='empty-resolution-ledger'                 PASSED
+#:   16:22 run -- spans    -- absence='empty-resolution-ledger-despite-mentions' FAILED
+#:
+#: Adding an id here requires that kind of evidence, not an argument.
+REJECTED_BEFORE_RESOLUTION_CASE_IDS: frozenset[str] = frozenset(
+    {
+        "adv.oversized.question",
+        "adv.oversized.subject-set",
+    }
+)
+
+
 class TestDeclaredMentionTextsMatchTheProducer:
     """CHAOS-3462 B6: every declared span must be what production really
     yields for that question.
@@ -513,6 +544,55 @@ class TestDeclaredMentionTextsMatchTheProducer:
             f"a single-shot exact_match would be unclassifiable: {missing!r}"
         )
 
+    def test_the_rejected_before_resolution_exemption_is_still_earned(self) -> None:
+        """The exemption below is ASSERTED, not merely listed.
+
+        An exemption list that nobody re-checks is the thing that rots -- I
+        argued exactly that in CHAOS-3578 and used it to justify NOT exempting
+        these two cases, which is what broke them. So the list carries its own
+        guards, and both of them fail loudly rather than going quiet:
+
+        1. an exempted case must NOT declare ``expected_mention_texts``. Doing
+           so is the precise defect the exemption exists to prevent -- it flips
+           the honest ``empty-resolution-ledger`` absence to the broken
+           ``empty-resolution-ledger-despite-mentions`` one.
+        2. an exempted id must still name a real ACTIVE case. A stale id
+           silently exempts nothing and hides that the list has drifted.
+
+        WHAT THIS DOES NOT CATCH, stated rather than papered over: if the
+        oversize rejection is ever removed so one of these cases DOES reach
+        subject resolution, it becomes able to declare spans and this static
+        list would keep excusing it. No static check can see that. The live
+        signal is the case's own receipt -- a non-null ``resolution_path``
+        where the exemption claims the ledger is empty by construction -- and
+        that is a run-time observation, not a collection-time one. Recorded as
+        residual risk, because a guard that pretended to cover it would be
+        worse than an honest note.
+        """
+
+        active = {case.id: case for case in _active_cases()}
+        unknown = sorted(REJECTED_BEFORE_RESOLUTION_CASE_IDS - active.keys())
+        assert not unknown, (
+            f"exempted id(s) {unknown} are not active corpus cases. A stale "
+            "exemption excuses nothing and hides that the list has drifted -- "
+            "remove them, or fix the id."
+        )
+        contradictory = sorted(
+            cid
+            for cid in REJECTED_BEFORE_RESOLUTION_CASE_IDS
+            if active[cid].expected_mention_texts
+        )
+        assert not contradictory, (
+            f"case(s) {contradictory} are exempted from declaring spans BECAUSE "
+            "their request is rejected before subject resolution, yet they "
+            "declare expected_mention_texts anyway. That is the exact defect "
+            "the exemption exists to prevent: declaring spans flips the honest "
+            "'empty-resolution-ledger' absence to the broken "
+            "'empty-resolution-ledger-despite-mentions' one and fails the case. "
+            "Measured both ways on 2026-08-07 -- passed at 11:11 without spans, "
+            "failed at 16:22 with them."
+        )
+
     @pytest.mark.asyncio
     async def test_every_case_whose_question_names_mentions_declares_spans(
         self,
@@ -554,6 +634,8 @@ class TestDeclaredMentionTextsMatchTheProducer:
             if not list(getattr(interpreted, "mentions", None) or []):
                 continue
             extracting += 1
+            if case.id in REJECTED_BEFORE_RESOLUTION_CASE_IDS:
+                continue
             if not case.expected_mention_texts:
                 missing.append(case.id)
 

--- a/tests/acceptance/world/ask-dev-world.v1/corpus/case-adv.oversized.question.json
+++ b/tests/acceptance/world/ask-dev-world.v1/corpus/case-adv.oversized.question.json
@@ -38,31 +38,5 @@
   "notes": "Targets question_interpreter.py's real oversized-rejection guard (module docstring / count_mention_candidates / MAX_MENTIONS=25, read directly): subject_preflight.py's SubjectPreflight.run checks `interpretation.total_named_mention_count > MAX_MENTIONS` BEFORE any catalog round trip and, if so, terminates with outcome=PublicOutcome.UNSUPPORTED, diagnostic='oversized_mention_set_in_v1', ledger=None (subject_preflight.py lines ~394-410, read directly) -- 'Bounds are rejections, never truncations (CHAOS-3301)'. Because the run never reaches RESOLVING_SUBJECTS (no resolve_mention call is ever made, ledger stays None), no dev_run_resolutions entries are ever written -- resolution_path is null, and expected_scope_resolution_outcome is null too (no entity ever gets a chance to commit), mirroring scope.unsupported-request/prohibited-write's own null/null pattern for a pre-resolution short-circuit, just reached via a different guard. 30 distinct quoted/noun-adjacent repo mentions (well past MAX_MENTIONS=25) spread across a genuinely long, repetitive-theme question, authored per the task instruction to target the real oversized-rejection guard with prose length/repetition pressure rather than a bare enumerated list (that shape is adv.oversized.subject-set's own, deliberately distinct, job).",
   "$comment_resolution_path_invariant": "resolution_path_in REMOVED (CHAOS-3462 B4). The oversized rejection fires in subject_preflight against interpretation.total_named_mention_count > MAX_MENTIONS -- AFTER mention extraction but BEFORE any catalog round trip or ledger construction (_terminate is called with ledger=None and no terminating_resolution_entry), so orchestrator's append_resolution sites never run. The 25 extracted mentions are therefore not evidence of a written ledger. derive_resolution_path returns None; resolution_path_in could never pass. Profile null is CORRECT and stays.",
   "$comment_principal_pool": "CHAOS-3490: user_alias assigned by deterministic round-robin over the ordinary-primary pool (sorted case id, index 14 of 85). The pool is role-identical to primary.ordinary, so this changes request DISTRIBUTION only -- never what this case proves. Spreading exists because production caps one user at 20 requests/15min and 85 cases on one alias made a single-pass armed run impossible.",
-  "expected_mention_texts": [
-    "meridian/service-01",
-    "meridian/service-02",
-    "meridian/service-03",
-    "meridian/service-04",
-    "meridian/service-05",
-    "meridian/service-06",
-    "meridian/service-07",
-    "meridian/service-08",
-    "meridian/service-09",
-    "meridian/service-10",
-    "meridian/service-11",
-    "meridian/service-12",
-    "meridian/service-13",
-    "meridian/service-14",
-    "meridian/service-15",
-    "meridian/service-16",
-    "meridian/service-17",
-    "meridian/service-18",
-    "meridian/service-19",
-    "meridian/service-20",
-    "meridian/service-21",
-    "meridian/service-22",
-    "meridian/service-23",
-    "meridian/service-24",
-    "meridian/service-25"
-  ]
+  "$comment_no_spans_3588": "expected_mention_texts DELIBERATELY NOT DECLARED, and this is the guard working rather than an omission. CHAOS-3578 added 25 producer-derived spans here on the reasoning that covering a case beats exempting it. THE ARMED RUN OF 2026-08-07 16:22 PROVED THAT WRONG: this case went from passed to FAILED, on resolution_path_measured with absence reason 'empty-resolution-ledger-despite-mentions'. MECHANISM (resolution_path.py:498-506): an empty ledger is HONEST as 'empty-resolution-ledger' and BROKEN as 'empty-resolution-ledger-despite-mentions'; the only thing separating them is whether the case declares spans. That module's own docstring says it -- 'ABSENCE_EMPTY_LEDGER stays honest, because a zero-mention question genuinely appends nothing. Only the mention-declaring case's empty ledger became a defect.' WHY THIS CASE MUST NOT DECLARE SPANS: its oversized request is rejected BEFORE subject resolution ever runs, so its ledger is empty by construction, permanently. Declaring spans asserts that resolution was reached, which is false for this case and cannot become true while the oversize rejection stands. Evidence both ways, same case: 11:11 run absence='empty-resolution-ledger' PASSED with no spans; 16:22 run absence='empty-resolution-ledger-despite-mentions' FAILED with them."
 }

--- a/tests/acceptance/world/ask-dev-world.v1/corpus/case-adv.oversized.subject-set.json
+++ b/tests/acceptance/world/ask-dev-world.v1/corpus/case-adv.oversized.subject-set.json
@@ -38,31 +38,5 @@
   "notes": "Targets question_interpreter.py's real oversized-rejection guard (module docstring / count_mention_candidates / MAX_MENTIONS=25, read directly): subject_preflight.py's SubjectPreflight.run checks `interpretation.total_named_mention_count > MAX_MENTIONS` BEFORE any catalog round trip and, if so, terminates with outcome=PublicOutcome.UNSUPPORTED, diagnostic='oversized_mention_set_in_v1', ledger=None (subject_preflight.py lines ~394-410, read directly) -- 'Bounds are rejections, never truncations (CHAOS-3301)'. Because the run never reaches RESOLVING_SUBJECTS (no resolve_mention call is ever made, ledger stays None), no dev_run_resolutions entries are ever written -- resolution_path is null, and expected_scope_resolution_outcome is null too (no entity ever gets a chance to commit), mirroring scope.unsupported-request/prohibited-write's own null/null pattern for a pre-resolution short-circuit, just reached via a different guard. 26 distinct quoted/noun-adjacent repo mentions (one past MAX_MENTIONS=25) in a compact enumeration -- pressure from the COUNT of named subjects in one message, not from prose length/repetition (that shape is adv.oversized.question's own job). Both ids exercise the identical production guard (subject_preflight.oversized_mention_set_in_v1) via two different question shapes, matching the task's framing that both are 'oversized pressure' variants of the same underlying bound.",
   "$comment_resolution_path_invariant": "resolution_path_in REMOVED (CHAOS-3462 B4). The oversized rejection fires in subject_preflight against interpretation.total_named_mention_count > MAX_MENTIONS -- AFTER mention extraction but BEFORE any catalog round trip or ledger construction (_terminate is called with ledger=None and no terminating_resolution_entry), so orchestrator's append_resolution sites never run. The 25 extracted mentions are therefore not evidence of a written ledger. derive_resolution_path returns None; resolution_path_in could never pass. Profile null is CORRECT and stays.",
   "$comment_principal_pool": "CHAOS-3490: user_alias assigned by deterministic round-robin over the ordinary-primary pool (sorted case id, index 16 of 85). The pool is role-identical to primary.ordinary, so this changes request DISTRIBUTION only -- never what this case proves. Spreading exists because production caps one user at 20 requests/15min and 85 cases on one alias made a single-pass armed run impossible.",
-  "expected_mention_texts": [
-    "meridian/probe-01",
-    "meridian/probe-02",
-    "meridian/probe-03",
-    "meridian/probe-04",
-    "meridian/probe-05",
-    "meridian/probe-06",
-    "meridian/probe-07",
-    "meridian/probe-08",
-    "meridian/probe-09",
-    "meridian/probe-10",
-    "meridian/probe-11",
-    "meridian/probe-12",
-    "meridian/probe-13",
-    "meridian/probe-14",
-    "meridian/probe-15",
-    "meridian/probe-16",
-    "meridian/probe-17",
-    "meridian/probe-18",
-    "meridian/probe-19",
-    "meridian/probe-20",
-    "meridian/probe-21",
-    "meridian/probe-22",
-    "meridian/probe-23",
-    "meridian/probe-24",
-    "meridian/probe-25"
-  ]
+  "$comment_no_spans_3588": "expected_mention_texts DELIBERATELY NOT DECLARED, and this is the guard working rather than an omission. CHAOS-3578 added 25 producer-derived spans here on the reasoning that covering a case beats exempting it. THE ARMED RUN OF 2026-08-07 16:22 PROVED THAT WRONG: this case went from passed to FAILED, on resolution_path_measured with absence reason 'empty-resolution-ledger-despite-mentions'. MECHANISM (resolution_path.py:498-506): an empty ledger is HONEST as 'empty-resolution-ledger' and BROKEN as 'empty-resolution-ledger-despite-mentions'; the only thing separating them is whether the case declares spans. That module's own docstring says it -- 'ABSENCE_EMPTY_LEDGER stays honest, because a zero-mention question genuinely appends nothing. Only the mention-declaring case's empty ledger became a defect.' WHY THIS CASE MUST NOT DECLARE SPANS: its oversized request is rejected BEFORE subject resolution ever runs, so its ledger is empty by construction, permanently. Declaring spans asserts that resolution was reached, which is false for this case and cannot become true while the oversize rejection stands. Evidence both ways, same case: 11:11 run absence='empty-resolution-ledger' PASSED with no spans; 16:22 run absence='empty-resolution-ledger-despite-mentions' FAILED with them."
 }


### PR DESCRIPTION
Phase 3 close-out: the pre-registration amendments, two recipe defects found by running it, and the correction the armed run forced on my own earlier commit.

**This PR is the durable evidence record for the CHAOS-3219 Phase 3 armed run.** The grade below is reproduced verbatim.

---

# ARMED RUN #3 — 2026-08-07 16:22 PT — **MEASURED**

Branch synced to main `3e4e24650`. Graded strictly against `tests/acceptance/PRE-REGISTRATION.phase3.v2.md` (as amended pre-run in `4f974f2c7`).

```
134 collected · 0 skipped · 90 executed · 3 failed · 131 passed · RUN_EXIT_CODE=1
receipt coverage complete: 90 executed corpus case(s), 90 recorded a result   → missing: 0
ZERO 429s / cost_limit_reached anywhere in the run
STACK STOLEN: 0  (container-id pin held across all three stage boundaries)
```

Exit 1 means the corpus went red on 3 cases. That is a **result**, not a degradation.

## Boot preconditions (all pass)

```
API_CONTAINER_PINNED=77d8499c18a3
QUA_VERIFIED=not-armed (shadow=0 commit=0)
IDENTITY MATCH 12b961997a122ff6e7a711db0a3a5724bdb668a28c262f2fdf94c88be3675e59  role=legacy_agent cases=96
ALLOWANCE OK: 6 orgs × 500,000,000 microUSD · counter absent
STACK READY — 8/8 healthy
```

## Predictions that landed

| bucket | prediction | outcome |
|---|---|---|
| **A** | six `denied`→`refused` flips green | ✅ all six — CHAOS-3541 confirmed live |
| **B** | **discriminator**: `adv.injection-request.url` + `scope.unsupported-request` STAY `unsupported` | ✅ both stayed |
| **C** | 3551 / 3577 / 3578 / pin-move cases green | ✅ all five |
| **E** | cross-tenant green branch + bystanders hold | ✅ organization-id green, `.project-id` and `.repository-id` both held |
| **D** | `deg.provider.unsupported` the ONLY red | ✅ red, failing exactly `public_outcome_in` |

**Bucket B is the one that mattered.** `adv.injection-request.url` sits in the same family as the four flipped injection cases and would have been flipped by anyone pattern-matching on case names. Had it flipped, bucket A's greens would have been right by luck. It stayed `unsupported`, so **the flip was demonstrably routed by refusal code** rather than applied to a family.

Bucket E's bystanders matter for the same reason: #1593 changed the resolution *route*, not one case's outcome, so checking only the named case would have read a route regression as success. Both held.

## MISSES: 2 — both self-inflicted, neither the product's

`adv.oversized.question` and `adv.oversized.subject-set`, failing `resolution_path_measured` with `empty-resolution-ledger-despite-mentions`.

**My CHAOS-3578 commit caused this.** I added producer-derived `expected_mention_texts` to both, arguing *"they are covered rather than exempted, because an exemption list is the thing that rots."* The run falsified that. Mechanism (`resolution_path.py:498-506`):

```python
if named_subject_mentions:  return ABSENCE_EMPTY_LEDGER_DESPITE_MENTIONS   # broken set
return ABSENCE_EMPTY_LEDGER                                                 # honest, passes
```

Both cases have their oversized request **rejected before subject resolution runs**, so the ledger is empty by construction — permanently. Declaring spans asserts resolution was reached, which is false for them. Same two cases, measured both ways the same day:

```
11:11 — no spans — absence='empty-resolution-ledger'                  PASSED
16:22 — spans    — absence='empty-resolution-ledger-despite-mentions' FAILED
```

**Not the re-minted world**, which I flagged as a candidate cause *before* seeing results: the absence reason changed in lockstep with the declaration and is computed from the declared-spans flag, not world data.

`64111072e` corrects it — spans removed, and the exemption I dismissed added as `REJECTED_BEFORE_RESOLUTION_CASE_IDS`, **asserted rather than listed**, with both guards mutation-proven by exit code.

## Vacuous green — do not cite as coverage

`readiness.capabilities.degraded` passed. Graded green per v2 (no deviation, no MISS), **but that green proves nothing about degraded-readiness handling**: it is driven by `provider_profile_override`, which nothing in `src/` reads. The same inert field is why `deg.provider.unsupported` is red. One field, two opposite-looking symptoms. That case, `deg.provider.unsupported`, and `readiness.capabilities.unsupported-model` all flip DECLARED-BLOCKED on CHAOS-3588 (#1595).

QUA shadow: **NOT MEASURED** (v2 Amendment 3), correctly disarmed throughout. Discovery signatures: neither sighted.

---

## Commits

| commit | what |
|---|---|
| `4f974f2c7` | Amend the pre-registration **before** the run — v2's own re-derive rule fired when four PRs merged. Includes correcting a claim that the identity digest had gone stale (it had not), and putting QUA shadow explicitly out of scope with the reasoning. |
| `a1541dc7d` | `armed_corpus_boot.sh` could not find the web checkout **from a worktree** — the layout it is actually run from. Found by running it (`BOOT_EXIT_CODE=64`), not by reading it. |
| `c16cd2e36` | Pin the api container id and re-check it at three stage boundaries, so a competing `compose up` is **named** rather than surfacing four stages later as `service "api" is not running`. Verified in all three states. |
| `64111072e` | The CHAOS-3578 correction above. |

Two of these four exist because the recipe was **executed**, not reviewed. The `web_root` defect and the stack-collision diagnosis were both invisible on the page.

Verified: 788 passed / 134 skipped across `tests/acceptance`; ruff + mypy clean.

Draft — sequencing behind #1595, which touches overlapping corpus case files. Rebase and gate to follow.
