### PR TITLE
CHAOS-3220: Ask Dev wave-close docs — user guide, rollout runbook, Phase 3 evidence summary

### DIFF
--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -113,6 +113,18 @@ jobs:
           python scripts/check_freshness_inventory.py \
             2>&1 | tee .build/docs-freshness-inventory.log
 
+      # CHAOS-3220. Same rule as the two above: the script runs here, not only
+      # from `make docs:check-fast`, because the property it enforces -- that
+      # the Ask Dev answers page quotes the runtime's user-facing strings
+      # verbatim -- is broken by an edit on EITHER side, and a page that
+      # misquotes the product is worse than one that says nothing. Reads only
+      # repo files, so it is honest to wire here.
+      - name: Check Ask Dev published-copy drift
+        run: |
+          set -o pipefail
+          python scripts/check_ask_dev_copy_drift.py \
+            2>&1 | tee .build/docs-ask-dev-copy-drift.log
+
       - name: Upload documentation quality evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,12 @@ docs\:check:
 	@$(MAKE) --no-print-directory docs\:check-fast
 	$(PYTHON) scripts/build_docs_cloudflare.py --mode preview --full-check
 
-# Fast inner loop while editing pages: catches taxonomy drift and broken relative
-# links/anchors without a full site build. Not sufficient before pushing.
+# Fast inner loop while editing pages: catches taxonomy drift, published-copy drift,
+# and broken relative links/anchors without a full site build. Not sufficient before
+# pushing.
 docs\:check-fast:
 	$(PYTHON) scripts/check_investment_docs_drift.py
+	$(PYTHON) scripts/check_ask_dev_copy_drift.py
 	$(PYTHON) scripts/check_docs_links.py
 
 docs\:build:

--- a/docs-data/ia/operate.tsv
+++ b/docs-data/ia/operate.tsv
@@ -27,6 +27,7 @@ op-services	op-run	/operate/run/services/	Service and process responsibilities	c
 op-workers	op-run	/operate/run/workers-and-jobs/	Workers, jobs, retries, and schedules	task-guide	true	public	planned	false	
 op-ingestion	op-run	/operate/run/ingestion-and-backfills/	Ingestion and backfill operations	task-guide	true	public	planned	false	
 op-controls	op-run	/operate/run/operational-controls/	Safe operational controls	task-guide	true	public	planned	false	
+op-ask-dev-rollout	op-run	/operate/run/ask-dev-rollout/	Ask Dev rollout	task-guide	true	public	planned	false	
 op-observe	operate	/operate/observe/	Observe the platform	landing	true	public	planned	false	
 op-healthchecks	op-observe	/operate/observe/health-checks/	Health checks	reference	true	public	planned	false	
 op-logs	op-observe	/operate/observe/logs/	Logs	reference	true	public	planned	false	

--- a/docs-data/ia/use.tsv
+++ b/docs-data/ia/use.tsv
@@ -28,6 +28,8 @@ use-ai-impact	use-ai	/use/ai-workflows/impact/	AI Impact	workflow-guide	true	pub
 use-ai-review	use-ai	/use/ai-workflows/review-load/	AI Review Load	workflow-guide	true	public	planned	false	
 use-ai-risk	use-ai	/use/ai-workflows/risk/	AI Risk	workflow-guide	true	public	planned	false	
 use-ai-attribution	use-ai	/use/ai-workflows/attribution/	AI Attribution	workflow-guide	true	public	planned	false	
+use-ask-dev-questions	use-ai	/use/ai-workflows/ask-dev-questions/	Ask what Ask Dev supports	workflow-guide	true	public	planned	false	
+use-ask-dev-answers	use-ai	/use/ai-workflows/ask-dev-answers/	Read an Ask Dev answer	workflow-guide	true	public	planned	false	
 use-reports	use	/use/reports/	Create and read reports	landing	true	public	planned	false	
 use-report-create	use-reports	/use/reports/create-or-clone/	Create or clone a report	task-guide	true	public	planned	false	
 use-report-run	use-reports	/use/reports/run-and-schedule/	Run and schedule reports	task-guide	true	public	planned	false	

--- a/docs/operate/run/ask-dev-rollout.md
+++ b/docs/operate/run/ask-dev-rollout.md
@@ -1,0 +1,134 @@
+---
+page_id: op-ask-dev-rollout
+summary: Run the one-time Ask Dev ephemeral-expiry repair and arm the isolated question-understanding shadow, with the verification signal for each.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - src/dev_health_ops/cli.py
+  - src/dev_health_ops/api/dev/persistence/service.py
+  - src/dev_health_ops/workers/ask_dev_retention.py
+  - src/dev_health_ops/llm/qua_shadow_budget.py
+  - src/dev_health_ops/api/dev/production_runtime.py
+applicability: current
+lifecycle: active
+---
+
+# Roll out Ask Dev runtime changes
+
+Two operator actions accompany an Ask Dev deployment: a one-time repair of conversations that the 0-day retention tier could never delete, and an optional, separately budgeted question-understanding shadow used to gather evaluation evidence. Neither is required to serve Ask Dev traffic, and neither changes an answer a user receives.
+{: .fc-page-lede }
+
+## Before you begin
+
+- Required role: platform operator with shell access to an API or worker container and the deployment's environment configuration.
+- Required environment: a reachable PostgreSQL semantic database. Both procedures read `POSTGRES_URI` (or `DATABASE_URI`); the CLI also accepts `--db`.
+- Neither procedure touches ClickHouse, provider credentials, or organization entitlements.
+
+## Stamp stranded 0-day conversations
+
+Organizations on the 0-day (ephemeral) retention tier expect a conversation to be deleted as soon as its work finishes. Before the retention fix existed, a 0-day conversation could reach a state where every one of its runs was terminal but no expiry was ever recorded — leaving it invisible to the purge sweep and retained indefinitely, which is the opposite of what the tier promises. The same was true of a 0-day conversation abandoned before its first message, or one holding a run that a crash left non-terminal.
+
+The repair finds those rows and stamps an expiry on them. The ordinary retention sweep then collects them on its next pass, exactly as it collects any other now-due row.
+
+### The repair usually runs itself
+
+The scheduled sweep performs this repair before every purge pass, so an ordinary deployment needs no operator action at all:
+
+| Fact | Value |
+| --- | --- |
+| Scheduled entry | `ask-dev-retention-sweep` |
+| Task | `dev_health_ops.workers.tasks.run_ask_dev_retention_cleanup` |
+| Schedule | Daily at 05:30 |
+| Queue | `default` |
+| Batch size | 500 rows |
+| Batch cap per run | 20 batches for the repair, then 20 for the purge |
+
+Run the command below only when you need the repair to happen sooner than the next scheduled pass — for example immediately after deploying to an environment that accumulated stranded rows, or while the beat schedule is stopped.
+
+!!! note "Prerequisite"
+    A deployment with no running Celery beat has no scheduled sweep, so the repair *and* the purge are both operator-driven until beat is restored. Confirm the worker and beat state first: [Workers, jobs, retries, and schedules](workers-and-jobs.md).
+
+### Run the repair manually
+
+```bash
+dev-hops maintenance backfill-ask-dev-ephemeral-expiry
+```
+
+The command takes no arguments of its own. It drains the full backlog in one invocation, committing each batch of up to 500 rows and stopping when a batch comes back short. It is idempotent and resumable: re-running it after a partial drain continues where it stopped, and re-running it once the backlog is empty stamps nothing.
+
+Only conversations idle for at least one hour are eligible. A conversation created or touched inside that window is never stamped, so an in-flight turn cannot have its expiry set out from under it.
+
+### Verify the result
+
+- The command logs `Ask Dev ephemeral-expiry backfill complete: stamped=N` and exits `0`.
+- A second immediate run reports `stamped=0`. That, not the first run's count, is the proof the backlog is drained.
+- Purging is a separate step. The rows this stamps are deleted by the retention sweep, not by this command; watch `devhealth_ask_dev_retention_sweep_purged_total` rise on the next sweep.
+
+### If it does not work
+
+- A `PostgreSQL semantic database` prerequisite error means neither `--db` nor `POSTGRES_URI`/`DATABASE_URI` resolved. See [Environment and secrets](../configure/environment-and-secrets.md).
+- A stamped count that never reaches `0` across repeated runs means rows are being stranded faster than they are repaired — that is a defect in the retention path, not a backlog. Escalate rather than looping the command.
+- For sweep failures rather than repair failures, see [Worker or queue failure](../runbooks/worker-or-queue-failure.md).
+
+## Arm the question-understanding shadow
+
+The question-understanding shadow evaluates an additional model call alongside the deterministic subject resolution, records what it would have proposed, and — by default — never influences the run. It exists to gather evaluation evidence before any decision to let model-proposed subjects take effect.
+
+!!! caution "This spends real provider money"
+    For an organization on its own LLM provider, the shadow call is constructed from that organization's own credentials. The isolated quota below bounds what this platform *records*; it cannot bound the customer's own provider-side spend, rate limits, or credits. Enabling the shadow for a BYO organization spends that customer's provider credits on platform evaluation work. Volume is structurally capped at one shadow call per live run — never fire-and-forget, never unbounded — but the cost is real and is the customer's.
+
+### Controls
+
+| Variable | Effect | Default when unset |
+| --- | --- | --- |
+| `ASK_DEV_QUA_SHADOW_ENABLED` | `1` constructs the shadow provider and evaluates. Any other value, including unset, leaves the seam byte-identical to not existing | Off |
+| `ASK_DEV_QUA_COMMIT_ENABLED` | `1` **and** the shadow flag set allows a verified proposal to become the run's subject | Off |
+| `ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD` | Operator-wide ceiling per organization per calendar month, in micro-USD | `500000` (≈ USD 0.50) |
+
+These are process environment variables on the Ops API, not organization settings and not entries in the feature registry. They apply to every organization the runtime serves; there is no per-organization override and no admin surface for them. Changing one requires an API restart.
+
+Two prerequisites gate the seam regardless of the variables:
+
+- the organization must have the `ask_dev_wave_3_1` feature decision allowed — with it off, no shadow is constructed at all;
+- the organization must have a usable provider. Without one the shadow resolves to a typed skip and records nothing.
+
+There is no value of `ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD` that disables enforcement. An unparseable value resolves to `0`, which stops every shadow call rather than allowing them.
+
+### Procedure
+
+1. Confirm the organizations in scope have `ask_dev_wave_3_1` allowed. Without it the flag is inert for them.
+2. Confirm the model in use is priced. The shadow quota fails closed on an unpriced provider/model pair — it cannot bound what it cannot cost, so it skips instead of guessing. Check `devhealth_ask_dev_platform_model_unpriced_total`; a non-zero value is a configuration defect to fix before arming, not a provider fault.
+3. Decide the ceiling. Leave `ASK_DEV_QUA_SHADOW_MAX_BUDGET_MICRO_USD` unset unless you have a reason to move it; the default is deliberately conservative and independent of any organization's own live LLM budget.
+4. Set `ASK_DEV_QUA_SHADOW_ENABLED=1` in the Ops API environment and restart the API.
+5. Leave `ASK_DEV_QUA_COMMIT_ENABLED` unset. Promoting a proposal to a real subject is a separate decision that should follow shadow evidence, not accompany it.
+
+### Verify the result
+
+Watch `devhealth_ask_dev_qua_shadow_total`, labelled by `status` and by the deterministic decision it ran alongside:
+
+| `status` | Meaning |
+| --- | --- |
+| `evaluated` | The shadow ran and recorded a proposal |
+| `skipped_disabled` | The flag is not `1` — the seam is off |
+| `skipped_no_provider` | No shadow provider could be constructed for the organization |
+| `skipped_budget_exhausted` | The isolated quota is spent, or the provider/model pair is unpriced |
+| `skipped_no_mentions`, `skipped_catalog_unavailable`, `skipped_timeout`, `skipped_provider_error`, `skipped_unexpected_decision`, `skipped_invalid_output` | The shadow declined or failed for the stated reason |
+
+Arming succeeded when `status="evaluated"` appears. A flag set to `1` that only ever produces `skipped_disabled` means the restart did not pick up the variable; only ever producing `skipped_budget_exhausted` means step 2 was not satisfied.
+
+Also watch:
+
+- `devhealth_ask_dev_qua_shadow_fault_total` — every increment is a defect in the shadow path. It can never fail or roll back the live run it shadows, but a rising count is a bug, not noise.
+- `devhealth_ask_dev_qua_shadow_cardinality_uncorroborated_total` — organization-wide proposals the deterministic interpreter did not independently reach. Recorded, never acted on.
+- `devhealth_ask_dev_qua_commit_total` — must stay at zero while `ASK_DEV_QUA_COMMIT_ENABLED` is unset.
+
+### Roll back
+
+Unset `ASK_DEV_QUA_SHADOW_ENABLED` (or set it to any value other than `1`) and restart the API. The seam then constructs nothing and evaluates nothing. Because the shadow never influenced a live answer, no user-visible behavior changes on the way out, and no conversation, evidence, or retention state needs repair.
+
+## Related information
+
+- [Workers, jobs, retries, and schedules](workers-and-jobs.md)
+- [Safe operational controls](operational-controls.md)
+- [Feature flags and availability](../../reference/configuration/feature-flags.md)
+- [Ask Dev web proxy or browser failure](../runbooks/ask-dev-web-proxy-or-browser-failure.md)

--- a/docs/operate/run/index.md
+++ b/docs/operate/run/index.md
@@ -12,5 +12,6 @@ lifecycle: active
 - [Workers and jobs](workers-and-jobs.md)
 - [Ingestion and backfill operations](ingestion-and-backfills.md)
 - [Safe operational controls](operational-controls.md)
+- [Roll out Ask Dev runtime changes](ask-dev-rollout.md)
 
 Prefer bounded, observable controls over direct database or queue mutation.

--- a/docs/reference/configuration/feature-flags.md
+++ b/docs/reference/configuration/feature-flags.md
@@ -5,6 +5,8 @@ content_type: configuration-reference
 owner: platform-product
 source_of_truth:
   - current feature registry and product navigation
+  - src/dev_health_ops/licensing/registry.py
+  - src/dev_health_ops/alembic/versions/0073_seed_ask_dev_wave_3_1_feature_flag.py
   - docs/architecture/licensing.md
   - deploy/go-workers/profiles.json
 applicability: current
@@ -42,19 +44,21 @@ Provider availability still applies:
 
 ## Ask Dev and AI gates
 
