### PR TITLE
CHAOS-3605: port GitHub work-item engine destinations

### DIFF
--- a/internal/providersync/github_work_item_derived_surfaces.go
+++ b/internal/providersync/github_work_item_derived_surfaces.go
@@ -10,12 +10,11 @@ import (
 	"github.com/google/uuid"
 )
 
-// This file ports three of the nine Python-derived work-item destinations:
+// This file owns three of the nine Python-derived work-item destinations:
 // estimate_coverage_metrics_daily, work_item_team_attributions, and
-// work_item_state_durations_daily. The remaining three derived destinations
-// this lane owns (issue_type_metrics_daily and the two investment surfaces)
-// are computed inline inside job_work_items.py and depend on two config-driven
-// engines that have no Go port yet; they land separately.
+// work_item_state_durations_daily. The three config-engine surfaces live in
+// github_work_item_engine_destinations.go because they share a separate,
+// atomic construction contract.
 //
 // Per D16 these builders mirror Python bug-for-bug. Every divergence a reader
 // might mistake for a defect is called out at its site with the Python line it

--- a/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
+++ b/internal/providersync/github_work_item_derived_surfaces_oracle_test.go
@@ -863,7 +863,7 @@ func githubDerivedOracleGoItem(t *testing.T, raw map[string]any) githubWorkItemR
 		WorkItemID: raw["work_item_id"].(string),
 		Provider:   raw["provider"].(string),
 		Title:      raw["title"].(string),
-		Type:       "issue",
+		Type:       githubDerivedOracleString(raw, "type", "issue"),
 		Status:     githubDerivedOracleString(raw, "status", "todo"),
 		ProjectID:  stringPointer(raw["project_id"].(string)),
 		CreatedAt:  githubDerivedOracleTime(t, raw["created_at"].(string)),
@@ -874,12 +874,26 @@ func githubDerivedOracleGoItem(t *testing.T, raw map[string]any) githubWorkItemR
 		parsed := githubDerivedOracleTime(t, value)
 		row.CompletedAt = &parsed
 	}
+	if value, ok := raw["started_at"].(string); ok {
+		parsed := githubDerivedOracleTime(t, value)
+		row.StartedAt = &parsed
+	}
 	if value, ok := raw["closed_at"].(string); ok {
 		parsed := githubDerivedOracleTime(t, value)
 		row.ClosedAt = &parsed
 	}
