### PR TITLE
fix(acceptance): skip the wave4 matrix loudly when its web config is absent (CHAOS-3586)

### DIFF
--- a/scripts/acceptance/run_ask_dev_compose.sh
+++ b/scripts/acceptance/run_ask_dev_compose.sh
@@ -410,24 +410,50 @@ TEST_SUPERUSER_PASSWORD=devhealth123 \
 # config rejects anything that is not exactly "0" or "1". Forwarding
 # ${acr_armed} (already normalized above) keeps that contract honest whether
 # or not this run armed ACR.
-if [[ ! -s "${org_ids_output}" ]]; then
-  echo "Wave 4 access matrix cannot run: ${org_ids_output} is missing or empty." >&2
-  echo "prepare_ask_dev_acceptance.py must have written the org-ids artifact" >&2
-  echo "(schema ask_dev_acceptance_org_ids.v1) before this point. Refusing to" >&2
-  echo "run the matrix against unknown tenants rather than skipping it." >&2
-  exit 1
+# PRESENCE GUARD (CHAOS-3586 follow-up). The config below lives in
+# dev-health-web and landed there AFTER this leg did -- an ordering mistake in
+# the original change: the ops half had a hard dependency on the web half and
+# merged first. Until the web change is on main, `playwright test -c <missing>`
+# exits 1 and `set -e` kills the whole run AFTER a full boot, seed and Phase 1
+# pass. That broke every launcher invocation whose --web-root is any checkout
+# without the config, including the nightly workflow.
+#
+# A source-reading contract test cannot catch this: it proves the invocation
+# exists in THIS file and can say nothing about whether the path resolves in
+# another repository. The reference is cross-repo and was dangling.
+#
+# So: skip when absent -- but a skip must never be readable as a pass. The
+# marker below is a single greppable line stating explicitly that the matrix
+# did NOT run and why, so no log reader and no artifact scraper can mistake
+# this run for one that exercised the matrix. When the web config IS present
+# the leg is mandatory and any failure still aborts the run.
+wave4_config="${web_root}/playwright.ask-dev-wave4.config.ts"
+if [[ ! -f "${wave4_config}" ]]; then
+  echo "WAVE4_ACCESS_MATRIX=NOT_RUN reason=config-absent web_root=${web_root}" >&2
+  echo "The Wave 4 access matrix did NOT execute: ${wave4_config} does not exist." >&2
+  echo "This run proves NOTHING about the Context Fabric Validation access matrix." >&2
+  echo "Point --web-root at a checkout carrying the config (CHAOS-3510) to run it." >&2
+else
+  if [[ ! -s "${org_ids_output}" ]]; then
+    echo "Wave 4 access matrix cannot run: ${org_ids_output} is missing or empty." >&2
+    echo "prepare_ask_dev_acceptance.py must have written the org-ids artifact" >&2
+    echo "(schema ask_dev_acceptance_org_ids.v1) before this point. Refusing to" >&2
+    echo "run the matrix against unknown tenants rather than skipping it." >&2
+    exit 1
+  fi
+  echo "WAVE4_ACCESS_MATRIX=RUNNING web_root=${web_root}"
+  ASK_DEV_LIVE_ACCEPTANCE=1 \
+  ASK_DEV_COMPOSE_WEB_READY=1 \
+  ASK_DEV_WAVE4_ACCESS_MATRIX=1 \
+  ASK_DEV_ACCEPTANCE_WEB_URL=http://127.0.0.1:3002 \
+  ASK_DEV_ACCEPTANCE_ORG_IDS="${org_ids_output}" \
+  ASK_DEV_ACCEPTANCE_ACR="${acr_armed}" \
+  PLAYWRIGHT_LIVE_BACKEND_URL="${acceptance_api_url}" \
+  TEST_SUPERUSER_EMAIL=admin@devhealth.example \
+  TEST_SUPERUSER_PASSWORD=devhealth123 \
+    "${web_root}/node_modules/.bin/playwright" test \
+    -c "${wave4_config}"
 fi