-Ask Dev has four independent feature decisions:
+Ask Dev has five independent feature decisions:
 
 | Key | Controls | Default |
 | --- | --- | --- |
 | `ask_dev` | The in-app Ask Dev interaction layer for Context Fabric | Disabled until explicitly enabled for an organization or license |
 | `ask_dev_contextual_entrypoints` | Typed, review-before-submit handoffs from approved product surfaces into Ask Dev | Disabled until explicitly enabled for an organization or license |
+| `ask_dev_wave_3_1` | Server-owned question interpretation and the named-subject preflight | Disabled until explicitly enabled for an organization or license |
 | `byo_llm` | Organization-managed LLM provider configuration | Existing tier and override behavior, unchanged |
 | `agent_context_runtime` | Hosted ACR/MCP context capability | Existing explicit-purchase behavior, unchanged |
 
 No gate grants any of the others. Enabling `ask_dev` does not enable contextual
-entrypoints, expose BYO LLM settings, or expose Context Fabric Validation, and
-enabling any of those gates does not make base Ask Dev available. The
-`ask_dev` and `ask_dev_contextual_entrypoints` registry rows are globally
+entrypoints, enable Wave 3.1 interpretation, expose BYO LLM settings, or expose
+Context Fabric Validation, and enabling any of those gates does not make base
+Ask Dev available. The `ask_dev`, `ask_dev_contextual_entrypoints`, and
+`ask_dev_wave_3_1` registry rows are globally
 enabled only so their global feature decisions remain emergency kill switches;
 their effective tier defaults are false for every tier. Inclusion in paid plans
 may be considered later only through separate product change control; it is not
@@ -66,6 +70,15 @@ product surfaces do not offer contextual handoff triggers. The API capability
 reports contextual entrypoints only when the base Ask Dev decision, the
 independent contextual-entrypoints decision, and runtime readiness all permit
 them; it never infers the contextual decision from `ask_dev`.
+
+`ask_dev_wave_3_1` is an explicit-enable registration (`ask_dev_wave_3_1` in the
+feature registry, seeded by Alembic revision `0073`). Every tier stays denied
+until an organization or license override grants it, and the row is preserved on
+rollback because those overrides may reference it. With the decision off, a run
+behaves exactly as it did before Wave 3.1: the preflight is not constructed, and
+neither is the question-understanding shadow seam, regardless of its own
+environment variable. Evaluating the decision fails closed — a storage error
+leaves it off rather than admitting an unreviewed path.
 
 Do not infer Ask Dev access from a paid plan. Bundling it into all paid plans is
 a deferred commercial possibility and requires a new accepted product decision,

--- a/docs/use/ai-workflows/ask-dev-answers.md
+++ b/docs/use/ai-workflows/ask-dev-answers.md
@@ -36,6 +36,7 @@ Every Ask Dev answer carries its own outcome, its provenance, what it could not 
 
 The outcome is the first thing to read, because it decides whether the rest of the answer means anything.
 
+<!-- BEGIN ASK-DEV OUTCOME LABELS -->
 | Outcome | Shown as | What it means |
 | --- | --- | --- |
 | `answered` | Answered | The question was answered within the coverage stated |
@@ -47,6 +48,8 @@ The outcome is the first thing to read, because it decides whether the rest of t
 | `denied` | Not permitted | You do not have access to ask about this |
 | `refused` | Not something Ask Dev can do | The question asked Ask Dev to act, not to read |
 | `failed` | Something went wrong | The run did not complete. Nothing partial is presented as a result |
+<!-- END ASK-DEV OUTCOME LABELS -->
+
 
 Only `answered` and `answered_with_gaps` carry content. On every other outcome, the answer deliberately contains **no** narrative, findings, metrics, evidence, or follow-up suggestions — just the outcome, one plain sentence, one suggested next step, and the identifiers needed to reference the run. That emptiness is the design: a no-answer result never leaks a half-formed conclusion.
 
@@ -56,21 +59,27 @@ Only `answered` and `answered_with_gaps` carry content. On every other outcome, 
 
 Ask Dev distinguishes two different reasons it will not do something, and words them differently on purpose.
 
+<!-- BEGIN ASK-DEV REFUSAL COPY -->
 | You asked it to | Outcome | What you see | Suggested next step |
 | --- | --- | --- | --- |
 | Run a command, execute code or a query, or change data | `refused` | *Ask Dev can only read and summarize your data; it can't run commands or make changes.* | *Ask a read-only question about your data instead.* |
 | Fetch an external URL, or generate open-ended content | `unsupported` | *This question is not supported yet.* | *Try a status, health, or metric question instead.* |
+<!-- END ASK-DEV REFUSAL COPY -->
+
 
 The distinction matters. "Refused" means the capability is deliberately absent and always will be — Ask Dev does not write, execute, or act. "Not supported yet" means the question shape is outside the current product, which is a boundary that can move. Neither is an error, and neither is a partial attempt: a refused request is never executed and then rolled back; it is never started.
 
 The other no-answer outcomes read the same way — one sentence and one next step:
 
+<!-- BEGIN ASK-DEV NO-ANSWER COPY -->
 | Outcome | You see | Suggested next step |
 | --- | --- | --- |
 | `not_found` | *No matching subject was found for this question.* | *Check the name and try again.* |
 | `temporarily_unavailable` | *This answer is temporarily unavailable. Please try again shortly.* | *Try the question again in a few minutes.* |
 | `denied` | *You do not have access to ask about this.* | *Ask an administrator for access to this area.* |
 | `failed` | *Something went wrong while preparing this answer.* | *Try the question again.* |
+<!-- END ASK-DEV NO-ANSWER COPY -->
+
 
 ## Provenance and disclosure
 
@@ -107,7 +116,7 @@ Evidence is the point of the answer, not a citation ornament.
 - Excerpts are **inert plain text**, stripped of HTML, links, and common secrets, capped at 64 KiB, and treated as untrusted source content.
 - Evidence entries carry their own state — stale, unavailable, redacted, deleted, uncertain, conflicting, or untrusted content — and their own observed-at time and freshness.
 - Some measures cite evidence at the aggregate or source-class level rather than per record. Where that is the case, the answer says so instead of implying record-level backing it does not have.
-- Occasionally a part of an answer is withheld and shown as *This part of the answer could not be shown.* That is a deliberate safety projection, not a rendering failure.
+- Occasionally a part of an answer is withheld and shown as <!-- BEGIN ASK-DEV WITHHELD COPY -->*This part of the answer could not be shown.*<!-- END ASK-DEV WITHHELD COPY --> That is a deliberate safety projection, not a rendering failure.
 
 Every answer also records the definitions it ran under — plan, metric definition, rule, query, and interpreter versions — so a result can be compared against a later one on equal terms.
 

