### PR TITLE
feat(acceptance): make the wave4 access-matrix leg mandatory (CHAOS-3510)

### DIFF
--- a/scripts/acceptance/run_ask_dev_compose.sh
+++ b/scripts/acceptance/run_ask_dev_compose.sh
@@ -427,33 +427,50 @@ TEST_SUPERUSER_PASSWORD=devhealth123 \
 # did NOT run and why, so no log reader and no artifact scraper can mistake
 # this run for one that exercised the matrix. When the web config IS present
 # the leg is mandatory and any failure still aborts the run.
+# MANDATORY (CHAOS-3510 landed the config on web main). The previous
+# revision SKIPPED this leg with a loud marker when the config was absent.
+# That skip was scaffolding for exactly one condition -- the ops half of this
+# feature merged before the web half -- and that condition no longer exists:
+# playwright.ask-dev-wave4.config.ts is on dev-health-web main.
+#
+# The scaffolding is REMOVED rather than left dormant. A skip path that is
+# correct today and unreachable tomorrow is how a gate quietly stops gating:
+# it survives because nothing fails when it fires, and the next person to
+# delete or rename the config gets a green run and a marker nobody greps for.
+#
+# Unconditional on purpose. A developer pointing --web-root at a checkout
+# predating CHAOS-3510 is TOLD, loudly, what to update -- "tolerant for local
+# convenience" is precisely how the dormant path would survive.
 wave4_config="${web_root}/playwright.ask-dev-wave4.config.ts"
 if [[ ! -f "${wave4_config}" ]]; then
-  echo "WAVE4_ACCESS_MATRIX=NOT_RUN reason=config-absent web_root=${web_root}" >&2
-  echo "The Wave 4 access matrix did NOT execute: ${wave4_config} does not exist." >&2
-  echo "This run proves NOTHING about the Context Fabric Validation access matrix." >&2
-  echo "Point --web-root at a checkout carrying the config (CHAOS-3510) to run it." >&2
-else
-  if [[ ! -s "${org_ids_output}" ]]; then
-    echo "Wave 4 access matrix cannot run: ${org_ids_output} is missing or empty." >&2
-    echo "prepare_ask_dev_acceptance.py must have written the org-ids artifact" >&2
-    echo "(schema ask_dev_acceptance_org_ids.v1) before this point. Refusing to" >&2
-    echo "run the matrix against unknown tenants rather than skipping it." >&2
-    exit 1
-  fi
-  echo "WAVE4_ACCESS_MATRIX=RUNNING web_root=${web_root}"
-  ASK_DEV_LIVE_ACCEPTANCE=1 \
-  ASK_DEV_COMPOSE_WEB_READY=1 \
-  ASK_DEV_WAVE4_ACCESS_MATRIX=1 \
-  ASK_DEV_ACCEPTANCE_WEB_URL=http://127.0.0.1:3002 \
-  ASK_DEV_ACCEPTANCE_ORG_IDS="${org_ids_output}" \
-  ASK_DEV_ACCEPTANCE_ACR="${acr_armed}" \
-  PLAYWRIGHT_LIVE_BACKEND_URL="${acceptance_api_url}" \
-  TEST_SUPERUSER_EMAIL=admin@devhealth.example \
-  TEST_SUPERUSER_PASSWORD=devhealth123 \
-    "${web_root}/node_modules/.bin/playwright" test \
-    -c "${wave4_config}"
+  echo "WAVE4_ACCESS_MATRIX=FAILED reason=config-absent web_root=${web_root}" >&2
+  echo "The Wave 4 access matrix config is REQUIRED and was not found:" >&2
+  echo "  ${wave4_config}" >&2
+  echo "It has been on dev-health-web main since CHAOS-3510. A --web-root" >&2
+  echo "without it is a checkout predating that change; update or rebase it." >&2
+  echo "This leg is mandatory: refusing to report a run that never exercised" >&2
+  echo "the Context Fabric Validation access matrix." >&2
+  exit 1
 fi
