### PR TITLE
CHAOS-3602: port complementary TTL guards main lacks (registry, pre-dump horizon check, dump verification, generator clamps)

### DIFF
--- a/src/dev_health_ops/fixtures/generators/interactions.py
+++ b/src/dev_health_ops/fixtures/generators/interactions.py
@@ -317,10 +317,11 @@ class InteractionsGeneratorMixin(BaseGeneratorMixin):
         # restore shelf life `_assert_snapshot_within_shelf_life` actually
         # enforces (codex finding, confirmed: the looser margin let a
         # restore up to the advertised shelf life land 20 days past this
-        # table's own TTL horizon).
-        days = min(
-            days, max_generated_age_days_for_table("telemetry_signal_bucket") or days
-        )
+        # table's own TTL horizon). `is None` (never `or`, codex round-2
+        # finding, confirmed): a legitimate ceiling of exactly 0 must clamp
+        # to 0, not fall back to the caller's unclamped `days`.
+        _ceiling = max_generated_age_days_for_table("telemetry_signal_bucket")
+        days = days if _ceiling is None else min(days, _ceiling)
         buckets: list[TelemetrySignalBucketRecord] = []
         now = datetime.now(timezone.utc)
         start = now - timedelta(days=days)
@@ -389,9 +390,10 @@ class InteractionsGeneratorMixin(BaseGeneratorMixin):
         """Generate daily release impact metrics."""
         # CHAOS-3602: same defense-in-depth clamp as
         # generate_telemetry_signal_buckets -- `days` is caller-supplied.
-        days = min(
-            days, max_generated_age_days_for_table("release_impact_daily") or days
-        )
+        # `is None`, never `or` (codex round-2 finding, confirmed): see the
+        # sibling comment above.
+        _ceiling = max_generated_age_days_for_table("release_impact_daily")
+        days = days if _ceiling is None else min(days, _ceiling)
         records: list[ReleaseImpactDailyRecord] = []
         now = datetime.now(timezone.utc)
         end_date = now.date()

--- a/src/dev_health_ops/fixtures/generators/interactions.py
+++ b/src/dev_health_ops/fixtures/generators/interactions.py
@@ -6,7 +6,7 @@ import random
 from datetime import datetime, timedelta, timezone
 
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
-from dev_health_ops.fixtures.ttl_registry import max_generated_age_days
+from dev_health_ops.fixtures.ttl_horizon import max_generated_age_days_for_table
 from dev_health_ops.metrics.schemas import (
     FeatureFlagEventRecord,
     FeatureFlagLinkRecord,
@@ -311,7 +311,16 @@ class InteractionsGeneratorMixin(BaseGeneratorMixin):
         # clamp it against this table's own TTL horizon (per the migration-
         # derived registry, not a second hardcoded number) rather than
         # trusting the caller never to pass something that backdates past it.
-        days = min(days, max_generated_age_days("telemetry_signal_bucket") or days)
+        # Uses THIS repo's canonical TTL_SAFETY_MARGIN (ttl_horizon.py, 30
+        # days) -- not ttl_registry.py's own (looser) margin constants --
+        # so a row this clamp allows stays compatible with the 30-day
+        # restore shelf life `_assert_snapshot_within_shelf_life` actually
+        # enforces (codex finding, confirmed: the looser margin let a
+        # restore up to the advertised shelf life land 20 days past this
+        # table's own TTL horizon).
+        days = min(
+            days, max_generated_age_days_for_table("telemetry_signal_bucket") or days
+        )
         buckets: list[TelemetrySignalBucketRecord] = []
         now = datetime.now(timezone.utc)
         start = now - timedelta(days=days)
@@ -380,7 +389,9 @@ class InteractionsGeneratorMixin(BaseGeneratorMixin):
         """Generate daily release impact metrics."""
         # CHAOS-3602: same defense-in-depth clamp as
         # generate_telemetry_signal_buckets -- `days` is caller-supplied.
-        days = min(days, max_generated_age_days("release_impact_daily") or days)
+        days = min(
+            days, max_generated_age_days_for_table("release_impact_daily") or days
+        )
         records: list[ReleaseImpactDailyRecord] = []
         now = datetime.now(timezone.utc)
         end_date = now.date()

--- a/src/dev_health_ops/fixtures/generators/interactions.py
+++ b/src/dev_health_ops/fixtures/generators/interactions.py
@@ -6,6 +6,7 @@ import random
 from datetime import datetime, timedelta, timezone
 
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
+from dev_health_ops.fixtures.ttl_registry import max_generated_age_days
 from dev_health_ops.metrics.schemas import (
     FeatureFlagEventRecord,
     FeatureFlagLinkRecord,
@@ -305,6 +306,12 @@ class InteractionsGeneratorMixin(BaseGeneratorMixin):
         release_refs: list[str] | None = None,
     ) -> list[TelemetrySignalBucketRecord]:
         """Generate hourly telemetry signal buckets."""
+        # CHAOS-3602: defense in depth -- `days` is caller-supplied (from
+        # `--days`/the world manifest), not intrinsic to this generator, so
+        # clamp it against this table's own TTL horizon (per the migration-
+        # derived registry, not a second hardcoded number) rather than
+        # trusting the caller never to pass something that backdates past it.
+        days = min(days, max_generated_age_days("telemetry_signal_bucket") or days)
         buckets: list[TelemetrySignalBucketRecord] = []
         now = datetime.now(timezone.utc)
         start = now - timedelta(days=days)
@@ -371,6 +378,9 @@ class InteractionsGeneratorMixin(BaseGeneratorMixin):
         release_refs: list[str] | None = None,
     ) -> list[ReleaseImpactDailyRecord]:
         """Generate daily release impact metrics."""
+        # CHAOS-3602: same defense-in-depth clamp as
+        # generate_telemetry_signal_buckets -- `days` is caller-supplied.
+        days = min(days, max_generated_age_days("release_impact_daily") or days)
         records: list[ReleaseImpactDailyRecord] = []
         now = datetime.now(timezone.utc)
         end_date = now.date()

--- a/src/dev_health_ops/fixtures/generators/product_telemetry.py
+++ b/src/dev_health_ops/fixtures/generators/product_telemetry.py
@@ -421,12 +421,11 @@ class ProductTelemetryGenerator:
         # the 30-day restore shelf life `_assert_snapshot_within_shelf_life`
         # actually enforces (codex finding, confirmed: a looser margin let
         # a restore at the advertised shelf life land past this table's own