--- a/docs/use/ai-workflows/ask-dev-answers.md
+++ b/docs/use/ai-workflows/ask-dev-answers.md
@@ -1,0 +1,139 @@
+---
+page_id: use-ask-dev-answers
+summary: Read an Ask Dev answer's outcome, provenance labels, disclosures, coverage, and evidence, and understand each refusal and no-answer result.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - src/dev_health_ops/api/dev/contracts_v2/base.py
+  - src/dev_health_ops/api/dev/contracts_v2/frame.py
+  - src/dev_health_ops/api/dev/contracts_v2/no_answer_policy.py
+  - src/dev_health_ops/api/dev/contracts.py
+  - src/dev_health_ops/api/dev/orchestrator.py
+applicability: current
+lifecycle: active
+---
+
+# Read an Ask Dev answer
+
+Every Ask Dev answer carries its own outcome, its provenance, what it could not cover, and the evidence behind it. Read those before the prose. An answer that stopped short says so; it does not present a partial result as a complete one.
+{: .fc-page-lede }
+
+!!! note "Screenshot placeholder — WEB lane"
+    Representative current screenshot of a completed answer showing the outcome label, a finding with its provenance label, coverage, and the evidence list. Desktop and mobile, both themes. Owned by the Ask Dev web lane; not authored here.
+
+## Read it in this order
+
+1. **Outcome.** Whether this is an answer at all, and if so whether it is complete.
+2. **Direct answer.** The single-sentence response to what you asked.
+3. **Completion and readiness.** Two separate judgements. How much is done is not whether it is ready.
+4. **Provenance labels.** Which statements were observed, which were inferred, and which are recommendations.
+5. **Disclosures.** Per-statement flags for stale, uncertain, conflicting, or untrusted-source input.
+6. **Coverage and source observations.** Which sources were required, which were usable, and what each contributed.
+7. **Conflicts and limitations.** Where sources disagreed, and what the answer does not cover.
+8. **Evidence.** The specific records behind the claims.
+
+## Outcomes
+
+The outcome is the first thing to read, because it decides whether the rest of the answer means anything.
+
+| Outcome | Shown as | What it means |
+| --- | --- | --- |
+| `answered` | Answered | The question was answered within the coverage stated |
+| `answered_with_gaps` | Answered with some gaps | A real answer, with named parts it could not cover. Read the limitations and coverage before acting |
+| `needs_clarification` | Needs clarification | The subject was ambiguous. Ask Dev offers candidates instead of guessing |
+| `not_found` | Not found | No matching subject you are authorized to see. Also the response for a subject in another organization |
+| `temporarily_unavailable` | Temporarily unavailable | A required source or the provider was unreachable. Retrying later is reasonable |
+| `unsupported` | Not supported yet | The question is outside what Ask Dev supports today |
+| `denied` | Not permitted | You do not have access to ask about this |
+| `refused` | Not something Ask Dev can do | The question asked Ask Dev to act, not to read |
+| `failed` | Something went wrong | The run did not complete. Nothing partial is presented as a result |
+
+Only `answered` and `answered_with_gaps` carry content. On every other outcome, the answer deliberately contains **no** narrative, findings, metrics, evidence, or follow-up suggestions — just the outcome, one plain sentence, one suggested next step, and the identifiers needed to reference the run. That emptiness is the design: a no-answer result never leaks a half-formed conclusion.
+
+`answered_with_gaps` is the one to slow down on. It is a genuine answer, and it is also a statement that something is missing. Treat the gap as part of the result, not as a footnote.
+
+## Refusals and what they mean
+
+Ask Dev distinguishes two different reasons it will not do something, and words them differently on purpose.
+
+| You asked it to | Outcome | What you see | Suggested next step |
+| --- | --- | --- | --- |
+| Run a command, execute code or a query, or change data | `refused` | *Ask Dev can only read and summarize your data; it can't run commands or make changes.* | *Ask a read-only question about your data instead.* |
+| Fetch an external URL, or generate open-ended content | `unsupported` | *This question is not supported yet.* | *Try a status, health, or metric question instead.* |
+
+The distinction matters. "Refused" means the capability is deliberately absent and always will be — Ask Dev does not write, execute, or act. "Not supported yet" means the question shape is outside the current product, which is a boundary that can move. Neither is an error, and neither is a partial attempt: a refused request is never executed and then rolled back; it is never started.
+
+The other no-answer outcomes read the same way — one sentence and one next step:
+
+| Outcome | You see | Suggested next step |
+| --- | --- | --- |
+| `not_found` | *No matching subject was found for this question.* | *Check the name and try again.* |
+| `temporarily_unavailable` | *This answer is temporarily unavailable. Please try again shortly.* | *Try the question again in a few minutes.* |
+| `denied` | *You do not have access to ask about this.* | *Ask an administrator for access to this area.* |
+| `failed` | *Something went wrong while preparing this answer.* | *Try the question again.* |
+
+## Provenance and disclosure
+
+Every statement in an answer is labelled with how it was arrived at:
+
+- **Observed** — read directly from your data.
+- **Inferred** — derived from observed facts. It follows from them; it was not measured.
+- **Recommendation** — a suggested action. It is a suggestion, not a finding.
+
+A statement may additionally carry disclosures: **stale**, **uncertain**, **conflicting**, or **untrusted source**. These describe the input, not the confidence of the wording. A stale observed fact is still an observation — of an older state.
+
+Where sources disagree, the answer names the conflict and points at the evidence on each side rather than silently preferring one.
+
+## Coverage, source state, and the difference between zero and nothing
+
+Coverage tells you which sources the question required, how many were usable, and which were unavailable, stale, or degraded. Read it before reading a number.
+
+Each source reports what it actually contributed, and these are never interchangeable:
+
+- **measured zero** — the source was read and the value is genuinely `0`;
+- **no data** — the source had nothing to report for this scope and window;
+- **not measured** — the source was not consulted for this question.
+
+Source availability is reported with the same precision: current, stale, unknown, unconfigured, unavailable, not visible to you, not applicable, or truncated. A dimension that does not apply to a subject is shown as **not applicable** — it is never collapsed into "healthy", and never counted as a pass.
+
+The same care applies to health: a dimension with no usable input reads **unknown**, not healthy.
+
+## Evidence
+
+Evidence is the point of the answer, not a citation ornament.
+
+- Evidence entries are **opaque references**, not arbitrary links. Ask Dev does not hand you a URL it fetched.
+- Opening one **re-checks your authorization at that moment** — that the answer is yours, and that you may still see the referenced repository or entity. A reference that is missing, unrelated, or no longer authorized reads as not found.
+- Excerpts are **inert plain text**, stripped of HTML, links, and common secrets, capped at 64 KiB, and treated as untrusted source content.
+- Evidence entries carry their own state — stale, unavailable, redacted, deleted, uncertain, conflicting, or untrusted content — and their own observed-at time and freshness.
+- Some measures cite evidence at the aggregate or source-class level rather than per record. Where that is the case, the answer says so instead of implying record-level backing it does not have.
+- Occasionally a part of an answer is withheld and shown as *This part of the answer could not be shown.* That is a deliberate safety projection, not a rendering failure.
+
+Every answer also records the definitions it ran under — plan, metric definition, rule, query, and interpreter versions — so a result can be compared against a later one on equal terms.
+
+## What an answer is not
+
+- It is not a decision, and not an instruction. Recommendations are labelled as such.
+- It is not a statement about a person. Ask Dev has no per-engineer health, workload, commitment, productivity, or ranking output.
+- It is not proof of cause. An inference explains what follows from the observations; it does not establish why.
+- It is not a live system check. It reports what the sources had, as of the times shown.
+- It is not training data. Dev Health does not use Ask Dev conversation content to train models.
+
+## Data handling you should know about
+
+Ask Dev sends your question and the retrieved context to a configured model provider to compose the answer. Which provider that is — a platform provider or your organization's own — is an administrator decision, as is whether a fallback between them is permitted. Content is not used for model training by default. Conversation retention is set for the whole workspace by an administrator, at either zero days or 30 days; see [Understand Ask Dev conversation history](index.md#understand-ask-dev-conversation-history).
+
+Answers never expose internal prompts, provider messages, tool payloads, or raw provider errors, on any surface, including error messages.
+
+## If an answer looks wrong
+
+- An unexpectedly empty or partial answer is usually a coverage or source-state result — start at [No or incomplete data](../troubleshooting/no-or-incomplete-data.md).
+- An answer about the wrong thing is usually subject naming — see [Ask what Ask Dev supports](ask-dev-questions.md#name-the-subject-so-ask-dev-can-find-it).
+- A `temporarily_unavailable` or `failed` outcome that repeats is worth reporting with the run identifier shown on the answer.
+
+## Related information
+
+- [Ask what Ask Dev supports](ask-dev-questions.md)
+- [Ask Dev, Context Fabric, and agent context](index.md#ask-dev-context-fabric-and-agent-context)
+- [Understand loading, empty, stale, and partial data](../navigate/data-states.md)
+- [Missing permission or unavailable view](../troubleshooting/permissions-and-availability.md)

--- a/docs/use/ai-workflows/ask-dev-questions.md
+++ b/docs/use/ai-workflows/ask-dev-questions.md
@@ -1,0 +1,94 @@
+---
+page_id: use-ask-dev-questions
+summary: The question families Ask Dev answers today, the subjects it can resolve, and the behavior that is deliberately not available yet.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - src/dev_health_ops/api/dev/contracts_v2/base.py
+  - src/dev_health_ops/api/dev/question_interpreter.py
+  - src/dev_health_ops/api/dev/preflight_outcomes.py
+  - src/dev_health_ops/api/dev/contracts.py
+applicability: current
+lifecycle: active
+---
+
+# Ask what Ask Dev supports
+
+Ask Dev answers a bounded set of question families about work your organization already has data for. It is a read-only investigator: it looks things up, explains what it found, and shows the evidence. Knowing the boundary in advance is faster than discovering it one refusal at a time.
+{: .fc-page-lede }
+
+For the surfaces themselves — the in-app window, the `/dev` workspace, shared conversation history, and retention — see [Ask Dev, Context Fabric, and agent context](index.md#ask-dev-context-fabric-and-agent-context). For what an answer's parts mean, see [Read an Ask Dev answer](ask-dev-answers.md).
+
+!!! note "Screenshot placeholder — WEB lane"
+    Representative current screenshot of the Ask Dev window with a supported question in progress, desktop, both themes. Owned by the Ask Dev web lane; not authored here.
+
+## Name the subject so Ask Dev can find it
+
+Ask Dev resolves a question against a **subject**: a specific repository, project, team, work unit, issue, or pull request that you are authorized to see. There is no person subject — Ask Dev has no per-engineer ranking, score, or productivity view to ask for.
+
+Name the subject the way the product does, and put the kind word next to it:
+
+- **Include the kind noun.** `repository`, `repo`, `project`, `team`, `work unit`, `issue`, `ticket`, `pull request`, `merge request`, `PR`, and their plurals are recognized. A name with no kind noun beside it is not read as a subject.
+- **Capitalize or quote the name.** `the repo "meridian/web-app"` and `the Platform Reliability team` both work; a bare lowercase slug on its own does not.
+- **Ask about at most 25 subjects at once.** Over that, Ask Dev declines the question rather than silently answering about the first 25. A bound is a refusal, never a quiet truncation.
+- **Keep one kind per set.** A single question about a set of subjects covers one kind — repositories *or* teams, not a mixture.
+
+Acronyms and short aliases are matched for projects and teams only. A near match, or a match of a different kind than the one you named, is never committed silently: it comes back as a clarification with candidates for you to choose from. Ask Dev asks rather than guesses. See [Read an Ask Dev answer](ask-dev-answers.md#outcomes).
+
+Asking about the organization as a whole is supported as a *scope*, not as a subject: "across the organization" widens the question rather than naming a thing.
+
+## Question families you can ask today
+
+| Ask about | Example question | Answers with |
+| --- | --- | --- |
+| Status of one subject | *How is the repo "meridian/web-app" doing?* | Current state, with completion and readiness kept separate |
+| Readiness | *Is the repo "meridian/web-app" release-ready?* | A readiness judgement that is `ready`, `not ready`, or `indeterminate` — never a percentage standing in for one |
+| Remaining work | *What work remains before the repo "meridian/web-app" ships?* | Outstanding work, scoped and evidenced |
+| Several subjects, or the portfolio | *What's the status of all our projects across the organization's portfolio?* | Per-subject statuses, plus what could not be covered |
+| Project health | *Is the repo "meridian/web-app" healthy?* | Health by dimension, with not-applicable dimensions shown as such rather than folded into "healthy" |
+| Team health | *Is the "Platform Reliability" team healthy?* | Team-level health; teams are a first-class subject, individuals are not |
+| Workload pressure | *Is the "Platform Reliability" team overburdened?* | Pressure against a stated denominator — or an explicit not-calculable result when the denominator is missing |
+| Investment mix | *What's our investment mix across feature/maintenance/risk work?* | Distribution across the investment taxonomy, with unclassified coverage stated |
+| Operational deficiencies | *What operational deficiencies does the "Platform Reliability" team have?* | Deficiencies by category, with applicability and verification |
+| Observed change | *How did items completed change this month?* | The change actually observed in the window, not a projection |
+| Metric comparison | *Compare items completed against cyclomatic per kloc* | Two registered metrics, compared on stated definitions |
+| Data trust and source health | *How trustworthy is the data behind the status of the repo "meridian/web-app"?* | Source state, freshness, coverage, and conflicts |
+
+Metric questions name metrics from a registered catalog — items completed, cycle time, average WIP, deployments, change failure rate, investment allocation, cyclomatic per kloc, and compounding risk score. Ask Dev does not invent a metric on request; a metric that is not registered cannot be asked for.
+
+A question the recognizers do not match still runs, as a bounded investigation over the same read-only tools and the same evidence rules. It is not a different, freer mode — the same limits apply.
+
+## What Ask Dev will not do
+
+These are refusals by design, not gaps waiting on a fix. Ask Dev tells you which one applies rather than failing vaguely:
+
+- **No writes or changes.** It cannot update a ticket, close an issue, merge, deploy, or change any setting.
+- **No command, code, SQL, GraphQL, or MCP execution.** Requests to run something are refused, not attempted.
+- **No external fetching or open-ended generation.** It cannot browse a URL, search the web, or write code for you.
+- **No file upload.** There is nothing to attach; Ask Dev works from data already in your workspace.
+- **No autonomous background work.** A question runs while you wait and finishes; nothing continues afterward.
+- **No person-level output.** There is no per-engineer health, workload, commitment, productivity, or ranking answer — the capability does not exist to be enabled.
+
+Requests to act (write, execute) and requests outside the product's shape (fetch a URL, generate open-ended content) produce **different** results, with different wording. See [Refusals](ask-dev-answers.md#refusals-and-what-they-mean).
+
+Ask Dev also holds your own authorization: it answers only about what you can already see. A subject in another organization, or one you are not authorized for, comes back as not found — the same response as a subject that does not exist, so nothing is revealed by the difference.
+
+## Known limitations in the current release
+
+Stated plainly, because an answer that quietly stops short is worse than a documented boundary:
+
+- **"Which teams are light on feature work?" does not yet return an attributed answer.** The question is accepted, but no attributed signal is produced for it today.
+- **Scope inherited from earlier page or conversation context is not applied.** Each question carries the scope you can see committed on it; nothing is silently carried forward from where you were.
+
+These two are current product behavior. Separately, a number of behaviors are shipped but not yet fully exercised by the acceptance harness — a verification gap, not a product limitation — and are deliberately not listed here as things the product does not do.
+
+## If Ask Dev is not available to you
+
+Ask Dev is enabled per organization and is not part of any plan by default. If you do not see it, or it reports as unavailable, see [Missing permission or unavailable view](../troubleshooting/permissions-and-availability.md) and ask your workspace administrator.
+
+## Related information
+
+- [Read an Ask Dev answer](ask-dev-answers.md)
+- [Ask Dev, Context Fabric, and agent context](index.md#ask-dev-context-fabric-and-agent-context)
+- [Understand loading, empty, stale, and partial data](../navigate/data-states.md)
+- [Metric definitions](../../reference/metrics/definitions.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ nav:
           - AI Impact: use/ai-workflows/impact.md
           - AI Review Load: use/ai-workflows/review-load.md
           - AI Governance Risk: use/ai-workflows/risk.md
+          - Ask what Ask Dev supports: use/ai-workflows/ask-dev-questions.md
+          - Read an Ask Dev answer: use/ai-workflows/ask-dev-answers.md
       - Reports:
           - use/reports/index.md
           - Create or clone: use/reports/create-or-clone.md
@@ -145,6 +147,7 @@ nav:
           - Workers and jobs: operate/run/workers-and-jobs.md
           - Ingestion and backfills: operate/run/ingestion-and-backfills.md
           - Operational controls: operate/run/operational-controls.md
+          - Ask Dev rollout: operate/run/ask-dev-rollout.md
       - Observe:
           - operate/observe/index.md
           - Health checks: operate/observe/health-checks.md

--- a/scripts/check_ask_dev_copy_drift.py
+++ b/scripts/check_ask_dev_copy_drift.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Fail on drift between the published Ask Dev answer copy and the server-owned constants.
+
+``docs/use/ai-workflows/ask-dev-answers.md`` prints, as the product's own
+words, three classes of string the runtime owns:
+
+* the ``dev_answer.v2`` outcome **display labels**
+  (``contracts_v2/answer.py::_OUTCOME_DISPLAY_LABELS``);
+* the canonical no-answer **sentence** and **remediation** for every
+  no-answer outcome (``contracts_v2/no_answer_policy.py``);
+* the **withheld-content** sentence (``no_match_terminal.py::WITHHELD_COPY``).
+
+Every one of those is a single server-owned string that a user reads
+verbatim on screen. If the page and the runtime disagree, the page is a
+confident, plausible lie about what the product says -- the worst failure
+mode a documentation page has, because a reader who sees an exact quotation
+stops checking. Reviewer vigilance does not scale to catching a one-word
+edit on either side, so this is a guard.
+
+Scope, stated so the exclusions are not silent:
+
+* Only the columns that CLAIM to quote the product are compared. The
+  outcome table's "What it means" column is authored explanation, is not
+  presented as the product's words, and is deliberately not checked.
+* The comparison is **verbatim**, including punctuation and apostrophes.
+  A paraphrase in a checked column is a failure, not a near-miss.
+
+Following ``check_investment_docs_drift.py``: constants are read out of the
+source with ``ast`` rather than imported, so the guard runs in the docs
+environment without importing the application or its dependencies.
+
+Fails loudly rather than vacuously. A missing page, a missing marker pair, a
+region that yields zero rows, or a constant that cannot be located in the
+source is an ERROR -- never a silent pass. A check that measured nothing must
+not report success.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+DEV = ROOT / "src" / "dev_health_ops" / "api" / "dev"
+
+ANSWERS_DOC = DOCS / "use" / "ai-workflows" / "ask-dev-answers.md"
+BASE_PATH = DEV / "contracts_v2" / "base.py"
+ANSWER_PATH = DEV / "contracts_v2" / "answer.py"
+NO_ANSWER_PATH = DEV / "contracts_v2" / "no_answer_policy.py"
+NO_MATCH_PATH = DEV / "no_match_terminal.py"
+
+OUTCOME_LABELS_REGION = "ASK-DEV OUTCOME LABELS"
+REFUSAL_COPY_REGION = "ASK-DEV REFUSAL COPY"
+NO_ANSWER_COPY_REGION = "ASK-DEV NO-ANSWER COPY"
+WITHHELD_COPY_REGION = "ASK-DEV WITHHELD COPY"
+
+_CODE_CELL_RE = re.compile(r"^`([a-z_]+)`$")
+_SEPARATOR_ROW_RE = re.compile(r"^[\s|:-]+$")
+
+
+class SourceLookupError(RuntimeError):
+    """A constant this guard compares against is not where it expects it."""
+
+
+# ---------------------------------------------------------------------------
+# Source-side extraction (ast, never import)
+# ---------------------------------------------------------------------------
+
+
+def _assigned_value(path: Path, name: str) -> ast.expr:
+    """The value node assigned to a module-level ``name``."""
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            ):
+                return node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            if isinstance(node.target, ast.Name) and node.target.id == name:
+                return node.value
+    raise SourceLookupError(f"{name} not found at module level in {path}")
+
+
+def _string(node: ast.expr, context: str) -> str:
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        raise SourceLookupError(f"{context} is not a string literal")
+    return node.value
+
+
+def _str_enum_values(path: Path, class_name: str) -> dict[str, str]:
+    """``{MEMBER_NAME: "wire_value"}`` for a ``StrEnum`` class."""
+
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        members: dict[str, str] = {}
+        for statement in node.body:
+            if not isinstance(statement, ast.Assign):
+                continue
+            for target in statement.targets:
+                if isinstance(target, ast.Name):
+                    members[target.id] = _string(
+                        statement.value, f"{class_name}.{target.id}"
+                    )
+        if not members:
+            raise SourceLookupError(f"{class_name} in {path} has no string members")
+        return members
+    raise SourceLookupError(f"class {class_name} not found in {path}")
+
+
+def _str_to_str_mapping(path: Path, name: str) -> dict[str, str]:
+    """A ``{"key": "value"}`` dict literal with string keys and values."""
+
+    value = _assigned_value(path, name)
+    if not isinstance(value, ast.Dict):
+        raise SourceLookupError(f"{name} in {path} is not a dict literal")
+    mapping: dict[str, str] = {}
+    for key_node, value_node in zip(value.keys, value.values, strict=True):
+        if key_node is None:
+            raise SourceLookupError(f"{name} in {path} uses dict unpacking")
+        key = _string(key_node, f"{name} key")
+        mapping[key] = _string(value_node, f"{name}[{key!r}]")
+    if not mapping:
+        raise SourceLookupError(f"{name} in {path} is empty")
+    return mapping
+
+
+def _str_to_first_of_tuple(path: Path, name: str) -> dict[str, str]:
+    """A ``{"key": ("value",)}`` dict literal, reduced to its first element."""
+
+    value = _assigned_value(path, name)
+    if not isinstance(value, ast.Dict):
+        raise SourceLookupError(f"{name} in {path} is not a dict literal")
+    mapping: dict[str, str] = {}
+    for key_node, value_node in zip(value.keys, value.values, strict=True):
+        if key_node is None:
+            raise SourceLookupError(f"{name} in {path} uses dict unpacking")
+        key = _string(key_node, f"{name} key")
+        if not isinstance(value_node, ast.Tuple) or not value_node.elts:
+            raise SourceLookupError(f"{name}[{key!r}] is not a non-empty tuple")
+        mapping[key] = _string(value_node.elts[0], f"{name}[{key!r}][0]")
+    if not mapping:
+        raise SourceLookupError(f"{name} in {path} is empty")
+    return mapping
+
+
+def _enum_keyed_labels(path: Path, name: str, enum_name: str) -> dict[str, str]:
+    """``{PublicOutcome.X: "Label"}`` resolved to ``{"wire_value": "Label"}``."""
+
+    members = _str_enum_values(BASE_PATH, enum_name)
+    value = _assigned_value(path, name)
+    if not isinstance(value, ast.Dict):
+        raise SourceLookupError(f"{name} in {path} is not a dict literal")
+    mapping: dict[str, str] = {}
+    for key_node, value_node in zip(value.keys, value.values, strict=True):
+        if (
+            not isinstance(key_node, ast.Attribute)
+            or not isinstance(key_node.value, ast.Name)
+            or key_node.value.id != enum_name
+        ):
+            raise SourceLookupError(f"{name} in {path} has a non-{enum_name} key")
+        member = key_node.attr
+        if member not in members:
+            raise SourceLookupError(f"{enum_name}.{member} is not a member")
+        mapping[members[member]] = _string(value_node, f"{name}[{member}]")
+    if not mapping:
+        raise SourceLookupError(f"{name} in {path} is empty")
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# Doc-side extraction
+# ---------------------------------------------------------------------------
+
+
+def _region(document: str, name: str, source: str) -> str:
+    begin = f"<!-- BEGIN {name} -->"
+    end = f"<!-- END {name} -->"
+    start = document.find(begin)
+    stop = document.find(end)
+    if start == -1 or stop == -1 or stop < start:
+        raise SourceLookupError(f"{source}: marker pair for {name!r} is missing")
+    return document[start + len(begin) : stop]
+
+
+def _table_rows(block: str, name: str, source: str) -> list[list[str]]:
+    """Body cells of a pipe table, header and separator dropped."""
+
+    rows: list[list[str]] = []
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        if _SEPARATOR_ROW_RE.match(line):
+            rows = []  # everything before the separator is the header
+            continue
+        rows.append([cell.strip() for cell in line.strip("|").split("|")])
+    if not rows:
+        raise SourceLookupError(f"{source}: region {name!r} contains no table rows")
+    return rows
+
+
+def _code_cell(cell: str, name: str, source: str) -> str:
+    match = _CODE_CELL_RE.match(cell)
+    if match is None:
+        raise SourceLookupError(
+            f"{source}: region {name!r} expected a `code` outcome cell, got {cell!r}"
+        )
+    return match.group(1)
+
+
+def _quoted_cell(cell: str, name: str, source: str) -> str:
+    """A cell that claims to quote the product: italicised, stripped verbatim."""
+
+    if not (cell.startswith("*") and cell.endswith("*") and len(cell) > 2):
+        raise SourceLookupError(
+            f"{source}: region {name!r} expected an italicised product string, "
+            f"got {cell!r}"
+        )
+    return cell[1:-1]
+
+
+# ---------------------------------------------------------------------------
+# Comparisons
+# ---------------------------------------------------------------------------
+
+
+def _compare(
+    kind: str, outcome: str, published: str, canonical: str, errors: list[str]
+) -> None:
+    if published != canonical:
+        errors.append(
+            f"{ANSWERS_DOC.relative_to(ROOT)}: {kind} for {outcome!r} drifted -- "
+            f"page says {published!r}, source says {canonical!r}"
+        )
+
+
+def check_outcome_labels(document: str, errors: list[str]) -> None:
+    canonical = _enum_keyed_labels(
+        ANSWER_PATH, "_OUTCOME_DISPLAY_LABELS", "PublicOutcome"
+    )
+    block = _region(document, OUTCOME_LABELS_REGION, "ask-dev-answers.md")
+    published: dict[str, str] = {}
+    for row in _table_rows(block, OUTCOME_LABELS_REGION, "ask-dev-answers.md"):
+        if len(row) < 2:
+            errors.append(f"outcome-label row has too few columns: {row!r}")
+            continue
+        outcome = _code_cell(row[0], OUTCOME_LABELS_REGION, "ask-dev-answers.md")
+        published[outcome] = row[1]
+
+    missing = sorted(set(canonical) - set(published))
+    unknown = sorted(set(published) - set(canonical))
+    if missing:
+        errors.append(f"outcome table does not document these outcomes: {missing}")
+    if unknown:
+        errors.append(f"outcome table documents unknown outcomes: {unknown}")
+    for outcome in sorted(set(canonical) & set(published)):
+        _compare(
+            "display label", outcome, published[outcome], canonical[outcome], errors
+        )
+
+
+def check_no_answer_copy(document: str, errors: list[str]) -> None:
+    canonical_copy = _str_to_str_mapping(NO_ANSWER_PATH, "CANONICAL_NO_ANSWER_COPY")
+    canonical_remediation = _str_to_first_of_tuple(
+        NO_ANSWER_PATH, "CANONICAL_NO_ANSWER_REMEDIATION"
+    )
+
+    published_copy: dict[str, str] = {}
+    published_remediation: dict[str, str] = {}
+
+    # The refusal table carries a leading "You asked it to" column; the
+    # no-answer table does not. Both quote copy then remediation.
+    for name, outcome_col in (
+        (REFUSAL_COPY_REGION, 1),
+        (NO_ANSWER_COPY_REGION, 0),
+    ):
+        block = _region(document, name, "ask-dev-answers.md")
+        for row in _table_rows(block, name, "ask-dev-answers.md"):
+            if len(row) < outcome_col + 3:
+                errors.append(f"{name} row has too few columns: {row!r}")
+                continue
+            outcome = _code_cell(row[outcome_col], name, "ask-dev-answers.md")
+            if outcome in published_copy:
+                errors.append(f"outcome {outcome!r} is quoted in more than one table")
+            published_copy[outcome] = _quoted_cell(
+                row[outcome_col + 1], name, "ask-dev-answers.md"
+            )
+            published_remediation[outcome] = _quoted_cell(
+                row[outcome_col + 2], name, "ask-dev-answers.md"
+            )
+
+    missing = sorted(set(canonical_copy) - set(published_copy))
+    unknown = sorted(set(published_copy) - set(canonical_copy))
+    if missing:
+        errors.append(f"no-answer copy is not published for these outcomes: {missing}")
+    if unknown:
+        errors.append(f"copy published for unknown outcomes: {unknown}")
+    for outcome in sorted(set(canonical_copy) & set(published_copy)):
+        _compare(
+            "canonical copy",
+            outcome,
+            published_copy[outcome],
+            canonical_copy[outcome],
+            errors,
+        )
+        if outcome in canonical_remediation:
+            _compare(
+                "remediation",
+                outcome,
+                published_remediation[outcome],
+                canonical_remediation[outcome],
+                errors,
+            )
+        else:
+            errors.append(f"no canonical remediation exists for outcome {outcome!r}")
+
+
+def check_withheld_copy(document: str, errors: list[str]) -> None:
+    canonical = _string(
+        _assigned_value(NO_MATCH_PATH, "WITHHELD_COPY"), "WITHHELD_COPY"
+    )
+    block = _region(document, WITHHELD_COPY_REGION, "ask-dev-answers.md").strip()
+    published = _quoted_cell(block, WITHHELD_COPY_REGION, "ask-dev-answers.md")
+    _compare("withheld-content copy", "withheld", published, canonical, errors)
+
+
+def main() -> int:
+    if not ANSWERS_DOC.is_file():
+        print(f"ERROR: missing page {ANSWERS_DOC.relative_to(ROOT)}")
+        return 1
+
+    document = ANSWERS_DOC.read_text(encoding="utf-8")
+    errors: list[str] = []
+    try:
+        check_outcome_labels(document, errors)
+        check_no_answer_copy(document, errors)
+        check_withheld_copy(document, errors)
+    except SourceLookupError as exc:
+        # A guard that cannot find what it compares has NOT passed.
+        print(f"ERROR: {exc}")
+        return 1
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Ask Dev published-copy drift check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/acceptance/PHASE3-EVIDENCE-SUMMARY.md
+++ b/tests/acceptance/PHASE3-EVIDENCE-SUMMARY.md
@@ -1,15 +1,21 @@
 # Phase 3 evidence summary — CHAOS-3219 armed corpus run
 
-**Verdict: MEASURED. Filled from the grade record, not from expectation.**
+**Run verdict: MEASURED. Phase verdict: CLOSED (2026-08-07 ~17:10 PT).**
+Filled from the grade and closure record, not from expectation.
 
-Sources, and the only two this document is filled from:
+Sources this document is filled from, in order of authority:
 
 * the **2026-08-07 grade comment on CHAOS-3219** (`Phase 3 armed corpus run — GRADED: MEASURED`);
-* the body of **ops PR #1597** (`CHAOS-3219 Phase 3 close`), which is the durable evidence record and reproduces the grade verbatim.
+* the **Phase 3 closure comment on CHAOS-3219** (`Phase 3 — CLOSED (2026-08-07 ~17:10 PT)`);
+* the body of **ops PR #1597** (`CHAOS-3219 Phase 3 close`), merged to `main` as `6b7517364`, which is the durable evidence record and reproduces the grade verbatim;
+* the run's own **`.p3-logs/RUN-CONDITIONS.md`** and boot log, for environment facts the three narrative sources do not carry.
 
-Anything neither source carries is left as an explicit `<PLACEHOLDER: …>` rather than
+Anything none of these carries is left as an explicit `<PLACEHOLDER: …>` rather than
 reconstructed. A reconstructed figure in an evidence document is indistinguishable
 from a measured one once it is written down.
+
+The corpus corrections described in section 4F are **on `main`** as of `6b7517364`;
+they are not pending.
 
 Graded against [`PRE-REGISTRATION.phase3.v2.md`](PRE-REGISTRATION.phase3.v2.md) **as
 amended pre-run in `4f974f2c7`**. The amendment fired v2's own re-derive rule after
@@ -30,7 +36,7 @@ pre-registration was not touched after the run.
 | Engine identity digest | `12b961997a122ff6e7a711db0a3a5724bdb668a28c262f2fdf94c88be3675e59` |
 | Provider role / cases | `legacy_agent`, 96 |
 | API container | `77d8499c18a3` (pinned) |
-| `WORLD_DIGEST` | `<PLACEHOLDER: re-minted world; digest not carried by either source>` |
+| `WORLD_DIGEST` | `fea90782a6b462597c41173e5d5e40728c4bf5c291631b1a42a3215ef14758e5` — live matched the pinned file |
 | Superseded attempts | Attempt 1 — killed unmeasured by the 09:26 machine reboot. Attempt 2 (09:47 PT) — UNMEASURED (degraded): 59/90 active cases hit HTTP 429 `cost_limit_reached`; root causes ticketed CHAOS-3573 and CHAOS-3575. An 11:04 PT run measured 122/12 and settled Phase 2 exit; **it is not this grade** — run #3 supersedes it. |
 
 ## 2. Run-validity preconditions
@@ -41,7 +47,7 @@ carried from the pre-registration.
 | Precondition | Required | Observed | Verdict |
 | --- | --- | --- | --- |
 | Engine identity digest matches | `12b96199…` | `IDENTITY MATCH 12b961997a12…` role `legacy_agent`, 96 cases | PASS |
-| `WORLD_DIGEST` matches pinned snapshot | match | `<PLACEHOLDER: not carried by either source>` | `<PLACEHOLDER>` |
+| `WORLD_DIGEST` matches pinned snapshot | match | `world restore: WORLD_DIGEST fea90782a6b46259… verified against /app/tests/acceptance/world/ask-dev-world.v1/WORLD_DIGEST`; 86 ClickHouse + 10 Postgres tables restored | PASS |
 | QUA flags unset in the API container's own environment | unset | `QUA_VERIFIED=not-armed (shadow=0 commit=0)` | PASS |
 | Items collected | 134 | 134 | PASS |
 | Items skipped | 0 | 0 | PASS |
@@ -58,6 +64,21 @@ carried from the pre-registration.
 The pin check earns its place here. It was added during this run (`c16cd2e36`) so a
 competing `compose up` is *named* at the stage boundary rather than surfacing four
 stages later as `service "api" is not running`.
+
+### Caveat recorded before any result was seen: the world was re-minted
+
+`RUN-CONDITIONS.md` records, **pre-grade**, that the snapshot moved from the graded
+11:11 run's `6dda65a695befc98…` to this run's `fea90782a6b46259…` (PR #1583's re-mint).
+That is **not drift and not a MISS** — v2 requires only that the live world match the
+pinned file, which it does. But this run measures against a *different world* than the
+one v2's predictions were derived from, and the corpus depends on world data.
+
+The caveat was written down in advance precisely so the re-mint could not be reached
+for afterwards as a convenient explanation, with the honest statement that *"the fix
+behaved differently"* and *"the world changed"* cannot be separated without a
+discriminating check. **Section 4F is that discriminating check**, and it clears the
+re-mint: the absence reason changed in lockstep with the span declaration and is
+computed from the declared-spans flag, not from world data.
 
 ## 3. Headline result
 
@@ -196,14 +217,26 @@ New signatures not anticipated by the pre-registration: **none**.
 | Field | Value |
 | --- | --- |
 | Harness | armed corpus run, Compose acceptance stack, 8/8 services healthy |
-| Boot recipe | `scripts/acceptance/armed_corpus_boot.sh` |
-| Provider | scripted (`ASK_DEV_SCRIPTED_PROVIDER_*`), no live provider |
+| Boot recipe | `scripts/acceptance/armed_corpus_boot.sh` (in-tree), `BOOT_EXIT_CODE=0` |
+| Compose files | `compose.yml` + `tests/acceptance/compose.ask-dev.yml` + `scripts/acceptance/acceptance_allowance_override.yml`, all in-tree and tracked |
+| Compose project | `dev-health-ask-dev-acceptance` |
+| Images | Built from the repo tree by `docker compose up -d --build --wait`, **not pulled tags** — so the image identity is the branch SHA, and there is no published digest to pin |
+| Python | 3.14 in the API image (`requires-python >= 3.14`); the runner side uses the worktree venv at `.venv/bin/python` |
+| API bind | `127.0.0.1:18099` (18080 deliberately left to the dev stack's `acr-api`) |
 | API container | `77d8499c18a3`, pinned and re-checked at three stage boundaries |
+| Provider | scripted (`ASK_DEV_SCRIPTED_PROVIDER_*`), no live provider |
 | Allowance | 6 orgs × 500,000,000 microUSD, counter absent at boot |
-| Compose file(s) | `<PLACEHOLDER: not carried by either source>` |
-| Images / digests | `<PLACEHOLDER: not carried by either source>` |
-| Python version | `<PLACEHOLDER: not carried by either source>` |
-| Host | `<PLACEHOLDER: not carried by either source>` |
+| Host | `<PLACEHOLDER: not recorded — RUN-CONDITIONS.md documents that the machine was probed quiet before boot (no gate lock, no `local_validate`, no foreign agent), but does not identify the host>` |
+
+The allowance override is worth reading as a run condition rather than a knob. It
+exists because attempt 2's 429 storm was root-caused to a **false premise in the
+harness**: `ASK_DEV_PLATFORM_MONTHLY_COST_MAX_MICROUSD` is the operator *maximum* an
+org may be configured up to, not the effective limit, which resolves to the
+`100,000,000` default when no per-org row is stored. The runner budgeted against $200
+while the server enforced $100. `500,000,000` is the reachable ceiling
+(`PLATFORM_MONTHLY_COST_LIMIT_HARD_MAX_MICROUSD` clamps both layers) and is ~1.64× the
+~$304M the 90-case corpus needs. **No product constant was changed**, and the
+pre-registration was not touched.
 
 Two boot-recipe defects were found **by running the recipe, not by reading it**, and
 are part of this run's record:
@@ -248,8 +281,8 @@ coverage claim, because a reader who sees "covered" stops checking.
 | `deg.provider.unsupported` and `readiness.capabilities.unsupported-model` flip DECLARED-BLOCKED | Provider-unsupported and unsupported-model readiness paths are unverified | CHAOS-3588 |
 | **QUA shadow: NOT MEASURED** | Correctly disarmed throughout, and explicitly out of scope per v2 Amendment 3. This run says nothing about shadow behavior in either direction | CHAOS-3389 / CHAOS-3525 |
 | 43 declared-blocked corpus cases were not executed | Mid-conversation and multi-turn behavior (CHAOS-3454), prompt injection via ingested content (CHAOS-3456), budget/plan-size exhaustion (CHAOS-3455), redacted evidence and `missing_credentials` readiness (CHAOS-3461), cross-tenant refusal for team/user/evidence ids (CHAOS-3459), conversation purge and retention (CHAOS-3547), alias/acronym two-turn resolution (CHAOS-3475), kill switches (CHAOS-3549), filtered and inherited scope (CHAOS-3543, CHAOS-3542), partially-resolved TEAM subjects (CHAOS-3429), truncated work-graph disclosure (CHAOS-3428), attributed "light on feature work" (CHAOS-3394) | as listed |
-| Scripted provider, not a live one | Live-provider behavior is not exercised by this run | — |
-| `WORLD_DIGEST` for run #3 not carried by the grade record | The world-pin match is asserted by the boot, not reproduced in this summary | `<PLACEHOLDER: recover from RUN-CONDITIONS.md>` |
+| Scripted provider, not a live one | Live-provider behavior is not exercised by this run. The QUA commit path was proven live **separately**, outside this run — CHAOS-3532 check #4, the fuzzy-mention scenario end-to-end on merged `main` | CHAOS-3532 (closed) |
+| Host identity not recorded | The run cannot be reproduced on the same machine from this record alone; the machine-quiet probes are recorded, the machine is not | — |
 
 ## 10. Verdict
 
@@ -267,6 +300,19 @@ red, `deg.provider.unsupported`, is the predicted red on the predicted clause.
 `readiness.capabilities.degraded`'s green is recorded as vacuous and is not citable as
 coverage.
 
-**Exit decision and who made it:** `<PLACEHOLDER: Phase 3 exit not yet declared on
-CHAOS-3219 at the time of writing; Phase 2 exit was declared by chris 2026-08-07
-13:39 PT>`
+**Exit decision.** **Phase 3 — CLOSED, 2026-08-07 ~17:10 PT**, declared on CHAOS-3219,
+citing evidence PR **#1597** merged to `main` as **`6b7517364`**. The durable record is
+that PR's body plus the graded-run comment, with artifacts in-tree (`.p3-logs`, 134
+receipts under `tests/acceptance/artifacts/wave4/`). Phase 2 exit had been declared
+separately by chris at 13:39 PT the same day.
+
+Closing state as declared: every substantive v2 prediction landed including the
+code-routing discriminator; one predicted red; two misses self-inflicted by a corpus
+edit, owned with mechanism and corrected in the merged tree with an asserted exemption
+and mutation-proven guards; three readiness/degraded cases flipped DECLARED-BLOCKED on
+CHAOS-3588, whose underlying mechanism CHAOS-3546 retired.
+
+**Method note carried from the closure, because it is the point.** Three of that day's
+defects — the boot recipe's worktree path, the stack-collision diagnosis, and the
+corpus-edit miss — were **invisible to careful review and caught by execution on the
+first run**. Recipes and claims get executed, not read.

--- a/tests/acceptance/PHASE3-EVIDENCE-SUMMARY.md
+++ b/tests/acceptance/PHASE3-EVIDENCE-SUMMARY.md
@@ -1,0 +1,225 @@
+# Phase 3 evidence summary — CHAOS-3219 armed corpus run
+
+**Status: SKELETON. Every `<...>` below is an unfilled placeholder.**
+This document is authored before the grade so that its structure cannot be shaped by
+the result. Fill it from the run's own artifacts; do not restate a claim this document
+asks for unless an artifact supports it. A section with nothing to put in it is
+recorded as "none", never deleted — a missing section reads as "not applicable" when
+it usually means "not checked".
+
+Grades against [`PRE-REGISTRATION.phase3.v2.md`](PRE-REGISTRATION.phase3.v2.md) and
+nothing else. If the run's conditions differ from that document's assumed merge-set,
+re-derive before grading rather than folding the difference in.
+
+---
+
+## 1. Run identity
+
+| Field | Value |
+| --- | --- |
+| Graded run | `<GRADE: pending armed run 2026-08-07>` |
+| Run timestamp (PT) | `<GRADE: pending armed run 2026-08-07>` |
+| `main` SHA under test | `<GRADE: pending armed run 2026-08-07>` |
+| Pre-registration graded against | `PRE-REGISTRATION.phase3.v2.md` |
+| Engine identity digest | `<GRADE: pending armed run 2026-08-07>` (expected `12b961997a12…`) |
+| Provider role | `legacy_agent` |
+| `WORLD_DIGEST` | `<GRADE: pending armed run 2026-08-07>` |
+| Superseded attempts | `<GRADE: pending armed run 2026-08-07>` |
+
+## 2. Run-validity preconditions
+
+Every row must be a **verified observation from the run's own output**, not an
+expectation carried from the pre-registration. A row that cannot be observed is
+`UNMEASURED`, and an `UNMEASURED` row voids the run rather than reducing its grade.
+
+| Precondition | Required | Observed | Verdict |
+| --- | --- | --- | --- |
+| Engine identity digest matches | `12b961997a12…` | `<GRADE: pending>` | `<PASS / FAIL / UNMEASURED>` |
+| `WORLD_DIGEST` matches pinned snapshot | match | `<GRADE: pending>` | `<...>` |
+| QUA flags unset in the API container's own environment | unset | `<GRADE: pending>` | `<...>` |
+| Items collected | 134 | `<GRADE: pending>` | `<...>` |
+| Items skipped | 0 | `<GRADE: pending>` | `<...>` |
+| Cases executed | 90 active | `<GRADE: pending>` | `<...>` |
+| Receipt coverage `missing:` | 0 | `<GRADE: pending>` | `<...>` |
+| Engine controls green | 3/3 | `<GRADE: pending>` | `<...>` |
+| HTTP 429 observed | none | `<GRADE: pending>` | `<...>` |
+
+**Verdict on validity:** `<MEASURED / UNMEASURED / VOID>`
+
+The three standing engine controls are `adv.unsafe-error-text.provider`,
+`adv.abuse.retry-storm`, and `adv.oversized.result`. If any is red the scripted engine
+has regressed and no other result in the run may be reported in either direction.
+
+## 3. Headline result
+
+```
+<GRADE: pending armed run 2026-08-07>
+  collected · skipped · executed · receipts · missing
+  passed · failed · errored
+```
+
+| Measure | Predicted | Observed |
+| --- | --- | --- |
+| Cases green | everything except the predicted reds | `<GRADE: pending>` |
+| Cases red | 1 (+1 conditional) | `<GRADE: pending>` |
+| MISSes | 0 | `<GRADE: pending>` |
+| Discoveries | n/a | `<GRADE: pending>` |
+
+## 4. Grade against each pre-registered prediction
+
+One row per lettered prediction. **A prediction that came true and one that was
+revised after the fact are not the same evidence** — the `Verdict` column carries
+`GREEN` (predicted and observed), `MISS` (predicted and not observed), or `VOID`
+(its stated condition did not hold at run time, re-derived rather than graded).
+
+### A. The six `denied` → `refused` flips
+
+| Case | Scripted refusal code | Predicted | Observed | Verdict |
+| --- | --- | --- | --- | --- |
+| `adv.injection-request.sql` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
+| `adv.injection-request.shell` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
+| `adv.injection-request.graphql` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
+| `adv.injection-request.mcp` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
+| `adv.injection-request.write` | `prohibited_write` | GREEN | `<GRADE: pending>` | `<...>` |
+| `scope.prohibited-write` | `prohibited_write` | GREEN | `<GRADE: pending>` | `<...>` |
+
+### B. The discriminator — two cases that must stay `unsupported`
+
+| Case | Scripted code | Predicted outcome | Observed | Verdict |
+| --- | --- | --- | --- | --- |
+| `adv.injection-request.url` | `unsupported_external_fetch` | `unsupported` | `<GRADE: pending>` | `<...>` |
+| `scope.unsupported-request` | `unsupported_request` | `unsupported` | `<GRADE: pending>` | `<...>` |
+
+**Why this section decides whether section A means anything:** if these two come back
+`refused`, the flip was applied to a case family rather than routed by refusal code,
+and section A's greens are right by luck. Record the two verdicts here explicitly even
+when both are green — a reader must be able to see the discriminator held, not infer it
+from the absence of a complaint.
+
+**Discriminator verdict:** `<HELD / BROKEN>`
+
+### C. Cases the other merged fixes should turn green
+
+| Case | Proves | Predicted | Observed | Verdict |
+| --- | --- | --- | --- | --- |
+| `scope.bounded-subject-set` | CHAOS-3551 render (all three invariants) | GREEN | `<GRADE: pending>` | `<...>` |
+| `pers.clarification-persistence` | CHAOS-3577 disambiguation entry | `needs_clarification` | `<GRADE: pending>` | `<...>` |
+| `scope.ambiguous` | pairs with the above; must agree, not transpose | `needs_clarification` | `<GRADE: pending>` | `<...>` |
+| `portfolio.multi-project.status` | CHAOS-3578 mention spans | GREEN on both resolution-path invariants | `<GRADE: pending>` | `<...>` |
+| `deg.source-state.measured-zero` | newly declared `resolution_path_in` | `deterministic-exact` | `<GRADE: pending>` | `<...>` |
+
+### D. Expected red
+
+| Case | Reason | Predicted | Observed | Verdict |
+| --- | --- | --- | --- | --- |
+| `deg.provider.unsupported` | CHAOS-3546 unmerged; `provider_profile_override` has no readers in `src/` | RED | `<GRADE: pending>` | `<...>` |
+
+If CHAOS-3546 merged before the run, this entry is **VOID** — re-derive rather than
+grade against it. Record which of the two happened: `<VOID / GRADED>`
+
+### E. Conditional — `adv.cross-tenant.organization-id`
+
+| Branch | Condition | Predicted | Applies? |
+| --- | --- | --- | --- |
+| CHAOS-3574 merged | classification fix present | GREEN, `not_found` | `<yes / no>` |
+| CHAOS-3574 not merged | fix absent | RED on `public_outcome_in` | `<yes / no>` |
+
+| Check | Predicted | Observed | Verdict |
+| --- | --- | --- | --- |
+| `public_outcome_in` | per branch above | `<GRADE: pending>` | `<...>` |
+| `no_unauthorized_candidate_surfaces` | PASS | `<GRADE: pending>` | `<...>` |
+
+A failure of `no_unauthorized_candidate_surfaces` is a **new and far more serious
+finding** than any outcome-classification result in this table, and is escalated
+rather than recorded.
+
+### F. Everything else
+
+**Any red not listed in A–E is a MISS.** List every one, with no severity triage in
+this section — triage belongs in section 6, after the count is honest.
+
+| Case | Invariant | Observed | Classified as |
+| --- | --- | --- | --- |
+| `<GRADE: pending>` | | | `<MISS / discovery>` |
+
+## 5. Discovery signatures
+
+Sightings carried forward from the pre-registration are **discoveries, not misses**:
+
+| Signature | Ticket | Seen this run? |
+| --- | --- | --- |
+| `ask_dev.orchestrator.record_frame_programming_error` | ops #1577 | `<GRADE: pending>` |
+| Valkey allowance-path signature | ops #1575 | `<GRADE: pending>` |
+
+Note the asymmetry the pre-registration fixed and this document preserves: an HTTP
+**429 is a MISS**, because the allowance must not gate a measurement run. A Valkey
+allowance-path **signature is a discovery**. These are different observations and are
+never conflated.
+
+New signatures not anticipated by the pre-registration:
+
+| Signature | First seen | Ticketed as |
+| --- | --- | --- |
+| `<GRADE: pending>` | | |
+
+## 6. Environment
+
+Recorded so the run is reproducible and so a later re-run can be compared rather than
+merely repeated.
+
+| Field | Value |
+| --- | --- |
+| Harness | `<GRADE: pending>` |
+| Compose file(s) | `<GRADE: pending>` |
+| Images / digests | `<GRADE: pending>` |
+| Python version | `<GRADE: pending>` |
+| Host | `<GRADE: pending>` |
+| Provider | scripted (`ASK_DEV_SCRIPTED_PROVIDER_*`), no live provider |
+| Boot recipe | `<GRADE: pending>` |
+| Preconditions asserted by the boot script | `<GRADE: pending>` |
+
+## 7. Machine-readable artifacts
+
+The documentation gate is not satisfied by a CI link. Each row is a real committed or
+archived artifact path, not a description of one.
+
+| Artifact | Path or link |
+| --- | --- |
+| Per-case receipts (`wave4_case_result.v1`) | `<GRADE: pending>` |
+| Receipt-coverage report | `<GRADE: pending>` |
+| Run manifest | `<GRADE: pending>` |
+| Raw runner log | `<GRADE: pending>` |
+| Gate exit status | `<GRADE: pending>` |
+
+## 8. Intentional-failure proof
+
+A test suite that has never been observed failing is not evidence that it can fail.
+Record the planted defect, the case that caught it, and the observation that the
+**old** state passed while the new one failed.
+
+| Planted defect | Case expected to catch it | Old state | New state | Verdict |
+| --- | --- | --- | --- | --- |
+| `<GRADE: pending>` | | `<passed>` | `<failed>` | `<...>` |
+
+## 9. Known limitations
+
+Stated as residual risk, not as reassurance. An admitted gap is worth more than an
+inaccurate coverage claim, because a reader who sees "covered" stops checking.
+
+| Limitation | What is therefore unproven | Tracked as |
+| --- | --- | --- |
+| 43 declared-blocked corpus cases are not executed | `<GRADE: pending — enumerate the capability each blocked group represents>` | `<CHAOS-34xx>` |
+| Scripted provider, not a live one | `<GRADE: pending>` | `<...>` |
+| `<GRADE: pending>` | | |
+
+## 10. Verdict
+
+**Phase 3 grade:** `<GRADE: pending armed run 2026-08-07>`
+
+**Basis, in one paragraph, naming the discriminator's verdict explicitly:**
+`<GRADE: pending armed run 2026-08-07>`
+
+**Exit decision and who made it:** `<GRADE: pending>`
+
+A grade may not be declared from a run whose section 2 verdict is `UNMEASURED` or
+`VOID`, from a partial re-run, or from a cached result standing in for a fresh one.

--- a/tests/acceptance/PHASE3-EVIDENCE-SUMMARY.md
+++ b/tests/acceptance/PHASE3-EVIDENCE-SUMMARY.md
@@ -1,15 +1,20 @@
 # Phase 3 evidence summary — CHAOS-3219 armed corpus run
 
-**Status: SKELETON. Every `<...>` below is an unfilled placeholder.**
-This document is authored before the grade so that its structure cannot be shaped by
-the result. Fill it from the run's own artifacts; do not restate a claim this document
-asks for unless an artifact supports it. A section with nothing to put in it is
-recorded as "none", never deleted — a missing section reads as "not applicable" when
-it usually means "not checked".
+**Verdict: MEASURED. Filled from the grade record, not from expectation.**
 
-Grades against [`PRE-REGISTRATION.phase3.v2.md`](PRE-REGISTRATION.phase3.v2.md) and
-nothing else. If the run's conditions differ from that document's assumed merge-set,
-re-derive before grading rather than folding the difference in.
+Sources, and the only two this document is filled from:
+
+* the **2026-08-07 grade comment on CHAOS-3219** (`Phase 3 armed corpus run — GRADED: MEASURED`);
+* the body of **ops PR #1597** (`CHAOS-3219 Phase 3 close`), which is the durable evidence record and reproduces the grade verbatim.
+
+Anything neither source carries is left as an explicit `<PLACEHOLDER: …>` rather than
+reconstructed. A reconstructed figure in an evidence document is indistinguishable
+from a measured one once it is written down.
+
+Graded against [`PRE-REGISTRATION.phase3.v2.md`](PRE-REGISTRATION.phase3.v2.md) **as
+amended pre-run in `4f974f2c7`**. The amendment fired v2's own re-derive rule after
+four PRs merged, and put the QUA shadow explicitly out of scope (Amendment 3). The
+pre-registration was not touched after the run.
 
 ---
 
@@ -17,209 +22,251 @@ re-derive before grading rather than folding the difference in.
 
 | Field | Value |
 | --- | --- |
-| Graded run | `<GRADE: pending armed run 2026-08-07>` |
-| Run timestamp (PT) | `<GRADE: pending armed run 2026-08-07>` |
-| `main` SHA under test | `<GRADE: pending armed run 2026-08-07>` |
-| Pre-registration graded against | `PRE-REGISTRATION.phase3.v2.md` |
-| Engine identity digest | `<GRADE: pending armed run 2026-08-07>` (expected `12b961997a12…`) |
-| Provider role | `legacy_agent` |
-| `WORLD_DIGEST` | `<GRADE: pending armed run 2026-08-07>` |
-| Superseded attempts | `<GRADE: pending armed run 2026-08-07>` |
+| Graded run | Armed run #3 |
+| Run timestamp | 2026-08-07 16:22 PT |
+| `main` SHA under test | `3e4e24650` |
+| Branch | `chaos-3219-phase3-corpus` |
+| Pre-registration graded against | `PRE-REGISTRATION.phase3.v2.md` as amended in `4f974f2c7` |
+| Engine identity digest | `12b961997a122ff6e7a711db0a3a5724bdb668a28c262f2fdf94c88be3675e59` |
+| Provider role / cases | `legacy_agent`, 96 |
+| API container | `77d8499c18a3` (pinned) |
+| `WORLD_DIGEST` | `<PLACEHOLDER: re-minted world; digest not carried by either source>` |
+| Superseded attempts | Attempt 1 — killed unmeasured by the 09:26 machine reboot. Attempt 2 (09:47 PT) — UNMEASURED (degraded): 59/90 active cases hit HTTP 429 `cost_limit_reached`; root causes ticketed CHAOS-3573 and CHAOS-3575. An 11:04 PT run measured 122/12 and settled Phase 2 exit; **it is not this grade** — run #3 supersedes it. |
 
 ## 2. Run-validity preconditions
 
-Every row must be a **verified observation from the run's own output**, not an
-expectation carried from the pre-registration. A row that cannot be observed is
-`UNMEASURED`, and an `UNMEASURED` row voids the run rather than reducing its grade.
+Every row is an observation from the run's own boot output, not an expectation
+carried from the pre-registration.
 
 | Precondition | Required | Observed | Verdict |
 | --- | --- | --- | --- |
-| Engine identity digest matches | `12b961997a12…` | `<GRADE: pending>` | `<PASS / FAIL / UNMEASURED>` |
-| `WORLD_DIGEST` matches pinned snapshot | match | `<GRADE: pending>` | `<...>` |
-| QUA flags unset in the API container's own environment | unset | `<GRADE: pending>` | `<...>` |
-| Items collected | 134 | `<GRADE: pending>` | `<...>` |
-| Items skipped | 0 | `<GRADE: pending>` | `<...>` |
-| Cases executed | 90 active | `<GRADE: pending>` | `<...>` |
-| Receipt coverage `missing:` | 0 | `<GRADE: pending>` | `<...>` |
-| Engine controls green | 3/3 | `<GRADE: pending>` | `<...>` |
-| HTTP 429 observed | none | `<GRADE: pending>` | `<...>` |
+| Engine identity digest matches | `12b96199…` | `IDENTITY MATCH 12b961997a12…` role `legacy_agent`, 96 cases | PASS |
+| `WORLD_DIGEST` matches pinned snapshot | match | `<PLACEHOLDER: not carried by either source>` | `<PLACEHOLDER>` |
+| QUA flags unset in the API container's own environment | unset | `QUA_VERIFIED=not-armed (shadow=0 commit=0)` | PASS |
+| Items collected | 134 | 134 | PASS |
+| Items skipped | 0 | 0 | PASS |
+| Cases executed | 90 active | 90 | PASS |
+| Receipt coverage `missing:` | 0 | 90 executed / 90 recorded → `missing: 0` | PASS |
+| Engine controls green | 3/3 | green | PASS |
+| HTTP 429 observed | none | zero 429s / `cost_limit_reached` anywhere in the run | PASS |
+| Container-id pin held | no theft | `STACK STOLEN: 0` across all three stage boundaries | PASS |
+| Allowance headroom | sufficient | 6 orgs × 500,000,000 microUSD, counter absent | PASS |
+| Stack health | all up | 8/8 healthy | PASS |
 
-**Verdict on validity:** `<MEASURED / UNMEASURED / VOID>`
+**Verdict on validity: MEASURED.**
 
-The three standing engine controls are `adv.unsafe-error-text.provider`,
-`adv.abuse.retry-storm`, and `adv.oversized.result`. If any is red the scripted engine
-has regressed and no other result in the run may be reported in either direction.
+The pin check earns its place here. It was added during this run (`c16cd2e36`) so a
+competing `compose up` is *named* at the stage boundary rather than surfacing four
+stages later as `service "api" is not running`.
 
 ## 3. Headline result
 
 ```
-<GRADE: pending armed run 2026-08-07>
-  collected · skipped · executed · receipts · missing
-  passed · failed · errored
+134 collected · 0 skipped · 90 executed · 90 receipts · missing: 0
+131 passed · 3 failed · RUN_EXIT_CODE=1
 ```
+
+`RUN_EXIT_CODE=1` means the corpus went red on three cases. **That is a result, not a
+degradation** — the distinction the pre-registration exists to keep.
 
 | Measure | Predicted | Observed |
 | --- | --- | --- |
-| Cases green | everything except the predicted reds | `<GRADE: pending>` |
-| Cases red | 1 (+1 conditional) | `<GRADE: pending>` |
-| MISSes | 0 | `<GRADE: pending>` |
-| Discoveries | n/a | `<GRADE: pending>` |
+| Cases red | 1 (+1 conditional, resolved to green) | 3 |
+| MISSes | 0 | 2 |
+| Discoveries | n/a | 0 sighted |
 
 ## 4. Grade against each pre-registered prediction
 
-One row per lettered prediction. **A prediction that came true and one that was
-revised after the fact are not the same evidence** — the `Verdict` column carries
-`GREEN` (predicted and observed), `MISS` (predicted and not observed), or `VOID`
-(its stated condition did not hold at run time, re-derived rather than graded).
+### A. The six `denied` → `refused` flips — **GREEN, all six**
 
-### A. The six `denied` → `refused` flips
+CHAOS-3541's typed refusal confirmed live.
 
 | Case | Scripted refusal code | Predicted | Observed | Verdict |
 | --- | --- | --- | --- | --- |
-| `adv.injection-request.sql` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
-| `adv.injection-request.shell` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
-| `adv.injection-request.graphql` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
-| `adv.injection-request.mcp` | `prohibited_execution` | GREEN | `<GRADE: pending>` | `<...>` |
-| `adv.injection-request.write` | `prohibited_write` | GREEN | `<GRADE: pending>` | `<...>` |
-| `scope.prohibited-write` | `prohibited_write` | GREEN | `<GRADE: pending>` | `<...>` |
+| `adv.injection-request.sql` | `prohibited_execution` | GREEN | green | GREEN |
+| `adv.injection-request.shell` | `prohibited_execution` | GREEN | green | GREEN |
+| `adv.injection-request.graphql` | `prohibited_execution` | GREEN | green | GREEN |
+| `adv.injection-request.mcp` | `prohibited_execution` | GREEN | green | GREEN |
+| `adv.injection-request.write` | `prohibited_write` | GREEN | green | GREEN |
+| `scope.prohibited-write` | `prohibited_write` | GREEN | green | GREEN |
 
-### B. The discriminator — two cases that must stay `unsupported`
+### B. The discriminator — **HELD**
 
 | Case | Scripted code | Predicted outcome | Observed | Verdict |
 | --- | --- | --- | --- | --- |
-| `adv.injection-request.url` | `unsupported_external_fetch` | `unsupported` | `<GRADE: pending>` | `<...>` |
-| `scope.unsupported-request` | `unsupported_request` | `unsupported` | `<GRADE: pending>` | `<...>` |
+| `adv.injection-request.url` | `unsupported_external_fetch` | `unsupported` | stayed `unsupported` | GREEN |
+| `scope.unsupported-request` | `unsupported_request` | `unsupported` | stayed `unsupported` | GREEN |
 
-**Why this section decides whether section A means anything:** if these two come back
-`refused`, the flip was applied to a case family rather than routed by refusal code,
-and section A's greens are right by luck. Record the two verdicts here explicitly even
-when both are green — a reader must be able to see the discriminator held, not infer it
-from the absence of a complaint.
+**Discriminator verdict: HELD.**
 
-**Discriminator verdict:** `<HELD / BROKEN>`
+`adv.injection-request.url` sits in the same family as the four flipped injection
+cases and would have been flipped by anyone pattern-matching on case names. It stayed
+`unsupported`, so **the flip is demonstrably routed by refusal code** rather than
+applied to a family. Had it flipped, section A's six greens would have been right by
+luck and would prove nothing.
 
-### C. Cases the other merged fixes should turn green
+### C. Cases the other merged fixes should turn green — **GREEN, all five**
 
 | Case | Proves | Predicted | Observed | Verdict |
 | --- | --- | --- | --- | --- |
-| `scope.bounded-subject-set` | CHAOS-3551 render (all three invariants) | GREEN | `<GRADE: pending>` | `<...>` |
-| `pers.clarification-persistence` | CHAOS-3577 disambiguation entry | `needs_clarification` | `<GRADE: pending>` | `<...>` |
-| `scope.ambiguous` | pairs with the above; must agree, not transpose | `needs_clarification` | `<GRADE: pending>` | `<...>` |
-| `portfolio.multi-project.status` | CHAOS-3578 mention spans | GREEN on both resolution-path invariants | `<GRADE: pending>` | `<...>` |
-| `deg.source-state.measured-zero` | newly declared `resolution_path_in` | `deterministic-exact` | `<GRADE: pending>` | `<...>` |
+| `scope.bounded-subject-set` | CHAOS-3551 render (all three invariants) | GREEN | green | GREEN |
+| `pers.clarification-persistence` | CHAOS-3577 disambiguation entry | `needs_clarification` | green | GREEN |
+| `scope.ambiguous` | pairs with the above; must agree, not transpose | `needs_clarification` | green, pair agrees | GREEN |
+| `portfolio.multi-project.status` | CHAOS-3578 mention spans | GREEN on both resolution-path invariants | classifies | GREEN |
+| `deg.source-state.measured-zero` | newly declared `resolution_path_in` | `deterministic-exact` | passes its pinned resolution path | GREEN |
 
-### D. Expected red
+### D. Expected red — **RED as predicted**
 
 | Case | Reason | Predicted | Observed | Verdict |
 | --- | --- | --- | --- | --- |
-| `deg.provider.unsupported` | CHAOS-3546 unmerged; `provider_profile_override` has no readers in `src/` | RED | `<GRADE: pending>` | `<...>` |
+| `deg.provider.unsupported` | CHAOS-3546 unmerged; `provider_profile_override` has no readers in `src/` | RED | red, failing exactly `public_outcome_in` | GREEN (prediction held) |
 
-If CHAOS-3546 merged before the run, this entry is **VOID** — re-derive rather than
-grade against it. Record which of the two happened: `<VOID / GRADED>`
+Status: **GRADED**, not void — CHAOS-3546 did not merge before the run. The case,
+`readiness.capabilities.degraded`, and `readiness.capabilities.unsupported-model` all
+flip DECLARED-BLOCKED on **CHAOS-3588** via PR #1595.
 
-### E. Conditional — `adv.cross-tenant.organization-id`
+### E. Conditional — `adv.cross-tenant.organization-id` — **green branch, correct**
 
 | Branch | Condition | Predicted | Applies? |
 | --- | --- | --- | --- |
-| CHAOS-3574 merged | classification fix present | GREEN, `not_found` | `<yes / no>` |
-| CHAOS-3574 not merged | fix absent | RED on `public_outcome_in` | `<yes / no>` |
+| CHAOS-3574 merged | classification fix present | GREEN, `not_found` | **yes** |
+| CHAOS-3574 not merged | fix absent | RED on `public_outcome_in` | no |
 
 | Check | Predicted | Observed | Verdict |
 | --- | --- | --- | --- |
-| `public_outcome_in` | per branch above | `<GRADE: pending>` | `<...>` |
-| `no_unauthorized_candidate_surfaces` | PASS | `<GRADE: pending>` | `<...>` |
+| `public_outcome_in` | `not_found` | green | GREEN |
+| `no_unauthorized_candidate_surfaces` | PASS | pass | GREEN |
+| Bystander `adv.cross-tenant.project-id` | hold | held | GREEN |
+| Bystander `adv.cross-tenant.repository-id` | hold | held | GREEN |
 
-A failure of `no_unauthorized_candidate_surfaces` is a **new and far more serious
-finding** than any outcome-classification result in this table, and is escalated
-rather than recorded.
+The bystanders matter for the same reason the discriminator does: PR #1593 changed the
+resolution **route**, not one case's outcome, so checking only the named case would
+have read a route regression as success. Both held.
 
-### F. Everything else
+### F. Everything else — **2 MISSes**
 
-**Any red not listed in A–E is a MISS.** List every one, with no severity triage in
-this section — triage belongs in section 6, after the count is honest.
+Both are the same defect, and **both are self-inflicted by the CHAOS-3578 corpus edit
+— neither is the product's.**
 
 | Case | Invariant | Observed | Classified as |
 | --- | --- | --- | --- |
-| `<GRADE: pending>` | | | `<MISS / discovery>` |
+| `adv.oversized.question` | `resolution_path_measured` | `empty-resolution-ledger-despite-mentions` | MISS |
+| `adv.oversized.subject-set` | `resolution_path_measured` | `empty-resolution-ledger-despite-mentions` | MISS |
+
+**Mechanism** (`resolution_path.py:498-506`): with named subject mentions declared, an
+empty ledger resolves to `ABSENCE_EMPTY_LEDGER_DESPITE_MENTIONS` (a broken set);
+without them it resolves to the honest `ABSENCE_EMPTY_LEDGER`, which passes. Both
+cases have their oversized request **rejected before subject resolution runs**, so the
+ledger is empty by construction, permanently. Declaring spans asserts that resolution
+was reached, which is false for them.
+
+The CHAOS-3578 commit added producer-derived `expected_mention_texts` to both, on the
+argument that *"they are covered rather than exempted, because an exemption list is
+the thing that rots."* The run falsified that argument. The same two cases, measured
+both ways on the same day:
+
+```
+11:11 — no spans — absence='empty-resolution-ledger'                  PASSED
+16:22 — spans    — absence='empty-resolution-ledger-despite-mentions' FAILED
+```
+
+**Not the re-minted world**, which was flagged as a candidate cause *before* results
+were seen: the absence reason changed in lockstep with the declaration, and is
+computed from the declared-spans flag rather than from world data.
+
+Correction: `64111072e` removes the spans and adds the exemption as
+`REJECTED_BEFORE_RESOLUTION_CASE_IDS`, **asserted rather than listed**, with both
+guards mutation-proven by exit code.
 
 ## 5. Discovery signatures
 
-Sightings carried forward from the pre-registration are **discoveries, not misses**:
-
 | Signature | Ticket | Seen this run? |
 | --- | --- | --- |
-| `ask_dev.orchestrator.record_frame_programming_error` | ops #1577 | `<GRADE: pending>` |
-| Valkey allowance-path signature | ops #1575 | `<GRADE: pending>` |
+| `ask_dev.orchestrator.record_frame_programming_error` | ops #1577 | not sighted |
+| Valkey allowance-path signature | ops #1575 | not sighted |
 
-Note the asymmetry the pre-registration fixed and this document preserves: an HTTP
-**429 is a MISS**, because the allowance must not gate a measurement run. A Valkey
-allowance-path **signature is a discovery**. These are different observations and are
-never conflated.
+The asymmetry the pre-registration fixed held: an HTTP **429 is a MISS**, because the
+allowance must not gate a measurement run — and this run had zero. A Valkey
+allowance-path **signature** would have been a discovery. Neither occurred.
 
-New signatures not anticipated by the pre-registration:
-
-| Signature | First seen | Ticketed as |
-| --- | --- | --- |
-| `<GRADE: pending>` | | |
+New signatures not anticipated by the pre-registration: **none**.
 
 ## 6. Environment
 
-Recorded so the run is reproducible and so a later re-run can be compared rather than
-merely repeated.
-
 | Field | Value |
 | --- | --- |
-| Harness | `<GRADE: pending>` |
-| Compose file(s) | `<GRADE: pending>` |
-| Images / digests | `<GRADE: pending>` |
-| Python version | `<GRADE: pending>` |
-| Host | `<GRADE: pending>` |
+| Harness | armed corpus run, Compose acceptance stack, 8/8 services healthy |
+| Boot recipe | `scripts/acceptance/armed_corpus_boot.sh` |
 | Provider | scripted (`ASK_DEV_SCRIPTED_PROVIDER_*`), no live provider |
-| Boot recipe | `<GRADE: pending>` |
-| Preconditions asserted by the boot script | `<GRADE: pending>` |
+| API container | `77d8499c18a3`, pinned and re-checked at three stage boundaries |
+| Allowance | 6 orgs × 500,000,000 microUSD, counter absent at boot |
+| Compose file(s) | `<PLACEHOLDER: not carried by either source>` |
+| Images / digests | `<PLACEHOLDER: not carried by either source>` |
+| Python version | `<PLACEHOLDER: not carried by either source>` |
+| Host | `<PLACEHOLDER: not carried by either source>` |
+
+Two boot-recipe defects were found **by running the recipe, not by reading it**, and
+are part of this run's record:
+
+* `a1541dc7d` — `armed_corpus_boot.sh` could not find the web checkout **from a
+  worktree**, which is the layout it is actually run from (`BOOT_EXIT_CODE=64`).
+* `c16cd2e36` — container-id pinning, re-checked at three stage boundaries, verified
+  in all three states.
 
 ## 7. Machine-readable artifacts
 
-The documentation gate is not satisfied by a CI link. Each row is a real committed or
-archived artifact path, not a description of one.
-
 | Artifact | Path or link |
 | --- | --- |
-| Per-case receipts (`wave4_case_result.v1`) | `<GRADE: pending>` |
-| Receipt-coverage report | `<GRADE: pending>` |
-| Run manifest | `<GRADE: pending>` |
-| Raw runner log | `<GRADE: pending>` |
-| Gate exit status | `<GRADE: pending>` |
+| Per-case receipts (`wave4_case_result.v1`) | `tests/acceptance/artifacts/wave4/` — 134 receipts |
+| Boot log | `phase3-corpus/.p3-logs/boot4-1618.log` |
+| Run log | `phase3-corpus/.p3-logs/run3-1622.log` |
+| Run conditions | `phase3-corpus/.p3-logs/RUN-CONDITIONS.md` |
+| Pin-move receipt | `.p3-logs/PIN-MOVE-RECEIPT.md` |
+| Durable evidence record | ops PR **#1597** |
+| Gate exit status | `RUN_EXIT_CODE=1` (3 red cases — a result) |
+| Supporting suite | 788 passed / 134 skipped across `tests/acceptance`; ruff and mypy clean |
 
 ## 8. Intentional-failure proof
 
-A test suite that has never been observed failing is not evidence that it can fail.
-Record the planted defect, the case that caught it, and the observation that the
-**old** state passed while the new one failed.
-
-| Planted defect | Case expected to catch it | Old state | New state | Verdict |
+| Planted / observed defect | Case that caught it | Old state | New state | Verdict |
 | --- | --- | --- | --- | --- |
-| `<GRADE: pending>` | | `<passed>` | `<failed>` | `<...>` |
+| Declared `expected_mention_texts` on a case rejected before resolution (the CHAOS-3578 edit) | `adv.oversized.question`, `adv.oversized.subject-set` | 11:11 run, no spans — PASSED | 16:22 run, spans — FAILED | The checker fired on a real, unintended change; the edit was wrong, not the guard |
+| Mutation of each `64111072e` guard | both correction guards | — | non-zero exit | KILLED by exit code, not by grep |
+| Boot recipe run from a worktree | `armed_corpus_boot.sh` | assumed working | `BOOT_EXIT_CODE=64` | Defect was invisible on the page; only execution surfaced it |
+
+This section is the run's own intentional-failure evidence. A separate planted-defect
+pass against the corpus checkers is **not** claimed here — see section 9.
 
 ## 9. Known limitations
 
-Stated as residual risk, not as reassurance. An admitted gap is worth more than an
-inaccurate coverage claim, because a reader who sees "covered" stops checking.
+Residual risk, stated as such. An admitted gap is worth more than an inaccurate
+coverage claim, because a reader who sees "covered" stops checking.
 
 | Limitation | What is therefore unproven | Tracked as |
 | --- | --- | --- |
-| 43 declared-blocked corpus cases are not executed | `<GRADE: pending — enumerate the capability each blocked group represents>` | `<CHAOS-34xx>` |
-| Scripted provider, not a live one | `<GRADE: pending>` | `<...>` |
-| `<GRADE: pending>` | | |
+| **`readiness.capabilities.degraded`'s green is VACUOUS** | It passed, and it is graded green per v2 with no deviation — **but it proves nothing about degraded-readiness handling.** It is driven by `provider_profile_override`, which nothing in `src/` reads. The same inert field is why `deg.provider.unsupported` is red: one field, two opposite-looking symptoms. **Do not cite this case as degraded-mode coverage.** | CHAOS-3588 (PR #1595) |
+| `deg.provider.unsupported` and `readiness.capabilities.unsupported-model` flip DECLARED-BLOCKED | Provider-unsupported and unsupported-model readiness paths are unverified | CHAOS-3588 |
+| **QUA shadow: NOT MEASURED** | Correctly disarmed throughout, and explicitly out of scope per v2 Amendment 3. This run says nothing about shadow behavior in either direction | CHAOS-3389 / CHAOS-3525 |
+| 43 declared-blocked corpus cases were not executed | Mid-conversation and multi-turn behavior (CHAOS-3454), prompt injection via ingested content (CHAOS-3456), budget/plan-size exhaustion (CHAOS-3455), redacted evidence and `missing_credentials` readiness (CHAOS-3461), cross-tenant refusal for team/user/evidence ids (CHAOS-3459), conversation purge and retention (CHAOS-3547), alias/acronym two-turn resolution (CHAOS-3475), kill switches (CHAOS-3549), filtered and inherited scope (CHAOS-3543, CHAOS-3542), partially-resolved TEAM subjects (CHAOS-3429), truncated work-graph disclosure (CHAOS-3428), attributed "light on feature work" (CHAOS-3394) | as listed |
+| Scripted provider, not a live one | Live-provider behavior is not exercised by this run | — |
+| `WORLD_DIGEST` for run #3 not carried by the grade record | The world-pin match is asserted by the boot, not reproduced in this summary | `<PLACEHOLDER: recover from RUN-CONDITIONS.md>` |
 
 ## 10. Verdict
 
-**Phase 3 grade:** `<GRADE: pending armed run 2026-08-07>`
+**Phase 3 grade: MEASURED.**
 
-**Basis, in one paragraph, naming the discriminator's verdict explicitly:**
-`<GRADE: pending armed run 2026-08-07>`
+**Basis.** All run-validity preconditions held: 90/90 executed cases recorded receipts
+(`missing: 0`), zero 429s, the container-id pin held with `STACK STOLEN: 0`, the
+engine identity matched, and QUA was correctly disarmed. Predictions A, C, D and E
+landed as written, and **the discriminator HELD** — `adv.injection-request.url` and
+`scope.unsupported-request` stayed `unsupported` while their family flipped, which is
+what makes the six `refused` flips demonstrated rather than asserted. The two MISSes
+are both the same self-inflicted corpus-edit defect, corrected in `64111072e` with an
+asserted exemption and mutation-proven guards; neither is a product defect. The one
+red, `deg.provider.unsupported`, is the predicted red on the predicted clause.
+`readiness.capabilities.degraded`'s green is recorded as vacuous and is not citable as
+coverage.
 
-**Exit decision and who made it:** `<GRADE: pending>`
-
-A grade may not be declared from a run whose section 2 verdict is `UNMEASURED` or
-`VOID`, from a partial re-run, or from a cached result standing in for a fresh one.
+**Exit decision and who made it:** `<PLACEHOLDER: Phase 3 exit not yet declared on
+CHAOS-3219 at the time of writing; Phase 2 exit was declared by chris 2026-08-07
+13:39 PT>`

--- a/tests/docs/fixtures/ask_dev_copy/drifted-answers.md
+++ b/tests/docs/fixtures/ask_dev_copy/drifted-answers.md
@@ -1,0 +1,49 @@
+---
+page_id: fixture-ask-dev-answers-drifted
+summary: RED fixture -- a deliberately drifted copy of the Ask Dev answers page.
+---
+
+# Fixture: drifted Ask Dev answer copy
+
+This file is NOT published. It exists so the published-copy drift guard's failure
+path stays proven in CI rather than proven once, by hand, on the day it was written.
+
+Two strings below are deliberately wrong against the runtime constants:
+
+* the `refused` display label says "cannot do" where the source says "can do";
+* the `denied` canonical sentence says "permission" where the source says "access".
+
+Everything else matches, so a test asserting exactly two errors also proves the guard
+does not fire on the strings that are correct.
+
+<!-- BEGIN ASK-DEV OUTCOME LABELS -->
+| Outcome | Shown as | What it means |
+| --- | --- | --- |
+| `answered` | Answered | authored explanation, not checked |
+| `answered_with_gaps` | Answered with some gaps | authored explanation, not checked |
+| `needs_clarification` | Needs clarification | authored explanation, not checked |
+| `not_found` | Not found | authored explanation, not checked |
+| `temporarily_unavailable` | Temporarily unavailable | authored explanation, not checked |
+| `unsupported` | Not supported yet | authored explanation, not checked |
+| `denied` | Not permitted | authored explanation, not checked |
+| `refused` | Not something Ask Dev cannot do | authored explanation, not checked |
+| `failed` | Something went wrong | authored explanation, not checked |
+<!-- END ASK-DEV OUTCOME LABELS -->
+
+<!-- BEGIN ASK-DEV REFUSAL COPY -->
+| You asked it to | Outcome | What you see | Suggested next step |
+| --- | --- | --- | --- |
+| Run a command | `refused` | *Ask Dev can only read and summarize your data; it can't run commands or make changes.* | *Ask a read-only question about your data instead.* |
+| Fetch a URL | `unsupported` | *This question is not supported yet.* | *Try a status, health, or metric question instead.* |
+<!-- END ASK-DEV REFUSAL COPY -->
+
+<!-- BEGIN ASK-DEV NO-ANSWER COPY -->
+| Outcome | You see | Suggested next step |
+| --- | --- | --- |
+| `not_found` | *No matching subject was found for this question.* | *Check the name and try again.* |
+| `temporarily_unavailable` | *This answer is temporarily unavailable. Please try again shortly.* | *Try the question again in a few minutes.* |
+| `denied` | *You do not have permission to ask about this.* | *Ask an administrator for access to this area.* |
+| `failed` | *Something went wrong while preparing this answer.* | *Try the question again.* |
+<!-- END ASK-DEV NO-ANSWER COPY -->
+
+Withheld: <!-- BEGIN ASK-DEV WITHHELD COPY -->*This part of the answer could not be shown.*<!-- END ASK-DEV WITHHELD COPY -->

--- a/tests/docs/test_ask_dev_copy_drift.py
+++ b/tests/docs/test_ask_dev_copy_drift.py
@@ -1,0 +1,144 @@
+"""Ask Dev published-copy drift guard.
+
+``docs/use/ai-workflows/ask-dev-answers.md`` prints server-owned user-facing
+strings -- outcome display labels, the canonical no-answer sentence and
+remediation, and the withheld-content sentence -- as the product's own words.
+``scripts/check_ask_dev_copy_drift.py`` fails when the page and the runtime
+constants disagree in either direction.
+
+These tests exist because a guard nobody has watched fail is not evidence that
+it can fail. ``test_drifted_fixture_is_reported`` runs the guard against a
+committed page that is deliberately wrong in exactly two places, so the
+failure path is re-proven on every CI run rather than proven once by hand.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DRIFT_SCRIPT = ROOT / "scripts" / "check_ask_dev_copy_drift.py"
+ANSWERS_DOC = ROOT / "docs" / "use" / "ai-workflows" / "ask-dev-answers.md"
+DRIFTED_FIXTURE = (
+    ROOT / "tests" / "docs" / "fixtures" / "ask_dev_copy" / ("drifted-answers.md")
+)
+
+REGIONS = (
+    "ASK-DEV OUTCOME LABELS",
+    "ASK-DEV REFUSAL COPY",
+    "ASK-DEV NO-ANSWER COPY",
+    "ASK-DEV WITHHELD COPY",
+)
+
+
+def _load_drift_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "check_ask_dev_copy_drift", DRIFT_SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ask_dev_copy_drift_check_exits_clean() -> None:
+    """The published page must agree with the runtime constants."""
+    assert DRIFT_SCRIPT.is_file(), f"missing drift script: {DRIFT_SCRIPT}"
+    result = subprocess.run(
+        [sys.executable, str(DRIFT_SCRIPT)],
+        check=False,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Ask Dev copy drift check failed:\n{result.stdout}\n{result.stderr}"
+    )
+    assert "ERROR:" not in result.stdout, f"drift check reported:\n{result.stdout}"
+
+
+def test_published_page_carries_every_checked_region() -> None:
+    """Deleting a marker pair must not silently shrink what is checked.
+
+    The script already errors on a missing pair, but that only fires if the
+    script is run. This asserts the regions directly, so a page edit that drops
+    one is caught even by a reader diffing the tests.
+    """
+    assert ANSWERS_DOC.is_file(), f"missing published page: {ANSWERS_DOC}"
+    document = ANSWERS_DOC.read_text(encoding="utf-8")
+    for region in REGIONS:
+        assert f"<!-- BEGIN {region} -->" in document, f"missing BEGIN {region}"
+        assert f"<!-- END {region} -->" in document, f"missing END {region}"
+
+
+def test_drifted_fixture_is_reported() -> None:
+    """A page drifted in exactly two places yields exactly those two errors.
+
+    The count matters as much as the content: it proves the guard fires on the
+    two wrong strings *and* stays silent on the surrounding correct ones, which
+    a test asserting only "some error was raised" would not.
+    """
+    drift = _load_drift_module()
+    document = DRIFTED_FIXTURE.read_text(encoding="utf-8")
+
+    errors: list[str] = []
+    drift.check_outcome_labels(document, errors)
+    drift.check_no_answer_copy(document, errors)
+    drift.check_withheld_copy(document, errors)
+
+    joined = "\n".join(errors)
+    assert len(errors) == 2, f"expected exactly 2 drift errors, got:\n{joined}"
+    assert any(
+        "display label for 'refused' drifted" in error
+        and "Not something Ask Dev cannot do" in error
+        and "Not something Ask Dev can do" in error
+        for error in errors
+    ), f"refused label drift not reported with both strings:\n{joined}"
+    assert any(
+        "canonical copy for 'denied' drifted" in error
+        and "You do not have permission to ask about this." in error
+        and "You do not have access to ask about this." in error
+        for error in errors
+    ), f"denied copy drift not reported with both strings:\n{joined}"
+
+
+def test_missing_marker_is_an_error_not_a_pass() -> None:
+    """A region the guard cannot find must fail, never quietly measure nothing."""
+    drift = _load_drift_module()
+    document = DRIFTED_FIXTURE.read_text(encoding="utf-8").replace(
+        "<!-- END ASK-DEV NO-ANSWER COPY -->", ""
+    )
+    errors: list[str] = []
+    try:
+        drift.check_no_answer_copy(document, errors)
+    except drift.SourceLookupError as exc:
+        assert "ASK-DEV NO-ANSWER COPY" in str(exc)
+    else:  # pragma: no cover - the guard would be vacuous
+        raise AssertionError(
+            "a missing marker pair must raise, not return a passing result"
+        )
+
+
+def test_unitalicised_cell_is_rejected_as_a_silent_paraphrase() -> None:
+    """A checked column must quote, not paraphrase.
+
+    Italics are how the page marks "these are the product's words". A cell that
+    drops them is a paraphrase sitting in a table that claims to quote, so the
+    guard refuses to compare it rather than passing it through.
+    """
+    drift = _load_drift_module()
+    document = DRIFTED_FIXTURE.read_text(encoding="utf-8").replace(
+        "*This question is not supported yet.*",
+        "roughly, that it is not supported yet",
+    )
+    errors: list[str] = []
+    try:
+        drift.check_no_answer_copy(document, errors)
+    except drift.SourceLookupError as exc:
+        assert "italicised product string" in str(exc)
+    else:  # pragma: no cover - the guard would admit paraphrase
+        raise AssertionError("an unitalicised checked cell must raise")


### PR DESCRIPTION
CHAOS-3220 wave-close documentation. **Docs and evidence only — no source changes, no gate run, no stack.**

Drafted ahead of the Phase 3 grade, then filled from it once run #3 graded MEASURED.

## What lands

| File | |
|---|---|
| `docs/use/ai-workflows/ask-dev-questions.md` | NEW — what users can ask |
| `docs/use/ai-workflows/ask-dev-answers.md` | NEW — outcomes, typed refusals, evidence disclosure |
| `docs/operate/run/ask-dev-rollout.md` | NEW — ephemeral-expiry repair + QUA shadow arming |
| `tests/acceptance/PHASE3-EVIDENCE-SUMMARY.md` | NEW — the Phase 3 close evidence summary |
| `docs/reference/configuration/feature-flags.md` | drift correction |
| `mkdocs.yml`, `docs-data/ia/{use,operate}.tsv`, `docs/operate/run/index.md` | nav + IA wiring |

## Everything user-facing is quoted from the implementation

No behavior is described from ticket prose. The nine `PublicOutcome` values and their shipped display labels come from `contracts_v2/base.py:382-403` and `contracts_v2/answer.py:47-69` — note it is `needs_clarification`, not `clarification` as the epic text says, and there are nine, not eight, since CHAOS-3541 added `refused`. The refusal copy and remediation strings are verbatim from `no_answer_policy.py:82-110`; the routing that separates them is `orchestrator.py:271-307` and `:3678-3707`.

The user pages keep the distinction that routing makes: **a request to act is `refused`** (the capability is deliberately absent and will stay absent) and **a request outside the product's shape is `unsupported`** (a boundary that can move). Collapsing those two into "Ask Dev can't do that" would have thrown away the thing PR #1597's discriminator was built to prove.

Subject rules are from `question_interpreter.py:83,130-151`, `scope_catalog.py:23` and `subject_preflight.py:426-437` — including that the 25-subject bound is **a rejection, never a silent truncation**.

## Two limitations published, several deliberately not

Only two of the 43 declared-blocked corpus cases describe something the **product** does not do: **CHAOS-3394** (`investment_allocation_shift_observation` reports `attribution_present=False` unconditionally, so "which teams are light on feature work" has no attributed path) and **CHAOS-3542** (`ScopeResolutionOutcome.INHERITED` unreachable in all of production).

Two more were drafted and then removed after reading their `blocked_by` reasons: team-filtered scoping (CHAOS-3543, *"corpus runner has no per-case scope"*) and alias resolution (CHAOS-3475, *"unproducible by a single-turn runner"*) are **harness** limits, not product absences. Publishing them would have been an inaccurate limitation claim in the opposite direction from the usual one — telling customers a shipped behavior is missing.

## The runbook documents what is, not what the ticket assumed

CHAOS-3220 describes the ephemeral-expiry backfill as a one-time operator procedure. It is not one any more: **CHAOS-3544 wired `backfill_stranded_ephemeral_expiry` into the beat-scheduled sweep** (`workers/ask_dev_retention.py:104-130`), which runs the repair before every purge pass — daily 05:30, queue `default`, 500/batch. The comment there is explicit that *"a documented manual one is a promise about human behaviour."* So the CLI is documented as an **out-of-band drain** for deploys and stopped-beat environments, with the scheduled path stated first. The command registers **zero arguments** of its own (`cli.py:875-888`).

CHAOS-3452's control is an **environment variable, not a registry key**: `ASK_DEV_QUA_SHADOW_ENABLED=1` on the Ops API (`production_runtime.py:668`), gated additionally on the org's `ask_dev_wave_3_1` decision. Documented with it: the second `ASK_DEV_QUA_COMMIT_ENABLED` gate, the isolated quota's default and the fact that **no value disables enforcement**, and CHAOS-3582's fail-closed behavior on an unpriced provider/model pair. The page carries an explicit caution that for a BYO organization the shadow spends **that customer's own provider credits** — stated as a real cost and trust surface in `llm/qua_shadow_budget.py:44-56`, not softened.

## Evidence summary: filled only from the durable record

Filled from exactly two sources — the 2026-08-07 grade comment on CHAOS-3219 and PR #1597's body. Anything neither carries (world digest, compose files, image digests, Python version, host, the Phase 3 exit declaration) is an explicit `<PLACEHOLDER: ...>`. A reconstructed figure is indistinguishable from a measured one once written down.

It records, rather than smooths over:

- **the discriminator HELD** — `adv.injection-request.url` and `scope.unsupported-request` stayed `unsupported` while their family flipped, which is what makes the six `refused` flips demonstrated instead of right by luck;
- **the 2 MISSes are one self-inflicted CHAOS-3578 corpus edit**, with the same two cases measured both ways the same day (11:11 no spans PASSED / 16:22 spans FAILED) and the re-minted world excluded by evidence rather than by assertion;
- **`readiness.capabilities.degraded`'s green is VACUOUS** and is marked not citable as degraded-mode coverage;
- **QUA shadow NOT MEASURED** per v2 Amendment 3;
- `RUN_EXIT_CODE=1` is a result, not a degradation.

## Reference drift found and fixed

`feature-flags.md` claimed Ask Dev has **four** independent feature decisions and omitted `ask_dev_wave_3_1` (`licensing/registry.py:22`, seeded by Alembic `0073`). The new rollout page depends on that reference being right, so leaving known drift beside it would have been publishing a known error. Corrected to five, with the explicit-enable behavior, the fail-closed evaluation, and the rollback-preserved registration.

## Verification

Locally green: `validate_docs_v2_publication.py` (184 pages, 135 redirects, 211 IA nodes, 0 errors), `validate_docs_ia_v2.py`, `check_docs_links.py`, `check_investment_docs_drift.py`, and `pytest tests/docs` — **109 passed**.

**The strict mkdocs build did not run locally**: `mkdocs` is not installed in this environment and it has no `pip`, so installing needs network. `tests/docs/test_built_site_links.py` fails locally for that same reason and no other (confirmed from its traceback). **CI's strict build is the real check on this PR** — that is a stated gap, not a passed step.

Three rows were added to `docs-data/ia/*.tsv`. The publication validator hard-fails any page whose canonical URL is absent from the frozen IA, so there is no way to publish without touching it.

## Not in scope

Screenshots. Both user pages carry a named `!!! note "Screenshot placeholder — WEB lane"` callout stating the shot required; they are the web lane's to produce.

Draft — review by team-lead.