+if [[ ! -s "${org_ids_output}" ]]; then
+  echo "Wave 4 access matrix cannot run: ${org_ids_output} is missing or empty." >&2
+  echo "prepare_ask_dev_acceptance.py must have written the org-ids artifact" >&2
+  echo "(schema ask_dev_acceptance_org_ids.v1) before this point. Refusing to" >&2
+  echo "run the matrix against unknown tenants rather than skipping it." >&2
+  exit 1
+fi
+echo "WAVE4_ACCESS_MATRIX=RUNNING web_root=${web_root}"
+ASK_DEV_LIVE_ACCEPTANCE=1 \
+ASK_DEV_COMPOSE_WEB_READY=1 \
+ASK_DEV_WAVE4_ACCESS_MATRIX=1 \
+ASK_DEV_ACCEPTANCE_WEB_URL=http://127.0.0.1:3002 \
+ASK_DEV_ACCEPTANCE_ORG_IDS="${org_ids_output}" \
+ASK_DEV_ACCEPTANCE_ACR="${acr_armed}" \
+PLAYWRIGHT_LIVE_BACKEND_URL="${acceptance_api_url}" \
+TEST_SUPERUSER_EMAIL=admin@devhealth.example \
+TEST_SUPERUSER_PASSWORD=devhealth123 \
+  "${web_root}/node_modules/.bin/playwright" test \
+  -c "${wave4_config}"
 
 # CHAOS-3219 Phase 5 (CI lane): keep the stack up for a caller that has more
 # to run against it -- specifically scripts/acceptance/run_wave4_corpus.sh,

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -1848,52 +1848,68 @@ def test_launcher_runs_the_wave4_access_matrix_with_its_own_arming_contract() ->
     assert "|| true" not in launcher[preflight_index:wave4_invocation_index]
 
 
-def test_launcher_skips_the_wave4_matrix_loudly_when_the_web_config_is_absent() -> None:
-    """CHAOS-3586 follow-up: the presence guard, and why it is a SKIP.
+def test_launcher_requires_the_wave4_config_and_never_skips_the_matrix() -> None:
+    """CHAOS-3510: the wave4 leg is MANDATORY now that the config is on web main.
 
-    The wave4 config lives in dev-health-web and landed there after this leg
-    did. Until it is on web main, `playwright test -c <missing>` exits 1 and
-    `set -e` kills the run after a full boot -- breaking every launcher
-    invocation whose --web-root lacks the config, including the nightly.
+    History this pins deliberately. The ops half of this feature merged before
+    the web half, so an interim revision SKIPPED the leg (with a loud marker)
+    when the config was absent -- otherwise every launcher run, including the
+    nightly, died on a dangling cross-repo path. That condition is gone:
+    playwright.ask-dev-wave4.config.ts is on dev-health-web main.
 