-	if value, ok := raw["story_points"].(int); ok {
-		points := float64(value)
+	if value, ok := raw["story_points"]; ok && value != nil {
+		var points float64
+		switch typed := value.(type) {
+		case int:
+			points = float64(typed)
+		case int64:
+			points = float64(typed)
+		case float64:
+			points = typed
+		default:
+			t.Fatalf("story_points has unsupported oracle type %T", value)
+		}
 		row.StoryPoints = &points
 	}
 	if value, ok := raw["project_key"].(string); ok {
@@ -888,6 +902,11 @@ func githubDerivedOracleGoItem(t *testing.T, raw map[string]any) githubWorkItemR
 	if values, ok := raw["assignees"].([]any); ok {
 		for _, value := range values {
 			row.Assignees = append(row.Assignees, value.(string))
+		}
+	}
+	if values, ok := raw["labels"].([]any); ok {
+		for _, value := range values {
+			row.Labels = append(row.Labels, value.(string))
 		}
 	}
 	if value, ok := raw["repo_id"].(string); ok {

--- a/internal/providersync/github_work_item_engine_destinations.go
+++ b/internal/providersync/github_work_item_engine_destinations.go
@@ -1,0 +1,414 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	githubIssueTypeMetricsDestination             = "issue_type_metrics_daily"
+	githubInvestmentClassificationsDestination    = "investment_classifications_daily"
+	githubInvestmentMetricsDestination            = "investment_metrics_daily"
+	githubWorkItemEngineDestinationStampPrecision = time.Second
+	githubWorkItemEngineArtifactType              = "work_item"
+)
+
+// githubIssueTypeMetricsDailyRow mirrors IssueTypeMetricsRecord. repo_id is
+// nullable in the migration schema; a nil pointer represents Python's
+// uuid.UUID(int=0) sentinel after it is converted back to None at row creation.
+type githubIssueTypeMetricsDailyRow struct {
+	RepoID         *uuid.UUID               `json:"repo_id"`
+	Day            githubWorkItemDerivedDay `json:"day"`
+	Provider       string                   `json:"provider"`
+	TeamID         string                   `json:"team_id"`
+	IssueTypeNorm  string                   `json:"issue_type_norm"`
+	CreatedCount   int                      `json:"created_count"`
+	CompletedCount int                      `json:"completed_count"`
+	ActiveCount    int                      `json:"active_count"`
+	CycleP50Hours  float64                  `json:"cycle_p50_hours"`
+	CycleP90Hours  float64                  `json:"cycle_p90_hours"`
+	LeadP50Hours   float64                  `json:"lead_p50_hours"`
+	ComputedAt     time.Time                `json:"computed_at"`
+	OrgID          string                   `json:"org_id"`
+}
+
+// githubInvestmentClassificationDailyRow mirrors
+// InvestmentClassificationRecord. InvestmentArea and RuleID remain pointers:
+// the legacy Python dataclass accepts None from a present-and-null rule output,
+// even though ClickHouse cannot persist a null investment_area. The adapter
+// owns that storage refusal; inventing a value in the compute layer would be a
+// Python/Go divergence.
+type githubInvestmentClassificationDailyRow struct {
+	RepoID         *uuid.UUID               `json:"repo_id"`
+	Day            githubWorkItemDerivedDay `json:"day"`
+	ArtifactType   string                   `json:"artifact_type"`
+	ArtifactID     string                   `json:"artifact_id"`
+	Provider       string                   `json:"provider"`
+	InvestmentArea *string                  `json:"investment_area"`
+	ProjectStream  string                   `json:"project_stream"`
+	Confidence     float64                  `json:"confidence"`
+	RuleID         *string                  `json:"rule_id"`
+	ComputedAt     time.Time                `json:"computed_at"`
+	OrgID          string                   `json:"org_id"`
+}
+
+// githubInvestmentMetricsDailyRow mirrors InvestmentMetricsRecord. TeamID is
+// the empty string for Python's unassigned team: the inline producer first
+// maps "unassigned" to None and then applies `or ""` at the record boundary.
+type githubInvestmentMetricsDailyRow struct {
+	RepoID             *uuid.UUID               `json:"repo_id"`
+	Day                githubWorkItemDerivedDay `json:"day"`
+	TeamID             string                   `json:"team_id"`
+	InvestmentArea     *string                  `json:"investment_area"`
+	ProjectStream      string                   `json:"project_stream"`
+	DeliveryUnits      int                      `json:"delivery_units"`
+	WorkItemsCompleted int                      `json:"work_items_completed"`
+	PRsMerged          int                      `json:"prs_merged"`
+	ChurnLOC           int                      `json:"churn_loc"`
+	CycleP50Hours      float64                  `json:"cycle_p50_hours"`
+	ComputedAt         time.Time                `json:"computed_at"`
+	OrgID              string                   `json:"org_id"`
+}
+
+// GitHubWorkItemEngineDeriver is the concrete implementation of the three
+// per-day destinations that depend on config-driven engines. Both engines are
+// one atomic capability: constructing or running a partial engine fails closed
+// instead of fabricating an empty destination for the missing half.
+type GitHubWorkItemEngineDeriver struct {
+	statusMapping        *StatusMapping
+	investmentClassifier *InvestmentClassifier
+}
+
+func NewGitHubWorkItemEngineDeriver(
+	statusMapping *StatusMapping,
+	investmentClassifier *InvestmentClassifier,
+) (*GitHubWorkItemEngineDeriver, error) {
+	if statusMapping == nil || investmentClassifier == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	return &GitHubWorkItemEngineDeriver{
+		statusMapping:        statusMapping,
+		investmentClassifier: investmentClassifier,
+	}, nil
+}
+
+// Derive computes exactly one day's rows. GitHubWorkItemDeriver owns the day
+// loop and appends this map through githubWorkItemMergeEngineRows, so multi-day
+// windows cannot accidentally retain only the last day.
+func (engine *GitHubWorkItemEngineDeriver) Derive(
+	ctx context.Context,
+	claim Claim,
+	rows githubWorkItemRows,
+	day time.Time,
+	computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) (map[string][]json.RawMessage, error) {
+	if ctx == nil || engine == nil || engine.statusMapping == nil ||
+		engine.investmentClassifier == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || !isWorkItemFamilyDataset(claim.Dataset) ||
+		day.IsZero() || computedAt.IsZero() {
+		return nil, ErrInvalidConfiguration
+	}
+	for _, item := range rows.WorkItems {
+		// Validate before every time-window skip. A foreign future row is still a
+		// foreign row and must not become harmless merely because it is inactive.
+		if err := assertGitHubWorkItemDerivedTenancy(claim, item); err != nil {
+			return nil, err
+		}
+	}
+
+	dayUTC := githubWorkItemDerivedUTCDate(day)
+	end := dayUTC.AddDate(0, 0, 1)
+	stamp := githubWorkItemDerivedStamp(
+		computedAt, githubWorkItemEngineDestinationStampPrecision,
+	)
+	issueTypes := buildGitHubIssueTypeMetricsDaily(
+		claim, rows, dayUTC, end, stamp, derived, engine.statusMapping,
+	)
+	classifications, metrics, err := buildGitHubInvestmentDestinationsDaily(
+		claim, rows, dayUTC, end, stamp, derived, engine.investmentClassifier,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	values := map[string]any{
+		githubIssueTypeMetricsDestination:          issueTypes,
+		githubInvestmentClassificationsDestination: classifications,
+		githubInvestmentMetricsDestination:         metrics,
+	}
+	result := make(map[string][]json.RawMessage, len(values))
+	for _, destination := range githubWorkItemDerivedEngineDestinations {
+		value, owned := values[destination]
+		if !owned {
+			return nil, ErrInvalidConfiguration
+		}
+		encoded, err := marshalGitHubWorkItemDerivedRows(value)
+		if err != nil {
+			return nil, err
+		}
+		result[destination] = encoded
+	}
+	if len(result) != len(values) {
+		return nil, ErrInvalidConfiguration
+	}
+	return result, nil
+}
+
+type githubNullableUUIDKey struct {
+	value uuid.UUID
+	valid bool
+}
+
+func newGitHubNullableUUIDKey(value *uuid.UUID) githubNullableUUIDKey {
+	if value == nil || *value == uuid.Nil {
+		return githubNullableUUIDKey{}
+	}
+	return githubNullableUUIDKey{value: *value, valid: true}
+}
+
+func (key githubNullableUUIDKey) pointer() *uuid.UUID {
+	if !key.valid {
+		return nil
+	}
+	value := key.value
+	return &value
+}
+
+type githubIssueTypeMetricsKey struct {
+	repoID                          githubNullableUUIDKey
+	provider, teamID, issueTypeNorm string
+}
+
+type githubIssueTypeMetricsBucket struct {
+	created, completed, active int
+	cycleHours                 []float64
+}
+
+// buildGitHubIssueTypeMetricsDaily mirrors the issue-type path in the production
+// Python work-item engine helper. In particular, the bucket is opened before any
+// time check, so a future-only item still materializes an all-zero row (D16).
+func buildGitHubIssueTypeMetricsDaily(
+	claim Claim,
+	rows githubWorkItemRows,
+	dayUTC, end, computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+	statusMapping *StatusMapping,
+) []githubIssueTypeMetricsDailyRow {
+	buckets := make(map[githubIssueTypeMetricsKey]*githubIssueTypeMetricsBucket)
+	order := make([]githubIssueTypeMetricsKey, 0, len(rows.WorkItems))
+	for _, item := range rows.WorkItems {
+		teamID, _, _ := derived.resolve(githubWorkItemDerivationSubjectFromRow(item))
+		key := githubIssueTypeMetricsKey{
+			repoID:        newGitHubNullableUUIDKey(item.RepoID),
+			provider:      item.Provider,
+			teamID:        normalizeGitHubWorkItemDerivedTeamID(teamID),
+			issueTypeNorm: statusMapping.NormalizeType(item.Provider, item.Type, item.Labels),
+		}
+		bucket := buckets[key]
+		if bucket == nil {
+			bucket = &githubIssueTypeMetricsBucket{}
+			buckets[key] = bucket
+			order = append(order, key)
+		}
+		created := item.CreatedAt.UTC()
+		if !created.Before(dayUTC) && created.Before(end) {
+			bucket.created++
+		}
+		if item.CompletedAt != nil {
+			completed := item.CompletedAt.UTC()
+			if !completed.Before(dayUTC) && completed.Before(end) {
+				bucket.completed++
+				if item.StartedAt != nil {
+					cycle := completed.Sub(item.StartedAt.UTC()).Hours()
+					if cycle >= 0 {
+						bucket.cycleHours = append(bucket.cycleHours, cycle)
+					}
+				}
+			}
+		}
+		if created.Before(end) &&
+			(item.CompletedAt == nil || !item.CompletedAt.UTC().Before(dayUTC)) {
+			bucket.active++
+		}
+	}
+
+	result := make([]githubIssueTypeMetricsDailyRow, 0, len(order))
+	for _, key := range order {
+		bucket := buckets[key]
+		sort.Float64s(bucket.cycleHours)
+		var p50, p90 float64
+		if len(bucket.cycleHours) > 0 {
+			p50 = bucket.cycleHours[len(bucket.cycleHours)/2]
+			p90 = bucket.cycleHours[int(float64(len(bucket.cycleHours))*0.9)]
+		}
+		result = append(result, githubIssueTypeMetricsDailyRow{
+			RepoID:         key.repoID.pointer(),
+			Day:            newGitHubWorkItemDerivedDay(dayUTC),
+			Provider:       key.provider,
+			TeamID:         key.teamID,
+			IssueTypeNorm:  key.issueTypeNorm,
+			CreatedCount:   bucket.created,
+			CompletedCount: bucket.completed,
+			ActiveCount:    bucket.active,
+			CycleP50Hours:  p50,
+			CycleP90Hours:  p90,
+			LeadP50Hours:   0,
+			ComputedAt:     computedAt,
+			OrgID:          claim.OrgID,
+		})
+	}
+	return result
+}
+
+type githubInvestmentMetricKey struct {
+	repoID               githubNullableUUIDKey
+	teamID, area, stream string
+	areaValid            bool
+}
+
+type githubInvestmentMetricBucket struct {
+	deliveryUnits, completed, churn int
+	cycleHours                      []float64
+}
+
+func newGitHubInvestmentMetricKey(
+	repoID *uuid.UUID,
+	teamID string,
+	classification InvestmentClassification,
+) githubInvestmentMetricKey {
+	key := githubInvestmentMetricKey{
+		repoID: newGitHubNullableUUIDKey(repoID), teamID: teamID,
+	}
+	if classification.InvestmentArea != nil {
+		key.area = *classification.InvestmentArea
+		key.areaValid = true
+	}
+	if classification.ProjectStream != nil {
+		key.stream = *classification.ProjectStream
+	}
+	return key
+}
+
+func (key githubInvestmentMetricKey) areaPointer() *string {
+	if !key.areaValid {
+		return nil
+	}
+	value := key.area
+	return &value
+}
+
+// buildGitHubInvestmentDestinationsDaily mirrors the investment path in the
+// production Python work-item engine helper. Classifications cover active items;
+// aggregate metrics are the completed-in-day subset of those same active items.
+func buildGitHubInvestmentDestinationsDaily(
+	claim Claim,
+	rows githubWorkItemRows,
+	dayUTC, end, computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+	classifier *InvestmentClassifier,
+) ([]githubInvestmentClassificationDailyRow, []githubInvestmentMetricsDailyRow, error) {
+	classifications := make([]githubInvestmentClassificationDailyRow, 0, len(rows.WorkItems))
+	buckets := make(map[githubInvestmentMetricKey]*githubInvestmentMetricBucket)
+	order := make([]githubInvestmentMetricKey, 0, len(rows.WorkItems))
+	emptyComponent := ""
+	for _, item := range rows.WorkItems {
+		created := item.CreatedAt.UTC()
+		if !created.Before(end) ||
+			(item.CompletedAt != nil && item.CompletedAt.UTC().Before(dayUTC)) {
+			continue
+		}
+		classification, err := classifier.Classify(InvestmentArtifact{
+			Labels: item.Labels, Component: &emptyComponent,
+			Title: item.Title, Provider: item.Provider,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		stream := ""
+		if classification.ProjectStream != nil {
+			stream = *classification.ProjectStream
+		}
+		classifications = append(classifications, githubInvestmentClassificationDailyRow{
+			RepoID:         newGitHubNullableUUIDKey(item.RepoID).pointer(),
+			Day:            newGitHubWorkItemDerivedDay(dayUTC),
+			ArtifactType:   githubWorkItemEngineArtifactType,
+			ArtifactID:     item.WorkItemID,
+			Provider:       item.Provider,
+			InvestmentArea: classification.InvestmentArea,
+			ProjectStream:  stream,
+			Confidence:     classification.Confidence,
+			RuleID:         classification.RuleID,
+			ComputedAt:     computedAt,
+			OrgID:          claim.OrgID,
+		})
+
+		if item.CompletedAt == nil {
+			continue
+		}
+		completed := item.CompletedAt.UTC()
+		if completed.Before(dayUTC) || !completed.Before(end) {
+			continue
+		}
+		teamID, _, _ := derived.resolve(githubWorkItemDerivationSubjectFromRow(item))
+		team := normalizeGitHubWorkItemDerivedTeamID(teamID)
+		if team == githubWorkItemUnassignedTeamID {
+			team = ""
+		}
+		key := newGitHubInvestmentMetricKey(item.RepoID, team, classification)
+		bucket := buckets[key]
+		if bucket == nil {
+			bucket = &githubInvestmentMetricBucket{}
+			buckets[key] = bucket
+			order = append(order, key)
+		}
+		bucket.completed++
+		points := 1.0
+		if item.StoryPoints != nil && *item.StoryPoints != 0 {
+			points = *item.StoryPoints
+		}
+		if math.IsNaN(points) || math.IsInf(points, 0) ||
+			points >= float64(math.MaxInt64) || points < float64(math.MinInt64) {
+			return nil, nil, ErrInvalidConfiguration
+		}
+		bucket.deliveryUnits += int(math.Trunc(points))
+		if item.StartedAt != nil {
+			cycle := completed.Sub(item.StartedAt.UTC()).Hours()
+			if cycle >= 0 {
+				bucket.cycleHours = append(bucket.cycleHours, cycle)
+			}
+		}
+	}
+
+	metrics := make([]githubInvestmentMetricsDailyRow, 0, len(order))
+	for _, key := range order {
+		bucket := buckets[key]
+		sort.Float64s(bucket.cycleHours)
+		var p50 float64
+		if len(bucket.cycleHours) > 0 {
+			p50 = bucket.cycleHours[len(bucket.cycleHours)/2]
+		}
+		metrics = append(metrics, githubInvestmentMetricsDailyRow{
+			RepoID:             key.repoID.pointer(),
+			Day:                newGitHubWorkItemDerivedDay(dayUTC),
+			TeamID:             key.teamID,
+			InvestmentArea:     key.areaPointer(),
+			ProjectStream:      key.stream,
+			DeliveryUnits:      bucket.deliveryUnits,
+			WorkItemsCompleted: bucket.completed,
+			PRsMerged:          0,
+			ChurnLOC:           bucket.churn,
+			CycleP50Hours:      p50,
+			ComputedAt:         computedAt,
+			OrgID:              claim.OrgID,
+		})
+	}
+	return classifications, metrics, nil
+}
+
+var _ githubWorkItemEngineDeriver = (*GitHubWorkItemEngineDeriver)(nil)

--- a/internal/providersync/github_work_item_engine_destinations_oracle_test.go
+++ b/internal/providersync/github_work_item_engine_destinations_oracle_test.go
@@ -1,0 +1,376 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func githubWorkItemEngineOracleCases() []oracleCase {
+	repoID := "11111111-1111-4111-8111-111111111111"
+	mainFacts := githubDerivedOracleEmptyFacts()
+	mainFacts["Repos"] = []any{
+		githubDerivedOracleRepoFact(repoID, "acme/api", "payments", "Payments"),
+	}
+	return []oracleCase{
+		{
+			ID: "real_engines_grouping_upper_median_and_future_zero_row",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"RequireInvestmentMetrics": true, "AllowEmpty": false,
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": mainFacts,
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/api#1", map[string]any{
+						"repo_id": repoID, "type": "pull_request",
+						"labels":       []any{"bug", "security"},
+						"created_at":   "2026-08-04T01:00:00Z",
+						"started_at":   "2026-08-04T02:00:00Z",
+						"completed_at": "2026-08-04T10:00:00Z",
+						"story_points": 3.7,
+					}),
+					githubDerivedOracleItem("acme/api#2", map[string]any{
+						"repo_id": repoID, "labels": []any{"security", "bug"},
+						"started_at":   "2026-08-04T05:00:00Z",
+						"completed_at": "2026-08-04T14:00:00Z",
+						"story_points": 0,
+					}),
+					githubDerivedOracleItem("acme/api#3", map[string]any{
+						"project_id": "acme/other", "labels": []any{"feature", "chore"},
+					}),
+					githubDerivedOracleItem("acme/api#4", map[string]any{
+						"project_id": "acme/other",
+						"created_at": "2026-08-05T00:00:00Z",
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			ID: "boundary_completion_unassigned_and_negative_cycle",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"RequireInvestmentMetrics": true, "AllowEmpty": false,
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/other#1", map[string]any{
+						"project_id": "acme/other", "labels": []any{"maintenance"},
+						"started_at":   "2026-08-04T01:00:00Z",
+						"completed_at": "2026-08-04T00:00:00Z",
+					}),
+					githubDerivedOracleItem("acme/other#2", map[string]any{
+						"project_id": "acme/other", "labels": []any{"maintenance"},
+						"completed_at": "2026-08-03T23:59:59Z",
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			ID: "legacy_classifier_default_is_a_real_nonempty_row",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"RequireInvestmentMetrics": false, "AllowEmpty": false,
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/default#1", map[string]any{
+						"project_id": "acme/default", "labels": []any{},
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			// The inline producer deliberately ignores closed_at in both active
+			// and completed predicates. A closed-only item therefore remains
+			// active, is classified, and emits no completed investment metric.
+			ID: "closed_at_without_completed_at_remains_active",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"RequireInvestmentMetrics": false, "AllowEmpty": false,
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/closed#1", map[string]any{
+						"project_id": "acme/closed", "labels": []any{"bug"},
+						"closed_at": "2026-08-03T00:00:00Z",
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+		{
+			ID: "empty_input_keeps_all_three_destinations_present",
+			Input: map[string]any{
+				"OrgID": githubDerivedOracleOrg, "Day": "2026-08-04",
+				"RequireInvestmentMetrics": false, "AllowEmpty": true,
+				"ComputedAt": "2026-08-05T00:30:00Z", "AsOf": "2026-08-05T00:30:00Z",
+				"Facts":     githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{}, "Transitions": []any{},
+			},
+		},
+		{
+			ID: "three_day_window_uses_exclusive_midnight_before",
+			Input: map[string]any{
+				"OrgID":                    githubDerivedOracleOrg,
+				"SinceAt":                  "2026-08-03T00:00:00Z",
+				"BeforeAt":                 "2026-08-06T00:00:00Z",
+				"RequireInvestmentMetrics": true, "AllowEmpty": false,
+				"ComputedAt": "2026-08-06T00:30:00Z", "AsOf": "2026-08-06T00:30:00Z",
+				"Facts": githubDerivedOracleEmptyFacts(),
+				"WorkItems": []any{
+					githubDerivedOracleItem("acme/window#1", map[string]any{
+						"project_id": "acme/window", "labels": []any{"security", "bug"},
+						"created_at":   "2026-08-03T01:00:00Z",
+						"started_at":   "2026-08-04T02:00:00Z",
+						"completed_at": "2026-08-04T10:00:00Z",
+						"story_points": 2,
+					}),
+				},
+				"Transitions": []any{},
+			},
+		},
+	}
+}
+
+func TestGitHubIssueTypeMetricsMatchLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items/issue-type-metrics", githubWorkItemEngineOracleCases(),
+		func(t *testing.T, input map[string]any) githubIssueTypeMetricsColumns {
+			issueTypes, _, _ := buildGitHubWorkItemEngineOracleRows(t, input)
+			if !input["AllowEmpty"].(bool) && len(issueTypes) == 0 {
+				t.Fatal("oracle case produced no issue-type rows")
+			}
+			return newGitHubIssueTypeMetricsColumns(issueTypes)
+		}, nil,
+	)
+}
+
+func TestGitHubInvestmentClassificationsMatchLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items/investment-classifications", githubWorkItemEngineOracleCases(),
+		func(t *testing.T, input map[string]any) githubInvestmentClassificationColumns {
+			_, classifications, _ := buildGitHubWorkItemEngineOracleRows(t, input)
+			if !input["AllowEmpty"].(bool) && len(classifications) == 0 {
+				t.Fatal("oracle case produced no investment-classification rows")
+			}
+			return newGitHubInvestmentClassificationColumns(classifications)
+		}, nil,
+	)
+}
+
+func TestGitHubInvestmentMetricsMatchLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "github/work-items/investment-metrics", githubWorkItemEngineOracleCases(),
+		func(t *testing.T, input map[string]any) githubInvestmentMetricsColumns {
+			_, _, metrics := buildGitHubWorkItemEngineOracleRows(t, input)
+			// The open-item default case intentionally has no completed metric;
+			// the other two cases must keep the comparison non-vacuous.
+			if input["RequireInvestmentMetrics"].(bool) && len(metrics) == 0 {
+				t.Fatal("completed-item oracle case produced no investment metric rows")
+			}
+			return newGitHubInvestmentMetricsColumns(metrics)
+		}, nil,
+	)
+}
+
+func buildGitHubWorkItemEngineOracleRows(
+	t *testing.T,
+	input map[string]any,
+) (
+	[]githubIssueTypeMetricsDailyRow,
+	[]githubInvestmentClassificationDailyRow,
+	[]githubInvestmentMetricsDailyRow,
+) {
+	t.Helper()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = input["OrgID"].(string)
+	if sinceRaw, ok := input["SinceAt"].(string); ok {
+		since := githubDerivedOracleTime(t, sinceRaw)
+		before := githubDerivedOracleTime(t, input["BeforeAt"].(string))
+		claim.SinceAt, claim.BeforeAt = &since, &before
+	} else {
+		day, err := time.Parse("2006-01-02", input["Day"].(string))
+		if err != nil {
+			t.Fatal(err)
+		}
+		before := day.AddDate(0, 0, 1)
+		claim.SinceAt, claim.BeforeAt = &day, &before
+	}
+	computedAt := githubDerivedOracleTime(t, input["ComputedAt"].(string))
+	rows := githubWorkItemRows{}
+	for _, raw := range input["WorkItems"].([]any) {
+		rows.WorkItems = append(
+			rows.WorkItems, githubDerivedOracleGoItem(t, raw.(map[string]any)),
+		)
+	}
+	encodedFacts, err := json.Marshal(input["Facts"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var facts githubWorkItemDerivationFacts
+	if err := json.Unmarshal(encodedFacts, &facts); err != nil {
+		t.Fatal(err)
+	}
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &githubMultiDayOracleSource{facts: facts}
+	deriver := GitHubWorkItemDeriver{Source: source, engine: engine}
+	encoded, err := deriver.Derive(context.Background(), claim, rows, computedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.loads != 1 {
+		t.Fatalf("derivation context loads=%d want=1", source.loads)
+	}
+	for _, destination := range githubWorkItemDerivedEngineDestinations {
+		if _, present := encoded[destination]; !present {
+			t.Fatalf("engine destination %q absent from full deriver result", destination)
+		}
+	}
+	return decodeGitHubWorkItemEngineRows[githubIssueTypeMetricsDailyRow](
+			t, encoded[githubIssueTypeMetricsDestination],
+		),
+		decodeGitHubWorkItemEngineRows[githubInvestmentClassificationDailyRow](
+			t, encoded[githubInvestmentClassificationsDestination],
+		),
+		decodeGitHubWorkItemEngineRows[githubInvestmentMetricsDailyRow](
+			t, encoded[githubInvestmentMetricsDestination],
+		)
+}
+
+type githubIssueTypeMetricsColumns struct {
+	RepoID         []*uuid.UUID               `json:"repo_id"`
+	Day            []githubWorkItemDerivedDay `json:"day"`
+	Provider       []string                   `json:"provider"`
+	TeamID         []string                   `json:"team_id"`
+	IssueTypeNorm  []string                   `json:"issue_type_norm"`
+	CreatedCount   []int                      `json:"created_count"`
+	CompletedCount []int                      `json:"completed_count"`
+	ActiveCount    []int                      `json:"active_count"`
+	CycleP50Hours  []float64                  `json:"cycle_p50_hours"`
+	CycleP90Hours  []float64                  `json:"cycle_p90_hours"`
+	LeadP50Hours   []float64                  `json:"lead_p50_hours"`
+	ComputedAt     []time.Time                `json:"computed_at"`
+	OrgID          []string                   `json:"org_id"`
+}
+
+func newGitHubIssueTypeMetricsColumns(
+	rows []githubIssueTypeMetricsDailyRow,
+) githubIssueTypeMetricsColumns {
+	columns := githubIssueTypeMetricsColumns{
+		RepoID: []*uuid.UUID{}, Day: []githubWorkItemDerivedDay{}, Provider: []string{},
+		TeamID: []string{}, IssueTypeNorm: []string{}, CreatedCount: []int{},
+		CompletedCount: []int{}, ActiveCount: []int{}, CycleP50Hours: []float64{},
+		CycleP90Hours: []float64{}, LeadP50Hours: []float64{},
+		ComputedAt: []time.Time{}, OrgID: []string{},
+	}
+	for _, row := range rows {
+		columns.RepoID = append(columns.RepoID, row.RepoID)
+		columns.Day = append(columns.Day, row.Day)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.IssueTypeNorm = append(columns.IssueTypeNorm, row.IssueTypeNorm)
+		columns.CreatedCount = append(columns.CreatedCount, row.CreatedCount)
+		columns.CompletedCount = append(columns.CompletedCount, row.CompletedCount)
+		columns.ActiveCount = append(columns.ActiveCount, row.ActiveCount)
+		columns.CycleP50Hours = append(columns.CycleP50Hours, row.CycleP50Hours)
+		columns.CycleP90Hours = append(columns.CycleP90Hours, row.CycleP90Hours)
+		columns.LeadP50Hours = append(columns.LeadP50Hours, row.LeadP50Hours)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+type githubInvestmentClassificationColumns struct {
+	RepoID         []*uuid.UUID               `json:"repo_id"`
+	Day            []githubWorkItemDerivedDay `json:"day"`
+	ArtifactType   []string                   `json:"artifact_type"`
+	ArtifactID     []string                   `json:"artifact_id"`
+	Provider       []string                   `json:"provider"`
+	InvestmentArea []*string                  `json:"investment_area"`
+	ProjectStream  []string                   `json:"project_stream"`
+	Confidence     []float64                  `json:"confidence"`
+	RuleID         []*string                  `json:"rule_id"`
+	ComputedAt     []time.Time                `json:"computed_at"`
+	OrgID          []string                   `json:"org_id"`
+}
+
+func newGitHubInvestmentClassificationColumns(
+	rows []githubInvestmentClassificationDailyRow,
+) githubInvestmentClassificationColumns {
+	columns := githubInvestmentClassificationColumns{
+		RepoID: []*uuid.UUID{}, Day: []githubWorkItemDerivedDay{}, ArtifactType: []string{},
+		ArtifactID: []string{}, Provider: []string{}, InvestmentArea: []*string{},
+		ProjectStream: []string{}, Confidence: []float64{}, RuleID: []*string{},
+		ComputedAt: []time.Time{}, OrgID: []string{},
+	}
+	for _, row := range rows {
+		columns.RepoID = append(columns.RepoID, row.RepoID)
+		columns.Day = append(columns.Day, row.Day)
+		columns.ArtifactType = append(columns.ArtifactType, row.ArtifactType)
+		columns.ArtifactID = append(columns.ArtifactID, row.ArtifactID)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.InvestmentArea = append(columns.InvestmentArea, row.InvestmentArea)
+		columns.ProjectStream = append(columns.ProjectStream, row.ProjectStream)
+		columns.Confidence = append(columns.Confidence, row.Confidence)
+		columns.RuleID = append(columns.RuleID, row.RuleID)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+type githubInvestmentMetricsColumns struct {
+	RepoID             []*uuid.UUID               `json:"repo_id"`
+	Day                []githubWorkItemDerivedDay `json:"day"`
+	TeamID             []string                   `json:"team_id"`
+	InvestmentArea     []*string                  `json:"investment_area"`
+	ProjectStream      []string                   `json:"project_stream"`
+	DeliveryUnits      []int                      `json:"delivery_units"`
+	WorkItemsCompleted []int                      `json:"work_items_completed"`
+	PRsMerged          []int                      `json:"prs_merged"`
+	ChurnLOC           []int                      `json:"churn_loc"`
+	CycleP50Hours      []float64                  `json:"cycle_p50_hours"`
+	ComputedAt         []time.Time                `json:"computed_at"`
+	OrgID              []string                   `json:"org_id"`
+}
+
+func newGitHubInvestmentMetricsColumns(
+	rows []githubInvestmentMetricsDailyRow,
+) githubInvestmentMetricsColumns {
+	columns := githubInvestmentMetricsColumns{
+		RepoID: []*uuid.UUID{}, Day: []githubWorkItemDerivedDay{}, TeamID: []string{},
+		InvestmentArea: []*string{}, ProjectStream: []string{}, DeliveryUnits: []int{},
+		WorkItemsCompleted: []int{}, PRsMerged: []int{}, ChurnLOC: []int{},
+		CycleP50Hours: []float64{}, ComputedAt: []time.Time{}, OrgID: []string{},
+	}
+	for _, row := range rows {
+		columns.RepoID = append(columns.RepoID, row.RepoID)
+		columns.Day = append(columns.Day, row.Day)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.InvestmentArea = append(columns.InvestmentArea, row.InvestmentArea)
+		columns.ProjectStream = append(columns.ProjectStream, row.ProjectStream)
+		columns.DeliveryUnits = append(columns.DeliveryUnits, row.DeliveryUnits)
+		columns.WorkItemsCompleted = append(columns.WorkItemsCompleted, row.WorkItemsCompleted)
+		columns.PRsMerged = append(columns.PRsMerged, row.PRsMerged)
+		columns.ChurnLOC = append(columns.ChurnLOC, row.ChurnLOC)
+		columns.CycleP50Hours = append(columns.CycleP50Hours, row.CycleP50Hours)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}

--- a/internal/providersync/github_work_item_engine_destinations_test.go
+++ b/internal/providersync/github_work_item_engine_destinations_test.go
@@ -1,0 +1,541 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestNewGitHubWorkItemEngineDeriverRejectsPartialEngines(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testCase := range []struct {
+		name       string
+		mapping    *StatusMapping
+		classifier *InvestmentClassifier
+	}{
+		{name: "missing status mapping", classifier: classifier},
+		{name: "missing investment classifier", mapping: statusMapping},
+		{name: "both missing"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			engine, err := NewGitHubWorkItemEngineDeriver(
+				testCase.mapping, testCase.classifier,
+			)
+			if !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+			if engine != nil {
+				t.Fatalf("rejected constructor returned engine=%+v", engine)
+			}
+		})
+	}
+}
+
+func TestNewGitHubWorkItemDeriverLoadsBothExplicitConfigsAtomically(t *testing.T) {
+	conn := stubWorkItemConn{}
+	lease := githubWorkItemCompositionLease()
+	statusPath := resolveStatusMappingConfig(t, "real")
+	investmentPath := investmentConfigPath(t, "real")
+
+	for _, testCase := range []struct {
+		name           string
+		conn           driver.Conn
+		lease          providerfoundation.LeaseGuard
+		statusPath     string
+		investmentPath string
+	}{
+		{name: "missing connection", lease: lease, statusPath: statusPath, investmentPath: investmentPath},
+		{name: "missing lease", conn: conn, statusPath: statusPath, investmentPath: investmentPath},
+		{name: "blank status path", conn: conn, lease: lease, investmentPath: investmentPath},
+		{name: "blank investment path", conn: conn, lease: lease, statusPath: statusPath},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			deriver, err := NewGitHubWorkItemDeriver(
+				testCase.conn, testCase.lease,
+				testCase.statusPath, testCase.investmentPath,
+			)
+			if !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+			if deriver != nil {
+				t.Fatalf("rejected constructor returned deriver=%+v", deriver)
+			}
+		})
+	}
+
+	deriver, err := NewGitHubWorkItemDeriver(
+		conn, lease, statusPath, investmentPath,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, ok := deriver.Source.(githubWorkItemClickHouseDerivationContextSource)
+	if !ok || source.Conn == nil || source.Lease == nil {
+		t.Fatalf("constructor installed unreachable source=%T %+v", deriver.Source, source)
+	}
+	engine, ok := deriver.engine.(*GitHubWorkItemEngineDeriver)
+	if !ok || engine.statusMapping == nil || engine.investmentClassifier == nil {
+		t.Fatalf("constructor installed partial engine=%T %+v", deriver.engine, engine)
+	}
+}
+
+func TestNewGitHubWorkItemDeriverPreservesInvestmentLoaderContracts(t *testing.T) {
+	conn := stubWorkItemConn{}
+	lease := githubWorkItemCompositionLease()
+	statusPath := resolveStatusMappingConfig(t, "real")
+
+	// Python intentionally treats a named-but-missing investment file as an
+	// empty rule set and uses the legacy fallback. The atomic constructor must
+	// not reinterpret that established engine behavior as a path error.
+	missingPath := filepath.Join(t.TempDir(), "missing-investment.yaml")
+	deriver, err := NewGitHubWorkItemDeriver(
+		conn, lease, statusPath, missingPath,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := deriver.engine.(*GitHubWorkItemEngineDeriver)
+	component := ""
+	classification, err := engine.investmentClassifier.Classify(InvestmentArtifact{
+		Labels: []string{"security"}, Component: &component,
+		Title: "security item", Provider: "github",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if classification.InvestmentArea == nil ||
+		*classification.InvestmentArea != legacyDefaultInvestmentArea ||
+		classification.ProjectStream == nil ||
+		*classification.ProjectStream != legacyDefaultProjectStream ||
+		classification.Confidence != 0 {
+		t.Fatalf("missing-file fallback=%+v", classification)
+	}
+
+	if built, err := NewGitHubWorkItemDeriver(
+		conn, lease, statusPath, investmentConfigPath(t, "raises_priority_null"),
+	); err == nil || built != nil {
+		t.Fatalf("classifier load failure returned deriver=%+v error=%v", built, err)
+	}
+	if built, err := NewGitHubWorkItemDeriver(
+		conn, lease, filepath.Join(t.TempDir(), "missing-status.yaml"),
+		investmentConfigPath(t, "real"),
+	); err == nil || built != nil {
+		t.Fatalf("status load failure returned deriver=%+v error=%v", built, err)
+	}
+}
+
+func TestGitHubWorkItemEngineDeriverRejectsCorruptedPartialEngine(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, rows, day, computedAt, derived := githubWorkItemEngineFixture(t)
+
+	for _, testCase := range []struct {
+		name   string
+		engine *GitHubWorkItemEngineDeriver
+	}{
+		{name: "missing status mapping", engine: &GitHubWorkItemEngineDeriver{
+			investmentClassifier: classifier,
+		}},
+		{name: "missing investment classifier", engine: &GitHubWorkItemEngineDeriver{
+			statusMapping: statusMapping,
+		}},
+		{name: "both missing", engine: &GitHubWorkItemEngineDeriver{}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := testCase.engine.Derive(
+				context.Background(), claim, rows, day, computedAt, derived,
+			); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, rows, day, computedAt, derived := githubWorkItemEngineFixture(t)
+
+	encoded, err := engine.Derive(
+		context.Background(), claim, rows, day, computedAt, derived,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) != 3 {
+		t.Fatalf("destinations=%d want=3", len(encoded))
+	}
+
+	issueTypes := decodeGitHubWorkItemEngineRows[githubIssueTypeMetricsDailyRow](
+		t, encoded[githubIssueTypeMetricsDestination],
+	)
+	classifications := decodeGitHubWorkItemEngineRows[githubInvestmentClassificationDailyRow](
+		t, encoded[githubInvestmentClassificationsDestination],
+	)
+	metrics := decodeGitHubWorkItemEngineRows[githubInvestmentMetricsDailyRow](
+		t, encoded[githubInvestmentMetricsDestination],
+	)
+
+	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	wantStamp := computedAt.Truncate(time.Second)
+	wantIssueTypes := []githubIssueTypeMetricsDailyRow{
+		{
+			RepoID: &repoID, Day: "2026-08-04", Provider: "github",
+			TeamID: "payments", IssueTypeNorm: "bug",
+			CreatedCount: 1, CompletedCount: 2, ActiveCount: 2,
+			CycleP50Hours: 9, CycleP90Hours: 9, LeadP50Hours: 0,
+			ComputedAt: wantStamp, OrgID: claim.OrgID,
+		},
+		{
+			Day: "2026-08-04", Provider: "github", TeamID: "unassigned",
+			IssueTypeNorm: "chore", ActiveCount: 1,
+			ComputedAt: wantStamp, OrgID: claim.OrgID,
+		},
+		{
+			Day: "2026-08-04", Provider: "github", TeamID: "unassigned",
+			IssueTypeNorm: "issue", ComputedAt: wantStamp, OrgID: claim.OrgID,
+		},
+	}
+	if !reflect.DeepEqual(issueTypes, wantIssueTypes) {
+		t.Fatalf("issue types:\n got: %#v\nwant: %#v", issueTypes, wantIssueTypes)
+	}
+
+	security, general, secRule := "security", "general", "sec_general"
+	product, feature, featureRule := "product", "feature", "prod_feat"
+	wantClassifications := []githubInvestmentClassificationDailyRow{
+		{
+			RepoID: &repoID, Day: "2026-08-04", ArtifactType: "work_item",
+			ArtifactID: "acme/api#1", Provider: "github",
+			InvestmentArea: &security, ProjectStream: general,
+			Confidence: 1, RuleID: &secRule, ComputedAt: wantStamp, OrgID: claim.OrgID,
+		},
+		{
+			RepoID: &repoID, Day: "2026-08-04", ArtifactType: "work_item",
+			ArtifactID: "acme/api#2", Provider: "github",
+			InvestmentArea: &security, ProjectStream: general,
+			Confidence: 1, RuleID: &secRule, ComputedAt: wantStamp, OrgID: claim.OrgID,
+		},
+		{
+			Day: "2026-08-04", ArtifactType: "work_item",
+			ArtifactID: "acme/api#3", Provider: "github",
+			InvestmentArea: &product, ProjectStream: feature,
+			Confidence: 1, RuleID: &featureRule, ComputedAt: wantStamp, OrgID: claim.OrgID,
+		},
+	}
+	if !reflect.DeepEqual(classifications, wantClassifications) {
+		t.Fatalf("classifications:\n got: %#v\nwant: %#v", classifications, wantClassifications)
+	}
+
+	wantMetrics := []githubInvestmentMetricsDailyRow{
+		{
+			RepoID: &repoID, Day: "2026-08-04", TeamID: "payments",
+			InvestmentArea: &security, ProjectStream: general,
+			DeliveryUnits: 4, WorkItemsCompleted: 2,
+			CycleP50Hours: 9, ComputedAt: wantStamp, OrgID: claim.OrgID,
+		},
+	}
+	if !reflect.DeepEqual(metrics, wantMetrics) {
+		t.Fatalf("investment metrics:\n got: %#v\nwant: %#v", metrics, wantMetrics)
+	}
+}
+
+func TestGitHubWorkItemDeriverPropagatesReachableClassifierError(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	// This config is valid at construction time. Its first rule has an explicit
+	// null match block, so the mirrored Python AttributeError is raised only
+	// when a real work item reaches Classify.
+	classifier, err := NewInvestmentClassifier(
+		investmentConfigPath(t, "raises_match_null"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, rows, _, computedAt, _ := githubWorkItemEngineFixture(t)
+	deriver := GitHubWorkItemDeriver{
+		Source: &fakeGitHubWorkItemDerivationContextSource{},
+		engine: engine,
+	}
+
+	derived, err := deriver.Derive(context.Background(), claim, rows, computedAt)
+	if derived != nil {
+		t.Fatalf("classifier failure returned partial derived rows=%v", derived)
+	}
+	var configError *InvestmentConfigError
+	if !errors.As(err, &configError) || configError.PythonException != "AttributeError" {
+		t.Fatalf("error=%T %v want reachable mirrored AttributeError", err, err)
+	}
+}
+
+func TestGitHubWorkItemEngineDeriverSuppliesPythonWorkItemArtifactShape(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	claim, rows, day, computedAt, derived := githubWorkItemEngineFixture(t)
+	rows.WorkItems = rows.WorkItems[:1]
+
+	t.Run("component is present and empty", func(t *testing.T) {
+		classifier, err := NewInvestmentClassifier(
+			investmentConfigPath(t, "bare_component"),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+		if err != nil {
+			t.Fatal(err)
+		}
+		componentRows := rows
+		componentRows.WorkItems = append([]githubWorkItemRow(nil), rows.WorkItems...)
+		componentRows.WorkItems[0].Labels = []string{"barecomponent"}
+		encoded, err := engine.Derive(
+			context.Background(), claim, componentRows, day, computedAt, derived,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		classifications := decodeGitHubWorkItemEngineRows[githubInvestmentClassificationDailyRow](
+			t, encoded[githubInvestmentClassificationsDestination],
+		)
+		if len(classifications) != 1 || classifications[0].InvestmentArea == nil ||
+			*classifications[0].InvestmentArea != "bare_component_area" ||
+			classifications[0].RuleID == nil ||
+			*classifications[0].RuleID != "bare_component" {
+			t.Fatalf("empty component did not reach bare-string matcher: %+v", classifications)
+		}
+	})
+
+	t.Run("paths are absent", func(t *testing.T) {
+		classifier, err := NewInvestmentClassifier(
+			investmentConfigPath(t, "path_prefix_null"),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded, err := engine.Derive(
+			context.Background(), claim, rows, day, computedAt, derived,
+		)
+		if err != nil {
+			t.Fatalf("path-prefix rule must stay inert without artifact paths: %v", err)
+		}
+		classifications := decodeGitHubWorkItemEngineRows[githubInvestmentClassificationDailyRow](
+			t, encoded[githubInvestmentClassificationsDestination],
+		)
+		if len(classifications) != 1 || classifications[0].InvestmentArea == nil ||
+			*classifications[0].InvestmentArea != legacyDefaultInvestmentArea ||
+			classifications[0].ProjectStream != legacyDefaultProjectStream ||
+			classifications[0].Confidence != 0 ||
+			classifications[0].RuleID == nil ||
+			*classifications[0].RuleID != legacyFallbackRuleID {
+			t.Fatalf("pathless artifact did not take legacy fallback: %+v", classifications)
+		}
+	})
+}
+
+func TestGitHubWorkItemEngineClosedAtDoesNotTerminateWithoutCompletedAt(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, fixtureRows, day, computedAt, derived := githubWorkItemEngineFixture(t)
+	item := fixtureRows.WorkItems[2]
+	closedAt := day.Add(-time.Hour)
+	item.ClosedAt, item.CompletedAt = &closedAt, nil
+	encoded, err := engine.Derive(
+		context.Background(), claim,
+		githubWorkItemRows{WorkItems: []githubWorkItemRow{item}},
+		day, computedAt, derived,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issueTypes := decodeGitHubWorkItemEngineRows[githubIssueTypeMetricsDailyRow](
+		t, encoded[githubIssueTypeMetricsDestination],
+	)
+	classifications := decodeGitHubWorkItemEngineRows[githubInvestmentClassificationDailyRow](
+		t, encoded[githubInvestmentClassificationsDestination],
+	)
+	metrics := decodeGitHubWorkItemEngineRows[githubInvestmentMetricsDailyRow](
+		t, encoded[githubInvestmentMetricsDestination],
+	)
+	if len(issueTypes) != 1 || issueTypes[0].ActiveCount != 1 ||
+		issueTypes[0].CompletedCount != 0 || len(classifications) != 1 ||
+		len(metrics) != 0 {
+		t.Fatalf(
+			"closed-only item issue=%+v classifications=%+v metrics=%+v",
+			issueTypes, classifications, metrics,
+		)
+	}
+}
+
+func TestGitHubWorkItemEngineClosedAtInsideDayDoesNotCreateCompletionMetric(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, fixtureRows, day, computedAt, derived := githubWorkItemEngineFixture(t)
+	item := fixtureRows.WorkItems[2]
+	closedAt := day.Add(10 * time.Hour)
+	item.ClosedAt, item.CompletedAt = &closedAt, nil
+	encoded, err := engine.Derive(
+		context.Background(), claim,
+		githubWorkItemRows{WorkItems: []githubWorkItemRow{item}},
+		day, computedAt, derived,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics := decodeGitHubWorkItemEngineRows[githubInvestmentMetricsDailyRow](
+		t, encoded[githubInvestmentMetricsDestination],
+	)
+	if len(metrics) != 0 {
+		t.Fatalf("closed-only in-day item emitted completion metrics=%+v", metrics)
+	}
+}
+
+func TestGitHubWorkItemEngineUnassignedInvestmentMetricUsesEmptyTeam(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine, err := NewGitHubWorkItemEngineDeriver(statusMapping, classifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, fixtureRows, day, computedAt, derived := githubWorkItemEngineFixture(t)
+	item := fixtureRows.WorkItems[2]
+	startedAt, completedAt := day.Add(2*time.Hour), day.Add(10*time.Hour)
+	item.StartedAt, item.CompletedAt = &startedAt, &completedAt
+	encoded, err := engine.Derive(
+		context.Background(), claim,
+		githubWorkItemRows{WorkItems: []githubWorkItemRow{item}},
+		day, computedAt, derived,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics := decodeGitHubWorkItemEngineRows[githubInvestmentMetricsDailyRow](
+		t, encoded[githubInvestmentMetricsDestination],
+	)
+	if len(metrics) != 1 || metrics[0].TeamID != "" {
+		t.Fatalf("unassigned metric rows=%+v want one row with empty team_id", metrics)
+	}
+}
+
+func githubWorkItemEngineFixture(
+	t *testing.T,
+) (Claim, githubWorkItemRows, time.Time, time.Time, githubWorkItemDerivationContext) {
+	t.Helper()
+	claim := githubWorkItemOracleClaim()
+	claim.OrgID = "org-acme"
+	day := time.Date(2026, 8, 4, 0, 0, 0, 0, time.UTC)
+	computedAt := time.Date(2026, 8, 5, 0, 30, 17, 987654321, time.UTC)
+	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	stringValue := func(value string) *string { return &value }
+	floatValue := func(value float64) *float64 { return &value }
+	timeValue := func(value time.Time) *time.Time { return &value }
+	item := func(id string) githubWorkItemRow {
+		return githubWorkItemRow{
+			WorkItemID: id, Provider: "github", Title: id, Type: "issue",
+			Status: "todo", ProjectID: stringValue("acme/api"),
+			CreatedAt: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: day, OrgID: claim.OrgID,
+		}
+	}
+	first := item("acme/api#1")
+	first.RepoID = &repoID
+	first.Type = "pull_request"
+	first.Labels = []string{"bug", "security"}
+	first.CreatedAt = time.Date(2026, 8, 4, 1, 0, 0, 0, time.UTC)
+	first.StartedAt = timeValue(time.Date(2026, 8, 4, 2, 0, 0, 0, time.UTC))
+	first.CompletedAt = timeValue(time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC))
+	first.StoryPoints = floatValue(3.7)
+
+	second := item("acme/api#2")
+	second.RepoID = &repoID
+	second.Labels = []string{"security", "bug"}
+	second.StartedAt = timeValue(time.Date(2026, 8, 4, 5, 0, 0, 0, time.UTC))
+	second.CompletedAt = timeValue(time.Date(2026, 8, 4, 14, 0, 0, 0, time.UTC))
+	second.StoryPoints = floatValue(0)
+
+	third := item("acme/api#3")
+	third.ProjectID = stringValue("acme/other")
+	third.Labels = []string{"feature", "chore"}
+
+	future := item("acme/api#4")
+	future.ProjectID = stringValue("acme/other")
+	future.CreatedAt = time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC)
+
+	prior := item("acme/api#5")
+	prior.ProjectID = stringValue("acme/other")
+	prior.Labels = []string{"maintenance"}
+	prior.CompletedAt = timeValue(time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC))
+
+	repoIDString := repoID.String()
+	derived := newGitHubWorkItemDerivationContext(githubWorkItemDerivationFacts{
+		Repos: []githubWorkItemDerivationRepoFact{{
+			Provider: "github", TeamID: "payments", TeamName: "Payments",
+			RepoID: &repoIDString, RepoFullName: "acme/api", IsPrimary: 1,
+			Specificity: 100, Priority: 10,
+			UpdatedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		}},
+	})
+	return claim, githubWorkItemRows{WorkItems: []githubWorkItemRow{
+		first, second, third, future, prior,
+	}}, day, computedAt, derived
+}
+
+func decodeGitHubWorkItemEngineRows[T any](
+	t *testing.T, rows []json.RawMessage,
+) []T {
+	t.Helper()
+	result := make([]T, 0, len(rows))
+	for _, raw := range rows {
+		var row T
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		result = append(result, row)
+	}
+	return result
+}

--- a/internal/providersync/github_work_item_engine_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_engine_effects_clickhouse.go
@@ -1,0 +1,653 @@
+package providersync
+
+import (
+	"context"
+	"math"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// These three tables are plain MergeTree tables, so FINAL does not deduplicate
+// them. Issue-type metrics and classifications have no production latest-row
+// reader contract and therefore accept only one unambiguous full row (identical
+// retries may collapse). Investment metrics follows its production argMax
+// contract but rejects divergent rows tied at the newest computed_at.
+
+type GitHubIssueTypeMetricsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+type GitHubInvestmentClassificationsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+type GitHubInvestmentMetricsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func githubWorkItemEngineNullableUUID(value *uuid.UUID) string {
+	if value == nil {
+		return ""
+	}
+	return value.String()
+}
+
+func githubIssueTypeMetricsSortingKey(row githubIssueTypeMetricsDailyRow) string {
+	return strings.Join([]string{
+		row.OrgID, githubWorkItemEngineNullableUUID(row.RepoID), string(row.Day),
+		row.Provider, row.TeamID, row.IssueTypeNorm,
+	}, "\x00")
+}
+
+func githubInvestmentClassificationSortingKey(
+	row githubInvestmentClassificationDailyRow,
+) string {
+	return strings.Join([]string{
+		row.OrgID, githubWorkItemEngineNullableUUID(row.RepoID), string(row.Day),
+		row.Provider, row.ArtifactType,
+		githubWorkItemDerivedNullableString(row.InvestmentArea), row.ProjectStream,
+		row.ArtifactID,
+	}, "\x00")
+}
+
+func githubInvestmentMetricsSortingKey(row githubInvestmentMetricsDailyRow) string {
+	return strings.Join([]string{
+		row.OrgID, githubWorkItemEngineNullableUUID(row.RepoID), string(row.Day), row.TeamID,
+		githubWorkItemDerivedNullableString(row.InvestmentArea), row.ProjectStream,
+	}, "\x00")
+}
+
+func githubWorkItemEngineUInt32(value int) bool {
+	return value >= 0 && uint64(value) <= math.MaxUint32
+}
+
+func githubWorkItemEngineUInt64(value int) bool { return value >= 0 }
+
+func validGitHubIssueTypeMetricsRow(
+	identity GitHubWorkItemEffectIdentity,
+	row githubIssueTypeMetricsDailyRow,
+) bool {
+	_, dayErr := row.Day.time()
+	return row.OrgID == identity.OrgID && row.Provider == identity.Provider &&
+		dayErr == nil && row.TeamID != "" && row.IssueTypeNorm != "" &&
+		!row.ComputedAt.IsZero() &&
+		githubWorkItemEngineUInt32(row.CreatedCount) &&
+		githubWorkItemEngineUInt32(row.CompletedCount) &&
+		githubWorkItemEngineUInt32(row.ActiveCount)
+}
+
+func validGitHubInvestmentClassificationRow(
+	identity GitHubWorkItemEffectIdentity,
+	row githubInvestmentClassificationDailyRow,
+) bool {
+	_, dayErr := row.Day.time()
+	return row.OrgID == identity.OrgID && row.Provider == identity.Provider &&
+		dayErr == nil && row.ArtifactType == githubWorkItemEngineArtifactType &&
+		row.ArtifactID != "" && row.InvestmentArea != nil && row.RuleID != nil &&
+		!row.ComputedAt.IsZero()
+}
+
+func validGitHubInvestmentMetricsRow(
+	identity GitHubWorkItemEffectIdentity,
+	row githubInvestmentMetricsDailyRow,
+) bool {
+	_, dayErr := row.Day.time()
+	return row.OrgID == identity.OrgID && dayErr == nil &&
+		row.InvestmentArea != nil && !row.ComputedAt.IsZero() &&
+		githubWorkItemEngineUInt32(row.DeliveryUnits) &&
+		githubWorkItemEngineUInt32(row.WorkItemsCompleted) &&
+		githubWorkItemEngineUInt32(row.PRsMerged) &&
+		githubWorkItemEngineUInt64(row.ChurnLOC)
+}
+
+func (sink GitHubIssueTypeMetricsClickHouseEffects) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubIssueTypeMetricsDailyRow](
+		identity, effect, githubIssueTypeMetricsDestination,
+	)
+	if err != nil || ctx == nil || sink.Conn == nil || sink.Lease == nil {
+		return ErrInvalidConfiguration
+	}
+	for _, row := range rows {
+		if !validGitHubIssueTypeMetricsRow(identity, row) {
+			return ErrInvalidConfiguration
+		}
+	}
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubIssueTypeMetricsSortingKey) {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO issue_type_metrics_daily
+(repo_id, day, provider, team_id, issue_type_norm, created_count,
+completed_count, active_count, cycle_p50_hours, cycle_p90_hours,
+lead_p50_hours, computed_at, org_id)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		day, _ := row.Day.time()
+		if err := batch.Append(
+			row.RepoID, day, row.Provider, row.TeamID, row.IssueTypeNorm,
+			uint32(row.CreatedCount), uint32(row.CompletedCount), uint32(row.ActiveCount),
+			row.CycleP50Hours, row.CycleP90Hours, row.LeadP50Hours,
+			githubWorkItemDerivedSeconds(row.ComputedAt), identity.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubIssueTypeMetricsClickHouseEffects) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubIssueTypeMetricsDailyRow](
+		identity, effect, githubIssueTypeMetricsDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	for _, row := range rows {
+		if !validGitHubIssueTypeMetricsRow(identity, row) {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubIssueTypeMetricsSortingKey) {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return inspectGitHubWorkItemDerivedRows(rows, func(row githubIssueTypeMetricsDailyRow) (EffectInspection, error) {
+		return sink.inspect(ctx, identity, row)
+	})
+}
+
+func (sink GitHubIssueTypeMetricsClickHouseEffects) inspect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	expected githubIssueTypeMetricsDailyRow,
+) (EffectInspection, error) {
+	day, _ := expected.Day.time()
+	query := `SELECT repo_id, created_count, completed_count, active_count,
+cycle_p50_hours, cycle_p90_hours, lead_p50_hours, computed_at
+FROM issue_type_metrics_daily
+WHERE org_id = ? AND day = ? AND provider = ? AND team_id = ?
+	AND issue_type_norm = ?`
+	arguments := []any{
+		identity.OrgID, day, expected.Provider, expected.TeamID, expected.IssueTypeNorm,
+	}
+	if expected.RepoID == nil {
+		query += ` AND repo_id IS NULL`
+	} else {
+		query += ` AND repo_id = ?`
+		arguments = append(arguments, *expected.RepoID)
+	}
+	// There is no production latest-row reader contract for this table. Read
+	// every DISTINCT full row for the logical identity. GROUP BY collapses
+	// byte-identical replay duplicates while retaining ANY historical
+	// divergence; without a reader contract, even an older competing row is
+	// ambiguous and must fail closed.
+	query += ` GROUP BY repo_id, created_count, completed_count, active_count,
+cycle_p50_hours, cycle_p90_hours, lead_p50_hours, computed_at`
+	scan, err := sink.Conn.Query(ctx, query, arguments...)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer scan.Close()
+	var actual githubIssueTypeMetricsDailyRow
+	distinctRows := 0
+	for scan.Next() {
+		candidate := githubIssueTypeMetricsDailyRow{
+			Day: expected.Day, Provider: expected.Provider, TeamID: expected.TeamID,
+			IssueTypeNorm: expected.IssueTypeNorm, OrgID: identity.OrgID,
+		}
+		var created, completed, active uint32
+		if err := scan.Scan(
+			&candidate.RepoID, &created, &completed, &active,
+			&candidate.CycleP50Hours, &candidate.CycleP90Hours, &candidate.LeadP50Hours,
+			&candidate.ComputedAt,
+		); err != nil {
+			return EffectConflict, err
+		}
+		candidate.CreatedCount = int(created)
+		candidate.CompletedCount = int(completed)
+		candidate.ActiveCount = int(active)
+		if distinctRows == 0 {
+			actual = candidate
+		}
+		distinctRows++
+	}
+	if err := scan.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitHubIssueTypeMetricsVersion(
+		expected, actual, distinctRows, identity.OrgID,
+	), nil
+}
+
+func (sink GitHubInvestmentClassificationsClickHouseEffects) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubInvestmentClassificationDailyRow](
+		identity, effect, githubInvestmentClassificationsDestination,
+	)
+	if err != nil || ctx == nil || sink.Conn == nil || sink.Lease == nil {
+		return ErrInvalidConfiguration
+	}
+	for _, row := range rows {
+		if !validGitHubInvestmentClassificationRow(identity, row) {
+			return ErrInvalidConfiguration
+		}
+	}
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentClassificationSortingKey) {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO investment_classifications_daily
+(repo_id, day, artifact_type, artifact_id, provider, investment_area,
+project_stream, confidence, rule_id, computed_at, org_id)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		day, _ := row.Day.time()
+		if err := batch.Append(
+			row.RepoID, day, row.ArtifactType, row.ArtifactID, row.Provider,
+			*row.InvestmentArea, row.ProjectStream, row.Confidence, *row.RuleID,
+			githubWorkItemDerivedSeconds(row.ComputedAt), identity.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubInvestmentClassificationsClickHouseEffects) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubInvestmentClassificationDailyRow](
+		identity, effect, githubInvestmentClassificationsDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	for _, row := range rows {
+		if !validGitHubInvestmentClassificationRow(identity, row) {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentClassificationSortingKey) {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return inspectGitHubWorkItemDerivedRows(rows, func(row githubInvestmentClassificationDailyRow) (EffectInspection, error) {
+		return sink.inspect(ctx, identity, row)
+	})
+}
+
+func (sink GitHubInvestmentClassificationsClickHouseEffects) inspect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	expected githubInvestmentClassificationDailyRow,
+) (EffectInspection, error) {
+	day, _ := expected.Day.time()
+	query := `SELECT repo_id, confidence, rule_id, computed_at
+FROM investment_classifications_daily
+WHERE org_id = ? AND day = ? AND provider = ? AND artifact_type = ?
+	AND investment_area = ? AND project_stream = ? AND artifact_id = ?`
+	arguments := []any{
+		identity.OrgID, day, expected.Provider, expected.ArtifactType,
+		*expected.InvestmentArea, expected.ProjectStream, expected.ArtifactID,
+	}
+	if expected.RepoID == nil {
+		query += ` AND repo_id IS NULL`
+	} else {
+		query += ` AND repo_id = ?`
+		arguments = append(arguments, *expected.RepoID)
+	}
+	// No production reader defines either a latest-row rule or a tie-break for
+	// this table. Collapse only identical full-row replays; any different row at
+	// the same logical identity remains a conflict, even at an older version.
+	query += ` GROUP BY repo_id, confidence, rule_id, computed_at`
+	scan, err := sink.Conn.Query(ctx, query, arguments...)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer scan.Close()
+	var actual githubInvestmentClassificationDailyRow
+	distinctRows := 0
+	for scan.Next() {
+		candidate := githubInvestmentClassificationDailyRow{
+			Day: expected.Day, ArtifactType: expected.ArtifactType,
+			ArtifactID: expected.ArtifactID, Provider: expected.Provider,
+			InvestmentArea: expected.InvestmentArea, ProjectStream: expected.ProjectStream,
+			OrgID: identity.OrgID,
+		}
+		if err := scan.Scan(
+			&candidate.RepoID, &candidate.Confidence, &candidate.RuleID, &candidate.ComputedAt,
+		); err != nil {
+			return EffectConflict, err
+		}
+		if distinctRows == 0 {
+			actual = candidate
+		}
+		distinctRows++
+	}
+	if err := scan.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitHubInvestmentClassificationVersion(
+		expected, actual, distinctRows, identity.OrgID,
+	), nil
+}
+
+func (sink GitHubInvestmentMetricsClickHouseEffects) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubInvestmentMetricsDailyRow](
+		identity, effect, githubInvestmentMetricsDestination,
+	)
+	if err != nil || ctx == nil || sink.Conn == nil || sink.Lease == nil {
+		return ErrInvalidConfiguration
+	}
+	for _, row := range rows {
+		if !validGitHubInvestmentMetricsRow(identity, row) {
+			return ErrInvalidConfiguration
+		}
+	}
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentMetricsSortingKey) {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO investment_metrics_daily
+(repo_id, day, team_id, investment_area, project_stream, delivery_units,
+work_items_completed, prs_merged, churn_loc, cycle_p50_hours, computed_at, org_id)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		day, _ := row.Day.time()
+		if err := batch.Append(
+			row.RepoID, day, row.TeamID, *row.InvestmentArea, row.ProjectStream,
+			uint32(row.DeliveryUnits), uint32(row.WorkItemsCompleted), uint32(row.PRsMerged),
+			uint64(row.ChurnLOC), row.CycleP50Hours,
+			githubWorkItemDerivedSeconds(row.ComputedAt), identity.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitHubInvestmentMetricsClickHouseEffects) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	rows, err := validateGitHubWorkItemDerivedEffect[githubInvestmentMetricsDailyRow](
+		identity, effect, githubInvestmentMetricsDestination,
+	)
+	if err != nil || ctx == nil || sink.Lease == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	for _, row := range rows {
+		if !validGitHubInvestmentMetricsRow(identity, row) {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+	}
+	if !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentMetricsSortingKey) {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return inspectGitHubWorkItemDerivedRows(rows, func(row githubInvestmentMetricsDailyRow) (EffectInspection, error) {
+		return sink.inspect(ctx, identity, row)
+	})
+}
+
+func (sink GitHubInvestmentMetricsClickHouseEffects) inspect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	expected githubInvestmentMetricsDailyRow,
+) (EffectInspection, error) {
+	day, _ := expected.Day.time()
+	query := `SELECT repo_id, delivery_units, work_items_completed, prs_merged,
+churn_loc, cycle_p50_hours, computed_at
+FROM investment_metrics_daily
+WHERE org_id = ? AND day = ? AND team_id = ?
+	AND investment_area = ? AND project_stream = ?`
+	arguments := []any{
+		identity.OrgID, day, expected.TeamID, *expected.InvestmentArea,
+		expected.ProjectStream,
+	}
+	if expected.RepoID == nil {
+		query += ` AND repo_id IS NULL`
+	} else {
+		query += ` AND repo_id = ?`
+		arguments = append(arguments, *expected.RepoID)
+	}
+	// Production readers use argMax for this rollup. That is deterministic only
+	// when the newest full value tuple is unique, so readback makes that premise
+	// explicit: identical retries collapse, but equal-time divergence remains
+	// multiple groups and fails closed instead of accepting argMax's arbitrary
+	// winner.
+	query += ` GROUP BY repo_id, delivery_units, work_items_completed, prs_merged,
+churn_loc, cycle_p50_hours, computed_at`
+	scan, err := sink.Conn.Query(ctx, query, arguments...)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer scan.Close()
+	var actual githubInvestmentMetricsDailyRow
+	latestDistinct := 0
+	for scan.Next() {
+		candidate := githubInvestmentMetricsDailyRow{
+			Day: expected.Day, TeamID: expected.TeamID,
+			InvestmentArea: expected.InvestmentArea, ProjectStream: expected.ProjectStream,
+			OrgID: identity.OrgID,
+		}
+		var delivery, completed, merged uint32
+		var churn uint64
+		if err := scan.Scan(
+			&candidate.RepoID, &delivery, &completed, &merged, &churn,
+			&candidate.CycleP50Hours, &candidate.ComputedAt,
+		); err != nil {
+			return EffectConflict, err
+		}
+		candidate.DeliveryUnits = int(delivery)
+		candidate.WorkItemsCompleted = int(completed)
+		candidate.PRsMerged = int(merged)
+		if churn > math.MaxInt64 {
+			return EffectConflict, ErrInvalidConfiguration
+		}
+		candidate.ChurnLOC = int(churn)
+		switch {
+		case latestDistinct == 0 || candidate.ComputedAt.After(actual.ComputedAt):
+			actual = candidate
+			latestDistinct = 1
+		case candidate.ComputedAt.Equal(actual.ComputedAt):
+			latestDistinct++
+		}
+	}
+	if err := scan.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitHubInvestmentMetricsVersion(
+		expected, actual, latestDistinct, identity.OrgID,
+	), nil
+}
+
+func compareGitHubIssueTypeMetricsVersion(
+	expected, actual githubIssueTypeMetricsDailyRow,
+	distinctRows int,
+	orgID string,
+) EffectInspection {
+	if distinctRows != 1 {
+		if distinctRows == 0 {
+			return EffectAbsent
+		}
+		return EffectConflict
+	}
+	if actual.OrgID != orgID {
+		return EffectConflict
+	}
+	if !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {
+		return EffectConflict
+	}
+	if actual.Day != expected.Day || actual.Provider != expected.Provider ||
+		actual.TeamID != expected.TeamID || actual.IssueTypeNorm != expected.IssueTypeNorm ||
+		!githubWorkItemEngineUUIDPointerEqual(actual.RepoID, expected.RepoID) ||
+		actual.CreatedCount != expected.CreatedCount ||
+		actual.CompletedCount != expected.CompletedCount ||
+		actual.ActiveCount != expected.ActiveCount ||
+		actual.CycleP50Hours != expected.CycleP50Hours ||
+		actual.CycleP90Hours != expected.CycleP90Hours ||
+		actual.LeadP50Hours != expected.LeadP50Hours {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func compareGitHubInvestmentClassificationVersion(
+	expected, actual githubInvestmentClassificationDailyRow,
+	distinctRows int,
+	orgID string,
+) EffectInspection {
+	if distinctRows != 1 {
+		if distinctRows == 0 {
+			return EffectAbsent
+		}
+		return EffectConflict
+	}
+	if actual.OrgID != orgID {
+		return EffectConflict
+	}
+	if !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {
+		return EffectConflict
+	}
+	if actual.Day != expected.Day || actual.Provider != expected.Provider ||
+		actual.ArtifactType != expected.ArtifactType ||
+		actual.ArtifactID != expected.ArtifactID ||
+		!githubWorkItemDerivedStringPointerEqual(
+			actual.InvestmentArea, expected.InvestmentArea,
+		) || actual.ProjectStream != expected.ProjectStream ||
+		!githubWorkItemEngineUUIDPointerEqual(actual.RepoID, expected.RepoID) ||
+		actual.Confidence != expected.Confidence ||
+		!githubWorkItemDerivedStringPointerEqual(actual.RuleID, expected.RuleID) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func compareGitHubInvestmentMetricsVersion(
+	expected, actual githubInvestmentMetricsDailyRow,
+	latestDistinct int,
+	orgID string,
+) EffectInspection {
+	if latestDistinct != 1 {
+		if latestDistinct == 0 {
+			return EffectAbsent
+		}
+		return EffectConflict
+	}
+	if actual.OrgID != orgID {
+		return EffectConflict
+	}
+	if verdict, decided := githubWorkItemDerivedVersionOrder(
+		actual.ComputedAt, githubWorkItemDerivedSeconds(expected.ComputedAt),
+	); decided {
+		return verdict
+	}
+	if actual.Day != expected.Day || actual.TeamID != expected.TeamID ||
+		!githubWorkItemDerivedStringPointerEqual(
+			actual.InvestmentArea, expected.InvestmentArea,
+		) || actual.ProjectStream != expected.ProjectStream ||
+		!githubWorkItemEngineUUIDPointerEqual(actual.RepoID, expected.RepoID) ||
+		actual.DeliveryUnits != expected.DeliveryUnits ||
+		actual.WorkItemsCompleted != expected.WorkItemsCompleted ||
+		actual.PRsMerged != expected.PRsMerged || actual.ChurnLOC != expected.ChurnLOC ||
+		actual.CycleP50Hours != expected.CycleP50Hours {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func githubWorkItemEngineUUIDPointerEqual(left, right *uuid.UUID) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+var (
+	_ GitHubWorkItemEffectAdapter = GitHubIssueTypeMetricsClickHouseEffects{}
+	_ GitHubWorkItemEffectAdapter = GitHubInvestmentClassificationsClickHouseEffects{}
+	_ GitHubWorkItemEffectAdapter = GitHubInvestmentMetricsClickHouseEffects{}
+)

--- a/internal/providersync/github_work_item_engine_effects_integration_test.go
+++ b/internal/providersync/github_work_item_engine_effects_integration_test.go
@@ -1,0 +1,361 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+)
+
+// This suite authors no DDL. githubDerivedIntegrationConn applies the complete
+// production ClickHouse migration chain to a throwaway database before opening
+// the Go connection. These tables deliberately remain plain MergeTree tables:
+// issue/classification readback therefore treats every distinct historical row
+// as ambiguous, while investment metrics mirrors its production argMax reader
+// and rejects only a divergent tie at the newest timestamp.
+func TestGitHubWorkItemEngineEffectsAgainstMigratedSchema(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	lease := githubDerivedIntegrationLease()
+
+	for _, table := range []string{
+		"issue_type_metrics_daily",
+		"investment_classifications_daily",
+		"investment_metrics_daily",
+	} {
+		t.Run("plain_merge_tree_"+table, func(t *testing.T) {
+			var ddl string
+			if err := conn.QueryRow(ctx, "SHOW CREATE TABLE "+table).Scan(&ddl); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(ddl, "ENGINE = MergeTree") ||
+				strings.Contains(ddl, "ReplacingMergeTree") {
+				t.Fatalf("%s must remain plain MergeTree; DDL:\n%s", table, ddl)
+			}
+		})
+	}
+
+	t.Run(githubIssueTypeMetricsDestination, func(t *testing.T) {
+		sink := GitHubIssueTypeMetricsClickHouseEffects{Conn: conn, Lease: lease}
+		repoA := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+		repoB := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+		base := githubWorkItemEngineEffectIssueRow()
+		base.ComputedAt = base.ComputedAt.Add(123456789 * time.Nanosecond)
+		rows := []githubIssueTypeMetricsDailyRow{base, base, base}
+		rows[0].RepoID, rows[1].RepoID, rows[2].RepoID = &repoA, &repoB, nil
+		identity, effect := githubWorkItemEngineIntegrationBatch(
+			t, githubDerivedIntegrationOrg, githubIssueTypeMetricsDestination, rows,
+		)
+
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectAbsent, "before write",
+		)
+		foreignRows := append([]githubIssueTypeMetricsDailyRow(nil), rows...)
+		for index := range foreignRows {
+			foreignRows[index].OrgID = "org-other"
+		}
+		foreignIdentity, foreignEffect := githubWorkItemEngineIntegrationBatch(
+			t, "org-other", githubIssueTypeMetricsDestination, foreignRows,
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, foreignIdentity, foreignEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, foreignIdentity, foreignEffect, EffectExact, "foreign write",
+		)
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectAbsent, "foreign tenant fence",
+		)
+
+		if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectExact,
+			"same physical key across two repos and NULL repo",
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectExact, "identical retry",
+		)
+		assertGitHubWorkItemEnginePlainRetry(
+			t, ctx, conn,
+			`SELECT count(), min(computed_at), max(computed_at)
+FROM issue_type_metrics_daily
+WHERE org_id = ? AND day = ? AND provider = ? AND team_id = ?
+	AND issue_type_norm = ? AND repo_id = ? AND computed_at = ?`,
+			[]any{
+				base.OrgID, mustGitHubWorkItemDerivedDay(t, base.Day), base.Provider,
+				base.TeamID, base.IssueTypeNorm, repoA,
+			},
+			base.ComputedAt,
+		)
+
+		older := rows[0]
+		older.ComputedAt = older.ComputedAt.Add(-time.Hour)
+		older.CreatedCount++
+		olderIdentity, olderEffect := githubWorkItemEngineIntegrationBatch(
+			t, githubDerivedIntegrationOrg, githubIssueTypeMetricsDestination,
+			[]githubIssueTypeMetricsDailyRow{older},
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, olderIdentity, olderEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectConflict,
+			"older divergent history without a latest-row reader",
+		)
+	})
+
+	t.Run(githubInvestmentClassificationsDestination, func(t *testing.T) {
+		sink := GitHubInvestmentClassificationsClickHouseEffects{Conn: conn, Lease: lease}
+		repoA := uuid.MustParse("33333333-3333-4333-8333-333333333333")
+		repoB := uuid.MustParse("44444444-4444-4444-8444-444444444444")
+		base := githubWorkItemEngineEffectClassificationRow()
+		base.ArtifactID = "acme/api#classification"
+		base.ComputedAt = base.ComputedAt.Add(234567891 * time.Nanosecond)
+		rows := []githubInvestmentClassificationDailyRow{base, base, base}
+		rows[0].RepoID, rows[1].RepoID, rows[2].RepoID = &repoA, &repoB, nil
+		identity, effect := githubWorkItemEngineIntegrationBatch(
+			t, githubDerivedIntegrationOrg, githubInvestmentClassificationsDestination, rows,
+		)
+
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectAbsent, "before write",
+		)
+		foreignRows := append([]githubInvestmentClassificationDailyRow(nil), rows...)
+		for index := range foreignRows {
+			foreignRows[index].OrgID = "org-other"
+		}
+		foreignIdentity, foreignEffect := githubWorkItemEngineIntegrationBatch(
+			t, "org-other", githubInvestmentClassificationsDestination, foreignRows,
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, foreignIdentity, foreignEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, foreignIdentity, foreignEffect, EffectExact, "foreign write",
+		)
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectAbsent, "foreign tenant fence",
+		)
+
+		if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectExact,
+			"same physical key across two repos and NULL repo",
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectExact, "identical retry",
+		)
+		assertGitHubWorkItemEnginePlainRetry(
+			t, ctx, conn,
+			`SELECT count(), min(computed_at), max(computed_at)
+FROM investment_classifications_daily
+WHERE org_id = ? AND day = ? AND provider = ? AND artifact_type = ?
+	AND investment_area = ? AND project_stream = ? AND artifact_id = ?
+	AND repo_id = ? AND computed_at = ?`,
+			[]any{
+				base.OrgID, mustGitHubWorkItemDerivedDay(t, base.Day), base.Provider,
+				base.ArtifactType, *base.InvestmentArea, base.ProjectStream,
+				base.ArtifactID, repoA,
+			},
+			base.ComputedAt,
+		)
+
+		older := rows[0]
+		older.ComputedAt = older.ComputedAt.Add(-time.Hour)
+		older.Confidence = 0.5
+		olderIdentity, olderEffect := githubWorkItemEngineIntegrationBatch(
+			t, githubDerivedIntegrationOrg, githubInvestmentClassificationsDestination,
+			[]githubInvestmentClassificationDailyRow{older},
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, olderIdentity, olderEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectConflict,
+			"older divergent history without a latest-row reader",
+		)
+	})
+
+	t.Run(githubInvestmentMetricsDestination, func(t *testing.T) {
+		sink := GitHubInvestmentMetricsClickHouseEffects{Conn: conn, Lease: lease}
+		repoA := uuid.MustParse("55555555-5555-4555-8555-555555555555")
+		repoB := uuid.MustParse("66666666-6666-4666-8666-666666666666")
+		base := githubWorkItemEngineEffectMetricsRow()
+		base.TeamID = "investment-team"
+		base.ComputedAt = base.ComputedAt.Add(345678912 * time.Nanosecond)
+		rows := []githubInvestmentMetricsDailyRow{base, base, base}
+		rows[0].RepoID, rows[1].RepoID, rows[2].RepoID = &repoA, &repoB, nil
+		identity, effect := githubWorkItemEngineIntegrationBatch(
+			t, githubDerivedIntegrationOrg, githubInvestmentMetricsDestination, rows,
+		)
+
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectAbsent, "before write",
+		)
+		foreignRows := append([]githubInvestmentMetricsDailyRow(nil), rows...)
+		for index := range foreignRows {
+			foreignRows[index].OrgID = "org-other"
+		}
+		foreignIdentity, foreignEffect := githubWorkItemEngineIntegrationBatch(
+			t, "org-other", githubInvestmentMetricsDestination, foreignRows,
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, foreignIdentity, foreignEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, foreignIdentity, foreignEffect, EffectExact, "foreign write",
+		)
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectAbsent, "foreign tenant fence",
+		)
+
+		// Under the production argMax reader contract, an older persisted row is
+		// absent for the newer effect and may safely be superseded.
+		older := rows[0]
+		older.ComputedAt = older.ComputedAt.Add(-time.Hour)
+		older.DeliveryUnits++
+		olderIdentity, olderEffect := githubWorkItemEngineIntegrationBatch(
+			t, githubDerivedIntegrationOrg, githubInvestmentMetricsDestination,
+			[]githubInvestmentMetricsDailyRow{older},
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, olderIdentity, olderEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectAbsent, "older persisted version",
+		)
+
+		if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectExact,
+			"same physical key across two repos and NULL repo",
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectExact, "identical retry",
+		)
+		assertGitHubWorkItemEnginePlainRetry(
+			t, ctx, conn,
+			`SELECT count(), min(computed_at), max(computed_at)
+FROM investment_metrics_daily
+WHERE org_id = ? AND day = ? AND team_id = ? AND investment_area = ?
+	AND project_stream = ? AND repo_id = ? AND computed_at = ?`,
+			[]any{
+				base.OrgID, mustGitHubWorkItemDerivedDay(t, base.Day), base.TeamID,
+				*base.InvestmentArea, base.ProjectStream, repoA,
+			},
+			base.ComputedAt,
+		)
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, olderIdentity, olderEffect, EffectConflict,
+			"newer persisted version supersedes older effect",
+		)
+
+		tied := rows[0]
+		tied.DeliveryUnits++
+		tiedIdentity, tiedEffect := githubWorkItemEngineIntegrationBatch(
+			t, githubDerivedIntegrationOrg, githubInvestmentMetricsDestination,
+			[]githubInvestmentMetricsDailyRow{tied},
+		)
+		if err := sink.WriteGitHubWorkItemEffect(ctx, tiedIdentity, tiedEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitHubWorkItemEngineInspection(
+			t, ctx, sink, identity, effect, EffectConflict,
+			"equal-time divergent argMax tuple",
+		)
+	})
+}
+
+func githubWorkItemEngineIntegrationBatch[T any](
+	t *testing.T,
+	orgID string,
+	destination string,
+	rows []T,
+) (GitHubWorkItemEffectIdentity, EffectBatch) {
+	t.Helper()
+	effect := githubDerivedIntegrationEffect(t, destination, rows)
+	identity := githubDerivedIntegrationIdentity(destination, len(rows))
+	identity.OrgID = orgID
+	return identity, effect
+}
+
+func mustGitHubWorkItemDerivedDay(
+	t *testing.T, day githubWorkItemDerivedDay,
+) time.Time {
+	t.Helper()
+	parsed, err := day.time()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
+}
+
+func assertGitHubWorkItemEnginePlainRetry(
+	t *testing.T,
+	ctx context.Context,
+	conn driver.Conn,
+	query string,
+	arguments []any,
+	computedAt time.Time,
+) {
+	t.Helper()
+	storedAt := githubWorkItemDerivedSeconds(computedAt)
+	arguments = append(arguments, storedAt)
+	var count uint64
+	var minimum, maximum time.Time
+	if err := conn.QueryRow(ctx, query, arguments...).Scan(
+		&count, &minimum, &maximum,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("plain MergeTree retry rows=%d want=2 physical duplicates", count)
+	}
+	if !minimum.Equal(storedAt) || !maximum.Equal(storedAt) ||
+		minimum.Nanosecond() != 0 || maximum.Nanosecond() != 0 {
+		t.Fatalf(
+			"raw DateTime readback min=%s max=%s want seconds=%s",
+			minimum, maximum, storedAt,
+		)
+	}
+}
+
+func assertGitHubWorkItemEngineInspection(
+	t *testing.T,
+	ctx context.Context,
+	adapter GitHubWorkItemEffectAdapter,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+	want EffectInspection,
+	label string,
+) {
+	t.Helper()
+	got, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect)
+	if err != nil {
+		t.Fatalf("%s: inspect: %v", label, err)
+	}
+	if got != want {
+		t.Fatalf("%s: inspection=%s want=%s", label, got, want)
+	}
+}

--- a/internal/providersync/github_work_item_engine_effects_test.go
+++ b/internal/providersync/github_work_item_engine_effects_test.go
@@ -1,0 +1,536 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+var (
+	githubWorkItemEngineEffectAt      = time.Date(2026, 8, 5, 0, 30, 0, 0, time.UTC)
+	githubWorkItemEngineEffectOlderAt = time.Date(2026, 8, 4, 0, 30, 0, 0, time.UTC)
+	githubWorkItemEngineEffectNewerAt = time.Date(2026, 8, 6, 0, 30, 0, 0, time.UTC)
+)
+
+func githubWorkItemEngineEffectRepoID() *uuid.UUID {
+	value := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	return &value
+}
+
+func githubWorkItemEngineEffectIssueRow() githubIssueTypeMetricsDailyRow {
+	return githubIssueTypeMetricsDailyRow{
+		RepoID: githubWorkItemEngineEffectRepoID(), Day: "2026-08-04",
+		Provider: "github", TeamID: "payments", IssueTypeNorm: "bug",
+		CreatedCount: 1, CompletedCount: 2, ActiveCount: 3,
+		CycleP50Hours: 4, CycleP90Hours: 5, LeadP50Hours: 6,
+		ComputedAt: githubWorkItemEngineEffectAt, OrgID: "org-acme",
+	}
+}
+
+func TestCompareGitHubIssueTypeMetricsVersionRequiresOneUnambiguousFullRow(
+	t *testing.T,
+) {
+	tests := []struct {
+		name     string
+		mutate   func(*githubIssueTypeMetricsDailyRow)
+		distinct int
+		want     EffectInspection
+	}{
+		{name: "identical row", distinct: 1, want: EffectExact},
+		{name: "absent", distinct: 0, want: EffectAbsent},
+		{name: "two distinct groups conflict even when first equals expected", distinct: 2, want: EffectConflict},
+		{name: "older divergent row remains ambiguous", distinct: 2, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectOlderAt
+		}, want: EffectConflict},
+		{name: "single older row conflicts without a latest-row contract", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectOlderAt
+		}, want: EffectConflict},
+		{name: "single newer row conflicts", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectNewerAt
+		}, want: EffectConflict},
+		{name: "repo differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.RepoID = nil
+		}, want: EffectConflict},
+		{name: "created differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.CreatedCount++
+		}, want: EffectConflict},
+		{name: "completed differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.CompletedCount++
+		}, want: EffectConflict},
+		{name: "active differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.ActiveCount++
+		}, want: EffectConflict},
+		{name: "p50 differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.CycleP50Hours++
+		}, want: EffectConflict},
+		{name: "p90 differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.CycleP90Hours++
+		}, want: EffectConflict},
+		{name: "lead differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.LeadP50Hours++
+		}, want: EffectConflict},
+		{name: "tenant differs", distinct: 1, mutate: func(row *githubIssueTypeMetricsDailyRow) {
+			row.OrgID = "org-other"
+		}, want: EffectConflict},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			expected := githubWorkItemEngineEffectIssueRow()
+			actual := githubWorkItemEngineEffectIssueRow()
+			if testCase.mutate != nil {
+				testCase.mutate(&actual)
+			}
+			if got := compareGitHubIssueTypeMetricsVersion(
+				expected, actual, testCase.distinct, "org-acme",
+			); got != testCase.want {
+				t.Fatalf("inspection=%v want=%v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func githubWorkItemEngineEffectClassificationRow() githubInvestmentClassificationDailyRow {
+	area, rule := "security", "sec_general"
+	return githubInvestmentClassificationDailyRow{
+		RepoID: githubWorkItemEngineEffectRepoID(), Day: "2026-08-04",
+		ArtifactType: "work_item", ArtifactID: "acme/api#1", Provider: "github",
+		InvestmentArea: &area, ProjectStream: "general", Confidence: 1,
+		RuleID: &rule, ComputedAt: githubWorkItemEngineEffectAt, OrgID: "org-acme",
+	}
+}
+
+func TestCompareGitHubInvestmentClassificationVersionRequiresOneUnambiguousFullRow(
+	t *testing.T,
+) {
+	tests := []struct {
+		name     string
+		mutate   func(*githubInvestmentClassificationDailyRow)
+		distinct int
+		want     EffectInspection
+	}{
+		{name: "identical row", distinct: 1, want: EffectExact},
+		{name: "absent", distinct: 0, want: EffectAbsent},
+		{name: "two distinct groups conflict even when first equals expected", distinct: 2, want: EffectConflict},
+		{name: "older divergent row remains ambiguous", distinct: 2, mutate: func(row *githubInvestmentClassificationDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectOlderAt
+		}, want: EffectConflict},
+		{name: "single older row conflicts without a latest-row contract", distinct: 1, mutate: func(row *githubInvestmentClassificationDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectOlderAt
+		}, want: EffectConflict},
+		{name: "single newer row conflicts", distinct: 1, mutate: func(row *githubInvestmentClassificationDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectNewerAt
+		}, want: EffectConflict},
+		{name: "repo differs", distinct: 1, mutate: func(row *githubInvestmentClassificationDailyRow) {
+			row.RepoID = nil
+		}, want: EffectConflict},
+		{name: "confidence differs", distinct: 1, mutate: func(row *githubInvestmentClassificationDailyRow) {
+			row.Confidence = 0
+		}, want: EffectConflict},
+		{name: "rule differs", distinct: 1, mutate: func(row *githubInvestmentClassificationDailyRow) {
+			other := "other"
+			row.RuleID = &other
+		}, want: EffectConflict},
+		{name: "tenant differs", distinct: 1, mutate: func(row *githubInvestmentClassificationDailyRow) {
+			row.OrgID = "org-other"
+		}, want: EffectConflict},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			expected := githubWorkItemEngineEffectClassificationRow()
+			actual := githubWorkItemEngineEffectClassificationRow()
+			if testCase.mutate != nil {
+				testCase.mutate(&actual)
+			}
+			if got := compareGitHubInvestmentClassificationVersion(
+				expected, actual, testCase.distinct, "org-acme",
+			); got != testCase.want {
+				t.Fatalf("inspection=%v want=%v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func githubWorkItemEngineEffectMetricsRow() githubInvestmentMetricsDailyRow {
+	area := "security"
+	return githubInvestmentMetricsDailyRow{
+		RepoID: githubWorkItemEngineEffectRepoID(), Day: "2026-08-04",
+		TeamID: "payments", InvestmentArea: &area, ProjectStream: "general",
+		DeliveryUnits: 3, WorkItemsCompleted: 2, PRsMerged: 1, ChurnLOC: 4,
+		CycleP50Hours: 5, ComputedAt: githubWorkItemEngineEffectAt, OrgID: "org-acme",
+	}
+}
+
+func TestCompareGitHubInvestmentMetricsVersionRejectsAmbiguousNewestTuple(
+	t *testing.T,
+) {
+	tests := []struct {
+		name           string
+		mutate         func(*githubInvestmentMetricsDailyRow)
+		latestDistinct int
+		want           EffectInspection
+	}{
+		{name: "identical latest tuple", latestDistinct: 1, want: EffectExact},
+		{name: "absent", latestDistinct: 0, want: EffectAbsent},
+		{name: "equal-time divergence is not arbitrary argMax", latestDistinct: 2, want: EffectConflict},
+		{name: "older latest tuple is absent", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectOlderAt
+		}, want: EffectAbsent},
+		{name: "newer latest tuple conflicts", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.ComputedAt = githubWorkItemEngineEffectNewerAt
+		}, want: EffectConflict},
+		{name: "repo differs", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.RepoID = nil
+		}, want: EffectConflict},
+		{name: "units differ", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.DeliveryUnits++
+		}, want: EffectConflict},
+		{name: "completed differs", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.WorkItemsCompleted++
+		}, want: EffectConflict},
+		{name: "merged differs", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.PRsMerged++
+		}, want: EffectConflict},
+		{name: "churn differs", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.ChurnLOC++
+		}, want: EffectConflict},
+		{name: "cycle differs", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.CycleP50Hours++
+		}, want: EffectConflict},
+		{name: "tenant differs", latestDistinct: 1, mutate: func(row *githubInvestmentMetricsDailyRow) {
+			row.OrgID = "org-other"
+		}, want: EffectConflict},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			expected := githubWorkItemEngineEffectMetricsRow()
+			actual := githubWorkItemEngineEffectMetricsRow()
+			if testCase.mutate != nil {
+				testCase.mutate(&actual)
+			}
+			if got := compareGitHubInvestmentMetricsVersion(
+				expected, actual, testCase.latestDistinct, "org-acme",
+			); got != testCase.want {
+				t.Fatalf("inspection=%v want=%v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestGitHubWorkItemEngineLogicalKeysIncludeNullableRepoID(t *testing.T) {
+	repoA := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	repoB := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+
+	issueA := githubWorkItemEngineEffectIssueRow()
+	issueB := issueA
+	issueA.RepoID, issueB.RepoID = &repoA, &repoB
+	if !githubWorkItemDerivedUniqueSortingKeys(
+		[]githubIssueTypeMetricsDailyRow{issueA, issueB},
+		githubIssueTypeMetricsSortingKey,
+	) {
+		t.Fatal("issue logical identity collapsed different repo_id values")
+	}
+
+	classificationA := githubWorkItemEngineEffectClassificationRow()
+	classificationB := classificationA
+	classificationA.RepoID, classificationB.RepoID = nil, &repoB
+	if !githubWorkItemDerivedUniqueSortingKeys(
+		[]githubInvestmentClassificationDailyRow{classificationA, classificationB},
+		githubInvestmentClassificationSortingKey,
+	) {
+		t.Fatal("classification logical identity collapsed NULL and present repo_id")
+	}
+
+	metricA := githubWorkItemEngineEffectMetricsRow()
+	metricB := metricA
+	metricA.RepoID, metricB.RepoID = &repoA, nil
+	if !githubWorkItemDerivedUniqueSortingKeys(
+		[]githubInvestmentMetricsDailyRow{metricA, metricB},
+		githubInvestmentMetricsSortingKey,
+	) {
+		t.Fatal("investment metric logical identity collapsed present and NULL repo_id")
+	}
+}
+
+type githubWorkItemEngineRecordingConn struct {
+	driver.Conn
+	queries []string
+}
+
+func (conn *githubWorkItemEngineRecordingConn) Query(
+	_ context.Context, query string, _ ...any,
+) (driver.Rows, error) {
+	conn.queries = append(conn.queries, query)
+	return emptyGitHubWorkItemDerivationRows{}, nil
+}
+
+func TestGitHubWorkItemEnginePlainMergeTreeReadbacksNeverUseFinal(t *testing.T) {
+	ctx := context.Background()
+	conn := &githubWorkItemEngineRecordingConn{}
+	lease := githubWorkItemCompositionLease()
+
+	issueEffect := githubWorkItemEngineUnitEffect(
+		t, githubIssueTypeMetricsDestination,
+		[]githubIssueTypeMetricsDailyRow{githubWorkItemEngineEffectIssueRow()},
+	)
+	classificationEffect := githubWorkItemEngineUnitEffect(
+		t, githubInvestmentClassificationsDestination,
+		[]githubInvestmentClassificationDailyRow{
+			githubWorkItemEngineEffectClassificationRow(),
+		},
+	)
+	metricsEffect := githubWorkItemEngineUnitEffect(
+		t, githubInvestmentMetricsDestination,
+		[]githubInvestmentMetricsDailyRow{githubWorkItemEngineEffectMetricsRow()},
+	)
+	for _, testCase := range []struct {
+		name        string
+		destination string
+		adapter     GitHubWorkItemEffectAdapter
+		effect      EffectBatch
+	}{
+		{
+			name: "issue type", destination: githubIssueTypeMetricsDestination,
+			adapter: GitHubIssueTypeMetricsClickHouseEffects{Conn: conn, Lease: lease},
+			effect:  issueEffect,
+		},
+		{
+			name: "classification", destination: githubInvestmentClassificationsDestination,
+			adapter: GitHubInvestmentClassificationsClickHouseEffects{Conn: conn, Lease: lease},
+			effect:  classificationEffect,
+		},
+		{
+			name: "metrics", destination: githubInvestmentMetricsDestination,
+			adapter: GitHubInvestmentMetricsClickHouseEffects{Conn: conn, Lease: lease},
+			effect:  metricsEffect,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			identity := GitHubWorkItemEffectIdentity{
+				OrgID: "org-acme", Provider: "github", Dataset: "work-items",
+				Generation: "gen-1", Destination: testCase.destination,
+				RowCount: len(testCase.effect.Rows),
+			}
+			inspection, err := testCase.adapter.InspectGitHubWorkItemEffect(
+				ctx, identity, testCase.effect,
+			)
+			if err != nil || inspection != EffectAbsent {
+				t.Fatalf("inspection=%s err=%v want absent", inspection, err)
+			}
+		})
+	}
+	if len(conn.queries) != 3 {
+		t.Fatalf("readback queries=%d want=3", len(conn.queries))
+	}
+	for _, query := range conn.queries {
+		if strings.Contains(strings.ToUpper(query), "FINAL") {
+			t.Fatalf("plain MergeTree readback must not use FINAL:\n%s", query)
+		}
+	}
+}
+
+func githubWorkItemEngineUnitEffect[T any](
+	t *testing.T, destination string, rows []T,
+) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues(destination, EffectReadbackRequired, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+type githubWorkItemEngineWriteConn struct {
+	driver.Conn
+	prepares int
+	batch    *githubWorkItemEngineWriteBatch
+}
+
+func (conn *githubWorkItemEngineWriteConn) PrepareBatch(
+	context.Context, string, ...driver.PrepareBatchOption,
+) (driver.Batch, error) {
+	conn.prepares++
+	if conn.batch == nil {
+		conn.batch = &githubWorkItemEngineWriteBatch{}
+	}
+	return conn.batch, nil
+}
+
+type githubWorkItemEngineWriteBatch struct {
+	driver.Batch
+	appends, sends, aborts int
+}
+
+func (batch *githubWorkItemEngineWriteBatch) Append(...any) error {
+	batch.appends++
+	return nil
+}
+
+func (batch *githubWorkItemEngineWriteBatch) Send() error {
+	batch.sends++
+	return nil
+}
+
+func (batch *githubWorkItemEngineWriteBatch) Abort() error {
+	batch.aborts++
+	return nil
+}
+
+type githubWorkItemEngineAdapterCase struct {
+	name        string
+	destination string
+	valid       EffectBatch
+	forgedOrg   EffectBatch
+	adapter     func(driver.Conn, providerfoundation.LeaseGuard) GitHubWorkItemEffectAdapter
+}
+
+func githubWorkItemEngineAdapterCases(t *testing.T) []githubWorkItemEngineAdapterCase {
+	t.Helper()
+	issue := githubWorkItemEngineEffectIssueRow()
+	foreignIssue := issue
+	foreignIssue.OrgID = "org-other"
+	classification := githubWorkItemEngineEffectClassificationRow()
+	foreignClassification := classification
+	foreignClassification.OrgID = "org-other"
+	metrics := githubWorkItemEngineEffectMetricsRow()
+	foreignMetrics := metrics
+	foreignMetrics.OrgID = "org-other"
+	return []githubWorkItemEngineAdapterCase{
+		{
+			name: "issue type", destination: githubIssueTypeMetricsDestination,
+			valid: githubWorkItemEngineUnitEffect(
+				t, githubIssueTypeMetricsDestination, []githubIssueTypeMetricsDailyRow{issue},
+			),
+			forgedOrg: githubWorkItemEngineUnitEffect(
+				t, githubIssueTypeMetricsDestination,
+				[]githubIssueTypeMetricsDailyRow{foreignIssue},
+			),
+			adapter: func(conn driver.Conn, lease providerfoundation.LeaseGuard) GitHubWorkItemEffectAdapter {
+				return GitHubIssueTypeMetricsClickHouseEffects{Conn: conn, Lease: lease}
+			},
+		},
+		{
+			name: "classification", destination: githubInvestmentClassificationsDestination,
+			valid: githubWorkItemEngineUnitEffect(
+				t, githubInvestmentClassificationsDestination,
+				[]githubInvestmentClassificationDailyRow{classification},
+			),
+			forgedOrg: githubWorkItemEngineUnitEffect(
+				t, githubInvestmentClassificationsDestination,
+				[]githubInvestmentClassificationDailyRow{foreignClassification},
+			),
+			adapter: func(conn driver.Conn, lease providerfoundation.LeaseGuard) GitHubWorkItemEffectAdapter {
+				return GitHubInvestmentClassificationsClickHouseEffects{Conn: conn, Lease: lease}
+			},
+		},
+		{
+			name: "metrics", destination: githubInvestmentMetricsDestination,
+			valid: githubWorkItemEngineUnitEffect(
+				t, githubInvestmentMetricsDestination,
+				[]githubInvestmentMetricsDailyRow{metrics},
+			),
+			forgedOrg: githubWorkItemEngineUnitEffect(
+				t, githubInvestmentMetricsDestination,
+				[]githubInvestmentMetricsDailyRow{foreignMetrics},
+			),
+			adapter: func(conn driver.Conn, lease providerfoundation.LeaseGuard) GitHubWorkItemEffectAdapter {
+				return GitHubInvestmentMetricsClickHouseEffects{Conn: conn, Lease: lease}
+			},
+		},
+	}
+}
+
+func githubWorkItemEngineTestIdentity(
+	destination string, effect EffectBatch,
+) GitHubWorkItemEffectIdentity {
+	return GitHubWorkItemEffectIdentity{
+		OrgID: "org-acme", Provider: "github", Dataset: "work-items",
+		Generation: "gen-1", Destination: destination, RowCount: len(effect.Rows),
+	}
+}
+
+func TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease(t *testing.T) {
+	ctx := context.Background()
+	validLease := githubWorkItemCompositionLease()
+	for _, testCase := range githubWorkItemEngineAdapterCases(t) {
+		t.Run(testCase.name, func(t *testing.T) {
+			identity := githubWorkItemEngineTestIdentity(
+				testCase.destination, testCase.valid,
+			)
+
+			withoutConn := testCase.adapter(nil, validLease)
+			if err := withoutConn.WriteGitHubWorkItemEffect(
+				ctx, identity, testCase.valid,
+			); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("write without conn error=%v", err)
+			}
+			if _, err := withoutConn.InspectGitHubWorkItemEffect(
+				ctx, identity, testCase.valid,
+			); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("inspect without conn error=%v", err)
+			}
+
+			conn := &githubWorkItemEngineWriteConn{}
+			forged := testCase.adapter(conn, validLease)
+			if err := forged.WriteGitHubWorkItemEffect(
+				ctx, identity, testCase.forgedOrg,
+			); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("forged tenant write error=%v", err)
+			}
+			if _, err := forged.InspectGitHubWorkItemEffect(
+				ctx, identity, testCase.forgedOrg,
+			); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("forged tenant inspect error=%v", err)
+			}
+			if conn.prepares != 0 {
+				t.Fatalf("forged tenant prepared %d batches", conn.prepares)
+			}
+
+			lostBefore := providerfoundation.LeaseGuardFunc(
+				func(context.Context) error { return providerfoundation.ErrLeaseLost },
+			)
+			conn = &githubWorkItemEngineWriteConn{}
+			if err := testCase.adapter(conn, lostBefore).WriteGitHubWorkItemEffect(
+				ctx, identity, testCase.valid,
+			); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+				t.Fatalf("pre-write lease error=%v", err)
+			}
+			if conn.prepares != 0 {
+				t.Fatalf("lost lease prepared %d batches before refusal", conn.prepares)
+			}
+
+			readConn := &githubWorkItemEngineRecordingConn{}
+			inspection, err := testCase.adapter(
+				readConn, lostBefore,
+			).InspectGitHubWorkItemEffect(ctx, identity, testCase.valid)
+			if !errors.Is(err, providerfoundation.ErrLeaseLost) ||
+				inspection != EffectConflict {
+				t.Fatalf("pre-read lease inspection=%s error=%v", inspection, err)
+			}
+			if len(readConn.queries) != 0 {
+				t.Fatalf("lost read lease executed queries=%v", readConn.queries)
+			}
+
+			conn = &githubWorkItemEngineWriteConn{}
+			lostAfter := &secondAssertionLosesLease{}
+			if err := testCase.adapter(conn, lostAfter).WriteGitHubWorkItemEffect(
+				ctx, identity, testCase.valid,
+			); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+				t.Fatalf("post-append lease error=%v", err)
+			}
+			if lostAfter.calls != 2 || conn.prepares != 1 || conn.batch == nil ||
+				conn.batch.appends != 1 || conn.batch.sends != 0 || conn.batch.aborts != 1 {
+				t.Fatalf(
+					"post-append fence calls=%d prepares=%d batch=%+v",
+					lostAfter.calls, conn.prepares, conn.batch,
+				)
+			}
+		})
+	}
+}

