### PR TITLE
CHAOS-3570: treat NULL valid_from as satisfying as-of filters

### DIFF
--- a/src/dev_health_ops/audit/completeness.py
+++ b/src/dev_health_ops/audit/completeness.py
@@ -103,10 +103,24 @@ def build_incidents_query() -> str:
     current_mappings = current_operational_rows_sql(
         "operational_service_repository_mappings",
         (
-            "is_deleted = 0",
+            # CHAOS-3604: no `is_deleted` predicate here -- unlike
+            # operational_incidents, operational_service_repository_mappings
+            # has no `is_deleted` column. A stray `is_deleted = 0` filter
+            # here previously crashed this query outright against a live
+            # ClickHouse engine ("Correlated subqueries are not supported in
+            # JOINs yet") because the analyzer resolved the unknown column
+            # name across the JOIN into the sibling incident subquery's own
+            # `is_deleted` instead of raising a normal missing-column error.
+            # The mapping table has no soft-delete column at all, so no
+            # replacement filter belongs here -- do not re-add one.
+            # Pre-existing, unrelated to CHAOS-3570; fixed alongside it
+            # because it blocked live-verifying this reader.
             "is_active = 1",
             "repo_id IS NOT NULL",
-            "valid_from <= {as_of:DateTime64(6, 'UTC')}",
+            # CHAOS-3570: valid_from is Nullable; NULL <= x is false in
+            # ClickHouse, so a NULL valid_from ("valid since before records
+            # began") must be treated as satisfying the as-of filter.
+            "(valid_from IS NULL OR valid_from <= {as_of:DateTime64(6, 'UTC')})",
             "(valid_to IS NULL OR valid_to > {as_of:DateTime64(6, 'UTC')})",
         ),
     )

--- a/src/dev_health_ops/audit/completeness.py
+++ b/src/dev_health_ops/audit/completeness.py
@@ -124,19 +124,37 @@ def build_incidents_query() -> str:
             "(valid_to IS NULL OR valid_to > {as_of:DateTime64(6, 'UTC')})",
         ),
     )
+    # A service can carry more than one currently-active mapping identity to
+    # the same repository (e.g. an admin_configuration row alongside a
+    # bounded_service_repository_heuristic row -- see
+    # work_graph.operational_edges.build_operational_incident_edges's own
+    # preferred_mappings dedup for the same fan-out). Without deduping the
+    # join, one incident is counted once per coexisting mapping identity.
+    # Mirror active_incidents_query's own reviewed
+    # `ORDER BY ... LIMIT 1 BY repo_id, incident_id` pattern: collapse to one
+    # (repo_id, incident_id) pair before aggregating.
     return f"""
     SELECT
-      mapping.repo_id,
+      repo_id,
       countIf(
-        incident.started_at >= {{start:DateTime}}
-        AND incident.started_at < {{end:DateTime}}
+        started_at >= {{start:DateTime}}
+        AND started_at < {{end:DateTime}}
       ) AS count,
-      max(incident.last_synced) AS last_synced
-    FROM {current_incidents} AS incident
-    INNER JOIN {current_mappings} AS mapping
-      ON incident.org_id = mapping.org_id
-     AND incident.service_id = mapping.service_id
-    GROUP BY mapping.repo_id
+      max(last_synced) AS last_synced
+    FROM (
+        SELECT
+          mapping.repo_id AS repo_id,
+          incident.id AS incident_id,
+          incident.started_at AS started_at,
+          incident.last_synced AS last_synced
+        FROM {current_incidents} AS incident
+        INNER JOIN {current_mappings} AS mapping
+          ON incident.org_id = mapping.org_id
+         AND incident.service_id = mapping.service_id
+        ORDER BY mapping.repo_id, incident.id, incident.last_synced DESC
+        LIMIT 1 BY mapping.repo_id, incident.id
+    )
+    GROUP BY repo_id
     """
 
 

--- a/src/dev_health_ops/metrics/active_incidents.py
+++ b/src/dev_health_ops/metrics/active_incidents.py
@@ -57,7 +57,10 @@ def active_incidents_query(
         (
             "repo_id IS NOT NULL",
             "is_active = 1",
-            "valid_from <= {as_of:DateTime64(6, 'UTC')}",
+            # CHAOS-3570: valid_from is Nullable; NULL <= x is false in
+            # ClickHouse, so a NULL valid_from ("valid since before records
+            # began") must be treated as satisfying the as-of filter.
+            "(valid_from IS NULL OR valid_from <= {as_of:DateTime64(6, 'UTC')})",
             "(valid_to IS NULL OR valid_to > {as_of:DateTime64(6, 'UTC')})",
         ),
     )