-ASK_DEV_LIVE_ACCEPTANCE=1 \
-ASK_DEV_COMPOSE_WEB_READY=1 \
-ASK_DEV_WAVE4_ACCESS_MATRIX=1 \
-ASK_DEV_ACCEPTANCE_WEB_URL=http://127.0.0.1:3002 \
-ASK_DEV_ACCEPTANCE_ORG_IDS="${org_ids_output}" \
-ASK_DEV_ACCEPTANCE_ACR="${acr_armed}" \
-PLAYWRIGHT_LIVE_BACKEND_URL="${acceptance_api_url}" \
-TEST_SUPERUSER_EMAIL=admin@devhealth.example \
-TEST_SUPERUSER_PASSWORD=devhealth123 \
-  "${web_root}/node_modules/.bin/playwright" test \
-  -c "${web_root}/playwright.ask-dev-wave4.config.ts"
 
 # CHAOS-3219 Phase 5 (CI lane): keep the stack up for a caller that has more
 # to run against it -- specifically scripts/acceptance/run_wave4_corpus.sh,

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -1818,10 +1818,16 @@ def test_launcher_runs_the_wave4_access_matrix_with_its_own_arming_contract() ->
     # Ordering: the matrix runs after web is up and after the Phase 1 spec,
     # so a Phase 1 regression is reported against Phase 1 rather than
     # surfacing as a confusing access-matrix failure.
+    #
+    # Anchor the matrix on its INVOCATION SITE, not on the config filename.
+    # The filename now also appears in the presence guard's variable
+    # assignment and in prose above it, and anchoring on the string made this
+    # assertion silently measure the wrong position the moment the guard
+    # landed -- it failed loudly, which is the only reason it was caught.
     web_up_index = launcher.index("up -d --build --wait web")
     acceptance_config_index = launcher.index("playwright.ask-dev-acceptance.config.ts")
-    wave4_config_index = launcher.index("playwright.ask-dev-wave4.config.ts")
-    assert web_up_index < acceptance_config_index < wave4_config_index
+    wave4_invocation_index = launcher.index('-c "${wave4_config}"')
+    assert web_up_index < acceptance_config_index < wave4_invocation_index
 
     # The org-ids artifact must be written before it is forwarded. index()
     # raises rather than passing vacuously if either anchor disappears.
@@ -1838,5 +1844,56 @@ def test_launcher_runs_the_wave4_access_matrix_with_its_own_arming_contract() ->
     # whole lane exists to prevent.
     assert '[[ ! -s "${org_ids_output}" ]]' in launcher
     preflight_index = launcher.index('[[ ! -s "${org_ids_output}" ]]')
-    assert preflight_index < wave4_config_index
-    assert "|| true" not in launcher[preflight_index:wave4_config_index]
+    assert preflight_index < wave4_invocation_index
+    assert "|| true" not in launcher[preflight_index:wave4_invocation_index]
+
+
+def test_launcher_skips_the_wave4_matrix_loudly_when_the_web_config_is_absent() -> None:
+    """CHAOS-3586 follow-up: the presence guard, and why it is a SKIP.
+
+    The wave4 config lives in dev-health-web and landed there after this leg
+    did. Until it is on web main, `playwright test -c <missing>` exits 1 and
+    `set -e` kills the run after a full boot -- breaking every launcher
+    invocation whose --web-root lacks the config, including the nightly.
+
+    A skip is the right behaviour for an absent optional config, but a skip
+    that reads like a pass is the exact false green this lane exists to
+    prevent. So the guard must emit a single greppable marker naming the
+    outcome, and the assertions below pin that it does.
+    """
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+
+    # Guarded on the file, not on an env flag: an env flag would still let a
+    # caller arm a config that does not exist.
+    assert 'wave4_config="${web_root}/playwright.ask-dev-wave4.config.ts"' in launcher
+    assert 'if [[ ! -f "${wave4_config}" ]]; then' in launcher
+
+    # The marker is machine-greppable and states the outcome, not just a
+    # reason. A log scraper must be able to tell a skipped run from a run that
+    # exercised the matrix without parsing prose.
+    assert "WAVE4_ACCESS_MATRIX=NOT_RUN reason=config-absent" in launcher
+    assert "WAVE4_ACCESS_MATRIX=RUNNING" in launcher
+    assert (
+        "proves NOTHING about the Context Fabric Validation access matrix" in launcher
+    )
+
+    # The skip marker must come BEFORE the invocation, i.e. it is the
+    # else-branch, not dead text after a leg that already ran.
+    not_run_index = launcher.index("WAVE4_ACCESS_MATRIX=NOT_RUN")
+    running_index = launcher.index("WAVE4_ACCESS_MATRIX=RUNNING")
+    invocation_index = launcher.index('-c "${wave4_config}"')
+    assert not_run_index < running_index < invocation_index
+
+    # When the config IS present the leg stays mandatory: a real matrix
+    # failure must still abort the run.
+    #
+    # The slice deliberately runs to the END of the guarded block, not merely
+    # to the invocation. A first version of this assertion checked only
+    # [marker, invocation) and a mutation appending `|| true` to the
+    # invocation itself SURVIVED -- the swallow lands after the anchor, in the
+    # region that version never looked at. Mutation testing caught it; the
+    # lesson is that a region assertion is only as good as the region.
+    block_end = launcher.index("\nfi\n", invocation_index)
+    guarded_block = launcher[running_index:block_end]
+    assert "|| true" not in guarded_block
+    assert "set +e" not in guarded_block