--- a/internal/providersync/github_work_items_composition.go
+++ b/internal/providersync/github_work_items_composition.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ErrGitHubWorkItemSinkIncomplete reports a composite sink built while one or
-// more destination adapters are unported. It always wraps the destination names
+// more destination adapters are missing. It always wraps the destination names
 // so a caller learns WHICH surfaces are absent, never only that some are.
 var ErrGitHubWorkItemSinkIncomplete = errors.New(
 	"github work-item clickhouse sink is missing destination adapters",
@@ -88,12 +88,15 @@ func NewGitHubWorkItemClickHouseEffects(
 		WorkItemTeamAttributions: GitHubWorkItemTeamAttributionsClickHouseEffects{
 			Conn: conn, Lease: lease,
 		},
-
-		// investment_classifications_daily, investment_metrics_daily and
-		// issue_type_metrics_daily stay nil until their engines are ported.
-		// They are left unset rather than filled with a no-op adapter: a no-op
-		// would let complete() report a sink that silently writes nothing to
-		// three real tables.
+		InvestmentClassificationsDaily: GitHubInvestmentClassificationsClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+		InvestmentMetricsDaily: GitHubInvestmentMetricsClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
+		IssueTypeMetricsDaily: GitHubIssueTypeMetricsClickHouseEffects{
+			Conn: conn, Lease: lease,
+		},
 	}
 	if missing := sink.MissingDestinations(); len(missing) > 0 {
 		return sink, fmt.Errorf(
@@ -103,8 +106,8 @@ func NewGitHubWorkItemClickHouseEffects(
 	return sink, nil
 }
 
-// githubWorkItemDerivedOwnedDestinations is what the ported builders speak for
-// today: the metric triplet plus the three derived landing surfaces. It is a
+// githubWorkItemDerivedOwnedDestinations is what the non-engine builders speak
+// for: the metric triplet plus the three derived landing surfaces. It is a
 // strict subset of githubWorkItemDerivedDestinations, which the route requires
 // in full.
 var githubWorkItemDerivedOwnedDestinations = func() []string {
@@ -116,8 +119,8 @@ var githubWorkItemDerivedOwnedDestinations = func() []string {
 	return owned
 }()
 
-// githubWorkItemDerivedEngineDestinations is what the unported engines owe: the
-// canonical derived set minus what the ported builders already speak for.
+// githubWorkItemDerivedEngineDestinations is the concrete engine's exact
+// ownership: the canonical derived set minus what the other builders speak for.
 // Derived rather than hand-listed, so it cannot disagree with either.
 var githubWorkItemDerivedEngineDestinations = func() []string {
 	owed := make([]string, 0, len(githubWorkItemDerivedDestinations))
@@ -129,11 +132,10 @@ var githubWorkItemDerivedEngineDestinations = func() []string {
 	return owed
 }()
 
-// githubWorkItemEngineDeriver is the PR-C seam for the three engine-dependent
-// destinations. It is deliberately UNEXPORTED and has no production setter: the
-// only thing that can install one is a test inside this package, which is what
-// lets the composition be proven end-to-end without fabricating the engines'
-// output in production. When the engines land they replace this seam.
+// githubWorkItemEngineDeriver is the per-day seam for the three
+// engine-dependent destinations. GitHubWorkItemEngineDeriver is its concrete
+// production implementation; narrow test doubles still use the interface to
+// prove composition failure modes without invoking either config engine.
 //
 // IT TAKES A DAY AND IS CALLED ONCE PER DAY. All three destinations it will
 // serve are per-day in Python and stamp `day=d` on every row: issue-type
@@ -141,13 +143,10 @@ var githubWorkItemDerivedEngineDestinations = func() []string {
 // investment metrics (:1433) are all built inside the :1238 day loop, from
 // state that resets each iteration. A seam invoked once for the whole window
 // could not express that shape -- and a merge that ASSIGNED rather than
-// appended would silently keep only the last day's rows the moment a real
-// per-day engine replaced the stub. Shaped correctly now, while the only
-// implementation is a test double and the change costs nothing.
-//
-// PR-C OBLIGATION: the ported engines emit rows for the day they are handed,
-// not for the window. The per-day merge accumulates across days exactly as it
-// does for the ported builders.
+// appended would silently keep only the last day's rows. The concrete engine
+// emits rows for the day it is handed, not for the window; this seam preserves
+// that contract while package tests inject hostile doubles for fail-closed
+// proofs.
 type githubWorkItemEngineDeriver interface {
 	Derive(
 		context.Context,
@@ -168,8 +167,49 @@ type GitHubWorkItemDeriver struct {
 	// omitting a row, which D17 ratifies as fail-closed.
 	Source githubWorkItemDerivationContextSource
 
-	// engine is nil in every production build; see githubWorkItemEngineDeriver.
+	// engine is deliberately private. Production callers can install it only
+	// through NewGitHubWorkItemDeriver, which loads both configs atomically.
+	// Package tests may still inject hostile doubles to prove fail-closed paths.
 	engine githubWorkItemEngineDeriver
+}
+
+// NewGitHubWorkItemDeriver is the only production construction path that can
+// install the config-driven engine. Both config paths are explicit: the worker
+// must not inherit a status-mapping environment fallback or silently turn a
+// blank investment path into the classifier's intentional missing-file
+// fallback. Once paths are present, each loader's Python-parity behavior is
+// preserved -- in particular, a named-but-missing investment file constructs
+// the legacy-default classifier exactly as Python does.
+func NewGitHubWorkItemDeriver(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+	statusMappingConfigPath string,
+	investmentConfigPath string,
+) (*GitHubWorkItemDeriver, error) {
+	if conn == nil || lease == nil || strings.TrimSpace(statusMappingConfigPath) == "" ||
+		strings.TrimSpace(investmentConfigPath) == "" {
+		return nil, ErrInvalidConfiguration
+	}
+	statusMapping, err := LoadStatusMapping(statusMappingConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	investmentClassifier, err := NewInvestmentClassifier(investmentConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	engine, err := NewGitHubWorkItemEngineDeriver(
+		statusMapping, investmentClassifier,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &GitHubWorkItemDeriver{
+		Source: githubWorkItemClickHouseDerivationContextSource{
+			Conn: conn, Lease: lease,
+		},
+		engine: engine,
+	}, nil
 }
 
 // githubWorkItemDerivedMaxBackfillDays bounds the day loop.
@@ -335,7 +375,7 @@ func (deriver GitHubWorkItemDeriver) Derive(
 		}
 	}
 	if missing := githubWorkItemMissingDerivedDestinations(derived); len(missing) > 0 {
-		// Fails closed rather than emitting empty slices for the unported
+		// Fails closed rather than emitting empty slices for unavailable
 		// destinations. An empty slice is indistinguishable from "evaluated,
 		// produced nothing", which is precisely the claim this port cannot
 		// honestly make about a metric whose engine does not exist yet.
@@ -370,11 +410,10 @@ func githubWorkItemMergeDerivedRows(
 // githubWorkItemMergeEngineRows accumulates the engine seam's per-day output.
 //
 // It deliberately does NOT pre-open the engine's destinations. A key is created
-// only by an engine that actually emitted for it, so a destination the engine
-// never produced stays ABSENT and the missing-destination check fails the run
-// closed. Pre-opening them would hand every unported destination an empty slice
-// -- indistinguishable from "evaluated, produced nothing", which is exactly the
-// fabrication this deriver exists to refuse.
+// only by the configured engine actually emitting it, so a missing or partial
+// engine leaves a destination ABSENT and the missing-destination check fails the
+// run closed. Pre-opening would fabricate "evaluated, produced nothing" for a
+// capability that never ran.
 //
 // Membership is checked against the ENGINE's destinations rather than against
 // presence in `derived`, so an engine restating a ported builder's destination

--- a/internal/providersync/github_work_items_composition_test.go
+++ b/internal/providersync/github_work_items_composition_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -15,11 +14,9 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
-// githubWorkItemUnportedDestinations is the engine-dependent set this lane
-// deliberately leaves nil. Stated once, asserted from several directions below,
-// so PR-C gets exactly one place to update and every dependent assertion moves
-// with it.
-var githubWorkItemUnportedDestinations = []string{
+// githubWorkItemEngineTestDestinations is the engine-dependent set exercised by
+// the composition doubles below.
+var githubWorkItemEngineTestDestinations = []string{
 	"investment_classifications_daily",
 	"investment_metrics_daily",
 	"issue_type_metrics_daily",
@@ -66,48 +63,31 @@ func TestNewGitHubWorkItemClickHouseEffectsRejectsMissingDependencies(t *testing
 	}
 }
 
-// TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree is
-// the tripwire. It asserts the missing set is EXACTLY the three engine-dependent
-// destinations -- so when PR-C wires one, this test goes red and forces the
-// declaration to be updated rather than letting a stale "3 missing" claim ride.
-func TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree(
-	t *testing.T,
-) {
+// TestNewGitHubWorkItemClickHouseEffectsWiresAllSixteen is the constructor
+// tripwire: every canonical destination must be concrete before the returned
+// sink may be used.
+func TestNewGitHubWorkItemClickHouseEffectsWiresAllSixteen(t *testing.T) {
 	t.Parallel()
 	sink, err := NewGitHubWorkItemClickHouseEffects(
 		stubWorkItemConn{}, githubWorkItemCompositionLease(),
 	)
-	if !errors.Is(err, ErrGitHubWorkItemSinkIncomplete) {
-		t.Fatalf("error=%v want ErrGitHubWorkItemSinkIncomplete", err)
+	if err != nil {
+		t.Fatal(err)
 	}
 	missing := sink.MissingDestinations()
-	if !reflect.DeepEqual(missing, githubWorkItemUnportedDestinations) {
-		t.Fatalf("missing=%v want=%v", missing, githubWorkItemUnportedDestinations)
+	if len(missing) != 0 {
+		t.Fatalf("missing=%v want none", missing)
 	}
-	// The names must reach the operator through the error, not only through a
-	// method nobody calls.
-	for _, destination := range githubWorkItemUnportedDestinations {
-		if !strings.Contains(err.Error(), destination) {
-			t.Errorf("error %q does not name %q", err.Error(), destination)
-		}
+	if !sink.complete() {
+		t.Fatal("fully constructed sink did not report itself complete")
 	}
-	if sink.complete() {
-		t.Fatal("a sink missing three destinations reported itself complete")
-	}
-	// Every destination NOT in the unported set must be wired. Without this the
-	// test above would still pass if the constructor forgot a fourth adapter
-	// and the unported list were widened to match.
 	for _, destination := range workItemRouteDestinations() {
 		adapter, known := sink.adapterForDestination(destination)
-		wantWired := !slices.Contains(githubWorkItemUnportedDestinations, destination)
 		if !known {
 			t.Fatalf("destination %q is not dispatchable", destination)
 		}
-		if wantWired && adapter == nil {
+		if adapter == nil {
 			t.Errorf("destination %q should be wired but is nil", destination)
-		}
-		if !wantWired && adapter != nil {
-			t.Errorf("destination %q should be unported but is wired", destination)
 		}
 	}
 	if sink.Lease == nil {
@@ -328,13 +308,11 @@ func TestGitHubWorkItemDerivedDaysFailsClosedOnUnusableWindows(t *testing.T) {
 	}
 }
 
-// TestGitHubWorkItemEngineSeamIsInvokedPerDay pins the shape PR-C has to fill.
-// All three engine destinations are per-day in Python and stamp `day=d`
-// (job_work_items.py:1346/:1387/:1433, inside the :1238 loop), so a seam called
-// once per window could not express them -- and a merge that assigned rather
-// than appended would keep only the last day once a real engine replaced the
-// stub. Both failures are invisible while the stub returns empty, which is why
-// this asserts the days reaching the seam and the accumulated row count.
+// TestGitHubWorkItemEngineSeamIsInvokedPerDay pins the concrete engine's outer
+// composition contract. All three engine destinations are per-day in Python
+// and stamp `day=d` (job_work_items.py:1346/:1387/:1433 inside the :1238 loop),
+// so a seam called once per window cannot express them and assignment would
+// keep only the last day. The hostile double makes both failures observable.
 func TestGitHubWorkItemEngineSeamIsInvokedPerDay(t *testing.T) {
 	t.Parallel()
 	claim := githubWorkItemOracleClaim()
@@ -362,7 +340,7 @@ func TestGitHubWorkItemEngineSeamIsInvokedPerDay(t *testing.T) {
 		t.Fatalf("engine saw days=%v want=%v", recorder.days, wantDays)
 	}
 	// Accumulated, not overwritten: one row per day per destination.
-	for _, destination := range githubWorkItemUnportedDestinations {
+	for _, destination := range githubWorkItemEngineTestDestinations {
 		rows := derived[destination]
 		if len(rows) != len(wantDays) {
 			t.Fatalf("%s has %d rows over %d days; the merge is not accumulating",
@@ -388,8 +366,8 @@ func (engine *githubWorkItemRecordingEngine) Derive(
 	_ githubWorkItemDerivationContext,
 ) (map[string][]json.RawMessage, error) {
 	engine.days = append(engine.days, day)
-	produced := make(map[string][]json.RawMessage, len(githubWorkItemUnportedDestinations))
-	for _, destination := range githubWorkItemUnportedDestinations {
+	produced := make(map[string][]json.RawMessage, len(githubWorkItemEngineTestDestinations))
+	for _, destination := range githubWorkItemEngineTestDestinations {
 		produced[destination] = []json.RawMessage{
 			json.RawMessage(`{"day":"` + day.Format("2006-01-02") + `"}`),
 		}
@@ -559,9 +537,8 @@ func (source *countingGitHubWorkItemDerivationContextSource) Load(
 	return githubWorkItemDerivationFacts{}, nil
 }
 
-// githubWorkItemStubEngine stands in for the unported engines so composition can
-// be proven today. It is test-only by construction: GitHubWorkItemDeriver.engine
-// is unexported and no production code path sets it.
+// githubWorkItemStubEngine isolates composition mechanics from the real config
+// engines so error, omission and multi-day accumulation paths stay focused.
 type githubWorkItemStubEngine struct{ err error }
 
 func (engine githubWorkItemStubEngine) Derive(
@@ -575,8 +552,8 @@ func (engine githubWorkItemStubEngine) Derive(
 	if engine.err != nil {
 		return nil, engine.err
 	}
-	produced := make(map[string][]json.RawMessage, len(githubWorkItemUnportedDestinations))
-	for _, destination := range githubWorkItemUnportedDestinations {
+	produced := make(map[string][]json.RawMessage, len(githubWorkItemEngineTestDestinations))
+	for _, destination := range githubWorkItemEngineTestDestinations {
 		// Stamped with the day it was handed: an engine call hoisted out of the
 		// loop, or a merge that assigned instead of appending, shows up as a
 		// missing or wrong-dated row rather than as an indistinguishable empty.
@@ -587,10 +564,9 @@ func (engine githubWorkItemStubEngine) Derive(
 	return produced, nil
 }
 
-// TestGitHubWorkItemDeriverFailsClosedWithoutTheUnportedEngines proves the
-// deriver refuses to fabricate the three destinations it cannot compute, and
-// names them.
-func TestGitHubWorkItemDeriverFailsClosedWithoutTheUnportedEngines(t *testing.T) {
+// TestGitHubWorkItemDeriverFailsClosedWithoutConfiguredEngine proves a caller
+// that bypasses the atomic constructor cannot fabricate engine-backed success.
+func TestGitHubWorkItemDeriverFailsClosedWithoutConfiguredEngine(t *testing.T) {
 	t.Parallel()
 	claim := githubWorkItemOracleClaim()
 	deriver := GitHubWorkItemDeriver{Source: &fakeGitHubWorkItemDerivationContextSource{}}
@@ -605,7 +581,7 @@ func TestGitHubWorkItemDeriverFailsClosedWithoutTheUnportedEngines(t *testing.T)
 	if derived != nil {
 		t.Fatalf("failed derivation returned rows: %v", derived)
 	}
-	for _, destination := range githubWorkItemUnportedDestinations {
+	for _, destination := range githubWorkItemEngineTestDestinations {
 		if !strings.Contains(err.Error(), destination) {
 			t.Errorf("error %q does not name %q", err.Error(), destination)
 		}
@@ -708,7 +684,7 @@ func (engine githubWorkItemOverreachingEngine) Derive(
 	produced := map[string][]json.RawMessage{
 		engine.destination: {},
 	}
-	for _, destination := range githubWorkItemUnportedDestinations {
+	for _, destination := range githubWorkItemEngineTestDestinations {
 		produced[destination] = []json.RawMessage{}
 	}
 	return produced, nil
@@ -822,7 +798,7 @@ func TestGitHubWorkItemCompositionNeverFailsOpen(t *testing.T) {
 	t.Run("an engine covering only some destinations is refused", func(t *testing.T) {
 		t.Parallel()
 		partial := map[string][]json.RawMessage{
-			githubWorkItemUnportedDestinations[0]: {},
+			githubWorkItemEngineTestDestinations[0]: {},
 		}
 		deriver := GitHubWorkItemDeriver{
 			Source: &fakeGitHubWorkItemDerivationContextSource{},
@@ -833,28 +809,34 @@ func TestGitHubWorkItemCompositionNeverFailsOpen(t *testing.T) {
 			t.Fatalf("error=%v want ErrGitHubWorkItemsDerivationsUnavailable", err)
 		}
 		// The still-missing two must be named; the one it did cover must not.
-		for _, destination := range githubWorkItemUnportedDestinations[1:] {
+		for _, destination := range githubWorkItemEngineTestDestinations[1:] {
 			if !strings.Contains(err.Error(), destination) {
 				t.Errorf("error %q does not name still-missing %q", err.Error(), destination)
 			}
 		}
-		if strings.Contains(err.Error(), githubWorkItemUnportedDestinations[0]) {
+		if strings.Contains(err.Error(), githubWorkItemEngineTestDestinations[0]) {
 			t.Errorf("error %q names %q, which the engine did cover",
-				err.Error(), githubWorkItemUnportedDestinations[0])
+				err.Error(), githubWorkItemEngineTestDestinations[0])
 		}
 	})
 
-	t.Run("a sink built from a rejected constructor call refuses every write", func(t *testing.T) {
+	t.Run("a deliberately corrupted sink refuses every write", func(t *testing.T) {
 		t.Parallel()
-		// The caller that drops the error. The constructor hands back a
-		// populated sink so MissingDestinations stays readable, so the
-		// guarantee has to come from the write path refusing -- not from the
-		// caller having checked.
+		// The complete constructor no longer has an expected-error path. Model
+		// partial construction by removing one concrete engine adapter after
+		// construction; the composite gate must still refuse EVERY destination,
+		// not merely the missing one.
 		sink, err := NewGitHubWorkItemClickHouseEffects(
 			stubWorkItemConn{}, githubWorkItemCompositionLease(),
 		)
-		if err == nil {
-			t.Fatal("constructor unexpectedly reported a complete sink")
+		if err != nil {
+			t.Fatal(err)
+		}
+		sink.InvestmentMetricsDaily = nil
+		if !reflect.DeepEqual(
+			sink.MissingDestinations(), []string{githubInvestmentMetricsDestination},
+		) {
+			t.Fatalf("missing=%v want investment metrics", sink.MissingDestinations())
 		}
 		effects, buildErr := BuildGitHubWorkItemEffects(GitHubWorkItemEffectRows{})
 		if buildErr != nil {
@@ -873,8 +855,8 @@ func TestGitHubWorkItemCompositionNeverFailsOpen(t *testing.T) {
 }
 
 // TestGitHubWorkItemDeriverComposesTheFullSixteenEffectManifest is the
-// composition proof: real builders for the six ported destinations, the stub
-// engine for the three unported ones, through the route's effect construction,
+// composition proof: real non-engine builders plus a focused engine stub,
+// through the route's effect construction,
 // into a complete sink that routes all sixteen.
 func TestGitHubWorkItemDeriverComposesTheFullSixteenEffectManifest(t *testing.T) {
 	t.Parallel()

--- a/internal/providersync/github_work_items_effects_clickhouse.go
+++ b/internal/providersync/github_work_items_effects_clickhouse.go
@@ -280,8 +280,8 @@ func (sink GitHubWorkItemClickHouseEffects) adapterForDestination(
 }
 
 // MissingDestinations names every canonical destination this sink cannot serve,
-// in workItemRouteDestinations order. It is the typed form of "13 of 16": a
-// caller, a test, or an operator reading a constructor error learns WHICH
+// in workItemRouteDestinations order. A caller, a test, or an operator reading
+// a constructor error learns WHICH
 // surfaces are absent rather than only that something is.
 //
 // A destination the dispatch switch does not know is reported as missing rather
@@ -300,12 +300,11 @@ func (sink GitHubWorkItemClickHouseEffects) MissingDestinations() []string {
 	return missing
 }
 
-// complete gates every write and readback. It stays an ALL-SIXTEEN gate while
-// the three engine-dependent destinations are unported: a sink that served the
-// thirteen it has would land a generation whose derived surfaces are silently
-// absent, which is exactly the "evaluated and produced no rows" versus "the
-// composite forgot a destination" distinction GitHubWorkItemEffectRows exists
-// to preserve.
+// complete gates every write and readback. It remains an ALL-SIXTEEN gate: a
+// partially constructed sink would land a generation whose surfaces are
+// silently absent, which is exactly the "evaluated and produced no rows" versus
+// "the composite forgot a destination" distinction GitHubWorkItemEffectRows
+// exists to preserve.
 func (sink GitHubWorkItemClickHouseEffects) complete() bool {
 	return len(sink.MissingDestinations()) == 0
 }

--- a/internal/providersync/investment_classifier_reachability_test.go
+++ b/internal/providersync/investment_classifier_reachability_test.go
@@ -51,7 +51,7 @@ func investmentReflectCallSite(t *testing.T) investmentCallSitePremise {
 	output, err := exec.Command(
 		python,
 		filepath.Join(root, "internal/providersync/testdata/python_investment_call_site.py"),
-		filepath.Join(root, "src/dev_health_ops/metrics/job_work_items.py"),
+		filepath.Join(root, "src/dev_health_ops/metrics/work_item_engine_destinations.py"),
 		filepath.Join(root, "src/dev_health_ops/models/work_items.py"),
 	).CombinedOutput()
 	if err != nil {
@@ -74,9 +74,9 @@ func investmentReflectCallSite(t *testing.T) investmentCallSitePremise {
 //
 // Both facts come from production Python:
 //
-//   - the call site (metrics/job_work_items.py:1377) passes exactly labels,
-//     component, title and provider -- so `paths` is absent, which is what
-//     kills the three path_prefix rules;
+//   - the production helper called by metrics/job_work_items.py passes exactly
+//     labels, component, title and provider -- so `paths` is absent, which is
+//     what kills the three path_prefix rules;
 //   - WorkItem declares no `component` field, so that call site's
 //     `getattr(item, "component", "")` cannot return anything but "" -- which
 //     is what kills data_component.

--- a/internal/providersync/testdata/mutation-plans/github_work_item_engine_destinations.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_engine_destinations.json
@@ -1,0 +1,667 @@
+{
+  "schema_version": 1,
+  "name": "github work-item config-engine destinations and plain-MergeTree effects",
+  "build": [
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
+  ],
+  "mutations": [
+    {
+      "id": "E1-engine-constructor-accepts-nil-status-mapping",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\tif statusMapping == nil || investmentClassifier == nil {",
+      "replace": "\tif investmentClassifier == nil {",
+      "rationale": "Status mapping and investment classification are one atomic capability; accepting the classifier alone creates a partial engine that later panics or fabricates issue-type output.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemEngineDeriverRejectsPartialEngines$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E2-engine-constructor-accepts-nil-classifier",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\tif statusMapping == nil || investmentClassifier == nil {",
+      "replace": "\tif statusMapping == nil {",
+      "rationale": "Status mapping alone is not a complete engine: both investment destinations would be unevaluated.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemEngineDeriverRejectsPartialEngines$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E3-runtime-corruption-misses-nil-status-mapping",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\tif ctx == nil || engine == nil || engine.statusMapping == nil ||\n\t\tengine.investmentClassifier == nil || claim.Validate() != nil ||",
+      "replace": "\tif ctx == nil || engine == nil || false ||\n\t\tengine.investmentClassifier == nil || claim.Validate() != nil ||",
+      "rationale": "Package-level corruption or a hostile injected engine must still fail closed before dereferencing a missing status mapping.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverRejectsCorruptedPartialEngine$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E4-runtime-corruption-misses-nil-classifier",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tengine.investmentClassifier == nil || claim.Validate() != nil ||",
+      "replace": "\t\tfalse || claim.Validate() != nil ||",
+      "rationale": "A corrupted concrete engine with no classifier cannot claim either investment destination was evaluated.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverRejectsCorruptedPartialEngine$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E5-production-constructor-drops-engine",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tengine, err := NewGitHubWorkItemEngineDeriver(\n\t\tstatusMapping, investmentClassifier,\n\t)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\treturn &GitHubWorkItemDeriver{\n\t\tSource: githubWorkItemClickHouseDerivationContextSource{\n\t\t\tConn: conn, Lease: lease,\n\t\t},\n\t\tengine: engine,",
+      "replace": "\t_, err = NewGitHubWorkItemEngineDeriver(\n\t\tstatusMapping, investmentClassifier,\n\t)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\treturn &GitHubWorkItemDeriver{\n\t\tSource: githubWorkItemClickHouseDerivationContextSource{\n\t\t\tConn: conn, Lease: lease,\n\t\t},\n\t\tengine: nil,",
+      "rationale": "The exported path-based constructor must return a fully installed production deriver, not merely validate two configs and discard the engine.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemDeriverLoadsBothExplicitConfigsAtomically$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E6-production-constructor-accepts-blank-status-path",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tif conn == nil || lease == nil || strings.TrimSpace(statusMappingConfigPath) == \"\" ||\n\t\tstrings.TrimSpace(investmentConfigPath) == \"\" {",
+      "replace": "\tif conn == nil || lease == nil || false ||\n\t\tstrings.TrimSpace(investmentConfigPath) == \"\" {",
+      "rationale": "The exported constructor requires an explicit status config path and must reject blank input before any environment-aware loader can reinterpret it.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemDeriverLoadsBothExplicitConfigsAtomically$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E7-production-constructor-accepts-blank-investment-path",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\tif conn == nil || lease == nil || strings.TrimSpace(statusMappingConfigPath) == \"\" ||\n\t\tstrings.TrimSpace(investmentConfigPath) == \"\" {",
+      "replace": "\tif conn == nil || lease == nil || strings.TrimSpace(statusMappingConfigPath) == \"\" ||\n\t\tfalse {",
+      "rationale": "A blank investment path is configuration omission, not the classifier's intentional named-missing-file fallback.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemDeriverLoadsBothExplicitConfigsAtomically$", "./internal/providersync/"]]
+    },
+    {
+      "id": "C1-engine-stamp-rounded-to-minute",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "githubWorkItemEngineDestinationStampPrecision = time.Second",
+      "replace": "githubWorkItemEngineDestinationStampPrecision = time.Minute",
+      "rationale": "All three migration columns store DateTime seconds; coarser minute rounding changes the generated version and makes readback identify a different effect.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "C2-status-mapping-does-not-see-labels",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "statusMapping.NormalizeType(item.Provider, item.Type, item.Labels)",
+      "replace": "statusMapping.NormalizeType(item.Provider, item.Type, nil)",
+      "rationale": "Production status mapping consumes provider, raw type, and labels; dropping labels turns the bug-labelled pull request in the fixture back into a generic type.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "C3-future-zero-bucket-is-dropped",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tbucket := buckets[key]\n\t\tif bucket == nil {\n\t\t\tbucket = &githubIssueTypeMetricsBucket{}\n\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}\n\t\tcreated := item.CreatedAt.UTC()",
+      "replace": "\t\tcreated := item.CreatedAt.UTC()\n\t\tif !created.Before(end) {\n\t\t\tcontinue\n\t\t}\n\t\tbucket := buckets[key]\n\t\tif bucket == nil {\n\t\t\tbucket = &githubIssueTypeMetricsBucket{}\n\t\t\tbuckets[key] = bucket\n\t\t\torder = append(order, key)\n\t\t}",
+      "rationale": "Python opens an issue-type bucket before time filtering, so a future-only item still emits an all-zero group; moving the skip first silently loses the row.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "C4a-issue-p50-uses-lower-middle",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tvar p50, p90 float64\n\t\tif len(bucket.cycleHours) > 0 {\n\t\t\tp50 = bucket.cycleHours[len(bucket.cycleHours)/2]",
+      "replace": "\t\tvar p50, p90 float64\n\t\tif len(bucket.cycleHours) > 0 {\n\t\t\tp50 = bucket.cycleHours[(len(bucket.cycleHours)-1)/2]",
+      "rationale": "Python issue-type p50 uses upper-index selection; the two unequal cycle samples distinguish it from a lower median.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "C4b-investment-p50-uses-lower-middle",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tvar p50 float64\n\t\tif len(bucket.cycleHours) > 0 {\n\t\t\tp50 = bucket.cycleHours[len(bucket.cycleHours)/2]",
+      "replace": "\t\tvar p50 float64\n\t\tif len(bucket.cycleHours) > 0 {\n\t\t\tp50 = bucket.cycleHours[(len(bucket.cycleHours)-1)/2]",
+      "rationale": "Python investment p50 independently uses the upper middle cycle, not the issue-type implementation by proxy.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "C5-p90-index-is-not-python-upper-index",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "p90 = bucket.cycleHours[int(float64(len(bucket.cycleHours))*0.9)]",
+      "replace": "p90 = bucket.cycleHours[int(float64(len(bucket.cycleHours))*0.1)]",
+      "rationale": "The issue-type p90 is the element at int(n*0.9), not a lower quantile or interpolated percentile.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I1-classification-includes-items-completed-before-day",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tif !created.Before(end) ||\n\t\t\t(item.CompletedAt != nil && item.CompletedAt.UTC().Before(dayUTC)) {",
+      "replace": "\t\tif !created.Before(end) {",
+      "rationale": "Investment classifications cover items active during the day; an item completed before the day must not be classified into it.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I2-reachable-classifier-error-is-swallowed",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tif err != nil {\n\t\t\treturn nil, nil, err\n\t\t}",
+      "replace": "\t\tif err != nil {\n\t\t\treturn classifications, nil, nil\n\t\t}",
+      "rationale": "A config that loads but raises when a real row reaches Classify must abort the outer derivation without returning a partial manifest.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemDeriverPropagatesReachableClassifierError$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I3-work-item-component-is-absent-instead-of-empty",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tLabels: item.Labels, Component: &emptyComponent,",
+      "replace": "\t\t\tLabels: item.Labels, Component: func() *string { _ = emptyComponent; return nil }(),",
+      "rationale": "The Python work-item call site passes component='', which is observably different from an absent component for a bare-string component matcher.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverSuppliesPythonWorkItemArtifactShape$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I4-work-item-invents-a-classifier-path",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tLabels: item.Labels, Component: &emptyComponent,",
+      "replace": "\t\t\tLabels: item.Labels, Component: &emptyComponent, Paths: []string{\"synthetic\"},",
+      "rationale": "Work-item classification supplies no file paths; inventing one activates path-prefix rules that are inert on the live Python call site.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverSuppliesPythonWorkItemArtifactShape$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I5-zero-story-points-does-not-fall-back-to-one",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tif item.StoryPoints != nil && *item.StoryPoints != 0 {",
+      "replace": "\t\tif item.StoryPoints != nil {",
+      "rationale": "Python's `story_points or 1` maps both null and zero to one delivery unit.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I6-fractional-story-points-are-rounded-up",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "bucket.deliveryUnits += int(math.Trunc(points))",
+      "replace": "bucket.deliveryUnits += int(math.Ceil(points))",
+      "rationale": "Python int() truncates positive fractional story points; rounding 3.7 upward changes delivery units.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I7-closed-at-substitutes-for-completed-at-in-active-count",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tif created.Before(end) &&\n\t\t\t(item.CompletedAt == nil || !item.CompletedAt.UTC().Before(dayUTC)) {",
+      "replace": "\t\tif created.Before(end) &&\n\t\t\t(item.ClosedAt == nil || !item.ClosedAt.UTC().Before(dayUTC)) {",
+      "rationale": "The live producer deliberately uses completed_at only; a closed_at with no completed_at remains active and classified.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineClosedAtDoesNotTerminateWithoutCompletedAt$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I7b-closed-at-substitutes-for-completed-at-in-classification-activity",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tif !created.Before(end) ||\n\t\t\t(item.CompletedAt != nil && item.CompletedAt.UTC().Before(dayUTC)) {",
+      "replace": "\t\tif !created.Before(end) ||\n\t\t\t(item.ClosedAt != nil && item.ClosedAt.UTC().Before(dayUTC)) {",
+      "rationale": "Investment classifications use completed_at to determine whether a work item was active during the day; closed_at is not a substitute.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineClosedAtDoesNotTerminateWithoutCompletedAt$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I7c-closed-at-substitutes-for-completed-at-in-investment-metrics",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tif item.CompletedAt == nil {\n\t\t\tcontinue\n\t\t}\n\t\tcompleted := item.CompletedAt.UTC()",
+      "replace": "\t\tif item.ClosedAt == nil {\n\t\t\tcontinue\n\t\t}\n\t\tcompleted := item.ClosedAt.UTC()",
+      "rationale": "Investment metrics count only completed_at events in the day; a closed-only item must remain active without creating a completion metric.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineClosedAtInsideDayDoesNotCreateCompletionMetric$", "./internal/providersync/"]]
+    },
+    {
+      "id": "I8-unassigned-investment-team-is-not-normalized-to-empty",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tif team == githubWorkItemUnassignedTeamID {\n\t\t\tteam = \"\"\n\t\t}",
+      "replace": "\t\tif team == githubWorkItemUnassignedTeamID {\n\t\t\tteam = githubWorkItemUnassignedTeamID\n\t\t}",
+      "rationale": "Python maps its unassigned sentinel to None and then `or \"\"` at the investment metric row boundary.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineUnassignedInvestmentMetricUsesEmptyTeam$", "./internal/providersync/"]]
+    },
+    {
+      "id": "O1-engine-omits-real-investment-metrics-key",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\tgithubInvestmentMetricsDestination:         metrics,",
+      "replace": "\t\t\"investment_metrics_daily_disabled\":       metrics,",
+      "rationale": "Every engine destination key must be present even when its slice is empty; changing one key must fail rather than silently report a partial engine.",
+      "proof": [["go", "test", "-count=1", "-run", "^(TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay|TestGitHubWorkItemEngineDeriverRejectsCorruptedPartialEngine)$", "./internal/providersync/"]]
+    },
+    {
+      "id": "O2a-issue-row-stamps-wrong-day",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tDay:            newGitHubWorkItemDerivedDay(dayUTC),\n\t\t\tProvider:       key.provider,",
+      "replace": "\t\t\tDay:            newGitHubWorkItemDerivedDay(dayUTC.AddDate(0, 0, -1)),\n\t\t\tProvider:       key.provider,",
+      "rationale": "Issue-type metrics must stamp the exact day handed to the per-day seam.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "O2b-classification-row-stamps-wrong-day",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tDay:            newGitHubWorkItemDerivedDay(dayUTC),\n\t\t\tArtifactType:   githubWorkItemEngineArtifactType,",
+      "replace": "\t\t\tDay:            newGitHubWorkItemDerivedDay(dayUTC.AddDate(0, 0, -1)),\n\t\t\tArtifactType:   githubWorkItemEngineArtifactType,",
+      "rationale": "Each investment classification is a daily row and cannot inherit a window-level or neighboring day.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "O2c-investment-metric-row-stamps-wrong-day",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tDay:                newGitHubWorkItemDerivedDay(dayUTC),\n\t\t\tTeamID:             key.teamID,",
+      "replace": "\t\t\tDay:                newGitHubWorkItemDerivedDay(dayUTC.AddDate(0, 0, -1)),\n\t\t\tTeamID:             key.teamID,",
+      "rationale": "Investment aggregate rows must carry the current loop day so multi-day accumulation stays partitioned.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "O3a-issue-row-drops-tenant",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tLeadP50Hours:   0,\n\t\t\tComputedAt:     computedAt,\n\t\t\tOrgID:          claim.OrgID,",
+      "replace": "\t\t\tLeadP50Hours:   0,\n\t\t\tComputedAt:     computedAt,\n\t\t\tOrgID:          \"\",",
+      "rationale": "Issue-type rows must carry the frozen claim tenant before persistence.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "O3b-classification-row-drops-tenant",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tRuleID:         classification.RuleID,\n\t\t\tComputedAt:     computedAt,\n\t\t\tOrgID:          claim.OrgID,",
+      "replace": "\t\t\tRuleID:         classification.RuleID,\n\t\t\tComputedAt:     computedAt,\n\t\t\tOrgID:          \"\",",
+      "rationale": "Classification rows must carry the frozen claim tenant before persistence.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "O3c-investment-metric-row-drops-tenant",
+      "file": "internal/providersync/github_work_item_engine_destinations.go",
+      "find": "\t\t\tCycleP50Hours:      p50,\n\t\t\tComputedAt:         computedAt,\n\t\t\tOrgID:              claim.OrgID,",
+      "replace": "\t\t\tCycleP50Hours:      p50,\n\t\t\tComputedAt:         computedAt,\n\t\t\tOrgID:              \"\",",
+      "rationale": "Investment metric rows must carry the frozen claim tenant before persistence.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineDeriverUsesBothRealEnginesPerDay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P1-live-python-issue-producer-drops-explicit-tenant",
+      "file": "src/dev_health_ops/metrics/work_item_engine_destinations.py",
+      "find": "                lead_p50_hours=0.0,\n                computed_at=computed_at,\n                org_id=org_id,",
+      "replace": "                lead_p50_hours=0.0,\n                computed_at=computed_at,\n                org_id=\"\",",
+      "rationale": "The differential gate must execute the production Python helper rather than a copied oracle loop; changing its real issue row tenant must diverge from Go.",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/metrics/work_item_engine_destinations.py"],
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "P2-live-python-classification-producer-drops-explicit-tenant",
+      "file": "src/dev_health_ops/metrics/work_item_engine_destinations.py",
+      "find": "                rule_id=classification.rule_id,\n                computed_at=computed_at,\n                org_id=org_id,",
+      "replace": "                rule_id=classification.rule_id,\n                computed_at=computed_at,\n                org_id=\"\",",
+      "rationale": "The live oracle must execute the production classification producer and compare its explicit tenant independently of the issue family.",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/metrics/work_item_engine_destinations.py"],
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "P3-live-python-investment-metric-producer-drops-explicit-tenant",
+      "file": "src/dev_health_ops/metrics/work_item_engine_destinations.py",
+      "find": "                cycle_p50_hours=p50,\n                computed_at=computed_at,\n                org_id=org_id,",
+      "replace": "                cycle_p50_hours=p50,\n                computed_at=computed_at,\n                org_id=\"\",",
+      "rationale": "The live oracle must execute the production investment-metric producer and compare its tenant independently of both other engine families.",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/metrics/work_item_engine_destinations.py"],
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "K1-issue-logical-key-omits-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\trow.OrgID, githubWorkItemEngineNullableUUID(row.RepoID), string(row.Day),\n\t\trow.Provider, row.TeamID, row.IssueTypeNorm,",
+      "replace": "\t\trow.OrgID, \"\", string(row.Day),\n\t\trow.Provider, row.TeamID, row.IssueTypeNorm,",
+      "rationale": "repo_id is absent from the physical sorting key but remains part of effect identity; two repositories may otherwise collide in one valid batch.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineLogicalKeysIncludeNullableRepoID$", "./internal/providersync/"]]
+    },
+    {
+      "id": "K2-classification-logical-key-omits-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\trow.OrgID, githubWorkItemEngineNullableUUID(row.RepoID), string(row.Day),\n\t\trow.Provider, row.ArtifactType,",
+      "replace": "\t\trow.OrgID, \"\", string(row.Day),\n\t\trow.Provider, row.ArtifactType,",
+      "rationale": "A NULL repo and a concrete repo with the same artifact identity are distinct logical effects even though the migration sorting key omits repo_id.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineLogicalKeysIncludeNullableRepoID$", "./internal/providersync/"]]
+    },
+    {
+      "id": "K3-investment-metric-logical-key-omits-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\trow.OrgID, githubWorkItemEngineNullableUUID(row.RepoID), string(row.Day), row.TeamID,",
+      "replace": "\t\trow.OrgID, \"\", string(row.Day), row.TeamID,",
+      "rationale": "Investment metrics from distinct repositories can share every physical key field and must still coexist in one effect.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineLogicalKeysIncludeNullableRepoID$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1a-issue-readback-does-not-fence-present-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.TeamID, expected.IssueTypeNorm,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "replace": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.TeamID, expected.IssueTypeNorm,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND 1 = 1`\n\t}",
+      "rationale": "Issue readback must fence a present repo_id or colliding repositories contaminate one another.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^issue_type_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1b-classification-readback-does-not-fence-present-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.ArtifactType,\n\t\t*expected.InvestmentArea, expected.ProjectStream, expected.ArtifactID,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "replace": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.ArtifactType,\n\t\t*expected.InvestmentArea, expected.ProjectStream, expected.ArtifactID,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND 1 = 1`\n\t}",
+      "rationale": "Classification readback must independently fence a present repo_id despite the physical key omitting it.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_classifications_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1c-investment-metric-readback-does-not-fence-present-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.TeamID, *expected.InvestmentArea,\n\t\texpected.ProjectStream,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "replace": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.TeamID, *expected.InvestmentArea,\n\t\texpected.ProjectStream,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND 1 = 1`\n\t}",
+      "rationale": "Investment metric readback must independently fence a present repo_id for full logical identity.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1d-issue-readback-does-not-fence-null-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.TeamID, expected.IssueTypeNorm,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "replace": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.TeamID, expected.IssueTypeNorm,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND 1 = 1`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "rationale": "The NULL repo branch is a real logical identity and cannot be implemented only for present UUIDs.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^issue_type_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1e-classification-readback-does-not-fence-null-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.ArtifactType,\n\t\t*expected.InvestmentArea, expected.ProjectStream, expected.ArtifactID,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "replace": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.ArtifactType,\n\t\t*expected.InvestmentArea, expected.ProjectStream, expected.ArtifactID,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND 1 = 1`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "rationale": "Classification NULL repo readback must exclude concrete-repo siblings sharing its physical key.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_classifications_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1f-investment-metric-readback-does-not-fence-null-repo",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.TeamID, *expected.InvestmentArea,\n\t\texpected.ProjectStream,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND repo_id IS NULL`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "replace": "\targuments := []any{\n\t\tidentity.OrgID, day, expected.TeamID, *expected.InvestmentArea,\n\t\texpected.ProjectStream,\n\t}\n\tif expected.RepoID == nil {\n\t\tquery += ` AND 1 = 1`\n\t} else {\n\t\tquery += ` AND repo_id = ?`\n\t\targuments = append(arguments, *expected.RepoID)\n\t}",
+      "rationale": "Investment metric NULL repo readback must exclude concrete-repo siblings sharing its physical key.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1g-issue-readback-does-not-fence-org",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND day = ? AND provider = ? AND team_id = ?\n\tAND issue_type_norm = ?`\n\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.TeamID, expected.IssueTypeNorm,\n\t}",
+      "replace": "WHERE 1 = 1 AND day = ? AND provider = ? AND team_id = ?\n\tAND issue_type_norm = ?`\n\targuments := []any{\n\t\tday, expected.Provider, expected.TeamID, expected.IssueTypeNorm,\n\t}",
+      "rationale": "Issue readback must not accept an identical row from a foreign organization.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^issue_type_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1h-classification-readback-does-not-fence-org",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND day = ? AND provider = ? AND artifact_type = ?\n\tAND investment_area = ? AND project_stream = ? AND artifact_id = ?`\n\targuments := []any{\n\t\tidentity.OrgID, day, expected.Provider, expected.ArtifactType,\n\t\t*expected.InvestmentArea, expected.ProjectStream, expected.ArtifactID,\n\t}",
+      "replace": "WHERE 1 = 1 AND day = ? AND provider = ? AND artifact_type = ?\n\tAND investment_area = ? AND project_stream = ? AND artifact_id = ?`\n\targuments := []any{\n\t\tday, expected.Provider, expected.ArtifactType,\n\t\t*expected.InvestmentArea, expected.ProjectStream, expected.ArtifactID,\n\t}",
+      "rationale": "Classification readback must fence organization independently of row validation at write time.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_classifications_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R1i-investment-metric-readback-does-not-fence-org",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND day = ? AND team_id = ?\n\tAND investment_area = ? AND project_stream = ?`\n\targuments := []any{\n\t\tidentity.OrgID, day, expected.TeamID, *expected.InvestmentArea,\n\t\texpected.ProjectStream,\n\t}",
+      "replace": "WHERE 1 = 1 AND day = ? AND team_id = ?\n\tAND investment_area = ? AND project_stream = ?`\n\targuments := []any{\n\t\tday, expected.TeamID, *expected.InvestmentArea,\n\t\texpected.ProjectStream,\n\t}",
+      "rationale": "Investment metric readback must fence organization before applying latest-row semantics.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R2a-issue-readback-accepts-multiple-distinct-rows",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "func compareGitHubIssueTypeMetricsVersion(\n\texpected, actual githubIssueTypeMetricsDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows != 1 {",
+      "replace": "func compareGitHubIssueTypeMetricsVersion(\n\texpected, actual githubIssueTypeMetricsDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows == 0 {",
+      "rationale": "Issue-type metrics have no current-version reader contract, so a second distinct full row is independently ambiguous even when the first equals the effect.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitHubIssueTypeMetricsVersionRequiresOneUnambiguousFullRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R2b-classification-readback-accepts-multiple-distinct-rows",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "func compareGitHubInvestmentClassificationVersion(\n\texpected, actual githubInvestmentClassificationDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows != 1 {",
+      "replace": "func compareGitHubInvestmentClassificationVersion(\n\texpected, actual githubInvestmentClassificationDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows == 0 {",
+      "rationale": "Investment classifications independently reject any second distinct full row because no production reader defines a winner.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitHubInvestmentClassificationVersionRequiresOneUnambiguousFullRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R3a-issue-readback-ignores-computed-at-divergence",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "func compareGitHubIssueTypeMetricsVersion(\n\texpected, actual githubIssueTypeMetricsDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows != 1 {\n\t\tif distinctRows == 0 {\n\t\t\treturn EffectAbsent\n\t\t}\n\t\treturn EffectConflict\n\t}\n\tif actual.OrgID != orgID {\n\t\treturn EffectConflict\n\t}\n\tif !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {",
+      "replace": "func compareGitHubIssueTypeMetricsVersion(\n\texpected, actual githubIssueTypeMetricsDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows != 1 {\n\t\tif distinctRows == 0 {\n\t\t\treturn EffectAbsent\n\t\t}\n\t\treturn EffectConflict\n\t}\n\tif actual.OrgID != orgID {\n\t\treturn EffectConflict\n\t}\n\tif false && !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {",
+      "rationale": "A single older issue row is a conflict without a latest-row reader; computed_at is part of the full persisted row contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitHubIssueTypeMetricsVersionRequiresOneUnambiguousFullRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R3b-classification-readback-ignores-computed-at-divergence",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "func compareGitHubInvestmentClassificationVersion(\n\texpected, actual githubInvestmentClassificationDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows != 1 {\n\t\tif distinctRows == 0 {\n\t\t\treturn EffectAbsent\n\t\t}\n\t\treturn EffectConflict\n\t}\n\tif actual.OrgID != orgID {\n\t\treturn EffectConflict\n\t}\n\tif !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {",
+      "replace": "func compareGitHubInvestmentClassificationVersion(\n\texpected, actual githubInvestmentClassificationDailyRow,\n\tdistinctRows int,\n\torgID string,\n) EffectInspection {\n\tif distinctRows != 1 {\n\t\tif distinctRows == 0 {\n\t\t\treturn EffectAbsent\n\t\t}\n\t\treturn EffectConflict\n\t}\n\tif actual.OrgID != orgID {\n\t\treturn EffectConflict\n\t}\n\tif false && !actual.ComputedAt.Equal(githubWorkItemDerivedSeconds(expected.ComputedAt)) {",
+      "rationale": "Classification computed_at is independently part of the only unambiguous full-row match the adapter can prove.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitHubInvestmentClassificationVersionRequiresOneUnambiguousFullRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R4-investment-metrics-accepts-equal-time-divergence",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif latestDistinct != 1 {",
+      "replace": "\tif latestDistinct == 0 {",
+      "rationale": "argMax has no deterministic winner for divergent tuples tied at the newest timestamp; readback must conflict rather than accept the first row scanned.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitHubInvestmentMetricsVersionRejectsAmbiguousNewestTuple$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R5-investment-metrics-ignores-version-order",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t); decided {\n\t\treturn verdict\n\t}",
+      "replace": "\t); decided && false {\n\t\treturn verdict\n\t}",
+      "rationale": "Under the production argMax contract an older persisted row is absent and a newer one conflicts before value comparison.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitHubInvestmentMetricsVersionRejectsAmbiguousNewestTuple$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R6-investment-metrics-drops-divergent-newest-tuple",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "query += ` GROUP BY repo_id, delivery_units, work_items_completed, prs_merged,\nchurn_loc, cycle_p50_hours, computed_at`",
+      "replace": "query += ` GROUP BY repo_id, delivery_units, work_items_completed, prs_merged,\nchurn_loc, cycle_p50_hours, computed_at ORDER BY computed_at DESC, delivery_units ASC LIMIT 1 BY computed_at`",
+      "rationale": "The latest computed_at must retain every divergent full value tuple; selecting one grouped tuple recreates argMax's nondeterministic equal-time winner.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "F1-issue-readback-adds-final",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "FROM issue_type_metrics_daily\nWHERE org_id",
+      "replace": "FROM issue_type_metrics_daily FINAL\nWHERE org_id",
+      "rationale": "FINAL does not deduplicate a plain MergeTree and misstates the read contract; the query must use explicit full-row grouping.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEnginePlainMergeTreeReadbacksNeverUseFinal$", "./internal/providersync/"]]
+    },
+    {
+      "id": "F2-classification-readback-adds-final",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "FROM investment_classifications_daily\nWHERE org_id",
+      "replace": "FROM investment_classifications_daily FINAL\nWHERE org_id",
+      "rationale": "Classification retry/history semantics are explicit GROUP BY semantics, not FINAL on a plain engine.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEnginePlainMergeTreeReadbacksNeverUseFinal$", "./internal/providersync/"]]
+    },
+    {
+      "id": "F3-investment-metrics-readback-adds-final",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "FROM investment_metrics_daily\nWHERE org_id",
+      "replace": "FROM investment_metrics_daily FINAL\nWHERE org_id",
+      "rationale": "Investment metric latest-row semantics are implemented by explicit timestamp selection; FINAL is a no-op on its migrated plain MergeTree.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEnginePlainMergeTreeReadbacksNeverUseFinal$", "./internal/providersync/"]]
+    },
+    {
+      "id": "M1a-migration-chain-changes-issue-table-engine",
+      "file": "src/dev_health_ops/migrations/clickhouse/007_complexity_investment_issues.sql",
+      "find": "ENGINE = MergeTree\nPARTITION BY toYYYYMM(day)\nORDER BY (day, provider, team_id, issue_type_norm);",
+      "replace": "ENGINE = ReplacingMergeTree(computed_at)\nPARTITION BY toYYYYMM(day)\nORDER BY (day, provider, team_id, issue_type_norm);",
+      "rationale": "The integration proof must apply the real migration chain and observe the issue table's plain MergeTree engine rather than a hand-authored test schema.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^plain_merge_tree_issue_type_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "M1b-migration-chain-changes-classification-table-engine",
+      "file": "src/dev_health_ops/migrations/clickhouse/007_complexity_investment_issues.sql",
+      "find": "ENGINE = MergeTree\nPARTITION BY toYYYYMM(day)\nORDER BY (day, provider, artifact_type, investment_area, project_stream, artifact_id);",
+      "replace": "ENGINE = ReplacingMergeTree(computed_at)\nPARTITION BY toYYYYMM(day)\nORDER BY (day, provider, artifact_type, investment_area, project_stream, artifact_id);",
+      "rationale": "The classification schema assertion must be sourced from the production migration chain and detect an engine drift there.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^plain_merge_tree_investment_classifications_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "M1c-migration-chain-changes-investment-metric-table-engine",
+      "file": "src/dev_health_ops/migrations/clickhouse/007_complexity_investment_issues.sql",
+      "find": "ENGINE = MergeTree\nPARTITION BY toYYYYMM(day)\nORDER BY (day, team_id, investment_area, project_stream)\nSETTINGS allow_nullable_key = 1;",
+      "replace": "ENGINE = ReplacingMergeTree(computed_at)\nPARTITION BY toYYYYMM(day)\nORDER BY (day, team_id, investment_area, project_stream)\nSETTINGS allow_nullable_key = 1;",
+      "rationale": "The investment metric schema assertion must traverse the real migrations and independently reject a non-plain engine.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^plain_merge_tree_investment_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T1a-issue-row-org-not-validated",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "func validGitHubIssueTypeMetricsRow(\n\tidentity GitHubWorkItemEffectIdentity,\n\trow githubIssueTypeMetricsDailyRow,\n) bool {\n\t_, dayErr := row.Day.time()\n\treturn row.OrgID == identity.OrgID && row.Provider == identity.Provider &&",
+      "replace": "func validGitHubIssueTypeMetricsRow(\n\tidentity GitHubWorkItemEffectIdentity,\n\trow githubIssueTypeMetricsDailyRow,\n) bool {\n\t_, dayErr := row.Day.time()\n\treturn row.Provider == identity.Provider &&",
+      "rationale": "The issue adapter must reject a forged row tenant before either batch creation or readback.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^issue_type$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T1b-classification-row-org-not-validated",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "func validGitHubInvestmentClassificationRow(\n\tidentity GitHubWorkItemEffectIdentity,\n\trow githubInvestmentClassificationDailyRow,\n) bool {\n\t_, dayErr := row.Day.time()\n\treturn row.OrgID == identity.OrgID && row.Provider == identity.Provider &&",
+      "replace": "func validGitHubInvestmentClassificationRow(\n\tidentity GitHubWorkItemEffectIdentity,\n\trow githubInvestmentClassificationDailyRow,\n) bool {\n\t_, dayErr := row.Day.time()\n\treturn row.Provider == identity.Provider &&",
+      "rationale": "The classification adapter independently validates the row's tenant before persistence or inspection.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^classification$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T2-investment-metric-row-org-not-validated",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\treturn row.OrgID == identity.OrgID && dayErr == nil &&",
+      "replace": "\treturn dayErr == nil &&",
+      "rationale": "Investment metric rows also carry their own org and must match the identity before any batch or query is reached.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^metrics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S1a-issue-insert-swaps-created-and-completed-projection",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\t\tuint32(row.CreatedCount), uint32(row.CompletedCount), uint32(row.ActiveCount),",
+      "replace": "\t\t\tuint32(row.CompletedCount), uint32(row.CreatedCount), uint32(row.ActiveCount),",
+      "rationale": "The migrated issue sink column order must match its Append value projection, independently of row computation.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^issue_type_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S1b-classification-insert-swaps-artifact-and-provider-projection",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\t\trow.RepoID, day, row.ArtifactType, row.ArtifactID, row.Provider,",
+      "replace": "\t\t\trow.RepoID, day, row.ArtifactType, row.Provider, row.ArtifactID,",
+      "rationale": "The classification INSERT must preserve artifact_id/provider value order against the production migration schema.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_classifications_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S1c-investment-metric-insert-swaps-units-and-completed-projection",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\t\tuint32(row.DeliveryUnits), uint32(row.WorkItemsCompleted), uint32(row.PRsMerged),",
+      "replace": "\t\t\tuint32(row.WorkItemsCompleted), uint32(row.DeliveryUnits), uint32(row.PRsMerged),",
+      "rationale": "The investment metric INSERT independently pins delivery_units/work_items_completed value order.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2a-issue-insert-does-not-truncate-computed-at-to-seconds",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\t\trow.CycleP50Hours, row.CycleP90Hours, row.LeadP50Hours,\n\t\t\tgithubWorkItemDerivedSeconds(row.ComputedAt), identity.OrgID,",
+      "replace": "\t\t\trow.CycleP50Hours, row.CycleP90Hours, row.LeadP50Hours,\n\t\t\tgithubWorkItemDerivedSeconds(row.ComputedAt.Add(1000000000)), identity.OrgID,",
+      "rationale": "The issue writer must project the exact DateTime-second version expected by readback from a nanosecond-bearing input.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^issue_type_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2b-classification-insert-does-not-truncate-computed-at-to-seconds",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\tif err := batch.Append(\n\t\t\trow.RepoID, day, row.ArtifactType, row.ArtifactID, row.Provider,\n\t\t\t*row.InvestmentArea, row.ProjectStream, row.Confidence, *row.RuleID,\n\t\t\tgithubWorkItemDerivedSeconds(row.ComputedAt), identity.OrgID,",
+      "replace": "\t\tif err := batch.Append(\n\t\t\trow.RepoID, day, row.ArtifactType, row.ArtifactID, row.Provider,\n\t\t\t*row.InvestmentArea, row.ProjectStream, row.Confidence, *row.RuleID,\n\t\t\tgithubWorkItemDerivedSeconds(row.ComputedAt.Add(1000000000)), identity.OrgID,",
+      "rationale": "The classification writer independently preserves the expected second-precision version under its DateTime migration column.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_classifications_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2c-investment-metric-insert-does-not-truncate-computed-at-to-seconds",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\t\t\tuint64(row.ChurnLOC), row.CycleP50Hours,\n\t\t\tgithubWorkItemDerivedSeconds(row.ComputedAt), identity.OrgID,",
+      "replace": "\t\t\tuint64(row.ChurnLOC), row.CycleP50Hours,\n\t\t\tgithubWorkItemDerivedSeconds(row.ComputedAt.Add(1000000000)), identity.OrgID,",
+      "rationale": "The investment metric writer independently stamps the expected second-precision version from a nanosecond-bearing row.",
+      "build": ["go", "test", "-tags=integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags=integration", "-count=1", "-run", "^TestGitHubWorkItemEngineEffectsAgainstMigratedSchema$/^investment_metrics_daily$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L1a-issue-write-preflight-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubIssueTypeMetricsSortingKey) {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\tif len(rows) == 0 {",
+      "replace": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubIssueTypeMetricsSortingKey) {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn err\n\t}\n\tif len(rows) == 0 {",
+      "rationale": "The issue adapter must refuse a lost lease before PrepareBatch and observe zero prepares.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^issue_type$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L1b-classification-write-preflight-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentClassificationSortingKey) {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\tif len(rows) == 0 {",
+      "replace": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentClassificationSortingKey) {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn err\n\t}\n\tif len(rows) == 0 {",
+      "rationale": "The classification adapter independently fences its first write-side lease assertion.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^classification$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L1c-investment-metric-write-preflight-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentMetricsSortingKey) {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\tif len(rows) == 0 {",
+      "replace": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentMetricsSortingKey) {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn err\n\t}\n\tif len(rows) == 0 {",
+      "rationale": "The investment metric adapter independently fences lease ownership before creating a batch.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^metrics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L2a-issue-write-post-append-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()\n}\n\nfunc (sink GitHubIssueTypeMetricsClickHouseEffects) InspectGitHubWorkItemEffect(",
+      "replace": "\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()\n}\n\nfunc (sink GitHubIssueTypeMetricsClickHouseEffects) InspectGitHubWorkItemEffect(",
+      "rationale": "The issue adapter rechecks ownership after Append and must abort rather than Send on loss.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^issue_type$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L2b-classification-write-post-append-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()\n}\n\nfunc (sink GitHubInvestmentClassificationsClickHouseEffects) InspectGitHubWorkItemEffect(",
+      "replace": "\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()\n}\n\nfunc (sink GitHubInvestmentClassificationsClickHouseEffects) InspectGitHubWorkItemEffect(",
+      "rationale": "The classification adapter independently rechecks its lease after appending and before sending.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^classification$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L2c-investment-metric-write-post-append-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()\n}\n\nfunc (sink GitHubInvestmentMetricsClickHouseEffects) InspectGitHubWorkItemEffect(",
+      "replace": "\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()\n}\n\nfunc (sink GitHubInvestmentMetricsClickHouseEffects) InspectGitHubWorkItemEffect(",
+      "rationale": "The investment metric adapter independently aborts instead of sending after post-append lease loss.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^metrics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L3a-issue-readback-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubIssueTypeMetricsSortingKey) {\n\t\treturn EffectConflict, ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(rows) == 0 {",
+      "replace": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubIssueTypeMetricsSortingKey) {\n\t\treturn EffectConflict, ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(rows) == 0 {",
+      "rationale": "Issue readback must stop before any query when lease ownership is lost.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^issue_type$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L3b-classification-readback-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentClassificationSortingKey) {\n\t\treturn EffectConflict, ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(rows) == 0 {",
+      "replace": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentClassificationSortingKey) {\n\t\treturn EffectConflict, ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(rows) == 0 {",
+      "rationale": "Classification readback independently refuses to query after lease loss.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^classification$", "./internal/providersync/"]]
+    },
+    {
+      "id": "L3c-investment-metric-readback-lease-error-ignored",
+      "file": "internal/providersync/github_work_item_engine_effects_clickhouse.go",
+      "find": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentMetricsSortingKey) {\n\t\treturn EffectConflict, ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(rows) == 0 {",
+      "replace": "\tif !githubWorkItemDerivedUniqueSortingKeys(rows, githubInvestmentMetricsSortingKey) {\n\t\treturn EffectConflict, ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); false && err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(rows) == 0 {",
+      "rationale": "Investment metric readback independently fences its ClickHouse query behind a live lease.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitHubWorkItemEngineAdaptersFailClosedOnDependencyTenantAndLease$/^metrics$", "./internal/providersync/"]]
+    },
+    {
+      "id": "W1-composition-omits-classification-adapter",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tInvestmentClassificationsDaily: GitHubInvestmentClassificationsClickHouseEffects{\n\t\t\tConn: conn, Lease: lease,\n\t\t},",
+      "replace": "\t\tInvestmentClassificationsDaily: nil,",
+      "rationale": "The production sink constructor must wire the classification adapter; a nil slot keeps the 16-surface composite incomplete.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemClickHouseEffectsWiresAllSixteen$", "./internal/providersync/"]]
+    },
+    {
+      "id": "W2-composition-omits-investment-metrics-adapter",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tInvestmentMetricsDaily: GitHubInvestmentMetricsClickHouseEffects{\n\t\t\tConn: conn, Lease: lease,\n\t\t},",
+      "replace": "\t\tInvestmentMetricsDaily: nil,",
+      "rationale": "The production sink constructor must wire investment metrics into the complete feature-only composite.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemClickHouseEffectsWiresAllSixteen$", "./internal/providersync/"]]
+    },
+    {
+      "id": "W3-composition-omits-issue-type-adapter",
+      "file": "internal/providersync/github_work_items_composition.go",
+      "find": "\t\tIssueTypeMetricsDaily: GitHubIssueTypeMetricsClickHouseEffects{\n\t\t\tConn: conn, Lease: lease,\n\t\t},",
+      "replace": "\t\tIssueTypeMetricsDaily: nil,",
+      "rationale": "The production sink constructor must wire issue-type metrics rather than returning an apparently complete sink with a nil slot.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestNewGitHubWorkItemClickHouseEffectsWiresAllSixteen$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_items_composition.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_composition.json
@@ -55,7 +55,7 @@
           "test",
           "-count=1",
           "-run",
-          "^(TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel|TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree)$",
+          "^(TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel|TestNewGitHubWorkItemClickHouseEffectsWiresAllSixteen)$",
           "./internal/providersync/"
         ]
       ]
@@ -72,7 +72,7 @@
           "test",
           "-count=1",
           "-run",
-          "^(TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel|TestNewGitHubWorkItemClickHouseEffectsWiresThirteenAndNamesTheUnportedThree)$",
+          "^(TestGitHubWorkItemSinkMissingDestinationsIsClauseLevel|TestNewGitHubWorkItemClickHouseEffectsWiresAllSixteen)$",
           "./internal/providersync/"
         ]
       ],
@@ -113,18 +113,18 @@
       ]
     },
     {
-      "id": "D3-fabricate-empty-rows-for-unported-engines",
+      "id": "D3-fabricate-empty-rows-without-configured-engine",
       "file": "internal/providersync/github_work_items_composition.go",
       "find": "\tfor _, destination := range githubWorkItemDerivedOwnedDestinations {\n\t\tderived[destination] = []json.RawMessage{}\n\t}",
       "replace": "\tfor _, destination := range githubWorkItemDerivedDestinations {\n\t\tderived[destination] = []json.RawMessage{}\n\t}",
-      "rationale": "Opening the three unported destinations with empty slices makes the deriver claim it evaluated metrics whose engines do not exist. An empty slice is indistinguishable from 'evaluated, produced nothing', which is exactly the claim this port cannot honestly make.",
+      "rationale": "Opening the three engine destinations without a configured engine makes the deriver claim it evaluated capabilities that never ran. An empty slice is indistinguishable from 'evaluated, produced nothing'.",
       "proof": [
         [
           "go",
           "test",
           "-count=1",
           "-run",
-          "^(TestGitHubWorkItemDeriverFailsClosedWithoutTheUnportedEngines|TestGitHubWorkItemCompositionNeverFailsOpen)$",
+          "^(TestGitHubWorkItemDeriverFailsClosedWithoutConfiguredEngine|TestGitHubWorkItemCompositionNeverFailsOpen)$",
           "./internal/providersync/"
         ]
       ]
@@ -253,7 +253,7 @@
       "file": "internal/providersync/github_work_items_composition.go",
       "find": "\t\tderived[destination] = append(derived[destination], rows...)",
       "replace": "\t\tderived[destination] = rows",
-      "rationale": "Assign-not-append silently keeps only the LAST day's engine rows. Invisible while the stub returns empty, which is why the stub stamps the day it was handed.",
+      "rationale": "Assign-not-append silently keeps only the LAST day's engine rows. The hostile test double stamps the day it was handed so the loss remains observable independently of concrete engine computation.",
       "proof": [
         [
           "go",

--- a/internal/providersync/testdata/oracle_pairs/_github_work_item_derived_helpers.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_work_item_derived_helpers.py
@@ -25,12 +25,13 @@ lands second collapses the two modules into one.
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import contextlib
 import io
 import pathlib
 import uuid
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
@@ -43,6 +44,7 @@ with (
     contextlib.redirect_stdout(io.StringIO()),
     contextlib.redirect_stderr(io.StringIO()),
 ):
+    from dev_health_ops.analytics.investment import InvestmentClassifier
     from dev_health_ops.metrics.compute_work_item_state_durations import (
         compute_work_item_state_durations_daily,
     )
@@ -52,28 +54,31 @@ with (
         compute_work_item_team_attributions,
     )
     from dev_health_ops.metrics.loaders.clickhouse import ClickHouseDataLoader
+    from dev_health_ops.metrics.work_item_engine_destinations import (
+        compute_work_item_engine_destinations_daily,
+    )
     from dev_health_ops.models.work_items import (
         WorkItem,
         WorkItemDependency,
         WorkItemStatusTransition,
     )
+    from dev_health_ops.providers.status_mapping import load_status_mapping
     from dev_health_ops.providers.teams import build_project_key_resolver
+    from dev_health_ops.utils.cli import resolve_date_range
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 SCHEMA_SOURCE = REPO_ROOT / "src/dev_health_ops/metrics/schemas.py"
+STATUS_MAPPING_SOURCE = REPO_ROOT / "src/dev_health_ops/config/status_mapping.yaml"
+INVESTMENT_CONFIG_SOURCE = REPO_ROOT / "src/dev_health_ops/config/investment_areas.yaml"
+JOB_WORK_ITEMS_SOURCE = REPO_ROOT / "src/dev_health_ops/metrics/job_work_items.py"
 
-# Every record dataclass in this family defaults org_id to "" and relies on the
-# ClickHouse sink to inject the tenant from sink context at insert time
-# (sinks/clickhouse/core.py). The Go port has no sink-level context to inject
-# from, so it stamps the frozen claim's OrgID at compute time. The persisted
-# value is compared for real by the ClickHouse readback integration test, not
-# here. Declared in one place so the three pairs cannot drift in their reason.
+# The older derived-surface producers still leave org_id blank and rely on the
+# ClickHouse sink to inject it. The three engine destinations added by this lane
+# pass org_id explicitly and therefore do not use this exclusion.
 ORG_ID_EXCLUSION = (
-    "the Python compute functions never set org_id: the record dataclasses "
-    "default it to '' and the ClickHouse sink injects the tenant from sink "
-    "context at insert time. The Go port stamps the frozen claim's OrgID at "
-    "compute time instead, and the persisted value is proved equal by the "
-    "ClickHouse readback integration test rather than by this comparison."
+    "the Python compute function leaves org_id blank and the ClickHouse sink "
+    "injects the tenant from sink context at insert time; its Go peer stamps "
+    "the frozen claim tenant before persistence"
 )
 
 
@@ -264,7 +269,8 @@ class DerivedCase:
         self.org_id = str(case.get("OrgID") or "")
         self.as_of = _required_time(case.get("AsOf") or case["ComputedAt"])
         self.computed_at = _required_time(case["ComputedAt"])
-        self.day = date.fromisoformat(str(case["Day"]))
+        self.days = _case_days(case)
+        self.day = self.days[0]
         self.work_items = [_work_item(raw) for raw in case.get("WorkItems") or []]
         self.transitions = [_transition(raw) for raw in case.get("Transitions") or []]
         dependencies = [_dependency(raw) for raw in case.get("Dependencies") or []]
@@ -341,6 +347,85 @@ class DerivedCase:
             computed_at=self.computed_at,
             **self._resolver_kwargs(),
         )
+
+    def engine_destinations(self) -> tuple[list[Any], list[Any], list[Any]]:
+        """Execute the exact production helper called by job_work_items."""
+
+        return compute_work_item_engine_destinations_daily(
+            day=self.day,
+            work_items=self.work_items,
+            computed_at=self.computed_at,
+            org_id=self.org_id,
+            status_mapping=load_status_mapping(STATUS_MAPPING_SOURCE),
+            investment_classifier=InvestmentClassifier(INVESTMENT_CONFIG_SOURCE),
+            **self._resolver_kwargs(),
+        )
+
+    def engine_destinations_all_days(
+        self,
+    ) -> tuple[list[Any], list[Any], list[Any]]:
+        """Mirror the live job's per-day call while reusing one resolver context."""
+
+        _assert_engine_helper_called_inside_job_loop()
+        issue_types: list[Any] = []
+        classifications: list[Any] = []
+        metrics: list[Any] = []
+        for day in self.days:
+            self.day = day
+            daily_issue_types, daily_classifications, daily_metrics = (
+                self.engine_destinations()
+            )
+            issue_types.extend(daily_issue_types)
+            classifications.extend(daily_classifications)
+            metrics.extend(daily_metrics)
+        return issue_types, classifications, metrics
+
+
+def _case_days(case: dict[str, Any]) -> list[date]:
+    raw_days = case.get("Days")
+    if raw_days:
+        return [date.fromisoformat(str(value)) for value in raw_days]
+    if case.get("SinceAt") and case.get("BeforeAt"):
+        since = _required_time(case["SinceAt"])
+        before = _required_time(case["BeforeAt"])
+        if since.time() != datetime.min.time() or before.time() != datetime.min.time():
+            raise AssertionError("window oracle requires midnight-aligned date flags")
+        end_day, backfill_days = resolve_date_range(
+            argparse.Namespace(
+                since=since.date(),
+                before=before.date(),
+                backfill=1,
+                day=None,
+                date=None,
+            )
+        )
+        start_day = end_day - timedelta(days=backfill_days - 1)
+        return [start_day + timedelta(days=index) for index in range(backfill_days)]
+    return [date.fromisoformat(str(case["Day"]))]
+
+
+def _assert_engine_helper_called_inside_job_loop() -> None:
+    """Fail if the production job stops calling the compared helper per day."""
+
+    lines = JOB_WORK_ITEMS_SOURCE.read_text().splitlines()
+    loop_indices = [
+        index for index, line in enumerate(lines) if line.strip() == "for d in days:"
+    ]
+    if len(loop_indices) != 1:
+        raise AssertionError(
+            f"expected exactly one work-item day loop, found {len(loop_indices)}"
+        )
+    loop_index = loop_indices[0]
+    loop_indent = len(lines[loop_index]) - len(lines[loop_index].lstrip())
+    for line in lines[loop_index + 1 :]:
+        if line.strip() and len(line) - len(line.lstrip()) <= loop_indent:
+            break
+        if "compute_work_item_engine_destinations_daily(" in line:
+            return
+    raise AssertionError(
+        "compute_work_item_engine_destinations_daily is no longer called inside "
+        "job_work_items.py's per-day loop"
+    )
 
 
 def columns(records: list[Any], fields: frozenset[str]) -> dict[str, list[Any]]:

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_investment-classifications.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_investment-classifications.py
@@ -1,0 +1,33 @@
+"""Live producer oracle for investment_classifications_daily."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "InvestmentClassificationRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _, classifications, _ = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(classifications), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/investment-classifications",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_investment-metrics.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_investment-metrics.py
@@ -1,0 +1,33 @@
+"""Live producer oracle for investment_metrics_daily."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "InvestmentMetricsRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _, _, metrics = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(metrics), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/investment-metrics",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_work-items_issue-type-metrics.py
+++ b/internal/providersync/testdata/oracle_pairs/github_work-items_issue-type-metrics.py
@@ -1,0 +1,33 @@
+"""Live producer oracle for issue_type_metrics_daily."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "IssueTypeMetricsRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    issue_types, _, _ = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(issue_types), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/work-items/issue-type-metrics",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/python_investment_call_site.py
+++ b/internal/providersync/testdata/python_investment_call_site.py
@@ -2,8 +2,8 @@
 """Reflect the two premises the investment reachability tripwire stands on.
 
 The tripwire claims four of the real config's 44 rules cannot fire from the
-work-item call site. That claim rests entirely on two facts about PRODUCTION
-code, neither of which lives in the config file:
+work-item production-helper call site. That claim rests entirely on two facts
+about PRODUCTION code, neither of which lives in the config file:
 
   1. the call site builds its artifact as an inline dict literal whose keys are
      exactly ``labels``, ``component``, ``title`` and ``provider`` -- so

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -23,38 +23,30 @@ from dev_health_ops.metrics.compute_work_items import (
     compute_estimate_coverage_metrics_daily,
     compute_work_item_metrics_daily,
     compute_work_item_team_attributions,
-    resolve_team_attribution,
 )
 from dev_health_ops.metrics.job_daily import (
     REPO_ROOT,
     _discover_repos,
-    _to_utc,
 )
 from dev_health_ops.metrics.loaders.base import to_dataclass
 from dev_health_ops.metrics.loaders.clickhouse import ClickHouseDataLoader
-from dev_health_ops.metrics.schemas import (
-    InvestmentClassificationRecord,
-    InvestmentMetricsRecord,
-    IssueTypeMetricsRecord,
-)
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.metrics.work_item_engine_destinations import (
+    compute_work_item_engine_destinations_daily,
+)
 from dev_health_ops.metrics.work_items import (
     fetch_github_project_v2_items,
     fetch_gitlab_work_items,
     fetch_jira_work_items_with_extras,
     parse_github_projects_v2_env,
 )
-from dev_health_ops.models.work_items import (
-    WorkItem,
-    WorkItemType,
-)
+from dev_health_ops.models.work_items import WorkItem
 from dev_health_ops.providers.gitlab.instance import normalize_gitlab_instance
 from dev_health_ops.providers.identity import load_identity_resolver
 from dev_health_ops.providers.status_mapping import load_status_mapping
 from dev_health_ops.providers.teams import (
     build_project_key_resolver,
     load_team_resolver,
-    normalize_team_id,
 )
 from dev_health_ops.providers.usage import (
     attach_partial_observations,
@@ -1276,174 +1268,22 @@ def run_work_items_sync_job(
                 attribution_context=team_attribution_context,
             )
 
-            # --- Issue Type Metrics ---
-            issue_type_stats: dict[
-                tuple[uuid.UUID, Any, str, WorkItemType], dict[str, Any]
-            ] = {}
-
-            def _get_team(wi: Any) -> str:
-                team_id, _, _ = resolve_team_attribution(
-                    wi,
-                    team_resolver,
-                    pk_resolver,
-                    linked_issue_resolver=linked_issue_resolver,
-                    attribution_context=team_attribution_context,
-                )
-                return normalize_team_id(team_id)
-
-            def _normalize_investment_team_id(team_id: str | None) -> str | None:
-                if not team_id or team_id == "unassigned":
-                    return None
-                return team_id
-
-            start_dt = _to_utc(datetime.combine(d, time.min, tzinfo=timezone.utc))
-            end_dt = start_dt + timedelta(days=1)
-            for item in work_items:
-                r_id = getattr(item, "repo_id", None) or uuid.UUID(int=0)
-                prov = item.provider
-                team_id = _get_team(item)
-                norm_type = status_mapping.normalize_type(
-                    provider=prov,
-                    type_raw=item.type,
-                    labels=getattr(item, "labels", []),
-                )
-
-                key = (r_id, prov, team_id, norm_type)
-                if key not in issue_type_stats:
-                    issue_type_stats[key] = {
-                        "created": 0,
-                        "completed": 0,
-                        "active": 0,
-                        "cycle_hours": [],
-                    }
-
-                stats = issue_type_stats[key]
-                created = _to_utc(item.created_at)
-                if start_dt <= created < end_dt:
-                    stats["created"] += 1
-
-                if item.completed_at:
-                    completed = _to_utc(item.completed_at)
-                    if start_dt <= completed < end_dt:
-                        stats["completed"] += 1
-                        if item.started_at:
-                            started = _to_utc(item.started_at)
-                            h = (completed - started).total_seconds() / 3600.0
-                            if h >= 0:
-                                stats["cycle_hours"].append(h)
-
-                if created < end_dt and (
-                    not item.completed_at or _to_utc(item.completed_at) >= start_dt
-                ):
-                    stats["active"] += 1
-
-            issue_type_metrics_rows: list[IssueTypeMetricsRecord] = []
-            for (r_id, prov, team_id, norm_type), stat in issue_type_stats.items():
-                cycles = sorted(stat["cycle_hours"])
-                p50 = cycles[len(cycles) // 2] if cycles else 0.0
-                p90 = cycles[int(len(cycles) * 0.9)] if cycles else 0.0
-                issue_type_metrics_rows.append(
-                    IssueTypeMetricsRecord(
-                        repo_id=r_id if r_id.int != 0 else None,
-                        day=d,
-                        provider=prov,
-                        team_id=team_id,
-                        issue_type_norm=norm_type,
-                        created_count=stat["created"],
-                        completed_count=stat["completed"],
-                        active_count=stat["active"],
-                        cycle_p50_hours=p50,
-                        cycle_p90_hours=p90,
-                        lead_p50_hours=0.0,
-                        computed_at=computed_at,
-                    )
-                )
-
-            # --- Investment areas ---
-            investment_classifications: list[InvestmentClassificationRecord] = []
-            inv_metrics_map: dict[tuple[Any, str, str, str], dict[str, Any]] = {}
-
-            for item in work_items:
-                r_id = getattr(item, "repo_id", None) or uuid.UUID(int=0)
-                created = _to_utc(item.created_at)
-                if not (
-                    created < end_dt
-                    and (
-                        not item.completed_at or _to_utc(item.completed_at) >= start_dt
-                    )
-                ):
-                    continue
-
-                cls = investment_classifier.classify(
-                    {
-                        "labels": getattr(item, "labels", []),
-                        "component": getattr(item, "component", ""),
-                        "title": item.title,
-                        "provider": item.provider,
-                    }
-                )
-
-                investment_classifications.append(
-                    InvestmentClassificationRecord(
-                        repo_id=r_id if r_id.int != 0 else None,
-                        day=d,
-                        artifact_type="work_item",
-                        artifact_id=item.work_item_id,
-                        provider=item.provider,
-                        investment_area=cls.investment_area,
-                        project_stream=cls.project_stream or "",
-                        confidence=cls.confidence,
-                        rule_id=cls.rule_id,
-                        computed_at=computed_at,
-                    )
-                )
-
-                if item.completed_at:
-                    completed = _to_utc(item.completed_at)
-                    if not (start_dt <= completed < end_dt):
-                        continue
-                    team_id_value = _normalize_investment_team_id(_get_team(item)) or ""
-                    inv_key = (
-                        r_id,
-                        team_id_value,
-                        cls.investment_area,
-                        cls.project_stream or "",
-                    )
-                    if inv_key not in inv_metrics_map:
-                        inv_metrics_map[inv_key] = {
-                            "units": 0,
-                            "completed": 0,
-                            "churn": 0,
-                            "cycles": [],
-                        }
-                    inv_metrics_map[inv_key]["completed"] += 1
-                    points = getattr(item, "story_points", 1) or 1
-                    inv_metrics_map[inv_key]["units"] += int(points)
-                    if item.started_at:
-                        started = _to_utc(item.started_at)
-                        h = (completed - started).total_seconds() / 3600.0
-                        if h >= 0:
-                            inv_metrics_map[inv_key]["cycles"].append(h)
-
-            investment_metrics_rows: list[InvestmentMetricsRecord] = []
-            for (r_id, team_id, area, stream), data in inv_metrics_map.items():
-                cycles = sorted(data["cycles"])
-                p50 = cycles[len(cycles) // 2] if cycles else 0.0
-                investment_metrics_rows.append(
-                    InvestmentMetricsRecord(
-                        repo_id=r_id if r_id.int != 0 else None,
-                        day=d,
-                        team_id=team_id,
-                        investment_area=area,
-                        project_stream=stream,
-                        delivery_units=data["units"],
-                        work_items_completed=data["completed"],
-                        prs_merged=0,
-                        churn_loc=data["churn"],
-                        cycle_p50_hours=p50,
-                        computed_at=computed_at,
-                    )
-                )
+            (
+                issue_type_metrics_rows,
+                investment_classifications,
+                investment_metrics_rows,
+            ) = compute_work_item_engine_destinations_daily(
+                day=d,
+                work_items=work_items,
+                computed_at=computed_at,
+                org_id=org_id,
+                status_mapping=status_mapping,
+                investment_classifier=investment_classifier,
+                team_resolver=team_resolver,
+                project_key_resolver=pk_resolver,
+                linked_issue_resolver=linked_issue_resolver,
+                attribution_context=team_attribution_context,
+            )
 
             for s in sinks:
                 if wi_metrics:

--- a/src/dev_health_ops/metrics/work_item_engine_destinations.py
+++ b/src/dev_health_ops/metrics/work_item_engine_destinations.py
@@ -1,0 +1,233 @@
+"""Config-engine-derived daily work-item destinations.
+
+This is the production computation used by ``job_work_items`` and by the
+Python-Go differential oracle. Keeping it here prevents the oracle from
+reimplementing the former inline block and agreeing with a transcription that
+the worker itself never executes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any
+
+from dev_health_ops.analytics.investment import InvestmentClassifier
+from dev_health_ops.metrics.compute_work_items import (
+    TeamAttributionContext,
+    resolve_team_attribution,
+)
+from dev_health_ops.metrics.schemas import (
+    InvestmentClassificationRecord,
+    InvestmentMetricsRecord,
+    IssueTypeMetricsRecord,
+)
+from dev_health_ops.models.work_items import WorkItem, WorkItemType
+from dev_health_ops.providers.status_mapping import StatusMapping
+from dev_health_ops.providers.teams import (
+    LinkedIssueTeamResolver,
+    ProjectKeyTeamResolver,
+    TeamResolver,
+    normalize_team_id,
+)
+from dev_health_ops.utils.datetime import to_utc
+
+
+def compute_work_item_engine_destinations_daily(
+    *,
+    day: date,
+    work_items: Sequence[WorkItem],
+    computed_at: datetime,
+    org_id: str,
+    status_mapping: StatusMapping,
+    investment_classifier: InvestmentClassifier,
+    team_resolver: TeamResolver | None = None,
+    project_key_resolver: ProjectKeyTeamResolver | None = None,
+    linked_issue_resolver: LinkedIssueTeamResolver | None = None,
+    attribution_context: TeamAttributionContext | None = None,
+) -> tuple[
+    list[IssueTypeMetricsRecord],
+    list[InvestmentClassificationRecord],
+    list[InvestmentMetricsRecord],
+]:
+    """Compute the three config-engine surfaces for exactly one UTC day."""
+
+    issue_type_stats: dict[
+        tuple[uuid.UUID, Any, str, WorkItemType], dict[str, Any]
+    ] = {}
+
+    def _get_team(work_item: WorkItem) -> str:
+        team_id, _, _ = resolve_team_attribution(
+            work_item,
+            team_resolver,
+            project_key_resolver,
+            linked_issue_resolver=linked_issue_resolver,
+            attribution_context=attribution_context,
+        )
+        return normalize_team_id(team_id)
+
+    def _normalize_investment_team_id(team_id: str | None) -> str | None:
+        if not team_id or team_id == "unassigned":
+            return None
+        return team_id
+
+    start_dt = to_utc(datetime.combine(day, time.min, tzinfo=timezone.utc))
+    end_dt = start_dt + timedelta(days=1)
+    for item in work_items:
+        repo_id = getattr(item, "repo_id", None) or uuid.UUID(int=0)
+        provider = item.provider
+        team_id = _get_team(item)
+        normalized_type = status_mapping.normalize_type(
+            provider=provider,
+            type_raw=item.type,
+            labels=getattr(item, "labels", []),
+        )
+
+        key = (repo_id, provider, team_id, normalized_type)
+        if key not in issue_type_stats:
+            issue_type_stats[key] = {
+                "created": 0,
+                "completed": 0,
+                "active": 0,
+                "cycle_hours": [],
+            }
+
+        stats = issue_type_stats[key]
+        created = to_utc(item.created_at)
+        if start_dt <= created < end_dt:
+            stats["created"] += 1
+
+        if item.completed_at:
+            completed = to_utc(item.completed_at)
+            if start_dt <= completed < end_dt:
+                stats["completed"] += 1
+                if item.started_at:
+                    started = to_utc(item.started_at)
+                    hours = (completed - started).total_seconds() / 3600.0
+                    if hours >= 0:
+                        stats["cycle_hours"].append(hours)
+
+        if created < end_dt and (
+            not item.completed_at or to_utc(item.completed_at) >= start_dt
+        ):
+            stats["active"] += 1
+
+    issue_type_metrics_rows: list[IssueTypeMetricsRecord] = []
+    for (
+        repo_id,
+        provider,
+        team_id,
+        normalized_type,
+    ), stats in issue_type_stats.items():
+        cycles = sorted(stats["cycle_hours"])
+        p50 = cycles[len(cycles) // 2] if cycles else 0.0
+        p90 = cycles[int(len(cycles) * 0.9)] if cycles else 0.0
+        issue_type_metrics_rows.append(
+            IssueTypeMetricsRecord(
+                repo_id=repo_id if repo_id.int != 0 else None,
+                day=day,
+                provider=provider,
+                team_id=team_id,
+                issue_type_norm=normalized_type,
+                created_count=stats["created"],
+                completed_count=stats["completed"],
+                active_count=stats["active"],
+                cycle_p50_hours=p50,
+                cycle_p90_hours=p90,
+                lead_p50_hours=0.0,
+                computed_at=computed_at,
+                org_id=org_id,
+            )
+        )
+
+    investment_classifications: list[InvestmentClassificationRecord] = []
+    investment_metrics: dict[tuple[Any, str, str, str], dict[str, Any]] = {}
+
+    for item in work_items:
+        repo_id = getattr(item, "repo_id", None) or uuid.UUID(int=0)
+        created = to_utc(item.created_at)
+        if not (
+            created < end_dt
+            and (not item.completed_at or to_utc(item.completed_at) >= start_dt)
+        ):
+            continue
+
+        classification = investment_classifier.classify(
+            {
+                "labels": getattr(item, "labels", []),
+                "component": getattr(item, "component", ""),
+                "title": item.title,
+                "provider": item.provider,
+            }
+        )
+
+        investment_classifications.append(
+            InvestmentClassificationRecord(
+                repo_id=repo_id if repo_id.int != 0 else None,
+                day=day,
+                artifact_type="work_item",
+                artifact_id=item.work_item_id,
+                provider=item.provider,
+                investment_area=classification.investment_area,
+                project_stream=classification.project_stream or "",
+                confidence=classification.confidence,
+                rule_id=classification.rule_id,
+                computed_at=computed_at,
+                org_id=org_id,
+            )
+        )
+
+        if item.completed_at:
+            completed = to_utc(item.completed_at)
+            if not (start_dt <= completed < end_dt):
+                continue
+            team_id_value = _normalize_investment_team_id(_get_team(item)) or ""
+            investment_key = (
+                repo_id,
+                team_id_value,
+                classification.investment_area,
+                classification.project_stream or "",
+            )
+            if investment_key not in investment_metrics:
+                investment_metrics[investment_key] = {
+                    "units": 0,
+                    "completed": 0,
+                    "churn": 0,
+                    "cycles": [],
+                }
+            investment_metrics[investment_key]["completed"] += 1
+            points = getattr(item, "story_points", 1) or 1
+            investment_metrics[investment_key]["units"] += int(points)
+            if item.started_at:
+                started = to_utc(item.started_at)
+                hours = (completed - started).total_seconds() / 3600.0
+                if hours >= 0:
+                    investment_metrics[investment_key]["cycles"].append(hours)
+
+    investment_metrics_rows: list[InvestmentMetricsRecord] = []
+    for (repo_id, team_id, area, stream), data in investment_metrics.items():
+        cycles = sorted(data["cycles"])
+        p50 = cycles[len(cycles) // 2] if cycles else 0.0
+        investment_metrics_rows.append(
+            InvestmentMetricsRecord(
+                repo_id=repo_id if repo_id.int != 0 else None,
+                day=day,
+                team_id=team_id,
+                investment_area=area,
+                project_stream=stream,
+                delivery_units=data["units"],
+                work_items_completed=data["completed"],
+                prs_merged=0,
+                churn_loc=data["churn"],
+                cycle_p50_hours=p50,
+                computed_at=computed_at,
+                org_id=org_id,
+            )
+        )
+
+    return (
+        issue_type_metrics_rows,
+        investment_classifications,
+        investment_metrics_rows,
+    )

--- a/tests/metrics/test_work_item_engine_destinations.py
+++ b/tests/metrics/test_work_item_engine_destinations.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from dev_health_ops.analytics.investment import InvestmentClassifier
+from dev_health_ops.metrics.work_item_engine_destinations import (
+    compute_work_item_engine_destinations_daily,
+)
+from dev_health_ops.models.work_items import WorkItem
+from dev_health_ops.providers.status_mapping import StatusMapping, load_status_mapping
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _engines() -> tuple[StatusMapping, InvestmentClassifier]:
+    status = load_status_mapping(
+        _ROOT / "src/dev_health_ops/config/status_mapping.yaml"
+    )
+    investment = InvestmentClassifier(
+        _ROOT / "src/dev_health_ops/config/investment_areas.yaml"
+    )
+    return status, investment
+
+
+def test_engine_destination_records_carry_explicit_tenant_before_sink_projection():
+    status, investment = _engines()
+    issue_types, classifications, metrics = compute_work_item_engine_destinations_daily(
+        day=date(2026, 8, 4),
+        work_items=[
+            WorkItem(
+                work_item_id="acme/api#1",
+                provider="github",
+                title="security fix",
+                type="issue",
+                status="done",
+                status_raw="closed",
+                created_at=datetime(2026, 8, 4, 1, tzinfo=timezone.utc),
+                started_at=datetime(2026, 8, 4, 2, tzinfo=timezone.utc),
+                completed_at=datetime(2026, 8, 4, 3, tzinfo=timezone.utc),
+                labels=["security", "bug"],
+                story_points=2,
+            )
+        ],
+        computed_at=datetime(2026, 8, 5, 0, 30, tzinfo=timezone.utc),
+        org_id="org-acme",
+        status_mapping=status,
+        investment_classifier=investment,
+    )
+
+    assert issue_types and classifications and metrics
+    assert {row.org_id for row in issue_types} == {"org-acme"}
+    assert {row.org_id for row in classifications} == {"org-acme"}
+    assert {row.org_id for row in metrics} == {"org-acme"}
+
+
+def test_empty_input_evaluates_all_three_destinations_as_empty_lists():
+    status, investment = _engines()
+    result = compute_work_item_engine_destinations_daily(
+        day=date(2026, 8, 4),
+        work_items=[],
+        computed_at=datetime(2026, 8, 5, 0, 30, tzinfo=timezone.utc),
+        org_id="org-acme",
+        status_mapping=status,
+        investment_classifier=investment,
+    )
+
+    assert result == ([], [], [])


### PR DESCRIPTION
## Summary

- Port the final three GitHub work-item engine destinations to Go: `issue_type_metrics_daily`, `investment_classifications_daily`, and `investment_metrics_daily`.
- Add the production deriver constructor with explicit status/investment configuration and complete the 16-destination ClickHouse effect composition.
- Preserve Python behavior through live differential oracles, including multi-day windows, closed-vs-completed semantics, team normalization, story points, percentiles, and explicit tenant stamping.
- Add durable, tenant/repository-fenced plain-MergeTree readback with strict ambiguity handling, second-precision timestamps, lease checks, and real migration-chain integration coverage.

This PR is intentionally inactive: it does not register the route, change runtime matrices, enable deployment profiles, or perform cutover. It is stacked only on `feat/go-worker-runtime-migration`.

## Test evidence

- Focused mutation plan: 79/79 killed; zero survivors, invalids, or baseline failures.
- Existing composition mutation plan: 16 killed plus one predeclared equivalent survivor; zero unexpected results.
- Post-format/type edits: affected Python producer mutations P1-P3 rerun, 3/3 killed.
- `bash ci/check_go.sh live-python-oracles`: providersync and scheduler/sync passed with the worktree Python interpreter.
- Real ClickHouse migration-chain/readback integration: passed all target subtests.
- Full `internal/providersync` Go tests: passed outside the sandbox.
- `go vet ./internal/providersync` and integration-tagged vet: passed.
- Ruff check/format: passed.
- Focused Python tests: passed.
- Targeted mypy for all lane-owned files: passed.
- Mutation restore verification, anchor integrity, `git diff --check`, and `gofmt`: passed.
- Independent adversarial review repeated the live oracle and real migration-chain integration and found no blocker.

## Risk and rollback

- Main risk is parity drift or ambiguous ClickHouse replay semantics; differential oracles, clause-level mutations, full logical-key fencing, and real-schema integration cover those seams.
- No database migration is introduced here; tests apply the existing production migration chain.
- Rollback is removal/revert of this inactive feature commit. No production route or deployment profile consumes it yet.

## Tracking

- [CHAOS-3605](https://linear.app/fullchaos/issue/CHAOS-3605/github-work-items-pr-c-implement-the-final-three-engine-dependent)
- Successor activation/recovery work remains in CHAOS-3606.

SCREENSHOT-WAIVER: backend-only Go/Python worker migration; no rendered UI changes.