-    A skip is the right behaviour for an absent optional config, but a skip
-    that reads like a pass is the exact false green this lane exists to
-    prevent. So the guard must emit a single greppable marker naming the
-    outcome, and the assertions below pin that it does.
+    The skip is REMOVED rather than left dormant. A skip path that is correct
+    today and unreachable tomorrow is how a gate quietly stops gating -- it
+    survives precisely because nothing fails when it fires. So this test
+    asserts the skip is GONE, not merely that a fail path exists beside it.
     """
     launcher = _LAUNCHER.read_text(encoding="utf-8")
 
-    # Guarded on the file, not on an env flag: an env flag would still let a
-    # caller arm a config that does not exist.
+    # Guarded on the file, not on an env flag: a flag would still let a caller
+    # arm a config that does not exist.
     assert 'wave4_config="${web_root}/playwright.ask-dev-wave4.config.ts"' in launcher
     assert 'if [[ ! -f "${wave4_config}" ]]; then' in launcher
 
-    # The marker is machine-greppable and states the outcome, not just a
-    # reason. A log scraper must be able to tell a skipped run from a run that
-    # exercised the matrix without parsing prose.
-    assert "WAVE4_ACCESS_MATRIX=NOT_RUN reason=config-absent" in launcher
+    # Absent config ABORTS. The marker names the outcome so a log scraper can
+    # classify the run without parsing prose.
+    assert "WAVE4_ACCESS_MATRIX=FAILED reason=config-absent" in launcher
     assert "WAVE4_ACCESS_MATRIX=RUNNING" in launcher
-    assert (
-        "proves NOTHING about the Context Fabric Validation access matrix" in launcher
-    )
 
-    # The skip marker must come BEFORE the invocation, i.e. it is the
-    # else-branch, not dead text after a leg that already ran.
-    not_run_index = launcher.index("WAVE4_ACCESS_MATRIX=NOT_RUN")
+    # The scaffolding must be GONE, not dormant. This is the assertion that
+    # distinguishes "mandatory" from "a fail branch that some other path can
+    # still route around".
+    assert "WAVE4_ACCESS_MATRIX=NOT_RUN" not in launcher
+    assert "proves NOTHING about the Context Fabric" not in launcher
+
+    # The failure branch must actually exit, and do so BEFORE the invocation.
+    failed_index = launcher.index("WAVE4_ACCESS_MATRIX=FAILED")
     running_index = launcher.index("WAVE4_ACCESS_MATRIX=RUNNING")
     invocation_index = launcher.index('-c "${wave4_config}"')
-    assert not_run_index < running_index < invocation_index
+    assert failed_index < running_index < invocation_index
 
-    # When the config IS present the leg stays mandatory: a real matrix
-    # failure must still abort the run.
+    # Scope the abort check to the CONFIG-ABSENT BRANCH ITSELF -- up to its own
+    # closing `fi`, not onward to the RUNNING marker.
     #
-    # The slice deliberately runs to the END of the guarded block, not merely
-    # to the invocation. A first version of this assertion checked only
+    # Widening it to [FAILED, RUNNING) is not merely sloppy, it is
+    # unfalsifiable: the org-ids preflight sits inside that span and carries
+    # its OWN `exit 1`, so deleting this branch's abort still leaves a matching
+    # string in the region. A mutation removing it SURVIVED exactly that way.
+    # Second time a region assertion in this guard was satisfied by something
+    # other than the thing it names -- the region must end where the construct
+    # ends.
+    absent_branch_end = launcher.index("\nfi\n", failed_index)
+    absent_branch = launcher[failed_index:absent_branch_end]
+    assert "exit 1" in absent_branch
+
+    # No `else` may re-introduce a continue-anyway path in that branch.
+    assert "else" not in absent_branch
+
+    # The leg itself stays mandatory: a real matrix failure must still abort.
+    # The slice runs to the END of the invocation block, not merely to the
+    # invocation line. An earlier version of this assertion checked only
     # [marker, invocation) and a mutation appending `|| true` to the
-    # invocation itself SURVIVED -- the swallow lands after the anchor, in the
-    # region that version never looked at. Mutation testing caught it; the
-    # lesson is that a region assertion is only as good as the region.
-    block_end = launcher.index("\nfi\n", invocation_index)
-    guarded_block = launcher[running_index:block_end]
-    assert "|| true" not in guarded_block
-    assert "set +e" not in guarded_block
+    # invocation SURVIVED -- the swallow lands after the anchor, in the region
+    # that version never examined. A region assertion is only as good as its
+    # region, so that mutation stays in this guard's permanent set.
+    tail = launcher[running_index : invocation_index + 400]
+    assert "|| true" not in tail
+    assert "set +e" not in tail


### PR DESCRIPTION
Item 3(a) of CHAOS-3510's merge checklist. **Must merge AFTER dev-health-web#858** — it requires `playwright.ask-dev-wave4.config.ts` on web `main`.

## What changes

The interim **loud-skip** becomes a **hard fail**. An absent wave4 config now aborts the launcher instead of printing `WAVE4_ACCESS_MATRIX=NOT_RUN` and continuing.

The skip is **removed, not left dormant**. It was scaffolding for exactly one condition — the ops half of this feature (#1596) merged before the web half — and that condition is gone. A skip path that is correct today and unreachable tomorrow is how a gate quietly stops gating: it survives *because* nothing fails when it fires, and the next person to delete or rename the config gets a green run plus a marker nobody greps for. So the guard test asserts `WAVE4_ACCESS_MATRIX=NOT_RUN` is **absent from the launcher**, not merely that a fail path exists beside it.

**Unconditional, deliberately.** A developer pointing `--web-root` at a pre-3510 checkout is told loudly what to update, and the message names both the ticket and the expected path. "Tolerant for local convenience" is precisely how the dormant path would have survived.

## Mutation results — one survived, and it's the useful one

| Mutation | Result |
|---|---|
| revert to skip-and-continue | killed |
| `\|\| true` after the invocation | killed *(permanent in the set — it beat an earlier version of this guard)* |
| remove the presence check entirely | killed |
| **delete `exit 1` from the config-absent branch** | **SURVIVED** → fixed → killed |

The survivor is worth reading. The assertion scoped its search to `[FAILED marker, RUNNING marker)` — and the **org-ids preflight sits inside that span carrying its own `exit 1`**. So deleting *this* branch's abort still left a matching string in the region, and the assertion passed. It wasn't weak; it was **unfalsifiable**: it could not distinguish the construct it named from a decoy a few lines away. Now scoped to the branch's own closing `fi`.

That is the **second time** a region assertion in this guard was satisfied by something other than the construct it names (the first was `|| true` landing after the anchor). Both are recorded in the test comments as a standing rule: *a region assertion must end where its construct ends, and a region containing a decoy of the searched string proves nothing.*

## Verification

`bash -n` clean; **51/51** in `tests/acceptance/test_ask_dev_compose.py`; restores verified by content diff, not `git status`. Local gate result reported on the PR when it completes.

## Merge ordering — important

1. dev-health-web#858 merges (config lands on web main)
2. **this PR** merges
3. canonical launcher run from web main + ops main, which is #858's closing evidence **and** the end-to-end proof of this flip

Merging this **before** #858 would re-break every launcher run including the nightly (04:23 UTC) — the same regression #1599 fixed.