### PR DESCRIPTION
**Fixes a regression I introduced in #1596.** Unblocks the nightly and every launcher run whose `--web-root` lacks the wave4 config.

## The break

#1596 made the launcher invoke `${web_root}/playwright.ask-dev-wave4.config.ts` **unconditionally**. That file lives in dev-health-web and is still unmerged there (#858). Measured, not assumed:

- `git ls-tree origin/main` in web → **0** matches
- `playwright test -c <missing>` → `Error: ... does not exist`, **exit 1**
- launcher is `set -euo pipefail` → the run dies **after** a full boot, seed and Phase 1 pass

Blast radius: every launcher invocation against a checkout without the config, **including `.github/workflows/ask-dev-acceptance.yml`**, which checks out web main and runs nightly at **04:23 UTC**.

**Root error was ordering** — the ops half had a hard dependency on the web half and merged first. I recorded that dependency in one direction only.

**Why the existing guard couldn't catch it:** a source-reading contract test proves the invocation exists in *this* file and says nothing about whether the path resolves inside *another repository*. The reference was cross-repo and dangling — verification stopped exactly at the boundary the bug crossed.

## The fix

Run the leg only when the config is present. A skip is correct for an absent optional config, but **a skip that reads like a pass is the false green this lane exists to prevent** — so the else-branch emits a single greppable marker:

```
WAVE4_ACCESS_MATRIX=NOT_RUN reason=config-absent web_root=...
The Wave 4 access matrix did NOT execute: ... does not exist.
This run proves NOTHING about the Context Fabric Validation access matrix.
```

The positive path emits `WAVE4_ACCESS_MATRIX=RUNNING`. When the config **is** present the leg stays mandatory — no `|| true`, no `set +e`; any matrix failure still aborts the run.

**Deliberately NOT adding a config-must-exist CI assertion yet:** tonight's nightly checks out web main, which lacks the config until #858 lands, so the assertion would recreate the very failure this fixes. It's recorded on #858's merge checklist instead — the leg goes mandatory the moment the config exists on web main.

## Verification

**Guard exercised both ways before gating** (the RED-first pair for a skip guard): a `--web-root` without the config → marker emitted, run continues, exit 0; a `--web-root` with it → `RUNNING` marker, leg invoked.

Four mutations against the new test, and **two produced findings rather than just confirmations**:

| Mutation | Result |
|---|---|
| remove the presence guard (the original bug) | **killed** |
| silence the skip marker | **killed** |
| `\|\| true` after the invocation | **SURVIVED** → assertion fixed → killed |
| `set +e` inside the guarded block | **killed** |

1. The pre-existing ordering assertion anchored on the config **filename**, which now also appears in the guard's variable assignment. It failed loudly and was re-anchored on the invocation site `-c "${wave4_config}"`.
2. The `|| true` mutation **survived** the first version of the mandatory-leg assertion, because that version examined only `[marker, invocation)` and the swallow lands *after* the anchor. The slice now runs to the end of the guarded block. **A region assertion is only as good as its region.**

`bash -n` clean; 51/51 in `tests/acceptance/test_ask_dev_compose.py`; restores verified by content diff, not `git status`.

## Not verified end-to-end, and why

The guard's skip branch cannot be demonstrated through a *real* full launcher run today: any such run currently dies earlier, at the Phase 1 retention assertion (CHAOS-3581, fixed on unmerged web #859). The both-ways validation above used an extracted harness of the guard block — honest proxy, not the real thing.

The genuine end-to-end proof arrives with the web lane's window: that branch carries the 3581 fix (so Phase 1 passes) and lacks the wave4 config (so this guard skips). That run is the natural experiment for the skip branch, and its log should contain `WAVE4_ACCESS_MATRIX=NOT_RUN`.