--- a/src/dev_health_ops/work_graph/operational_edges.py
+++ b/src/dev_health_ops/work_graph/operational_edges.py
@@ -43,7 +43,10 @@ def build_operational_incident_edges(
     deployment_window = _timestamp_window("deployed_at", from_date, to_date)
     mapping_filters = (
         "is_active = 1",
-        "valid_from <= {now:DateTime}",
+        # CHAOS-3570: valid_from is Nullable; NULL <= x is false in
+        # ClickHouse, so a NULL valid_from ("valid since before records
+        # began") must be treated as satisfying the as-of filter.
+        "(valid_from IS NULL OR valid_from <= {now:DateTime})",
         "(valid_to IS NULL OR valid_to > {now:DateTime})",
         *(("repo_id = {repo_id:UUID}",) if repo_id else ()),
     )

--- a/tests/metrics/test_active_incidents.py
+++ b/tests/metrics/test_active_incidents.py
@@ -42,7 +42,9 @@ def test_active_incidents_query_projects_mapped_canonical_rows_with_org_scope(
     assert "incident.service_id = mapping.service_id" in query
     assert "repo_id IS NOT NULL" in query
     assert "is_active = 1" in query
-    assert "valid_from <= {as_of:DateTime64(6, 'UTC')}" in query
+    # CHAOS-3570: a NULL valid_from ("valid since before records began")
+    # must satisfy the as-of filter -- NULL <= x is false in ClickHouse.
+    assert "(valid_from IS NULL OR valid_from <= {as_of:DateTime64(6, 'UTC')})" in query
     assert "resolved_at IS NOT NULL" in query
     assert "incident.id AS incident_id" in query
 

--- a/tests/test_audit_completeness.py
+++ b/tests/test_audit_completeness.py
@@ -48,6 +48,17 @@ def test_incident_query_uses_canonical_service_mapping_projection(monkeypatch):
     # against a live ClickHouse engine. Never re-add it.
     mapping_clause = query.split("INNER JOIN")[1]
     assert "is_deleted" not in mapping_clause
+    # Codex review (CHAOS-3570 PR #1605): a service can carry more than one
+    # currently-active mapping identity to the same repository, so the
+    # incident/mapping JOIN must collapse to one (repo_id, incident.id) pair
+    # before countIf aggregates -- otherwise one incident is counted once
+    # per coexisting mapping identity. This ALWAYS-ON offline test is the
+    # only CI-visible tripwire for that collapse: the behavioral proof lives
+    # in a @pytest.mark.clickhouse live test, which CI filters out of both
+    # unit_tests() and ci_tests() (and would self-skip against CI's own
+    # CLICKHOUSE_URI=.../default anyway) -- so this text pin is what a
+    # regression in either CI tier can actually catch.
+    assert "LIMIT 1 BY mapping.repo_id, incident.id" in query
 
 
 def test_infer_repo_source_prefers_settings():

--- a/tests/test_audit_completeness.py
+++ b/tests/test_audit_completeness.py
@@ -40,6 +40,14 @@ def test_incident_query_uses_canonical_service_mapping_projection(monkeypatch):
     assert "incident.service_id = mapping.service_id" in query
     assert "is_active = 1" in query
     assert query.count("WHERE org_id = {org_id:String}") >= 2
+    # CHAOS-3570: a NULL valid_from ("valid since before records began")
+    # must satisfy the as-of filter -- NULL <= x is false in ClickHouse.
+    assert "(valid_from IS NULL OR valid_from <= {as_of:DateTime64(6, 'UTC')})" in query
+    # CHAOS-3604: operational_service_repository_mappings has no
+    # is_deleted column -- filtering it here crashes the query outright
+    # against a live ClickHouse engine. Never re-add it.
+    mapping_clause = query.split("INNER JOIN")[1]
+    assert "is_deleted" not in mapping_clause
 
 
 def test_infer_repo_source_prefers_settings():

--- a/tests/test_pagerduty_clickhouse_live.py
+++ b/tests/test_pagerduty_clickhouse_live.py
@@ -687,12 +687,20 @@ def test_audit_incidents_query_dedupes_coexisting_mapping_identities(
     backfill; see work_graph.operational_edges's own preferred_mappings
     dedup for the same fan-out). Without deduping the incident/mapping
     JOIN, one incident was counted once per coexisting mapping identity.
-    Plants exactly two such active mapping identities for the same
-    service/repo pair -- one dated, one NULL-start -- and asserts the
-    resolved incident is counted exactly once.
+
+    Plants two coexisting active mapping identities (one dated, one
+    NULL-start) for the SAME service/repo pair -- asserting the dedup key's
+    incident.id half -- *and* a third active mapping for the SAME service to
+    a DIFFERENT repository -- asserting the dedup key's repo_id half. A
+    dedup that collapsed on incident.id alone (dropping repo_id from the
+    key) would pass the first case but silently lose the second repo's
+    incident from the audit entirely, since service->multiple-repos is a
+    normal, supported configuration (see
+    work_graph.operational_edges:117-119).
     """
     org_id = "test-chaos-3570-dupe-mapping-dedup"
     repo_id = UUID("55555555-5555-5555-5555-555555555555")
+    other_repo_id = UUID("66666666-6666-6666-6666-666666666666")
     resolved_at = SOURCE_TIME + timedelta(hours=4)
     normalizer = PagerDutyNormalizer(
         org_id=org_id,
@@ -754,6 +762,27 @@ def test_audit_incidents_query_dedupes_coexisting_mapping_identities(
         valid_to=None,
         is_active=True,
     )
+    # A third active mapping for the SAME service to a DIFFERENT repo --
+    # both repos must appear in the result, each counted once.
+    mapping_other_repo = ServiceRepositoryMapping(
+        org_id=org_id,
+        provider="pagerduty",
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        source_entity_type="service_repository_mapping",
+        external_id="service-dupe:github:other/repo:admin",
+        source_version_at=resolved_at,
+        observed_at=resolved_at,
+        last_synced=resolved_at,
+        service_id=service.id,
+        repo_id=other_repo_id,
+        repo_provider="github",
+        repo_full_name="full-chaos/other-repo",
+        mapping_kind="admin",
+        rule_id="service_repository_mapping.admin.v1",
+        valid_from=SOURCE_TIME,
+        valid_to=None,
+        is_active=True,
+    )
 
     async def persist_projection_inputs() -> None:
         async with ClickHouseStore(pagerduty_scratch_dsn) as store:
@@ -761,7 +790,7 @@ def test_audit_incidents_query_dedupes_coexisting_mapping_identities(
             await store.insert_operational_services([service])
             await store.insert_operational_incidents([resolved_incident])
             await store.insert_operational_service_repository_mappings(
-                [mapping_dated, mapping_null_start]
+                [mapping_dated, mapping_null_start, mapping_other_repo]
             )
 
     asyncio.run(persist_projection_inputs())
@@ -778,11 +807,17 @@ def test_audit_incidents_query_dedupes_coexisting_mapping_identities(
                 "as_of": as_of,
             },
         )
-        assert rows
-        assert rows[0]["repo_id"] == repo_id
-        assert rows[0]["count"] == 1, (
+        counts_by_repo = {row["repo_id"]: row["count"] for row in rows}
+        assert set(counts_by_repo) == {repo_id, other_repo_id}, (
+            "expected one row per repository mapped from the service -- a "
+            "dedup keyed on incident.id alone (dropping repo_id) would "
+            "collapse these into one row and silently lose a repo's "
+            "incident from the audit"
+        )
+        assert counts_by_repo[repo_id] == 1, (
             "one incident double-counted across two coexisting active "
             "mapping identities for the same service/repo pair"
         )
+        assert counts_by_repo[other_repo_id] == 1
     finally:
         sink.close()

--- a/tests/test_pagerduty_clickhouse_live.py
+++ b/tests/test_pagerduty_clickhouse_live.py
@@ -18,6 +18,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from dev_health_ops.audit.completeness import build_incidents_query
 from dev_health_ops.metrics.active_incidents import (
     IncidentWindow,
     active_incidents_query,
@@ -59,6 +60,7 @@ from dev_health_ops.providers.pagerduty.models import (
 )
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 from dev_health_ops.storage.clickhouse import ClickHouseStore
+from dev_health_ops.work_graph.operational_edges import build_operational_incident_edges
 
 CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
 SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
@@ -425,5 +427,250 @@ def test_mapped_canonical_pagerduty_incident_drives_incident_metrics(
             "WHERE database = currentDatabase() AND name = 'incidents'",
         )
         assert legacy_table_count.result_rows == [(0,)]
+    finally:
+        sink.close()
+
+
+def test_null_valid_from_mapping_survives_every_as_of_reader(
+    pagerduty_scratch_dsn: str,
+) -> None:
+    """CHAOS-3570: a NULL valid_from service/repo mapping must still answer
+    every as-of consumer of ``operational_service_repository_mappings``.
+
+    ``valid_from`` is ``Nullable`` on that table, and ClickHouse's `NULL <=
+    x` is false, so a naive `valid_from <= {as_of}` predicate silently drops
+    a null-start mapping from every as-of answer. Per CHAOS-3570's agreed
+    semantics, a NULL valid_from means "valid since before records began"
+    and must satisfy any as_of filter (`valid_from IS NULL OR valid_from <=
+    {as_of}`). This plants exactly such a mapping and exercises the real
+    production query builders of all three swept as-of readers.
+    """
+    org_id = "test-chaos-3570-null-valid-from"
+    repo_id = UUID("33333333-3333-3333-3333-333333333333")
+    resolved_at = SOURCE_TIME + timedelta(hours=4)
+    normalizer = PagerDutyNormalizer(
+        org_id=org_id,
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        observed_at=resolved_at,
+    )
+    service = normalizer.service(
+        Service(
+            id="service-3570", name="Null Valid From Service", updated_at=SOURCE_TIME
+        )
+    )
+    resolved_incident = normalizer.incident(
+        Incident(
+            id="incident-3570",
+            title="Null valid_from regression",
+            status="resolved",
+            service=PagerDutyModel(id="service-3570"),
+            created_at=SOURCE_TIME,
+            resolved_at=resolved_at,
+            last_status_change_at=resolved_at,
+            updated_at=resolved_at,
+        )
+    )
+    # Given: a service/repo mapping with a NULL valid_from -- e.g. a mapping
+    # backfilled with no known start, or ingested before valid_from existed.
+    mapping = ServiceRepositoryMapping(
+        org_id=org_id,
+        provider="pagerduty",
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        source_entity_type="service_repository_mapping",
+        external_id="service-3570:github:full-chaos/null-valid-from",
+        source_version_at=resolved_at,
+        observed_at=resolved_at,
+        last_synced=resolved_at,
+        service_id=service.id,
+        repo_id=repo_id,
+        repo_provider="github",
+        repo_full_name="full-chaos/null-valid-from",
+        mapping_kind="admin",
+        rule_id="service_repository_mapping.admin.v1",
+        valid_from=None,
+        valid_to=None,
+        is_active=True,
+    )
+
+    async def persist_projection_inputs() -> None:
+        async with ClickHouseStore(pagerduty_scratch_dsn) as store:
+            store.org_id = org_id
+            await store.insert_operational_services([service])
+            await store.insert_operational_incidents([resolved_incident])
+            await store.insert_operational_service_repository_mappings([mapping])
+
+    asyncio.run(persist_projection_inputs())
+
+    sink = ClickHouseMetricsSink(pagerduty_scratch_dsn)
+    try:
+        sink.client.insert(
+            "repos",
+            [
+                [
+                    repo_id,
+                    "full-chaos/null-valid-from",
+                    None,
+                    SOURCE_TIME,
+                    None,
+                    None,
+                    resolved_at,
+                    org_id,
+                    "github",
+                    None,
+                ]
+            ],
+            column_names=[
+                "id",
+                "repo",
+                "ref",
+                "created_at",
+                "settings",
+                "tags",
+                "last_synced",
+                "org_id",
+                "provider",
+                "source_id",
+            ],
+        )
+
+        as_of = resolved_at + timedelta(seconds=1)
+
+        # When/Then: metrics.active_incidents.active_incidents_query still
+        # projects the incident through the null-start mapping.
+        projected = sink.query_dicts(
+            active_incidents_query(
+                window=IncidentWindow.RESOLVED,
+                org_id=org_id,
+                repo_filter="",
+            ),
+            {
+                "org_id": org_id,
+                "start": SOURCE_TIME,
+                "end": SOURCE_TIME + timedelta(days=1),
+                "as_of": as_of,
+            },
+        )
+        assert len(projected) == 1, (
+            "active_incidents_query dropped a NULL valid_from mapping (CHAOS-3570)"
+        )
+        assert projected[0]["repo_id"] == repo_id
+        assert projected[0]["incident_id"] == resolved_incident.id
+
+        # When/Then: audit.completeness.build_incidents_query still counts
+        # the incident through the null-start mapping.
+        audit_rows = sink.query_dicts(
+            build_incidents_query(),
+            {
+                "org_id": org_id,
+                "start": SOURCE_TIME,
+                "end": SOURCE_TIME + timedelta(days=1),
+                "as_of": as_of,
+            },
+        )
+        assert audit_rows, (
+            "build_incidents_query dropped a NULL valid_from mapping (CHAOS-3570)"
+        )
+        assert audit_rows[0]["repo_id"] == repo_id
+        assert audit_rows[0]["count"] == 1
+
+        # When/Then: work_graph.operational_edges still emits the
+        # MAPS_TO_REPOSITORY edge through the null-start mapping.
+        edges = build_operational_incident_edges(sink, org_id, as_of, 7, 0.3)
+        mapping_edges = [
+            edge for edge in edges if edge.edge_type.value == "maps_to_repository"
+        ]
+        assert mapping_edges, (
+            "build_operational_incident_edges dropped a NULL valid_from mapping "
+            "(CHAOS-3570)"
+        )
+        assert mapping_edges[0].target_id == str(repo_id)
+    finally:
+        sink.close()
+
+
+def test_audit_incidents_query_has_no_soft_delete_predicate_on_mapping_table(
+    pagerduty_scratch_dsn: str,
+) -> None:
+    """CHAOS-3604: build_incidents_query() must not filter `is_deleted` on
+    operational_service_repository_mappings -- that table has no such
+    column. Reintroducing it makes ClickHouse's JOIN analyzer resolve the
+    unknown column into the sibling operational_incidents subquery's own
+    `is_deleted` across the JOIN boundary and reject the query outright
+    with "Correlated subqueries are not supported in JOINs yet"
+    (NOT_IMPLEMENTED) -- a hard crash, not a silently wrong answer. This
+    pins the query executing successfully end to end against a live engine.
+    """
+    org_id = "test-chaos-3604-no-soft-delete-on-mapping"
+    repo_id = UUID("44444444-4444-4444-4444-444444444444")
+    resolved_at = SOURCE_TIME + timedelta(hours=4)
+    normalizer = PagerDutyNormalizer(
+        org_id=org_id,
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        observed_at=resolved_at,
+    )
+    service = normalizer.service(
+        Service(
+            id="service-3604", name="No Soft Delete Service", updated_at=SOURCE_TIME
+        )
+    )
+    resolved_incident = normalizer.incident(
+        Incident(
+            id="incident-3604",
+            title="Audit completeness live-execution regression",
+            status="resolved",
+            service=PagerDutyModel(id="service-3604"),
+            created_at=SOURCE_TIME,
+            resolved_at=resolved_at,
+            last_status_change_at=resolved_at,
+            updated_at=resolved_at,
+        )
+    )
+    mapping = ServiceRepositoryMapping(
+        org_id=org_id,
+        provider="pagerduty",
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        source_entity_type="service_repository_mapping",
+        external_id="service-3604:github:full-chaos/no-soft-delete",
+        source_version_at=resolved_at,
+        observed_at=resolved_at,
+        last_synced=resolved_at,
+        service_id=service.id,
+        repo_id=repo_id,
+        repo_provider="github",
+        repo_full_name="full-chaos/no-soft-delete",
+        mapping_kind="admin",
+        rule_id="service_repository_mapping.admin.v1",
+        valid_from=SOURCE_TIME,
+        is_active=True,
+    )
+
+    async def persist_projection_inputs() -> None:
+        async with ClickHouseStore(pagerduty_scratch_dsn) as store:
+            store.org_id = org_id
+            await store.insert_operational_services([service])
+            await store.insert_operational_incidents([resolved_incident])
+            await store.insert_operational_service_repository_mappings([mapping])
+
+    asyncio.run(persist_projection_inputs())
+
+    sink = ClickHouseMetricsSink(pagerduty_scratch_dsn)
+    try:
+        as_of = resolved_at + timedelta(seconds=1)
+        # Then: the query executes against a live engine (it would raise
+        # DatabaseError with "Correlated subqueries are not supported in
+        # JOINs yet" if the bogus is_deleted predicate were reintroduced)
+        # and counts the mapped incident.
+        rows = sink.query_dicts(
+            build_incidents_query(),
+            {
+                "org_id": org_id,
+                "start": SOURCE_TIME,
+                "end": SOURCE_TIME + timedelta(days=1),
+                "as_of": as_of,
+            },
+        )
+        assert rows
+        assert rows[0]["repo_id"] == repo_id
+        assert rows[0]["count"] == 1
     finally:
         sink.close()

--- a/tests/test_pagerduty_clickhouse_live.py
+++ b/tests/test_pagerduty_clickhouse_live.py
@@ -674,3 +674,115 @@ def test_audit_incidents_query_has_no_soft_delete_predicate_on_mapping_table(
         assert rows[0]["count"] == 1
     finally:
         sink.close()
+
+
+def test_audit_incidents_query_dedupes_coexisting_mapping_identities(
+    pagerduty_scratch_dsn: str,
+) -> None:
+    """Codex review of CHAOS-3570: broadening the as-of predicate to admit
+    NULL valid_from rows widens exposure to a pre-existing double-count --
+    a service can carry more than one currently-active mapping identity to
+    the same repository at once (e.g. an admin_configuration row alongside
+    a bounded_service_repository_heuristic row with a NULL valid_from
+    backfill; see work_graph.operational_edges's own preferred_mappings
+    dedup for the same fan-out). Without deduping the incident/mapping
+    JOIN, one incident was counted once per coexisting mapping identity.
+    Plants exactly two such active mapping identities for the same
+    service/repo pair -- one dated, one NULL-start -- and asserts the
+    resolved incident is counted exactly once.
+    """
+    org_id = "test-chaos-3570-dupe-mapping-dedup"
+    repo_id = UUID("55555555-5555-5555-5555-555555555555")
+    resolved_at = SOURCE_TIME + timedelta(hours=4)
+    normalizer = PagerDutyNormalizer(
+        org_id=org_id,
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        observed_at=resolved_at,
+    )
+    service = normalizer.service(
+        Service(id="service-dupe", name="Dupe Mapping Service", updated_at=SOURCE_TIME)
+    )
+    resolved_incident = normalizer.incident(
+        Incident(
+            id="incident-dupe",
+            title="Coexisting mapping identities regression",
+            status="resolved",
+            service=PagerDutyModel(id="service-dupe"),
+            created_at=SOURCE_TIME,
+            resolved_at=resolved_at,
+            last_status_change_at=resolved_at,
+            updated_at=resolved_at,
+        )
+    )
+    # Given: two DISTINCT active mapping identities (different external_id,
+    # so different canonical ids) for the SAME service -> repo pair.
+    mapping_dated = ServiceRepositoryMapping(
+        org_id=org_id,
+        provider="pagerduty",
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        source_entity_type="service_repository_mapping",
+        external_id="service-dupe:github:x/y:admin",
+        source_version_at=resolved_at,
+        observed_at=resolved_at,
+        last_synced=resolved_at,
+        service_id=service.id,
+        repo_id=repo_id,
+        repo_provider="github",
+        repo_full_name="full-chaos/dupe-mapping",
+        mapping_kind="admin",
+        rule_id="service_repository_mapping.admin.v1",
+        valid_from=SOURCE_TIME,
+        valid_to=None,
+        is_active=True,
+    )
+    mapping_null_start = ServiceRepositoryMapping(
+        org_id=org_id,
+        provider="pagerduty",
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        source_entity_type="service_repository_mapping",
+        external_id="service-dupe:github:x/y:heuristic",
+        source_version_at=resolved_at,
+        observed_at=resolved_at,
+        last_synced=resolved_at,
+        service_id=service.id,
+        repo_id=repo_id,
+        repo_provider="github",
+        repo_full_name="full-chaos/dupe-mapping",
+        mapping_kind="bounded_service_repository_heuristic",
+        rule_id="service_repository_mapping.bounded_name_match.v1",
+        valid_from=None,
+        valid_to=None,
+        is_active=True,
+    )
+
+    async def persist_projection_inputs() -> None:
+        async with ClickHouseStore(pagerduty_scratch_dsn) as store:
+            store.org_id = org_id
+            await store.insert_operational_services([service])
+            await store.insert_operational_incidents([resolved_incident])
+            await store.insert_operational_service_repository_mappings(
+                [mapping_dated, mapping_null_start]
+            )
+
+    asyncio.run(persist_projection_inputs())
+
+    sink = ClickHouseMetricsSink(pagerduty_scratch_dsn)
+    try:
+        as_of = resolved_at + timedelta(seconds=1)
+        rows = sink.query_dicts(
+            build_incidents_query(),
+            {
+                "org_id": org_id,
+                "start": SOURCE_TIME,
+                "end": SOURCE_TIME + timedelta(days=1),
+                "as_of": as_of,
+            },
+        )
+        assert rows
+        assert rows[0]["repo_id"] == repo_id
+        assert rows[0]["count"] == 1, (
+            "one incident double-counted across two coexisting active "
+            "mapping identities for the same service/repo pair"
+        )
+    finally:
+        sink.close()

--- a/tests/work_graph/test_operational_edges.py
+++ b/tests/work_graph/test_operational_edges.py
@@ -380,3 +380,20 @@ def test_repo_scoped_build_rejects_cross_repo_pr_edges_from_note_body() -> None:
     assert len(pr_edges) == 1
     assert "pull/7" in pr_edges[0].evidence
     assert pr_edges[0].repo_id == requested_repo_id
+
+
+def test_mapping_query_treats_null_valid_from_as_satisfying_as_of_filter() -> None:
+    # CHAOS-3570: a NULL valid_from ("valid since before records began")
+    # must satisfy the as-of filter -- NULL <= x is false in ClickHouse.
+    now = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    sink = MagicMock()
+    sink.query_dicts.return_value = []
+
+    build_operational_incident_edges(sink, "org-a", now, 7, 0.3)
+
+    mapping_query = next(
+        call.args[0]
+        for call in sink.query_dicts.call_args_list
+        if "operational_service_repository_mappings" in call.args[0]
+    )
+    assert "(valid_from IS NULL OR valid_from <= {now:DateTime})" in mapping_query


### PR DESCRIPTION
## Summary

- **CHAOS-3570** (HIGH, pre-existing, live in prod): `operational_service_repository_mappings.valid_from` is `Nullable`, and ClickHouse's `NULL <= x` is `false`, so every as-of reader silently dropped mapping rows with a NULL `valid_from` ("valid since before records began" per the ticket's agreed semantics). Fixed all 3 swept readers to `(valid_from IS NULL OR valid_from <= as_of)`:
  - `work_graph/operational_edges.py` (`build_operational_incident_edges`)
  - `metrics/active_incidents.py` (`active_incidents_query`)
  - `audit/completeness.py` (`build_incidents_query`)

  Sweep of all other `valid_from` readers: `team_project_ownership`, `team_repo_ownership`, `team_memberships`, `manual_attribution_fallbacks` all have **non-nullable** `valid_from DateTime64` columns (confirmed via migration DDL), so they're out of scope. `feature_flag_link.valid_from` is Nullable but has zero as-of readers today (write-only) — nothing to fix there.

- **CHAOS-3604** (found live-verifying the third reader): `build_incidents_query()` filtered a bogus `is_deleted = 0` predicate against `operational_service_repository_mappings`, which **has no `is_deleted` column**. Against a live ClickHouse engine this doesn't raise an ordinary missing-column error — the JOIN analyzer resolves the unknown name into the *sibling* `operational_incidents` subquery's own `is_deleted` across the JOIN boundary and rejects the query outright (`Correlated subqueries are not supported in JOINs yet`, NOT_IMPLEMENTED). So this reader has been **completely non-functional against real ClickHouse**, uncaught because its only coverage was string-matching unit tests plus a `@pytest.mark.clickhouse`-gated live suite CI doesn't run. Removed the bogus predicate — **the mapping table has no soft-delete column at all, so no replacement filter belongs there.**

- **Codex review finding, fixed**: `build_incidents_query()` joined incidents to raw mapping rows without deduping by `(repo_id, incident.id)`. A service can carry more than one currently-active mapping identity to the same repository at once (e.g. an `admin_configuration` row alongside a `bounded_service_repository_heuristic` row — `work_graph/operational_edges.py` already anticipates and dedups this same fan-out via its own `preferred_mappings` map). Admitting NULL-`valid_from` rows **widens exposure**: a NULL-start backfill mapping can now coexist with an existing dated mapping for the same service/repo, and each incident for that service was counted once per coexisting mapping identity. Live-repro'd count=2 for one incident before the fix; fixed by mirroring `active_incidents_query`'s own already-reviewed `ORDER BY ... LIMIT 1 BY repo_id, incident_id` dedup pattern. Confirmed count=1 after.

  Investigated and **refuted** the same concern for the other two readers, both live-verified immune: `active_incidents_query` already has this exact dedup baked into its SQL (plus every caller applies `deduplicate_active_incidents()`); `build_operational_incident_edges` already dedups via `preferred_mappings` before emitting edges.

  Note (non-blocking, second review round): the dedup subquery's `ORDER BY` is decorative for correctness — `last_synced` is per-incident and identical across the tied `(repo_id, incident.id)` rows it's meant to break ties on — and unbounded; `uniqExactIf` would be a sort-free equivalent. Mirroring `active_incidents_query`'s already-reviewed idiom exactly was the deliberate choice here rather than introducing a second dedup style in the same file.

- **Codex review round 2, both fixed**:
  1. The new dedup regression test only ran via `-m clickhouse`, which is filtered out of both `unit_tests()` and `ci_tests()` in `ci/run_tests.sh` (confirmed: lines 199 and 285), and its fixture would self-skip anyway against CI's own `CLICKHOUSE_URI=.../default` (`.github/workflows/test.yml:158-159,:308-309`) — so a later refactor dropping the `LIMIT 1 BY` collapse would go green in every CI-gating lane. Added an always-on offline text pin in `tests/test_audit_completeness.py` asserting the exact `LIMIT 1 BY mapping.repo_id, incident.id` clause is present.
  2. The live regression test only planted one repository, so it couldn't distinguish a correct `(repo_id, incident.id)` dedup key from an over-tightened `incident.id`-only key — the latter passes every existing test while silently dropping a repo's incident whenever a service maps to more than one repository (a normal, supported configuration — `work_graph/operational_edges.py:117-119`). Extended the live test with a third active mapping to a different repo for the same service; now asserts both repos appear in the result, each counted exactly once.

## Evidence

RED-first, done live against a real ClickHouse engine (manual scratch db, never touching the dev `default`): planted a NULL-`valid_from` mapping row via the real `ClickHouseStore` write path and ran the actual production query builders. All 3 CHAOS-3570 readers observably dropped the row before the fix; the CHAOS-3604 reader crashed outright with the predicate present at all (even with the original, unmodified `valid_from <= as_of`, before any of this PR's changes). The double-count reproduction planted two distinct active mapping identities for the same service/repo pair and observed `count: 2` on the unfixed query, `count: 1` after. All confirmed GREEN after the fixes.

**Test venue (codex review — CI does not execute these live tests):** these live-ClickHouse tests are `@pytest.mark.clickhouse`-marked, which is filtered out of both `unit_tests()` and `ci_tests()` in `ci/run_tests.sh` — a standing, repo-wide design decision (CI has no ClickHouse), not something introduced by this PR. The local gate (`ci/local_validate.sh`) also does **not** execute this file — I confirmed its live-CH stages are limited to the argMax proof, `tests/api/dev/test_project_declared_state_history_clickhouse_live.py`, and `tests/test_migration_075_reconcile_clickhouse_live.py`; `test_pagerduty_clickhouse_live.py` is not among them. **The evidence of record for every live assertion in this PR is my manual scratch-ClickHouse runs** (`chaos_3570_manual_verify`, created/dropped via `docker exec`, `default` never touched), documented above and re-run after each fix. This is a residual coverage-venue gap on the existing `-m clickhouse` suite as a whole, not specific to this PR's tests — flagging as a gate-config question for the orchestrator/chris rather than unilaterally changing CI or gate scope in this changeset.

Tests added/updated:
- `tests/test_pagerduty_clickhouse_live.py`:
  - `test_null_valid_from_mapping_survives_every_as_of_reader` (CHAOS-3570, all 3 readers end-to-end)
  - `test_audit_incidents_query_has_no_soft_delete_predicate_on_mapping_table` (CHAOS-3604)
  - `test_audit_incidents_query_dedupes_coexisting_mapping_identities` (codex double-count finding)
- Offline pins tightened to the exact predicate shape (not just substring) in `tests/metrics/test_active_incidents.py`, `tests/test_audit_completeness.py`, and a new unit test in `tests/work_graph/test_operational_edges.py` capturing the real query text.

**Residual (deferred, codex review):** codex also suggested adding future-start `valid_from`, expired `valid_to`, and duplicate-mapping edge cases to the live test file beyond the new double-count regression. Not added in this PR — the double-count finding already got a dedicated fixture-based test, and those additional cases test boundary behavior this PR doesn't change, not a defect this PR introduces.

## Related tickets

- CHAOS-3570 (this PR) — evidence comment posted with file:line references.
- CHAOS-3604 (filed this session, parent CHAOS-3498, related CHAOS-3570) — the `is_deleted` phantom-column crash, fixed alongside CHAOS-3570.
- CHAOS-3607 (filed this session, parent CHAOS-3498, related CHAOS-3563) — separate, NOT fixed here: `operational_incidents`' live schema is missing 4 columns the `OperationalIncident` dataclass declares. Confirmed pre-existing on a clean checkout of this branch's base, orthogonal to this PR.
- CHAOS-3609 (filed by the orchestrator, cherry-picked onto the base branch as `bf2287048`) — unrelated pre-existing mypy type drift in `trials/chaos_3499/` that blocked the gate; fixed on the base branch before this PR's gate run.

## Test plan

- [x] RED-first: planted NULL `valid_from` row, observed each of the 3 readers drop it on unmodified code (live ClickHouse)
- [x] GREEN: same plant, all 3 readers now return the row, after the fix
- [x] CHAOS-3604 regression: `build_incidents_query()` executes successfully against live ClickHouse and returns the expected row/count
- [x] Codex double-count finding: RED (count=2) → GREEN (count=1) live-repro'd and fixed; other 2 readers investigated and refuted with live evidence
- [x] Offline unit suite (full `tests/`, matching CI invocation): 13,377 passed / 245 skipped / 1 xfailed / 0 failures
- [x] `bash ci/local_validate.sh` (plain, full gate incl. live-ClickHouse argMax proof, declared-state-history, migration-075 reconcile stages): **GATE PASSED** at d0886f0a5 and again at 31d6484b1; re-running at 9a6d01a8e after the review-round-2 fixes
- [x] ruff format/check + mypy: clean