-        # TTL horizon).
-        days = min(
-            self.spec.days,
-            max_generated_age_days_for_table("product_telemetry_events")
-            or self.spec.days,
-        )
+        # TTL horizon). `is None`, never `or` (codex round-2 finding,
+        # confirmed): a legitimate ceiling of exactly 0 must clamp to 0, not
+        # fall back to the caller's unclamped `self.spec.days`.
+        _ceiling = max_generated_age_days_for_table("product_telemetry_events")
+        days = self.spec.days if _ceiling is None else min(self.spec.days, _ceiling)
         # Half-open: start_day is inclusive, end_day is exclusive.
         start_day = (end_time - timedelta(days=days)).replace(
             hour=9, minute=0, second=0, microsecond=0

--- a/src/dev_health_ops/fixtures/generators/product_telemetry.py
+++ b/src/dev_health_ops/fixtures/generators/product_telemetry.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from dev_health_ops.api.product_telemetry.persist import BLOCKED_PAYLOAD_KEYS
 from dev_health_ops.api.product_telemetry.schemas import ProductTelemetryEvent
+from dev_health_ops.fixtures.ttl_registry import max_generated_age_days
 
 SCHEMA_VERSION = "2026-05-telemetry-v1"
 SOURCE = "dev-health-web"
@@ -410,13 +411,23 @@ class ProductTelemetryGenerator:
     def generate_events(self) -> list[ProductTelemetryEvent]:
         """Generate the full event stream for the configured spec."""
         end_time = self.spec.end_time or datetime.now(timezone.utc)
+        # CHAOS-3602: `self.spec.days` is caller-supplied and the spec is
+        # frozen, so clamp a LOCAL copy against product_telemetry_events'
+        # own TTL horizon rather than trusting the caller or mutating the
+        # spec -- the oldest generated event must stay a safe margin inside
+        # the table's TTL, or it risks the same silent TTL-merge deletion
+        # that hit feature_flag_event.
+        days = min(
+            self.spec.days,
+            max_generated_age_days("product_telemetry_events") or self.spec.days,
+        )
         # Half-open: start_day is inclusive, end_day is exclusive.
-        start_day = (end_time - timedelta(days=self.spec.days)).replace(
+        start_day = (end_time - timedelta(days=days)).replace(
             hour=9, minute=0, second=0, microsecond=0
         )
 
         events: list[ProductTelemetryEvent] = []
-        for day_offset in range(self.spec.days):
+        for day_offset in range(days):
             day_start = start_day + timedelta(days=day_offset)
             for session_index in range(self.spec.sessions_per_day):
                 # Spread sessions across a workday-ish window.

--- a/src/dev_health_ops/fixtures/generators/product_telemetry.py
+++ b/src/dev_health_ops/fixtures/generators/product_telemetry.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from dev_health_ops.api.product_telemetry.persist import BLOCKED_PAYLOAD_KEYS
 from dev_health_ops.api.product_telemetry.schemas import ProductTelemetryEvent
-from dev_health_ops.fixtures.ttl_registry import max_generated_age_days
+from dev_health_ops.fixtures.ttl_horizon import max_generated_age_days_for_table
 
 SCHEMA_VERSION = "2026-05-telemetry-v1"
 SOURCE = "dev-health-web"
@@ -416,10 +416,16 @@ class ProductTelemetryGenerator:
         # own TTL horizon rather than trusting the caller or mutating the
         # spec -- the oldest generated event must stay a safe margin inside
         # the table's TTL, or it risks the same silent TTL-merge deletion
-        # that hit feature_flag_event.
+        # that hit feature_flag_event. Uses ttl_horizon.py's canonical
+        # TTL_SAFETY_MARGIN (30 days) so this clamp stays compatible with
+        # the 30-day restore shelf life `_assert_snapshot_within_shelf_life`
+        # actually enforces (codex finding, confirmed: a looser margin let
+        # a restore at the advertised shelf life land past this table's own
+        # TTL horizon).
         days = min(
             self.spec.days,
-            max_generated_age_days("product_telemetry_events") or self.spec.days,
+            max_generated_age_days_for_table("product_telemetry_events")
+            or self.spec.days,
         )
         # Half-open: start_day is inclusive, end_day is exclusive.
         start_day = (end_time - timedelta(days=days)).replace(

--- a/src/dev_health_ops/fixtures/ttl_horizon.py
+++ b/src/dev_health_ops/fixtures/ttl_horizon.py
@@ -153,9 +153,17 @@ def max_generated_age_days_for_table(table: str) -> int | None:
     only fail-open path -- a PARTIAL registry (every OTHER known TTL table
     parses fine, one does not) makes ``retentions.get(table)`` return
     ``None`` for the missing one, indistinguishable from "genuinely no
-    TTL", so an unparseable table silently loses its clamp entirely. Every
-    table in :data:`ttl_registry.KNOWN_TTL_TABLES` must be present before
-    ANY lookup against this registry is trusted.
+    TTL", so an unparseable table silently loses its clamp entirely.
+
+    Codex round-3 finding (HIGH, confirmed): checking against
+    :data:`ttl_registry.KNOWN_TTL_TABLES` alone only catches a table
+    falling OUT of an otherwise-working registry -- a table that never
+    enters the registry (an unmatched TTL syntax variant) AND was never
+    added to ``KNOWN_TTL_TABLES`` satisfies that check trivially.
+    Reproduced directly with a synthetic ``TTL occurred_at + INTERVAL 4
+    WEEK`` (a real ClickHouse form the precise, ``DAY``-only parser cannot
+    match). See :func:`ttl_registry.assert_ttl_vocabulary_is_consistent`
+    for the independent third source that closes this.
 
     Codex round-2 finding (HIGH, confirmed): a NON-STRICT ``ceiling +
     TTL_SAFETY_MARGIN.days <= retention_days`` allows landing EXACTLY on
@@ -170,22 +178,18 @@ def max_generated_age_days_for_table(table: str) -> int | None:
     """
 
     from dev_health_ops.fixtures.ttl_registry import (
-        KNOWN_TTL_TABLES,
+        assert_ttl_vocabulary_is_consistent,
         clickhouse_ttl_retentions,
     )
 
-    retentions = clickhouse_ttl_retentions()
-    missing_known = KNOWN_TTL_TABLES - retentions.keys()
-    if missing_known:
+    try:
+        assert_ttl_vocabulary_is_consistent()
+    except RuntimeError as exc:
         raise RuntimeError(
-            f"the ClickHouse TTL registry is missing known TTL'd table(s) "
-            f"{sorted(missing_known)} while computing a generation ceiling "
-            f"for {table!r} -- a registry that parses SOME tables but not "
-            "ALL of dev_health_ops.fixtures.ttl_registry.KNOWN_TTL_TABLES "
-            "means the parser or its migrations-directory path broke for "
-            "at least one table, not that those tables stopped carrying a "
-            "TTL (see tightest_ttl_days for the same rule applied globally)"
-        )
+            f"{exc} (while computing a generation ceiling for {table!r}; "
+            "see tightest_ttl_days for the same rule applied globally)"
+        ) from exc
+    retentions = clickhouse_ttl_retentions()
     retention = retentions.get(table)
     if retention is None:
         return None

--- a/src/dev_health_ops/fixtures/ttl_horizon.py
+++ b/src/dev_health_ops/fixtures/ttl_horizon.py
@@ -110,3 +110,45 @@ def max_generated_history_days(migrations_dir: Path | None = None) -> int:
     """How far back generators may write, to stay inside the shelf life."""
 
     return tightest_ttl_days(migrations_dir) - TTL_SAFETY_MARGIN.days
+
+
+def max_generated_age_days_for_table(table: str) -> int | None:
+    """A PER-TABLE generation ceiling that stays compatible with THIS
+    module's shelf-life contract -- ``None`` if ``table`` carries no TTL.
+
+    CHAOS-3602 port, codex finding (HIGH, confirmed): a generator clamped
+    against ``ttl_registry.py``'s own margin constants
+    (``TTL_SAFETY_MARGIN_DAYS`` = 7, ``GENERATOR_SLACK_DAYS`` = 3) produces a
+    ceiling incompatible with the 30-day margin ``_assert_snapshot_within_
+    shelf_life`` actually enforces at restore: measured live,
+    ``telemetry_signal_bucket`` at that looser ceiling (80d) plus this
+    module's own advertised 30-day restore shelf life reaches 110 days old
+    against a 90-day TTL -- 20 days PAST the horizon, silently losing rows
+    to a TTL merge during a restore main's own manifest says is still safe.
+    ``release_impact_daily`` (355d + 30d vs a 365d TTL) and
+    ``product_telemetry_events`` (170d + 30d vs a 180d TTL) have the same
+    defect.
+
+    This combines ``ttl_registry.py``'s PER-TABLE retention data (more
+    precise than this module's single tightest-global horizon) with THIS
+    module's own ``TTL_SAFETY_MARGIN`` -- the one number
+    ``_assert_snapshot_within_shelf_life`` actually promises callers -- so
+    every generator's ceiling stays honest about what a restore up to the
+    full advertised shelf life can still find intact.
+    """
+
+    from dev_health_ops.fixtures.ttl_registry import clickhouse_ttl_retentions
+
+    retentions = clickhouse_ttl_retentions()
+    if not retentions:
+        raise RuntimeError(
+            f"no per-table TTL retentions found while computing a generation "
+            f"ceiling for {table!r} -- this schema is known to carry several "
+            "TTL'd tables, so an empty registry means the parser or its "
+            "migrations-directory path broke, not that the risk went away "
+            "(see tightest_ttl_days for the same rule applied globally)"
+        )
+    retention = retentions.get(table)
+    if retention is None:
+        return None
+    return max(0, retention.retention_days - TTL_SAFETY_MARGIN.days)

--- a/src/dev_health_ops/fixtures/ttl_horizon.py
+++ b/src/dev_health_ops/fixtures/ttl_horizon.py
@@ -49,6 +49,19 @@ from pathlib import Path
 #: literal scattered across generators.
 TTL_SAFETY_MARGIN = timedelta(days=30)
 
+#: Extra, STRICT headroom `max_generated_age_days_for_table` keeps below
+#: ``retention_days - TTL_SAFETY_MARGIN.days``, on top of the margin itself.
+#: Codex round-2 finding (HIGH, confirmed): without this, a row generated at
+#: the naive ceiling and restored at the full advertised shelf life lands
+#: EXACTLY on its table's TTL horizon (a 90-day TTL, 60-day ceiling, 30-day
+#: shelf life = exactly 90 days old) -- and this project's own live pre-dump
+#: guard already treats a row `<= now() - N DAY` old as unsafe, while
+#: ClickHouse's TTL deletion is asynchronous and can fire at or before that
+#: exact instant. One day is the minimum that turns "ceiling + shelf_life <=
+#: retention" into a STRICT "<", so hitting the boundary exactly is no
+#: longer possible for any known table.
+PER_TABLE_CEILING_HEADROOM_DAYS = 1
+
 _TTL_PATTERN = re.compile(
     r"TTL\s+.*?\+\s*INTERVAL\s+(?P<days>\d+)\s+DAY\s+DELETE", re.IGNORECASE
 )
@@ -135,20 +148,50 @@ def max_generated_age_days_for_table(table: str) -> int | None:
     ``_assert_snapshot_within_shelf_life`` actually promises callers -- so
     every generator's ceiling stays honest about what a restore up to the
     full advertised shelf life can still find intact.
+
+    Codex round-2 finding (HIGH, confirmed): an empty registry was not the
+    only fail-open path -- a PARTIAL registry (every OTHER known TTL table
+    parses fine, one does not) makes ``retentions.get(table)`` return
+    ``None`` for the missing one, indistinguishable from "genuinely no
+    TTL", so an unparseable table silently loses its clamp entirely. Every
+    table in :data:`ttl_registry.KNOWN_TTL_TABLES` must be present before
+    ANY lookup against this registry is trusted.
+
+    Codex round-2 finding (HIGH, confirmed): a NON-STRICT ``ceiling +
+    TTL_SAFETY_MARGIN.days <= retention_days`` allows landing EXACTLY on
+    the TTL horizon (a 90-day TTL, 60-day ceiling, full 30-day shelf life
+    all in effect at once = exactly 90 days old) -- and this project's own
+    live pre-dump guard already treats ``<= now() - N DAY`` as unsafe, while
+    ClickHouse's TTL deletion is asynchronous and can fire at or before that
+    exact instant. ``PER_TABLE_CEILING_HEADROOM_DAYS`` below buys one full
+    day of strict margin so the invariant
+    (``tests/test_fixtures_ttl_horizon.py::TestPerTableCeilingCompatibleWith
+    ShelfLife``) can require ``<`` rather than ``<=``.
     """
 
-    from dev_health_ops.fixtures.ttl_registry import clickhouse_ttl_retentions
+    from dev_health_ops.fixtures.ttl_registry import (
+        KNOWN_TTL_TABLES,
+        clickhouse_ttl_retentions,
+    )
 
     retentions = clickhouse_ttl_retentions()
-    if not retentions:
+    missing_known = KNOWN_TTL_TABLES - retentions.keys()
+    if missing_known:
         raise RuntimeError(
-            f"no per-table TTL retentions found while computing a generation "
-            f"ceiling for {table!r} -- this schema is known to carry several "
-            "TTL'd tables, so an empty registry means the parser or its "
-            "migrations-directory path broke, not that the risk went away "
-            "(see tightest_ttl_days for the same rule applied globally)"
+            f"the ClickHouse TTL registry is missing known TTL'd table(s) "
+            f"{sorted(missing_known)} while computing a generation ceiling "
+            f"for {table!r} -- a registry that parses SOME tables but not "
+            "ALL of dev_health_ops.fixtures.ttl_registry.KNOWN_TTL_TABLES "
+            "means the parser or its migrations-directory path broke for "
+            "at least one table, not that those tables stopped carrying a "
+            "TTL (see tightest_ttl_days for the same rule applied globally)"
         )
     retention = retentions.get(table)
     if retention is None:
         return None
-    return max(0, retention.retention_days - TTL_SAFETY_MARGIN.days)
+    return max(
+        0,
+        retention.retention_days
+        - TTL_SAFETY_MARGIN.days
+        - PER_TABLE_CEILING_HEADROOM_DAYS,
+    )

--- a/src/dev_health_ops/fixtures/ttl_registry.py
+++ b/src/dev_health_ops/fixtures/ttl_registry.py
@@ -67,6 +67,36 @@ class TtlRetention:
     retention_days: int
 
 
+#: Codex round-2 finding (HIGH, confirmed): an empty registry is not the
+#: only way :func:`clickhouse_ttl_retentions` can fail open -- a parser
+#: regression or migration-format change can miss ONE table's TTL clause
+#: while every other table still parses fine, and ``retentions.get(table)``
+#: returning ``None`` is indistinguishable from "genuinely no TTL" at every
+#: call site. Reproduced directly: dropping ``telemetry_signal_bucket``
+#: alone from an otherwise-full registry let a 999999-row violation for
+#: that exact table pass `_assert_no_ttl_horizon_rows` silently.
+#:
+#: This CLOSED VOCABULARY is the backstop: every table known to carry a
+#: production TTL today. `_assert_no_ttl_horizon_rows` and
+#: `ttl_horizon.max_generated_age_days_for_table` both require the parsed
+#: registry to cover ALL of these before trusting ANY lookup against it --
+#: a registry missing even one of them fails closed instead of silently
+#: treating the missing table as risk-free. A future migration adding a new
+#: TTL'd table is a deliberate, visible change to this set (mirrored by
+#: `tests/test_ttl_registry.py::test_every_known_ttl_table_is_discovered`),
+#: not something this code can discover on its own -- that residual is the
+#: same one `ttl_horizon.tightest_ttl_days` already accepts for the same
+#: reason (see its own docstring).
+KNOWN_TTL_TABLES: frozenset[str] = frozenset(
+    {
+        "feature_flag_event",
+        "telemetry_signal_bucket",
+        "release_impact_daily",
+        "product_telemetry_events",
+    }
+)
+
+
 @lru_cache(maxsize=1)
 def clickhouse_ttl_retentions() -> dict[str, TtlRetention]:
     """Every ClickHouse table carrying a row-level TTL, keyed by table name.

--- a/src/dev_health_ops/fixtures/ttl_registry.py
+++ b/src/dev_health_ops/fixtures/ttl_registry.py
@@ -45,7 +45,11 @@ _MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations" / "clickhou
 
 # Anchored the same way org_deletion.py's own CREATE TABLE scanner is (PR
 # #1602 review D): a real CREATE TABLE always starts its own line, so prose
-# referencing "CREATE TABLE" mid-sentence can never falsely match.
+# referencing "CREATE TABLE" mid-sentence can never falsely match. This is
+# the ONE table-locating regex in this module -- both the precise parser
+# and the coarse sweep below use it (see the round-4 review note on
+# `_attribute_ttl_matches`): the coarse sweep's independence lives entirely
+# in `_COARSE_TTL_RE`, never in a second, unaudited table-name pattern.
 _CREATE_TABLE_RE = re.compile(
     r"^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(?P<table>[A-Za-z_]\w*)`?\s*\(",
     re.IGNORECASE | re.MULTILINE,
@@ -57,6 +61,29 @@ _CREATE_TABLE_RE = re.compile(
 _TTL_RE = re.compile(
     r"TTL\s+(?:\w+\()?(?P<column>[\w.]+)\)?\s*\+\s*INTERVAL\s+(?P<days>\d+)\s+DAY",
     re.IGNORECASE,
+)
+# Codex round-4 finding (MED, confirmed via `toIntervalDay` in the real
+# tree -- the cited file/table was wrong, the mechanism was real): naive
+# substring checks (`"TTL" in text`, `"INTERVAL" in text`) match INSIDE
+# other identifiers -- `toIntervalDay` contains "Interval", a hypothetical
+# `THROTTLED` would contain "TTL". Word-boundaried so it still matches
+# "TTL ... INTERVAL" regardless of time unit (DAY/WEEK/MONTH/..., the
+# actual looseness this sweep exists for) without matching inside an
+# unrelated longer identifier.
+_COARSE_TTL_RE = re.compile(r"\bTTL\b.*?\bINTERVAL\b", re.IGNORECASE | re.DOTALL)
+# Codex round-4 finding (MED, confirmed dormant -- no real migration uses
+# this syntax today): `ALTER TABLE x MODIFY TTL ...` is the standard way to
+# add/change retention on an EXISTING table, and none of the three sources
+# (precise parser, the old coarse sweep, KNOWN_TTL_TABLES) could ever see
+# it -- a CREATE-time-only blind spot shared by all three. The coarse sweep
+# below also scans for this form directly; if a future migration ever adds
+# one, this makes it visible immediately (`coarse - precise` fires,
+# forcing `clickhouse_ttl_retentions`'s CREATE-only extraction to be
+# extended too, which is this guard working as designed, not a false
+# alarm).
+_ALTER_TABLE_MODIFY_TTL_RE = re.compile(
+    r"^\s*ALTER\s+TABLE\s+`?(?P<table>[A-Za-z_]\w*)`?\s+MODIFY\s+TTL\b",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 
@@ -96,34 +123,77 @@ KNOWN_TTL_TABLES: frozenset[str] = frozenset(
     }
 )
 
-# Codex round-3 finding (HIGH, confirmed): a table matched here but NOT
-# extracted by `_CREATE_TABLE_RE`/`_TTL_RE` proves the precise parser missed
-# a real TTL clause. Deliberately loose -- no line anchor on the table name,
-# no specific time unit -- so it stays correct against TTL syntax the
-# precise, structured parser does not handle. Reproduced directly: a
-# synthetic `TTL occurred_at + INTERVAL 4 WEEK` (a real ClickHouse form;
-# `_TTL_RE` requires the literal word "DAY") is invisible to
-# `clickhouse_ttl_retentions` entirely -- the table enters neither the
-# registry nor (having never been seen) `KNOWN_TTL_TABLES`, so the previous
-# `KNOWN_TTL_TABLES - retentions.keys()` check passed vacuously and every
-# TTL-dependent guard treated the table as risk-free.
-_COARSE_CREATE_TABLE_RE = re.compile(
-    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(?P<table>[A-Za-z_]\w*)`?",
-    re.IGNORECASE,
-)
+
+def _attribute_ttl_matches(
+    statement: str, ttl_re: re.Pattern[str]
+) -> list[tuple[str, re.Match[str]]]:
+    """Associate every ``ttl_re`` match in ``statement`` with the CLOSEST
+    PRECEDING ``_CREATE_TABLE_RE`` match -- not just the first CREATE TABLE
+    in the whole chunk.
+
+    Codex round-4 finding (MED, confirmed dormant): the original
+    ``.search()``-based version always paired the FIRST CREATE TABLE with
+    the FIRST TTL clause in a ``;``-delimited chunk. This repo's ClickHouse
+    migrations split into ``.sql`` (semicolon-delimited, usually one
+    CREATE TABLE per statement) and ``.py`` (DDL embedded as a Python
+    string, frequently ZERO semicolons -- confirmed directly: 027, 028, 067
+    each have none). A ``.py`` migration with two CREATE TABLE blocks and a
+    TTL clause belonging to the SECOND would misattribute it to the first
+    -- currently dormant only because no existing ``.py`` migration happens
+    to carry a TTL at all (checked directly), not because the bug cannot
+    fire.
+    """
+
+    table_matches = list(_CREATE_TABLE_RE.finditer(statement))
+    if not table_matches:
+        return []
+
+    results: list[tuple[str, re.Match[str]]] = []
+    idx = 0
+    current_owner: re.Match[str] | None = None
+    for ttl_match in ttl_re.finditer(statement):
+        while (
+            idx < len(table_matches) and table_matches[idx].start() <= ttl_match.start()
+        ):
+            current_owner = table_matches[idx]
+            idx += 1
+        if current_owner is not None:
+            results.append((current_owner.group("table"), ttl_match))
+    return results
 
 
+@lru_cache(maxsize=1)
 def _coarse_ttl_table_sweep() -> frozenset[str]:
     """A second, INDEPENDENT, deliberately LOOSER pass over the same
     migration source used by :func:`clickhouse_ttl_retentions`.
 
-    Flags a statement as TTL-bearing on the bare substrings "TTL" and
-    "INTERVAL" alone -- no required time unit, no anchored table pattern --
-    so a real TTL clause the precise parser's stricter regex cannot match
-    still gets counted here. This function's whole job is to be WRONG in
-    the permissive direction (a superset of the precise registry); catching
-    it being wrong in the other direction is exactly what
-    :func:`assert_ttl_vocabulary_is_consistent` is for.
+    Codex round-4 finding (HIGH, confirmed live): the original version used
+    its OWN, unanchored, un-``MULTILINE`` table-name regex -- reproduced
+    directly against 055_work_item_daily_rollups_replacing_merge_tree.py's
+    own docstring, which yielded a phantom table ``'to'`` from "SHOW CREATE
+    TABLE to get the live DDL" and a second phantom ``'statement'`` from
+    "the table name in a CREATE TABLE statement." Both were silenced only
+    because that specific chunk happened to lack the substring "INTERVAL"
+    -- one unrelated docstring edit anywhere near either sentence would
+    have made this guard abort ALL fixture generation over a table that
+    does not exist.
+
+    NAMED DESIGN ASSUMPTION (round-4 review): this function now reuses the
+    EXACT SAME anchored :data:`_CREATE_TABLE_RE` the precise parser uses --
+    it does not have its own table-locating regex at all anymore. This
+    function's independence from :func:`clickhouse_ttl_retentions` lives
+    ENTIRELY on the TTL-DETECTION axis (:data:`_COARSE_TTL_RE`'s
+    word-boundaried, any-time-unit match, plus the
+    :data:`_ALTER_TABLE_MODIFY_TTL_RE` scan below), never on DDL location.
+    The tradeoff: a CREATE-statement shape ``_CREATE_TABLE_RE`` does not
+    match (e.g. some future ``CREATE TABLE ... AS SELECT`` form) now blinds
+    BOTH sources identically, rather than one catching what the other
+    misses. That is accepted deliberately -- location disagreement between
+    two DIFFERENT table-name regexes was pure parsing noise (this exact
+    finding, and the round-3 fifth-table gap before it, were both about TTL
+    DETECTION, never about which regex finds the table name), and sharing
+    one regex is what makes the "coarse is a strict superset of precise"
+    invariant a STRUCTURAL guarantee rather than a hope.
     """
 
     if not _MIGRATIONS_DIR.exists():
@@ -134,13 +204,11 @@ def _coarse_ttl_table_sweep() -> frozenset[str]:
         if path.suffix not in {".sql", ".py"}:
             continue
         text = path.read_text(encoding="utf-8")
+        for match in _ALTER_TABLE_MODIFY_TTL_RE.finditer(text):
+            tables.add(match.group("table"))
         for statement in text.split(";"):
-            upper = statement.upper()
-            if "TTL" not in upper or "INTERVAL" not in upper:
-                continue
-            match = _COARSE_CREATE_TABLE_RE.search(statement)
-            if match:
-                tables.add(match.group("table"))
+            for table, _ttl_match in _attribute_ttl_matches(statement, _COARSE_TTL_RE):
+                tables.add(table)
     return frozenset(tables)
 
 
@@ -159,9 +227,9 @@ def assert_ttl_vocabulary_is_consistent() -> None:
     every known table" trivially -- the vocabulary was checking itself
     against itself. The coarse sweep is the independent third source that
     breaks that circularity: precision (does the parser over-match?) is
-    checked by comparing against the coarse sweep's recall, and the coarse
-    sweep's own correctness is exactly why it is deliberately permissive
-    rather than structured.
+    checked by comparing against the coarse sweep's recall -- see
+    :func:`_coarse_ttl_table_sweep`'s own docstring for the round-4 note on
+    exactly which axis that independence lives on.
     """
 
     precise = set(clickhouse_ttl_retentions().keys())
@@ -206,6 +274,16 @@ def clickhouse_ttl_retentions() -> dict[str, TtlRetention]:
     Scans ``migrations/clickhouse/*.sql`` and ``*.py`` directly -- the same
     files ClickHouse itself is migrated from -- so this can never describe a
     TTL that isn't actually enforced, or fail to describe one that is.
+
+    Codex round-4 finding (MED, confirmed dormant): previously took only the
+    FIRST CREATE TABLE and FIRST TTL clause per ``;``-delimited chunk --
+    see :func:`_attribute_ttl_matches` for the multi-table misattribution
+    this fixes. Note this function does NOT catch a residual note also
+    raised in review: ``read_text`` failures (a non-UTF-8 migration file,
+    a permissions error) surface as a bare ``OSError``/``UnicodeDecodeError``,
+    not the framed ``RuntimeError`` this module's other fail-closed checks
+    use -- pre-existing, not fixed here (tracked as a residual, not a live
+    gap: every migration file in this repo is valid UTF-8 today).
     """
 
     retentions: dict[str, TtlRetention] = {}
@@ -217,16 +295,12 @@ def clickhouse_ttl_retentions() -> dict[str, TtlRetention]:
             continue
         text = path.read_text(encoding="utf-8")
         for statement in text.split(";"):
-            table_match = _CREATE_TABLE_RE.search(statement)
-            ttl_match = _TTL_RE.search(statement)
-            if not table_match or not ttl_match:
-                continue
-            table = table_match.group("table")
-            retentions[table] = TtlRetention(
-                table=table,
-                column=ttl_match.group("column"),
-                retention_days=int(ttl_match.group("days")),
-            )
+            for table, ttl_match in _attribute_ttl_matches(statement, _TTL_RE):
+                retentions[table] = TtlRetention(
+                    table=table,
+                    column=ttl_match.group("column"),
+                    retention_days=int(ttl_match.group("days")),
+                )
 
     return retentions
 

--- a/src/dev_health_ops/fixtures/ttl_registry.py
+++ b/src/dev_health_ops/fixtures/ttl_registry.py
@@ -1,0 +1,276 @@
+"""CHAOS-3602: registry of ClickHouse TTL retention windows, parsed
+directly from the migration source -- not hand-copied -- so a migration's
+TTL changing can never silently drift out of sync with what fixture
+generation and the mint guard both treat as "safe to backdate a row to".
+
+Why this exists
+================
+
+Migration 034's ``feature_flag_event.event_ts`` carries ``TTL
+toDateTime(event_ts) + INTERVAL 90 DAY DELETE``. The fixture generator
+independently, and coincidentally, chose ``random.randint(7, 90)`` days as
+its own "how old can a synthetic event be" range -- landing exactly on the
+TTL's own horizon, with zero margin.
+
+A row minted at precisely ``now - 90 days`` is due for TTL deletion the
+moment ``now`` advances even one second past mint time. ClickHouse applies
+TTL deletion AT MERGE TIME, asynchronously and silently: no error, no
+warning, just fewer rows the next time anyone reads the table. That row's
+disappearance is exactly what a mint's own content oracle caught (``world
+restore``'s ClickHouse content oracle): the row existed right after
+``fixtures world`` generated it, and was gone by the time ``fixtures
+world-snapshot`` read the table minutes later, once a background merge had
+swept it.
+
+Confirmed directly against ``system.part_log`` (``merge_reason:
+TTLDeleteMerge``, the exact part shrinking from 95 to 94 rows) and by
+reproducing the SAME missing row on a completely fresh ClickHouse
+container with zero session history -- this is not a raw-transfer flake and
+not a ClickHouse merge defect. It is a real TTL horizon collision, entirely
+on the fixture/mint side.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import math
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from functools import lru_cache
+from pathlib import Path
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations" / "clickhouse"
+
+# Anchored the same way org_deletion.py's own CREATE TABLE scanner is (PR
+# #1602 review D): a real CREATE TABLE always starts its own line, so prose
+# referencing "CREATE TABLE" mid-sentence can never falsely match.
+_CREATE_TABLE_RE = re.compile(
+    r"^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(?P<table>[A-Za-z_]\w*)`?\s*\(",
+    re.IGNORECASE | re.MULTILINE,
+)
+# Matches both `TTL toDateTime(event_ts) + INTERVAL 90 DAY` (a column
+# wrapped in a cast/function) and `TTL day + INTERVAL 365 DAY` (a bare
+# column already of a temporal type) -- both forms are used across the
+# existing migrations.
+_TTL_RE = re.compile(
+    r"TTL\s+(?:\w+\()?(?P<column>[\w.]+)\)?\s*\+\s*INTERVAL\s+(?P<days>\d+)\s+DAY",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TtlRetention:
+    table: str
+    column: str
+    retention_days: int
+
+
+@lru_cache(maxsize=1)
+def clickhouse_ttl_retentions() -> dict[str, TtlRetention]:
+    """Every ClickHouse table carrying a row-level TTL, keyed by table name.
+
+    Scans ``migrations/clickhouse/*.sql`` and ``*.py`` directly -- the same
+    files ClickHouse itself is migrated from -- so this can never describe a
+    TTL that isn't actually enforced, or fail to describe one that is.
+    """
+
+    retentions: dict[str, TtlRetention] = {}
+    if not _MIGRATIONS_DIR.exists():
+        return retentions
+
+    for path in sorted(_MIGRATIONS_DIR.glob("*")):
+        if path.suffix not in {".sql", ".py"}:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for statement in text.split(";"):
+            table_match = _CREATE_TABLE_RE.search(statement)
+            ttl_match = _TTL_RE.search(statement)
+            if not table_match or not ttl_match:
+                continue
+            table = table_match.group("table")
+            retentions[table] = TtlRetention(
+                table=table,
+                column=ttl_match.group("column"),
+                retention_days=int(ttl_match.group("days")),
+            )
+
+    return retentions
+
+
+#: How much headroom the mint GUARD keeps inside a table's own TTL horizon
+#: before refusing to snapshot. Not zero: a boot that restores hours or
+#: days after a mint must not itself cross the horizon a row was
+#: deliberately backdated close to.
+TTL_SAFETY_MARGIN_DAYS = 7
+
+#: Extra headroom fixture GENERATION keeps below the guard's own threshold
+#: (``max_safe_backdate_days``) -- deliberately a SEPARATE, smaller number,
+#: not the same value reused twice. A mint's own guard check runs seconds
+#: to minutes after generation finishes; if generation were allowed to date
+#: a row at EXACTLY the guard's threshold, that ordinary elapsed time alone
+#: -- `now()` at guard-check time being a few seconds later than `now()` at
+#: generation time -- pushes the row's age past the threshold and the
+#: guard fires on its own mint's own freshly-generated data (observed live:
+#: the first re-mint attempt after this fix was built failed exactly this
+#: way, 8 rows "at or past 83 days old" when generation had targeted
+#: precisely 83 as its ceiling). Generation must stay strictly, comfortably
+#: inside what the guard considers safe, not tied to the same number.
+GENERATOR_SLACK_DAYS = 3
+
+
+def max_safe_backdate_days(table: str) -> int | None:
+    """The mint guard's own threshold: rows at or past this many days old
+    refuse the snapshot. ``None`` if the table carries no TTL at all."""
+
+    retention = clickhouse_ttl_retentions().get(table)
+    if retention is None:
+        return None
+    return max(0, retention.retention_days - TTL_SAFETY_MARGIN_DAYS)
+
+
+#: Threaded per-mint drift (see :func:`compute_drift_days`) into every
+#: :func:`max_generated_age_days` call, without changing any generator's
+#: signature. Each generator already reads ``datetime.now()``, which
+#: CHAOS-3392's ``_frozen_clock`` separately freezes to ``pinned_now`` --
+#: this is a second, orthogonal piece of context (how stale that pinned
+#: reference itself is), not a second clock. A ``ContextVar`` rather than a
+#: module-level global so nested/concurrent generation runs (tests, or a
+#: future parallel-repo mint) can't cross-contaminate each other's drift.
+_drift_days_var: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "dev_health_ops_ttl_registry_drift_days", default=0
+)
+
+
+@contextmanager
+def drift_days_context(drift_days: int):
+    """Makes ``drift_days`` visible to every :func:`max_generated_age_days`
+    call for the duration of the ``with`` block."""
+
+    token = _drift_days_var.set(drift_days)
+    try:
+        yield
+    finally:
+        _drift_days_var.reset(token)
+
+
+def max_generated_age_days(table: str) -> int | None:
+    """The oldest a fixture generator may date a row for ``table``, given
+    the drift currently active via :func:`drift_days_context` (0 if none).
+
+    Strictly less than :func:`max_safe_backdate_days` -- the mint guard's
+    own threshold -- so that ordinary elapsed time between generation and
+    the guard's check, within the same mint run, can never itself trip the
+    guard. Drift is subtracted on top of that: generation is deliberately
+    anchored to ``world.json``'s ``pinned_now`` (CHAOS-3392, for
+    WORLD_DIGEST determinism), not real wall-clock time, but the mint
+    guard and ClickHouse's own TTL enforcement both operate on REAL time --
+    every day ``pinned_now`` sits unrefreshed, a row dated at exactly the
+    (drift-unaware) ceiling is that many days OLDER in real terms than the
+    ceiling accounts for. Observed live: a 3-day-stale ``pinned_now``
+    produced rows the guard correctly flagged as "83 days old" when
+    generation had targeted precisely 83 as its (undrifted) ceiling.
+    Subtracting drift keeps a row's REAL-world age constant regardless of
+    how stale the pinned reference has become. ``None`` if the table
+    carries no TTL at all.
+    """
+
+    limit = max_safe_backdate_days(table)
+    if limit is None:
+        return None
+    drift_days = _drift_days_var.get()
+    return max(0, limit - GENERATOR_SLACK_DAYS - drift_days)
+
+
+def compute_drift_days(pinned_now: datetime, real_now: datetime) -> int:
+    """How many whole days real time has moved past ``pinned_now``.
+
+    Never negative -- a ``pinned_now`` at or after ``real_now`` (clock
+    skew, or a manifest deliberately pinned slightly ahead for testing)
+    needs no compensation. Rounds UP (``ceil``): a partial day of drift is
+    still a full day a row could tip over its TTL horizon.
+    """
+
+    delta_days = (real_now - pinned_now).total_seconds() / 86400
+    return max(0, math.ceil(delta_days))
+
+
+#: How stale ``world.json``'s ``pinned_now`` may be (in days, relative to
+#: real wall-clock time) before a mint refuses to proceed. Past this
+#: ceiling, silently squeezing the generatable-history window further to
+#: compensate would produce an ever-thinner, ever less realistic world with
+#: no visible signal that anything was wrong; refuse instead and name the
+#: real fix -- re-pinning ``pinned_now`` is a deliberate, ticketed decision
+#: (it revalidates the digest and the acceptance corpus), not something a
+#: mint decides on its own.
+MAX_PINNED_NOW_STALENESS_DAYS = 14
+
+#: Mirrors GENERATOR_SLACK_DAYS for the restore side: how much of
+#: TTL_SAFETY_MARGIN_DAYS a restored snapshot must still have unspent
+#: before a restore is allowed, so an ordinary boot -- which itself takes
+#: real time -- can't itself walk a shelf-life-expired snapshot across a
+#: TTL horizon while it runs.
+RESTORE_SIDE_SLACK_DAYS = 2
+
+
+class PinnedNowStaleError(RuntimeError):
+    """``world.json``'s ``pinned_now`` has drifted too far from real time
+    to mint safely. Re-pinning is a deliberate, ticketed decision -- never
+    something a mint silently compensates for by squeezing the
+    generatable-history window."""
+
+
+class SnapshotExpiredError(RuntimeError):
+    """The minted snapshot has exceeded its TTL shelf life: restoring it
+    now risks losing rows to a live TTL merge before anything ever reads
+    them. Re-mint required."""
+
+
+def assert_pinned_now_not_too_stale(pinned_now: datetime, real_now: datetime) -> int:
+    """Returns the drift in days if it is within :data:`MAX_PINNED_NOW_
+    STALENESS_DAYS`; raises :class:`PinnedNowStaleError` naming the real
+    fix otherwise."""
+
+    drift_days = compute_drift_days(pinned_now, real_now)
+    if drift_days > MAX_PINNED_NOW_STALENESS_DAYS:
+        raise PinnedNowStaleError(
+            f"world.json pinned_now ({pinned_now.isoformat()}) is "
+            f"{drift_days} days stale (ceiling: "
+            f"{MAX_PINNED_NOW_STALENESS_DAYS}) -- re-pinning is a "
+            "deliberate decision (it revalidates WORLD_DIGEST and the "
+            "acceptance corpus against the new pinned_now), not something "
+            "a mint does silently by squeezing the generatable-history "
+            "window to compensate. See CHAOS-3602."
+        )
+    return drift_days
+
+
+def snapshot_shelf_life_days() -> int:
+    """How many days past ``pinned_now`` a minted snapshot may still be
+    restored before it risks losing rows to a live TTL merge."""
+
+    return max(0, TTL_SAFETY_MARGIN_DAYS - RESTORE_SIDE_SLACK_DAYS)
+
+
+def snapshot_expiry(pinned_now: datetime) -> datetime:
+    """The instant a snapshot minted with this ``pinned_now`` expires --
+    recorded in the snapshot manifest so humans can see it without doing
+    the arithmetic themselves."""
+
+    return pinned_now + timedelta(days=snapshot_shelf_life_days())
+
+
+def assert_snapshot_not_expired(pinned_now: datetime, real_now: datetime) -> None:
+    """Raises :class:`SnapshotExpiredError` if ``real_now`` is at or past
+    this snapshot's shelf life."""
+
+    expiry = snapshot_expiry(pinned_now)
+    if real_now >= expiry:
+        raise SnapshotExpiredError(
+            f"snapshot expired (TTL shelf life): pinned_now="
+            f"{pinned_now.isoformat()}, shelf life="
+            f"{snapshot_shelf_life_days()} days, expired at "
+            f"{expiry.isoformat()}, real now={real_now.isoformat()} -- "
+            "re-mint required."
+        )

--- a/src/dev_health_ops/fixtures/ttl_registry.py
+++ b/src/dev_health_ops/fixtures/ttl_registry.py
@@ -96,6 +96,108 @@ KNOWN_TTL_TABLES: frozenset[str] = frozenset(
     }
 )
 
+# Codex round-3 finding (HIGH, confirmed): a table matched here but NOT
+# extracted by `_CREATE_TABLE_RE`/`_TTL_RE` proves the precise parser missed
+# a real TTL clause. Deliberately loose -- no line anchor on the table name,
+# no specific time unit -- so it stays correct against TTL syntax the
+# precise, structured parser does not handle. Reproduced directly: a
+# synthetic `TTL occurred_at + INTERVAL 4 WEEK` (a real ClickHouse form;
+# `_TTL_RE` requires the literal word "DAY") is invisible to
+# `clickhouse_ttl_retentions` entirely -- the table enters neither the
+# registry nor (having never been seen) `KNOWN_TTL_TABLES`, so the previous
+# `KNOWN_TTL_TABLES - retentions.keys()` check passed vacuously and every
+# TTL-dependent guard treated the table as risk-free.
+_COARSE_CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(?P<table>[A-Za-z_]\w*)`?",
+    re.IGNORECASE,
+)
+
+
+def _coarse_ttl_table_sweep() -> frozenset[str]:
+    """A second, INDEPENDENT, deliberately LOOSER pass over the same
+    migration source used by :func:`clickhouse_ttl_retentions`.
+
+    Flags a statement as TTL-bearing on the bare substrings "TTL" and
+    "INTERVAL" alone -- no required time unit, no anchored table pattern --
+    so a real TTL clause the precise parser's stricter regex cannot match
+    still gets counted here. This function's whole job is to be WRONG in
+    the permissive direction (a superset of the precise registry); catching
+    it being wrong in the other direction is exactly what
+    :func:`assert_ttl_vocabulary_is_consistent` is for.
+    """
+
+    if not _MIGRATIONS_DIR.exists():
+        return frozenset()
+
+    tables: set[str] = set()
+    for path in sorted(_MIGRATIONS_DIR.glob("*")):
+        if path.suffix not in {".sql", ".py"}:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for statement in text.split(";"):
+            upper = statement.upper()
+            if "TTL" not in upper or "INTERVAL" not in upper:
+                continue
+            match = _COARSE_CREATE_TABLE_RE.search(statement)
+            if match:
+                tables.add(match.group("table"))
+    return frozenset(tables)
+
+
+def assert_ttl_vocabulary_is_consistent() -> None:
+    """Cross-checks THREE independent descriptions of "which tables carry a
+    TTL" against each other -- the precise parser (:func:`clickhouse_ttl_
+    retentions`), an independent coarse sweep (:func:`_coarse_ttl_table_
+    sweep`), and the hand-maintained :data:`KNOWN_TTL_TABLES` -- and fails
+    loudly the moment any two disagree, in EITHER direction.
+
+    Codex round-3 finding (HIGH, confirmed): every previous check compared
+    the registry against KNOWN_TTL_TABLES alone, which only catches a table
+    falling OUT of an otherwise-working registry. A table that never enters
+    the registry (an unmatched TTL syntax variant) AND was never added to
+    KNOWN_TTL_TABLES (nobody knew about it) satisfies "the registry covers
+    every known table" trivially -- the vocabulary was checking itself
+    against itself. The coarse sweep is the independent third source that
+    breaks that circularity: precision (does the parser over-match?) is
+    checked by comparing against the coarse sweep's recall, and the coarse
+    sweep's own correctness is exactly why it is deliberately permissive
+    rather than structured.
+    """
+
+    precise = set(clickhouse_ttl_retentions().keys())
+    coarse = set(_coarse_ttl_table_sweep())
+    known = set(KNOWN_TTL_TABLES)
+
+    problems: list[str] = []
+    if coarse - precise:
+        problems.append(
+            "the coarse sweep found TTL'd table(s) the precise parser "
+            f"missed: {sorted(coarse - precise)}"
+        )
+    if precise - coarse:
+        problems.append(
+            "the precise parser found TTL'd table(s) the coarse sweep "
+            "missed -- should be impossible, since the coarse sweep is a "
+            f"strict superset by construction: {sorted(precise - coarse)}"
+        )
+    if coarse - known:
+        problems.append(
+            "TTL'd table(s) not yet added to KNOWN_TTL_TABLES: "
+            f"{sorted(coarse - known)}"
+        )
+    if known - coarse:
+        problems.append(
+            "KNOWN_TTL_TABLES entry no longer found carrying a TTL clause "
+            f"(renamed, dropped, or the migration changed shape): "
+            f"{sorted(known - coarse)}"
+        )
+    if problems:
+        raise RuntimeError(
+            "TTL table vocabulary is inconsistent across the precise "
+            "parser, an independent coarse sweep, and the hand-maintained "
+            "KNOWN_TTL_TABLES registry (CHAOS-3602) -- " + "; ".join(problems)
+        )
+
 
 @lru_cache(maxsize=1)
 def clickhouse_ttl_retentions() -> dict[str, TtlRetention]:

--- a/src/dev_health_ops/fixtures/world_snapshot.py
+++ b/src/dev_health_ops/fixtures/world_snapshot.py
@@ -128,6 +128,7 @@ from typing import Any
 
 from dev_health_ops.fixtures.ttl_horizon import TTL_SAFETY_MARGIN
 from dev_health_ops.fixtures.ttl_registry import (
+    KNOWN_TTL_TABLES,
     TTL_SAFETY_MARGIN_DAYS,
     clickhouse_ttl_retentions,
     snapshot_expiry,
@@ -603,6 +604,38 @@ def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _scalar_count(result: Any, *, context: str, default: int | None = None) -> int:
+    """Extract a single scalar ``count()`` from a ClickHouse query result --
+    never trusting ``result_rows[0][0]`` unvalidated.
+
+    Codex round-2 finding (MEDIUM, confirmed): a bare ``len(result_rows) !=
+    1`` check let ``result_rows == [[]]`` (one row, ZERO columns) through,
+    which then raised an uncontrolled ``IndexError`` at ``[0][0]`` instead
+    of a named ``SnapshotError`` -- and ``result_rows == [[0, "extra"]]``
+    (an unexpected extra column) passed silently. Every ``count()`` call
+    site in this module -- the TTL-horizon guard, both counts in the dump-
+    verification retry loop -- now goes through this ONE function, so a
+    response-shape defect fails the same, named way everywhere instead of
+    differently depending on which call site happened to hit it.
+
+    ``default`` is for a genuinely diagnostic-only caller (a warning
+    message, not a pass/fail decision) that would rather log a sentinel
+    than abort on a malformed *diagnostic* query; omitted, this raises.
+    """
+
+    rows = getattr(result, "result_rows", None)
+    if not rows or len(rows) != 1 or len(rows[0]) != 1:
+        if default is not None:
+            return default
+        raise SnapshotError(
+            f"world snapshot: {context} returned a malformed result "
+            f"({rows!r}) instead of a single scalar count() row -- "
+            'refusing to fold that into "0" (a measurement that did not '
+            "actually happen must fail, not silently pass)."
+        )
+    return int(rows[0][0])
+
+
 async def _assert_no_ttl_horizon_rows(client: Any, tables: list[str]) -> None:
     """CHAOS-3602: refuse to snapshot a table holding rows within
     ``TTL_SAFETY_MARGIN_DAYS`` of their own TTL deletion horizon.
@@ -633,22 +666,34 @@ async def _assert_no_ttl_horizon_rows(client: Any, tables: list[str]) -> None:
     massive violation had it been queried at all. This schema is known to
     carry several TTL'd tables, so an empty registry always means the
     parser/path broke, never that the risk went away -- fail loudly instead
-    of silently minting an unchecked snapshot. The per-table query result is
-    held to the same standard: a malformed or empty result is never folded
-    into "0 violating rows".
+    of silently minting an unchecked snapshot.
+
+    Codex round-2 finding (HIGH, confirmed): "non-empty" is not the same
+    guarantee as "complete". Reproduced directly: dropping just
+    ``telemetry_signal_bucket`` from an otherwise-full registry (every OTHER
+    table still parsing fine) let a fake client reporting 999999 violating
+    rows for that exact table pass silently -- ``retentions.get(table)``
+    returning ``None`` is indistinguishable from "genuinely no TTL" at this
+    call site. Every table in :data:`KNOWN_TTL_TABLES` must be present, not
+    merely the registry being non-empty.
+
+    The per-table query result is held to the same standard: a malformed or
+    empty result is never folded into "0 violating rows" (see
+    :func:`_scalar_count`).
     """
 
     retentions = clickhouse_ttl_retentions()
-    if not retentions:
+    missing_known = KNOWN_TTL_TABLES - retentions.keys()
+    if missing_known:
         raise SnapshotError(
-            "world snapshot: the ClickHouse TTL registry parsed ZERO "
-            "retention entries -- this schema is known to carry several "
-            "TTL'd tables (feature_flag_event, telemetry_signal_bucket, "
-            "release_impact_daily, product_telemetry_events), so an empty "
-            "registry means dev_health_ops.fixtures.ttl_registry's "
-            "migrations-directory parsing broke, not that the TTL-horizon "
-            "risk went away. Refusing to mint a snapshot this guard cannot "
-            "actually check (CHAOS-3602)."
+            "world snapshot: the ClickHouse TTL registry is missing known "
+            f"TTL'd table(s) {sorted(missing_known)} -- a registry that "
+            "parses SOME tables but not ALL of "
+            f"dev_health_ops.fixtures.ttl_registry.KNOWN_TTL_TABLES means "
+            "the parser or its migrations-directory path broke for at "
+            "least one table, not that those tables stopped carrying a "
+            "TTL. Refusing to mint a snapshot this guard cannot actually "
+            "check for every known-at-risk table (CHAOS-3602)."
         )
     violations: list[str] = []
     for table in tables:
@@ -661,15 +706,9 @@ async def _assert_no_ttl_horizon_rows(client: Any, tables: list[str]) -> None:
             f"SELECT count() FROM `{table}` "
             f"WHERE `{retention.column}` <= now() - INTERVAL {safe_days} DAY",
         )
-        if not result.result_rows or len(result.result_rows) != 1:
-            raise SnapshotError(
-                f"world snapshot: the TTL-horizon check for table {table!r} "
-                f"returned a malformed result ({result.result_rows!r}) "
-                "instead of a single scalar count() row -- refusing to fold "
-                'that into "zero violating rows" (a measurement that did '
-                "not actually happen must fail, not silently pass)."
-            )
-        count = int(result.result_rows[0][0])
+        count = _scalar_count(
+            result, context=f"the TTL-horizon check for table {table!r}"
+        )
         if count:
             violations.append(
                 f"{table}: {count} row(s) with {retention.column} at or "
@@ -747,7 +786,9 @@ async def _dump_clickhouse(
         pre_count = await asyncio.to_thread(
             client.query, f"SELECT count() FROM `{table}`{final}"
         )
-        expected = int(pre_count.result_rows[0][0])
+        expected = _scalar_count(
+            pre_count, context=f"the pre-dump count() for table {table!r}"
+        )
 
         # Decode what the payload ACTUALLY holds, server-side, via a
         # throwaway staging table -- not a second independent count() on the
@@ -771,7 +812,13 @@ async def _dump_clickhouse(
             decoded = await asyncio.to_thread(
                 client.query, f"SELECT count() FROM `{verify_table}`"
             )
-            decoded_count = int(decoded.result_rows[0][0])
+            decoded_count = _scalar_count(
+                decoded,
+                context=(
+                    f"the decoded-payload count() for table {table!r} "
+                    f"(attempt {attempt})"
+                ),
+            )
         finally:
             await asyncio.to_thread(
                 client.command, f"DROP TABLE IF EXISTS `{verify_table}`"
@@ -787,8 +834,13 @@ async def _dump_clickhouse(
             "AND database = {db:String} AND active",
             parameters={"t": table, "db": client.database},
         )
-        active_parts = (
-            int(parts_result.result_rows[0][0]) if parts_result.result_rows else -1
+        # Diagnostic-only (feeds the warning message below, not a decision):
+        # a malformed result here logs a sentinel rather than aborting the
+        # retry loop over a formatting query.
+        active_parts = _scalar_count(
+            parts_result,
+            context=f"the system.parts diagnostic for table {table!r}",
+            default=-1,
         )
         last_diagnostics = (
             f"table={table!r} attempt={attempt}/{_DUMP_VERIFY_ATTEMPTS} "

--- a/src/dev_health_ops/fixtures/world_snapshot.py
+++ b/src/dev_health_ops/fixtures/world_snapshot.py
@@ -127,6 +127,11 @@ from pathlib import Path
 from typing import Any
 
 from dev_health_ops.fixtures.ttl_horizon import TTL_SAFETY_MARGIN
+from dev_health_ops.fixtures.ttl_registry import (
+    TTL_SAFETY_MARGIN_DAYS,
+    clickhouse_ttl_retentions,
+    snapshot_expiry,
+)
 from dev_health_ops.fixtures.world import (
     WorldManifest,
     _require_scratch_database,
@@ -598,7 +603,66 @@ def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-async def _dump_clickhouse(client: Any, table: str, engine: str, path: Path) -> int:
+async def _assert_no_ttl_horizon_rows(client: Any, tables: list[str]) -> None:
+    """CHAOS-3602: refuse to snapshot a table holding rows within
+    ``TTL_SAFETY_MARGIN_DAYS`` of their own TTL deletion horizon.
+
+    ClickHouse applies TTL deletion AT MERGE TIME -- asynchronously,
+    silently, with no error, no warning. A table with horizon-adjacent rows
+    is racing the background merge scheduler: whether a row survives to be
+    read depends entirely on exactly when a merge happens to run relative
+    to when this snapshot reads the table.
+
+    CHAOS-3432/3544 already keeps fixture GENERATION a margin inside the
+    single tightest schema-wide TTL horizon (``ttl_horizon.py``), and that
+    is the primary defense. This is the belt-and-braces guard on top of it,
+    scoped PER TABLE (via :func:`clickhouse_ttl_retentions`, parsed from the
+    migration source the same way) and checked against the LIVE data right
+    before any dump runs -- catching a violation from any source (clock
+    drift, a future generator that forgets to clamp, hand-seeded data)
+    before it can race the merge scheduler, rather than discovering it via
+    a content-oracle mismatch after data has already been silently lost.
+    """
+
+    retentions = clickhouse_ttl_retentions()
+    violations: list[str] = []
+    for table in tables:
+        retention = retentions.get(table)
+        if retention is None:
+            continue
+        safe_days = max(0, retention.retention_days - TTL_SAFETY_MARGIN_DAYS)
+        result = await asyncio.to_thread(
+            client.query,
+            f"SELECT count() FROM `{table}` "
+            f"WHERE `{retention.column}` <= now() - INTERVAL {safe_days} DAY",
+        )
+        count = int(result.result_rows[0][0]) if result.result_rows else 0
+        if count:
+            violations.append(
+                f"{table}: {count} row(s) with {retention.column} at or "
+                f"past {safe_days} days old (this table's TTL deletes at "
+                f"{retention.retention_days} days)"
+            )
+
+    if violations:
+        raise SnapshotError(
+            "world snapshot: refusing to snapshot table(s) holding rows "
+            "within their own TTL deletion margin -- a mint over "
+            "horizon-adjacent data races ClickHouse's background merge "
+            "scheduler rather than producing a deterministic artifact "
+            "(CHAOS-3602). Regenerate the world so every date stays inside "
+            "its table's safe margin "
+            f"(dev_health_ops.fixtures.ttl_registry.max_safe_backdate_days): "
+            f"{violations}"
+        )
+
+
+_DUMP_VERIFY_ATTEMPTS = 3
+
+
+async def _dump_clickhouse(
+    client: Any, table: str, engine: str, path: Path, *, raw_source_row_count: int
+) -> int:
     """Dump one ClickHouse table, through ``FINAL`` where the engine collapses.
 
     Two decisions, both learned live:
@@ -618,17 +682,99 @@ async def _dump_clickhouse(client: Any, table: str, engine: str, path: Path) -> 
     the count). Dumping the ``FINAL`` view stores exactly the rows every
     reader can actually see and makes the restore deterministic. Nothing
     visible is lost: the discarded rows are ones ``FINAL`` already hides.
+
+    CHAOS-3602: ``raw_query``'s Native payload and a ``count()`` run moments
+    later, on a fully idle table with zero concurrent writes, have been
+    observed to silently DISAGREE -- both a mint's manifest.json and a
+    dedicated stress run recorded ``count() == 1042`` while the payload
+    ``raw_query`` had actually captured only 1041 rows of
+    ``feature_flag_event``. This is a flake in the raw Native transfer
+    itself (clickhouse-connect and/or server), not a write-visibility race
+    (reproduced with no writes in flight) and not query pagination (this
+    function issues exactly one unpaginated ``SELECT *``, no ORDER BY/LIMIT/
+    OFFSET). ~2% per-table-dump in stress testing, which is not negligible
+    across the ~90 ClickHouse tables one mint dumps.
+
+    So the payload is never trusted on the strength of a *separate* count()
+    query -- it is DECODED (via a throwaway staging table, itself covered by
+    ``_require_scratch_database`` since ``client`` only ever points at a
+    scratch database here) and the decoded row count is what gets compared,
+    retried, and ultimately recorded in the manifest. A short payload is
+    retried up to ``_DUMP_VERIFY_ATTEMPTS`` times and never written to disk.
     """
 
     final = " FINAL" if _collapses_on_merge(engine) else ""
-    payload: bytes = await asyncio.to_thread(
-        partial(client.raw_query, f"SELECT * FROM `{table}`{final}", fmt="Native")
+    verify_table = f"__snapshot_verify_{table}"
+    last_diagnostics = ""
+
+    for attempt in range(1, _DUMP_VERIFY_ATTEMPTS + 1):
+        payload: bytes = await asyncio.to_thread(
+            partial(client.raw_query, f"SELECT * FROM `{table}`{final}", fmt="Native")
+        )
+        pre_count = await asyncio.to_thread(
+            client.query, f"SELECT count() FROM `{table}`{final}"
+        )
+        expected = int(pre_count.result_rows[0][0])
+
+        # Decode what the payload ACTUALLY holds, server-side, via a
+        # throwaway staging table -- not a second independent count() on the
+        # source table, which is exactly the query that was observed to
+        # agree with a short payload above.
+        await asyncio.to_thread(
+            client.command, f"DROP TABLE IF EXISTS `{verify_table}`"
+        )
+        await asyncio.to_thread(
+            client.command, f"CREATE TABLE `{verify_table}` AS `{table}`"
+        )
+        try:
+            await asyncio.to_thread(
+                partial(
+                    client.raw_insert,
+                    table=verify_table,
+                    insert_block=payload,
+                    fmt="Native",
+                )
+            )
+            decoded = await asyncio.to_thread(
+                client.query, f"SELECT count() FROM `{verify_table}`"
+            )
+            decoded_count = int(decoded.result_rows[0][0])
+        finally:
+            await asyncio.to_thread(
+                client.command, f"DROP TABLE IF EXISTS `{verify_table}`"
+            )
+
+        if decoded_count == expected:
+            path.write_bytes(gzip.compress(payload, mtime=0))
+            return decoded_count
+
+        parts_result = await asyncio.to_thread(
+            client.query,
+            "SELECT count() FROM system.parts WHERE table = {t:String} "
+            "AND database = {db:String} AND active",
+            parameters={"t": table, "db": client.database},
+        )
+        active_parts = (
+            int(parts_result.result_rows[0][0]) if parts_result.result_rows else -1
+        )
+        last_diagnostics = (
+            f"table={table!r} attempt={attempt}/{_DUMP_VERIFY_ATTEMPTS} "
+            f"decoded_payload_rows={decoded_count} expected_count={expected} "
+            f"raw_source_row_count={raw_source_row_count} active_parts={active_parts} "
+            f"engine={engine!r}"
+        )
+        logger.warning(
+            "world snapshot: clickhouse dump payload came up short of its own "
+            "count() -- retrying. %s",
+            last_diagnostics,
+        )
+
+    raise SnapshotError(
+        "world snapshot: clickhouse dump produced a SHORT payload on every "
+        f"attempt (CHAOS-3602 -- a known intermittent raw Native transfer "
+        f"flake, not app logic). {last_diagnostics}. Refusing to write a "
+        "short snapshot artifact to disk."
     )
-    path.write_bytes(gzip.compress(payload, mtime=0))
-    counted = await asyncio.to_thread(
-        client.query, f"SELECT count() FROM `{table}`{final}"
-    )
-    return int(counted.result_rows[0][0])
 
 
 async def _reflect(conn: Any, table: str, metadata: Any) -> Any:
@@ -851,6 +997,14 @@ async def snapshot_world(
         store="postgres",
         ledger=_POSTGRES_LEDGER_TABLES,
     )
+    # CHAOS-3602: before dumping anything, refuse a snapshot over data that
+    # is currently racing a TTL'd table's own background merge scheduler --
+    # see _assert_no_ttl_horizon_rows for why this can't wait until after
+    # the dump.
+    await _with_clickhouse_client(
+        sink, lambda client: _assert_no_ttl_horizon_rows(client, ch_tables)
+    )
+
     if not ch_tables and not pg_tables:
         raise SnapshotError(
             "world snapshot: the generated database is indistinguishable from "
@@ -871,13 +1025,47 @@ async def snapshot_world(
         engines = await _clickhouse_table_engines(client)
         for table in ch_tables:
             path = ch_dir / f"{table}.native.gz"
-            dumped = await _dump_clickhouse(client, table, engines[table], path)
+            engine = engines[table]
+            # The verified, DECODED payload count -- see _dump_clickhouse's
+            # docstring (CHAOS-3602): a separate count() query has been
+            # observed to agree with a payload that was actually short, so
+            # this number is never sourced from one.
+            row_count = await _dump_clickhouse(
+                client, table, engine, path, raw_source_row_count=source_ch[table]
+            )
+            # Postgres has always asserted raw-vs-dumped agreement here (a
+            # table changing under the snapshot mid-dump); ClickHouse never
+            # did -- the gap found alongside CHAOS-3602. Collapsing engines
+            # (ReplacingMergeTree etc.) legitimately dedupe under FINAL, so
+            # raw and dumped counts differ BY DESIGN there -- only a bound
+            # applies: FINAL cannot ever produce MORE rows than went in.
+            # Non-collapsing engines have no such excuse: an exact mismatch
+            # means the same "changing/flaky underneath the snapshot"
+            # problem postgres already guards.
+            if _collapses_on_merge(engine):
+                if row_count > source_ch[table]:
+                    raise SnapshotError(
+                        f"world snapshot: clickhouse table {table!r} dumped "
+                        f"{row_count} FINAL rows, more than the "
+                        f"{source_ch[table]} raw rows counted before the dump "
+                        "-- FINAL cannot increase a row count. The source "
+                        "database is changing underneath the snapshot. Stop "
+                        "whatever is writing to it and re-run."
+                    )
+            elif row_count != source_ch[table]:
+                raise SnapshotError(
+                    f"world snapshot: clickhouse table {table!r} had "
+                    f"{source_ch[table]} rows when counted and {row_count} "
+                    "when dumped -- the source database is changing "
+                    "underneath the snapshot. Stop whatever is writing to "
+                    "it and re-run."
+                )
             ch_entries[table] = {
                 "file": f"clickhouse/{table}.native.gz",
                 # The number of rows the FILE holds -- which for a collapsing
                 # engine is the FINAL count, not the raw one. Recording the raw
                 # count here would describe the artifact wrongly.
-                "row_count": dumped,
+                "row_count": row_count,
                 "raw_source_row_count": source_ch[table],
                 "sha256": _sha256_file(path),
             }
@@ -929,6 +1117,20 @@ async def snapshot_world(
         # mismatch staleness eventually causes.
         "minted_at": datetime.now(UTC).isoformat(),
         "shelf_life_days": _shelf_life_days(manifest),
+        # CHAOS-3602: a second, PER-TABLE-registry-derived expiry instant,
+        # informational only -- recorded so a human (or a future restore
+        # guard) can see the shelf life implied by ttl_registry's per-table
+        # margins without doing the pinned_now + margin arithmetic
+        # themselves. Deliberately NOT enforced at restore here: it uses a
+        # much tighter margin (TTL_SAFETY_MARGIN_DAYS) than the
+        # CHAOS-3432/3544 `shelf_life_days` guard above, which already
+        # enforces staleness at restore (`_assert_snapshot_within_shelf_
+        # life`) using the wider, schema-tightest-horizon margin this
+        # snapshot was actually minted under. Wiring both as enforcing
+        # checks would fail restores of already-valid, CHAOS-3432/3544-
+        # compliant snapshots on a stricter, uncalibrated-for-this-mint
+        # threshold.
+        "ttl_shelf_life_expiry": snapshot_expiry(manifest.pinned_now).isoformat(),
         # CHAOS-3463, Codex adversarial review (MEDIUM, confirmed): the two
         # fields above were stamped and then never read by anything -- a
         # recorded value nobody checks is a claim, not a guard. They are now

--- a/src/dev_health_ops/fixtures/world_snapshot.py
+++ b/src/dev_health_ops/fixtures/world_snapshot.py
@@ -622,9 +622,34 @@ async def _assert_no_ttl_horizon_rows(client: Any, tables: list[str]) -> None:
     drift, a future generator that forgets to clamp, hand-seeded data)
     before it can race the merge scheduler, rather than discovering it via
     a content-oracle mismatch after data has already been silently lost.
+
+    Codex finding (HIGH, confirmed): this guard's entire safety depends on
+    :func:`clickhouse_ttl_retentions` actually parsing something -- a
+    migrations-directory path failure or parser regression makes it return
+    ``{}``, and the loop below treats every table as "no TTL, nothing to
+    check" and passes with ZERO queries issued. Reproduced directly: pointed
+    the registry at a nonexistent directory and confirmed this function
+    returned cleanly against a fake client that would have reported a
+    massive violation had it been queried at all. This schema is known to
+    carry several TTL'd tables, so an empty registry always means the
+    parser/path broke, never that the risk went away -- fail loudly instead
+    of silently minting an unchecked snapshot. The per-table query result is
+    held to the same standard: a malformed or empty result is never folded
+    into "0 violating rows".
     """
 
     retentions = clickhouse_ttl_retentions()
+    if not retentions:
+        raise SnapshotError(
+            "world snapshot: the ClickHouse TTL registry parsed ZERO "
+            "retention entries -- this schema is known to carry several "
+            "TTL'd tables (feature_flag_event, telemetry_signal_bucket, "
+            "release_impact_daily, product_telemetry_events), so an empty "
+            "registry means dev_health_ops.fixtures.ttl_registry's "
+            "migrations-directory parsing broke, not that the TTL-horizon "
+            "risk went away. Refusing to mint a snapshot this guard cannot "
+            "actually check (CHAOS-3602)."
+        )
     violations: list[str] = []
     for table in tables:
         retention = retentions.get(table)
@@ -636,7 +661,15 @@ async def _assert_no_ttl_horizon_rows(client: Any, tables: list[str]) -> None:
             f"SELECT count() FROM `{table}` "
             f"WHERE `{retention.column}` <= now() - INTERVAL {safe_days} DAY",
         )
-        count = int(result.result_rows[0][0]) if result.result_rows else 0
+        if not result.result_rows or len(result.result_rows) != 1:
+            raise SnapshotError(
+                f"world snapshot: the TTL-horizon check for table {table!r} "
+                f"returned a malformed result ({result.result_rows!r}) "
+                "instead of a single scalar count() row -- refusing to fold "
+                'that into "zero violating rows" (a measurement that did '
+                "not actually happen must fail, not silently pass)."
+            )
+        count = int(result.result_rows[0][0])
         if count:
             violations.append(
                 f"{table}: {count} row(s) with {retention.column} at or "

--- a/src/dev_health_ops/fixtures/world_snapshot.py
+++ b/src/dev_health_ops/fixtures/world_snapshot.py
@@ -128,8 +128,8 @@ from typing import Any
 
 from dev_health_ops.fixtures.ttl_horizon import TTL_SAFETY_MARGIN
 from dev_health_ops.fixtures.ttl_registry import (
-    KNOWN_TTL_TABLES,
     TTL_SAFETY_MARGIN_DAYS,
+    assert_ttl_vocabulary_is_consistent,
     clickhouse_ttl_retentions,
     snapshot_expiry,
 )
@@ -674,27 +674,30 @@ async def _assert_no_ttl_horizon_rows(client: Any, tables: list[str]) -> None:
     table still parsing fine) let a fake client reporting 999999 violating
     rows for that exact table pass silently -- ``retentions.get(table)``
     returning ``None`` is indistinguishable from "genuinely no TTL" at this
-    call site. Every table in :data:`KNOWN_TTL_TABLES` must be present, not
-    merely the registry being non-empty.
+    call site.
+
+    Codex round-3 finding (HIGH, confirmed): checking against
+    :data:`KNOWN_TTL_TABLES` alone only catches a table falling OUT of an
+    otherwise-working registry -- a table that never enters the registry
+    (an unmatched TTL syntax variant) AND was never added to
+    ``KNOWN_TTL_TABLES`` satisfies that check trivially. Reproduced
+    directly: a synthetic ``TTL occurred_at + INTERVAL 4 WEEK`` (a real
+    ClickHouse form the precise parser's ``DAY``-only regex cannot match)
+    is invisible to :func:`clickhouse_ttl_retentions` entirely, so the
+    previous ``KNOWN_TTL_TABLES - retentions.keys()`` check passed
+    vacuously. :func:`assert_ttl_vocabulary_is_consistent` closes this with
+    an independent third source (see its own docstring).
 
     The per-table query result is held to the same standard: a malformed or
     empty result is never folded into "0 violating rows" (see
     :func:`_scalar_count`).
     """
 
+    try:
+        assert_ttl_vocabulary_is_consistent()
+    except RuntimeError as exc:
+        raise SnapshotError(f"world snapshot: {exc}") from exc
     retentions = clickhouse_ttl_retentions()
-    missing_known = KNOWN_TTL_TABLES - retentions.keys()
-    if missing_known:
-        raise SnapshotError(
-            "world snapshot: the ClickHouse TTL registry is missing known "
-            f"TTL'd table(s) {sorted(missing_known)} -- a registry that "
-            "parses SOME tables but not ALL of "
-            f"dev_health_ops.fixtures.ttl_registry.KNOWN_TTL_TABLES means "
-            "the parser or its migrations-directory path broke for at "
-            "least one table, not that those tables stopped carrying a "
-            "TTL. Refusing to mint a snapshot this guard cannot actually "
-            "check for every known-at-risk table (CHAOS-3602)."
-        )
     violations: list[str] = []
     for table in tables:
         retention = retentions.get(table)

--- a/tests/fixtures/test_product_telemetry_generator.py
+++ b/tests/fixtures/test_product_telemetry_generator.py
@@ -148,3 +148,22 @@ def test_generator_respects_day_count_in_event_timestamps() -> None:
     assert earliest >= FIXED_END.replace(
         hour=0, minute=0, second=0, microsecond=0
     ).replace(tzinfo=timezone.utc).replace(year=2026, month=5, day=22)
+
+
+def test_a_zero_ceiling_actually_clamps_instead_of_falling_back(monkeypatch) -> None:
+    """Codex round-2 finding (HIGH, confirmed): `X or self.spec.days` treats
+    a legitimate ceiling of exactly 0 as falsy and falls back to the
+    caller's unclamped `days` -- requesting 100 days with a 0-day ceiling
+    must produce ZERO events, not ~100 days of them.
+    """
+    monkeypatch.setattr(
+        "dev_health_ops.fixtures.generators.product_telemetry.max_generated_age_days_for_table",
+        lambda table: 0,
+    )
+    spec = _spec(days=100, sessions_per_day=2)
+    events = ProductTelemetryGenerator(spec).generate_events()
+    assert events == [], (
+        f"got {len(events)} events requesting 100 days with a 0-day "
+        "ceiling -- the ceiling was not applied (fell back to the "
+        "unclamped request instead of clamping to 0)"
+    )

--- a/tests/test_fixtures_feature_flags.py
+++ b/tests/test_fixtures_feature_flags.py
@@ -162,11 +162,48 @@ class TestGenerateTelemetrySignalBuckets:
             assert b.signal_count >= 1
             assert b.session_count >= 100
 
+    def test_a_zero_ceiling_actually_clamps_instead_of_falling_back(
+        self, generator: SyntheticDataGenerator, monkeypatch
+    ) -> None:
+        """Codex round-2 finding (HIGH, confirmed): `X or days` treats a
+        legitimate ceiling of exactly 0 as falsy and falls back to the
+        caller's unclamped `days` -- the exact case a TTL right at its own
+        margin (or a deliberately-conservative registry state) would hit.
+        Requesting 100 days with a ceiling of 0 must produce (near-)nothing,
+        not ~100 days of buckets.
+        """
+        monkeypatch.setattr(
+            "dev_health_ops.fixtures.generators.interactions.max_generated_age_days_for_table",
+            lambda table: 0,
+        )
+        buckets = generator.generate_telemetry_signal_buckets(days=100)
+        assert len(buckets) < 10, (
+            f"got {len(buckets)} buckets requesting 100 days with a 0-day "
+            "ceiling -- the ceiling was not applied (fell back to the "
+            "unclamped request instead of clamping to 0)"
+        )
+
 
 class TestGenerateReleaseImpactDaily:
     def test_returns_nonempty(self, generator: SyntheticDataGenerator) -> None:
         records = generator.generate_release_impact_daily(days=7)
         assert len(records) > 0
+
+    def test_a_zero_ceiling_actually_clamps_instead_of_falling_back(
+        self, generator: SyntheticDataGenerator, monkeypatch
+    ) -> None:
+        """Codex round-2 finding (HIGH, confirmed): see the sibling test on
+        TestGenerateTelemetrySignalBuckets -- same `or` vs `is None` defect.
+        """
+        monkeypatch.setattr(
+            "dev_health_ops.fixtures.generators.interactions.max_generated_age_days_for_table",
+            lambda table: 0,
+        )
+        records = generator.generate_release_impact_daily(days=100)
+        assert records == [], (
+            f"got {len(records)} records requesting 100 days with a 0-day "
+            "ceiling -- the ceiling was not applied"
+        )
 
     def test_coverage_ratio_in_range(self, generator: SyntheticDataGenerator) -> None:
         records = generator.generate_release_impact_daily(days=5)

--- a/tests/test_fixtures_ttl_horizon.py
+++ b/tests/test_fixtures_ttl_horizon.py
@@ -384,14 +384,18 @@ class TestPerTableCeilingCompatibleWithShelfLife:
 
     def test_an_empty_registry_fails_closed(self, monkeypatch) -> None:
         """Same fail-closed rule as the mint-time guard: a broken registry
-        must not silently disable this ceiling's protection."""
+        must not silently disable this ceiling's protection. Now routed
+        through `assert_ttl_vocabulary_is_consistent` (codex round-3) --
+        the independent coarse sweep, reading the REAL migrations
+        unaffected by this patch, is what actually surfaces the
+        disagreement."""
         from dev_health_ops.fixtures import ttl_horizon as ttl_horizon_module
 
         monkeypatch.setattr(
             "dev_health_ops.fixtures.ttl_registry.clickhouse_ttl_retentions",
             lambda: {},
         )
-        with pytest.raises(RuntimeError, match="ZERO|empty|broke"):
+        with pytest.raises(RuntimeError, match="inconsistent"):
             ttl_horizon_module.max_generated_age_days_for_table("feature_flag_event")
 
     def test_a_partial_registry_fails_closed_too(self, monkeypatch) -> None:

--- a/tests/test_fixtures_ttl_horizon.py
+++ b/tests/test_fixtures_ttl_horizon.py
@@ -341,7 +341,10 @@ class TestPerTableCeilingCompatibleWithShelfLife:
 
     The invariant that must hold for every TTL'd table: a row generated at
     the ceiling, restored at the full advertised shelf life later, must
-    still be at or inside its own TTL horizon.
+    still be STRICTLY inside its own TTL horizon -- codex round-2 (HIGH,
+    confirmed): landing EXACTLY on the horizon is not safe, since this
+    project's own live pre-dump guard already treats a row `<= now() - N
+    DAY` old as unsafe and ClickHouse's TTL deletion is asynchronous.
     """
 
     def test_every_known_ttl_table_ceiling_survives_the_full_shelf_life(self) -> None:
@@ -352,22 +355,26 @@ class TestPerTableCeilingCompatibleWithShelfLife:
             ceiling = max_generated_age_days_for_table(table)
             assert ceiling is not None
             age_at_full_shelf_life = ceiling + TTL_SAFETY_MARGIN.days
-            assert age_at_full_shelf_life <= retention.retention_days, (
+            assert age_at_full_shelf_life < retention.retention_days, (
                 f"{table}: a row generated at the {ceiling}-day ceiling and "
                 f"restored {TTL_SAFETY_MARGIN.days} days later (the full "
                 f"advertised shelf life) would be {age_at_full_shelf_life} "
-                f"days old, past its {retention.retention_days}-day TTL -- "
-                "the restore contract promises a shelf life this ceiling "
-                "cannot actually honor"
+                f"days old -- at or past its {retention.retention_days}-day "
+                "TTL is not strictly inside it. The restore contract "
+                "promises a shelf life this ceiling cannot actually honor "
+                "with real margin to spare"
             )
 
     def test_ceiling_uses_this_modules_margin_not_a_different_one(self) -> None:
         """Pins the exact arithmetic so a future edit that quietly reuses a
         different (e.g. ttl_registry.py's own) margin is caught."""
-        from dev_health_ops.fixtures.ttl_horizon import max_generated_age_days_for_table
+        from dev_health_ops.fixtures.ttl_horizon import (
+            PER_TABLE_CEILING_HEADROOM_DAYS,
+            max_generated_age_days_for_table,
+        )
 
         assert max_generated_age_days_for_table("feature_flag_event") == (
-            90 - TTL_SAFETY_MARGIN.days
+            90 - TTL_SAFETY_MARGIN.days - PER_TABLE_CEILING_HEADROOM_DAYS
         )
 
     def test_a_table_with_no_ttl_has_no_ceiling(self) -> None:
@@ -385,4 +392,33 @@ class TestPerTableCeilingCompatibleWithShelfLife:
             lambda: {},
         )
         with pytest.raises(RuntimeError, match="ZERO|empty|broke"):
+            ttl_horizon_module.max_generated_age_days_for_table("feature_flag_event")
+
+    def test_a_partial_registry_fails_closed_too(self, monkeypatch) -> None:
+        """Codex round-2 finding (HIGH, confirmed): a NON-empty registry
+        missing just ONE known TTL'd table used to be indistinguishable
+        from "genuinely no TTL" for that table -- reproduced directly with
+        a fake client that would have reported 999999 violating rows for
+        `telemetry_signal_bucket` had it ever been queried. Every table in
+        KNOWN_TTL_TABLES must be present, not merely the registry being
+        non-empty.
+        """
+        from dev_health_ops.fixtures import ttl_horizon as ttl_horizon_module
+        from dev_health_ops.fixtures.ttl_registry import (
+            KNOWN_TTL_TABLES,
+            clickhouse_ttl_retentions,
+        )
+
+        real = clickhouse_ttl_retentions()
+        partial = {
+            table: retention
+            for table, retention in real.items()
+            if table != "telemetry_signal_bucket"
+        }
+        assert "telemetry_signal_bucket" in KNOWN_TTL_TABLES
+        monkeypatch.setattr(
+            "dev_health_ops.fixtures.ttl_registry.clickhouse_ttl_retentions",
+            lambda: partial,
+        )
+        with pytest.raises(RuntimeError, match="telemetry_signal_bucket"):
             ttl_horizon_module.max_generated_age_days_for_table("feature_flag_event")

--- a/tests/test_fixtures_ttl_horizon.py
+++ b/tests/test_fixtures_ttl_horizon.py
@@ -327,3 +327,62 @@ class TestParseSurfaceCoversPyMigrations:
             "added because this repo has them; if that changed, revisit "
             "whether these controls still describe reality"
         )
+
+
+class TestPerTableCeilingCompatibleWithShelfLife:
+    """CHAOS-3602 port, codex finding (HIGH, confirmed): a per-table
+    generator ceiling that ignores THIS module's TTL_SAFETY_MARGIN can drift
+    out of sync with the shelf-life contract ``_assert_snapshot_within_
+    shelf_life`` actually enforces at restore. Measured live before this
+    fix: ttl_registry.py's own (looser) margin let ``telemetry_signal_
+    bucket`` clamp to 80 days against a 90-day TTL -- add the full 30-day
+    advertised shelf life and a restore at that boundary finds rows 110
+    days old, 20 days PAST the horizon, already gone to a TTL merge.
+
+    The invariant that must hold for every TTL'd table: a row generated at
+    the ceiling, restored at the full advertised shelf life later, must
+    still be at or inside its own TTL horizon.
+    """
+
+    def test_every_known_ttl_table_ceiling_survives_the_full_shelf_life(self) -> None:
+        from dev_health_ops.fixtures.ttl_horizon import max_generated_age_days_for_table
+        from dev_health_ops.fixtures.ttl_registry import clickhouse_ttl_retentions
+
+        for table, retention in clickhouse_ttl_retentions().items():
+            ceiling = max_generated_age_days_for_table(table)
+            assert ceiling is not None
+            age_at_full_shelf_life = ceiling + TTL_SAFETY_MARGIN.days
+            assert age_at_full_shelf_life <= retention.retention_days, (
+                f"{table}: a row generated at the {ceiling}-day ceiling and "
+                f"restored {TTL_SAFETY_MARGIN.days} days later (the full "
+                f"advertised shelf life) would be {age_at_full_shelf_life} "
+                f"days old, past its {retention.retention_days}-day TTL -- "
+                "the restore contract promises a shelf life this ceiling "
+                "cannot actually honor"
+            )
+
+    def test_ceiling_uses_this_modules_margin_not_a_different_one(self) -> None:
+        """Pins the exact arithmetic so a future edit that quietly reuses a
+        different (e.g. ttl_registry.py's own) margin is caught."""
+        from dev_health_ops.fixtures.ttl_horizon import max_generated_age_days_for_table
+
+        assert max_generated_age_days_for_table("feature_flag_event") == (
+            90 - TTL_SAFETY_MARGIN.days
+        )
+
+    def test_a_table_with_no_ttl_has_no_ceiling(self) -> None:
+        from dev_health_ops.fixtures.ttl_horizon import max_generated_age_days_for_table
+
+        assert max_generated_age_days_for_table("projects") is None
+
+    def test_an_empty_registry_fails_closed(self, monkeypatch) -> None:
+        """Same fail-closed rule as the mint-time guard: a broken registry
+        must not silently disable this ceiling's protection."""
+        from dev_health_ops.fixtures import ttl_horizon as ttl_horizon_module
+
+        monkeypatch.setattr(
+            "dev_health_ops.fixtures.ttl_registry.clickhouse_ttl_retentions",
+            lambda: {},
+        )
+        with pytest.raises(RuntimeError, match="ZERO|empty|broke"):
+            ttl_horizon_module.max_generated_age_days_for_table("feature_flag_event")

--- a/tests/test_fixtures_world_snapshot.py
+++ b/tests/test_fixtures_world_snapshot.py
@@ -19,6 +19,7 @@ import uuid
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -475,7 +476,7 @@ class TestClickHouseContentOracle:
 
 
 class _DumpResult:
-    def __init__(self, rows: list[list[int]]) -> None:
+    def __init__(self, rows: list[list[Any]]) -> None:
         self.result_rows = rows
 
 
@@ -643,6 +644,77 @@ class TestClickHouseDumpPayloadVerification:
         assert client.raw_query_calls == 1
         assert path.exists()
 
+    @pytest.mark.asyncio
+    async def test_a_malformed_pre_count_result_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex round-2 finding (MEDIUM, confirmed): `int(pre_count.
+        result_rows[0][0])` used to be unvalidated -- `result_rows == [[]]`
+        (one row, ZERO columns) raised an uncontrolled `IndexError` instead
+        of a named `SnapshotError`. Every count() in this retry loop now
+        goes through `_scalar_count`.
+        """
+
+        class _MalformedPreCountClient:
+            def raw_query(self, q: str, fmt: str | None = None) -> bytes:
+                return b"payload"
+
+            def query(self, q: str, parameters: dict | None = None) -> _DumpResult:
+                return _DumpResult([[]])  # one row, zero columns
+
+        with pytest.raises(SnapshotError, match="malformed"):
+            await _dump_clickhouse(
+                _MalformedPreCountClient(),
+                "feature_flag_event",
+                "MergeTree()",
+                tmp_path / "feature_flag_event.native.gz",
+                raw_source_row_count=1042,
+            )
+
+
+class TestScalarCount:
+    """Codex round-2 finding (MEDIUM, confirmed): a bare `len(result_rows)
+    != 1` check let `result_rows == [[]]` (one row, ZERO columns) through to
+    an unvalidated `[0][0]` -- an uncontrolled IndexError, not a named
+    SnapshotError. `[[0, "extra"]]` (an unexpected extra column) passed
+    silently. `_scalar_count` is the one function every count() call site in
+    this module goes through now.
+    """
+
+    def test_a_single_scalar_row_is_accepted(self) -> None:
+        from dev_health_ops.fixtures.world_snapshot import _scalar_count
+
+        assert _scalar_count(_DumpResult([[7]]), context="test") == 7
+
+    def test_zero_rows_is_rejected(self) -> None:
+        from dev_health_ops.fixtures.world_snapshot import _scalar_count
+
+        with pytest.raises(SnapshotError, match="malformed"):
+            _scalar_count(_DumpResult([]), context="test")
+
+    def test_one_row_zero_columns_is_rejected_not_an_indexerror(self) -> None:
+        from dev_health_ops.fixtures.world_snapshot import _scalar_count
+
+        with pytest.raises(SnapshotError, match="malformed"):
+            _scalar_count(_DumpResult([[]]), context="test")
+
+    def test_one_row_two_columns_is_rejected(self) -> None:
+        from dev_health_ops.fixtures.world_snapshot import _scalar_count
+
+        with pytest.raises(SnapshotError, match="malformed"):
+            _scalar_count(_DumpResult([[0, "extra"]]), context="test")
+
+    def test_two_rows_is_rejected(self) -> None:
+        from dev_health_ops.fixtures.world_snapshot import _scalar_count
+
+        with pytest.raises(SnapshotError, match="malformed"):
+            _scalar_count(_DumpResult([[1], [2]]), context="test")
+
+    def test_a_default_is_returned_instead_of_raising_when_given(self) -> None:
+        from dev_health_ops.fixtures.world_snapshot import _scalar_count
+
+        assert _scalar_count(_DumpResult([]), context="test", default=-1) == -1
+
 
 class _FakeTtlCountClient:
     """Reports a controllable row count for whichever table's TTL-horizon
@@ -717,12 +789,47 @@ class TestTtlHorizonGuard:
         monkeypatch.setattr(world_snapshot, "clickhouse_ttl_retentions", lambda: {})
         client = _FakeTtlCountClient(counts={"feature_flag_event": 999999})
 
-        with pytest.raises(SnapshotError, match="ZERO"):
+        with pytest.raises(SnapshotError, match="missing known"):
             await _assert_no_ttl_horizon_rows(client, ["feature_flag_event"])
 
         assert client.queries == [], (
             "must fail before issuing a single per-table query once the "
             "registry itself looks broken"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_partial_registry_fails_closed_too(self, monkeypatch) -> None:
+        """Codex round-2 finding (HIGH, confirmed): "non-empty" is not the
+        same guarantee as "complete". Dropping just one known TTL'd table
+        from an otherwise-full registry used to let a massive violation for
+        THAT exact table pass silently -- `retentions.get(table)` returning
+        `None` is indistinguishable from "genuinely no TTL" at this call
+        site. Every table in KNOWN_TTL_TABLES must be present.
+        """
+        from dev_health_ops.fixtures import world_snapshot
+        from dev_health_ops.fixtures.ttl_registry import (
+            KNOWN_TTL_TABLES,
+            clickhouse_ttl_retentions,
+        )
+
+        real = clickhouse_ttl_retentions()
+        partial = {
+            table: retention
+            for table, retention in real.items()
+            if table != "telemetry_signal_bucket"
+        }
+        assert "telemetry_signal_bucket" in KNOWN_TTL_TABLES
+        monkeypatch.setattr(
+            world_snapshot, "clickhouse_ttl_retentions", lambda: partial
+        )
+        client = _FakeTtlCountClient(counts={"telemetry_signal_bucket": 999999})
+
+        with pytest.raises(SnapshotError, match="telemetry_signal_bucket"):
+            await _assert_no_ttl_horizon_rows(client, ["telemetry_signal_bucket"])
+
+        assert client.queries == [], (
+            "must fail before issuing a single per-table query once the "
+            "registry looks incomplete"
         )
 
     @pytest.mark.asyncio

--- a/tests/test_fixtures_world_snapshot.py
+++ b/tests/test_fixtures_world_snapshot.py
@@ -24,6 +24,7 @@ import pytest
 
 from dev_health_ops.fixtures.world_snapshot import (
     _CLICKHOUSE_LEDGER_TABLES,
+    _DUMP_VERIFY_ATTEMPTS,
     _POSTGRES_LEDGER_TABLES,
     ACCEPTANCE_ENVIRONMENT,
     SNAPSHOT_SCHEMA_VERSION,
@@ -31,10 +32,12 @@ from dev_health_ops.fixtures.world_snapshot import (
     RestoreRefusedError,
     SnapshotError,
     _assert_content_identity,
+    _assert_no_ttl_horizon_rows,
     _assert_round_trip,
     _assert_schema_compatible,
     _changed_tables,
     _decode_value,
+    _dump_clickhouse,
     _encode_value,
     _require_acceptance_environment,
     _require_empty_targets,
@@ -469,6 +472,234 @@ class TestClickHouseContentOracle:
                 source={},
                 target={"teams": "b" * 64},
             )
+
+
+class _DumpResult:
+    def __init__(self, rows: list[list[int]]) -> None:
+        self.result_rows = rows
+
+
+class _FakeShortPayloadClient:
+    """CHAOS-3602: `raw_query`'s Native payload and a same-session `count()`
+    have been observed to silently disagree on a fully idle, unchanging
+    table. This fake makes that disagreement DETERMINISTIC: each entry in
+    ``payload_row_counts`` is what a real decode of that attempt's payload
+    would count (i.e. what a throwaway staging table would report after
+    `raw_insert`-ing it), while `source_count` is what the source table's own
+    `count()` reports EVERY time -- exactly like the real incident, where
+    that query kept saying 1042 even on the attempt whose payload actually
+    held only 1041 rows.
+    """
+
+    database = "ask_dev_world_scratch"
+
+    def __init__(self, *, payload_row_counts: list[int], source_count: int) -> None:
+        self.payload_row_counts = list(payload_row_counts)
+        self.source_count = source_count
+        self.raw_query_calls = 0
+        self.raw_insert_calls = 0
+        self.commands: list[str] = []
+        self._last_inserted_index: int | None = None
+
+    def raw_query(self, query: str, fmt: str | None = None) -> bytes:
+        assert fmt == "Native"
+        assert (
+            "ORDER BY" not in query and "LIMIT" not in query and "OFFSET" not in query
+        )
+        index = self.raw_query_calls
+        self.raw_query_calls += 1
+        # The "payload" is just a tag identifying which attempt produced it --
+        # this fake never really encodes/decodes Native bytes, only tracks
+        # which attempt's (fake) payload was inserted where.
+        return f"payload-{index}".encode()
+
+    def query(self, query: str, parameters: dict | None = None) -> _DumpResult:
+        if "system.parts" in query:
+            return _DumpResult([[3]])
+        if "__snapshot_verify_" in query:
+            assert self._last_inserted_index is not None, (
+                "decoded a verify table before any raw_insert into it"
+            )
+            return _DumpResult([[self.payload_row_counts[self._last_inserted_index]]])
+        # The SOURCE table's own count() -- observed live to say the FULL
+        # count even on an attempt whose payload was short.
+        return _DumpResult([[self.source_count]])
+
+    def command(self, cmd: str, parameters: dict | None = None) -> None:
+        self.commands.append(cmd)
+
+    def raw_insert(
+        self, table: str, insert_block: bytes, fmt: str | None = None
+    ) -> None:
+        assert fmt == "Native"
+        assert table.startswith("__snapshot_verify_")
+        self.raw_insert_calls += 1
+        index = int(insert_block.decode().removeprefix("payload-"))
+        self._last_inserted_index = index
+
+
+class TestClickHouseDumpPayloadVerification:
+    """CHAOS-3602: the mint's own content oracle caught `feature_flag_event`
+    missing a row after a real `_dump_clickhouse` call. The manifest it
+    produced recorded `raw_source_row_count: 1042` AND `row_count: 1042` --
+    both counts agreed -- yet the actual `.native.gz` file, decoded by hand,
+    held only 1041 distinct rows. Stress testing against the live, IDLE
+    table (zero concurrent writes) reproduced it again directly: repeated
+    `raw_query(Native)` dumps of unchanging data intermittently came up one
+    row short, at roughly a 2% per-dump rate. Ruled out: query pagination
+    (this function issues one unpaginated `SELECT *`, confirmed by reading
+    it) and write-visibility timing (reproduced with no writes in flight).
+    The only correct fix is to never trust a separate `count()` query --
+    decode the payload itself and compare THAT.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_short_payload_is_retried_and_the_recovered_attempt_is_what_gets_written(
+        self, tmp_path: Path
+    ) -> None:
+        """Attempt 1's payload decodes to 1041 (short); attempt 2's decodes
+        to 1042 (matches). The OLD code -- which never decoded the payload,
+        only trusted a same-session count() -- would have accepted attempt 1
+        immediately, since that count() said 1042 the whole time. The fix
+        must retry past it and write only the verified attempt's bytes.
+        """
+
+        client = _FakeShortPayloadClient(
+            payload_row_counts=[1041, 1042], source_count=1042
+        )
+        path = tmp_path / "feature_flag_event.native.gz"
+
+        row_count = await _dump_clickhouse(
+            client,
+            "feature_flag_event",
+            "MergeTree()",
+            path,
+            raw_source_row_count=1042,
+        )
+
+        assert row_count == 1042, "must report the DECODED count, not a trusted count()"
+        assert client.raw_query_calls == 2, (
+            "must have retried once after the short attempt"
+        )
+        assert client.raw_insert_calls == 2, (
+            "must decode-verify EVERY attempt, not just trust the first"
+        )
+        assert path.exists()
+        # The bytes actually on disk must be attempt 2's (the verified one),
+        # never attempt 1's short payload.
+        assert path.read_bytes() != b""
+        import gzip as _gzip
+
+        written = _gzip.decompress(path.read_bytes())
+        assert written == b"payload-1", (
+            "the SHORT attempt-1 payload must never reach disk"
+        )
+
+    @pytest.mark.asyncio
+    async def test_short_on_every_attempt_raises_and_writes_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """The exhausted-retries path: every attempt's payload decodes short.
+        Old code had no such concept -- it would have written the FIRST
+        short payload and reported the source table's count() as if it
+        described the file. New code must fail loudly and touch no file.
+        """
+
+        client = _FakeShortPayloadClient(
+            payload_row_counts=[1041] * _DUMP_VERIFY_ATTEMPTS, source_count=1042
+        )
+        path = tmp_path / "feature_flag_event.native.gz"
+
+        with pytest.raises(SnapshotError, match="CHAOS-3602"):
+            await _dump_clickhouse(
+                client,
+                "feature_flag_event",
+                "MergeTree()",
+                path,
+                raw_source_row_count=1042,
+            )
+
+        assert client.raw_query_calls == _DUMP_VERIFY_ATTEMPTS
+        assert not path.exists(), "a payload that never verified must never reach disk"
+
+    @pytest.mark.asyncio
+    async def test_a_payload_that_verifies_on_the_first_attempt_needs_no_retry(
+        self, tmp_path: Path
+    ) -> None:
+        """The ordinary, overwhelming-majority case: no flake at all."""
+
+        client = _FakeShortPayloadClient(payload_row_counts=[1042], source_count=1042)
+        path = tmp_path / "feature_flag_event.native.gz"
+
+        row_count = await _dump_clickhouse(
+            client,
+            "feature_flag_event",
+            "MergeTree()",
+            path,
+            raw_source_row_count=1042,
+        )
+
+        assert row_count == 1042
+        assert client.raw_query_calls == 1
+        assert path.exists()
+
+
+class _FakeTtlCountClient:
+    """Reports a controllable row count for whichever table's TTL-horizon
+    query is issued -- keyed by table name appearing in the query text,
+    which is how `_assert_no_ttl_horizon_rows` actually builds its SQL."""
+
+    def __init__(self, *, counts: dict[str, int]) -> None:
+        self.counts = counts
+        self.queries: list[str] = []
+
+    def query(self, q: str, parameters: dict | None = None) -> _DumpResult:
+        self.queries.append(q)
+        for table, count in self.counts.items():
+            if f"FROM `{table}`" in q:
+                return _DumpResult([[count]])
+        return _DumpResult([[0]])
+
+
+class TestTtlHorizonGuard:
+    """CHAOS-3602: a mint over data currently racing a TTL'd table's own
+    background merge scheduler is nondeterministic BY DESIGN -- ClickHouse
+    applies TTL deletion at merge time, silently, with no error. This guard
+    must catch it BEFORE any dump, not after a content-oracle mismatch has
+    already meant real data loss.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_table_with_no_horizon_adjacent_rows_passes(self) -> None:
+        client = _FakeTtlCountClient(counts={"feature_flag_event": 0})
+        await _assert_no_ttl_horizon_rows(client, ["feature_flag_event"])
+
+    @pytest.mark.asyncio
+    async def test_a_table_with_horizon_adjacent_rows_is_refused(self) -> None:
+        client = _FakeTtlCountClient(counts={"feature_flag_event": 3})
+        with pytest.raises(SnapshotError, match="feature_flag_event"):
+            await _assert_no_ttl_horizon_rows(client, ["feature_flag_event"])
+
+    @pytest.mark.asyncio
+    async def test_a_table_with_no_known_ttl_is_never_queried(self) -> None:
+        """No TTL, no risk -- and no wasted query for every one of the ~90
+        tables a mint dumps that were never at risk in the first place."""
+        client = _FakeTtlCountClient(counts={})
+        await _assert_no_ttl_horizon_rows(client, ["projects"])
+        assert client.queries == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_violating_tables_are_all_named_in_one_error(self) -> None:
+        client = _FakeTtlCountClient(
+            counts={"feature_flag_event": 1, "telemetry_signal_bucket": 5}
+        )
+        with pytest.raises(SnapshotError) as exc_info:
+            await _assert_no_ttl_horizon_rows(
+                client, ["feature_flag_event", "telemetry_signal_bucket", "projects"]
+            )
+        message = str(exc_info.value)
+        assert "feature_flag_event" in message
+        assert "telemetry_signal_bucket" in message
 
 
 class TestContentHashManifestShape:

--- a/tests/test_fixtures_world_snapshot.py
+++ b/tests/test_fixtures_world_snapshot.py
@@ -701,6 +701,50 @@ class TestTtlHorizonGuard:
         assert "feature_flag_event" in message
         assert "telemetry_signal_bucket" in message
 
+    @pytest.mark.asyncio
+    async def test_an_empty_registry_fails_closed_instead_of_skipping_every_table(
+        self, monkeypatch
+    ) -> None:
+        """Codex finding (HIGH, confirmed): `clickhouse_ttl_retentions()`
+        returning `{}` (migrations-directory path broken, parser
+        regression) used to make every table read as "no TTL, nothing to
+        check" and pass with ZERO queries issued -- silently minting an
+        unchecked snapshot. Reproduced directly against a client that would
+        report a massive violation if it were ever actually queried.
+        """
+        from dev_health_ops.fixtures import world_snapshot
+
+        monkeypatch.setattr(world_snapshot, "clickhouse_ttl_retentions", lambda: {})
+        client = _FakeTtlCountClient(counts={"feature_flag_event": 999999})
+
+        with pytest.raises(SnapshotError, match="ZERO"):
+            await _assert_no_ttl_horizon_rows(client, ["feature_flag_event"])
+
+        assert client.queries == [], (
+            "must fail before issuing a single per-table query once the "
+            "registry itself looks broken"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_query_result_fails_closed_instead_of_reading_as_zero(
+        self,
+    ) -> None:
+        """Codex finding (HIGH, confirmed): an empty/malformed
+        `result.result_rows` was folded into `count = 0` -- a driver
+        returning something other than a single scalar count row (a
+        transient response-shape defect, a mocking/wiring bug) silently
+        read as "no violating rows" and let the mint proceed unchecked.
+        """
+
+        class _MalformedResultClient:
+            def query(self, q: str, parameters: dict | None = None) -> _DumpResult:
+                return _DumpResult([])  # no rows at all -- malformed
+
+        with pytest.raises(SnapshotError, match="malformed"):
+            await _assert_no_ttl_horizon_rows(
+                _MalformedResultClient(), ["feature_flag_event"]
+            )
+
 
 class TestContentHashManifestShape:
     """The hashes are stored as a LIST of objects, not a `{table: hash}` map.

--- a/tests/test_fixtures_world_snapshot.py
+++ b/tests/test_fixtures_world_snapshot.py
@@ -774,62 +774,36 @@ class TestTtlHorizonGuard:
         assert "telemetry_signal_bucket" in message
 
     @pytest.mark.asyncio
-    async def test_an_empty_registry_fails_closed_instead_of_skipping_every_table(
+    async def test_a_broken_ttl_vocabulary_fails_closed_before_any_query(
         self, monkeypatch
     ) -> None:
-        """Codex finding (HIGH, confirmed): `clickhouse_ttl_retentions()`
-        returning `{}` (migrations-directory path broken, parser
-        regression) used to make every table read as "no TTL, nothing to
-        check" and pass with ZERO queries issued -- silently minting an
-        unchecked snapshot. Reproduced directly against a client that would
-        report a massive violation if it were ever actually queried.
+        """This guard's OWN contract: whatever `assert_ttl_vocabulary_is_
+        consistent` decides, this function must propagate it as a
+        `SnapshotError` before issuing a single per-table query. The
+        vocabulary-consistency logic itself (empty registry, partial
+        registry, a fifth TTL table the precise parser misses via an
+        unmatched syntax variant, a registry extra, a KNOWN_TTL_TABLES
+        entry that's gone stale, ...) is exhaustively covered in
+        `tests/test_ttl_registry.py::TestVocabularyConsistency` -- this
+        test proves this guard actually calls it and wraps its failure
+        correctly, not that the check's own logic is correct.
         """
         from dev_health_ops.fixtures import world_snapshot
 
-        monkeypatch.setattr(world_snapshot, "clickhouse_ttl_retentions", lambda: {})
+        def _broken() -> None:
+            raise RuntimeError("synthetic vocabulary break: table_x")
+
+        monkeypatch.setattr(
+            world_snapshot, "assert_ttl_vocabulary_is_consistent", _broken
+        )
         client = _FakeTtlCountClient(counts={"feature_flag_event": 999999})
 
-        with pytest.raises(SnapshotError, match="missing known"):
+        with pytest.raises(SnapshotError, match="synthetic vocabulary break"):
             await _assert_no_ttl_horizon_rows(client, ["feature_flag_event"])
 
         assert client.queries == [], (
             "must fail before issuing a single per-table query once the "
-            "registry itself looks broken"
-        )
-
-    @pytest.mark.asyncio
-    async def test_a_partial_registry_fails_closed_too(self, monkeypatch) -> None:
-        """Codex round-2 finding (HIGH, confirmed): "non-empty" is not the
-        same guarantee as "complete". Dropping just one known TTL'd table
-        from an otherwise-full registry used to let a massive violation for
-        THAT exact table pass silently -- `retentions.get(table)` returning
-        `None` is indistinguishable from "genuinely no TTL" at this call
-        site. Every table in KNOWN_TTL_TABLES must be present.
-        """
-        from dev_health_ops.fixtures import world_snapshot
-        from dev_health_ops.fixtures.ttl_registry import (
-            KNOWN_TTL_TABLES,
-            clickhouse_ttl_retentions,
-        )
-
-        real = clickhouse_ttl_retentions()
-        partial = {
-            table: retention
-            for table, retention in real.items()
-            if table != "telemetry_signal_bucket"
-        }
-        assert "telemetry_signal_bucket" in KNOWN_TTL_TABLES
-        monkeypatch.setattr(
-            world_snapshot, "clickhouse_ttl_retentions", lambda: partial
-        )
-        client = _FakeTtlCountClient(counts={"telemetry_signal_bucket": 999999})
-
-        with pytest.raises(SnapshotError, match="telemetry_signal_bucket"):
-            await _assert_no_ttl_horizon_rows(client, ["telemetry_signal_bucket"])
-
-        assert client.queries == [], (
-            "must fail before issuing a single per-table query once the "
-            "registry looks incomplete"
+            "vocabulary check itself fails"
         )
 
     @pytest.mark.asyncio

--- a/tests/test_ttl_registry.py
+++ b/tests/test_ttl_registry.py
@@ -12,6 +12,7 @@ import pytest
 
 from dev_health_ops.fixtures import ttl_registry as ttl_registry_module
 from dev_health_ops.fixtures.ttl_registry import (
+    KNOWN_TTL_TABLES,
     MAX_PINNED_NOW_STALENESS_DAYS,
     RESTORE_SIDE_SLACK_DAYS,
     TTL_SAFETY_MARGIN_DAYS,
@@ -42,14 +43,12 @@ class TestParsesTheRealMigrations:
 
     def test_every_known_ttl_table_is_discovered(self) -> None:
         """Pins the full current set so a migration adding/removing a TTL
-        is a visible, deliberate test change -- not a silent gap."""
+        is a visible, deliberate test change -- not a silent gap. Checked
+        against the SAME `KNOWN_TTL_TABLES` constant the runtime fail-closed
+        checks use, not a second hand-copied literal that could drift from
+        it independently."""
         retentions = clickhouse_ttl_retentions()
-        assert retentions.keys() >= {
-            "feature_flag_event",
-            "telemetry_signal_bucket",
-            "release_impact_daily",
-            "product_telemetry_events",
-        }
+        assert retentions.keys() >= KNOWN_TTL_TABLES
 
     def test_a_table_with_no_ttl_has_no_safe_backdate_limit(self) -> None:
         assert max_safe_backdate_days("projects") is None

--- a/tests/test_ttl_registry.py
+++ b/tests/test_ttl_registry.py
@@ -1,0 +1,326 @@
+"""CHAOS-3602: the TTL registry must describe what ClickHouse ACTUALLY
+enforces, parsed from the migration source itself -- never a hand-copied
+number that can silently drift once a migration's TTL changes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.fixtures import ttl_registry as ttl_registry_module
+from dev_health_ops.fixtures.ttl_registry import (
+    MAX_PINNED_NOW_STALENESS_DAYS,
+    RESTORE_SIDE_SLACK_DAYS,
+    TTL_SAFETY_MARGIN_DAYS,
+    PinnedNowStaleError,
+    SnapshotExpiredError,
+    assert_pinned_now_not_too_stale,
+    assert_snapshot_not_expired,
+    clickhouse_ttl_retentions,
+    compute_drift_days,
+    drift_days_context,
+    max_generated_age_days,
+    max_safe_backdate_days,
+    snapshot_expiry,
+    snapshot_shelf_life_days,
+)
+
+
+class TestParsesTheRealMigrations:
+    """The table that actually caused CHAOS-3602 must be discovered
+    correctly against the checked-in migration, not a fixture string."""
+
+    def test_feature_flag_event_is_discovered_with_its_real_ttl(self) -> None:
+        retentions = clickhouse_ttl_retentions()
+        assert "feature_flag_event" in retentions
+        retention = retentions["feature_flag_event"]
+        assert retention.column == "event_ts"
+        assert retention.retention_days == 90
+
+    def test_every_known_ttl_table_is_discovered(self) -> None:
+        """Pins the full current set so a migration adding/removing a TTL
+        is a visible, deliberate test change -- not a silent gap."""
+        retentions = clickhouse_ttl_retentions()
+        assert retentions.keys() >= {
+            "feature_flag_event",
+            "telemetry_signal_bucket",
+            "release_impact_daily",
+            "product_telemetry_events",
+        }
+
+    def test_a_table_with_no_ttl_has_no_safe_backdate_limit(self) -> None:
+        assert max_safe_backdate_days("projects") is None
+
+    def test_safe_backdate_is_retention_minus_margin(self) -> None:
+        assert (
+            max_safe_backdate_days("feature_flag_event") == 90 - TTL_SAFETY_MARGIN_DAYS
+        )
+
+
+class TestGeneratorCeilingHasRealSlackBelowTheGuardThreshold:
+    """CHAOS-3602 follow-up bug, caught live on the first re-mint attempt
+    after the fix: generation and the mint guard both used
+    `max_safe_backdate_days` -- the SAME value -- as their boundary. A row
+    generated at exactly that ceiling, checked by the guard a few seconds
+    later (ordinary elapsed time within one mint run), was already "at or
+    past" the guard's own threshold purely because `now()` had ticked
+    forward between generation and the check. The guard fired on its own
+    mint's freshly-generated data: 8 `feature_flag_event` rows "at or past
+    83 days old" when generation had targeted precisely 83 as its ceiling.
+
+    `max_generated_age_days` must be a genuinely SEPARATE, smaller number
+    -- not the same threshold reused for both roles.
+    """
+
+    def test_generator_ceiling_is_strictly_below_the_guard_threshold(self) -> None:
+        for table in clickhouse_ttl_retentions():
+            guard_threshold = max_safe_backdate_days(table)
+            generator_ceiling = max_generated_age_days(table)
+            assert guard_threshold is not None
+            assert generator_ceiling is not None
+            assert generator_ceiling < guard_threshold, (
+                f"{table}: generator ceiling ({generator_ceiling}) must stay "
+                f"strictly below the guard's own threshold "
+                f"({guard_threshold}) -- equal values give zero slack for "
+                "the ordinary time elapsed between generation and the "
+                "guard's check within the same mint run"
+            )
+
+    def test_the_slack_is_at_least_a_full_day(self) -> None:
+        """A gap of a fraction of a day would still be fragile against a
+        slow mint run; require at least a full day of real headroom."""
+        for table in clickhouse_ttl_retentions():
+            guard_threshold = max_safe_backdate_days(table)
+            generator_ceiling = max_generated_age_days(table)
+            assert guard_threshold is not None
+            assert generator_ceiling is not None
+            assert guard_threshold - generator_ceiling >= 1
+
+
+class TestParserHandlesBothTtlSyntaxForms:
+    """Migration 034 uses two different TTL spellings across its own
+    tables: `TTL toDateTime(event_ts) + INTERVAL 90 DAY` (a column wrapped
+    in a cast) and `TTL day + INTERVAL 365 DAY` (a bare column already of a
+    temporal type). Both must parse -- proven against synthetic source, not
+    just observed by accident against the real files.
+    """
+
+    def _parse_text(self, tmp_path: Path, text: str) -> dict:
+        migrations_dir = tmp_path / "clickhouse"
+        migrations_dir.mkdir()
+        (migrations_dir / "999_synthetic.sql").write_text(text)
+        original = ttl_registry_module._MIGRATIONS_DIR
+        ttl_registry_module._MIGRATIONS_DIR = migrations_dir
+        try:
+            clickhouse_ttl_retentions.cache_clear()
+            return clickhouse_ttl_retentions()
+        finally:
+            ttl_registry_module._MIGRATIONS_DIR = original
+            clickhouse_ttl_retentions.cache_clear()
+
+    def test_wrapped_column_form(self, tmp_path: Path) -> None:
+        retentions = self._parse_text(
+            tmp_path,
+            "CREATE TABLE IF NOT EXISTS synth_wrapped (\n"
+            "    occurred_at DateTime64(3, 'UTC')\n"
+            ") ENGINE = MergeTree()\n"
+            "TTL toDateTime(occurred_at) + INTERVAL 42 DAY DELETE;",
+        )
+        assert retentions["synth_wrapped"].column == "occurred_at"
+        assert retentions["synth_wrapped"].retention_days == 42
+
+    def test_bare_column_form(self, tmp_path: Path) -> None:
+        retentions = self._parse_text(
+            tmp_path,
+            "CREATE TABLE IF NOT EXISTS synth_bare (\n"
+            "    day Date\n"
+            ") ENGINE = MergeTree()\n"
+            "TTL day + INTERVAL 99 DAY DELETE;",
+        )
+        assert retentions["synth_bare"].column == "day"
+        assert retentions["synth_bare"].retention_days == 99
+
+    def test_a_table_with_no_ttl_clause_is_not_registered(self, tmp_path: Path) -> None:
+        retentions = self._parse_text(
+            tmp_path,
+            "CREATE TABLE IF NOT EXISTS synth_no_ttl (\n"
+            "    id String\n"
+            ") ENGINE = MergeTree()\n"
+            "ORDER BY id;",
+        )
+        assert "synth_no_ttl" not in retentions
+
+
+class TestRegistryTracksSourceChanges:
+    """The whole point of parsing rather than hand-copying: change the TTL
+    in the (synthetic) migration source and the registry MUST reflect the
+    new number immediately, proving there is no cached/hardcoded literal
+    that could drift out of sync with a real migration edit.
+    """
+
+    def test_changing_the_migration_changes_the_registry(self, tmp_path: Path) -> None:
+        migrations_dir = tmp_path / "clickhouse"
+        migrations_dir.mkdir()
+        path = migrations_dir / "999_synthetic.sql"
+        path.write_text(
+            "CREATE TABLE IF NOT EXISTS synth (\n"
+            "    event_ts DateTime64(3, 'UTC')\n"
+            ") ENGINE = MergeTree()\n"
+            "TTL toDateTime(event_ts) + INTERVAL 30 DAY DELETE;"
+        )
+        original = ttl_registry_module._MIGRATIONS_DIR
+        ttl_registry_module._MIGRATIONS_DIR = migrations_dir
+        try:
+            clickhouse_ttl_retentions.cache_clear()
+            assert clickhouse_ttl_retentions()["synth"].retention_days == 30
+
+            path.write_text(
+                "CREATE TABLE IF NOT EXISTS synth (\n"
+                "    event_ts DateTime64(3, 'UTC')\n"
+                ") ENGINE = MergeTree()\n"
+                "TTL toDateTime(event_ts) + INTERVAL 15 DAY DELETE;"
+            )
+            clickhouse_ttl_retentions.cache_clear()
+            assert clickhouse_ttl_retentions()["synth"].retention_days == 15, (
+                "the registry did not track a real migration edit -- it is "
+                "reading a stale/cached value instead of the source"
+            )
+        finally:
+            ttl_registry_module._MIGRATIONS_DIR = original
+            clickhouse_ttl_retentions.cache_clear()
+
+
+class TestComputeDriftDays:
+    def test_no_drift_when_pinned_now_is_real_now(self) -> None:
+        now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+        assert compute_drift_days(now, now) == 0
+
+    def test_a_future_pinned_now_needs_no_compensation(self) -> None:
+        real_now = datetime(2026, 8, 8, tzinfo=timezone.utc)
+        pinned_now = real_now + timedelta(days=5)
+        assert compute_drift_days(pinned_now, real_now) == 0
+
+    def test_three_days_stale_matches_the_incident(self) -> None:
+        """The exact scenario that blocked a real mint: pinned_now =
+        2026-08-05, real now = 2026-08-08."""
+        pinned_now = datetime(2026, 8, 5, tzinfo=timezone.utc)
+        real_now = datetime(2026, 8, 8, tzinfo=timezone.utc)
+        assert compute_drift_days(pinned_now, real_now) == 3
+
+    def test_a_partial_day_of_drift_rounds_up(self) -> None:
+        pinned_now = datetime(2026, 8, 5, 0, 0, tzinfo=timezone.utc)
+        real_now = datetime(2026, 8, 6, 1, 0, tzinfo=timezone.utc)  # 1 day + 1 hour
+        assert compute_drift_days(pinned_now, real_now) == 2
+
+
+class TestDriftThreadedIntoTheClamp:
+    """CHAOS-3602 follow-up, live incident: generation clamped ages against
+    `max_safe_backdate_days` alone, ignorant of how stale `pinned_now` had
+    become. A world minted with `pinned_now` 3 days behind real time
+    produced rows the mint guard correctly flagged as past its own
+    threshold -- the exact 3-day-drift case reproduced here.
+    """
+
+    def test_zero_drift_leaves_the_ceiling_unchanged(self) -> None:
+        guard_threshold = max_safe_backdate_days("feature_flag_event")
+        assert guard_threshold is not None
+        with drift_days_context(0):
+            assert (
+                max_generated_age_days("feature_flag_event")
+                == guard_threshold - ttl_registry_module.GENERATOR_SLACK_DAYS
+            )
+
+    def test_three_day_drift_shaves_three_more_days_off_the_ceiling(self) -> None:
+        """The live incident, reproduced deterministically: with no drift
+        threaded, generation's own ceiling was left exactly 3 days too high
+        for a pinned_now that was 3 days stale."""
+        with drift_days_context(0):
+            undrifted_ceiling = max_generated_age_days("feature_flag_event")
+        assert undrifted_ceiling is not None
+        with drift_days_context(3):
+            drifted_ceiling = max_generated_age_days("feature_flag_event")
+        assert drifted_ceiling == undrifted_ceiling - 3
+
+    def test_drift_never_pushes_the_ceiling_negative(self) -> None:
+        with drift_days_context(10_000):
+            assert max_generated_age_days("feature_flag_event") == 0
+
+    def test_drift_context_is_scoped_and_reverts(self) -> None:
+        baseline = max_generated_age_days("feature_flag_event")
+        assert baseline is not None
+        with drift_days_context(5):
+            assert max_generated_age_days("feature_flag_event") == baseline - 5
+        assert max_generated_age_days("feature_flag_event") == baseline
+
+    def test_a_table_with_no_ttl_ignores_drift_entirely(self) -> None:
+        with drift_days_context(5):
+            assert max_generated_age_days("projects") is None
+
+
+class TestPinnedNowStalenessCeiling:
+    """A mint must refuse rather than silently squeeze the generatable-
+    history window to compensate for an unbounded amount of pinned_now
+    drift."""
+
+    def test_drift_inside_the_ceiling_returns_the_drift_and_does_not_raise(
+        self,
+    ) -> None:
+        pinned_now = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        real_now = pinned_now + timedelta(days=MAX_PINNED_NOW_STALENESS_DAYS - 1)
+        assert (
+            assert_pinned_now_not_too_stale(pinned_now, real_now)
+            == MAX_PINNED_NOW_STALENESS_DAYS - 1
+        )
+
+    def test_drift_past_the_ceiling_is_refused_with_a_named_fix(self) -> None:
+        pinned_now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        real_now = pinned_now + timedelta(days=MAX_PINNED_NOW_STALENESS_DAYS + 1)
+        with pytest.raises(PinnedNowStaleError) as exc_info:
+            assert_pinned_now_not_too_stale(pinned_now, real_now)
+        message = str(exc_info.value)
+        assert "pinned_now" in message
+        assert "re-pinning is a deliberate decision" in message
+
+    def test_drift_exactly_at_the_ceiling_is_still_allowed(self) -> None:
+        pinned_now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        real_now = pinned_now + timedelta(days=MAX_PINNED_NOW_STALENESS_DAYS)
+        assert (
+            assert_pinned_now_not_too_stale(pinned_now, real_now)
+            == MAX_PINNED_NOW_STALENESS_DAYS
+        )
+
+
+class TestSnapshotShelfLife:
+    """A minted snapshot's dates are frozen relative to pinned_now, but
+    ClickHouse's TTL enforcement always runs on real time -- once enough
+    real time passes, the snapshot's oldest rows are due for a live TTL
+    merge regardless of what any boot does."""
+
+    def test_shelf_life_is_margin_minus_restore_slack(self) -> None:
+        assert (
+            snapshot_shelf_life_days()
+            == TTL_SAFETY_MARGIN_DAYS - RESTORE_SIDE_SLACK_DAYS
+        )
+
+    def test_expiry_is_pinned_now_plus_shelf_life(self) -> None:
+        pinned_now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        assert snapshot_expiry(pinned_now) == pinned_now + timedelta(
+            days=snapshot_shelf_life_days()
+        )
+
+    def test_restoring_before_expiry_is_allowed(self) -> None:
+        pinned_now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        real_now = snapshot_expiry(pinned_now) - timedelta(days=1)
+        assert_snapshot_not_expired(pinned_now, real_now)  # must not raise
+
+    def test_restoring_at_or_past_expiry_is_refused_with_a_named_fix(self) -> None:
+        pinned_now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        real_now = snapshot_expiry(pinned_now)
+        with pytest.raises(SnapshotExpiredError) as exc_info:
+            assert_snapshot_not_expired(pinned_now, real_now)
+        message = str(exc_info.value)
+        assert "expired" in message
+        assert "re-mint required" in message

--- a/tests/test_ttl_registry.py
+++ b/tests/test_ttl_registry.py
@@ -20,6 +20,7 @@ from dev_health_ops.fixtures.ttl_registry import (
     SnapshotExpiredError,
     assert_pinned_now_not_too_stale,
     assert_snapshot_not_expired,
+    assert_ttl_vocabulary_is_consistent,
     clickhouse_ttl_retentions,
     compute_drift_days,
     drift_days_context,
@@ -186,6 +187,157 @@ class TestRegistryTracksSourceChanges:
             assert clickhouse_ttl_retentions()["synth"].retention_days == 15, (
                 "the registry did not track a real migration edit -- it is "
                 "reading a stale/cached value instead of the source"
+            )
+        finally:
+            ttl_registry_module._MIGRATIONS_DIR = original
+            clickhouse_ttl_retentions.cache_clear()
+
+
+class TestVocabularyConsistency:
+    """Codex round-3 finding (HIGH, confirmed): checking a parsed registry
+    against KNOWN_TTL_TABLES alone only catches a table falling OUT of an
+    otherwise-working registry -- a table that never enters EITHER the
+    registry or KNOWN_TTL_TABLES in the first place (an unmatched TTL
+    syntax variant) satisfies that check trivially. The registry's own
+    "completeness" was being checked against a vocabulary that itself never
+    learned about the new table -- pure circularity.
+
+    `assert_ttl_vocabulary_is_consistent` breaks that circularity with a
+    THIRD, independent source: a deliberately looser sweep of the same
+    migration files.
+    """
+
+    def _swap_migrations_dir(self, tmp_path: Path, text: str):
+        migrations_dir = tmp_path / "clickhouse"
+        migrations_dir.mkdir()
+        (migrations_dir / "999_synthetic.sql").write_text(text)
+        original = ttl_registry_module._MIGRATIONS_DIR
+        ttl_registry_module._MIGRATIONS_DIR = migrations_dir
+        clickhouse_ttl_retentions.cache_clear()
+        return original
+
+    def _restore_migrations_dir(self, original) -> None:
+        ttl_registry_module._MIGRATIONS_DIR = original
+        clickhouse_ttl_retentions.cache_clear()
+
+    def test_the_real_repo_is_internally_consistent(self) -> None:
+        """Sanity: the actual migrations directory, as it stands today,
+        must not trip this check -- otherwise every other test in this
+        module (and every guard that calls this first) would be
+        unreachable."""
+        assert_ttl_vocabulary_is_consistent()  # must not raise
+
+    def test_a_fifth_ttl_table_the_precise_parser_misses_fails_loudly(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact codex round-3 repro: `TTL ... + INTERVAL 4 WEEK` is
+        real ClickHouse syntax, but `_TTL_RE` requires the literal word
+        "DAY" and never matches it -- so `clickhouse_ttl_retentions` never
+        sees this table, and (having never been seen) neither does
+        KNOWN_TTL_TABLES. The coarse sweep, which only requires the bare
+        substrings "TTL" and "INTERVAL", still finds it -- and that
+        disagreement must fail loudly rather than pass vacuously.
+        """
+        original = self._swap_migrations_dir(
+            tmp_path,
+            "CREATE TABLE IF NOT EXISTS fifth_ttl_table (\n"
+            "    occurred_at DateTime64(3, 'UTC')\n"
+            ") ENGINE = MergeTree()\n"
+            "TTL occurred_at + INTERVAL 4 WEEK;",
+        )
+        try:
+            # Confirms the precise parser really does miss it -- the
+            # premise of this whole test.
+            assert "fifth_ttl_table" not in clickhouse_ttl_retentions()
+
+            with pytest.raises(RuntimeError, match="fifth_ttl_table"):
+                assert_ttl_vocabulary_is_consistent()
+        finally:
+            self._restore_migrations_dir(original)
+
+    def test_a_registry_extra_the_coarse_sweep_does_not_see_fails_too(
+        self, monkeypatch
+    ) -> None:
+        """The reverse imbalance: the precise parser reports a table the
+        coarse sweep does not -- should be impossible in practice (the
+        coarse sweep is a strict superset by construction), but the check
+        must be genuinely bidirectional, not one-sided.
+        """
+        real = clickhouse_ttl_retentions()
+        fake_extra = dict(real)
+        fake_extra["totally_fictional_table"] = ttl_registry_module.TtlRetention(
+            table="totally_fictional_table", column="ts", retention_days=10
+        )
+        monkeypatch.setattr(
+            ttl_registry_module, "clickhouse_ttl_retentions", lambda: fake_extra
+        )
+
+        with pytest.raises(RuntimeError, match="totally_fictional_table"):
+            assert_ttl_vocabulary_is_consistent()
+
+    def test_a_coarse_table_missing_from_known_ttl_tables_fails(
+        self, monkeypatch
+    ) -> None:
+        """A table the coarse sweep (and, by extension, the precise parser)
+        finds, but that KNOWN_TTL_TABLES has not been updated to include --
+        the hand-maintained vocabulary itself must be kept honest too."""
+        monkeypatch.setattr(
+            ttl_registry_module,
+            "KNOWN_TTL_TABLES",
+            frozenset({"feature_flag_event"}),
+        )
+        with pytest.raises(RuntimeError, match="not yet added to KNOWN_TTL_TABLES"):
+            assert_ttl_vocabulary_is_consistent()
+
+    def test_both_scanners_cover_py_migrations_not_just_sql(
+        self, tmp_path: Path
+    ) -> None:
+        """Standing repo trap (reference_ops_clickhouse_python_migrations):
+        this repo's ClickHouse migrations are BOTH .sql AND .py, and a .py
+        migration carries its DDL as a Python string -- grepping/globbing
+        *.sql alone is a known way to reach a wrong-schema conclusion here.
+        A fifth TTL'd table declared ONLY in a .py migration must be found
+        by BOTH the precise parser and the coarse sweep, or the exact
+        vacuous-pass this test class exists to close reproduces one
+        directory over (a .py-only table, invisible to both scanners,
+        would satisfy `assert_ttl_vocabulary_is_consistent` just as
+        trivially as the WEEK-unit case above). No real .py migration
+        declares a TTL today (checked: `grep -l TTL
+        migrations/clickhouse/*.py` finds only a docstring mentioning the
+        word, `grep -c INTERVAL` on it is 0), so this cannot be demonstrated
+        against the real tree -- it would pass whether or not .py were
+        scanned. This feeds the parser a .py-sourced TTL directly, so the
+        claim is OBSERVED rather than asserted.
+        """
+        migrations_dir = tmp_path / "clickhouse"
+        migrations_dir.mkdir()
+        (migrations_dir / "999_added_via_python.py").write_text(
+            'SQL = """\n'
+            "CREATE TABLE py_sourced_ttl_table (\n"
+            "    occurred_at DateTime64(3, 'UTC')\n"
+            ") ENGINE = MergeTree()\n"
+            "ORDER BY occurred_at\n"
+            "TTL toDateTime(occurred_at) + INTERVAL 45 DAY DELETE;\n"
+            '"""\n'
+        )
+        original = ttl_registry_module._MIGRATIONS_DIR
+        ttl_registry_module._MIGRATIONS_DIR = migrations_dir
+        clickhouse_ttl_retentions.cache_clear()
+        try:
+            precise = clickhouse_ttl_retentions()
+            assert "py_sourced_ttl_table" in precise, (
+                "the precise parser did not find a TTL declared inside a "
+                ".py migration -- it is scanning *.sql only"
+            )
+            assert precise["py_sourced_ttl_table"].retention_days == 45
+
+            coarse = ttl_registry_module._coarse_ttl_table_sweep()
+            assert "py_sourced_ttl_table" in coarse, (
+                "the coarse sweep did not find a TTL declared inside a .py "
+                "migration -- it is scanning *.sql only, which would let a "
+                "fifth TTL'd table added via a .py migration alone "
+                "reproduce the exact vacuous-pass this sweep exists to "
+                "close, one directory over"
             )
         finally:
             ttl_registry_module._MIGRATIONS_DIR = original

--- a/tests/test_ttl_registry.py
+++ b/tests/test_ttl_registry.py
@@ -116,10 +116,12 @@ class TestParserHandlesBothTtlSyntaxForms:
         ttl_registry_module._MIGRATIONS_DIR = migrations_dir
         try:
             clickhouse_ttl_retentions.cache_clear()
+            ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
             return clickhouse_ttl_retentions()
         finally:
             ttl_registry_module._MIGRATIONS_DIR = original
             clickhouse_ttl_retentions.cache_clear()
+            ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
 
     def test_wrapped_column_form(self, tmp_path: Path) -> None:
         retentions = self._parse_text(
@@ -191,6 +193,7 @@ class TestRegistryTracksSourceChanges:
         finally:
             ttl_registry_module._MIGRATIONS_DIR = original
             clickhouse_ttl_retentions.cache_clear()
+            ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
 
 
 class TestVocabularyConsistency:
@@ -214,11 +217,13 @@ class TestVocabularyConsistency:
         original = ttl_registry_module._MIGRATIONS_DIR
         ttl_registry_module._MIGRATIONS_DIR = migrations_dir
         clickhouse_ttl_retentions.cache_clear()
+        ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
         return original
 
     def _restore_migrations_dir(self, original) -> None:
         ttl_registry_module._MIGRATIONS_DIR = original
         clickhouse_ttl_retentions.cache_clear()
+        ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
 
     def test_the_real_repo_is_internally_consistent(self) -> None:
         """Sanity: the actual migrations directory, as it stands today,
@@ -323,6 +328,7 @@ class TestVocabularyConsistency:
         original = ttl_registry_module._MIGRATIONS_DIR
         ttl_registry_module._MIGRATIONS_DIR = migrations_dir
         clickhouse_ttl_retentions.cache_clear()
+        ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
         try:
             precise = clickhouse_ttl_retentions()
             assert "py_sourced_ttl_table" in precise, (
@@ -342,6 +348,207 @@ class TestVocabularyConsistency:
         finally:
             ttl_registry_module._MIGRATIONS_DIR = original
             clickhouse_ttl_retentions.cache_clear()
+            ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
+
+
+class TestCoarseSweepDoesNotMatchProse:
+    """Codex round-4 finding (HIGH, confirmed LIVE against the real tree):
+    the original coarse table-name regex had no line anchor and no
+    trailing ``(``, so it matched prose mid-sentence -- exactly the class
+    PR #1602 review D already hardened the PRECISE parser against.
+    Reproduced directly: running the old regex against
+    055_work_item_daily_rollups_replacing_merge_tree.py's own docstring
+    yielded phantom tables ``'to'`` (from "SHOW CREATE TABLE to get the
+    live DDL") and ``'statement'`` (from "the table name in a CREATE TABLE
+    statement."). Both were silenced only because that specific chunk
+    happens to lack the substring "INTERVAL" -- one unrelated docstring
+    edit anywhere near either sentence would have made
+    ``assert_ttl_vocabulary_is_consistent`` abort ALL fixture generation
+    over a table that does not exist.
+    """
+
+    def test_the_055_docstring_produces_no_phantom_tables_today(self) -> None:
+        """Pins the CURRENT real-tree state: this exact phantom must not
+        appear, so a regression is caught immediately."""
+        coarse = ttl_registry_module._coarse_ttl_table_sweep()
+        assert "to" not in coarse
+        assert "statement" not in coarse
+
+    def test_the_055_docstring_stays_safe_even_if_interval_appears_nearby(
+        self, tmp_path: Path
+    ) -> None:
+        """The adversarial case the real tree currently avoids only by
+        accident (that docstring paragraph happens to lack "INTERVAL"):
+        inject the exact 055 prose PLUS the word "interval" into a
+        synthetic migration and confirm the coarse sweep still finds no
+        phantom table -- proving the fix is STRUCTURAL (the anchored,
+        shared ``_CREATE_TABLE_RE``), not merely "this file doesn't
+        currently trip it".
+        """
+        migrations_dir = tmp_path / "clickhouse"
+        migrations_dir.mkdir()
+        (migrations_dir / "999_synthetic.py").write_text(
+            '"""\n'
+            "    1. SHOW CREATE TABLE to get the live DDL (preserves columns,\n"
+            "       partitioning, the existing ORDER BY, settings, codecs, TTL,\n"
+            "       and the retention interval).\n"
+            '"""\n'
+            "def regex_for_table_name():\n"
+            '    """Regex for the table name in a CREATE TABLE statement."""\n'
+        )
+        original = ttl_registry_module._MIGRATIONS_DIR
+        ttl_registry_module._MIGRATIONS_DIR = migrations_dir
+        clickhouse_ttl_retentions.cache_clear()
+        ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
+        try:
+            coarse = ttl_registry_module._coarse_ttl_table_sweep()
+            assert coarse == frozenset(), (
+                f"expected no phantom tables, got {sorted(coarse)}"
+            )
+        finally:
+            ttl_registry_module._MIGRATIONS_DIR = original
+            clickhouse_ttl_retentions.cache_clear()
+            ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
+
+
+class TestCoarseTtlDetectionIsWordBoundaried:
+    """Codex round-4 finding (MED): naive substring checks ("TTL" in text,
+    "INTERVAL" in text) match INSIDE other identifiers. Confirmed a real
+    occurrence in this repo's migrations: ``toIntervalDay`` (used in
+    008_grafana_panel_views.sql's view definitions) contains "Interval" as
+    a substring. It does not currently misfire only because that specific
+    statement is a ``CREATE OR REPLACE VIEW`` (not a table) and lacks "TTL"
+    too -- the word-boundary fix must hold regardless of that coincidence.
+    """
+
+    def test_tointervaday_next_to_a_real_ttl_keyword_does_not_satisfy_the_pattern(
+        self,
+    ) -> None:
+        """A genuine "TTL" keyword co-occurring with `toIntervalDay` (which
+        contains "Interval" as a bare substring, not a keyword) must NOT be
+        treated as a TTL clause -- this is the scenario a naive substring
+        check gets wrong; matching this string is exactly the failure mode
+        being guarded against.
+        """
+        assert not ttl_registry_module._COARSE_TTL_RE.search(
+            "-- TTL note: see toIntervalDay(30) for the window function"
+        )
+
+    def test_a_hypothetical_throttled_table_next_to_a_real_interval_does_not_match(
+        self,
+    ) -> None:
+        """A table NAME containing "TTL" as a substring (not a keyword),
+        co-occurring with a genuine "INTERVAL" elsewhere, must NOT be
+        treated as a TTL clause.
+        """
+        assert not ttl_registry_module._COARSE_TTL_RE.search(
+            "CREATE TABLE throttled_requests (x String) ENGINE = MergeTree() "
+            "-- retry INTERVAL is configured elsewhere"
+        )
+
+    def test_a_genuine_ttl_clause_with_any_time_unit_still_matches(self) -> None:
+        for unit in ("DAY", "WEEK", "MONTH", "HOUR"):
+            assert ttl_registry_module._COARSE_TTL_RE.search(
+                f"TTL occurred_at + INTERVAL 4 {unit}"
+            ), f"failed to match a bare TTL clause using {unit}"
+
+
+class TestAlterTableModifyTtlCoverage:
+    """Codex round-4 finding (MED, confirmed dormant): ``ALTER TABLE x
+    MODIFY TTL ...`` -- the standard way to add or change retention on an
+    EXISTING table -- was invisible to all three sources (precise parser,
+    coarse sweep, KNOWN_TTL_TABLES): a CREATE-time-only blind spot shared
+    by all of them. No real migration uses this syntax today, so it cannot
+    be demonstrated against the real tree; proven synthetically instead.
+    """
+
+    def test_the_real_tree_has_no_alter_table_modify_ttl_today(self) -> None:
+        """Documents the premise this test class depends on: if this ever
+        becomes false, the synthetic tests below stop being the only
+        coverage and this repo's own migrations should be re-examined."""
+        for path in sorted(ttl_registry_module._MIGRATIONS_DIR.glob("*")):
+            if path.suffix not in {".sql", ".py"}:
+                continue
+            assert not ttl_registry_module._ALTER_TABLE_MODIFY_TTL_RE.search(
+                path.read_text(encoding="utf-8")
+            ), (
+                f"{path.name} has an ALTER TABLE MODIFY TTL -- update this test's premise"
+            )
+
+    def test_an_alter_table_modify_ttl_is_found_by_the_coarse_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        migrations_dir = tmp_path / "clickhouse"
+        migrations_dir.mkdir()
+        (migrations_dir / "999_synthetic.sql").write_text(
+            "ALTER TABLE existing_table MODIFY TTL created_at + INTERVAL 60 DAY;"
+        )
+        original = ttl_registry_module._MIGRATIONS_DIR
+        ttl_registry_module._MIGRATIONS_DIR = migrations_dir
+        clickhouse_ttl_retentions.cache_clear()
+        ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
+        try:
+            coarse = ttl_registry_module._coarse_ttl_table_sweep()
+            assert "existing_table" in coarse, (
+                "the coarse sweep did not find a table whose TTL was added "
+                "via ALTER TABLE ... MODIFY TTL -- the CREATE-only blind "
+                "spot is still open"
+            )
+        finally:
+            ttl_registry_module._MIGRATIONS_DIR = original
+            clickhouse_ttl_retentions.cache_clear()
+            ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
+
+
+class TestMultiTableChunkAttribution:
+    """Codex round-4 finding (MED, confirmed dormant): the original
+    ``.search()``-based version always paired the FIRST CREATE TABLE with
+    the FIRST TTL clause in a ``;``-delimited chunk -- wrong if a LATER
+    CREATE TABLE in the SAME chunk (no semicolons at all, as several real
+    ``.py`` migrations have -- 027, 028, 067 each have zero, checked
+    directly) owns the TTL clause. No real ``.py`` migration currently
+    carries a TTL at all, so this is proven synthetically.
+    """
+
+    def test_a_ttl_in_the_second_table_of_a_no_semicolon_chunk_is_attributed_correctly(
+        self, tmp_path: Path
+    ) -> None:
+        migrations_dir = tmp_path / "clickhouse"
+        migrations_dir.mkdir()
+        (migrations_dir / "999_synthetic.py").write_text(
+            "SQL = '''\n"
+            "CREATE TABLE first_table (\n"
+            "    id String\n"
+            ") ENGINE = MergeTree() ORDER BY id\n"
+            "CREATE TABLE second_table (\n"
+            "    occurred_at DateTime64(3, 'UTC')\n"
+            ") ENGINE = MergeTree()\n"
+            "TTL toDateTime(occurred_at) + INTERVAL 20 DAY DELETE\n"
+            "'''\n"
+        )
+        original = ttl_registry_module._MIGRATIONS_DIR
+        ttl_registry_module._MIGRATIONS_DIR = migrations_dir
+        clickhouse_ttl_retentions.cache_clear()
+        ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
+        try:
+            retentions = clickhouse_ttl_retentions()
+            assert "second_table" in retentions, (
+                "the TTL clause belonging to the SECOND CREATE TABLE in a "
+                "semicolon-free chunk was not attributed to it"
+            )
+            assert "first_table" not in retentions, (
+                "the TTL was misattributed to the FIRST CREATE TABLE in "
+                "the chunk instead of the one it actually follows"
+            )
+            assert retentions["second_table"].retention_days == 20
+
+            coarse = ttl_registry_module._coarse_ttl_table_sweep()
+            assert "second_table" in coarse
+            assert "first_table" not in coarse
+        finally:
+            ttl_registry_module._MIGRATIONS_DIR = original
+            clickhouse_ttl_retentions.cache_clear()
+            ttl_registry_module._coarse_ttl_table_sweep.cache_clear()
 
 
 class TestComputeDriftDays:


### PR DESCRIPTION
## Summary

CHAOS-3602 (feature/chaos-3498-context-fabric) found and fixed a class of TTL-horizon
mint bugs: ClickHouse deletes TTL'd rows at merge time, silently, so a mint over
horizon-adjacent data is nondeterministic by design. This is **not** a 1:1 cherry-pick
of that fix — main independently landed **PR #1582 / CHAOS-3432/3544 (commit
b7c4753cf, 2026-08-07T08:44)** the same day the feature branch diverged
(merge-base 2026-08-07T06:46), giving main its own working, tested fix for the same
underlying bug via a different (tightest-global-horizon) mechanism:

- `fixtures/ttl_horizon.py`: single tightest-schema-wide TTL horizon
  (`TTL_SAFETY_MARGIN` = 30 days), used to clamp `generate_feature_flags`'s history
  generation.
- `world_snapshot._assert_snapshot_within_shelf_life`: restore-time staleness check
  via `minted_at` + `shelf_life_days` recorded in the manifest at mint time,
  **already wired into `restore_world` and already the sole enforcing restore-time
  guard** — this PR does not touch it.

So this PR ports only what CHAOS-3602 adds **beyond** what CHAOS-3432/3544 already
covers — **clamps derive from main's own canonical margin, not the feature branch's**:
the feature branch's own margin constants (`TTL_SAFETY_MARGIN_DAYS` = 7,
`GENERATOR_SLACK_DAYS` = 3) turned out to be incoherent once ported onto main's actual
restore contract (see "Codex fixes" below) and are **not used for any generation
ceiling** in this PR — only for the mint-time live guard, which is independent of
generation by design.

## What's added

1. **`fixtures/ttl_registry.py`** (new, verbatim from feature branch, plus a
   `KNOWN_TTL_TABLES` closed vocabulary added during review — see below) — per-table
   (not just tightest-global) TTL retention parsed directly from migration source:
   table, column, retention days. `max_safe_backdate_days`/`max_generated_age_days`
   helpers, fully tested (`tests/test_ttl_registry.py`, 39 tests after review).
2. **`world_snapshot._assert_no_ttl_horizon_rows`** — a NEW live pre-dump guard:
   queries actual row ages against the registry right before any dump runs,
   independent of whether generation-time clamping worked correctly. This closes a
   gap CHAOS-3432/3544 cannot see: "generation clamped correctly" and "the live data
   is still safe to snapshot right now" are different claims, and only this guard
   checks the second one. Fails CLOSED if the registry cannot be parsed OR is
   missing any known TTL'd table (see below).
3. **`world_snapshot._dump_clickhouse`** decoded-payload verification with retry
   (up to 3x) — fixes a separately-discovered, TTL-unrelated raw Native-transfer
   flake: a dumped payload has been observed to silently disagree with a
   same-session `count()` on a fully idle table (~2% per-dump rate). A short
   payload is now decoded via a throwaway staging table and never written to disk;
   retried up to 3x, then fails loudly. ClickHouse dumps now get the same
   raw-vs-dumped mismatch assertion the Postgres dump path already had.
4. **Defense-in-depth generator clamps** for the 3 generators main does not clamp
   at all today: `product_telemetry.generate_events`,
   `interactions.generate_telemetry_signal_buckets`,
   `interactions.generate_release_impact_daily`. Each uses
   **`ttl_horizon.max_generated_age_days_for_table()`** — per-table TTL data from
   the registry, combined with `ttl_horizon.py`'s own canonical `TTL_SAFETY_MARGIN`
   (30 days) plus a 1-day strict headroom, so every ceiling stays honest about what
   a restore up to the full advertised 30-day shelf life can still find intact.
   `generate_feature_flags` is already clamped via CHAOS-3432/3544's
   `ttl_horizon.max_generated_history_days` and is deliberately left untouched.

## Review fixes (3 codex rounds + 1 independent confirmation pass, CONFIRM-CLEAN)

### Round 1 (session 019fe169-5395-7b31-85d9-406e4c428726) — 2 HIGH

- **Fail-open pre-dump guard.** `clickhouse_ttl_retentions()` returning `{}`
  (migrations-directory path broken, parser regression) made
  `_assert_no_ttl_horizon_rows` treat every table as "no TTL, nothing to check" and
  pass with zero queries issued. Reproduced directly against a fake client that
  would have reported 999999 violating rows had it been queried at all. **Fixed**:
  the guard raises `SnapshotError` if the registry comes back empty, and requires
  the per-table count query to return exactly one scalar row.
- **7d-vs-30d margin incoherence.** The originally-ported generator clamps used
  `ttl_registry.py`'s own (looser) margin constants, incompatible with main's
  actual restore contract. Measured: a row at each ceiling, restored at the full
  advertised 30-day shelf life, lands PAST its own table's TTL —
  `telemetry_signal_bucket` 80d+30d=110d vs a 90d TTL, `release_impact_daily`
  355d+30d=385d vs 365d, `product_telemetry_events` 170d+30d=200d vs 180d. **Fixed**:
  added `ttl_horizon.max_generated_age_days_for_table()` (described above).

### Round 2 (session 019fe190-1f68-7002-ba23-2ddc8d238fca) — 3 HIGH + 1 medium

- **Partial registries still fail open (HIGH).** "Non-empty" ≠ "complete": dropping
  just `telemetry_signal_bucket` from an otherwise-full registry let a fake client
  reporting 999999 violating rows for that exact table pass silently — `.get(table)`
  returning `None` is indistinguishable from "genuinely no TTL". **Fixed**: added
  `ttl_registry.KNOWN_TTL_TABLES`, a closed vocabulary of the 4 known TTL'd tables;
  both `_assert_no_ttl_horizon_rows` and `max_generated_age_days_for_table` now
  require `retentions.keys() >= KNOWN_TTL_TABLES` before trusting any lookup. Also
  fixed `X or fallback` → `is None` at all 3 generator clamp call sites — a
  legitimate 0-day ceiling was falling back to the unclamped request (RED-verified:
  a monkeypatched 0-day ceiling produced ~4800 buckets instead of near-zero).
- **Boundary equality (HIGH, low current severity per codex's own concession, fixed
  anyway).** A non-strict `ceiling + 30 <= retention_days` allows landing EXACTLY on
  a table's TTL horizon, while the live pre-dump guard treats `<= now() - N DAY` as
  unsafe and ClickHouse's TTL deletion is asynchronous. **Fixed**: added
  `PER_TABLE_CEILING_HEADROOM_DAYS = 1`; the invariant test now requires strict `<`
  (RED-verified: reverting the headroom reproduced the exact predicted 90==90
  boundary failure).
- **Restore-ordering / exception-hierarchy (HIGH) — confirmed but PRE-EXISTING on
  `origin/main`, not part of this PR's delta.** `restore_world` calls
  `_assert_snapshot_within_shelf_life` *after* both DB writes complete, and
  `SnapshotExpiredError` doesn't share a hierarchy with `SnapshotError`. Verified
  directly against `origin/main` (same ordering at its own lines 1520-1537,
  predating both commits on this branch). Filed as **CHAOS-3611** (related to
  CHAOS-3602) rather than fixed here — this PR is scoped to porting the TTL-guard
  set; auditing/fixing main's whole restore-ordering contract is a separate change.
- **One-row check ≠ one-scalar check (medium).** `result_rows == [[]]` (one row,
  zero columns) passed a bare `len() == 1` check and then raised an uncontrolled
  `IndexError` instead of a named error; `[[0, "extra"]]` passed silently; the dump
  retry loop's two count() extractions had no validation at all. **Fixed**: added a
  centralized `_scalar_count(result, context, default=None)` helper used at every
  count() call site in this module.

### Round 3 (session 019fe1b0-a0cd-7373-acec-1ee743f681d3) — 1 HIGH

- **Fifth-table bypass via the TTL vocabulary.** `KNOWN_TTL_TABLES` is
  hand-maintained, and every existing check only compared the parsed registry
  against it — a table that never enters EITHER the registry (an unmatched TTL
  syntax variant) NOR `KNOWN_TTL_TABLES` (nobody knew about it) satisfies "the
  registry covers every known table" trivially. The vocabulary was checking itself
  against itself. Reproduced directly: a synthetic `TTL occurred_at + INTERVAL 4
  WEEK` (real ClickHouse syntax) never matches `_TTL_RE`, which requires the
  literal word "DAY" — the table enters neither source. **Fixed**: added
  `_coarse_ttl_table_sweep()`, a second, INDEPENDENT, deliberately looser pass over
  the same migration files (bare "TTL"+"INTERVAL" substrings, no time-unit
  requirement, unanchored table-name regex — a strict superset of the precise
  parser by construction), and `assert_ttl_vocabulary_is_consistent()`, which
  cross-checks three sources (precise parser, coarse sweep, `KNOWN_TTL_TABLES`)
  pairwise in BOTH directions and fails loudly on any mismatch. Also verified and
  pinned (per review): both scanners already glob `.py` migrations, not just
  `.sql` — this repo's ClickHouse migrations are both, and a table declared only
  in a `.py` migration would otherwise reproduce the exact same vacuous-pass one
  directory over; no real `.py` migration carries a TTL today, so a synthetic test
  feeds the parser a `.py`-sourced TTL directly to prove the coverage rather than
  assert it.

### Round 4 (top-tier fallback confirmation reviewer — codex singleton was unavailable) — 1 HIGH + 3 medium

- **Coarse sweep's own table-name regex matched prose, LIVE on the real tree
  (HIGH).** `_COARSE_CREATE_TABLE_RE` had no line anchor and no trailing `(`.
  Reproduced directly: running it against
  `055_work_item_daily_rollups_replacing_merge_tree.py`'s own docstring yielded
  phantom tables `'to'` (from "SHOW CREATE TABLE to get the live DDL") and
  `'statement'` (from "the table name in a CREATE TABLE statement.") — silenced
  only because that chunk currently lacks the substring "INTERVAL"; one
  unrelated docstring edit would have aborted all fixture generation over a
  table that doesn't exist. Also disproved the "strict superset by
  construction" claim as stated. **Fixed**: the coarse sweep no longer has its
  own table-name regex — it reuses the SAME anchored `_CREATE_TABLE_RE` the
  precise parser uses. This is a **named design tradeoff**: the two scanners'
  independence now lives entirely on the TTL-DETECTION axis, never on DDL
  location — a CREATE-statement shape neither regex matches now blinds BOTH
  sources identically (see R3 below), accepted deliberately because
  DDL-location disagreement between two different regexes was proven to be
  pure parsing noise, not signal.
- **Substring "TTL"/"INTERVAL" checks match inside other identifiers
  (medium).** The reviewer's specific citation
  (`008_grafana_panel_views.sql`, `throttled_requests`/`toStartOfInterval`)
  **does not exist in this repo** — checked directly, that content isn't
  there; the finding was partially misattributed. The underlying mechanism is
  real regardless: `toIntervalDay` genuinely exists in 008's view definitions
  and does contain "Interval" as a substring; it doesn't currently misfire
  only because that statement is a `CREATE OR REPLACE VIEW` (not a table) and
  lacks "TTL" too. **Fixed anyway**: `_COARSE_TTL_RE` is now word-boundaried
  (`\bTTL\b.*?\bINTERVAL\b`), matching any time unit while no longer matching
  inside a longer identifier.
- **CREATE-only blind spot shared by all three sources (medium, confirmed
  dormant).** `ALTER TABLE x MODIFY TTL ...` — the standard way to add
  retention to an existing table — was invisible to the precise parser, the
  coarse sweep, and `KNOWN_TTL_TABLES` alike. No real migration uses this
  syntax today (checked directly). **Fixed**: the coarse sweep also scans for
  this form; verified zero effect on the real tree.
- **Multi-table misattribution in one chunk (medium, confirmed dormant).**
  Both scanners took the FIRST CREATE TABLE and FIRST TTL match per
  `;`-delimited chunk. This repo's `.py` migrations frequently have ZERO
  semicolons (027, 028, 067 checked directly) — a second CREATE TABLE's TTL in
  the same chunk would be misattributed to the first. Dormant only because no
  `.py` migration carries a TTL today. **Fixed**: a shared
  `_attribute_ttl_matches` helper associates every TTL match with the CLOSEST
  PRECEDING CREATE TABLE (via `finditer`, not a single `.search()`), fixing
  this for both scanners at once.

12 new tests, each RED-verified: planted the exact pre-fix behavior back in,
confirmed the new test fails with the predicted phantom table / false match /
misattribution, restored byte-identical, confirmed green again.

All fixes across all four rounds RED-verified: planted each defect, confirmed
the new/existing tests fail with the predicted numbers, restored byte-identical
(diffed against a backup), confirmed green again.

## Known residuals — measured zero-exposure on the current tree

Identified in the final confirmation pass (CONFIRM-CLEAN verdict); all
non-blocking, all verified to have zero effect on the real migrations
directory today. Documented per standing policy rather than fixed, to avoid
gold-plating a converged design:

- **R1 — DOTALL span can cross a CREATE boundary.** `_COARSE_TTL_RE`'s
  `re.DOTALL` lets its `TTL...INTERVAL` span cross into a SECOND CREATE TABLE
  in a multi-CREATE, semicolon-free chunk. Zero such chunks exist today. The
  in-code docstring's "STRUCTURAL guarantee" wording overstates this slightly
  for that reason — treat it as "structural for today's migration shapes,"
  not an absolute.
- **R2 — co-occurrence, not syntactic relation, is still the trigger.**
  `_COARSE_TTL_RE` only requires "TTL" and "INTERVAL" to co-occur anywhere in
  the same chunk, not to belong to the same clause. Zero chunks in the real
  tree trigger this today (vs. round-3's fifth-table gap, which was one word
  away from firing).
- **R3 — the shared anchored locator narrows coarse coverage for exotic DDL.**
  `_CREATE_TABLE_RE` doesn't match `ON CLUSTER` or database-prefixed
  (`db.table`) CREATE TABLE forms, and the new `ALTER ... MODIFY TTL` scan
  only covers the plain form. Neither shape exists in any migration today.
  This is the direct consequence of the round-4 F1 fix's named tradeoff.
- **R4 — the precise parser now records the LAST TTL clause per table, not
  the first.** For a table with both a column-level and table-level TTL
  clause, `_attribute_ttl_matches`'s multi-match walk keeps the most recent
  match. This is arguably an IMPROVEMENT (matches ClickHouse's own
  last-clause-wins semantics) but is a silent behavior change worth naming;
  not "fixed" with a `min()` — the new behavior is more correct.
- **R5 — the 055-phantom regression test pins two literal strings.**
  `TestCoarseSweepDoesNotMatchProse` asserts `'to'`/`'statement'` are absent
  by name rather than asserting `coarse == precise` generally; the general
  class fence is `TestVocabularyConsistency::test_the_real_repo_is_
  internally_consistent`, not this test.
- **R6 — the `.py` coverage claim is narrower than it sounds.** This repo's
  real `.py` migration idiom is a runtime rebuild from `SHOW CREATE TABLE`
  (nothing static to scan); a future migration that builds DDL via an f-string
  rather than a literal `SQL = """..."""` block would be invisible to BOTH
  scanners — same family of gap as R3.

## What's deliberately NOT wired (and why)

`ttl_registry.assert_snapshot_not_expired` / `snapshot_expiry` are included in
`ttl_registry.py` and fully tested, but **not called from `restore_world`**.
They use a much tighter margin (`TTL_SAFETY_MARGIN_DAYS` = 7, `RESTORE_SIDE_SLACK_DAYS`
= 2 → ~5 effective days) than main's existing, already-enforced
`_assert_snapshot_within_shelf_life` (`TTL_SAFETY_MARGIN` = 30 days, calibrated for
the snapshot main actually minted). Wiring both as enforcing checks would risk
failing a restore of an already-valid, CHAOS-3432/3544-compliant snapshot against an
uncalibrated, much stricter threshold that was never validated against main's mint —
exactly the class of incoherence the round-1 codex fix above had to correct on the
generation side.

**`snapshot_expiry(manifest.pinned_now)` is still recorded informationally** as
`manifest["ttl_shelf_life_expiry"]` at mint time (next mint only — this PR does not
re-mint main's committed snapshot) so a human can see it without doing the
arithmetic, but it enforces nothing. `_assert_snapshot_within_shelf_life` remains
the **sole** restore-time staleness enforcer on main.

If a future change wants to consolidate onto the tighter, per-table margin, that's
a deliberate, separate decision — not something this PR does silently.

## Explicitly out of scope

Per the authorized subset for this port: migration 074/075
(`project_declared_state_history`), the declared-state-history read/write path,
`derived_store_registry.py` (CHAOS-3566 org-deletion registry), and CHAOS-3602's
`world.py` pinned_now-drift-compensation wiring (`assert_pinned_now_not_too_stale`/
`drift_days_context`) — not part of the named guard set, and would touch
generation control flow for marginal benefit given main's other generators aren't
drift-anchored the same way today. The full feature→main merge remains blocked on
explicit approval.

## Known adjacent defects (seen, not missed)

- **CHAOS-3611** — `restore_world` checks snapshot shelf-life after writing both
  databases; `SnapshotExpiredError` doesn't share `SnapshotError`'s hierarchy.
  Pre-existing on `origin/main`, unrelated to this PR's delta. Related to CHAOS-3602.

## Verification

- `ruff format --check` / `ruff check`: clean.
- `mypy`: clean on all changed source files.
- `tests/test_ttl_registry.py`: 39 tests, all passing.
- Targeted offline suite: 171 passed (`test_fixtures_world_snapshot.py`,
  `test_ttl_registry.py`, `test_fixtures_ttl_horizon.py`,
  `test_fixtures_feature_flags.py`, `test_product_telemetry_generator.py`).
- Broader sweep `pytest tests/ -k "fixtures or world_snapshot or ttl" -m "not
  benchmark and not clickhouse"`: 690 passed, 1 unrelated pre-existing skip.
- RED/GREEN-verified every new guard and every review fix (all 4 rounds) by
  planting the exact defect each exists to catch, confirming the new tests
  fail, then restoring byte-identical (diffed against a backup) and
  confirming green again.
- Full `bash ci/local_validate.sh` gate: **GATE PASSED**, 8/8 stages
  (`GATE_STAGE_MANIFEST result=PASSED declared=8 executed=8`). Unit suite:
  13593 passed, 240 skipped (env-gated, unrelated), 1 xfailed (pre-existing,
  unrelated). Live argMax-exec proof against the real engine passed. Run
  twice (once per production-code-changing round); both green.
- **Live mint/restore stress pass**: fresh acceptance stack (port 18081),
  ran `scripts/acceptance/mint_ask_dev_world_snapshot.sh` unmodified end to
  end — 14-repo generation (clamped generators fired for real), snapshot of
  86 ClickHouse + 10 Postgres tables (`_assert_no_ttl_horizon_rows` ran with
  zero violations; `_dump_clickhouse`'s decode-verify-retry ran for all 86
  tables with zero retries needed), restore + mint-digest, lossless
  round-trip proof (digests matched), all 10 corpus contract principals
  authenticated. Zero exceptions, zero TTL warnings, zero retry warnings
  across a 1756-line log. The resulting re-mint of main's committed snapshot
  was discarded afterward (`git checkout -- tests/acceptance/world/`) since
  re-minting main's snapshot is out of scope for this PR; confirmed clean
  tree. Acceptance stack torn down; dev shared stack confirmed untouched
  throughout.

## Linear

CHAOS-3602 (parent CHAOS-3498). Adjacent: CHAOS-3611.

