### PR TITLE
CHAOS-3615: freeze the backend-neutral Ask Dev investigation contract and evaluation rules

### DIFF
--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.comparable_history_without_edge_validity.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.comparable_history_without_edge_validity.json
@@ -18,12 +18,12 @@
     }
   ],
   "time_context": {
-    "analytical_slice": "current",
-    "as_of": null,
+    "analytical_slice": "historical",
+    "as_of": "2026-05-08T00:00:00Z",
     "edge_validity_basis": "not_required",
     "end": "2026-08-08T00:00:00Z",
-    "historical_comparability": "not_applicable",
-    "start": "2026-07-09T00:00:00Z",
+    "historical_comparability": "comparable",
+    "start": "2026-05-08T00:00:00Z",
     "timezone": "America/Los_Angeles"
   }
 }

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.current_slice_carrying_as_of.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.current_slice_carrying_as_of.json
@@ -20,6 +20,7 @@
   "time_context": {
     "analytical_slice": "current",
     "as_of": "2026-05-08T00:00:00Z",
+    "edge_validity_basis": "not_required",
     "end": "2026-08-08T00:00:00Z",
     "historical_comparability": "not_applicable",
     "start": "2026-07-09T00:00:00Z",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.current_slice_carrying_as_of.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.current_slice_carrying_as_of.json
@@ -1,0 +1,28 @@
+{
+  "comparison_shape": "singular_subject",
+  "conversation_reference_ids": [
+    "conv_2026_08_08_a"
+  ],
+  "interpretation_limitations": [],
+  "job_id": "job_nightfall_status",
+  "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+  "job_uncertainty": "precise",
+  "question_family": "project_status_drivers",
+  "schema_version": "ask_dev_analytical_job.v1",
+  "surface_context_refs": [
+    {
+      "entity_id": "proj_nightfall_migration",
+      "entity_kind": "project",
+      "surface_id": "surface_project_overview",
+      "surface_kind": "project_page"
+    }
+  ],
+  "time_context": {
+    "analytical_slice": "current",
+    "as_of": "2026-05-08T00:00:00Z",
+    "end": "2026-08-08T00:00:00Z",
+    "historical_comparability": "not_applicable",
+    "start": "2026-07-09T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.historical_slice_without_as_of.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.historical_slice_without_as_of.json
@@ -1,0 +1,28 @@
+{
+  "comparison_shape": "singular_subject",
+  "conversation_reference_ids": [
+    "conv_2026_08_08_a"
+  ],
+  "interpretation_limitations": [],
+  "job_id": "job_nightfall_status",
+  "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+  "job_uncertainty": "precise",
+  "question_family": "project_status_drivers",
+  "schema_version": "ask_dev_analytical_job.v1",
+  "surface_context_refs": [
+    {
+      "entity_id": "proj_nightfall_migration",
+      "entity_kind": "project",
+      "surface_id": "surface_project_overview",
+      "surface_kind": "project_page"
+    }
+  ],
+  "time_context": {
+    "analytical_slice": "historical",
+    "as_of": null,
+    "end": "2026-08-08T00:00:00Z",
+    "historical_comparability": "comparable",
+    "start": "2026-07-09T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.historical_slice_without_as_of.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.historical_slice_without_as_of.json
@@ -20,6 +20,7 @@
   "time_context": {
     "analytical_slice": "historical",
     "as_of": null,
+    "edge_validity_basis": "observed_intervals",
     "end": "2026-08-08T00:00:00Z",
     "historical_comparability": "comparable",
     "start": "2026-07-09T00:00:00Z",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.unavailable_edge_validity_mislabelled.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.unavailable_edge_validity_mislabelled.json
@@ -18,12 +18,12 @@
     }
   ],
   "time_context": {
-    "analytical_slice": "current",
-    "as_of": null,
-    "edge_validity_basis": "not_required",
+    "analytical_slice": "historical",
+    "as_of": "2026-05-08T00:00:00Z",
+    "edge_validity_basis": "unavailable",
     "end": "2026-08-08T00:00:00Z",
-    "historical_comparability": "not_applicable",
-    "start": "2026-07-09T00:00:00Z",
+    "historical_comparability": "not_comparable_missing_baseline",
+    "start": "2026-05-08T00:00:00Z",
     "timezone": "America/Los_Angeles"
   }
 }

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.uncertain_job_without_limitations.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.uncertain_job_without_limitations.json
@@ -1,0 +1,28 @@
+{
+  "comparison_shape": "singular_subject",
+  "conversation_reference_ids": [
+    "conv_2026_08_08_a"
+  ],
+  "interpretation_limitations": [],
+  "job_id": "job_nightfall_status",
+  "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+  "job_uncertainty": "broad_with_uncertainty",
+  "question_family": "project_status_drivers",
+  "schema_version": "ask_dev_analytical_job.v1",
+  "surface_context_refs": [
+    {
+      "entity_id": "proj_nightfall_migration",
+      "entity_kind": "project",
+      "surface_id": "surface_project_overview",
+      "surface_kind": "project_page"
+    }
+  ],
+  "time_context": {
+    "analytical_slice": "current",
+    "as_of": null,
+    "end": "2026-08-08T00:00:00Z",
+    "historical_comparability": "not_applicable",
+    "start": "2026-07-09T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.uncertain_job_without_limitations.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_analytical_job.v1.uncertain_job_without_limitations.json
@@ -20,6 +20,7 @@
   "time_context": {
     "analytical_slice": "current",
     "as_of": null,
+    "edge_validity_basis": "not_required",
     "end": "2026-08-08T00:00:00Z",
     "historical_comparability": "not_applicable",
     "start": "2026-07-09T00:00:00Z",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_comparison_cohort.v1.comparison_claimed_without_dimensions.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_comparison_cohort.v1.comparison_claimed_without_dimensions.json
@@ -1,0 +1,46 @@
+{
+  "authorization_filtered_count": 0,
+  "cohort_id": "cohort_nightfall_singular",
+  "cohort_uncertainty": null,
+  "comparison_shape": "discovered_cohort",
+  "completeness": "complete",
+  "exclusions": [
+    {
+      "canonical_id": "proj_nightfall",
+      "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+      "reason": "ambiguous_identity",
+      "subject_kind": "project"
+    }
+  ],
+  "members": [
+    {
+      "canonical_id": "proj_nightfall_migration",
+      "display_label": "Nightfall Migration",
+      "inclusion_basis": [
+        "explicitly_named"
+      ],
+      "inclusion_evidence_classification": "explicitly_named_by_question",
+      "inclusion_evidence_ids": [],
+      "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+      "relevance": "current",
+      "subject_kind": "project"
+    },
+    {
+      "canonical_id": "proj_atlas",
+      "display_label": "Atlas",
+      "inclusion_basis": [
+        "shared_dependency"
+      ],
+      "inclusion_evidence_classification": null,
+      "inclusion_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "inclusion_rationale": "Depends on the same stalled dependency.",
+      "relevance": "current",
+      "subject_kind": "project"
+    }
+  ],
+  "schema_version": "ask_dev_comparison_cohort.v1",
+  "supported_comparison_dimensions": [],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_comparison_cohort.v1.truncated_without_reason.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_comparison_cohort.v1.truncated_without_reason.json
@@ -1,0 +1,32 @@
+{
+  "authorization_filtered_count": 0,
+  "cohort_id": "cohort_nightfall_singular",
+  "cohort_uncertainty": null,
+  "comparison_shape": "singular_subject",
+  "completeness": "truncated",
+  "exclusions": [
+    {
+      "canonical_id": "proj_nightfall",
+      "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+      "reason": "ambiguous_identity",
+      "subject_kind": "project"
+    }
+  ],
+  "members": [
+    {
+      "canonical_id": "proj_nightfall_migration",
+      "display_label": "Nightfall Migration",
+      "inclusion_basis": [
+        "explicitly_named"
+      ],
+      "inclusion_evidence_classification": "explicitly_named_by_question",
+      "inclusion_evidence_ids": [],
+      "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+      "relevance": "current",
+      "subject_kind": "project"
+    }
+  ],
+  "schema_version": "ask_dev_comparison_cohort.v1",
+  "supported_comparison_dimensions": [],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_comparison_cohort.v1.unrelated_member_without_inclusion_evidence.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_comparison_cohort.v1.unrelated_member_without_inclusion_evidence.json
@@ -1,0 +1,46 @@
+{
+  "authorization_filtered_count": 0,
+  "cohort_id": "cohort_nightfall_singular",
+  "cohort_uncertainty": null,
+  "comparison_shape": "discovered_cohort",
+  "completeness": "complete",
+  "exclusions": [
+    {
+      "canonical_id": "proj_nightfall",
+      "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+      "reason": "ambiguous_identity",
+      "subject_kind": "project"
+    }
+  ],
+  "members": [
+    {
+      "canonical_id": "proj_nightfall_migration",
+      "display_label": "Nightfall Migration",
+      "inclusion_basis": [
+        "explicitly_named"
+      ],
+      "inclusion_evidence_classification": "explicitly_named_by_question",
+      "inclusion_evidence_ids": [],
+      "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+      "relevance": "current",
+      "subject_kind": "project"
+    },
+    {
+      "canonical_id": "proj_unrelated_billing",
+      "display_label": "Billing Revamp",
+      "inclusion_basis": [
+        "comparable_delivery_profile"
+      ],
+      "inclusion_evidence_classification": null,
+      "inclusion_evidence_ids": [],
+      "inclusion_rationale": "Also a project.",
+      "relevance": "current",
+      "subject_kind": "project"
+    }
+  ],
+  "schema_version": "ask_dev_comparison_cohort.v1",
+  "supported_comparison_dimensions": [
+    "delivery_throughput"
+  ],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.capacity_driver_without_staffing_qualification.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.capacity_driver_without_staffing_qualification.json
@@ -1,0 +1,79 @@
+{
+  "candidates": [
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "svc_auth_gateway"
+      ],
+      "assertion_basis": "measured",
+      "category": "dependency_pressure",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_dependency_stall",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+      "supporting_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "team_platform"
+      ],
+      "assertion_basis": "measured",
+      "category": "capacity_or_staffing",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_review_backlog",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "contributing_driver",
+      "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+      "supporting_evidence_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration"
+      ],
+      "assertion_basis": "measured",
+      "category": "delivery_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_cycle_time_rising",
+      "exclusion_reason": "symptom_of_another_candidate",
+      "relevance": "current",
+      "role": "symptom",
+      "staffing_qualification": null,
+      "standing": "excluded",
+      "summary": "Median cycle time on the project has risen over the window.",
+      "supporting_evidence_ids": [
+        "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+      ],
+      "supporting_path_ids": []
+    }
+  ],
+  "candidates_truncated": false,
+  "principal_driver_ids": [
+    "drv_dependency_stall"
+  ],
+  "schema_version": "ask_dev_driver_analysis.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.historical_driver_promoted_to_principal.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.historical_driver_promoted_to_principal.json
@@ -1,0 +1,79 @@
+{
+  "candidates": [
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "svc_auth_gateway"
+      ],
+      "assertion_basis": "measured",
+      "category": "dependency_pressure",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_dependency_stall",
+      "exclusion_reason": null,
+      "relevance": "historical_only",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+      "supporting_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "team_platform"
+      ],
+      "assertion_basis": "measured",
+      "category": "review_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_review_backlog",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "contributing_driver",
+      "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+      "supporting_evidence_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration"
+      ],
+      "assertion_basis": "measured",
+      "category": "delivery_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_cycle_time_rising",
+      "exclusion_reason": "symptom_of_another_candidate",
+      "relevance": "current",
+      "role": "symptom",
+      "staffing_qualification": null,
+      "standing": "excluded",
+      "summary": "Median cycle time on the project has risen over the window.",
+      "supporting_evidence_ids": [
+        "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+      ],
+      "supporting_path_ids": []
+    }
+  ],
+  "candidates_truncated": false,
+  "principal_driver_ids": [
+    "drv_dependency_stall"
+  ],
+  "schema_version": "ask_dev_driver_analysis.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.principal_driver_without_supporting_path.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.principal_driver_without_supporting_path.json
@@ -1,0 +1,77 @@
+{
+  "candidates": [
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "svc_auth_gateway"
+      ],
+      "assertion_basis": "measured",
+      "category": "dependency_pressure",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_dependency_stall",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+      "supporting_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "supporting_path_ids": []
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "team_platform"
+      ],
+      "assertion_basis": "measured",
+      "category": "review_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_review_backlog",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "contributing_driver",
+      "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+      "supporting_evidence_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration"
+      ],
+      "assertion_basis": "measured",
+      "category": "delivery_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_cycle_time_rising",
+      "exclusion_reason": "symptom_of_another_candidate",
+      "relevance": "current",
+      "role": "symptom",
+      "staffing_qualification": null,
+      "standing": "excluded",
+      "summary": "Median cycle time on the project has risen over the window.",
+      "supporting_evidence_ids": [
+        "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+      ],
+      "supporting_path_ids": []
+    }
+  ],
+  "candidates_truncated": false,
+  "principal_driver_ids": [
+    "drv_dependency_stall"
+  ],
+  "schema_version": "ask_dev_driver_analysis.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.principal_list_contradicts_standings.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.principal_list_contradicts_standings.json
@@ -1,0 +1,77 @@
+{
+  "candidates": [
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "svc_auth_gateway"
+      ],
+      "assertion_basis": "measured",
+      "category": "dependency_pressure",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_dependency_stall",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+      "supporting_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "team_platform"
+      ],
+      "assertion_basis": "measured",
+      "category": "review_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_review_backlog",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "contributing_driver",
+      "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+      "supporting_evidence_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration"
+      ],
+      "assertion_basis": "measured",
+      "category": "delivery_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_cycle_time_rising",
+      "exclusion_reason": "symptom_of_another_candidate",
+      "relevance": "current",
+      "role": "symptom",
+      "staffing_qualification": null,
+      "standing": "excluded",
+      "summary": "Median cycle time on the project has risen over the window.",
+      "supporting_evidence_ids": [
+        "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+      ],
+      "supporting_path_ids": []
+    }
+  ],
+  "candidates_truncated": false,
+  "principal_driver_ids": [],
+  "schema_version": "ask_dev_driver_analysis.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.staffing_certainty_without_denominator.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.staffing_certainty_without_denominator.json
@@ -1,0 +1,83 @@
+{
+  "candidates": [
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "svc_auth_gateway"
+      ],
+      "assertion_basis": "measured",
+      "category": "dependency_pressure",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_dependency_stall",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+      "supporting_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "team_platform"
+      ],
+      "assertion_basis": "measured",
+      "category": "capacity_or_staffing",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_review_backlog",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": {
+        "denominator_source_classes": [],
+        "denominator_state": "denominator_absent",
+        "qualification_note": "No allocation data."
+      },
+      "standing": "contributing_driver",
+      "summary": "The team is understaffed for the remaining work.",
+      "supporting_evidence_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration"
+      ],
+      "assertion_basis": "measured",
+      "category": "delivery_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_cycle_time_rising",
+      "exclusion_reason": "symptom_of_another_candidate",
+      "relevance": "current",
+      "role": "symptom",
+      "staffing_qualification": null,
+      "standing": "excluded",
+      "summary": "Median cycle time on the project has risen over the window.",
+      "supporting_evidence_ids": [
+        "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+      ],
+      "supporting_path_ids": []
+    }
+  ],
+  "candidates_truncated": false,
+  "principal_driver_ids": [
+    "drv_dependency_stall"
+  ],
+  "schema_version": "ask_dev_driver_analysis.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.symptom_promoted_to_principal_driver.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_driver_analysis.v1.symptom_promoted_to_principal_driver.json
@@ -1,0 +1,80 @@
+{
+  "candidates": [
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "svc_auth_gateway"
+      ],
+      "assertion_basis": "measured",
+      "category": "dependency_pressure",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_dependency_stall",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+      "supporting_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "team_platform"
+      ],
+      "assertion_basis": "measured",
+      "category": "review_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_review_backlog",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "contributing_driver",
+      "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+      "supporting_evidence_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration"
+      ],
+      "assertion_basis": "measured",
+      "category": "delivery_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_cycle_time_rising",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "symptom",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "Median cycle time on the project has risen over the window.",
+      "supporting_evidence_ids": [
+        "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+      ],
+      "supporting_path_ids": []
+    }
+  ],
+  "candidates_truncated": false,
+  "principal_driver_ids": [
+    "drv_dependency_stall",
+    "drv_cycle_time_rising"
+  ],
+  "schema_version": "ask_dev_driver_analysis.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.conflict_citing_unindexed_evidence.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.conflict_citing_unindexed_evidence.json
@@ -1,0 +1,194 @@
+{
+  "authorization_filtered_count": 0,
+  "clarification_needs": [],
+  "conflicts": [
+    {
+      "conflict_id": "conflict_1",
+      "description": "Two sources disagree on the release state.",
+      "evidence_ref_ids": [
+        "ev1_0707070707070707070707070707070707070707",
+        "ev1_0808080808080808080808080808080808080808"
+      ],
+      "resolution": "unresolved"
+    }
+  ],
+  "evidence_index": [
+    {
+      "evidence": {
+        "citation_text": "Project registered under this display name.",
+        "confidence": 1.0,
+        "display_label": "Nightfall Migration registration",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": [
+        "proj_nightfall_migration"
+      ]
+    },
+    {
+      "evidence": {
+        "citation_text": "Dependency has no released version carrying the change.",
+        "confidence": 1.0,
+        "display_label": "authlib release status",
+        "entity_id": "dep_authlib",
+        "entity_type": "dependency",
+        "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/dependency/dep_authlib",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [
+        "drv_dependency_stall"
+      ],
+      "supports_entity_ids": [
+        "svc_auth_gateway",
+        "dep_authlib"
+      ],
+      "supports_path_ids": [
+        "path_dependency"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Open review count exceeded the drain rate for the window.",
+        "confidence": 1.0,
+        "display_label": "Platform review queue",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/team/team_platform",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "review",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "review",
+      "supports_driver_ids": [
+        "drv_review_backlog"
+      ],
+      "supports_entity_ids": [
+        "team_platform"
+      ],
+      "supports_path_ids": [
+        "path_ownership"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Median cycle time rose over the window.",
+        "confidence": 1.0,
+        "display_label": "Cycle time p50",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_item",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_item",
+      "supports_driver_ids": [
+        "drv_cycle_time_rising"
+      ],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": []
+    }
+  ],
+  "evidence_truncated": false,
+  "limitations": [
+    {
+      "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+      "kind": "missing_source"
+    },
+    {
+      "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+      "kind": "stale_source"
+    },
+    {
+      "detail": "Release state disputed.",
+      "kind": "conflicting_evidence"
+    }
+  ],
+  "missing_sources": [
+    {
+      "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+      "source_class": "investment_allocation",
+      "state": "unconfigured"
+    }
+  ],
+  "schema_version": "ask_dev_evidence_coverage.v1",
+  "source_health": [
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_graph",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "review",
+      "state": "available_current"
+    },
+    {
+      "detail": "Last deployment sync completed 31 hours ago.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "deployment",
+      "state": "available_stale"
+    }
+  ],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.conflict_citing_unindexed_evidence.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.conflict_citing_unindexed_evidence.json
@@ -184,6 +184,24 @@
       "state": "available_current"
     },
     {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_item",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "status_change",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "pull_request",
+      "state": "available_current"
+    },
+    {
       "detail": "Last deployment sync completed 31 hours ago.",
       "observed_at": "2026-08-08T12:00:00Z",
       "source_class": "deployment",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.evidence_supporting_nothing.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.evidence_supporting_nothing.json
@@ -199,6 +199,24 @@
       "state": "available_current"
     },
     {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_item",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "status_change",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "pull_request",
+      "state": "available_current"
+    },
+    {
       "detail": "Last deployment sync completed 31 hours ago.",
       "observed_at": "2026-08-08T12:00:00Z",
       "source_class": "deployment",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.evidence_supporting_nothing.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.evidence_supporting_nothing.json
@@ -1,0 +1,209 @@
+{
+  "authorization_filtered_count": 0,
+  "clarification_needs": [],
+  "conflicts": [],
+  "evidence_index": [
+    {
+      "evidence": {
+        "citation_text": "Project registered under this display name.",
+        "confidence": 1.0,
+        "display_label": "Nightfall Migration registration",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": [
+        "proj_nightfall_migration"
+      ]
+    },
+    {
+      "evidence": {
+        "citation_text": "Dependency has no released version carrying the change.",
+        "confidence": 1.0,
+        "display_label": "authlib release status",
+        "entity_id": "dep_authlib",
+        "entity_type": "dependency",
+        "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/dependency/dep_authlib",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [
+        "drv_dependency_stall"
+      ],
+      "supports_entity_ids": [
+        "svc_auth_gateway",
+        "dep_authlib"
+      ],
+      "supports_path_ids": [
+        "path_dependency"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Open review count exceeded the drain rate for the window.",
+        "confidence": 1.0,
+        "display_label": "Platform review queue",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/team/team_platform",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "review",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "review",
+      "supports_driver_ids": [
+        "drv_review_backlog"
+      ],
+      "supports_entity_ids": [
+        "team_platform"
+      ],
+      "supports_path_ids": [
+        "path_ownership"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Median cycle time rose over the window.",
+        "confidence": 1.0,
+        "display_label": "Cycle time p50",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_item",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_item",
+      "supports_driver_ids": [
+        "drv_cycle_time_rising"
+      ],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "1,482 commits in the window.",
+        "confidence": 1.0,
+        "display_label": "Recent commits",
+        "entity_id": "repo_dev_health",
+        "entity_type": "repository",
+        "evidence_ref_id": "ev1_e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/repository/repo_dev_health",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "code_change",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "code_change",
+      "supports_driver_ids": [],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": []
+    }
+  ],
+  "evidence_truncated": false,
+  "limitations": [
+    {
+      "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+      "kind": "missing_source"
+    },
+    {
+      "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+      "kind": "stale_source"
+    }
+  ],
+  "missing_sources": [
+    {
+      "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+      "source_class": "investment_allocation",
+      "state": "unconfigured"
+    }
+  ],
+  "schema_version": "ask_dev_evidence_coverage.v1",
+  "source_health": [
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_graph",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "review",
+      "state": "available_current"
+    },
+    {
+      "detail": "Last deployment sync completed 31 hours ago.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "deployment",
+      "state": "available_stale"
+    }
+  ],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.graph_native_field_smuggled_as_extra.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.graph_native_field_smuggled_as_extra.json
@@ -1,0 +1,183 @@
+{
+  "authorization_filtered_count": 0,
+  "clarification_needs": [],
+  "conflicts": [],
+  "evidence_index": [
+    {
+      "evidence": {
+        "citation_text": "Project registered under this display name.",
+        "confidence": 1.0,
+        "display_label": "Nightfall Migration registration",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": [
+        "proj_nightfall_migration"
+      ]
+    },
+    {
+      "evidence": {
+        "citation_text": "Dependency has no released version carrying the change.",
+        "confidence": 1.0,
+        "display_label": "authlib release status",
+        "entity_id": "dep_authlib",
+        "entity_type": "dependency",
+        "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/dependency/dep_authlib",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [
+        "drv_dependency_stall"
+      ],
+      "supports_entity_ids": [
+        "svc_auth_gateway",
+        "dep_authlib"
+      ],
+      "supports_path_ids": [
+        "path_dependency"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Open review count exceeded the drain rate for the window.",
+        "confidence": 1.0,
+        "display_label": "Platform review queue",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/team/team_platform",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "review",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "review",
+      "supports_driver_ids": [
+        "drv_review_backlog"
+      ],
+      "supports_entity_ids": [
+        "team_platform"
+      ],
+      "supports_path_ids": [
+        "path_ownership"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Median cycle time rose over the window.",
+        "confidence": 1.0,
+        "display_label": "Cycle time p50",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_item",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_item",
+      "supports_driver_ids": [
+        "drv_cycle_time_rising"
+      ],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": []
+    }
+  ],
+  "evidence_truncated": false,
+  "graph_node_ids": [
+    "4:8a1f:12"
+  ],
+  "limitations": [
+    {
+      "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+      "kind": "missing_source"
+    },
+    {
+      "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+      "kind": "stale_source"
+    }
+  ],
+  "missing_sources": [
+    {
+      "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+      "source_class": "investment_allocation",
+      "state": "unconfigured"
+    }
+  ],
+  "schema_version": "ask_dev_evidence_coverage.v1",
+  "source_health": [
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_graph",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "review",
+      "state": "available_current"
+    },
+    {
+      "detail": "Last deployment sync completed 31 hours ago.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "deployment",
+      "state": "available_stale"
+    }
+  ],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.graph_native_field_smuggled_as_extra.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.graph_native_field_smuggled_as_extra.json
@@ -173,6 +173,24 @@
       "state": "available_current"
     },
     {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_item",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "status_change",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "pull_request",
+      "state": "available_current"
+    },
+    {
       "detail": "Last deployment sync completed 31 hours ago.",
       "observed_at": "2026-08-08T12:00:00Z",
       "source_class": "deployment",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.missing_source_undisclosed.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.missing_source_undisclosed.json
@@ -1,0 +1,176 @@
+{
+  "authorization_filtered_count": 0,
+  "clarification_needs": [],
+  "conflicts": [],
+  "evidence_index": [
+    {
+      "evidence": {
+        "citation_text": "Project registered under this display name.",
+        "confidence": 1.0,
+        "display_label": "Nightfall Migration registration",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": [
+        "proj_nightfall_migration"
+      ]
+    },
+    {
+      "evidence": {
+        "citation_text": "Dependency has no released version carrying the change.",
+        "confidence": 1.0,
+        "display_label": "authlib release status",
+        "entity_id": "dep_authlib",
+        "entity_type": "dependency",
+        "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/dependency/dep_authlib",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [
+        "drv_dependency_stall"
+      ],
+      "supports_entity_ids": [
+        "svc_auth_gateway",
+        "dep_authlib"
+      ],
+      "supports_path_ids": [
+        "path_dependency"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Open review count exceeded the drain rate for the window.",
+        "confidence": 1.0,
+        "display_label": "Platform review queue",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/team/team_platform",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "review",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "review",
+      "supports_driver_ids": [
+        "drv_review_backlog"
+      ],
+      "supports_entity_ids": [
+        "team_platform"
+      ],
+      "supports_path_ids": [
+        "path_ownership"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Median cycle time rose over the window.",
+        "confidence": 1.0,
+        "display_label": "Cycle time p50",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_item",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_item",
+      "supports_driver_ids": [
+        "drv_cycle_time_rising"
+      ],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": []
+    }
+  ],
+  "evidence_truncated": false,
+  "limitations": [
+    {
+      "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+      "kind": "stale_source"
+    }
+  ],
+  "missing_sources": [
+    {
+      "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+      "source_class": "investment_allocation",
+      "state": "unconfigured"
+    }
+  ],
+  "schema_version": "ask_dev_evidence_coverage.v1",
+  "source_health": [
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_graph",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "review",
+      "state": "available_current"
+    },
+    {
+      "detail": "Last deployment sync completed 31 hours ago.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "deployment",
+      "state": "available_stale"
+    }
+  ],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.source_both_observed_and_missing.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_evidence_coverage.v1.source_both_observed_and_missing.json
@@ -140,6 +140,10 @@
   "evidence_truncated": false,
   "limitations": [
     {
+      "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+      "kind": "missing_source"
+    },
+    {
       "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
       "kind": "stale_source"
     }
@@ -149,6 +153,11 @@
       "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
       "source_class": "investment_allocation",
       "state": "unconfigured"
+    },
+    {
+      "impact": "Reported unavailable while also reported available_current.",
+      "source_class": "work_graph",
+      "state": "unavailable"
     }
   ],
   "schema_version": "ask_dev_evidence_coverage.v1",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.authorization_filtering_undisclosed.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.authorization_filtering_undisclosed.json
@@ -1,0 +1,517 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "contributing_driver",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 4,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.authorization_filtering_undisclosed.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.authorization_filtering_undisclosed.json
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -310,6 +311,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -326,6 +345,7 @@
     "authorization_filtered_count": 4,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.cohort_member_outside_authorized_set.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.cohort_member_outside_authorized_set.json
@@ -19,12 +19,12 @@
       }
     ],
     "time_context": {
-      "analytical_slice": "current_vs_historical",
-      "as_of": "2026-05-08T00:00:00Z",
-      "edge_validity_basis": "unavailable",
+      "analytical_slice": "current",
+      "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
-      "historical_comparability": "not_comparable_missing_edge_validity",
-      "start": "2026-05-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
       "timezone": "America/Los_Angeles"
     }
   },
@@ -44,7 +44,7 @@
     ],
     "members": [
       {
-        "canonical_id": "proj_nightfall_migration",
+        "canonical_id": "proj_private_other_org",
         "display_label": "Nightfall Migration",
         "inclusion_basis": [
           "explicitly_named"
@@ -64,7 +64,6 @@
     "candidates": [
       {
         "affected_subject_ids": [
-          "proj_nightfall_migration",
           "svc_auth_gateway"
         ],
         "assertion_basis": "measured",
@@ -88,7 +87,6 @@
       },
       {
         "affected_subject_ids": [
-          "proj_nightfall_migration",
           "team_platform"
         ],
         "assertion_basis": "measured",
@@ -112,7 +110,7 @@
       },
       {
         "affected_subject_ids": [
-          "proj_nightfall_migration"
+          "team_platform"
         ],
         "assertion_basis": "measured",
         "category": "delivery_pressure",
@@ -169,11 +167,11 @@
         "relevance": "current",
         "source_class": "work_graph",
         "supports_driver_ids": [],
-        "supports_entity_ids": [],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
         "supports_path_ids": [],
-        "supports_subject_ids": [
-          "proj_nightfall_migration"
-        ]
+        "supports_subject_ids": []
       },
       {
         "evidence": {
@@ -287,10 +285,6 @@
       {
         "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
         "kind": "stale_source"
-      },
-      {
-        "detail": "Relationship edges carry no validity interval, so the as-of state cannot be reconstructed; the historical half of this comparison is reported NOT COMPARABLE rather than as no change.",
-        "kind": "historical_slice_not_comparable"
       }
     ],
     "missing_sources": [

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.dashboard_redirect_without_direct_judgment.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.dashboard_redirect_without_direct_judgment.json
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -308,6 +309,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -324,6 +343,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.dashboard_redirect_without_direct_judgment.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.dashboard_redirect_without_direct_judgment.json
@@ -1,0 +1,515 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.evidence_citation_absent_from_index.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.evidence_citation_absent_from_index.json
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -310,6 +311,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -326,6 +345,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.evidence_citation_absent_from_index.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.evidence_citation_absent_from_index.json
@@ -1,0 +1,517 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "contributing_driver",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.evidence_entity_outside_authorized_set.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.evidence_entity_outside_authorized_set.json
@@ -19,12 +19,12 @@
       }
     ],
     "time_context": {
-      "analytical_slice": "current_vs_historical",
-      "as_of": "2026-05-08T00:00:00Z",
-      "edge_validity_basis": "unavailable",
+      "analytical_slice": "current",
+      "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
-      "historical_comparability": "not_comparable_missing_edge_validity",
-      "start": "2026-05-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
       "timezone": "America/Los_Angeles"
     }
   },
@@ -180,7 +180,7 @@
           "citation_text": "Dependency has no released version carrying the change.",
           "confidence": 1.0,
           "display_label": "authlib release status",
-          "entity_id": "dep_authlib",
+          "entity_id": "dep_private_other_org",
           "entity_type": "dependency",
           "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
           "flags": {},
@@ -287,10 +287,6 @@
       {
         "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
         "kind": "stale_source"
-      },
-      {
-        "detail": "Relationship edges carry no validity interval, so the as-of state cannot be reconstructed; the historical half of this comparison is reported NOT COMPARABLE rather than as no change.",
-        "kind": "historical_slice_not_comparable"
       }
     ],
     "missing_sources": [

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.family_required_source_unaccounted.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.family_required_source_unaccounted.json
@@ -19,12 +19,12 @@
       }
     ],
     "time_context": {
-      "analytical_slice": "current_vs_historical",
-      "as_of": "2026-05-08T00:00:00Z",
-      "edge_validity_basis": "unavailable",
+      "analytical_slice": "current",
+      "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
-      "historical_comparability": "not_comparable_missing_edge_validity",
-      "start": "2026-05-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
       "timezone": "America/Los_Angeles"
     }
   },
@@ -283,14 +283,6 @@
       {
         "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
         "kind": "missing_source"
-      },
-      {
-        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
-        "kind": "stale_source"
-      },
-      {
-        "detail": "Relationship edges carry no validity interval, so the as-of state cannot be reconstructed; the historical half of this comparison is reported NOT COMPARABLE rather than as no change.",
-        "kind": "historical_slice_not_comparable"
       }
     ],
     "missing_sources": [
@@ -331,12 +323,6 @@
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "pull_request",
         "state": "available_current"
-      },
-      {
-        "detail": "Last deployment sync completed 31 hours ago.",
-        "observed_at": "2026-08-08T12:00:00Z",
-        "source_class": "deployment",
-        "state": "available_stale"
       }
     ],
     "truncation_reason": null

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.no_match_without_limitation_or_clarification.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.no_match_without_limitation_or_clarification.json
@@ -1,0 +1,498 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [],
+    "missing_sources": [],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "no_match",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "proposed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "proposed",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.no_match_without_limitation_or_clarification.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.no_match_without_limitation_or_clarification.json
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -293,6 +294,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -309,6 +328,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.not_comparable_slice_undisclosed.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.not_comparable_slice_undisclosed.json
@@ -1,0 +1,517 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current_vs_historical",
+      "as_of": "2026-05-08T00:00:00Z",
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_comparable_missing_edge_validity",
+      "start": "2026-05-08T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "contributing_driver",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.not_comparable_slice_undisclosed.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.not_comparable_slice_undisclosed.json
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current_vs_historical",
       "as_of": "2026-05-08T00:00:00Z",
+      "edge_validity_basis": "unavailable",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_comparable_missing_edge_validity",
       "start": "2026-05-08T00:00:00Z",
@@ -310,6 +311,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -326,6 +345,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.organization_widening_after_unresolved_reference.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.organization_widening_after_unresolved_reference.json
@@ -26,6 +26,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -322,10 +323,34 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
         "state": "available_stale"
+      },
+      {
+        "detail": "Source availability was checked before widening.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "source_health",
+        "state": "available_current"
       }
     ],
     "truncation_reason": null
@@ -338,6 +363,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.organization_widening_after_unresolved_reference.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.organization_widening_after_unresolved_reference.json
@@ -1,0 +1,537 @@
+{
+  "analytical_job": {
+    "comparison_shape": "organization_wide",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [
+      {
+        "detail": "The question named no subject and no time context.",
+        "kind": "interpretation_uncertainty"
+      }
+    ],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report what is going sideways; no subject was named.",
+    "job_uncertainty": "ambiguous",
+    "question_family": "clarification_and_no_match",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "organization_wide",
+    "completeness": "complete",
+    "exclusions": [],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "One of two candidates for the named reference.",
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "canonical_id": "proj_nightfall",
+        "display_label": "Nightfall",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The other candidate for the named reference.",
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [
+      "delivery_throughput"
+    ],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "ambiguous",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": [
+      {
+        "candidate_ids": [
+          "cand_1",
+          "cand_2"
+        ],
+        "mention_id": "mention_1",
+        "mention_text": "the nightfall thing",
+        "reason": "multiple_candidates"
+      }
+    ]
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.question_family_shape_mismatch.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.question_family_shape_mismatch.json
@@ -8,7 +8,7 @@
     "job_id": "job_nightfall_status",
     "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
     "job_uncertainty": "precise",
-    "question_family": "project_status_drivers",
+    "question_family": "struggling_teams",
     "schema_version": "ask_dev_analytical_job.v1",
     "surface_context_refs": [
       {
@@ -19,12 +19,12 @@
       }
     ],
     "time_context": {
-      "analytical_slice": "current_vs_historical",
-      "as_of": "2026-05-08T00:00:00Z",
-      "edge_validity_basis": "unavailable",
+      "analytical_slice": "current",
+      "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
-      "historical_comparability": "not_comparable_missing_edge_validity",
-      "start": "2026-05-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
       "timezone": "America/Los_Angeles"
     }
   },
@@ -287,10 +287,6 @@
       {
         "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
         "kind": "stale_source"
-      },
-      {
-        "detail": "Relationship edges carry no validity interval, so the as-of state cannot be reconstructed; the historical half of this comparison is reported NOT COMPARABLE rather than as no change.",
-        "kind": "historical_slice_not_comparable"
       }
     ],
     "missing_sources": [

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.source_class_off_the_trial_allowlist.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_packet.v1.source_class_off_the_trial_allowlist.json
@@ -19,12 +19,12 @@
       }
     ],
     "time_context": {
-      "analytical_slice": "current_vs_historical",
-      "as_of": "2026-05-08T00:00:00Z",
-      "edge_validity_basis": "unavailable",
+      "analytical_slice": "current",
+      "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
-      "historical_comparability": "not_comparable_missing_edge_validity",
-      "start": "2026-05-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
       "timezone": "America/Los_Angeles"
     }
   },
@@ -287,10 +287,6 @@
       {
         "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
         "kind": "stale_source"
-      },
-      {
-        "detail": "Relationship edges carry no validity interval, so the as-of state cannot be reconstructed; the historical half of this comparison is reported NOT COMPARABLE rather than as no change.",
-        "kind": "historical_slice_not_comparable"
       }
     ],
     "missing_sources": [
@@ -337,6 +333,12 @@
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
         "state": "available_stale"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "temporal_context",
+        "state": "available_current"
       }
     ],
     "truncation_reason": null

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_versions.v1.duplicate_source_contract_version.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_versions.v1.duplicate_source_contract_version.json
@@ -1,0 +1,27 @@
+{
+  "corpus_version": null,
+  "packet_schema_version": "ask_dev_investigation_packet.v1",
+  "projection_version": "work_graph_projection.v1",
+  "query_version": "ask_dev_investigation_queries.v1",
+  "ranking_version": "ask_dev_investigation_ranking.v1",
+  "schema_version": "ask_dev_investigation_versions.v1",
+  "source_contract_versions": [
+    {
+      "contract_version": "work_graph.v1",
+      "source_class": "work_graph"
+    },
+    {
+      "contract_version": "review_metrics.v1",
+      "source_class": "review"
+    },
+    {
+      "contract_version": "work_item.v1",
+      "source_class": "work_item"
+    },
+    {
+      "contract_version": "work_graph.v2",
+      "source_class": "work_graph"
+    }
+  ],
+  "trial": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_versions.v1.no_source_contract_versions.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_investigation_versions.v1.no_source_contract_versions.json
@@ -1,0 +1,10 @@
+{
+  "corpus_version": null,
+  "packet_schema_version": "ask_dev_investigation_packet.v1",
+  "projection_version": "work_graph_projection.v1",
+  "query_version": "ask_dev_investigation_queries.v1",
+  "ranking_version": "ask_dev_investigation_ranking.v1",
+  "schema_version": "ask_dev_investigation_versions.v1",
+  "source_contract_versions": [],
+  "trial": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.disconnected_path_presented_as_chain.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.disconnected_path_presented_as_chain.json
@@ -1,0 +1,111 @@
+{
+  "authorization_filtered_count": 0,
+  "authorized_entity_ids": [
+    "proj_nightfall_migration",
+    "team_platform",
+    "svc_auth_gateway",
+    "dep_authlib",
+    "svc_unrelated"
+  ],
+  "entities": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_kind": "team",
+      "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "display_label": "Auth Gateway",
+      "entity_id": "svc_auth_gateway",
+      "entity_kind": "service",
+      "inclusion_reason": "The project's remaining work all lands in this service.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "display_label": "authlib",
+      "entity_id": "dep_authlib",
+      "entity_kind": "dependency",
+      "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    }
+  ],
+  "entities_truncated": false,
+  "paths": [
+    {
+      "evidence_ref_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "owned_by_team",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "team_platform",
+          "target_entity_kind": "team"
+        }
+      ],
+      "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_ownership",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "team_platform",
+      "truncated": false,
+      "truncation_reason": null
+    },
+    {
+      "evidence_ref_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "svc_auth_gateway",
+          "target_entity_kind": "service"
+        },
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "svc_unrelated",
+          "source_entity_kind": "service",
+          "target_entity_id": "dep_authlib",
+          "target_entity_kind": "dependency"
+        }
+      ],
+      "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_dependency",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "dep_authlib",
+      "truncated": false,
+      "truncation_reason": null
+    }
+  ],
+  "paths_truncated": false,
+  "schema_version": "ask_dev_related_context.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.disconnected_path_presented_as_chain.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.disconnected_path_presented_as_chain.json
@@ -2,6 +2,7 @@
   "authorization_filtered_count": 0,
   "authorized_entity_ids": [
     "proj_nightfall_migration",
+    "proj_nightfall",
     "team_platform",
     "svc_auth_gateway",
     "dep_authlib",

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.entity_citing_undeclared_path.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.entity_citing_undeclared_path.json
@@ -1,0 +1,110 @@
+{
+  "authorization_filtered_count": 0,
+  "authorized_entity_ids": [
+    "proj_nightfall_migration",
+    "team_platform",
+    "svc_auth_gateway",
+    "dep_authlib"
+  ],
+  "entities": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_kind": "team",
+      "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_never_declared"
+      ]
+    },
+    {
+      "display_label": "Auth Gateway",
+      "entity_id": "svc_auth_gateway",
+      "entity_kind": "service",
+      "inclusion_reason": "The project's remaining work all lands in this service.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "display_label": "authlib",
+      "entity_id": "dep_authlib",
+      "entity_kind": "dependency",
+      "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    }
+  ],
+  "entities_truncated": false,
+  "paths": [
+    {
+      "evidence_ref_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "owned_by_team",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "team_platform",
+          "target_entity_kind": "team"
+        }
+      ],
+      "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_ownership",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "team_platform",
+      "truncated": false,
+      "truncation_reason": null
+    },
+    {
+      "evidence_ref_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "svc_auth_gateway",
+          "target_entity_kind": "service"
+        },
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "svc_auth_gateway",
+          "source_entity_kind": "service",
+          "target_entity_id": "dep_authlib",
+          "target_entity_kind": "dependency"
+        }
+      ],
+      "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_dependency",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "dep_authlib",
+      "truncated": false,
+      "truncation_reason": null
+    }
+  ],
+  "paths_truncated": false,
+  "schema_version": "ask_dev_related_context.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.entity_citing_undeclared_path.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.entity_citing_undeclared_path.json
@@ -2,6 +2,7 @@
   "authorization_filtered_count": 0,
   "authorized_entity_ids": [
     "proj_nightfall_migration",
+    "proj_nightfall",
     "team_platform",
     "svc_auth_gateway",
     "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.path_cited_but_never_reaching_entity.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.path_cited_but_never_reaching_entity.json
@@ -27,7 +27,7 @@
       "observed_at": "2026-08-08T12:00:00Z",
       "relevance": "current",
       "supporting_path_ids": [
-        "path_dependency"
+        "path_ownership"
       ]
     },
     {

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.path_crosses_unauthorized_entity.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.path_crosses_unauthorized_entity.json
@@ -1,0 +1,109 @@
+{
+  "authorization_filtered_count": 0,
+  "authorized_entity_ids": [
+    "proj_nightfall_migration",
+    "team_platform",
+    "svc_auth_gateway"
+  ],
+  "entities": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_kind": "team",
+      "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "display_label": "Auth Gateway",
+      "entity_id": "svc_auth_gateway",
+      "entity_kind": "service",
+      "inclusion_reason": "The project's remaining work all lands in this service.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "display_label": "authlib",
+      "entity_id": "dep_authlib",
+      "entity_kind": "dependency",
+      "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    }
+  ],
+  "entities_truncated": false,
+  "paths": [
+    {
+      "evidence_ref_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "owned_by_team",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "team_platform",
+          "target_entity_kind": "team"
+        }
+      ],
+      "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_ownership",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "team_platform",
+      "truncated": false,
+      "truncation_reason": null
+    },
+    {
+      "evidence_ref_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "svc_auth_gateway",
+          "target_entity_kind": "service"
+        },
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "svc_auth_gateway",
+          "source_entity_kind": "service",
+          "target_entity_id": "dep_authlib",
+          "target_entity_kind": "dependency"
+        }
+      ],
+      "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_dependency",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "dep_authlib",
+      "truncated": false,
+      "truncation_reason": null
+    }
+  ],
+  "paths_truncated": false,
+  "schema_version": "ask_dev_related_context.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.reversed_relationship_direction.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.reversed_relationship_direction.json
@@ -1,0 +1,110 @@
+{
+  "authorization_filtered_count": 0,
+  "authorized_entity_ids": [
+    "proj_nightfall_migration",
+    "team_platform",
+    "svc_auth_gateway",
+    "dep_authlib"
+  ],
+  "entities": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_kind": "team",
+      "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "display_label": "Auth Gateway",
+      "entity_id": "svc_auth_gateway",
+      "entity_kind": "service",
+      "inclusion_reason": "The project's remaining work all lands in this service.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "display_label": "authlib",
+      "entity_id": "dep_authlib",
+      "entity_kind": "dependency",
+      "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    }
+  ],
+  "entities_truncated": false,
+  "paths": [
+    {
+      "evidence_ref_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "owned_by_team",
+          "relevance": "current",
+          "source_entity_id": "team_platform",
+          "source_entity_kind": "team",
+          "target_entity_id": "proj_nightfall_migration",
+          "target_entity_kind": "project"
+        }
+      ],
+      "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+      "origin_entity_id": "team_platform",
+      "path_id": "path_ownership",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "proj_nightfall_migration",
+      "truncated": false,
+      "truncation_reason": null
+    },
+    {
+      "evidence_ref_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "svc_auth_gateway",
+          "target_entity_kind": "service"
+        },
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "svc_auth_gateway",
+          "source_entity_kind": "service",
+          "target_entity_id": "dep_authlib",
+          "target_entity_kind": "dependency"
+        }
+      ],
+      "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_dependency",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "dep_authlib",
+      "truncated": false,
+      "truncation_reason": null
+    }
+  ],
+  "paths_truncated": false,
+  "schema_version": "ask_dev_related_context.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.reversed_relationship_direction.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_related_context.v1.reversed_relationship_direction.json
@@ -2,6 +2,7 @@
   "authorization_filtered_count": 0,
   "authorized_entity_ids": [
     "proj_nightfall_migration",
+    "proj_nightfall",
     "team_platform",
     "svc_auth_gateway",
     "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.absent_truncation_disclosure_field.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.absent_truncation_disclosure_field.json
@@ -1,0 +1,57 @@
+{
+  "authorization_filtered_count": 0,
+  "candidates": [
+    {
+      "candidate_id": "cand_1",
+      "canonical_id": "proj_nightfall_migration",
+      "commitment_state": "committed",
+      "display_label": "Nightfall Migration",
+      "match_confidence": 0.97,
+      "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [
+            "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+          ],
+          "matched_text": "Nightfall Migration",
+          "signal": "exact_display_name",
+          "source_class": "work_graph"
+        },
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "surface_project_overview",
+          "signal": "surface_context_reference",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 1,
+      "relevance": "current",
+      "subject_kind": "project"
+    },
+    {
+      "candidate_id": "cand_2",
+      "canonical_id": "proj_nightfall",
+      "commitment_state": "rejected",
+      "display_label": "Nightfall",
+      "match_confidence": 0.41,
+      "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "Nightfall",
+          "signal": "fuzzy_label",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 2,
+      "relevance": "historical_only",
+      "subject_kind": "project"
+    }
+  ],
+  "committed_subject_ids": [
+    "proj_nightfall_migration"
+  ],
+  "schema_version": "ask_dev_subject_discovery.v1",
+  "truncation_reason": null,
+  "unresolved_mentions": []
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.candidate_ranks_out_of_order.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.candidate_ranks_out_of_order.json
@@ -1,0 +1,58 @@
+{
+  "authorization_filtered_count": 0,
+  "candidates": [
+    {
+      "candidate_id": "cand_1",
+      "canonical_id": "proj_nightfall_migration",
+      "commitment_state": "committed",
+      "display_label": "Nightfall Migration",
+      "match_confidence": 0.97,
+      "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [
+            "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+          ],
+          "matched_text": "Nightfall Migration",
+          "signal": "exact_display_name",
+          "source_class": "work_graph"
+        },
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "surface_project_overview",
+          "signal": "surface_context_reference",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 2,
+      "relevance": "current",
+      "subject_kind": "project"
+    },
+    {
+      "candidate_id": "cand_2",
+      "canonical_id": "proj_nightfall",
+      "commitment_state": "rejected",
+      "display_label": "Nightfall",
+      "match_confidence": 0.41,
+      "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "Nightfall",
+          "signal": "fuzzy_label",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 1,
+      "relevance": "historical_only",
+      "subject_kind": "project"
+    }
+  ],
+  "candidates_truncated": false,
+  "committed_subject_ids": [
+    "proj_nightfall_migration"
+  ],
+  "schema_version": "ask_dev_subject_discovery.v1",
+  "truncation_reason": null,
+  "unresolved_mentions": []
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.commitment_below_rank_one.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.commitment_below_rank_one.json
@@ -1,0 +1,58 @@
+{
+  "authorization_filtered_count": 0,
+  "candidates": [
+    {
+      "candidate_id": "cand_1",
+      "canonical_id": "proj_nightfall_migration",
+      "commitment_state": "proposed",
+      "display_label": "Nightfall Migration",
+      "match_confidence": 0.97,
+      "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [
+            "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+          ],
+          "matched_text": "Nightfall Migration",
+          "signal": "exact_display_name",
+          "source_class": "work_graph"
+        },
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "surface_project_overview",
+          "signal": "surface_context_reference",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 1,
+      "relevance": "current",
+      "subject_kind": "project"
+    },
+    {
+      "candidate_id": "cand_2",
+      "canonical_id": "proj_nightfall",
+      "commitment_state": "committed",
+      "display_label": "Nightfall",
+      "match_confidence": 0.41,
+      "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "Nightfall",
+          "signal": "exact_display_name",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 2,
+      "relevance": "historical_only",
+      "subject_kind": "project"
+    }
+  ],
+  "candidates_truncated": false,
+  "committed_subject_ids": [
+    "proj_nightfall"
+  ],
+  "schema_version": "ask_dev_subject_discovery.v1",
+  "truncation_reason": null,
+  "unresolved_mentions": []
+}

--- a/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.commitment_on_fuzzy_label_alone.json
+++ b/contracts/ask-dev-investigation/v1/examples/negative/ask_dev_subject_discovery.v1.commitment_on_fuzzy_label_alone.json
@@ -1,0 +1,50 @@
+{
+  "authorization_filtered_count": 0,
+  "candidates": [
+    {
+      "candidate_id": "cand_1",
+      "canonical_id": "proj_nightfall",
+      "commitment_state": "committed",
+      "display_label": "Nightfall",
+      "match_confidence": 0.97,
+      "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "Nightfall",
+          "signal": "fuzzy_label",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 1,
+      "relevance": "current",
+      "subject_kind": "project"
+    },
+    {
+      "candidate_id": "cand_2",
+      "canonical_id": "proj_nightfall_migration",
+      "commitment_state": "rejected",
+      "display_label": "Nightfall Migration",
+      "match_confidence": 0.41,
+      "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "Nightfall",
+          "signal": "fuzzy_label",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 2,
+      "relevance": "historical_only",
+      "subject_kind": "project"
+    }
+  ],
+  "candidates_truncated": false,
+  "committed_subject_ids": [
+    "proj_nightfall"
+  ],
+  "schema_version": "ask_dev_subject_discovery.v1",
+  "truncation_reason": null,
+  "unresolved_mentions": []
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_analytical_job.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_analytical_job.v1.json
@@ -1,0 +1,28 @@
+{
+  "comparison_shape": "singular_subject",
+  "conversation_reference_ids": [
+    "conv_2026_08_08_a"
+  ],
+  "interpretation_limitations": [],
+  "job_id": "job_nightfall_status",
+  "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+  "job_uncertainty": "precise",
+  "question_family": "project_status_drivers",
+  "schema_version": "ask_dev_analytical_job.v1",
+  "surface_context_refs": [
+    {
+      "entity_id": "proj_nightfall_migration",
+      "entity_kind": "project",
+      "surface_id": "surface_project_overview",
+      "surface_kind": "project_page"
+    }
+  ],
+  "time_context": {
+    "analytical_slice": "current",
+    "as_of": null,
+    "end": "2026-08-08T00:00:00Z",
+    "historical_comparability": "not_applicable",
+    "start": "2026-07-09T00:00:00Z",
+    "timezone": "America/Los_Angeles"
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_comparison_cohort.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_comparison_cohort.v1.json
@@ -1,0 +1,32 @@
+{
+  "authorization_filtered_count": 0,
+  "cohort_id": "cohort_nightfall_singular",
+  "cohort_uncertainty": null,
+  "comparison_shape": "singular_subject",
+  "completeness": "complete",
+  "exclusions": [
+    {
+      "canonical_id": "proj_nightfall",
+      "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+      "reason": "ambiguous_identity",
+      "subject_kind": "project"
+    }
+  ],
+  "members": [
+    {
+      "canonical_id": "proj_nightfall_migration",
+      "display_label": "Nightfall Migration",
+      "inclusion_basis": [
+        "explicitly_named"
+      ],
+      "inclusion_evidence_classification": "explicitly_named_by_question",
+      "inclusion_evidence_ids": [],
+      "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+      "relevance": "current",
+      "subject_kind": "project"
+    }
+  ],
+  "schema_version": "ask_dev_comparison_cohort.v1",
+  "supported_comparison_dimensions": [],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_driver_analysis.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_driver_analysis.v1.json
@@ -1,0 +1,79 @@
+{
+  "candidates": [
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "svc_auth_gateway"
+      ],
+      "assertion_basis": "measured",
+      "category": "dependency_pressure",
+      "confidence_qualifier": "measured_certain",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_dependency_stall",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "principal_driver",
+      "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+      "supporting_evidence_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration",
+        "team_platform"
+      ],
+      "assertion_basis": "measured",
+      "category": "review_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_review_backlog",
+      "exclusion_reason": null,
+      "relevance": "current",
+      "role": "driver",
+      "staffing_qualification": null,
+      "standing": "contributing_driver",
+      "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+      "supporting_evidence_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "affected_subject_ids": [
+        "proj_nightfall_migration"
+      ],
+      "assertion_basis": "measured",
+      "category": "delivery_pressure",
+      "confidence_qualifier": "qualified",
+      "conflict_note": null,
+      "conflicting_evidence_ids": [],
+      "driver_id": "drv_cycle_time_rising",
+      "exclusion_reason": "symptom_of_another_candidate",
+      "relevance": "current",
+      "role": "symptom",
+      "staffing_qualification": null,
+      "standing": "excluded",
+      "summary": "Median cycle time on the project has risen over the window.",
+      "supporting_evidence_ids": [
+        "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+      ],
+      "supporting_path_ids": []
+    }
+  ],
+  "candidates_truncated": false,
+  "principal_driver_ids": [
+    "drv_dependency_stall"
+  ],
+  "schema_version": "ask_dev_driver_analysis.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_evidence_coverage.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_evidence_coverage.v1.json
@@ -1,0 +1,180 @@
+{
+  "authorization_filtered_count": 0,
+  "clarification_needs": [],
+  "conflicts": [],
+  "evidence_index": [
+    {
+      "evidence": {
+        "citation_text": "Project registered under this display name.",
+        "confidence": 1.0,
+        "display_label": "Nightfall Migration registration",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": [
+        "proj_nightfall_migration"
+      ]
+    },
+    {
+      "evidence": {
+        "citation_text": "Dependency has no released version carrying the change.",
+        "confidence": 1.0,
+        "display_label": "authlib release status",
+        "entity_id": "dep_authlib",
+        "entity_type": "dependency",
+        "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/dependency/dep_authlib",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_graph",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_graph",
+      "supports_driver_ids": [
+        "drv_dependency_stall"
+      ],
+      "supports_entity_ids": [
+        "svc_auth_gateway",
+        "dep_authlib"
+      ],
+      "supports_path_ids": [
+        "path_dependency"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Open review count exceeded the drain rate for the window.",
+        "confidence": 1.0,
+        "display_label": "Platform review queue",
+        "entity_id": "team_platform",
+        "entity_type": "team",
+        "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/team/team_platform",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "review",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "review",
+      "supports_driver_ids": [
+        "drv_review_backlog"
+      ],
+      "supports_entity_ids": [
+        "team_platform"
+      ],
+      "supports_path_ids": [
+        "path_ownership"
+      ],
+      "supports_subject_ids": []
+    },
+    {
+      "evidence": {
+        "citation_text": "Median cycle time rose over the window.",
+        "confidence": 1.0,
+        "display_label": "Cycle time p50",
+        "entity_id": "proj_nightfall_migration",
+        "entity_type": "project",
+        "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+        "flags": {},
+        "freshness": "fresh",
+        "link": {
+          "internal_path": "/work/project/proj_nightfall_migration",
+          "source_url": null
+        },
+        "observed_at": "2026-08-08T12:00:00Z",
+        "provenance": "Canonical work graph projection",
+        "repository_ids": [],
+        "schema_version": "dev_evidence_ref.v1",
+        "source_system": "work_item",
+        "source_version": "work_graph.v1",
+        "valid_entity_ids": []
+      },
+      "relevance": "current",
+      "source_class": "work_item",
+      "supports_driver_ids": [
+        "drv_cycle_time_rising"
+      ],
+      "supports_entity_ids": [],
+      "supports_path_ids": [],
+      "supports_subject_ids": []
+    }
+  ],
+  "evidence_truncated": false,
+  "limitations": [
+    {
+      "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+      "kind": "missing_source"
+    },
+    {
+      "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+      "kind": "stale_source"
+    }
+  ],
+  "missing_sources": [
+    {
+      "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+      "source_class": "investment_allocation",
+      "state": "unconfigured"
+    }
+  ],
+  "schema_version": "ask_dev_evidence_coverage.v1",
+  "source_health": [
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_graph",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "review",
+      "state": "available_current"
+    },
+    {
+      "detail": "Last deployment sync completed 31 hours ago.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "deployment",
+      "state": "available_stale"
+    }
+  ],
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_evidence_coverage.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_evidence_coverage.v1.json
@@ -170,6 +170,24 @@
       "state": "available_current"
     },
     {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "work_item",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "status_change",
+      "state": "available_current"
+    },
+    {
+      "detail": null,
+      "observed_at": "2026-08-08T12:00:00Z",
+      "source_class": "pull_request",
+      "state": "available_current"
+    },
+    {
       "detail": "Last deployment sync completed 31 hours ago.",
       "observed_at": "2026-08-08T12:00:00Z",
       "source_class": "deployment",

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.discovery_without_commitment.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.discovery_without_commitment.json
@@ -26,6 +26,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -319,6 +320,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -335,6 +354,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.discovery_without_commitment.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.discovery_without_commitment.json
@@ -1,0 +1,524 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [
+      {
+        "detail": "The question named a project ambiguously; the job was widened to 'status and drivers of the best-matching project'.",
+        "kind": "interpretation_uncertainty"
+      }
+    ],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "broad_with_uncertainty",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "contributing_driver",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      },
+      {
+        "detail": "The subject was not committed; findings are reported against the top-ranked candidate and remain provisional.",
+        "kind": "interpretation_uncertainty"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported_with_gaps",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "proposed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "proposed",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.json
@@ -1,0 +1,517 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "contributing_driver",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.json
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -310,6 +311,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -326,6 +345,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.needs_clarification_with_widening.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.needs_clarification_with_widening.json
@@ -26,6 +26,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -329,10 +330,34 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
         "state": "available_stale"
+      },
+      {
+        "detail": "Source availability was checked before widening.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "source_health",
+        "state": "available_current"
       }
     ],
     "truncation_reason": null
@@ -345,6 +370,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.needs_clarification_with_widening.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.needs_clarification_with_widening.json
@@ -1,0 +1,544 @@
+{
+  "analytical_job": {
+    "comparison_shape": "organization_wide",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [
+      {
+        "detail": "The question named no subject and no time context.",
+        "kind": "interpretation_uncertainty"
+      }
+    ],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report what is going sideways; no subject was named.",
+    "job_uncertainty": "ambiguous",
+    "question_family": "clarification_and_no_match",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "organization_wide",
+    "completeness": "complete",
+    "exclusions": [],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "One of two candidates for the named reference.",
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "canonical_id": "proj_nightfall",
+        "display_label": "Nightfall",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The other candidate for the named reference.",
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [
+      "delivery_throughput"
+    ],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "candidate_only",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [
+      {
+        "candidate_ids": [
+          "cand_1",
+          "cand_2"
+        ],
+        "kind": "ambiguous_subject",
+        "prompt": "Two projects match 'nightfall'. Did you mean the Nightfall Migration, or the archived Nightfall project?"
+      }
+    ],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "needs_clarification",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "ambiguous",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": [
+      {
+        "candidate_ids": [
+          "cand_1",
+          "cand_2"
+        ],
+        "mention_id": "mention_1",
+        "mention_text": "the nightfall thing",
+        "reason": "multiple_candidates"
+      }
+    ]
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.not_comparable_historical_slice.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.not_comparable_historical_slice.json
@@ -1,0 +1,521 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current_vs_historical",
+      "as_of": "2026-05-08T00:00:00Z",
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_comparable_missing_edge_validity",
+      "start": "2026-05-08T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "contributing_driver",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      },
+      {
+        "detail": "Relationship edges carry no validity interval, so the as-of state cannot be reconstructed; the historical half of this comparison is reported NOT COMPARABLE rather than as no change.",
+        "kind": "historical_slice_not_comparable"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.qualified_capacity_without_denominator.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.qualified_capacity_without_denominator.json
@@ -8,7 +8,7 @@
     "job_id": "job_nightfall_status",
     "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
     "job_uncertainty": "precise",
-    "question_family": "project_capacity",
+    "question_family": "staffing_language",
     "schema_version": "ask_dev_analytical_job.v1",
     "surface_context_refs": [
       {
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -318,10 +319,34 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
         "state": "available_stale"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "cognitive_load",
+        "state": "available_current"
       }
     ],
     "truncation_reason": null
@@ -334,6 +359,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.qualified_capacity_without_denominator.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.qualified_capacity_without_denominator.json
@@ -1,0 +1,525 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_capacity",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "inferred",
+        "category": "capacity_or_staffing",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": {
+          "denominator_source_classes": [],
+          "denominator_state": "denominator_absent",
+          "qualification_note": "No allocation or headcount denominator is configured. The capacity judgment is inferred from queue growth and WIP and is reported as qualified rather than withheld."
+        },
+        "standing": "contributing_driver",
+        "summary": "The owning team appears capacity-constrained relative to the outstanding work, inferred from review queue growth and work in progress rather than from an allocation denominator.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      },
+      {
+        "detail": "No allocation denominator exists for this organization; the capacity statement is qualified accordingly and is not a measured claim.",
+        "kind": "absent_staffing_denominator"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": null,
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": null
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.trial_metadata_present.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.trial_metadata_present.json
@@ -1,0 +1,522 @@
+{
+  "analytical_job": {
+    "comparison_shape": "singular_subject",
+    "conversation_reference_ids": [
+      "conv_2026_08_08_a"
+    ],
+    "interpretation_limitations": [],
+    "job_id": "job_nightfall_status",
+    "job_statement": "Report the current delivery status of the Nightfall Migration project and identify its principal current drivers.",
+    "job_uncertainty": "precise",
+    "question_family": "project_status_drivers",
+    "schema_version": "ask_dev_analytical_job.v1",
+    "surface_context_refs": [
+      {
+        "entity_id": "proj_nightfall_migration",
+        "entity_kind": "project",
+        "surface_id": "surface_project_overview",
+        "surface_kind": "project_page"
+      }
+    ],
+    "time_context": {
+      "analytical_slice": "current",
+      "as_of": null,
+      "end": "2026-08-08T00:00:00Z",
+      "historical_comparability": "not_applicable",
+      "start": "2026-07-09T00:00:00Z",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "comparison_cohort": {
+    "authorization_filtered_count": 0,
+    "cohort_id": "cohort_nightfall_singular",
+    "cohort_uncertainty": null,
+    "comparison_shape": "singular_subject",
+    "completeness": "complete",
+    "exclusions": [
+      {
+        "canonical_id": "proj_nightfall",
+        "rationale": "Archived project with a near-identical name; excluded so the near-miss is recorded rather than silently dropped.",
+        "reason": "ambiguous_identity",
+        "subject_kind": "project"
+      }
+    ],
+    "members": [
+      {
+        "canonical_id": "proj_nightfall_migration",
+        "display_label": "Nightfall Migration",
+        "inclusion_basis": [
+          "explicitly_named"
+        ],
+        "inclusion_evidence_classification": "explicitly_named_by_question",
+        "inclusion_evidence_ids": [],
+        "inclusion_rationale": "The question names this project directly; it is the sole subject rather than a member of a comparison set.",
+        "relevance": "current",
+        "subject_kind": "project"
+      }
+    ],
+    "schema_version": "ask_dev_comparison_cohort.v1",
+    "supported_comparison_dimensions": [],
+    "truncation_reason": null
+  },
+  "driver_analysis": {
+    "candidates": [
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "svc_auth_gateway"
+        ],
+        "assertion_basis": "measured",
+        "category": "dependency_pressure",
+        "confidence_qualifier": "measured_certain",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_dependency_stall",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "principal_driver",
+        "summary": "The migration's remaining work is blocked behind an unreleased authlib change the gateway depends on.",
+        "supporting_evidence_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration",
+          "team_platform"
+        ],
+        "assertion_basis": "measured",
+        "category": "review_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_review_backlog",
+        "exclusion_reason": null,
+        "relevance": "current",
+        "role": "driver",
+        "staffing_qualification": null,
+        "standing": "contributing_driver",
+        "summary": "The owning team's review queue has grown faster than it is being drained, extending the tail of every change.",
+        "supporting_evidence_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "affected_subject_ids": [
+          "proj_nightfall_migration"
+        ],
+        "assertion_basis": "measured",
+        "category": "delivery_pressure",
+        "confidence_qualifier": "qualified",
+        "conflict_note": null,
+        "conflicting_evidence_ids": [],
+        "driver_id": "drv_cycle_time_rising",
+        "exclusion_reason": "symptom_of_another_candidate",
+        "relevance": "current",
+        "role": "symptom",
+        "staffing_qualification": null,
+        "standing": "excluded",
+        "summary": "Median cycle time on the project has risen over the window.",
+        "supporting_evidence_ids": [
+          "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+        ],
+        "supporting_path_ids": []
+      }
+    ],
+    "candidates_truncated": false,
+    "principal_driver_ids": [
+      "drv_dependency_stall"
+    ],
+    "schema_version": "ask_dev_driver_analysis.v1",
+    "truncation_reason": null
+  },
+  "evidence_coverage": {
+    "authorization_filtered_count": 0,
+    "clarification_needs": [],
+    "conflicts": [],
+    "evidence_index": [
+      {
+        "evidence": {
+          "citation_text": "Project registered under this display name.",
+          "confidence": 1.0,
+          "display_label": "Nightfall Migration registration",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": [
+          "proj_nightfall_migration"
+        ]
+      },
+      {
+        "evidence": {
+          "citation_text": "Dependency has no released version carrying the change.",
+          "confidence": 1.0,
+          "display_label": "authlib release status",
+          "entity_id": "dep_authlib",
+          "entity_type": "dependency",
+          "evidence_ref_id": "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/dependency/dep_authlib",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_graph",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_graph",
+        "supports_driver_ids": [
+          "drv_dependency_stall"
+        ],
+        "supports_entity_ids": [
+          "svc_auth_gateway",
+          "dep_authlib"
+        ],
+        "supports_path_ids": [
+          "path_dependency"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Open review count exceeded the drain rate for the window.",
+          "confidence": 1.0,
+          "display_label": "Platform review queue",
+          "entity_id": "team_platform",
+          "entity_type": "team",
+          "evidence_ref_id": "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/team/team_platform",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "review",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "review",
+        "supports_driver_ids": [
+          "drv_review_backlog"
+        ],
+        "supports_entity_ids": [
+          "team_platform"
+        ],
+        "supports_path_ids": [
+          "path_ownership"
+        ],
+        "supports_subject_ids": []
+      },
+      {
+        "evidence": {
+          "citation_text": "Median cycle time rose over the window.",
+          "confidence": 1.0,
+          "display_label": "Cycle time p50",
+          "entity_id": "proj_nightfall_migration",
+          "entity_type": "project",
+          "evidence_ref_id": "ev1_d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4",
+          "flags": {},
+          "freshness": "fresh",
+          "link": {
+            "internal_path": "/work/project/proj_nightfall_migration",
+            "source_url": null
+          },
+          "observed_at": "2026-08-08T12:00:00Z",
+          "provenance": "Canonical work graph projection",
+          "repository_ids": [],
+          "schema_version": "dev_evidence_ref.v1",
+          "source_system": "work_item",
+          "source_version": "work_graph.v1",
+          "valid_entity_ids": []
+        },
+        "relevance": "current",
+        "source_class": "work_item",
+        "supports_driver_ids": [
+          "drv_cycle_time_rising"
+        ],
+        "supports_entity_ids": [],
+        "supports_path_ids": [],
+        "supports_subject_ids": []
+      }
+    ],
+    "evidence_truncated": false,
+    "limitations": [
+      {
+        "detail": "Investment allocation is unconfigured for this organization; capacity statements are out of scope for this packet.",
+        "kind": "missing_source"
+      },
+      {
+        "detail": "Deployment evidence is 31 hours old; a release landing since then would not be reflected.",
+        "kind": "stale_source"
+      }
+    ],
+    "missing_sources": [
+      {
+        "impact": "No allocation denominator is available, so no staffing claim is made about this project.",
+        "source_class": "investment_allocation",
+        "state": "unconfigured"
+      }
+    ],
+    "schema_version": "ask_dev_evidence_coverage.v1",
+    "source_health": [
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_graph",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "review",
+        "state": "available_current"
+      },
+      {
+        "detail": "Last deployment sync completed 31 hours ago.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "deployment",
+        "state": "available_stale"
+      }
+    ],
+    "truncation_reason": null
+  },
+  "organization_id": "org_fullchaos",
+  "outcome": "supported",
+  "packet_id": "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13",
+  "produced_at": "2026-08-08T12:00:00Z",
+  "related_context": {
+    "authorization_filtered_count": 0,
+    "authorized_entity_ids": [
+      "proj_nightfall_migration",
+      "team_platform",
+      "svc_auth_gateway",
+      "dep_authlib"
+    ],
+    "entities": [
+      {
+        "display_label": "Platform",
+        "entity_id": "team_platform",
+        "entity_kind": "team",
+        "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_ownership"
+        ]
+      },
+      {
+        "display_label": "Auth Gateway",
+        "entity_id": "svc_auth_gateway",
+        "entity_kind": "service",
+        "inclusion_reason": "The project's remaining work all lands in this service.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      },
+      {
+        "display_label": "authlib",
+        "entity_id": "dep_authlib",
+        "entity_kind": "dependency",
+        "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+        "observed_at": "2026-08-08T12:00:00Z",
+        "relevance": "current",
+        "supporting_path_ids": [
+          "path_dependency"
+        ]
+      }
+    ],
+    "entities_truncated": false,
+    "paths": [
+      {
+        "evidence_ref_ids": [
+          "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "owned_by_team",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "team_platform",
+            "target_entity_kind": "team"
+          }
+        ],
+        "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_ownership",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "team_platform",
+        "truncated": false,
+        "truncation_reason": null
+      },
+      {
+        "evidence_ref_ids": [
+          "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+        ],
+        "hops": [
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "proj_nightfall_migration",
+            "source_entity_kind": "project",
+            "target_entity_id": "svc_auth_gateway",
+            "target_entity_kind": "service"
+          },
+          {
+            "direction": "forward",
+            "observed_at": "2026-08-08T12:00:00Z",
+            "relationship": "depends_on",
+            "relevance": "current",
+            "source_entity_id": "svc_auth_gateway",
+            "source_entity_kind": "service",
+            "target_entity_id": "dep_authlib",
+            "target_entity_kind": "dependency"
+          }
+        ],
+        "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+        "origin_entity_id": "proj_nightfall_migration",
+        "path_id": "path_dependency",
+        "relevance": "current",
+        "source_health": "available_current",
+        "terminal_entity_id": "dep_authlib",
+        "truncated": false,
+        "truncation_reason": null
+      }
+    ],
+    "paths_truncated": false,
+    "schema_version": "ask_dev_related_context.v1",
+    "truncation_reason": null
+  },
+  "schema_version": "ask_dev_investigation_packet.v1",
+  "subject_discovery": {
+    "authorization_filtered_count": 0,
+    "candidates": [
+      {
+        "candidate_id": "cand_1",
+        "canonical_id": "proj_nightfall_migration",
+        "commitment_state": "committed",
+        "display_label": "Nightfall Migration",
+        "match_confidence": 0.97,
+        "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [
+              "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+            ],
+            "matched_text": "Nightfall Migration",
+            "signal": "exact_display_name",
+            "source_class": "work_graph"
+          },
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "surface_project_overview",
+            "signal": "surface_context_reference",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 1,
+        "relevance": "current",
+        "subject_kind": "project"
+      },
+      {
+        "candidate_id": "cand_2",
+        "canonical_id": "proj_nightfall",
+        "commitment_state": "rejected",
+        "display_label": "Nightfall",
+        "match_confidence": 0.41,
+        "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+        "match_signals": [
+          {
+            "evidence_ref_ids": [],
+            "matched_text": "Nightfall",
+            "signal": "fuzzy_label",
+            "source_class": "work_graph"
+          }
+        ],
+        "rank": 2,
+        "relevance": "historical_only",
+        "subject_kind": "project"
+      }
+    ],
+    "candidates_truncated": false,
+    "committed_subject_ids": [
+      "proj_nightfall_migration"
+    ],
+    "schema_version": "ask_dev_subject_discovery.v1",
+    "truncation_reason": null,
+    "unresolved_mentions": []
+  },
+  "versions": {
+    "corpus_version": "chaos_3616_corpus.v1",
+    "packet_schema_version": "ask_dev_investigation_packet.v1",
+    "projection_version": "work_graph_projection.v1",
+    "query_version": "ask_dev_investigation_queries.v1",
+    "ranking_version": "ask_dev_investigation_ranking.v1",
+    "schema_version": "ask_dev_investigation_versions.v1",
+    "source_contract_versions": [
+      {
+        "contract_version": "work_graph.v1",
+        "source_class": "work_graph"
+      },
+      {
+        "contract_version": "review_metrics.v1",
+        "source_class": "review"
+      },
+      {
+        "contract_version": "work_item.v1",
+        "source_class": "work_item"
+      }
+    ],
+    "trial": {
+      "arm_id": "arm_under_test",
+      "fixture_version": "chaos_3616_corpus.v1",
+      "producer_id": "investigation_arm.v1",
+      "run_id": "0f9d3c21-7b45-4c8e-9a10-5d6e7f801234"
+    }
+  }
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.trial_metadata_present.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_packet.v1.trial_metadata_present.json
@@ -21,6 +21,7 @@
     "time_context": {
       "analytical_slice": "current",
       "as_of": null,
+      "edge_validity_basis": "not_required",
       "end": "2026-08-08T00:00:00Z",
       "historical_comparability": "not_applicable",
       "start": "2026-07-09T00:00:00Z",
@@ -310,6 +311,24 @@
         "state": "available_current"
       },
       {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "work_item",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "status_change",
+        "state": "available_current"
+      },
+      {
+        "detail": null,
+        "observed_at": "2026-08-08T12:00:00Z",
+        "source_class": "pull_request",
+        "state": "available_current"
+      },
+      {
         "detail": "Last deployment sync completed 31 hours ago.",
         "observed_at": "2026-08-08T12:00:00Z",
         "source_class": "deployment",
@@ -326,6 +345,7 @@
     "authorization_filtered_count": 0,
     "authorized_entity_ids": [
       "proj_nightfall_migration",
+      "proj_nightfall",
       "team_platform",
       "svc_auth_gateway",
       "dep_authlib"

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_versions.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_investigation_versions.v1.json
@@ -1,0 +1,23 @@
+{
+  "corpus_version": null,
+  "packet_schema_version": "ask_dev_investigation_packet.v1",
+  "projection_version": "work_graph_projection.v1",
+  "query_version": "ask_dev_investigation_queries.v1",
+  "ranking_version": "ask_dev_investigation_ranking.v1",
+  "schema_version": "ask_dev_investigation_versions.v1",
+  "source_contract_versions": [
+    {
+      "contract_version": "work_graph.v1",
+      "source_class": "work_graph"
+    },
+    {
+      "contract_version": "review_metrics.v1",
+      "source_class": "review"
+    },
+    {
+      "contract_version": "work_item.v1",
+      "source_class": "work_item"
+    }
+  ],
+  "trial": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_related_context.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_related_context.v1.json
@@ -1,0 +1,110 @@
+{
+  "authorization_filtered_count": 0,
+  "authorized_entity_ids": [
+    "proj_nightfall_migration",
+    "team_platform",
+    "svc_auth_gateway",
+    "dep_authlib"
+  ],
+  "entities": [
+    {
+      "display_label": "Platform",
+      "entity_id": "team_platform",
+      "entity_kind": "team",
+      "inclusion_reason": "Owns the project; the team whose review capacity gates the remaining work.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_ownership"
+      ]
+    },
+    {
+      "display_label": "Auth Gateway",
+      "entity_id": "svc_auth_gateway",
+      "entity_kind": "service",
+      "inclusion_reason": "The project's remaining work all lands in this service.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    },
+    {
+      "display_label": "authlib",
+      "entity_id": "dep_authlib",
+      "entity_kind": "dependency",
+      "inclusion_reason": "Shared dependency the gateway is blocked behind; the terminal node of the driver's lineage.",
+      "observed_at": "2026-08-08T12:00:00Z",
+      "relevance": "current",
+      "supporting_path_ids": [
+        "path_dependency"
+      ]
+    }
+  ],
+  "entities_truncated": false,
+  "paths": [
+    {
+      "evidence_ref_ids": [
+        "ev1_c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "owned_by_team",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "team_platform",
+          "target_entity_kind": "team"
+        }
+      ],
+      "inclusion_reason": "Establishes which team's review capacity applies to the project's outstanding changes.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_ownership",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "team_platform",
+      "truncated": false,
+      "truncation_reason": null
+    },
+    {
+      "evidence_ref_ids": [
+        "ev1_b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+      ],
+      "hops": [
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "proj_nightfall_migration",
+          "source_entity_kind": "project",
+          "target_entity_id": "svc_auth_gateway",
+          "target_entity_kind": "service"
+        },
+        {
+          "direction": "forward",
+          "observed_at": "2026-08-08T12:00:00Z",
+          "relationship": "depends_on",
+          "relevance": "current",
+          "source_entity_id": "svc_auth_gateway",
+          "source_entity_kind": "service",
+          "target_entity_id": "dep_authlib",
+          "target_entity_kind": "dependency"
+        }
+      ],
+      "inclusion_reason": "The two-hop chain from the project to the stalled shared dependency; the mechanism behind the principal driver.",
+      "origin_entity_id": "proj_nightfall_migration",
+      "path_id": "path_dependency",
+      "relevance": "current",
+      "source_health": "available_current",
+      "terminal_entity_id": "dep_authlib",
+      "truncated": false,
+      "truncation_reason": null
+    }
+  ],
+  "paths_truncated": false,
+  "schema_version": "ask_dev_related_context.v1",
+  "truncation_reason": null
+}

--- a/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_subject_discovery.v1.json
+++ b/contracts/ask-dev-investigation/v1/examples/positive/ask_dev_subject_discovery.v1.json
@@ -1,0 +1,58 @@
+{
+  "authorization_filtered_count": 0,
+  "candidates": [
+    {
+      "candidate_id": "cand_1",
+      "canonical_id": "proj_nightfall_migration",
+      "commitment_state": "committed",
+      "display_label": "Nightfall Migration",
+      "match_confidence": 0.97,
+      "match_rationale": "The question's phrase 'the Nightfall migration' matches this project's registered display name exactly, and the surface the question was asked from is this project's overview page.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [
+            "ev1_a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+          ],
+          "matched_text": "Nightfall Migration",
+          "signal": "exact_display_name",
+          "source_class": "work_graph"
+        },
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "surface_project_overview",
+          "signal": "surface_context_reference",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 1,
+      "relevance": "current",
+      "subject_kind": "project"
+    },
+    {
+      "candidate_id": "cand_2",
+      "canonical_id": "proj_nightfall",
+      "commitment_state": "rejected",
+      "display_label": "Nightfall",
+      "match_confidence": 0.41,
+      "match_rationale": "A similarly named archived project. Retained as a ranked candidate so the near-miss is visible rather than silently discarded.",
+      "match_signals": [
+        {
+          "evidence_ref_ids": [],
+          "matched_text": "Nightfall",
+          "signal": "fuzzy_label",
+          "source_class": "work_graph"
+        }
+      ],
+      "rank": 2,
+      "relevance": "historical_only",
+      "subject_kind": "project"
+    }
+  ],
+  "candidates_truncated": false,
+  "committed_subject_ids": [
+    "proj_nightfall_migration"
+  ],
+  "schema_version": "ask_dev_subject_discovery.v1",
+  "truncation_reason": null,
+  "unresolved_mentions": []
+}

--- a/contracts/ask-dev-investigation/v1/manifest.json
+++ b/contracts/ask-dev-investigation/v1/manifest.json
@@ -6,68 +6,93 @@
         {
           "case": "organization_widening_after_unresolved_reference",
           "path": "examples/negative/ask_dev_investigation_packet.v1.organization_widening_after_unresolved_reference.json",
-          "sha256": "850a2dd60008542327742be77008e77a69a8b9de9d294a711553c1d6e2f74b47"
+          "sha256": "9a8c9fb94dc787abb97a48cc6c5e633773a80af7b8a100317496e9368c2b7efd"
         },
         {
           "case": "dashboard_redirect_without_direct_judgment",
           "path": "examples/negative/ask_dev_investigation_packet.v1.dashboard_redirect_without_direct_judgment.json",
-          "sha256": "3e1cbdf8d6738bacdf42399a994ab042e46b37098660bc63cb493a458dcdc70d"
+          "sha256": "446c6830235e7e9f393caa07b9929163093116456add59c097c36159fc959321"
         },
         {
           "case": "evidence_citation_absent_from_index",
           "path": "examples/negative/ask_dev_investigation_packet.v1.evidence_citation_absent_from_index.json",
-          "sha256": "2fe3ea3cfa33d0c1ccaa12e9f74768187161a339f8ae850e45a734bf0eaf1157"
+          "sha256": "f1da3e01f099502c26e8a07e051b2fc0c9a4a0def1e0d2f2a00c28b217b9876e"
         },
         {
           "case": "no_match_without_limitation_or_clarification",
           "path": "examples/negative/ask_dev_investigation_packet.v1.no_match_without_limitation_or_clarification.json",
-          "sha256": "d086e3d33ae6f31aa910bef649461a6e6593977130bd97085e3b9ed699fa386a"
+          "sha256": "09654c72eb445daaafcb3f4f95478829d7a1565b14f2497cddacfcdc97aa9983"
         },
         {
           "case": "authorization_filtering_undisclosed",
           "path": "examples/negative/ask_dev_investigation_packet.v1.authorization_filtering_undisclosed.json",
-          "sha256": "bb2b52cceeac6d40d89ba29b0613b8e44444e80dc31751562842973f4848a6c6"
+          "sha256": "ebdf714b833971d1f37dc346f06f2fe9495daaad2ee5b2cd22d856fada75c92d"
         },
         {
           "case": "not_comparable_slice_undisclosed",
           "path": "examples/negative/ask_dev_investigation_packet.v1.not_comparable_slice_undisclosed.json",
-          "sha256": "c68babae7de8b4523b8c9c87c0e50671a31dd9ec3a110b15bbdbddcf3a09d2e2"
+          "sha256": "ec9c02cda2b20c24c085e1c6f13702488dc2cedead678dd65fc3d67eef54bbaf"
+        },
+        {
+          "case": "cohort_member_outside_authorized_set",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.cohort_member_outside_authorized_set.json",
+          "sha256": "3c9a05384080291b782338899ed9f9c86257aecfdae3010fcbbd4da75037d839"
+        },
+        {
+          "case": "evidence_entity_outside_authorized_set",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.evidence_entity_outside_authorized_set.json",
+          "sha256": "797d6cd2b71584a3cff141d1dfef45f868c131a00fd093580f8c62adb002e839"
+        },
+        {
+          "case": "source_class_off_the_trial_allowlist",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.source_class_off_the_trial_allowlist.json",
+          "sha256": "cc631191e631035067ea7105a044664127d0a59f938eeefb2055e10bf408d803"
+        },
+        {
+          "case": "question_family_shape_mismatch",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.question_family_shape_mismatch.json",
+          "sha256": "4699b790b3627a73c72ed10f96a682a6797d8eb43a8d809ba0b39b263a492e59"
+        },
+        {
+          "case": "family_required_source_unaccounted",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.family_required_source_unaccounted.json",
+          "sha256": "24e5425bf217870c1418c36fa651aed286e6452fce52e70cd73de8941160b0dc"
         }
       ],
       "positive": {
         "path": "examples/positive/ask_dev_investigation_packet.v1.json",
-        "sha256": "1b405da8bbbef4d37245137f09ec0370a4ee21b1fcef6dcc5cc6e353d86aa701"
+        "sha256": "c1b8d933fe963e211d3d29a0686bc4d63e3458f1ac8bfd3f39c737094f5639fc"
       },
       "positive_variants": [
         {
           "case": "discovery_without_commitment",
           "path": "examples/positive/ask_dev_investigation_packet.v1.discovery_without_commitment.json",
-          "sha256": "522171950ac06a3fc60a38492903fba3f5183445b68db50226d17c65f92aa75d"
+          "sha256": "7bf4b59111a442a55e767ffe89ba0850769937f905b317e79e3e425db549d3b3"
         },
         {
           "case": "not_comparable_historical_slice",
           "path": "examples/positive/ask_dev_investigation_packet.v1.not_comparable_historical_slice.json",
-          "sha256": "6d58a2717317ac379f41e12e3f73443efd62fc2f453438d24d8c33dfcb733089"
+          "sha256": "15c318248d9bf2afd1068e2be117235e3d6856b91c4b4b64022571c50ff1e686"
         },
         {
           "case": "qualified_capacity_without_denominator",
           "path": "examples/positive/ask_dev_investigation_packet.v1.qualified_capacity_without_denominator.json",
-          "sha256": "48ed8afb7031a23795ef9353855073f78c7b2a0927f5052a60608418b4918e68"
+          "sha256": "f2196c11de554f6f796ddf5bd7baf10853b088bd0b5b95e17a301296b1f9d345"
         },
         {
           "case": "needs_clarification_with_widening",
           "path": "examples/positive/ask_dev_investigation_packet.v1.needs_clarification_with_widening.json",
-          "sha256": "91e343acc73807d6b5eacc1ef9145d22bf1bb108c00fa20b7c121bb4a5999fa4"
+          "sha256": "f00e82b5f9f78ebf6cf577028885c6d5072612928f04b1f2cf46514bdf031c80"
         },
         {
           "case": "trial_metadata_present",
           "path": "examples/positive/ask_dev_investigation_packet.v1.trial_metadata_present.json",
-          "sha256": "c89fe18af567f1d3326d3f80f2f0a92925ef641738676ddb67a25a2e134209d1"
+          "sha256": "ad527f8d02e9750dcb2ff7bce45312a22899c4ec27beb5faea617b346f988fa9"
         }
       ],
       "schema": {
         "path": "schemas/ask_dev_investigation_packet.v1.schema.json",
-        "sha256": "1b29712f4d4a8cb36c5addc4fc7bcc89ca79b928a56c4dbb41a5824143e6d7a0"
+        "sha256": "1778efab1665b2d474f36e744d53ca4368ac7d4ee33eff25db843da017693a30"
       },
       "schema_version": "ask_dev_investigation_packet.v1"
     },
@@ -76,27 +101,37 @@
         {
           "case": "uncertain_job_without_limitations",
           "path": "examples/negative/ask_dev_analytical_job.v1.uncertain_job_without_limitations.json",
-          "sha256": "d948775a338f59e38607f9961ab58f0a138c94ffefc38035773cd298118cb5ad"
+          "sha256": "7936de2b0a6fc411d14891ccb86ae4d82381b93c53acb1185da3266169e68cdd"
         },
         {
           "case": "current_slice_carrying_as_of",
           "path": "examples/negative/ask_dev_analytical_job.v1.current_slice_carrying_as_of.json",
-          "sha256": "1fb1d62c319b645a8e8a58b8f4081ecca57c0dea2602155fc1962ea167170cfc"
+          "sha256": "c71ccf3268a47a9232145356e705a56f4f77271c6e9279027af2b4e75163bf26"
         },
         {
           "case": "historical_slice_without_as_of",
           "path": "examples/negative/ask_dev_analytical_job.v1.historical_slice_without_as_of.json",
-          "sha256": "04ad6afe348dbb8e49243384f32fc47f7c9bb8a88cebe8b8153d16da4bdad474"
+          "sha256": "31f4488fec65dc0f66fbe1ce05ce05afb45b044b8086c1d044b7b74b4feff0b2"
+        },
+        {
+          "case": "comparable_history_without_edge_validity",
+          "path": "examples/negative/ask_dev_analytical_job.v1.comparable_history_without_edge_validity.json",
+          "sha256": "6ce0376fbcc373d502ac02f16bb40d35ccae70f47f01630376ce3ebe0d0370c2"
+        },
+        {
+          "case": "unavailable_edge_validity_mislabelled",
+          "path": "examples/negative/ask_dev_analytical_job.v1.unavailable_edge_validity_mislabelled.json",
+          "sha256": "d3c75d0a62758a678f567577adca570d79ba9275f51744699fe653b582ed4aba"
         }
       ],
       "positive": {
         "path": "examples/positive/ask_dev_analytical_job.v1.json",
-        "sha256": "a8edf583be6c160d166a3349be577e0333f82f73032d6cca1e9c29022be6a43b"
+        "sha256": "f1bb59ce5b8f49e51e2a28a854e7a7693764a9fc389e5bd1f542a451e4c4ba85"
       },
       "positive_variants": [],
       "schema": {
         "path": "schemas/ask_dev_analytical_job.v1.schema.json",
-        "sha256": "49cc6d49ff393e6dd9d258b5c55d69f827026cc311314c84acca0d034e3da0b3"
+        "sha256": "b30ea7667adb697f3776508e3558fe48cf2e6c755da5dd6ca3418b272015ecef"
       },
       "schema_version": "ask_dev_analytical_job.v1"
     },
@@ -168,7 +203,7 @@
         {
           "case": "reversed_relationship_direction",
           "path": "examples/negative/ask_dev_related_context.v1.reversed_relationship_direction.json",
-          "sha256": "1b9ae4b29234d541ce9716f2b9490426d1d25edf0777fce2f794c7898b3c9952"
+          "sha256": "98c7cee4ee9a0d2332e8da7dfde9c79fc7a633223c8d4c2a0f3b88272d8f3395"
         },
         {
           "case": "path_crosses_unauthorized_entity",
@@ -178,17 +213,22 @@
         {
           "case": "disconnected_path_presented_as_chain",
           "path": "examples/negative/ask_dev_related_context.v1.disconnected_path_presented_as_chain.json",
-          "sha256": "2995ac90fcf378d07ea4099b8f8ac7a415552e543a17c58ec43ce28342d5e001"
+          "sha256": "7bf4b4b41af816b002bc4d11b9e7d7ccc9ace684004a8656a5b1ff5eade6cbf2"
         },
         {
           "case": "entity_citing_undeclared_path",
           "path": "examples/negative/ask_dev_related_context.v1.entity_citing_undeclared_path.json",
-          "sha256": "d6f424a6c2df00a1c62a207170ae06f16f2fe11de4a83491e8d77a5035690238"
+          "sha256": "09a20760e251e0b4970363d5d617912f56e2f581a8c408175bbc02fd258e48aa"
+        },
+        {
+          "case": "path_cited_but_never_reaching_entity",
+          "path": "examples/negative/ask_dev_related_context.v1.path_cited_but_never_reaching_entity.json",
+          "sha256": "e8d5b2a787d7891e7947f4a5107c45bc31309b46c922013fe55a7905a1da6b6b"
         }
       ],
       "positive": {
         "path": "examples/positive/ask_dev_related_context.v1.json",
-        "sha256": "20448c2d2324605673e125072b89e79e7e10e2459df905fc247caf852c33e662"
+        "sha256": "ba06c3ab06d642b38f13992bf24ede2eae26b433da6b26809280a6536c8ff77a"
       },
       "positive_variants": [],
       "schema": {
@@ -246,27 +286,32 @@
         {
           "case": "evidence_supporting_nothing",
           "path": "examples/negative/ask_dev_evidence_coverage.v1.evidence_supporting_nothing.json",
-          "sha256": "b04bcfb83d865f4c2a61ea39e5efcdc748578efdac92a7d129702befdcc3b98b"
+          "sha256": "c8dbd3b320aa4285ac6db7afc327a2e8e9547ec9f064a360f662ee9292ae98f4"
         },
         {
           "case": "missing_source_undisclosed",
           "path": "examples/negative/ask_dev_evidence_coverage.v1.missing_source_undisclosed.json",
-          "sha256": "d77f3e2d3783ba7dc0b7f2c9283991631c8abbc33387ce4e04022ae3d8a05ffa"
+          "sha256": "ed8388037416953e207e0d210508f0bb03ce3470d4f41e8dbccb520e637b74fa"
         },
         {
           "case": "conflict_citing_unindexed_evidence",
           "path": "examples/negative/ask_dev_evidence_coverage.v1.conflict_citing_unindexed_evidence.json",
-          "sha256": "ee22fdac9c48de7298d55010aacb4698fc9a04e28a8f676dd6feb355c3f7b2f5"
+          "sha256": "25a7fcd0ee647073f1ea8f05b6008cb3d4b7ff97b3a1a8bfafc7302d03566e3d"
         },
         {
           "case": "graph_native_field_smuggled_as_extra",
           "path": "examples/negative/ask_dev_evidence_coverage.v1.graph_native_field_smuggled_as_extra.json",
-          "sha256": "b34ef86603302e280ad90ab4e1ad6bbe88c1a95a4370894774573d3b823c95d6"
+          "sha256": "12bb820f35d62797549e19e30b5723882ef4dd8607873b342a5e6813aa7aacc4"
+        },
+        {
+          "case": "source_both_observed_and_missing",
+          "path": "examples/negative/ask_dev_evidence_coverage.v1.source_both_observed_and_missing.json",
+          "sha256": "226e25164d48d1b9f9afda8b8d66774f9db9b969e9f05af50e2f7eb5f69f6b01"
         }
       ],
       "positive": {
         "path": "examples/positive/ask_dev_evidence_coverage.v1.json",
-        "sha256": "3f7def2371533e9b059eefb2d4fdb06dc8009b46bf476204f009b8943415294f"
+        "sha256": "47fc5b283faac6781e7e13e1b244b821fed5685a017fe7e8e80e4daf650eab1b"
       },
       "positive_variants": [],
       "schema": {
@@ -303,7 +348,7 @@
   "registries": [
     {
       "path": "registries/question_families.json",
-      "sha256": "e25dc201c365ec1f7efed79f97fc4bb823a941236d06212a3fcd9726175064eb"
+      "sha256": "9f6b01e15c63c4cbed9d7d4b2394d2bc8636e13a7ebc11c7eab024ef96de3c5b"
     },
     {
       "path": "registries/scoring_dimensions.json",
@@ -318,5 +363,11 @@
       "sha256": "d8bfea26a9585407d3df0dd850b698cfa7bf15102917d366c48a5d3c0b26ad4e"
     }
   ],
-  "schema_version": "ask_dev_investigation_contract_manifest.v1"
+  "schema_version": "ask_dev_investigation_contract_manifest.v1",
+  "validation_policy": {
+    "canonical_validator": "dev_health_ops.api.dev.investigation_contract.packet.INVESTIGATION_CONTRACT_MODELS",
+    "json_schema_scope": "structural_only",
+    "note": "The generated JSON Schemas describe field shape, not the contract's semantics. A packet that validates against the schema alone has not been checked for authorization scope, evidence closure, driver standing, family obligations, historical comparability or any other cross-field rule. Any consumer -- including a future non-Python arm -- must run the canonical validator or reimplement these rules and prove equivalence against examples/negative.",
+    "schema_only_validation_is_sufficient": false
+  }
 }

--- a/contracts/ask-dev-investigation/v1/manifest.json
+++ b/contracts/ask-dev-investigation/v1/manifest.json
@@ -311,7 +311,7 @@
     },
     {
       "path": "registries/fault_modes.json",
-      "sha256": "c291788b5836f44c74af317b86c97c792158fd822bbe0c4b9958379c8f8d5b5b"
+      "sha256": "27aa1ef8622b385a00e19a661a68af11231821934a142644b5da810102ec96e0"
     },
     {
       "path": "registries/trial_allowlists.json",

--- a/contracts/ask-dev-investigation/v1/manifest.json
+++ b/contracts/ask-dev-investigation/v1/manifest.json
@@ -1,0 +1,322 @@
+{
+  "compatibility": "internal-trial-artifact-not-client-served",
+  "contracts": [
+    {
+      "negative": [
+        {
+          "case": "organization_widening_after_unresolved_reference",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.organization_widening_after_unresolved_reference.json",
+          "sha256": "850a2dd60008542327742be77008e77a69a8b9de9d294a711553c1d6e2f74b47"
+        },
+        {
+          "case": "dashboard_redirect_without_direct_judgment",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.dashboard_redirect_without_direct_judgment.json",
+          "sha256": "3e1cbdf8d6738bacdf42399a994ab042e46b37098660bc63cb493a458dcdc70d"
+        },
+        {
+          "case": "evidence_citation_absent_from_index",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.evidence_citation_absent_from_index.json",
+          "sha256": "2fe3ea3cfa33d0c1ccaa12e9f74768187161a339f8ae850e45a734bf0eaf1157"
+        },
+        {
+          "case": "no_match_without_limitation_or_clarification",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.no_match_without_limitation_or_clarification.json",
+          "sha256": "d086e3d33ae6f31aa910bef649461a6e6593977130bd97085e3b9ed699fa386a"
+        },
+        {
+          "case": "authorization_filtering_undisclosed",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.authorization_filtering_undisclosed.json",
+          "sha256": "bb2b52cceeac6d40d89ba29b0613b8e44444e80dc31751562842973f4848a6c6"
+        },
+        {
+          "case": "not_comparable_slice_undisclosed",
+          "path": "examples/negative/ask_dev_investigation_packet.v1.not_comparable_slice_undisclosed.json",
+          "sha256": "c68babae7de8b4523b8c9c87c0e50671a31dd9ec3a110b15bbdbddcf3a09d2e2"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_investigation_packet.v1.json",
+        "sha256": "1b405da8bbbef4d37245137f09ec0370a4ee21b1fcef6dcc5cc6e353d86aa701"
+      },
+      "positive_variants": [
+        {
+          "case": "discovery_without_commitment",
+          "path": "examples/positive/ask_dev_investigation_packet.v1.discovery_without_commitment.json",
+          "sha256": "522171950ac06a3fc60a38492903fba3f5183445b68db50226d17c65f92aa75d"
+        },
+        {
+          "case": "not_comparable_historical_slice",
+          "path": "examples/positive/ask_dev_investigation_packet.v1.not_comparable_historical_slice.json",
+          "sha256": "6d58a2717317ac379f41e12e3f73443efd62fc2f453438d24d8c33dfcb733089"
+        },
+        {
+          "case": "qualified_capacity_without_denominator",
+          "path": "examples/positive/ask_dev_investigation_packet.v1.qualified_capacity_without_denominator.json",
+          "sha256": "48ed8afb7031a23795ef9353855073f78c7b2a0927f5052a60608418b4918e68"
+        },
+        {
+          "case": "needs_clarification_with_widening",
+          "path": "examples/positive/ask_dev_investigation_packet.v1.needs_clarification_with_widening.json",
+          "sha256": "91e343acc73807d6b5eacc1ef9145d22bf1bb108c00fa20b7c121bb4a5999fa4"
+        },
+        {
+          "case": "trial_metadata_present",
+          "path": "examples/positive/ask_dev_investigation_packet.v1.trial_metadata_present.json",
+          "sha256": "c89fe18af567f1d3326d3f80f2f0a92925ef641738676ddb67a25a2e134209d1"
+        }
+      ],
+      "schema": {
+        "path": "schemas/ask_dev_investigation_packet.v1.schema.json",
+        "sha256": "1b29712f4d4a8cb36c5addc4fc7bcc89ca79b928a56c4dbb41a5824143e6d7a0"
+      },
+      "schema_version": "ask_dev_investigation_packet.v1"
+    },
+    {
+      "negative": [
+        {
+          "case": "uncertain_job_without_limitations",
+          "path": "examples/negative/ask_dev_analytical_job.v1.uncertain_job_without_limitations.json",
+          "sha256": "d948775a338f59e38607f9961ab58f0a138c94ffefc38035773cd298118cb5ad"
+        },
+        {
+          "case": "current_slice_carrying_as_of",
+          "path": "examples/negative/ask_dev_analytical_job.v1.current_slice_carrying_as_of.json",
+          "sha256": "1fb1d62c319b645a8e8a58b8f4081ecca57c0dea2602155fc1962ea167170cfc"
+        },
+        {
+          "case": "historical_slice_without_as_of",
+          "path": "examples/negative/ask_dev_analytical_job.v1.historical_slice_without_as_of.json",
+          "sha256": "04ad6afe348dbb8e49243384f32fc47f7c9bb8a88cebe8b8153d16da4bdad474"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_analytical_job.v1.json",
+        "sha256": "a8edf583be6c160d166a3349be577e0333f82f73032d6cca1e9c29022be6a43b"
+      },
+      "positive_variants": [],
+      "schema": {
+        "path": "schemas/ask_dev_analytical_job.v1.schema.json",
+        "sha256": "49cc6d49ff393e6dd9d258b5c55d69f827026cc311314c84acca0d034e3da0b3"
+      },
+      "schema_version": "ask_dev_analytical_job.v1"
+    },
+    {
+      "negative": [
+        {
+          "case": "commitment_on_fuzzy_label_alone",
+          "path": "examples/negative/ask_dev_subject_discovery.v1.commitment_on_fuzzy_label_alone.json",
+          "sha256": "4712724d742cc6d7c58818109b193eb011b7a8aa13602e5afdad015a338581c3"
+        },
+        {
+          "case": "commitment_below_rank_one",
+          "path": "examples/negative/ask_dev_subject_discovery.v1.commitment_below_rank_one.json",
+          "sha256": "378a2f48ec000a370da1f25ec8fb1225c71502a72a0744186c7ab6ddcd34203b"
+        },
+        {
+          "case": "candidate_ranks_out_of_order",
+          "path": "examples/negative/ask_dev_subject_discovery.v1.candidate_ranks_out_of_order.json",
+          "sha256": "31e3154d2dd8714dc8aa22781bab0f02494791161af9ee0b587a99233cf3bbfb"
+        },
+        {
+          "case": "absent_truncation_disclosure_field",
+          "path": "examples/negative/ask_dev_subject_discovery.v1.absent_truncation_disclosure_field.json",
+          "sha256": "6483a790e0175951f49bb0edaf5569cbd662b57d49162aca996852b7bee7a279"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_subject_discovery.v1.json",
+        "sha256": "85a251c232a270741d4bef9144c6335afa28ceb9f93e7e063e0c3ff53664ced9"
+      },
+      "positive_variants": [],
+      "schema": {
+        "path": "schemas/ask_dev_subject_discovery.v1.schema.json",
+        "sha256": "950fbf4e56534861be1961c09872c689719517374f4250b2c1d57902efa78bac"
+      },
+      "schema_version": "ask_dev_subject_discovery.v1"
+    },
+    {
+      "negative": [
+        {
+          "case": "unrelated_member_without_inclusion_evidence",
+          "path": "examples/negative/ask_dev_comparison_cohort.v1.unrelated_member_without_inclusion_evidence.json",
+          "sha256": "2ee43c24075bb1fb9735d05cb4c9fdbccdafae69429721079b77c91ef40aef69"
+        },
+        {
+          "case": "comparison_claimed_without_dimensions",
+          "path": "examples/negative/ask_dev_comparison_cohort.v1.comparison_claimed_without_dimensions.json",
+          "sha256": "8b3b83fda24366b0dab9b1c582f98a458ee12ab3d4c9f8194518e6214e377e54"
+        },
+        {
+          "case": "truncated_without_reason",
+          "path": "examples/negative/ask_dev_comparison_cohort.v1.truncated_without_reason.json",
+          "sha256": "226d0a46ed30e20b5ebc390ebce2d35f2ffc41a4ca892d080634e48eb805013b"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_comparison_cohort.v1.json",
+        "sha256": "2c5415f73e7d6026d2a54fea3e67fc8c5369ae4a53711b890165b3c8246d8131"
+      },
+      "positive_variants": [],
+      "schema": {
+        "path": "schemas/ask_dev_comparison_cohort.v1.schema.json",
+        "sha256": "7e43ac210e8ef5eb167fce53f8c08f5fd59ff7055dde83803597f9902dec3c5a"
+      },
+      "schema_version": "ask_dev_comparison_cohort.v1"
+    },
+    {
+      "negative": [
+        {
+          "case": "reversed_relationship_direction",
+          "path": "examples/negative/ask_dev_related_context.v1.reversed_relationship_direction.json",
+          "sha256": "1b9ae4b29234d541ce9716f2b9490426d1d25edf0777fce2f794c7898b3c9952"
+        },
+        {
+          "case": "path_crosses_unauthorized_entity",
+          "path": "examples/negative/ask_dev_related_context.v1.path_crosses_unauthorized_entity.json",
+          "sha256": "ba67b4560b02627164b838c4d983e14f1ef2fa5874f6b064449a0f40753abbd3"
+        },
+        {
+          "case": "disconnected_path_presented_as_chain",
+          "path": "examples/negative/ask_dev_related_context.v1.disconnected_path_presented_as_chain.json",
+          "sha256": "2995ac90fcf378d07ea4099b8f8ac7a415552e543a17c58ec43ce28342d5e001"
+        },
+        {
+          "case": "entity_citing_undeclared_path",
+          "path": "examples/negative/ask_dev_related_context.v1.entity_citing_undeclared_path.json",
+          "sha256": "d6f424a6c2df00a1c62a207170ae06f16f2fe11de4a83491e8d77a5035690238"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_related_context.v1.json",
+        "sha256": "20448c2d2324605673e125072b89e79e7e10e2459df905fc247caf852c33e662"
+      },
+      "positive_variants": [],
+      "schema": {
+        "path": "schemas/ask_dev_related_context.v1.schema.json",
+        "sha256": "34cbfcfba216af0e85efd4f4a6a604e4e1a930db33ce2043fc112f01f50c70ba"
+      },
+      "schema_version": "ask_dev_related_context.v1"
+    },
+    {
+      "negative": [
+        {
+          "case": "symptom_promoted_to_principal_driver",
+          "path": "examples/negative/ask_dev_driver_analysis.v1.symptom_promoted_to_principal_driver.json",
+          "sha256": "aed76f6ea3f36831360a1c2f575a0052032780719af84ad2658746a1952934f5"
+        },
+        {
+          "case": "principal_driver_without_supporting_path",
+          "path": "examples/negative/ask_dev_driver_analysis.v1.principal_driver_without_supporting_path.json",
+          "sha256": "a653ecf5d48cc4535edfe2308e2dc8b975175d939c9e891150ca1d4c50ba2cc4"
+        },
+        {
+          "case": "historical_driver_promoted_to_principal",
+          "path": "examples/negative/ask_dev_driver_analysis.v1.historical_driver_promoted_to_principal.json",
+          "sha256": "2fdddca45d5439bedf4c38b23d22e41125dcff21c2c8aef787b8cc77ae9d3d82"
+        },
+        {
+          "case": "staffing_certainty_without_denominator",
+          "path": "examples/negative/ask_dev_driver_analysis.v1.staffing_certainty_without_denominator.json",
+          "sha256": "a7d8aef3f6951f524f3b1063a6efd6892a8f1d40115981904d8521ca657a206f"
+        },
+        {
+          "case": "capacity_driver_without_staffing_qualification",
+          "path": "examples/negative/ask_dev_driver_analysis.v1.capacity_driver_without_staffing_qualification.json",
+          "sha256": "106d9c78497c895ea2583cdc63685fc622f98305827e7dcb99e4d9ac08890f40"
+        },
+        {
+          "case": "principal_list_contradicts_standings",
+          "path": "examples/negative/ask_dev_driver_analysis.v1.principal_list_contradicts_standings.json",
+          "sha256": "8e72c2fe226abeaed944da152b66488ecf4771c9d784708e13317c656d14bdb1"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_driver_analysis.v1.json",
+        "sha256": "7e59e30afa67636ad39d8a6ab096d191566279429a1e66fbab1df8b1f8a44ae9"
+      },
+      "positive_variants": [],
+      "schema": {
+        "path": "schemas/ask_dev_driver_analysis.v1.schema.json",
+        "sha256": "fef9b7efb31d8ad6037b3163ce2dc7c10ad890f94c9f87391c86be40b7b4919c"
+      },
+      "schema_version": "ask_dev_driver_analysis.v1"
+    },
+    {
+      "negative": [
+        {
+          "case": "evidence_supporting_nothing",
+          "path": "examples/negative/ask_dev_evidence_coverage.v1.evidence_supporting_nothing.json",
+          "sha256": "b04bcfb83d865f4c2a61ea39e5efcdc748578efdac92a7d129702befdcc3b98b"
+        },
+        {
+          "case": "missing_source_undisclosed",
+          "path": "examples/negative/ask_dev_evidence_coverage.v1.missing_source_undisclosed.json",
+          "sha256": "d77f3e2d3783ba7dc0b7f2c9283991631c8abbc33387ce4e04022ae3d8a05ffa"
+        },
+        {
+          "case": "conflict_citing_unindexed_evidence",
+          "path": "examples/negative/ask_dev_evidence_coverage.v1.conflict_citing_unindexed_evidence.json",
+          "sha256": "ee22fdac9c48de7298d55010aacb4698fc9a04e28a8f676dd6feb355c3f7b2f5"
+        },
+        {
+          "case": "graph_native_field_smuggled_as_extra",
+          "path": "examples/negative/ask_dev_evidence_coverage.v1.graph_native_field_smuggled_as_extra.json",
+          "sha256": "b34ef86603302e280ad90ab4e1ad6bbe88c1a95a4370894774573d3b823c95d6"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_evidence_coverage.v1.json",
+        "sha256": "3f7def2371533e9b059eefb2d4fdb06dc8009b46bf476204f009b8943415294f"
+      },
+      "positive_variants": [],
+      "schema": {
+        "path": "schemas/ask_dev_evidence_coverage.v1.schema.json",
+        "sha256": "8f2f196f8d25e22c30adffd753e4ae096472597f2c5df22c04cd4f15c2956d6b"
+      },
+      "schema_version": "ask_dev_evidence_coverage.v1"
+    },
+    {
+      "negative": [
+        {
+          "case": "no_source_contract_versions",
+          "path": "examples/negative/ask_dev_investigation_versions.v1.no_source_contract_versions.json",
+          "sha256": "0207a80c988b906dbf2bb6facfa68c348e7de0489cf953cfbb890d02a739b2f1"
+        },
+        {
+          "case": "duplicate_source_contract_version",
+          "path": "examples/negative/ask_dev_investigation_versions.v1.duplicate_source_contract_version.json",
+          "sha256": "b13bba50b5b7dd7f520c9b7d945e08254a9acea4c7ab371790b558009d22cd70"
+        }
+      ],
+      "positive": {
+        "path": "examples/positive/ask_dev_investigation_versions.v1.json",
+        "sha256": "48267bad460e4f8bb3566f0e02da82c89b5e2d796922d1cee45554b8e8c8cad4"
+      },
+      "positive_variants": [],
+      "schema": {
+        "path": "schemas/ask_dev_investigation_versions.v1.schema.json",
+        "sha256": "79ef80cfee26c02906fb02136b1104abae529016b14d18aa1345d6494f9cf1e1"
+      },
+      "schema_version": "ask_dev_investigation_versions.v1"
+    }
+  ],
+  "registries": [
+    {
+      "path": "registries/question_families.json",
+      "sha256": "e25dc201c365ec1f7efed79f97fc4bb823a941236d06212a3fcd9726175064eb"
+    },
+    {
+      "path": "registries/scoring_dimensions.json",
+      "sha256": "d370dc690c505ebdf7a873ab2e570151d6b0e92686b9abbf448f7b109494239c"
+    },
+    {
+      "path": "registries/fault_modes.json",
+      "sha256": "c291788b5836f44c74af317b86c97c792158fd822bbe0c4b9958379c8f8d5b5b"
+    },
+    {
+      "path": "registries/trial_allowlists.json",
+      "sha256": "d8bfea26a9585407d3df0dd850b698cfa7bf15102917d366c48a5d3c0b26ad4e"
+    }
+  ],
+  "schema_version": "ask_dev_investigation_contract_manifest.v1"
+}

--- a/contracts/ask-dev-investigation/v1/registries/fault_modes.json
+++ b/contracts/ask-dev-investigation/v1/registries/fault_modes.json
@@ -123,7 +123,7 @@
       }
     },
     {
-      "bad_behaviour": "A lineage path routes through an entity the caller may not see, leaking its existence through the path even if its own record is never returned. Rejected: every endpoint of every hop, and every related entity, must be in the packet's authorized entity set.",
+      "bad_behaviour": "A lineage path routes through an entity the caller may not see, leaking its existence through the path even if its own record is never returned. Rejected: every endpoint of every hop, and every related entity, must be in the packet's authorized entity set. Residual, stated rather than glossed: that set is producer-declared, so the contract proves the traversal was consistent with the claim, not that the claim is true -- CHAOS-3616 must also score this dimension against a real authorization oracle.",
       "dimension_ids": [
         "zero_unauthorized_results",
         "lineage_path_precision"

--- a/contracts/ask-dev-investigation/v1/registries/fault_modes.json
+++ b/contracts/ask-dev-investigation/v1/registries/fault_modes.json
@@ -1,0 +1,193 @@
+{
+  "fault_modes": [
+    {
+      "bad_behaviour": "An arm commits to 'Nightfall' when the question meant 'Nightfall Migration', on the strength of a fuzzy label match alone. The contract cannot know which is correct -- that is the oracle's job -- but it can refuse the shape that makes the mistake invisible: a committed subject whose every match signal is fuzzy, or a ranked candidate with no stated signal at all.",
+      "dimension_ids": [
+        "subject_top_1",
+        "subject_top_3",
+        "alias_acronym_rename_resolution",
+        "clarification_candidate_precision",
+        "conversational_reference_resolution"
+      ],
+      "fault_mode_id": "wrong_but_similar_subject_ranked_first",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_commitment_on_fuzzy_label_alone_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "A wrong but similarly named subject ranks above the correct target",
+      "validator_reference": {
+        "model_name": "SubjectDiscovery",
+        "validator_name": "validate_commitment_is_evidenced"
+      }
+    },
+    {
+      "bad_behaviour": "The question named a subject, resolution failed, and the arm answered about the whole organization instead of asking. Rejected unless the packet's outcome is NEEDS_CLARIFICATION and it carries a subject clarification need.",
+      "dimension_ids": [
+        "no_unsafe_organization_widening",
+        "clarification_candidate_precision"
+      ],
+      "fault_mode_id": "organization_widening_after_unresolved_reference",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_organization_widening_after_unresolved_mention_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "Organization-wide widening after an unresolved named reference",
+      "validator_reference": {
+        "model_name": "AskDevInvestigationPacket",
+        "validator_name": "validate_no_unsafe_organization_widening"
+      }
+    },
+    {
+      "bad_behaviour": "An arm floods the evidence index with whatever it had most of -- commits, comments -- none of it attached to any included entity, path or driver, burying the lineage that was actually asked for. Rejected in both directions: an indexed item that supports nothing, and a referenced handle that is not indexed.",
+      "dimension_ids": [
+        "evidence_closure",
+        "relevant_entity_recall",
+        "relevant_relationship_recall",
+        "lineage_path_precision",
+        "cross_source_association"
+      ],
+      "fault_mode_id": "irrelevant_evidence_displaces_lineage",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_evidence_that_supports_nothing_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "Irrelevant high-volume evidence displaces the expected lineage",
+      "validator_reference": {
+        "model_name": "InvestigationEvidenceEntry",
+        "validator_name": "validate_supports_something"
+      }
+    },
+    {
+      "bad_behaviour": "'Cycle time is up' promoted to principal driver with no lineage explaining why. Rejected: principal standing requires the DRIVER role, at least one supporting path, at least one evidence handle, and current relevance.",
+      "dimension_ids": [
+        "symptom_versus_driver_distinction",
+        "principal_driver_precision",
+        "unsupported_attribution_rate",
+        "current_relevance"
+      ],
+      "fault_mode_id": "symptom_labelled_as_principal_driver",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_symptom_promoted_to_principal_driver_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "A symptom is labelled the principal driver without supporting paths",
+      "validator_reference": {
+        "model_name": "DriverCandidate",
+        "validator_name": "validate_principal_standing_is_earned"
+      }
+    },
+    {
+      "bad_behaviour": "'This project is understaffed' asserted as measured fact with no allocation denominator. Rejected. The mirror-image drift is rejected too, by a positive test: a missing denominator with a QUALIFIED confidence qualifier is a legal, useful packet -- missing staffing data reduces confidence, it does not make the question unsupported.",
+      "dimension_ids": [
+        "zero_unsupported_staffing_certainty",
+        "unsupported_attribution_rate"
+      ],
+      "fault_mode_id": "staffing_certainty_without_allocation_evidence",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_certain_staffing_claim_without_denominator_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "A staffing claim is presented as certain without allocation evidence",
+      "validator_reference": {
+        "model_name": "DriverCandidate",
+        "validator_name": "validate_staffing_claims_are_qualified"
+      }
+    },
+    {
+      "bad_behaviour": "A cohort member with no stated inclusion basis, no rationale, or neither evidence nor an explicit no-evidence classification. Whether a *well-explained* member is factually relevant remains an oracle judgment; what the contract removes is the ability to add one silently.",
+      "dimension_ids": [
+        "cohort_precision",
+        "cohort_recall",
+        "cohort_inclusion_explainability",
+        "cohort_exclusion_explainability"
+      ],
+      "fault_mode_id": "unrelated_cohort_member",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_cohort_member_without_inclusion_evidence_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "The cohort includes an unrelated project",
+      "validator_reference": {
+        "model_name": "CohortMember",
+        "validator_name": "validate_inclusion_is_evidenced"
+      }
+    },
+    {
+      "bad_behaviour": "'Team owns project' emitted as 'project owns team', or a blocked-by edge pointing the wrong way. Rejected against the relationship allowlist's declared canonical orientation.",
+      "dimension_ids": [
+        "lineage_direction_correctness",
+        "lineage_path_precision"
+      ],
+      "fault_mode_id": "reversed_relationship_direction",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_reversed_relationship_direction_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "A relationship is reversed",
+      "validator_reference": {
+        "model_name": "LineageHop",
+        "validator_name": "validate_direction_matches_allowlist"
+      }
+    },
+    {
+      "bad_behaviour": "A lineage path routes through an entity the caller may not see, leaking its existence through the path even if its own record is never returned. Rejected: every endpoint of every hop, and every related entity, must be in the packet's authorized entity set.",
+      "dimension_ids": [
+        "zero_unauthorized_results",
+        "lineage_path_precision"
+      ],
+      "fault_mode_id": "path_crosses_unauthorized_entity",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_path_through_unauthorized_entity_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "A path crosses an unauthorized entity",
+      "validator_reference": {
+        "model_name": "RelatedContext",
+        "validator_name": "validate_paths_stay_inside_authorized_set"
+      }
+    },
+    {
+      "bad_behaviour": "A packet claims SUPPORTED while carrying no asserted driver at all -- the structural form of 'here are some links, you work it out'. Rejected: a supported outcome requires at least one principal or contributing driver, each of which must itself be path- and evidence-backed.",
+      "dimension_ids": [
+        "answer_usefulness_beyond_dashboard",
+        "principal_driver_precision",
+        "principal_driver_recall"
+      ],
+      "fault_mode_id": "dashboard_redirect_without_direct_judgment",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_supported_outcome_without_any_asserted_driver_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "Dashboard redirection appears without a direct judgment",
+      "validator_reference": {
+        "model_name": "AskDevInvestigationPacket",
+        "validator_name": "validate_supported_outcome_asserts_a_judgment"
+      }
+    },
+    {
+      "bad_behaviour": "The dangerous defaults are all the reassuring ones: authorization_filtered_count = 0, truncated = False. Each would let an arm that filtered or truncated look like one that did not. Every such field on this contract is required with no default, so omitting it is a validation error rather than a comforting zero.",
+      "dimension_ids": [
+        "cohort_exclusion_explainability",
+        "zero_unauthorized_results",
+        "useful_uncertainty_behaviour"
+      ],
+      "fault_mode_id": "absent_required_field_silently_defaults",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_disclosure_fields_have_no_reassuring_default",
+      "rejecting_mechanism": "required_field",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "An absent required field silently defaults to a privileged value",
+      "validator_reference": null
+    },
+    {
+      "bad_behaviour": "A cohort that claims to compare while declaring zero comparison dimensions; a question family reduced to one prompt and one metric; a scoring dimension no fault mode can fail. Each is well-formed and proves nothing. Rejected at the contract layer for cohorts and at the registry layer for families and dimensions.",
+      "dimension_ids": [
+        "comparative_judgment_support",
+        "cohort_recall",
+        "useful_uncertainty_behaviour",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage"
+      ],
+      "fault_mode_id": "wildcard_or_optional_field_makes_check_vacuous",
+      "proving_test": "tests/api/dev/test_chaos_3615_fault_modes.py::test_cohort_claiming_comparison_without_dimensions_is_rejected",
+      "rejecting_mechanism": "contract_validator",
+      "schema_version": "ask_dev_fault_mode.v1",
+      "title": "A wildcard or optional field makes a check vacuous",
+      "validator_reference": {
+        "model_name": "ComparisonCohort",
+        "validator_name": "validate_comparison_is_not_vacuous"
+      }
+    }
+  ],
+  "schema_version": "ask_dev_fault_mode_registry.v1"
+}

--- a/contracts/ask-dev-investigation/v1/registries/question_families.json
+++ b/contracts/ask-dev-investigation/v1/registries/question_families.json
@@ -1,0 +1,738 @@
+{
+  "families": [
+    {
+      "analytical_job_statement": "Identify which teams are currently under strain and explain why, from cross-source evidence rather than a single health chart. The subject set is discovered, not supplied: the question names no team, so an arm that requires a committed subject before it will investigate cannot answer this family at all.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "What teams are currently struggling, and why?",
+          "variant_id": "struggling_teams.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "Which teams need attention right now?",
+          "variant_id": "struggling_teams.e2"
+        }
+      ],
+      "family_id": "struggling_teams",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "who's having a rough time at the moment?",
+          "variant_id": "struggling_teams.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "any teams we should be worried about?",
+          "variant_id": "struggling_teams.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "where are things not going well?",
+          "variant_id": "struggling_teams.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "discovered_cohort",
+        "portfolio_wide"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "dashboard_redirect_as_answer",
+        "pre_enumerated_intent_required",
+        "unqualified_staffing_certainty",
+        "auto_unsupported_on_missing_denominator"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "comparison_cohort",
+        "related_context",
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "work_item",
+        "review",
+        "cognitive_load",
+        "health_profile",
+        "incident"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "cohort_precision",
+        "cohort_recall",
+        "cohort_inclusion_explainability",
+        "principal_driver_precision",
+        "principal_driver_recall",
+        "symptom_versus_driver_distinction",
+        "answer_usefulness_beyond_dashboard",
+        "cross_source_association"
+      ],
+      "staffing_denominator_policy": "qualify_when_absent",
+      "title": "Struggling teams and teams needing attention"
+    },
+    {
+      "analytical_job_statement": "Locate where pressure is concentrated and of what kind. Five distinct pressure classes, deliberately in one family: an arm that can only see delivery pressure will score well on a delivery-only family and badly here, which is the point.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "Which teams need attention because of delivery, operational, review, dependency, or investment pressure?",
+          "variant_id": "pressure_signals.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "Where is delivery pressure highest right now?",
+          "variant_id": "pressure_signals.e2"
+        }
+      ],
+      "family_id": "pressure_signals",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "what's under the most pressure?",
+          "variant_id": "pressure_signals.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "where are we bottlenecked?",
+          "variant_id": "pressure_signals.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "who's drowning in reviews?",
+          "variant_id": "pressure_signals.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "discovered_cohort",
+        "portfolio_wide",
+        "explicit_cohort"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "dashboard_redirect_as_answer",
+        "unqualified_staffing_certainty",
+        "auto_unsupported_on_missing_denominator"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "comparison_cohort",
+        "related_context",
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "work_item",
+        "pull_request",
+        "review",
+        "incident",
+        "investment_allocation",
+        "deficiency_inventory"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "cohort_precision",
+        "cohort_recall",
+        "relevant_relationship_recall",
+        "principal_driver_precision",
+        "symptom_versus_driver_distinction",
+        "comparative_judgment_support",
+        "cross_source_association"
+      ],
+      "staffing_denominator_policy": "qualify_when_absent",
+      "title": "Delivery, operational, review, dependency and investment pressure"
+    },
+    {
+      "analytical_job_statement": "Judge which projects look capacity-constrained and which look unusually lightly loaded relative to demand. Both directions are in scope: an arm that only ever reports overload is not measuring capacity, it is measuring activity.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "Which projects appear capacity-constrained, understaffed, overstaffed, or unusually lightly loaded relative to demand?",
+          "variant_id": "project_capacity.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "Which projects are capacity-constrained right now?",
+          "variant_id": "project_capacity.e2"
+        }
+      ],
+      "family_id": "project_capacity",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "what are we under-resourcing?",
+          "variant_id": "project_capacity.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "anything that looks over-provisioned?",
+          "variant_id": "project_capacity.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "where do we have slack?",
+          "variant_id": "project_capacity.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "discovered_cohort",
+        "portfolio_wide",
+        "explicit_cohort"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "unqualified_staffing_certainty",
+        "auto_unsupported_on_missing_denominator",
+        "dashboard_redirect_as_answer"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "comparison_cohort",
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "work_item",
+        "investment_allocation",
+        "cognitive_load",
+        "work_graph"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "cohort_precision",
+        "cohort_recall",
+        "comparative_judgment_support",
+        "zero_unsupported_staffing_certainty",
+        "unsupported_attribution_rate",
+        "answer_usefulness_beyond_dashboard"
+      ],
+      "staffing_denominator_policy": "qualify_when_absent",
+      "title": "Project capacity constraints and lightly loaded projects"
+    },
+    {
+      "analytical_job_statement": "Answer questions phrased in staffing language without inventing a staffing denominator the platform does not have. The correct behaviour when allocation data is absent is a qualified answer that says what it is inferring from -- not silence, and not certainty.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "Which projects are understaffed?",
+          "variant_id": "staffing_language.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "Is this project overstaffed for what it is being asked to deliver?",
+          "variant_id": "staffing_language.e2"
+        }
+      ],
+      "family_id": "staffing_language",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "do we have enough people on this?",
+          "variant_id": "staffing_language.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "are we spreading ourselves too thin here?",
+          "variant_id": "staffing_language.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "is anyone sitting idle on that project?",
+          "variant_id": "staffing_language.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "singular_subject",
+        "explicit_cohort",
+        "discovered_cohort"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "unqualified_staffing_certainty",
+        "auto_unsupported_on_missing_denominator"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "investment_allocation",
+        "work_item",
+        "cognitive_load"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "zero_unsupported_staffing_certainty",
+        "unsupported_attribution_rate",
+        "subject_top_1",
+        "answer_usefulness_beyond_dashboard"
+      ],
+      "staffing_denominator_policy": "qualify_when_absent",
+      "title": "Understaffed and overstaffed language with qualified evidence"
+    },
+    {
+      "analytical_job_statement": "State where a named project actually stands and what is principally driving that, distinguishing drivers from symptoms and current causes from historical ones.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "What is the actual status of Project XYZ, and what are the principal current drivers?",
+          "variant_id": "project_status_drivers.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "Why is ACR still not finished?",
+          "variant_id": "project_status_drivers.e2"
+        }
+      ],
+      "family_id": "project_status_drivers",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "what's the deal with the auth work?",
+          "variant_id": "project_status_drivers.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "where did that project get to?",
+          "variant_id": "project_status_drivers.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "what's holding it up?",
+          "variant_id": "project_status_drivers.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "singular_subject"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "dashboard_redirect_as_answer",
+        "unqualified_staffing_certainty",
+        "auto_unsupported_on_missing_denominator"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "related_context",
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "status_change",
+        "work_item",
+        "pull_request",
+        "review",
+        "deployment"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "subject_top_1",
+        "subject_top_3",
+        "principal_driver_precision",
+        "principal_driver_recall",
+        "symptom_versus_driver_distinction",
+        "lineage_path_precision",
+        "lineage_direction_correctness",
+        "current_relevance",
+        "answer_usefulness_beyond_dashboard"
+      ],
+      "staffing_denominator_policy": "qualify_when_absent",
+      "title": "Project status and principal current drivers"
+    },
+    {
+      "analytical_job_statement": "Find projects exposed through a dependency they share with something already in trouble. This family is the clearest test of whether relationship traversal adds anything: the answer is not visible in any single project's own metrics.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "Which projects are at risk because of shared dependencies?",
+          "variant_id": "portfolio_dependency_risk.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "What else is exposed if this dependency slips?",
+          "variant_id": "portfolio_dependency_risk.e2"
+        }
+      ],
+      "family_id": "portfolio_dependency_risk",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "what else does that break?",
+          "variant_id": "portfolio_dependency_risk.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "who else is on the hook for this?",
+          "variant_id": "portfolio_dependency_risk.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "if that library is stuck, what else is stuck?",
+          "variant_id": "portfolio_dependency_risk.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "discovered_cohort",
+        "portfolio_wide"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "dashboard_redirect_as_answer"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "comparison_cohort",
+        "related_context",
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "work_graph",
+        "work_item",
+        "deployment",
+        "incident"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "relevant_entity_recall",
+        "relevant_relationship_recall",
+        "lineage_path_precision",
+        "lineage_direction_correctness",
+        "cohort_precision",
+        "cohort_recall",
+        "cross_source_association"
+      ],
+      "staffing_denominator_policy": "not_applicable",
+      "title": "Portfolio and shared-dependency risk"
+    },
+    {
+      "analytical_job_statement": "Find work declared complete that lacks the delivery, release, documentation or operational evidence completion would imply. Requires both halves -- the declaration and the evidence -- from different source classes, by construction.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "Which declared-complete projects lack delivery, release, documentation, or operational evidence?",
+          "variant_id": "declared_versus_actual.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "Is this actually done?",
+          "variant_id": "declared_versus_actual.e2"
+        }
+      ],
+      "family_id": "declared_versus_actual",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "is that really finished?",
+          "variant_id": "declared_versus_actual.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "did that ever actually ship?",
+          "variant_id": "declared_versus_actual.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "anything marked done that isn't?",
+          "variant_id": "declared_versus_actual.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "singular_subject",
+        "discovered_cohort",
+        "portfolio_wide"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "dashboard_redirect_as_answer"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "related_context",
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "status_change",
+        "pull_request",
+        "deployment",
+        "ci_run",
+        "test_report",
+        "deficiency_inventory"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "cross_source_association",
+        "principal_driver_precision",
+        "unsupported_attribution_rate",
+        "current_relevance",
+        "answer_usefulness_beyond_dashboard"
+      ],
+      "staffing_denominator_policy": "not_applicable",
+      "title": "Declared status versus actual delivery and readiness evidence"
+    },
+    {
+      "analytical_job_statement": "Resolve a reference that is not the canonical name -- an acronym, an old name, a provider key, a nickname -- to the right canonical subject, or say honestly that it is ambiguous. The failure to score hardest is confident resolution to the wrong similarly-named thing.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "What about the auth work?",
+          "variant_id": "ambiguous_identity.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "How is ACR doing?",
+          "variant_id": "ambiguous_identity.e2"
+        }
+      ],
+      "family_id": "ambiguous_identity",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "how's the thing we used to call Northstar going?",
+          "variant_id": "ambiguous_identity.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "status on DHO?",
+          "variant_id": "ambiguous_identity.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "what happened to the payments rewrite?",
+          "variant_id": "ambiguous_identity.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "singular_subject",
+        "explicit_cohort"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "pre_enumerated_intent_required"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "work_graph",
+        "work_item",
+        "status_change"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "subject_top_1",
+        "subject_top_3",
+        "alias_acronym_rename_resolution",
+        "clarification_candidate_precision",
+        "no_unsafe_organization_widening"
+      ],
+      "staffing_denominator_policy": "not_applicable",
+      "title": "Ambiguous aliases, acronyms and renamed entities"
+    },
+    {
+      "analytical_job_statement": "Resolve a reference that only makes sense against the conversation or the surface the user is on. 'What about the other project we discussed?' has no answer without context and must not be answered by guessing.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "What about the other project we discussed?",
+          "variant_id": "colloquial_follow_up.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "What happened with the project that kept cycling in review?",
+          "variant_id": "colloquial_follow_up.e2"
+        }
+      ],
+      "family_id": "colloquial_follow_up",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "and the other one?",
+          "variant_id": "colloquial_follow_up.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "what about that thing from earlier?",
+          "variant_id": "colloquial_follow_up.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "same question for the second team",
+          "variant_id": "colloquial_follow_up.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "singular_subject",
+        "explicit_cohort"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "pre_enumerated_intent_required"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "work_graph",
+        "review",
+        "work_item"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "conversational_reference_resolution",
+        "subject_top_1",
+        "clarification_candidate_precision",
+        "no_unsafe_organization_widening"
+      ],
+      "staffing_denominator_policy": "not_applicable",
+      "title": "Colloquial references and conversational follow-ups"
+    },
+    {
+      "analytical_job_statement": "Behave well when the question cannot be answered as asked: ask a useful clarifying question with a short, plausible candidate list, or say there is no match. Never widen to the whole organization, and never manufacture a subject.",
+      "exact_variants": [
+        {
+          "kind": "exact",
+          "text": "What is going sideways?",
+          "variant_id": "clarification_and_no_match.e1"
+        },
+        {
+          "kind": "exact",
+          "text": "How is Atlas doing?",
+          "variant_id": "clarification_and_no_match.e2"
+        }
+      ],
+      "family_id": "clarification_and_no_match",
+      "natural_variants": [
+        {
+          "kind": "natural",
+          "text": "what about that other team, the new one?",
+          "variant_id": "clarification_and_no_match.n1"
+        },
+        {
+          "kind": "natural",
+          "text": "how's the project going",
+          "variant_id": "clarification_and_no_match.n2"
+        },
+        {
+          "kind": "natural",
+          "text": "give me the update",
+          "variant_id": "clarification_and_no_match.n3"
+        }
+      ],
+      "permitted_comparison_shapes": [
+        "singular_subject",
+        "discovered_cohort"
+      ],
+      "prohibited_reductions": [
+        "single_dashboard_metric",
+        "single_exact_prompt",
+        "person_level_ranking",
+        "pre_enumerated_intent_required"
+      ],
+      "required_packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "evidence_coverage"
+      ],
+      "required_source_classes": [
+        "work_graph",
+        "source_health"
+      ],
+      "schema_version": "ask_dev_question_family.v1",
+      "scoring_dimension_ids": [
+        "evidence_closure",
+        "useful_uncertainty_behaviour",
+        "zero_unauthorized_results",
+        "zero_person_level_ranking",
+        "zero_graph_native_surface_leakage",
+        "clarification_candidate_precision",
+        "no_unsafe_organization_widening",
+        "subject_top_3"
+      ],
+      "staffing_denominator_policy": "not_applicable",
+      "title": "Clarification and safe no-match behaviour"
+    }
+  ],
+  "mandatory_prohibited_reductions": [
+    "single_dashboard_metric",
+    "single_exact_prompt",
+    "person_level_ranking"
+  ],
+  "schema_version": "ask_dev_question_family_registry.v1"
+}

--- a/contracts/ask-dev-investigation/v1/registries/question_families.json
+++ b/contracts/ask-dev-investigation/v1/registries/question_families.json
@@ -697,7 +697,8 @@
       ],
       "permitted_comparison_shapes": [
         "singular_subject",
-        "discovered_cohort"
+        "discovered_cohort",
+        "organization_wide"
       ],
       "prohibited_reductions": [
         "single_dashboard_metric",

--- a/contracts/ask-dev-investigation/v1/registries/scoring_dimensions.json
+++ b/contracts/ask-dev-investigation/v1/registries/scoring_dimensions.json
@@ -1,0 +1,590 @@
+{
+  "aggregate_score_prohibited": true,
+  "dimensions": [
+    {
+      "aggregate_prohibited": true,
+      "definition": "The expected canonical subject is the rank-1 candidate. Scored per question family; a family whose questions name no subject is scored NOT APPLICABLE rather than 0, so an unnameable family cannot drag a score down or prop one up.",
+      "dimension_id": "subject_top_1",
+      "fault_mode_ids": [
+        "wrong_but_similar_subject_ranked_first"
+      ],
+      "measurement_kind": "ordinal_top_k",
+      "packet_fields": [
+        "subject_discovery.candidates[].rank",
+        "subject_discovery.candidates[].canonical_id"
+      ],
+      "packet_sections": [
+        "subject_discovery"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Correct canonical subject at rank 1"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "The expected canonical subject appears in the top three candidates. Reported alongside rank-1 rather than instead of it: an arm that is reliably top-3 but rarely top-1 is a clarification-first product, not a resolution product, and the two must stay distinguishable.",
+      "dimension_id": "subject_top_3",
+      "fault_mode_ids": [
+        "wrong_but_similar_subject_ranked_first"
+      ],
+      "measurement_kind": "ordinal_top_k",
+      "packet_fields": [
+        "subject_discovery.candidates[].rank",
+        "subject_discovery.candidates[].canonical_id"
+      ],
+      "packet_sections": [
+        "subject_discovery"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Correct canonical subject within rank 3"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "When the arm asks for clarification, the candidates it offers contain the expected subject and exclude obvious non-candidates. A clarification listing every project in the organization is a failure of this dimension even though it technically contains the right answer.",
+      "dimension_id": "clarification_candidate_precision",
+      "fault_mode_ids": [
+        "wrong_but_similar_subject_ranked_first",
+        "organization_widening_after_unresolved_reference"
+      ],
+      "measurement_kind": "precision",
+      "packet_fields": [
+        "subject_discovery.unresolved_mentions[].candidate_ids",
+        "evidence_coverage.clarification_needs[].candidate_ids"
+      ],
+      "packet_sections": [
+        "subject_discovery",
+        "evidence_coverage"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Useful clarification candidate precision"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "A reference by alias, acronym, previous name or provider identifier resolves to the correct canonical subject, and the packet says which signal did it. Scoring the signal as well as the outcome is deliberate: an arm that gets the right answer by fuzzy label is not doing alias resolution and will not generalize.",
+      "dimension_id": "alias_acronym_rename_resolution",
+      "fault_mode_ids": [
+        "wrong_but_similar_subject_ranked_first"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "subject_discovery.candidates[].match_signals[].signal",
+        "subject_discovery.candidates[].match_signals[].matched_text"
+      ],
+      "packet_sections": [
+        "subject_discovery"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Alias, acronym and renamed-entity resolution"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "'What about the other project we discussed?' resolves against conversation or surface context, or is escalated to clarification. Silently guessing is scored as a failure, not a partial success.",
+      "dimension_id": "conversational_reference_resolution",
+      "fault_mode_ids": [
+        "wrong_but_similar_subject_ranked_first"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "analytical_job.surface_context_refs",
+        "analytical_job.conversation_reference_ids",
+        "subject_discovery.candidates[].match_signals[].signal"
+      ],
+      "packet_sections": [
+        "analytical_job",
+        "subject_discovery"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Conversational and surface reference resolution"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "An unresolved named reference never silently becomes an organization-wide sweep. Must be zero: widening after a failed resolution is how a question about one team becomes a report on everybody, and it is both a privacy and a usefulness failure.",
+      "dimension_id": "no_unsafe_organization_widening",
+      "fault_mode_ids": [
+        "organization_widening_after_unresolved_reference"
+      ],
+      "measurement_kind": "boolean_zero",
+      "packet_fields": [
+        "analytical_job.comparison_shape",
+        "subject_discovery.unresolved_mentions",
+        "evidence_coverage.clarification_needs[].kind"
+      ],
+      "packet_sections": [
+        "analytical_job",
+        "subject_discovery",
+        "comparison_cohort"
+      ],
+      "polarity": "must_be_zero",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "No unsafe organization widening"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Members of the cohort belong in it. An unrelated project in the cohort is the failure this scores.",
+      "dimension_id": "cohort_precision",
+      "fault_mode_ids": [
+        "unrelated_cohort_member"
+      ],
+      "measurement_kind": "precision",
+      "packet_fields": [
+        "comparison_cohort.members[].canonical_id"
+      ],
+      "packet_sections": [
+        "comparison_cohort"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Comparison cohort precision"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Subjects that belong in the cohort are in it. Reported alongside precision because a one-member cohort is trivially precise.",
+      "dimension_id": "cohort_recall",
+      "fault_mode_ids": [
+        "unrelated_cohort_member",
+        "wildcard_or_optional_field_makes_check_vacuous"
+      ],
+      "measurement_kind": "recall",
+      "packet_fields": [
+        "comparison_cohort.members[].canonical_id",
+        "comparison_cohort.completeness"
+      ],
+      "packet_sections": [
+        "comparison_cohort"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Comparison cohort recall"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Every member states a closed-vocabulary basis and a rationale, and carries either evidence handles or an explicit no-evidence classification.",
+      "dimension_id": "cohort_inclusion_explainability",
+      "fault_mode_ids": [
+        "unrelated_cohort_member"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "comparison_cohort.members[].inclusion_basis",
+        "comparison_cohort.members[].inclusion_rationale",
+        "comparison_cohort.members[].inclusion_evidence_ids"
+      ],
+      "packet_sections": [
+        "comparison_cohort"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Explainable cohort inclusion"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Subjects the arm considered and rejected are listed with reasons. Scored separately from inclusion because an arm can be perfectly explainable about what it kept while being silent about what it dropped, which is where quiet authorization filtering hides.",
+      "dimension_id": "cohort_exclusion_explainability",
+      "fault_mode_ids": [
+        "unrelated_cohort_member",
+        "absent_required_field_silently_defaults"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "comparison_cohort.exclusions[].reason",
+        "comparison_cohort.exclusions[].rationale",
+        "comparison_cohort.authorization_filtered_count"
+      ],
+      "packet_sections": [
+        "comparison_cohort"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Explainable cohort exclusion"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "The entities a human investigator would consider relevant are present in the related-context section.",
+      "dimension_id": "relevant_entity_recall",
+      "fault_mode_ids": [
+        "irrelevant_evidence_displaces_lineage"
+      ],
+      "measurement_kind": "recall",
+      "packet_fields": [
+        "related_context.entities[].entity_id"
+      ],
+      "packet_sections": [
+        "related_context"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Relevant entity recall"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "The relationships that explain the situation are present, not just the entities they connect.",
+      "dimension_id": "relevant_relationship_recall",
+      "fault_mode_ids": [
+        "irrelevant_evidence_displaces_lineage"
+      ],
+      "measurement_kind": "recall",
+      "packet_fields": [
+        "related_context.paths[].hops[].relationship"
+      ],
+      "packet_sections": [
+        "related_context"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Relevant relationship and path recall"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Included paths actually connect what they claim to connect, and each states why it was included.",
+      "dimension_id": "lineage_path_precision",
+      "fault_mode_ids": [
+        "irrelevant_evidence_displaces_lineage",
+        "path_crosses_unauthorized_entity"
+      ],
+      "measurement_kind": "precision",
+      "packet_fields": [
+        "related_context.paths[].hops",
+        "related_context.paths[].inclusion_reason"
+      ],
+      "packet_sections": [
+        "related_context"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Lineage path precision"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Every hop's direction matches the relationship's canonical orientation. 'A blocks B' and 'B blocks A' are different claims about the world and only one of them is actionable.",
+      "dimension_id": "lineage_direction_correctness",
+      "fault_mode_ids": [
+        "reversed_relationship_direction"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "related_context.paths[].hops[].direction",
+        "related_context.paths[].hops[].relationship"
+      ],
+      "packet_sections": [
+        "related_context"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Lineage direction correctness"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "The investigation connects facts across source classes rather than staying inside one. A packet whose entire evidence index is one source class has not done cross-source association, whatever its other scores.",
+      "dimension_id": "cross_source_association",
+      "fault_mode_ids": [
+        "irrelevant_evidence_displaces_lineage"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "evidence_coverage.evidence_index[].source_class"
+      ],
+      "packet_sections": [
+        "evidence_coverage"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Cross-source association"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Every evidence handle referenced anywhere in the packet is declared in the evidence index, and every indexed item supports something the packet includes. Both halves matter: the first stops dangling citations, the second stops a high-volume evidence dump from displacing the lineage that was actually asked for.",
+      "dimension_id": "evidence_closure",
+      "fault_mode_ids": [
+        "irrelevant_evidence_displaces_lineage"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "evidence_coverage.evidence_index[].evidence.evidence_ref_id",
+        "evidence_coverage.evidence_index[].supports_path_ids",
+        "evidence_coverage.evidence_index[].supports_driver_ids"
+      ],
+      "packet_sections": [
+        "evidence_coverage"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Evidence closure"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "What the packet presents as current is current. A dependency that was removed last quarter is not a current driver, however strong its historical evidence.",
+      "dimension_id": "current_relevance",
+      "fault_mode_ids": [
+        "symptom_labelled_as_principal_driver"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "related_context.entities[].relevance",
+        "driver_analysis.candidates[].relevance"
+      ],
+      "packet_sections": [
+        "related_context",
+        "driver_analysis"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Current relevance"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Drivers the packet promotes to principal standing really are the principal current drivers.",
+      "dimension_id": "principal_driver_precision",
+      "fault_mode_ids": [
+        "symptom_labelled_as_principal_driver",
+        "dashboard_redirect_without_direct_judgment"
+      ],
+      "measurement_kind": "precision",
+      "packet_fields": [
+        "driver_analysis.principal_driver_ids"
+      ],
+      "packet_sections": [
+        "driver_analysis"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Principal driver precision"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "The principal current drivers a human investigator would name are present. Reported alongside precision because an arm that promotes nothing is trivially precise and useless.",
+      "dimension_id": "principal_driver_recall",
+      "fault_mode_ids": [
+        "dashboard_redirect_without_direct_judgment"
+      ],
+      "measurement_kind": "recall",
+      "packet_fields": [
+        "driver_analysis.principal_driver_ids",
+        "driver_analysis.candidates"
+      ],
+      "packet_sections": [
+        "driver_analysis"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Principal driver recall"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Rising cycle time is a symptom; the review bottleneck causing it is a driver. Scored on whether the packet classifies each candidate correctly, not merely on whether it lists both.",
+      "dimension_id": "symptom_versus_driver_distinction",
+      "fault_mode_ids": [
+        "symptom_labelled_as_principal_driver"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "driver_analysis.candidates[].role",
+        "driver_analysis.candidates[].standing",
+        "driver_analysis.candidates[].supporting_path_ids"
+      ],
+      "packet_sections": [
+        "driver_analysis"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Symptom versus driver distinction"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "How often the packet asserts a causal or measured claim without the supporting basis it declares. Must trend to zero; unlike the must-be-zero dimensions it is reported as a rate because partial credit is meaningful here.",
+      "dimension_id": "unsupported_attribution_rate",
+      "fault_mode_ids": [
+        "symptom_labelled_as_principal_driver",
+        "staffing_certainty_without_allocation_evidence"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "driver_analysis.candidates[].assertion_basis",
+        "driver_analysis.candidates[].supporting_evidence_ids",
+        "driver_analysis.candidates[].confidence_qualifier"
+      ],
+      "packet_sections": [
+        "driver_analysis"
+      ],
+      "polarity": "must_be_zero",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Unsupported attribution rate"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "A comparison question gets a cohort with declared comparison dimensions, not a list of subjects the reader must compare themselves.",
+      "dimension_id": "comparative_judgment_support",
+      "fault_mode_ids": [
+        "wildcard_or_optional_field_makes_check_vacuous"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "comparison_cohort.supported_comparison_dimensions",
+        "comparison_cohort.members"
+      ],
+      "packet_sections": [
+        "comparison_cohort"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Comparative judgment support"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "The packet supports a direct judgment. 'Open the project dashboard' is not a successful outcome, and a packet whose only substance is surface references is scored zero here regardless of how well formed it is.",
+      "dimension_id": "answer_usefulness_beyond_dashboard",
+      "fault_mode_ids": [
+        "dashboard_redirect_without_direct_judgment"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "driver_analysis.candidates[].standing",
+        "driver_analysis.candidates[].summary",
+        "evidence_coverage.evidence_index"
+      ],
+      "packet_sections": [
+        "driver_analysis",
+        "evidence_coverage"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Direct answer usefulness beyond dashboard redirection"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "Limitations named are the ones that actually bit, and are specific enough to act on. A packet that discloses every possible limitation on every question scores no better than one that discloses none.",
+      "dimension_id": "useful_uncertainty_behaviour",
+      "fault_mode_ids": [
+        "wildcard_or_optional_field_makes_check_vacuous",
+        "absent_required_field_silently_defaults"
+      ],
+      "measurement_kind": "rate",
+      "packet_fields": [
+        "evidence_coverage.limitations[].kind",
+        "evidence_coverage.missing_sources",
+        "evidence_coverage.conflicts"
+      ],
+      "packet_sections": [
+        "evidence_coverage"
+      ],
+      "polarity": "higher_is_better",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Useful uncertainty and limitation behaviour"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "No entity, path or evidence item outside the caller's authorized set appears anywhere in the packet. Must be zero.",
+      "dimension_id": "zero_unauthorized_results",
+      "fault_mode_ids": [
+        "path_crosses_unauthorized_entity",
+        "absent_required_field_silently_defaults"
+      ],
+      "measurement_kind": "boolean_zero",
+      "packet_fields": [
+        "related_context.authorized_entity_ids",
+        "related_context.paths[].hops",
+        "related_context.authorization_filtered_count"
+      ],
+      "packet_sections": [
+        "related_context",
+        "evidence_coverage"
+      ],
+      "polarity": "must_be_zero",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Zero unauthorized or cross-tenant results"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "No person is ranked, scored or compared. Must be zero, and is structurally impossible in this contract: there is no person subject kind and no per-person comparison dimension, so the dimension scores the *arm's whole surface*, not just its packet.",
+      "dimension_id": "zero_person_level_ranking",
+      "fault_mode_ids": [
+        "wildcard_or_optional_field_makes_check_vacuous"
+      ],
+      "measurement_kind": "boolean_zero",
+      "packet_fields": [
+        "subject_discovery.candidates[].subject_kind",
+        "comparison_cohort.supported_comparison_dimensions"
+      ],
+      "packet_sections": [
+        "subject_discovery",
+        "comparison_cohort",
+        "driver_analysis"
+      ],
+      "polarity": "must_be_zero",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Zero person-level ranking"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "No staffing or capacity claim is presented as certain without allocation evidence. Must be zero. The converse is explicitly not scored here: a missing denominator must reduce confidence, never make the question unsupported.",
+      "dimension_id": "zero_unsupported_staffing_certainty",
+      "fault_mode_ids": [
+        "staffing_certainty_without_allocation_evidence"
+      ],
+      "measurement_kind": "boolean_zero",
+      "packet_fields": [
+        "driver_analysis.candidates[].staffing_qualification",
+        "driver_analysis.candidates[].confidence_qualifier"
+      ],
+      "packet_sections": [
+        "driver_analysis"
+      ],
+      "polarity": "must_be_zero",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Zero unsupported staffing certainty"
+    },
+    {
+      "aggregate_prohibited": true,
+      "definition": "No backend identity, query language, node identifier or traversal syntax reaches the packet. Must be zero. Enforced structurally by the contract's own vocabulary and checked against the generated schemas, not merely reviewed.",
+      "dimension_id": "zero_graph_native_surface_leakage",
+      "fault_mode_ids": [
+        "wildcard_or_optional_field_makes_check_vacuous"
+      ],
+      "measurement_kind": "boolean_zero",
+      "packet_fields": [
+        "versions.trial",
+        "related_context.paths[].hops[].relationship"
+      ],
+      "packet_sections": [
+        "versions",
+        "related_context"
+      ],
+      "polarity": "must_be_zero",
+      "reported_per_question_family": true,
+      "schema_version": "ask_dev_scoring_dimension.v1",
+      "title": "Zero graph-native surface leakage"
+    }
+  ],
+  "reporting_shape": "per_question_family_x_per_dimension",
+  "schema_version": "ask_dev_scoring_registry.v1"
+}

--- a/contracts/ask-dev-investigation/v1/registries/trial_allowlists.json
+++ b/contracts/ask-dev-investigation/v1/registries/trial_allowlists.json
@@ -1,0 +1,405 @@
+{
+  "relationship_types": [
+    {
+      "canonical_reading": "the dependent entity is the source; the thing depended upon is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "project",
+          "target_kind": "service"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "dependency"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "project"
+        },
+        {
+          "source_kind": "service",
+          "target_kind": "service"
+        },
+        {
+          "source_kind": "service",
+          "target_kind": "dependency"
+        },
+        {
+          "source_kind": "repository",
+          "target_kind": "dependency"
+        },
+        {
+          "source_kind": "initiative",
+          "target_kind": "project"
+        }
+      ],
+      "relationship": "depends_on",
+      "symmetric": false,
+      "title": "Depends on"
+    },
+    {
+      "canonical_reading": "the blocked entity is the source; the blocker is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "work_unit",
+          "target_kind": "work_unit"
+        },
+        {
+          "source_kind": "work_unit",
+          "target_kind": "issue"
+        },
+        {
+          "source_kind": "issue",
+          "target_kind": "issue"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "work_unit"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "dependency"
+        },
+        {
+          "source_kind": "pull_request",
+          "target_kind": "pull_request"
+        }
+      ],
+      "relationship": "blocked_by",
+      "symmetric": false,
+      "title": "Blocked by"
+    },
+    {
+      "canonical_reading": "the owned entity is the source; the owning team is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "project",
+          "target_kind": "team"
+        },
+        {
+          "source_kind": "repository",
+          "target_kind": "team"
+        },
+        {
+          "source_kind": "service",
+          "target_kind": "team"
+        },
+        {
+          "source_kind": "work_unit",
+          "target_kind": "team"
+        },
+        {
+          "source_kind": "initiative",
+          "target_kind": "team"
+        }
+      ],
+      "relationship": "owned_by_team",
+      "symmetric": false,
+      "title": "Owned by team"
+    },
+    {
+      "canonical_reading": "the contributing artifact is the source; the larger unit is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "work_unit",
+          "target_kind": "project"
+        },
+        {
+          "source_kind": "issue",
+          "target_kind": "project"
+        },
+        {
+          "source_kind": "pull_request",
+          "target_kind": "project"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "initiative"
+        },
+        {
+          "source_kind": "repository",
+          "target_kind": "project"
+        }
+      ],
+      "relationship": "contributes_to",
+      "symmetric": false,
+      "title": "Contributes to"
+    },
+    {
+      "canonical_reading": "the parent is the source; the child is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "initiative",
+          "target_kind": "project"
+        },
+        {
+          "source_kind": "portfolio",
+          "target_kind": "initiative"
+        },
+        {
+          "source_kind": "work_unit",
+          "target_kind": "work_unit"
+        },
+        {
+          "source_kind": "issue",
+          "target_kind": "issue"
+        },
+        {
+          "source_kind": "team",
+          "target_kind": "team"
+        }
+      ],
+      "relationship": "parent_of",
+      "symmetric": false,
+      "title": "Parent of"
+    },
+    {
+      "canonical_reading": "the unit of intent is the source; the implementing change is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "work_unit",
+          "target_kind": "pull_request"
+        },
+        {
+          "source_kind": "issue",
+          "target_kind": "pull_request"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "pull_request"
+        }
+      ],
+      "relationship": "implemented_by",
+      "symmetric": false,
+      "title": "Implemented by"
+    },
+    {
+      "canonical_reading": "the reviewing team is the source; the reviewed change is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "team",
+          "target_kind": "pull_request"
+        },
+        {
+          "source_kind": "team",
+          "target_kind": "repository"
+        }
+      ],
+      "relationship": "reviews",
+      "symmetric": false,
+      "title": "Reviews"
+    },
+    {
+      "canonical_reading": "the deploying change is the source; the deployed service is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "pull_request",
+          "target_kind": "service"
+        },
+        {
+          "source_kind": "repository",
+          "target_kind": "service"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "service"
+        }
+      ],
+      "relationship": "deploys",
+      "symmetric": false,
+      "title": "Deploys"
+    },
+    {
+      "canonical_reading": "the operating team is the source; the operated service is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "team",
+          "target_kind": "service"
+        },
+        {
+          "source_kind": "team",
+          "target_kind": "repository"
+        }
+      ],
+      "relationship": "operates",
+      "symmetric": false,
+      "title": "Operates"
+    },
+    {
+      "canonical_reading": "the referring artifact is the source; the referenced artifact is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "pull_request",
+          "target_kind": "issue"
+        },
+        {
+          "source_kind": "issue",
+          "target_kind": "work_unit"
+        },
+        {
+          "source_kind": "work_unit",
+          "target_kind": "issue"
+        },
+        {
+          "source_kind": "pull_request",
+          "target_kind": "work_unit"
+        }
+      ],
+      "relationship": "references",
+      "symmetric": false,
+      "title": "References"
+    },
+    {
+      "canonical_reading": "the member entity is the source; the portfolio is the target",
+      "forward_pairs": [
+        {
+          "source_kind": "project",
+          "target_kind": "portfolio"
+        },
+        {
+          "source_kind": "initiative",
+          "target_kind": "portfolio"
+        },
+        {
+          "source_kind": "team",
+          "target_kind": "portfolio"
+        }
+      ],
+      "relationship": "belongs_to_portfolio",
+      "symmetric": false,
+      "title": "Belongs to portfolio"
+    },
+    {
+      "canonical_reading": "both endpoints depend on a common third entity; the ordering is arbitrary",
+      "forward_pairs": [
+        {
+          "source_kind": "project",
+          "target_kind": "project"
+        },
+        {
+          "source_kind": "service",
+          "target_kind": "service"
+        },
+        {
+          "source_kind": "project",
+          "target_kind": "service"
+        },
+        {
+          "source_kind": "team",
+          "target_kind": "team"
+        }
+      ],
+      "relationship": "shares_dependency_with",
+      "symmetric": true,
+      "title": "Shares dependency with"
+    }
+  ],
+  "schema_version": "ask_dev_trial_allowlists.v1",
+  "slice_boundaries": [
+    {
+      "definition": "Entities, relationships and evidence that are valid now. The investigation reads the live projection: no as-of timestamp is supplied and no edge-validity interval is consulted. This is the slice every 'what is happening / what is going sideways / who needs attention' question runs in, and it is deliberately the slice that CHAOS-3569 does not block.",
+      "known_gap": null,
+      "permitted_comparability": [
+        "not_applicable"
+      ],
+      "requires_as_of": false,
+      "requires_edge_validity": false,
+      "schema_version": "ask_dev_slice_boundary.v1",
+      "slice_id": "current",
+      "title": "Current"
+    },
+    {
+      "definition": "The state as of a supplied past instant. Requires an as-of timestamp and requires every traversed edge to carry a validity interval covering that instant, so that relationships which did not exist then are not reported as if they did.",
+      "known_gap": "CHAOS-3569 (native historical edge validity) is open. Rows whose edges lack a validity interval are reported NOT COMPARABLE and excluded from historical scoring -- they are not trial failures and they do not block the current slice.",
+      "permitted_comparability": [
+        "comparable",
+        "not_comparable_missing_edge_validity",
+        "not_comparable_missing_baseline"
+      ],
+      "requires_as_of": true,
+      "requires_edge_validity": true,
+      "schema_version": "ask_dev_slice_boundary.v1",
+      "slice_id": "historical",
+      "title": "Historical"
+    },
+    {
+      "definition": "A change question: the current state compared against the state as of a supplied past instant. Inherits every requirement of the historical slice, plus a baseline that must itself be reconstructable -- a comparison against a baseline that cannot be rebuilt is NOT COMPARABLE rather than a zero delta.",
+      "known_gap": "CHAOS-3569 as above, plus: a missing baseline must be reported NOT_COMPARABLE_MISSING_BASELINE and never silently rendered as 'no change'.",
+      "permitted_comparability": [
+        "comparable",
+        "not_comparable_missing_edge_validity",
+        "not_comparable_missing_baseline"
+      ],
+      "requires_as_of": true,
+      "requires_edge_validity": true,
+      "schema_version": "ask_dev_slice_boundary.v1",
+      "slice_id": "current_vs_historical",
+      "title": "Current versus historical"
+    }
+  ],
+  "source_classes": [
+    {
+      "rationale": "declared status and its transitions -- the 'declared' half of the declared-versus-actual family",
+      "source_class": "status_change"
+    },
+    {
+      "rationale": "canonical units of work; the substrate for delivery pressure, scope change and blocked-by lineage",
+      "source_class": "work_item"
+    },
+    {
+      "rationale": "canonical entity identity and membership -- how a candidate subject becomes a canonical ID at all",
+      "source_class": "work_graph"
+    },
+    {
+      "rationale": "implementing changes; the 'actual delivery evidence' half of the declared-versus-actual family",
+      "source_class": "pull_request"
+    },
+    {
+      "rationale": "change volume and locality behind delivery pressure",
+      "source_class": "code_change"
+    },
+    {
+      "rationale": "review pressure, and the cycled-in-review colloquial family",
+      "source_class": "review"
+    },
+    {
+      "rationale": "readiness evidence for declared-complete claims",
+      "source_class": "ci_run"
+    },
+    {
+      "rationale": "readiness evidence for declared-complete claims",
+      "source_class": "test_report"
+    },
+    {
+      "rationale": "release evidence for declared-complete claims",
+      "source_class": "deployment"
+    },
+    {
+      "rationale": "operational pressure and its driver lineage",
+      "source_class": "incident"
+    },
+    {
+      "rationale": "operational readiness controls behind operational-deficiency drivers",
+      "source_class": "operational_control"
+    },
+    {
+      "rationale": "source availability and freshness -- required to distinguish 'no signal' from 'no data'",
+      "source_class": "source_health"
+    },
+    {
+      "rationale": "team-level interruption/context-spread/review-request rollups behind the struggling-teams family. Team-level only: this source class also backs per-developer rollups, which the packet cannot express because no person subject kind exists",
+      "source_class": "cognitive_load"
+    },
+    {
+      "rationale": "investment mix pressure, and the nearest available proxy for a capacity denominator",
+      "source_class": "investment_allocation"
+    },
+    {
+      "rationale": "code-owned health-rule findings; a derived judgment over other sources, never a primary source of its own",
+      "source_class": "health_profile"
+    },
+    {
+      "rationale": "operational-deficiency inventory behind readiness and operational pressure judgments",
+      "source_class": "deficiency_inventory"
+    }
+  ]
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_analytical_job.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_analytical_job.v1.schema.json
@@ -1,0 +1,301 @@
+{
+  "$defs": {
+    "AnalyticalSlice": {
+      "description": "Current-versus-historical slice of the investigation.\n\nSlice boundaries, and what each slice requires of edge validity, are\ndeclared once in :mod:`.allowlists` (``SLICE_BOUNDARIES``).",
+      "enum": [
+        "current",
+        "historical",
+        "current_vs_historical"
+      ],
+      "title": "AnalyticalSlice",
+      "type": "string"
+    },
+    "BoundedTimeContext": {
+      "additionalProperties": false,
+      "description": "The bounded time window, and which slice of history it addresses.",
+      "properties": {
+        "analytical_slice": {
+          "$ref": "#/$defs/AnalyticalSlice"
+        },
+        "as_of": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "As Of"
+        },
+        "end": {
+          "format": "date-time",
+          "title": "End",
+          "type": "string"
+        },
+        "historical_comparability": {
+          "$ref": "#/$defs/HistoricalComparability"
+        },
+        "start": {
+          "format": "date-time",
+          "title": "Start",
+          "type": "string"
+        },
+        "timezone": {
+          "maxLength": 64,
+          "minLength": 1,
+          "title": "Timezone",
+          "type": "string"
+        }
+      },
+      "required": [
+        "start",
+        "end",
+        "timezone",
+        "analytical_slice",
+        "historical_comparability"
+      ],
+      "title": "BoundedTimeContext",
+      "type": "object"
+    },
+    "ComparisonShape": {
+      "description": "The requested comparison or singular-subject shape.",
+      "enum": [
+        "singular_subject",
+        "explicit_cohort",
+        "discovered_cohort",
+        "portfolio_wide",
+        "organization_wide"
+      ],
+      "title": "ComparisonShape",
+      "type": "string"
+    },
+    "HistoricalComparability": {
+      "description": "Whether a historical slice can be fairly compared at all.\n\n``NOT_COMPARABLE_MISSING_EDGE_VALIDITY`` is the CHAOS-3569 state: native\nhistorical edge validity is not implemented, so as-of traversal cannot\nbe reconstructed for those rows. The correction plan is explicit that\nsuch rows are **NOT COMPARABLE, not blockers** \u2014 a packet that declares\nthis state is still a *valid* packet and may still be ``SUPPORTED``\n(pinned by ``test_not_comparable_historical_slice_is_valid_and_\nsupported``). What it may not do is stay silent: the packet must also\ncarry a ``HISTORICAL_SLICE_NOT_COMPARABLE`` limitation.",
+      "enum": [
+        "not_applicable",
+        "comparable",
+        "not_comparable_missing_edge_validity",
+        "not_comparable_missing_baseline"
+      ],
+      "title": "HistoricalComparability",
+      "type": "string"
+    },
+    "InvestigationSubjectKind": {
+      "description": "What an investigation may take as a subject, cohort member or node.\n\nA superset of the *organizational* kinds an Ask Dev question can name,\nand a strict subset of \"anything in the work graph\": there is no person\nkind, by design (see the module docstring). ``EntityKind``\n(``contracts_v2.base``) is the answer-frame subject vocabulary and is\ndeliberately not reused here \u2014 it carries ``pull_request``/``issue`` as\n*subjects* of a status answer, whereas this enum has to describe\nportfolio, initiative and service nodes that a status answer never takes\nas its subject but a lineage path routinely crosses.",
+      "enum": [
+        "team",
+        "project",
+        "portfolio",
+        "initiative",
+        "repository",
+        "service",
+        "work_unit",
+        "issue",
+        "pull_request",
+        "dependency"
+      ],
+      "title": "InvestigationSubjectKind",
+      "type": "string"
+    },
+    "JobUncertainty": {
+      "description": "How precisely the analytical job could be interpreted.\n\n``BROAD_WITH_UNCERTAINTY`` exists because the correction addendum bans\nrequiring a fully pre-enumerated intent before investigation may begin:\n\"what is going sideways?\" is a legitimate job whose subject set is\ndiscovered, not declared. A broad or ambiguous job must carry at least\none interpretation limitation, which is what stops the state from being\na free pass.",
+      "enum": [
+        "precise",
+        "broad_with_uncertainty",
+        "ambiguous"
+      ],
+      "title": "JobUncertainty",
+      "type": "string"
+    },
+    "PacketLimitation": {
+      "additionalProperties": false,
+      "description": "One safe, closed-vocabulary limitation the packet is disclosing.",
+      "properties": {
+        "detail": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Detail",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/PacketLimitationKind"
+        }
+      },
+      "required": [
+        "kind",
+        "detail"
+      ],
+      "title": "PacketLimitation",
+      "type": "object"
+    },
+    "PacketLimitationKind": {
+      "enum": [
+        "missing_source",
+        "stale_source",
+        "conflicting_evidence",
+        "authorization_filtered",
+        "truncated_traversal",
+        "absent_staffing_denominator",
+        "historical_slice_not_comparable",
+        "interpretation_uncertainty"
+      ],
+      "title": "PacketLimitationKind",
+      "type": "string"
+    },
+    "QuestionFamilyID": {
+      "description": "The ten frozen families of the corrected trial.",
+      "enum": [
+        "struggling_teams",
+        "pressure_signals",
+        "project_capacity",
+        "staffing_language",
+        "project_status_drivers",
+        "portfolio_dependency_risk",
+        "declared_versus_actual",
+        "ambiguous_identity",
+        "colloquial_follow_up",
+        "clarification_and_no_match"
+      ],
+      "title": "QuestionFamilyID",
+      "type": "string"
+    },
+    "SurfaceContextRef": {
+      "additionalProperties": false,
+      "description": "A safe reference to the surface or conversation the question came from.\n\nDeliberately three closed/opaque fields and no URL: see\n``vocabulary.SurfaceKind``.",
+      "properties": {
+        "entity_id": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entity Id"
+        },
+        "entity_kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InvestigationSubjectKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "surface_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Surface Id",
+          "type": "string"
+        },
+        "surface_kind": {
+          "$ref": "#/$defs/SurfaceKind"
+        }
+      },
+      "required": [
+        "surface_kind",
+        "surface_id"
+      ],
+      "title": "SurfaceContextRef",
+      "type": "object"
+    },
+    "SurfaceKind": {
+      "description": "Safe surface/conversation context references.\n\nClosed rather than free text on purpose: a surface reference is the one\nfield on an investigation packet whose natural implementation is \"paste\nthe URL the user was looking at\", and a URL is both an unbounded\ndisclosure channel and the exact shape of a dashboard redirect.",
+      "enum": [
+        "dashboard",
+        "project_page",
+        "team_page",
+        "portfolio_page",
+        "report",
+        "conversation"
+      ],
+      "title": "SurfaceKind",
+      "type": "string"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_analytical_job.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "The normalized analytical job, with its uncertainty stated.\n\n``job_uncertainty`` is what keeps this contract from requiring a\npre-enumerated intent: an arm may declare a broad job it is uncertain\nabout and still investigate, provided it says so. The\n``question_family`` is a *family*, not an enumerated intent \u2014 ten of\nthem cover the whole trial, and one of them is \"clarification and safe\nno-match\".",
+  "properties": {
+    "comparison_shape": {
+      "$ref": "#/$defs/ComparisonShape"
+    },
+    "conversation_reference_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "title": "Conversation Reference Ids",
+      "type": "array"
+    },
+    "interpretation_limitations": {
+      "items": {
+        "$ref": "#/$defs/PacketLimitation"
+      },
+      "maxItems": 25,
+      "title": "Interpretation Limitations",
+      "type": "array"
+    },
+    "job_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+      "title": "Job Id",
+      "type": "string"
+    },
+    "job_statement": {
+      "maxLength": 2048,
+      "minLength": 1,
+      "title": "Job Statement",
+      "type": "string"
+    },
+    "job_uncertainty": {
+      "$ref": "#/$defs/JobUncertainty"
+    },
+    "question_family": {
+      "$ref": "#/$defs/QuestionFamilyID"
+    },
+    "schema_version": {
+      "const": "ask_dev_analytical_job.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "surface_context_refs": {
+      "items": {
+        "$ref": "#/$defs/SurfaceContextRef"
+      },
+      "maxItems": 10,
+      "title": "Surface Context Refs",
+      "type": "array"
+    },
+    "time_context": {
+      "$ref": "#/$defs/BoundedTimeContext"
+    }
+  },
+  "required": [
+    "schema_version",
+    "job_id",
+    "question_family",
+    "job_uncertainty",
+    "job_statement",
+    "comparison_shape",
+    "time_context"
+  ],
+  "title": "AnalyticalJob",
+  "type": "object"
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_analytical_job.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_analytical_job.v1.schema.json
@@ -30,6 +30,9 @@
           "default": null,
           "title": "As Of"
         },
+        "edge_validity_basis": {
+          "$ref": "#/$defs/EdgeValidityBasis"
+        },
         "end": {
           "format": "date-time",
           "title": "End",
@@ -55,7 +58,8 @@
         "end",
         "timezone",
         "analytical_slice",
-        "historical_comparability"
+        "historical_comparability",
+        "edge_validity_basis"
       ],
       "title": "BoundedTimeContext",
       "type": "object"
@@ -70,6 +74,16 @@
         "organization_wide"
       ],
       "title": "ComparisonShape",
+      "type": "string"
+    },
+    "EdgeValidityBasis": {
+      "description": "What backs a slice's claim that its relationships were valid *then*.\n\nAdded after adversarial review round 1 (finding M7). ``SLICE_BOUNDARIES``\ndeclared that historical slices require edge validity, but nothing on the\nwire recorded whether an arm actually had it \u2014 so a packet could label a\nhistorical slice ``COMPARABLE`` while having read the live projection,\nproducing a confident and entirely false delta.\n\n``NOT_REQUIRED`` is the current slice. ``OBSERVED_INTERVALS`` means every\ntraversed edge carried a validity interval covering the as-of instant, and\nis the only basis on which a historical slice may be ``COMPARABLE``.\n``UNAVAILABLE`` is the CHAOS-3569 state and forces\n``NOT_COMPARABLE_MISSING_EDGE_VALIDITY``.",
+      "enum": [
+        "not_required",
+        "observed_intervals",
+        "unavailable"
+      ],
+      "title": "EdgeValidityBasis",
       "type": "string"
     },
     "HistoricalComparability": {

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_comparison_cohort.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_comparison_cohort.v1.schema.json
@@ -1,0 +1,313 @@
+{
+  "$defs": {
+    "CohortCompleteness": {
+      "enum": [
+        "complete",
+        "truncated",
+        "best_effort_uncertain"
+      ],
+      "title": "CohortCompleteness",
+      "type": "string"
+    },
+    "CohortEvidenceClassification": {
+      "description": "Closed reasons a cohort member may carry no evidence handle.\n\nThe same \"evidence refs XOR an explicit no-evidence classification \u2014\nnever both, never neither\" pattern as\n``contracts_v2.embedded.MetricEvidenceClassification`` and\n``contracts_v2.deficiency.DeficiencyEvidenceClassification``, applied to\ncohort membership here.",
+      "enum": [
+        "explicitly_named_by_question",
+        "canonical_registry_membership"
+      ],
+      "title": "CohortEvidenceClassification",
+      "type": "string"
+    },
+    "CohortExclusion": {
+      "additionalProperties": false,
+      "description": "A subject considered for the cohort and deliberately left out.",
+      "properties": {
+        "canonical_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Canonical Id",
+          "type": "string"
+        },
+        "rationale": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Rationale",
+          "type": "string"
+        },
+        "reason": {
+          "$ref": "#/$defs/CohortExclusionReason"
+        },
+        "subject_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "subject_kind",
+        "canonical_id",
+        "reason",
+        "rationale"
+      ],
+      "title": "CohortExclusion",
+      "type": "object"
+    },
+    "CohortExclusionReason": {
+      "enum": [
+        "out_of_authorized_scope",
+        "insufficient_evidence",
+        "not_comparable_slice",
+        "archived_or_inactive",
+        "truncation_budget",
+        "ambiguous_identity",
+        "excluded_by_question"
+      ],
+      "title": "CohortExclusionReason",
+      "type": "string"
+    },
+    "CohortInclusionBasis": {
+      "description": "Why a subject is in the comparison cohort.\n\nThere is deliberately no ``unspecified`` member and the field is\n``min_length=1``: \"an unrelated project appears in the cohort\" is a named\nfault mode, and the cheapest way for an arm to commit it is to include a\nmember with no stated basis at all.",
+      "enum": [
+        "explicitly_named",
+        "shared_dependency",
+        "shared_team_ownership",
+        "same_portfolio",
+        "same_initiative",
+        "comparable_delivery_profile",
+        "peer_of_named_subject"
+      ],
+      "title": "CohortInclusionBasis",
+      "type": "string"
+    },
+    "CohortMember": {
+      "additionalProperties": false,
+      "description": "A subject in the comparison cohort, with its inclusion justified.",
+      "properties": {
+        "canonical_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Canonical Id",
+          "type": "string"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "inclusion_basis": {
+          "items": {
+            "$ref": "#/$defs/CohortInclusionBasis"
+          },
+          "maxItems": 5,
+          "minItems": 1,
+          "title": "Inclusion Basis",
+          "type": "array"
+        },
+        "inclusion_evidence_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CohortEvidenceClassification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "inclusion_evidence_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Inclusion Evidence Ids",
+          "type": "array"
+        },
+        "inclusion_rationale": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Inclusion Rationale",
+          "type": "string"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "subject_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "subject_kind",
+        "canonical_id",
+        "display_label",
+        "inclusion_basis",
+        "inclusion_rationale",
+        "relevance"
+      ],
+      "title": "CohortMember",
+      "type": "object"
+    },
+    "ComparisonDimension": {
+      "description": "Axes a cohort may be compared on.\n\nEvery member is a *unit-of-work or system* axis. None is per-person, and\nnone may be derived per-person: person-level productivity, workload and\nstaffing ranking is prohibited outright, and this enum is one of the two\nstructural places that ban is enforced (the other being the absence of a\nperson member on :class:`InvestigationSubjectKind`).",
+      "enum": [
+        "delivery_throughput",
+        "cycle_time",
+        "review_load",
+        "work_in_progress",
+        "dependency_exposure",
+        "incident_load",
+        "deployment_frequency",
+        "investment_mix",
+        "open_deficiency_count",
+        "status_declaration_gap",
+        "capacity_load_ratio",
+        "data_coverage"
+      ],
+      "title": "ComparisonDimension",
+      "type": "string"
+    },
+    "ComparisonShape": {
+      "description": "The requested comparison or singular-subject shape.",
+      "enum": [
+        "singular_subject",
+        "explicit_cohort",
+        "discovered_cohort",
+        "portfolio_wide",
+        "organization_wide"
+      ],
+      "title": "ComparisonShape",
+      "type": "string"
+    },
+    "InvestigationSubjectKind": {
+      "description": "What an investigation may take as a subject, cohort member or node.\n\nA superset of the *organizational* kinds an Ask Dev question can name,\nand a strict subset of \"anything in the work graph\": there is no person\nkind, by design (see the module docstring). ``EntityKind``\n(``contracts_v2.base``) is the answer-frame subject vocabulary and is\ndeliberately not reused here \u2014 it carries ``pull_request``/``issue`` as\n*subjects* of a status answer, whereas this enum has to describe\nportfolio, initiative and service nodes that a status answer never takes\nas its subject but a lineage path routinely crosses.",
+      "enum": [
+        "team",
+        "project",
+        "portfolio",
+        "initiative",
+        "repository",
+        "service",
+        "work_unit",
+        "issue",
+        "pull_request",
+        "dependency"
+      ],
+      "title": "InvestigationSubjectKind",
+      "type": "string"
+    },
+    "RelevanceState": {
+      "description": "Whether a node, path, driver or evidence item is *currently* relevant.",
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "RelevanceState",
+      "type": "string"
+    },
+    "TruncationReason": {
+      "enum": [
+        "path_budget",
+        "node_budget",
+        "cohort_budget",
+        "evidence_budget",
+        "time_budget",
+        "authorization_filter",
+        "source_unavailable"
+      ],
+      "title": "TruncationReason",
+      "type": "string"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_comparison_cohort.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "The comparison cohort, its exclusions, and how complete it is.",
+  "properties": {
+    "authorization_filtered_count": {
+      "minimum": 0,
+      "title": "Authorization Filtered Count",
+      "type": "integer"
+    },
+    "cohort_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+      "title": "Cohort Id",
+      "type": "string"
+    },
+    "cohort_uncertainty": {
+      "anyOf": [
+        {
+          "maxLength": 2048,
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cohort Uncertainty"
+    },
+    "comparison_shape": {
+      "$ref": "#/$defs/ComparisonShape"
+    },
+    "completeness": {
+      "$ref": "#/$defs/CohortCompleteness"
+    },
+    "exclusions": {
+      "items": {
+        "$ref": "#/$defs/CohortExclusion"
+      },
+      "maxItems": 50,
+      "title": "Exclusions",
+      "type": "array"
+    },
+    "members": {
+      "items": {
+        "$ref": "#/$defs/CohortMember"
+      },
+      "maxItems": 50,
+      "title": "Members",
+      "type": "array"
+    },
+    "schema_version": {
+      "const": "ask_dev_comparison_cohort.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "supported_comparison_dimensions": {
+      "items": {
+        "$ref": "#/$defs/ComparisonDimension"
+      },
+      "maxItems": 12,
+      "title": "Supported Comparison Dimensions",
+      "type": "array"
+    },
+    "truncation_reason": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TruncationReason"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "schema_version",
+    "cohort_id",
+    "comparison_shape",
+    "completeness",
+    "authorization_filtered_count"
+  ],
+  "title": "ComparisonCohort",
+  "type": "object"
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_driver_analysis.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_driver_analysis.v1.schema.json
@@ -1,0 +1,342 @@
+{
+  "$defs": {
+    "AssertionBasis": {
+      "description": "Measured, source-asserted and inferred distinctions.\n\nThe governing rule is \"the graph determines what is relevant; canonical\nservices determine what is measurable\". ``MEASURED`` therefore means a\ncanonical Ops service produced the number and minted evidence for it;\n``SOURCE_ASSERTED`` means a provider (or a human in a provider field)\nsaid so; ``INFERRED`` means the investigation concluded it. Only\n``MEASURED`` may be presented as certain.",
+      "enum": [
+        "measured",
+        "source_asserted",
+        "inferred"
+      ],
+      "title": "AssertionBasis",
+      "type": "string"
+    },
+    "ConfidenceQualifier": {
+      "enum": [
+        "measured_certain",
+        "qualified",
+        "uncertain",
+        "unsupported"
+      ],
+      "title": "ConfidenceQualifier",
+      "type": "string"
+    },
+    "DriverCandidate": {
+      "additionalProperties": false,
+      "description": "A candidate driver, its standing, and everything that standing rests on.",
+      "properties": {
+        "affected_subject_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 50,
+          "minItems": 1,
+          "title": "Affected Subject Ids",
+          "type": "array"
+        },
+        "assertion_basis": {
+          "$ref": "#/$defs/AssertionBasis"
+        },
+        "category": {
+          "$ref": "#/$defs/DriverCategory"
+        },
+        "confidence_qualifier": {
+          "$ref": "#/$defs/ConfidenceQualifier"
+        },
+        "conflict_note": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Conflict Note"
+        },
+        "conflicting_evidence_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Conflicting Evidence Ids",
+          "type": "array"
+        },
+        "driver_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Driver Id",
+          "type": "string"
+        },
+        "exclusion_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DriverExclusionReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "role": {
+          "$ref": "#/$defs/DriverRole"
+        },
+        "staffing_qualification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StaffingQualification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "standing": {
+          "$ref": "#/$defs/DriverStanding"
+        },
+        "summary": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Summary",
+          "type": "string"
+        },
+        "supporting_evidence_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Supporting Evidence Ids",
+          "type": "array"
+        },
+        "supporting_path_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supporting Path Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "driver_id",
+        "category",
+        "summary",
+        "affected_subject_ids",
+        "role",
+        "standing",
+        "assertion_basis",
+        "confidence_qualifier",
+        "relevance"
+      ],
+      "title": "DriverCandidate",
+      "type": "object"
+    },
+    "DriverCategory": {
+      "enum": [
+        "delivery_pressure",
+        "review_pressure",
+        "operational_pressure",
+        "dependency_pressure",
+        "investment_mix",
+        "capacity_or_staffing",
+        "scope_change",
+        "quality_or_defect",
+        "external_blocker",
+        "data_coverage"
+      ],
+      "title": "DriverCategory",
+      "type": "string"
+    },
+    "DriverExclusionReason": {
+      "description": "Why a candidate did not reach principal-driver standing.",
+      "enum": [
+        "no_supporting_path",
+        "evidence_conflict_unresolved",
+        "not_currently_relevant",
+        "symptom_of_another_candidate",
+        "unauthorized_evidence",
+        "insufficient_measurement"
+      ],
+      "title": "DriverExclusionReason",
+      "type": "string"
+    },
+    "DriverRole": {
+      "description": "Symptom-versus-driver classification.\n\n``CONTEXTUAL_CORRELATE`` is the honest third option: something that moved\nat the same time and is worth reporting but is neither the cause nor a\nconsequence. Collapsing it into ``DRIVER`` is precisely how unsupported\nattribution enters an answer.",
+      "enum": [
+        "driver",
+        "symptom",
+        "contextual_correlate"
+      ],
+      "title": "DriverRole",
+      "type": "string"
+    },
+    "DriverStanding": {
+      "enum": [
+        "principal_driver",
+        "contributing_driver",
+        "candidate_only",
+        "excluded"
+      ],
+      "title": "DriverStanding",
+      "type": "string"
+    },
+    "RelevanceState": {
+      "description": "Whether a node, path, driver or evidence item is *currently* relevant.",
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "RelevanceState",
+      "type": "string"
+    },
+    "SourceClass": {
+      "description": "The closed platform vocabulary of investigable source classes.\n\nA *source class* names a kind of platform data an investigation step can\ndraw on. It is deliberately a closed enum rather than an ``OpaqueID``,\nbecause the same token is what ``dev_coverage``'s\n``unavailable_required_sources``/``stale_required_sources`` disclose on a\n**denied** answer (see ``validators.NO_ANSWER_FRAME_FIELD_POLICY``):\nadversarial review round 3 used the free-form ``OpaqueID`` shape to smuggle\na subject-derived identifier (``\"private/Nightfall\"``) out through a frame\nwhose every other field was correctly empty. A closed vocabulary means the\ncoverage counts stay answerable for a denial while carrying nothing a\nproducer chose.\n\nAdding a source class is therefore a deliberate contract change, not an\nincidental string: a new adapter must add its member here (and regenerate\nthe exported schemas) before it can appear on the wire.",
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "SourceClass",
+      "type": "string"
+    },
+    "StaffingDenominatorState": {
+      "description": "How much allocation evidence backs a capacity/staffing claim.\n\nThe correction addendum is explicit on both halves of this: a missing\ndenominator must **reduce confidence and require qualification**, and it\nmust **not automatically make capacity questions unsupported**. Both\nhalves are pinned by tests \u2014 ``DENOMINATOR_ABSENT`` with a\n``MEASURED_CERTAIN`` qualifier is rejected, and ``DENOMINATOR_ABSENT``\nwith a ``QUALIFIED`` qualifier is accepted.",
+      "enum": [
+        "allocation_evidence_available",
+        "partial_allocation_evidence",
+        "denominator_absent"
+      ],
+      "title": "StaffingDenominatorState",
+      "type": "string"
+    },
+    "StaffingQualification": {
+      "additionalProperties": false,
+      "description": "How much allocation evidence stands behind a capacity claim.",
+      "properties": {
+        "denominator_source_classes": {
+          "items": {
+            "$ref": "#/$defs/SourceClass"
+          },
+          "maxItems": 10,
+          "title": "Denominator Source Classes",
+          "type": "array"
+        },
+        "denominator_state": {
+          "$ref": "#/$defs/StaffingDenominatorState"
+        },
+        "qualification_note": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Qualification Note",
+          "type": "string"
+        }
+      },
+      "required": [
+        "denominator_state",
+        "qualification_note"
+      ],
+      "title": "StaffingQualification",
+      "type": "object"
+    },
+    "TruncationReason": {
+      "enum": [
+        "path_budget",
+        "node_budget",
+        "cohort_budget",
+        "evidence_budget",
+        "time_budget",
+        "authorization_filter",
+        "source_unavailable"
+      ],
+      "title": "TruncationReason",
+      "type": "string"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_driver_analysis.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Every driver candidate, and which of them are principal.",
+  "properties": {
+    "candidates": {
+      "items": {
+        "$ref": "#/$defs/DriverCandidate"
+      },
+      "maxItems": 50,
+      "title": "Candidates",
+      "type": "array"
+    },
+    "candidates_truncated": {
+      "title": "Candidates Truncated",
+      "type": "boolean"
+    },
+    "principal_driver_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+        "type": "string"
+      },
+      "maxItems": 10,
+      "title": "Principal Driver Ids",
+      "type": "array"
+    },
+    "schema_version": {
+      "const": "ask_dev_driver_analysis.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "truncation_reason": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TruncationReason"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "schema_version",
+    "candidates_truncated"
+  ],
+  "title": "DriverAnalysis",
+  "type": "object"
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_evidence_coverage.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_evidence_coverage.v1.schema.json
@@ -1,0 +1,643 @@
+{
+  "$defs": {
+    "ClarificationNeed": {
+      "additionalProperties": false,
+      "description": "A question the investigation needs answered before it can proceed.",
+      "properties": {
+        "candidate_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Candidate Ids",
+          "type": "array"
+        },
+        "kind": {
+          "$ref": "#/$defs/ClarificationNeedKind"
+        },
+        "prompt": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "prompt"
+      ],
+      "title": "ClarificationNeed",
+      "type": "object"
+    },
+    "ClarificationNeedKind": {
+      "enum": [
+        "ambiguous_subject",
+        "missing_time_context",
+        "missing_comparison_basis",
+        "unresolved_conversational_reference",
+        "unsupported_by_available_sources"
+      ],
+      "title": "ClarificationNeedKind",
+      "type": "string"
+    },
+    "ConflictResolution": {
+      "enum": [
+        "unresolved",
+        "resolved_by_precedence",
+        "resolved_by_recency",
+        "deferred_to_canonical_service"
+      ],
+      "title": "ConflictResolution",
+      "type": "string"
+    },
+    "DevCitationLink": {
+      "additionalProperties": false,
+      "properties": {
+        "internal_path": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "pattern": "^/[^\\s]*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Internal Path"
+        },
+        "source_url": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Url"
+        }
+      },
+      "title": "DevCitationLink",
+      "type": "object"
+    },
+    "DevEvidenceFlags": {
+      "additionalProperties": false,
+      "properties": {
+        "conflicting": {
+          "default": false,
+          "title": "Conflicting",
+          "type": "boolean"
+        },
+        "deleted": {
+          "default": false,
+          "title": "Deleted",
+          "type": "boolean"
+        },
+        "redacted": {
+          "default": false,
+          "title": "Redacted",
+          "type": "boolean"
+        },
+        "stale": {
+          "default": false,
+          "title": "Stale",
+          "type": "boolean"
+        },
+        "unavailable": {
+          "default": false,
+          "title": "Unavailable",
+          "type": "boolean"
+        },
+        "uncertain": {
+          "default": false,
+          "title": "Uncertain",
+          "type": "boolean"
+        },
+        "untrusted_content": {
+          "default": true,
+          "title": "Untrusted Content",
+          "type": "boolean"
+        }
+      },
+      "title": "DevEvidenceFlags",
+      "type": "object"
+    },
+    "DevEvidenceRefV2": {
+      "additionalProperties": false,
+      "properties": {
+        "citation_text": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Citation Text"
+        },
+        "confidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "entity_type": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Type",
+          "type": "string"
+        },
+        "evidence_ref_id": {
+          "maxLength": 44,
+          "minLength": 44,
+          "pattern": "^ev1_[0-9a-f]{40}$",
+          "title": "Evidence Ref Id",
+          "type": "string"
+        },
+        "flags": {
+          "$ref": "#/$defs/DevEvidenceFlags"
+        },
+        "freshness": {
+          "$ref": "#/$defs/FreshnessState"
+        },
+        "link": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevCitationLink"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "provenance": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Provenance",
+          "type": "string"
+        },
+        "repository_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Repository Ids",
+          "type": "array"
+        },
+        "schema_version": {
+          "const": "dev_evidence_ref.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "source_system": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Source System",
+          "type": "string"
+        },
+        "source_version": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Source Version",
+          "type": "string"
+        },
+        "valid_entity_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Valid Entity Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "evidence_ref_id",
+        "source_system",
+        "source_version",
+        "entity_type",
+        "entity_id",
+        "display_label",
+        "observed_at",
+        "freshness",
+        "provenance",
+        "confidence",
+        "flags"
+      ],
+      "title": "DevEvidenceRefV2",
+      "type": "object"
+    },
+    "FreshnessState": {
+      "enum": [
+        "fresh",
+        "stale",
+        "unavailable",
+        "unknown"
+      ],
+      "title": "FreshnessState",
+      "type": "string"
+    },
+    "InvestigationEvidenceEntry": {
+      "additionalProperties": false,
+      "description": "One evidence item, and what in this packet it actually supports.",
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/DevEvidenceRefV2"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        },
+        "supports_driver_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Driver Ids",
+          "type": "array"
+        },
+        "supports_entity_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Entity Ids",
+          "type": "array"
+        },
+        "supports_path_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Path Ids",
+          "type": "array"
+        },
+        "supports_subject_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Subject Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "evidence",
+        "source_class",
+        "relevance"
+      ],
+      "title": "InvestigationEvidenceEntry",
+      "type": "object"
+    },
+    "MissingSource": {
+      "additionalProperties": false,
+      "description": "A source the investigation wanted and did not get.",
+      "properties": {
+        "impact": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Impact",
+          "type": "string"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        },
+        "state": {
+          "$ref": "#/$defs/SourceRequirementState"
+        }
+      },
+      "required": [
+        "source_class",
+        "state",
+        "impact"
+      ],
+      "title": "MissingSource",
+      "type": "object"
+    },
+    "PacketLimitation": {
+      "additionalProperties": false,
+      "description": "One safe, closed-vocabulary limitation the packet is disclosing.",
+      "properties": {
+        "detail": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Detail",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/PacketLimitationKind"
+        }
+      },
+      "required": [
+        "kind",
+        "detail"
+      ],
+      "title": "PacketLimitation",
+      "type": "object"
+    },
+    "PacketLimitationKind": {
+      "enum": [
+        "missing_source",
+        "stale_source",
+        "conflicting_evidence",
+        "authorization_filtered",
+        "truncated_traversal",
+        "absent_staffing_denominator",
+        "historical_slice_not_comparable",
+        "interpretation_uncertainty"
+      ],
+      "title": "PacketLimitationKind",
+      "type": "string"
+    },
+    "RelevanceState": {
+      "description": "Whether a node, path, driver or evidence item is *currently* relevant.",
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "RelevanceState",
+      "type": "string"
+    },
+    "SourceClass": {
+      "description": "The closed platform vocabulary of investigable source classes.\n\nA *source class* names a kind of platform data an investigation step can\ndraw on. It is deliberately a closed enum rather than an ``OpaqueID``,\nbecause the same token is what ``dev_coverage``'s\n``unavailable_required_sources``/``stale_required_sources`` disclose on a\n**denied** answer (see ``validators.NO_ANSWER_FRAME_FIELD_POLICY``):\nadversarial review round 3 used the free-form ``OpaqueID`` shape to smuggle\na subject-derived identifier (``\"private/Nightfall\"``) out through a frame\nwhose every other field was correctly empty. A closed vocabulary means the\ncoverage counts stay answerable for a denial while carrying nothing a\nproducer chose.\n\nAdding a source class is therefore a deliberate contract change, not an\nincidental string: a new adapter must add its member here (and regenerate\nthe exported schemas) before it can appear on the wire.",
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "SourceClass",
+      "type": "string"
+    },
+    "SourceConflict": {
+      "additionalProperties": false,
+      "description": "Two or more evidence items that disagree.",
+      "properties": {
+        "conflict_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Conflict Id",
+          "type": "string"
+        },
+        "description": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "minItems": 2,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "resolution": {
+          "$ref": "#/$defs/ConflictResolution"
+        }
+      },
+      "required": [
+        "conflict_id",
+        "evidence_ref_ids",
+        "description",
+        "resolution"
+      ],
+      "title": "SourceConflict",
+      "type": "object"
+    },
+    "SourceHealthObservation": {
+      "additionalProperties": false,
+      "description": "The observed state of one source class during the investigation.",
+      "properties": {
+        "detail": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Detail"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        },
+        "state": {
+          "$ref": "#/$defs/SourceRequirementState"
+        }
+      },
+      "required": [
+        "source_class",
+        "state"
+      ],
+      "title": "SourceHealthObservation",
+      "type": "object"
+    },
+    "SourceRequirementState": {
+      "description": "Per-source fulfillment state (CHAOS-3294 deliverable list, verbatim).\n\nDistinct from ``dev_source_requirement.v1.requirement_level`` (the\na-priori ``mandatory | conditional | optional | not_applicable``\ndeclaration): this enum is the *observed*, executed outcome recorded on\n``dev_source_observation.v1.observed_state`` once a plan step actually\nran. Kept in ``base`` because both the plan and result contract modules\nreference it (the plan's applicability rules describe which states are\nacceptable; the result records which state was actually observed).",
+      "enum": [
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated"
+      ],
+      "title": "SourceRequirementState",
+      "type": "string"
+    },
+    "TruncationReason": {
+      "enum": [
+        "path_budget",
+        "node_budget",
+        "cohort_budget",
+        "evidence_budget",
+        "time_budget",
+        "authorization_filter",
+        "source_unavailable"
+      ],
+      "title": "TruncationReason",
+      "type": "string"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_evidence_coverage.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "The evidence index, what was missing, and what the packet cannot say.",
+  "properties": {
+    "authorization_filtered_count": {
+      "minimum": 0,
+      "title": "Authorization Filtered Count",
+      "type": "integer"
+    },
+    "clarification_needs": {
+      "items": {
+        "$ref": "#/$defs/ClarificationNeed"
+      },
+      "maxItems": 10,
+      "title": "Clarification Needs",
+      "type": "array"
+    },
+    "conflicts": {
+      "items": {
+        "$ref": "#/$defs/SourceConflict"
+      },
+      "maxItems": 25,
+      "title": "Conflicts",
+      "type": "array"
+    },
+    "evidence_index": {
+      "items": {
+        "$ref": "#/$defs/InvestigationEvidenceEntry"
+      },
+      "maxItems": 200,
+      "title": "Evidence Index",
+      "type": "array"
+    },
+    "evidence_truncated": {
+      "title": "Evidence Truncated",
+      "type": "boolean"
+    },
+    "limitations": {
+      "items": {
+        "$ref": "#/$defs/PacketLimitation"
+      },
+      "maxItems": 25,
+      "title": "Limitations",
+      "type": "array"
+    },
+    "missing_sources": {
+      "items": {
+        "$ref": "#/$defs/MissingSource"
+      },
+      "maxItems": 25,
+      "title": "Missing Sources",
+      "type": "array"
+    },
+    "schema_version": {
+      "const": "ask_dev_evidence_coverage.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "source_health": {
+      "items": {
+        "$ref": "#/$defs/SourceHealthObservation"
+      },
+      "maxItems": 25,
+      "title": "Source Health",
+      "type": "array"
+    },
+    "truncation_reason": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TruncationReason"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "schema_version",
+    "authorization_filtered_count",
+    "evidence_truncated"
+  ],
+  "title": "EvidenceCoverage",
+  "type": "object"
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_packet.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_packet.v1.schema.json
@@ -1,0 +1,2256 @@
+{
+  "$defs": {
+    "AnalyticalJob": {
+      "additionalProperties": false,
+      "description": "The normalized analytical job, with its uncertainty stated.\n\n``job_uncertainty`` is what keeps this contract from requiring a\npre-enumerated intent: an arm may declare a broad job it is uncertain\nabout and still investigate, provided it says so. The\n``question_family`` is a *family*, not an enumerated intent \u2014 ten of\nthem cover the whole trial, and one of them is \"clarification and safe\nno-match\".",
+      "properties": {
+        "comparison_shape": {
+          "$ref": "#/$defs/ComparisonShape"
+        },
+        "conversation_reference_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Conversation Reference Ids",
+          "type": "array"
+        },
+        "interpretation_limitations": {
+          "items": {
+            "$ref": "#/$defs/PacketLimitation"
+          },
+          "maxItems": 25,
+          "title": "Interpretation Limitations",
+          "type": "array"
+        },
+        "job_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Job Id",
+          "type": "string"
+        },
+        "job_statement": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Job Statement",
+          "type": "string"
+        },
+        "job_uncertainty": {
+          "$ref": "#/$defs/JobUncertainty"
+        },
+        "question_family": {
+          "$ref": "#/$defs/QuestionFamilyID"
+        },
+        "schema_version": {
+          "const": "ask_dev_analytical_job.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "surface_context_refs": {
+          "items": {
+            "$ref": "#/$defs/SurfaceContextRef"
+          },
+          "maxItems": 10,
+          "title": "Surface Context Refs",
+          "type": "array"
+        },
+        "time_context": {
+          "$ref": "#/$defs/BoundedTimeContext"
+        }
+      },
+      "required": [
+        "schema_version",
+        "job_id",
+        "question_family",
+        "job_uncertainty",
+        "job_statement",
+        "comparison_shape",
+        "time_context"
+      ],
+      "title": "AnalyticalJob",
+      "type": "object"
+    },
+    "AnalyticalSlice": {
+      "description": "Current-versus-historical slice of the investigation.\n\nSlice boundaries, and what each slice requires of edge validity, are\ndeclared once in :mod:`.allowlists` (``SLICE_BOUNDARIES``).",
+      "enum": [
+        "current",
+        "historical",
+        "current_vs_historical"
+      ],
+      "title": "AnalyticalSlice",
+      "type": "string"
+    },
+    "AssertionBasis": {
+      "description": "Measured, source-asserted and inferred distinctions.\n\nThe governing rule is \"the graph determines what is relevant; canonical\nservices determine what is measurable\". ``MEASURED`` therefore means a\ncanonical Ops service produced the number and minted evidence for it;\n``SOURCE_ASSERTED`` means a provider (or a human in a provider field)\nsaid so; ``INFERRED`` means the investigation concluded it. Only\n``MEASURED`` may be presented as certain.",
+      "enum": [
+        "measured",
+        "source_asserted",
+        "inferred"
+      ],
+      "title": "AssertionBasis",
+      "type": "string"
+    },
+    "BoundedTimeContext": {
+      "additionalProperties": false,
+      "description": "The bounded time window, and which slice of history it addresses.",
+      "properties": {
+        "analytical_slice": {
+          "$ref": "#/$defs/AnalyticalSlice"
+        },
+        "as_of": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "As Of"
+        },
+        "end": {
+          "format": "date-time",
+          "title": "End",
+          "type": "string"
+        },
+        "historical_comparability": {
+          "$ref": "#/$defs/HistoricalComparability"
+        },
+        "start": {
+          "format": "date-time",
+          "title": "Start",
+          "type": "string"
+        },
+        "timezone": {
+          "maxLength": 64,
+          "minLength": 1,
+          "title": "Timezone",
+          "type": "string"
+        }
+      },
+      "required": [
+        "start",
+        "end",
+        "timezone",
+        "analytical_slice",
+        "historical_comparability"
+      ],
+      "title": "BoundedTimeContext",
+      "type": "object"
+    },
+    "ClarificationNeed": {
+      "additionalProperties": false,
+      "description": "A question the investigation needs answered before it can proceed.",
+      "properties": {
+        "candidate_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Candidate Ids",
+          "type": "array"
+        },
+        "kind": {
+          "$ref": "#/$defs/ClarificationNeedKind"
+        },
+        "prompt": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "prompt"
+      ],
+      "title": "ClarificationNeed",
+      "type": "object"
+    },
+    "ClarificationNeedKind": {
+      "enum": [
+        "ambiguous_subject",
+        "missing_time_context",
+        "missing_comparison_basis",
+        "unresolved_conversational_reference",
+        "unsupported_by_available_sources"
+      ],
+      "title": "ClarificationNeedKind",
+      "type": "string"
+    },
+    "CohortCompleteness": {
+      "enum": [
+        "complete",
+        "truncated",
+        "best_effort_uncertain"
+      ],
+      "title": "CohortCompleteness",
+      "type": "string"
+    },
+    "CohortEvidenceClassification": {
+      "description": "Closed reasons a cohort member may carry no evidence handle.\n\nThe same \"evidence refs XOR an explicit no-evidence classification \u2014\nnever both, never neither\" pattern as\n``contracts_v2.embedded.MetricEvidenceClassification`` and\n``contracts_v2.deficiency.DeficiencyEvidenceClassification``, applied to\ncohort membership here.",
+      "enum": [
+        "explicitly_named_by_question",
+        "canonical_registry_membership"
+      ],
+      "title": "CohortEvidenceClassification",
+      "type": "string"
+    },
+    "CohortExclusion": {
+      "additionalProperties": false,
+      "description": "A subject considered for the cohort and deliberately left out.",
+      "properties": {
+        "canonical_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Canonical Id",
+          "type": "string"
+        },
+        "rationale": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Rationale",
+          "type": "string"
+        },
+        "reason": {
+          "$ref": "#/$defs/CohortExclusionReason"
+        },
+        "subject_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "subject_kind",
+        "canonical_id",
+        "reason",
+        "rationale"
+      ],
+      "title": "CohortExclusion",
+      "type": "object"
+    },
+    "CohortExclusionReason": {
+      "enum": [
+        "out_of_authorized_scope",
+        "insufficient_evidence",
+        "not_comparable_slice",
+        "archived_or_inactive",
+        "truncation_budget",
+        "ambiguous_identity",
+        "excluded_by_question"
+      ],
+      "title": "CohortExclusionReason",
+      "type": "string"
+    },
+    "CohortInclusionBasis": {
+      "description": "Why a subject is in the comparison cohort.\n\nThere is deliberately no ``unspecified`` member and the field is\n``min_length=1``: \"an unrelated project appears in the cohort\" is a named\nfault mode, and the cheapest way for an arm to commit it is to include a\nmember with no stated basis at all.",
+      "enum": [
+        "explicitly_named",
+        "shared_dependency",
+        "shared_team_ownership",
+        "same_portfolio",
+        "same_initiative",
+        "comparable_delivery_profile",
+        "peer_of_named_subject"
+      ],
+      "title": "CohortInclusionBasis",
+      "type": "string"
+    },
+    "CohortMember": {
+      "additionalProperties": false,
+      "description": "A subject in the comparison cohort, with its inclusion justified.",
+      "properties": {
+        "canonical_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Canonical Id",
+          "type": "string"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "inclusion_basis": {
+          "items": {
+            "$ref": "#/$defs/CohortInclusionBasis"
+          },
+          "maxItems": 5,
+          "minItems": 1,
+          "title": "Inclusion Basis",
+          "type": "array"
+        },
+        "inclusion_evidence_classification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CohortEvidenceClassification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "inclusion_evidence_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Inclusion Evidence Ids",
+          "type": "array"
+        },
+        "inclusion_rationale": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Inclusion Rationale",
+          "type": "string"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "subject_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "subject_kind",
+        "canonical_id",
+        "display_label",
+        "inclusion_basis",
+        "inclusion_rationale",
+        "relevance"
+      ],
+      "title": "CohortMember",
+      "type": "object"
+    },
+    "ComparisonCohort": {
+      "additionalProperties": false,
+      "description": "The comparison cohort, its exclusions, and how complete it is.",
+      "properties": {
+        "authorization_filtered_count": {
+          "minimum": 0,
+          "title": "Authorization Filtered Count",
+          "type": "integer"
+        },
+        "cohort_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Cohort Id",
+          "type": "string"
+        },
+        "cohort_uncertainty": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cohort Uncertainty"
+        },
+        "comparison_shape": {
+          "$ref": "#/$defs/ComparisonShape"
+        },
+        "completeness": {
+          "$ref": "#/$defs/CohortCompleteness"
+        },
+        "exclusions": {
+          "items": {
+            "$ref": "#/$defs/CohortExclusion"
+          },
+          "maxItems": 50,
+          "title": "Exclusions",
+          "type": "array"
+        },
+        "members": {
+          "items": {
+            "$ref": "#/$defs/CohortMember"
+          },
+          "maxItems": 50,
+          "title": "Members",
+          "type": "array"
+        },
+        "schema_version": {
+          "const": "ask_dev_comparison_cohort.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "supported_comparison_dimensions": {
+          "items": {
+            "$ref": "#/$defs/ComparisonDimension"
+          },
+          "maxItems": 12,
+          "title": "Supported Comparison Dimensions",
+          "type": "array"
+        },
+        "truncation_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruncationReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schema_version",
+        "cohort_id",
+        "comparison_shape",
+        "completeness",
+        "authorization_filtered_count"
+      ],
+      "title": "ComparisonCohort",
+      "type": "object"
+    },
+    "ComparisonDimension": {
+      "description": "Axes a cohort may be compared on.\n\nEvery member is a *unit-of-work or system* axis. None is per-person, and\nnone may be derived per-person: person-level productivity, workload and\nstaffing ranking is prohibited outright, and this enum is one of the two\nstructural places that ban is enforced (the other being the absence of a\nperson member on :class:`InvestigationSubjectKind`).",
+      "enum": [
+        "delivery_throughput",
+        "cycle_time",
+        "review_load",
+        "work_in_progress",
+        "dependency_exposure",
+        "incident_load",
+        "deployment_frequency",
+        "investment_mix",
+        "open_deficiency_count",
+        "status_declaration_gap",
+        "capacity_load_ratio",
+        "data_coverage"
+      ],
+      "title": "ComparisonDimension",
+      "type": "string"
+    },
+    "ComparisonShape": {
+      "description": "The requested comparison or singular-subject shape.",
+      "enum": [
+        "singular_subject",
+        "explicit_cohort",
+        "discovered_cohort",
+        "portfolio_wide",
+        "organization_wide"
+      ],
+      "title": "ComparisonShape",
+      "type": "string"
+    },
+    "ConfidenceQualifier": {
+      "enum": [
+        "measured_certain",
+        "qualified",
+        "uncertain",
+        "unsupported"
+      ],
+      "title": "ConfidenceQualifier",
+      "type": "string"
+    },
+    "ConflictResolution": {
+      "enum": [
+        "unresolved",
+        "resolved_by_precedence",
+        "resolved_by_recency",
+        "deferred_to_canonical_service"
+      ],
+      "title": "ConflictResolution",
+      "type": "string"
+    },
+    "DevCitationLink": {
+      "additionalProperties": false,
+      "properties": {
+        "internal_path": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "pattern": "^/[^\\s]*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Internal Path"
+        },
+        "source_url": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Url"
+        }
+      },
+      "title": "DevCitationLink",
+      "type": "object"
+    },
+    "DevEvidenceFlags": {
+      "additionalProperties": false,
+      "properties": {
+        "conflicting": {
+          "default": false,
+          "title": "Conflicting",
+          "type": "boolean"
+        },
+        "deleted": {
+          "default": false,
+          "title": "Deleted",
+          "type": "boolean"
+        },
+        "redacted": {
+          "default": false,
+          "title": "Redacted",
+          "type": "boolean"
+        },
+        "stale": {
+          "default": false,
+          "title": "Stale",
+          "type": "boolean"
+        },
+        "unavailable": {
+          "default": false,
+          "title": "Unavailable",
+          "type": "boolean"
+        },
+        "uncertain": {
+          "default": false,
+          "title": "Uncertain",
+          "type": "boolean"
+        },
+        "untrusted_content": {
+          "default": true,
+          "title": "Untrusted Content",
+          "type": "boolean"
+        }
+      },
+      "title": "DevEvidenceFlags",
+      "type": "object"
+    },
+    "DevEvidenceRefV2": {
+      "additionalProperties": false,
+      "properties": {
+        "citation_text": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Citation Text"
+        },
+        "confidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "entity_type": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Type",
+          "type": "string"
+        },
+        "evidence_ref_id": {
+          "maxLength": 44,
+          "minLength": 44,
+          "pattern": "^ev1_[0-9a-f]{40}$",
+          "title": "Evidence Ref Id",
+          "type": "string"
+        },
+        "flags": {
+          "$ref": "#/$defs/DevEvidenceFlags"
+        },
+        "freshness": {
+          "$ref": "#/$defs/FreshnessState"
+        },
+        "link": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevCitationLink"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "observed_at": {
+          "format": "date-time",
+          "title": "Observed At",
+          "type": "string"
+        },
+        "provenance": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Provenance",
+          "type": "string"
+        },
+        "repository_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Repository Ids",
+          "type": "array"
+        },
+        "schema_version": {
+          "const": "dev_evidence_ref.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "source_system": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Source System",
+          "type": "string"
+        },
+        "source_version": {
+          "maxLength": 128,
+          "minLength": 1,
+          "title": "Source Version",
+          "type": "string"
+        },
+        "valid_entity_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Valid Entity Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "evidence_ref_id",
+        "source_system",
+        "source_version",
+        "entity_type",
+        "entity_id",
+        "display_label",
+        "observed_at",
+        "freshness",
+        "provenance",
+        "confidence",
+        "flags"
+      ],
+      "title": "DevEvidenceRefV2",
+      "type": "object"
+    },
+    "DriverAnalysis": {
+      "additionalProperties": false,
+      "description": "Every driver candidate, and which of them are principal.",
+      "properties": {
+        "candidates": {
+          "items": {
+            "$ref": "#/$defs/DriverCandidate"
+          },
+          "maxItems": 50,
+          "title": "Candidates",
+          "type": "array"
+        },
+        "candidates_truncated": {
+          "title": "Candidates Truncated",
+          "type": "boolean"
+        },
+        "principal_driver_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Principal Driver Ids",
+          "type": "array"
+        },
+        "schema_version": {
+          "const": "ask_dev_driver_analysis.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "truncation_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruncationReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schema_version",
+        "candidates_truncated"
+      ],
+      "title": "DriverAnalysis",
+      "type": "object"
+    },
+    "DriverCandidate": {
+      "additionalProperties": false,
+      "description": "A candidate driver, its standing, and everything that standing rests on.",
+      "properties": {
+        "affected_subject_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 50,
+          "minItems": 1,
+          "title": "Affected Subject Ids",
+          "type": "array"
+        },
+        "assertion_basis": {
+          "$ref": "#/$defs/AssertionBasis"
+        },
+        "category": {
+          "$ref": "#/$defs/DriverCategory"
+        },
+        "confidence_qualifier": {
+          "$ref": "#/$defs/ConfidenceQualifier"
+        },
+        "conflict_note": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Conflict Note"
+        },
+        "conflicting_evidence_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Conflicting Evidence Ids",
+          "type": "array"
+        },
+        "driver_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Driver Id",
+          "type": "string"
+        },
+        "exclusion_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DriverExclusionReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "role": {
+          "$ref": "#/$defs/DriverRole"
+        },
+        "staffing_qualification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StaffingQualification"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "standing": {
+          "$ref": "#/$defs/DriverStanding"
+        },
+        "summary": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Summary",
+          "type": "string"
+        },
+        "supporting_evidence_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Supporting Evidence Ids",
+          "type": "array"
+        },
+        "supporting_path_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supporting Path Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "driver_id",
+        "category",
+        "summary",
+        "affected_subject_ids",
+        "role",
+        "standing",
+        "assertion_basis",
+        "confidence_qualifier",
+        "relevance"
+      ],
+      "title": "DriverCandidate",
+      "type": "object"
+    },
+    "DriverCategory": {
+      "enum": [
+        "delivery_pressure",
+        "review_pressure",
+        "operational_pressure",
+        "dependency_pressure",
+        "investment_mix",
+        "capacity_or_staffing",
+        "scope_change",
+        "quality_or_defect",
+        "external_blocker",
+        "data_coverage"
+      ],
+      "title": "DriverCategory",
+      "type": "string"
+    },
+    "DriverExclusionReason": {
+      "description": "Why a candidate did not reach principal-driver standing.",
+      "enum": [
+        "no_supporting_path",
+        "evidence_conflict_unresolved",
+        "not_currently_relevant",
+        "symptom_of_another_candidate",
+        "unauthorized_evidence",
+        "insufficient_measurement"
+      ],
+      "title": "DriverExclusionReason",
+      "type": "string"
+    },
+    "DriverRole": {
+      "description": "Symptom-versus-driver classification.\n\n``CONTEXTUAL_CORRELATE`` is the honest third option: something that moved\nat the same time and is worth reporting but is neither the cause nor a\nconsequence. Collapsing it into ``DRIVER`` is precisely how unsupported\nattribution enters an answer.",
+      "enum": [
+        "driver",
+        "symptom",
+        "contextual_correlate"
+      ],
+      "title": "DriverRole",
+      "type": "string"
+    },
+    "DriverStanding": {
+      "enum": [
+        "principal_driver",
+        "contributing_driver",
+        "candidate_only",
+        "excluded"
+      ],
+      "title": "DriverStanding",
+      "type": "string"
+    },
+    "EvidenceCoverage": {
+      "additionalProperties": false,
+      "description": "The evidence index, what was missing, and what the packet cannot say.",
+      "properties": {
+        "authorization_filtered_count": {
+          "minimum": 0,
+          "title": "Authorization Filtered Count",
+          "type": "integer"
+        },
+        "clarification_needs": {
+          "items": {
+            "$ref": "#/$defs/ClarificationNeed"
+          },
+          "maxItems": 10,
+          "title": "Clarification Needs",
+          "type": "array"
+        },
+        "conflicts": {
+          "items": {
+            "$ref": "#/$defs/SourceConflict"
+          },
+          "maxItems": 25,
+          "title": "Conflicts",
+          "type": "array"
+        },
+        "evidence_index": {
+          "items": {
+            "$ref": "#/$defs/InvestigationEvidenceEntry"
+          },
+          "maxItems": 200,
+          "title": "Evidence Index",
+          "type": "array"
+        },
+        "evidence_truncated": {
+          "title": "Evidence Truncated",
+          "type": "boolean"
+        },
+        "limitations": {
+          "items": {
+            "$ref": "#/$defs/PacketLimitation"
+          },
+          "maxItems": 25,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "missing_sources": {
+          "items": {
+            "$ref": "#/$defs/MissingSource"
+          },
+          "maxItems": 25,
+          "title": "Missing Sources",
+          "type": "array"
+        },
+        "schema_version": {
+          "const": "ask_dev_evidence_coverage.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "source_health": {
+          "items": {
+            "$ref": "#/$defs/SourceHealthObservation"
+          },
+          "maxItems": 25,
+          "title": "Source Health",
+          "type": "array"
+        },
+        "truncation_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruncationReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schema_version",
+        "authorization_filtered_count",
+        "evidence_truncated"
+      ],
+      "title": "EvidenceCoverage",
+      "type": "object"
+    },
+    "FreshnessState": {
+      "enum": [
+        "fresh",
+        "stale",
+        "unavailable",
+        "unknown"
+      ],
+      "title": "FreshnessState",
+      "type": "string"
+    },
+    "HistoricalComparability": {
+      "description": "Whether a historical slice can be fairly compared at all.\n\n``NOT_COMPARABLE_MISSING_EDGE_VALIDITY`` is the CHAOS-3569 state: native\nhistorical edge validity is not implemented, so as-of traversal cannot\nbe reconstructed for those rows. The correction plan is explicit that\nsuch rows are **NOT COMPARABLE, not blockers** \u2014 a packet that declares\nthis state is still a *valid* packet and may still be ``SUPPORTED``\n(pinned by ``test_not_comparable_historical_slice_is_valid_and_\nsupported``). What it may not do is stay silent: the packet must also\ncarry a ``HISTORICAL_SLICE_NOT_COMPARABLE`` limitation.",
+      "enum": [
+        "not_applicable",
+        "comparable",
+        "not_comparable_missing_edge_validity",
+        "not_comparable_missing_baseline"
+      ],
+      "title": "HistoricalComparability",
+      "type": "string"
+    },
+    "InvestigationEvidenceEntry": {
+      "additionalProperties": false,
+      "description": "One evidence item, and what in this packet it actually supports.",
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/DevEvidenceRefV2"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        },
+        "supports_driver_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Driver Ids",
+          "type": "array"
+        },
+        "supports_entity_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Entity Ids",
+          "type": "array"
+        },
+        "supports_path_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Path Ids",
+          "type": "array"
+        },
+        "supports_subject_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Supports Subject Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "evidence",
+        "source_class",
+        "relevance"
+      ],
+      "title": "InvestigationEvidenceEntry",
+      "type": "object"
+    },
+    "InvestigationOutcome": {
+      "description": "What the investigation concluded \u2014 *not* what the user is told.\n\nDeliberately distinct from ``contracts_v2.base.PublicOutcome``: that\nenum is the public answer-envelope vocabulary of an Ask Dev answer, and\nreusing it here would make the packet look like an answer. A packet is\nan input to the Ask Dev frame, never a substitute for it.",
+      "enum": [
+        "supported",
+        "supported_with_gaps",
+        "needs_clarification",
+        "no_match",
+        "unsupported"
+      ],
+      "title": "InvestigationOutcome",
+      "type": "string"
+    },
+    "InvestigationSubjectKind": {
+      "description": "What an investigation may take as a subject, cohort member or node.\n\nA superset of the *organizational* kinds an Ask Dev question can name,\nand a strict subset of \"anything in the work graph\": there is no person\nkind, by design (see the module docstring). ``EntityKind``\n(``contracts_v2.base``) is the answer-frame subject vocabulary and is\ndeliberately not reused here \u2014 it carries ``pull_request``/``issue`` as\n*subjects* of a status answer, whereas this enum has to describe\nportfolio, initiative and service nodes that a status answer never takes\nas its subject but a lineage path routinely crosses.",
+      "enum": [
+        "team",
+        "project",
+        "portfolio",
+        "initiative",
+        "repository",
+        "service",
+        "work_unit",
+        "issue",
+        "pull_request",
+        "dependency"
+      ],
+      "title": "InvestigationSubjectKind",
+      "type": "string"
+    },
+    "InvestigationVersions": {
+      "additionalProperties": false,
+      "description": "Every version an investigation result is reproducible against.",
+      "properties": {
+        "corpus_version": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 3,
+              "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Corpus Version"
+        },
+        "packet_schema_version": {
+          "const": "ask_dev_investigation_packet.v1",
+          "title": "Packet Schema Version",
+          "type": "string"
+        },
+        "projection_version": {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "title": "Projection Version",
+          "type": "string"
+        },
+        "query_version": {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "title": "Query Version",
+          "type": "string"
+        },
+        "ranking_version": {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "title": "Ranking Version",
+          "type": "string"
+        },
+        "schema_version": {
+          "const": "ask_dev_investigation_versions.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "source_contract_versions": {
+          "items": {
+            "$ref": "#/$defs/SourceContractVersion"
+          },
+          "maxItems": 25,
+          "minItems": 1,
+          "title": "Source Contract Versions",
+          "type": "array"
+        },
+        "trial": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TrialMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schema_version",
+        "packet_schema_version",
+        "query_version",
+        "ranking_version",
+        "projection_version",
+        "source_contract_versions"
+      ],
+      "title": "InvestigationVersions",
+      "type": "object"
+    },
+    "JobUncertainty": {
+      "description": "How precisely the analytical job could be interpreted.\n\n``BROAD_WITH_UNCERTAINTY`` exists because the correction addendum bans\nrequiring a fully pre-enumerated intent before investigation may begin:\n\"what is going sideways?\" is a legitimate job whose subject set is\ndiscovered, not declared. A broad or ambiguous job must carry at least\none interpretation limitation, which is what stops the state from being\na free pass.",
+      "enum": [
+        "precise",
+        "broad_with_uncertainty",
+        "ambiguous"
+      ],
+      "title": "JobUncertainty",
+      "type": "string"
+    },
+    "LineageHop": {
+      "additionalProperties": false,
+      "description": "One traversed edge.\n\n``source_entity_id`` is always the entity traversal started from and\n``target_entity_id`` the entity it arrived at; ``direction`` says whether\nthat traversal followed the relationship's canonical orientation or ran\nagainst it. Separating traversal order from canonical orientation is\nwhat makes a reversed relationship detectable at all \u2014 with a single\ncombined field, \"team owns project\" and \"project owned by team\" are the\nsame bytes.",
+      "properties": {
+        "direction": {
+          "$ref": "#/$defs/RelationshipDirection"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "relationship": {
+          "$ref": "#/$defs/RelationshipType"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "source_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Source Entity Id",
+          "type": "string"
+        },
+        "source_entity_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        },
+        "target_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Target Entity Id",
+          "type": "string"
+        },
+        "target_entity_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "source_entity_id",
+        "source_entity_kind",
+        "relationship",
+        "direction",
+        "target_entity_id",
+        "target_entity_kind",
+        "relevance"
+      ],
+      "title": "LineageHop",
+      "type": "object"
+    },
+    "LineagePath": {
+      "additionalProperties": false,
+      "description": "A bounded chain of hops, and why it was included.",
+      "properties": {
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "hops": {
+          "items": {
+            "$ref": "#/$defs/LineageHop"
+          },
+          "maxItems": 6,
+          "minItems": 1,
+          "title": "Hops",
+          "type": "array"
+        },
+        "inclusion_reason": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Inclusion Reason",
+          "type": "string"
+        },
+        "origin_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Origin Entity Id",
+          "type": "string"
+        },
+        "path_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Path Id",
+          "type": "string"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "source_health": {
+          "$ref": "#/$defs/SourceRequirementState"
+        },
+        "terminal_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Terminal Entity Id",
+          "type": "string"
+        },
+        "truncated": {
+          "title": "Truncated",
+          "type": "boolean"
+        },
+        "truncation_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruncationReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "path_id",
+        "origin_entity_id",
+        "terminal_entity_id",
+        "hops",
+        "inclusion_reason",
+        "relevance",
+        "truncated",
+        "source_health"
+      ],
+      "title": "LineagePath",
+      "type": "object"
+    },
+    "MissingSource": {
+      "additionalProperties": false,
+      "description": "A source the investigation wanted and did not get.",
+      "properties": {
+        "impact": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Impact",
+          "type": "string"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        },
+        "state": {
+          "$ref": "#/$defs/SourceRequirementState"
+        }
+      },
+      "required": [
+        "source_class",
+        "state",
+        "impact"
+      ],
+      "title": "MissingSource",
+      "type": "object"
+    },
+    "PacketLimitation": {
+      "additionalProperties": false,
+      "description": "One safe, closed-vocabulary limitation the packet is disclosing.",
+      "properties": {
+        "detail": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Detail",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/PacketLimitationKind"
+        }
+      },
+      "required": [
+        "kind",
+        "detail"
+      ],
+      "title": "PacketLimitation",
+      "type": "object"
+    },
+    "PacketLimitationKind": {
+      "enum": [
+        "missing_source",
+        "stale_source",
+        "conflicting_evidence",
+        "authorization_filtered",
+        "truncated_traversal",
+        "absent_staffing_denominator",
+        "historical_slice_not_comparable",
+        "interpretation_uncertainty"
+      ],
+      "title": "PacketLimitationKind",
+      "type": "string"
+    },
+    "QuestionFamilyID": {
+      "description": "The ten frozen families of the corrected trial.",
+      "enum": [
+        "struggling_teams",
+        "pressure_signals",
+        "project_capacity",
+        "staffing_language",
+        "project_status_drivers",
+        "portfolio_dependency_risk",
+        "declared_versus_actual",
+        "ambiguous_identity",
+        "colloquial_follow_up",
+        "clarification_and_no_match"
+      ],
+      "title": "QuestionFamilyID",
+      "type": "string"
+    },
+    "RelatedContext": {
+      "additionalProperties": false,
+      "description": "Related entities, the paths that reach them, and the authorized set.",
+      "properties": {
+        "authorization_filtered_count": {
+          "minimum": 0,
+          "title": "Authorization Filtered Count",
+          "type": "integer"
+        },
+        "authorized_entity_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 500,
+          "title": "Authorized Entity Ids",
+          "type": "array"
+        },
+        "entities": {
+          "items": {
+            "$ref": "#/$defs/RelatedEntity"
+          },
+          "maxItems": 100,
+          "title": "Entities",
+          "type": "array"
+        },
+        "entities_truncated": {
+          "title": "Entities Truncated",
+          "type": "boolean"
+        },
+        "paths": {
+          "items": {
+            "$ref": "#/$defs/LineagePath"
+          },
+          "maxItems": 100,
+          "title": "Paths",
+          "type": "array"
+        },
+        "paths_truncated": {
+          "title": "Paths Truncated",
+          "type": "boolean"
+        },
+        "schema_version": {
+          "const": "ask_dev_related_context.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "truncation_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruncationReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schema_version",
+        "authorization_filtered_count",
+        "entities_truncated",
+        "paths_truncated"
+      ],
+      "title": "RelatedContext",
+      "type": "object"
+    },
+    "RelatedEntity": {
+      "additionalProperties": false,
+      "description": "A canonical entity the investigation pulled in, and its justification.\n\n``supporting_path_ids`` is ``min_length=1``: an entity nothing connects\nto the subject is not related context, it is noise that displaces the\nlineage actually asked for.",
+      "properties": {
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "entity_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        },
+        "inclusion_reason": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Inclusion Reason",
+          "type": "string"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "supporting_path_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "minItems": 1,
+          "title": "Supporting Path Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "entity_id",
+        "entity_kind",
+        "display_label",
+        "inclusion_reason",
+        "supporting_path_ids",
+        "relevance"
+      ],
+      "title": "RelatedEntity",
+      "type": "object"
+    },
+    "RelationshipDirection": {
+      "description": "Which way a hop was traversed relative to the relationship's own\ncanonical orientation (declared in :mod:`.relationships`).\n\nA hop that claims ``FORWARD`` while its endpoint kinds match only the\nreverse orientation is exactly the named \"a relationship is reversed\"\nfault, and is rejected by ``LineageHop.validate_direction_matches_\nallowlist``.",
+      "enum": [
+        "forward",
+        "reverse"
+      ],
+      "title": "RelationshipDirection",
+      "type": "string"
+    },
+    "RelationshipType": {
+      "description": "The closed technical relationship vocabulary for the trial.",
+      "enum": [
+        "depends_on",
+        "blocked_by",
+        "owned_by_team",
+        "contributes_to",
+        "parent_of",
+        "implemented_by",
+        "reviews",
+        "deploys",
+        "operates",
+        "references",
+        "belongs_to_portfolio",
+        "shares_dependency_with"
+      ],
+      "title": "RelationshipType",
+      "type": "string"
+    },
+    "RelevanceState": {
+      "description": "Whether a node, path, driver or evidence item is *currently* relevant.",
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "RelevanceState",
+      "type": "string"
+    },
+    "SourceClass": {
+      "description": "The closed platform vocabulary of investigable source classes.\n\nA *source class* names a kind of platform data an investigation step can\ndraw on. It is deliberately a closed enum rather than an ``OpaqueID``,\nbecause the same token is what ``dev_coverage``'s\n``unavailable_required_sources``/``stale_required_sources`` disclose on a\n**denied** answer (see ``validators.NO_ANSWER_FRAME_FIELD_POLICY``):\nadversarial review round 3 used the free-form ``OpaqueID`` shape to smuggle\na subject-derived identifier (``\"private/Nightfall\"``) out through a frame\nwhose every other field was correctly empty. A closed vocabulary means the\ncoverage counts stay answerable for a denial while carrying nothing a\nproducer chose.\n\nAdding a source class is therefore a deliberate contract change, not an\nincidental string: a new adapter must add its member here (and regenerate\nthe exported schemas) before it can appear on the wire.",
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "SourceClass",
+      "type": "string"
+    },
+    "SourceConflict": {
+      "additionalProperties": false,
+      "description": "Two or more evidence items that disagree.",
+      "properties": {
+        "conflict_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Conflict Id",
+          "type": "string"
+        },
+        "description": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        },
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "minItems": 2,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "resolution": {
+          "$ref": "#/$defs/ConflictResolution"
+        }
+      },
+      "required": [
+        "conflict_id",
+        "evidence_ref_ids",
+        "description",
+        "resolution"
+      ],
+      "title": "SourceConflict",
+      "type": "object"
+    },
+    "SourceContractVersion": {
+      "additionalProperties": false,
+      "description": "Which version of a source's own contract the investigation read.",
+      "properties": {
+        "contract_version": {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "title": "Contract Version",
+          "type": "string"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        }
+      },
+      "required": [
+        "source_class",
+        "contract_version"
+      ],
+      "title": "SourceContractVersion",
+      "type": "object"
+    },
+    "SourceHealthObservation": {
+      "additionalProperties": false,
+      "description": "The observed state of one source class during the investigation.",
+      "properties": {
+        "detail": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Detail"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        },
+        "state": {
+          "$ref": "#/$defs/SourceRequirementState"
+        }
+      },
+      "required": [
+        "source_class",
+        "state"
+      ],
+      "title": "SourceHealthObservation",
+      "type": "object"
+    },
+    "SourceRequirementState": {
+      "description": "Per-source fulfillment state (CHAOS-3294 deliverable list, verbatim).\n\nDistinct from ``dev_source_requirement.v1.requirement_level`` (the\na-priori ``mandatory | conditional | optional | not_applicable``\ndeclaration): this enum is the *observed*, executed outcome recorded on\n``dev_source_observation.v1.observed_state`` once a plan step actually\nran. Kept in ``base`` because both the plan and result contract modules\nreference it (the plan's applicability rules describe which states are\nacceptable; the result records which state was actually observed).",
+      "enum": [
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated"
+      ],
+      "title": "SourceRequirementState",
+      "type": "string"
+    },
+    "StaffingDenominatorState": {
+      "description": "How much allocation evidence backs a capacity/staffing claim.\n\nThe correction addendum is explicit on both halves of this: a missing\ndenominator must **reduce confidence and require qualification**, and it\nmust **not automatically make capacity questions unsupported**. Both\nhalves are pinned by tests \u2014 ``DENOMINATOR_ABSENT`` with a\n``MEASURED_CERTAIN`` qualifier is rejected, and ``DENOMINATOR_ABSENT``\nwith a ``QUALIFIED`` qualifier is accepted.",
+      "enum": [
+        "allocation_evidence_available",
+        "partial_allocation_evidence",
+        "denominator_absent"
+      ],
+      "title": "StaffingDenominatorState",
+      "type": "string"
+    },
+    "StaffingQualification": {
+      "additionalProperties": false,
+      "description": "How much allocation evidence stands behind a capacity claim.",
+      "properties": {
+        "denominator_source_classes": {
+          "items": {
+            "$ref": "#/$defs/SourceClass"
+          },
+          "maxItems": 10,
+          "title": "Denominator Source Classes",
+          "type": "array"
+        },
+        "denominator_state": {
+          "$ref": "#/$defs/StaffingDenominatorState"
+        },
+        "qualification_note": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Qualification Note",
+          "type": "string"
+        }
+      },
+      "required": [
+        "denominator_state",
+        "qualification_note"
+      ],
+      "title": "StaffingQualification",
+      "type": "object"
+    },
+    "SubjectCandidate": {
+      "additionalProperties": false,
+      "description": "One candidate canonical subject and why it is a candidate.\n\n``match_signals`` is ``min_length=1``: a ranked candidate with no stated\nsignal is the shape in which a wrong-but-similarly-named project reaches\nrank 1 unexaminably.",
+      "properties": {
+        "candidate_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Candidate Id",
+          "type": "string"
+        },
+        "canonical_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Canonical Id",
+          "type": "string"
+        },
+        "commitment_state": {
+          "$ref": "#/$defs/SubjectCommitmentState"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "match_confidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Match Confidence",
+          "type": "number"
+        },
+        "match_rationale": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Match Rationale",
+          "type": "string"
+        },
+        "match_signals": {
+          "items": {
+            "$ref": "#/$defs/SubjectMatchEvidence"
+          },
+          "maxItems": 10,
+          "minItems": 1,
+          "title": "Match Signals",
+          "type": "array"
+        },
+        "rank": {
+          "maximum": 25,
+          "minimum": 1,
+          "title": "Rank",
+          "type": "integer"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "subject_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "candidate_id",
+        "rank",
+        "subject_kind",
+        "canonical_id",
+        "display_label",
+        "commitment_state",
+        "match_rationale",
+        "match_signals",
+        "match_confidence",
+        "relevance"
+      ],
+      "title": "SubjectCandidate",
+      "type": "object"
+    },
+    "SubjectCommitmentState": {
+      "description": "Proposed-versus-committed subject state.\n\n``PROPOSED`` is the normal state during discovery, and the correction\naddendum is explicit that *exact subject commitment must not be a\nprerequisite for authorized candidate and context discovery* \u2014 so a\npacket with zero committed subjects and a populated related-context\nsection is legal, and\n``test_chaos_3615_packet_contract.py::\ntest_discovery_without_any_commitment_is_legal`` pins that.",
+      "enum": [
+        "proposed",
+        "committed",
+        "rejected",
+        "ambiguous"
+      ],
+      "title": "SubjectCommitmentState",
+      "type": "string"
+    },
+    "SubjectDiscovery": {
+      "additionalProperties": false,
+      "description": "Candidate subjects, what was committed, and what stayed unresolved.\n\nCommitment is *not* a prerequisite for the rest of the packet: a\ndiscovery section with zero committed subjects is legal and is exercised\nby a positive fixture, because the correction addendum forbids requiring\nexact subject commitment before authorized context discovery.",
+      "properties": {
+        "authorization_filtered_count": {
+          "minimum": 0,
+          "title": "Authorization Filtered Count",
+          "type": "integer"
+        },
+        "candidates": {
+          "items": {
+            "$ref": "#/$defs/SubjectCandidate"
+          },
+          "maxItems": 25,
+          "title": "Candidates",
+          "type": "array"
+        },
+        "candidates_truncated": {
+          "title": "Candidates Truncated",
+          "type": "boolean"
+        },
+        "committed_subject_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Committed Subject Ids",
+          "type": "array"
+        },
+        "schema_version": {
+          "const": "ask_dev_subject_discovery.v1",
+          "title": "Schema Version",
+          "type": "string"
+        },
+        "truncation_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruncationReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "unresolved_mentions": {
+          "items": {
+            "$ref": "#/$defs/UnresolvedMention"
+          },
+          "maxItems": 10,
+          "title": "Unresolved Mentions",
+          "type": "array"
+        }
+      },
+      "required": [
+        "schema_version",
+        "authorization_filtered_count",
+        "candidates_truncated"
+      ],
+      "title": "SubjectDiscovery",
+      "type": "object"
+    },
+    "SubjectMatchEvidence": {
+      "additionalProperties": false,
+      "description": "What matched, and what backs the claim that it matched.",
+      "properties": {
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "matched_text": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Matched Text",
+          "type": "string"
+        },
+        "signal": {
+          "$ref": "#/$defs/SubjectMatchSignal"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        }
+      },
+      "required": [
+        "signal",
+        "matched_text",
+        "source_class"
+      ],
+      "title": "SubjectMatchEvidence",
+      "type": "object"
+    },
+    "SubjectMatchSignal": {
+      "description": "What actually caused a candidate to match the question's reference.\n\nThis is the anti-drift vocabulary for fault mode\n``wrong_but_similar_subject_ranked_first``: a candidate cannot be\ncommitted on ``FUZZY_LABEL`` alone, because a similarly-named project is\nexactly what fuzzy label matching returns.",
+      "enum": [
+        "exact_canonical_id",
+        "exact_display_name",
+        "alias",
+        "acronym",
+        "previous_name",
+        "provider_identifier",
+        "conversational_reference",
+        "surface_context_reference",
+        "fuzzy_label"
+      ],
+      "title": "SubjectMatchSignal",
+      "type": "string"
+    },
+    "SurfaceContextRef": {
+      "additionalProperties": false,
+      "description": "A safe reference to the surface or conversation the question came from.\n\nDeliberately three closed/opaque fields and no URL: see\n``vocabulary.SurfaceKind``.",
+      "properties": {
+        "entity_id": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Entity Id"
+        },
+        "entity_kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InvestigationSubjectKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "surface_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Surface Id",
+          "type": "string"
+        },
+        "surface_kind": {
+          "$ref": "#/$defs/SurfaceKind"
+        }
+      },
+      "required": [
+        "surface_kind",
+        "surface_id"
+      ],
+      "title": "SurfaceContextRef",
+      "type": "object"
+    },
+    "SurfaceKind": {
+      "description": "Safe surface/conversation context references.\n\nClosed rather than free text on purpose: a surface reference is the one\nfield on an investigation packet whose natural implementation is \"paste\nthe URL the user was looking at\", and a URL is both an unbounded\ndisclosure channel and the exact shape of a dashboard redirect.",
+      "enum": [
+        "dashboard",
+        "project_page",
+        "team_page",
+        "portfolio_page",
+        "report",
+        "conversation"
+      ],
+      "title": "SurfaceKind",
+      "type": "string"
+    },
+    "TrialMetadata": {
+      "additionalProperties": false,
+      "description": "Evaluation metadata \u2014 never product truth.\n\nArm identity lives here and only here, and the field that holds it is\noptional on :class:`InvestigationVersions`. That is the structural\nstatement of \"arm identity should be evaluation metadata\": a native\npacket is complete without it, no consumer may branch on it, and no\nfield anywhere in this contract is mandatory only for one arm.",
+      "properties": {
+        "arm_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Arm Id",
+          "type": "string"
+        },
+        "fixture_version": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 3,
+              "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fixture Version"
+        },
+        "producer_id": {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "title": "Producer Id",
+          "type": "string"
+        },
+        "run_id": {
+          "anyOf": [
+            {
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Run Id"
+        }
+      },
+      "required": [
+        "arm_id",
+        "producer_id"
+      ],
+      "title": "TrialMetadata",
+      "type": "object"
+    },
+    "TruncationReason": {
+      "enum": [
+        "path_budget",
+        "node_budget",
+        "cohort_budget",
+        "evidence_budget",
+        "time_budget",
+        "authorization_filter",
+        "source_unavailable"
+      ],
+      "title": "TruncationReason",
+      "type": "string"
+    },
+    "UnresolvedMention": {
+      "additionalProperties": false,
+      "description": "A reference in the question that discovery could not resolve.",
+      "properties": {
+        "candidate_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Candidate Ids",
+          "type": "array"
+        },
+        "mention_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Mention Id",
+          "type": "string"
+        },
+        "mention_text": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Mention Text",
+          "type": "string"
+        },
+        "reason": {
+          "$ref": "#/$defs/UnresolvedMentionReason"
+        }
+      },
+      "required": [
+        "mention_id",
+        "mention_text",
+        "reason"
+      ],
+      "title": "UnresolvedMention",
+      "type": "object"
+    },
+    "UnresolvedMentionReason": {
+      "enum": [
+        "no_candidate",
+        "multiple_candidates",
+        "authorization_filtered",
+        "out_of_scope"
+      ],
+      "title": "UnresolvedMentionReason",
+      "type": "string"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_investigation_packet.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A bounded, authorized, backend-neutral investigation result.\n\nNot a final user answer, not a dashboard response, not a graph-native\nquery response, not an LLM reasoning trace, not arbitrary traversal\noutput. It is the input the Ask Dev frame reasons over, and the artifact\nboth trial arms are scored on.",
+  "properties": {
+    "analytical_job": {
+      "$ref": "#/$defs/AnalyticalJob"
+    },
+    "comparison_cohort": {
+      "$ref": "#/$defs/ComparisonCohort"
+    },
+    "driver_analysis": {
+      "$ref": "#/$defs/DriverAnalysis"
+    },
+    "evidence_coverage": {
+      "$ref": "#/$defs/EvidenceCoverage"
+    },
+    "organization_id": {
+      "maxLength": 128,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+      "title": "Organization Id",
+      "type": "string"
+    },
+    "outcome": {
+      "$ref": "#/$defs/InvestigationOutcome"
+    },
+    "packet_id": {
+      "maxLength": 36,
+      "minLength": 36,
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "title": "Packet Id",
+      "type": "string"
+    },
+    "produced_at": {
+      "format": "date-time",
+      "title": "Produced At",
+      "type": "string"
+    },
+    "related_context": {
+      "$ref": "#/$defs/RelatedContext"
+    },
+    "schema_version": {
+      "const": "ask_dev_investigation_packet.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "subject_discovery": {
+      "$ref": "#/$defs/SubjectDiscovery"
+    },
+    "versions": {
+      "$ref": "#/$defs/InvestigationVersions"
+    }
+  },
+  "required": [
+    "schema_version",
+    "packet_id",
+    "organization_id",
+    "produced_at",
+    "outcome",
+    "analytical_job",
+    "subject_discovery",
+    "comparison_cohort",
+    "related_context",
+    "driver_analysis",
+    "evidence_coverage",
+    "versions"
+  ],
+  "title": "AskDevInvestigationPacket",
+  "type": "object"
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_packet.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_packet.v1.schema.json
@@ -114,6 +114,9 @@
           "default": null,
           "title": "As Of"
         },
+        "edge_validity_basis": {
+          "$ref": "#/$defs/EdgeValidityBasis"
+        },
         "end": {
           "format": "date-time",
           "title": "End",
@@ -139,7 +142,8 @@
         "end",
         "timezone",
         "analytical_slice",
-        "historical_comparability"
+        "historical_comparability",
+        "edge_validity_basis"
       ],
       "title": "BoundedTimeContext",
       "type": "object"
@@ -918,6 +922,16 @@
         "excluded"
       ],
       "title": "DriverStanding",
+      "type": "string"
+    },
+    "EdgeValidityBasis": {
+      "description": "What backs a slice's claim that its relationships were valid *then*.\n\nAdded after adversarial review round 1 (finding M7). ``SLICE_BOUNDARIES``\ndeclared that historical slices require edge validity, but nothing on the\nwire recorded whether an arm actually had it \u2014 so a packet could label a\nhistorical slice ``COMPARABLE`` while having read the live projection,\nproducing a confident and entirely false delta.\n\n``NOT_REQUIRED`` is the current slice. ``OBSERVED_INTERVALS`` means every\ntraversed edge carried a validity interval covering the as-of instant, and\nis the only basis on which a historical slice may be ``COMPARABLE``.\n``UNAVAILABLE`` is the CHAOS-3569 state and forces\n``NOT_COMPARABLE_MISSING_EDGE_VALIDITY``.",
+      "enum": [
+        "not_required",
+        "observed_intervals",
+        "unavailable"
+      ],
+      "title": "EdgeValidityBasis",
       "type": "string"
     },
     "EvidenceCoverage": {

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_versions.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_versions.v1.schema.json
@@ -1,0 +1,188 @@
+{
+  "$defs": {
+    "SourceClass": {
+      "description": "The closed platform vocabulary of investigable source classes.\n\nA *source class* names a kind of platform data an investigation step can\ndraw on. It is deliberately a closed enum rather than an ``OpaqueID``,\nbecause the same token is what ``dev_coverage``'s\n``unavailable_required_sources``/``stale_required_sources`` disclose on a\n**denied** answer (see ``validators.NO_ANSWER_FRAME_FIELD_POLICY``):\nadversarial review round 3 used the free-form ``OpaqueID`` shape to smuggle\na subject-derived identifier (``\"private/Nightfall\"``) out through a frame\nwhose every other field was correctly empty. A closed vocabulary means the\ncoverage counts stay answerable for a denial while carrying nothing a\nproducer chose.\n\nAdding a source class is therefore a deliberate contract change, not an\nincidental string: a new adapter must add its member here (and regenerate\nthe exported schemas) before it can appear on the wire.",
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "SourceClass",
+      "type": "string"
+    },
+    "SourceContractVersion": {
+      "additionalProperties": false,
+      "description": "Which version of a source's own contract the investigation read.",
+      "properties": {
+        "contract_version": {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "title": "Contract Version",
+          "type": "string"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        }
+      },
+      "required": [
+        "source_class",
+        "contract_version"
+      ],
+      "title": "SourceContractVersion",
+      "type": "object"
+    },
+    "TrialMetadata": {
+      "additionalProperties": false,
+      "description": "Evaluation metadata \u2014 never product truth.\n\nArm identity lives here and only here, and the field that holds it is\noptional on :class:`InvestigationVersions`. That is the structural\nstatement of \"arm identity should be evaluation metadata\": a native\npacket is complete without it, no consumer may branch on it, and no\nfield anywhere in this contract is mandatory only for one arm.",
+      "properties": {
+        "arm_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Arm Id",
+          "type": "string"
+        },
+        "fixture_version": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 3,
+              "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fixture Version"
+        },
+        "producer_id": {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "title": "Producer Id",
+          "type": "string"
+        },
+        "run_id": {
+          "anyOf": [
+            {
+              "maxLength": 36,
+              "minLength": 36,
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Run Id"
+        }
+      },
+      "required": [
+        "arm_id",
+        "producer_id"
+      ],
+      "title": "TrialMetadata",
+      "type": "object"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_investigation_versions.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Every version an investigation result is reproducible against.",
+  "properties": {
+    "corpus_version": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 3,
+          "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Corpus Version"
+    },
+    "packet_schema_version": {
+      "const": "ask_dev_investigation_packet.v1",
+      "title": "Packet Schema Version",
+      "type": "string"
+    },
+    "projection_version": {
+      "maxLength": 128,
+      "minLength": 3,
+      "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+      "title": "Projection Version",
+      "type": "string"
+    },
+    "query_version": {
+      "maxLength": 128,
+      "minLength": 3,
+      "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+      "title": "Query Version",
+      "type": "string"
+    },
+    "ranking_version": {
+      "maxLength": 128,
+      "minLength": 3,
+      "pattern": "^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)*\\.v\\d+(?:\\.\\d+)*$",
+      "title": "Ranking Version",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "ask_dev_investigation_versions.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "source_contract_versions": {
+      "items": {
+        "$ref": "#/$defs/SourceContractVersion"
+      },
+      "maxItems": 25,
+      "minItems": 1,
+      "title": "Source Contract Versions",
+      "type": "array"
+    },
+    "trial": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TrialMetadata"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "schema_version",
+    "packet_schema_version",
+    "query_version",
+    "ranking_version",
+    "projection_version",
+    "source_contract_versions"
+  ],
+  "title": "InvestigationVersions",
+  "type": "object"
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_related_context.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_related_context.v1.schema.json
@@ -1,0 +1,369 @@
+{
+  "$defs": {
+    "InvestigationSubjectKind": {
+      "description": "What an investigation may take as a subject, cohort member or node.\n\nA superset of the *organizational* kinds an Ask Dev question can name,\nand a strict subset of \"anything in the work graph\": there is no person\nkind, by design (see the module docstring). ``EntityKind``\n(``contracts_v2.base``) is the answer-frame subject vocabulary and is\ndeliberately not reused here \u2014 it carries ``pull_request``/``issue`` as\n*subjects* of a status answer, whereas this enum has to describe\nportfolio, initiative and service nodes that a status answer never takes\nas its subject but a lineage path routinely crosses.",
+      "enum": [
+        "team",
+        "project",
+        "portfolio",
+        "initiative",
+        "repository",
+        "service",
+        "work_unit",
+        "issue",
+        "pull_request",
+        "dependency"
+      ],
+      "title": "InvestigationSubjectKind",
+      "type": "string"
+    },
+    "LineageHop": {
+      "additionalProperties": false,
+      "description": "One traversed edge.\n\n``source_entity_id`` is always the entity traversal started from and\n``target_entity_id`` the entity it arrived at; ``direction`` says whether\nthat traversal followed the relationship's canonical orientation or ran\nagainst it. Separating traversal order from canonical orientation is\nwhat makes a reversed relationship detectable at all \u2014 with a single\ncombined field, \"team owns project\" and \"project owned by team\" are the\nsame bytes.",
+      "properties": {
+        "direction": {
+          "$ref": "#/$defs/RelationshipDirection"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "relationship": {
+          "$ref": "#/$defs/RelationshipType"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "source_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Source Entity Id",
+          "type": "string"
+        },
+        "source_entity_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        },
+        "target_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Target Entity Id",
+          "type": "string"
+        },
+        "target_entity_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "source_entity_id",
+        "source_entity_kind",
+        "relationship",
+        "direction",
+        "target_entity_id",
+        "target_entity_kind",
+        "relevance"
+      ],
+      "title": "LineageHop",
+      "type": "object"
+    },
+    "LineagePath": {
+      "additionalProperties": false,
+      "description": "A bounded chain of hops, and why it was included.",
+      "properties": {
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "hops": {
+          "items": {
+            "$ref": "#/$defs/LineageHop"
+          },
+          "maxItems": 6,
+          "minItems": 1,
+          "title": "Hops",
+          "type": "array"
+        },
+        "inclusion_reason": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Inclusion Reason",
+          "type": "string"
+        },
+        "origin_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Origin Entity Id",
+          "type": "string"
+        },
+        "path_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Path Id",
+          "type": "string"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "source_health": {
+          "$ref": "#/$defs/SourceRequirementState"
+        },
+        "terminal_entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Terminal Entity Id",
+          "type": "string"
+        },
+        "truncated": {
+          "title": "Truncated",
+          "type": "boolean"
+        },
+        "truncation_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruncationReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "path_id",
+        "origin_entity_id",
+        "terminal_entity_id",
+        "hops",
+        "inclusion_reason",
+        "relevance",
+        "truncated",
+        "source_health"
+      ],
+      "title": "LineagePath",
+      "type": "object"
+    },
+    "RelatedEntity": {
+      "additionalProperties": false,
+      "description": "A canonical entity the investigation pulled in, and its justification.\n\n``supporting_path_ids`` is ``min_length=1``: an entity nothing connects\nto the subject is not related context, it is noise that displaces the\nlineage actually asked for.",
+      "properties": {
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "entity_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Entity Id",
+          "type": "string"
+        },
+        "entity_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        },
+        "inclusion_reason": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Inclusion Reason",
+          "type": "string"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "supporting_path_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "minItems": 1,
+          "title": "Supporting Path Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "entity_id",
+        "entity_kind",
+        "display_label",
+        "inclusion_reason",
+        "supporting_path_ids",
+        "relevance"
+      ],
+      "title": "RelatedEntity",
+      "type": "object"
+    },
+    "RelationshipDirection": {
+      "description": "Which way a hop was traversed relative to the relationship's own\ncanonical orientation (declared in :mod:`.relationships`).\n\nA hop that claims ``FORWARD`` while its endpoint kinds match only the\nreverse orientation is exactly the named \"a relationship is reversed\"\nfault, and is rejected by ``LineageHop.validate_direction_matches_\nallowlist``.",
+      "enum": [
+        "forward",
+        "reverse"
+      ],
+      "title": "RelationshipDirection",
+      "type": "string"
+    },
+    "RelationshipType": {
+      "description": "The closed technical relationship vocabulary for the trial.",
+      "enum": [
+        "depends_on",
+        "blocked_by",
+        "owned_by_team",
+        "contributes_to",
+        "parent_of",
+        "implemented_by",
+        "reviews",
+        "deploys",
+        "operates",
+        "references",
+        "belongs_to_portfolio",
+        "shares_dependency_with"
+      ],
+      "title": "RelationshipType",
+      "type": "string"
+    },
+    "RelevanceState": {
+      "description": "Whether a node, path, driver or evidence item is *currently* relevant.",
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "RelevanceState",
+      "type": "string"
+    },
+    "SourceRequirementState": {
+      "description": "Per-source fulfillment state (CHAOS-3294 deliverable list, verbatim).\n\nDistinct from ``dev_source_requirement.v1.requirement_level`` (the\na-priori ``mandatory | conditional | optional | not_applicable``\ndeclaration): this enum is the *observed*, executed outcome recorded on\n``dev_source_observation.v1.observed_state`` once a plan step actually\nran. Kept in ``base`` because both the plan and result contract modules\nreference it (the plan's applicability rules describe which states are\nacceptable; the result records which state was actually observed).",
+      "enum": [
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated"
+      ],
+      "title": "SourceRequirementState",
+      "type": "string"
+    },
+    "TruncationReason": {
+      "enum": [
+        "path_budget",
+        "node_budget",
+        "cohort_budget",
+        "evidence_budget",
+        "time_budget",
+        "authorization_filter",
+        "source_unavailable"
+      ],
+      "title": "TruncationReason",
+      "type": "string"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_related_context.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Related entities, the paths that reach them, and the authorized set.",
+  "properties": {
+    "authorization_filtered_count": {
+      "minimum": 0,
+      "title": "Authorization Filtered Count",
+      "type": "integer"
+    },
+    "authorized_entity_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+        "type": "string"
+      },
+      "maxItems": 500,
+      "title": "Authorized Entity Ids",
+      "type": "array"
+    },
+    "entities": {
+      "items": {
+        "$ref": "#/$defs/RelatedEntity"
+      },
+      "maxItems": 100,
+      "title": "Entities",
+      "type": "array"
+    },
+    "entities_truncated": {
+      "title": "Entities Truncated",
+      "type": "boolean"
+    },
+    "paths": {
+      "items": {
+        "$ref": "#/$defs/LineagePath"
+      },
+      "maxItems": 100,
+      "title": "Paths",
+      "type": "array"
+    },
+    "paths_truncated": {
+      "title": "Paths Truncated",
+      "type": "boolean"
+    },
+    "schema_version": {
+      "const": "ask_dev_related_context.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "truncation_reason": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TruncationReason"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "schema_version",
+    "authorization_filtered_count",
+    "entities_truncated",
+    "paths_truncated"
+  ],
+  "title": "RelatedContext",
+  "type": "object"
+}

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_subject_discovery.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_subject_discovery.v1.schema.json
@@ -1,0 +1,323 @@
+{
+  "$defs": {
+    "InvestigationSubjectKind": {
+      "description": "What an investigation may take as a subject, cohort member or node.\n\nA superset of the *organizational* kinds an Ask Dev question can name,\nand a strict subset of \"anything in the work graph\": there is no person\nkind, by design (see the module docstring). ``EntityKind``\n(``contracts_v2.base``) is the answer-frame subject vocabulary and is\ndeliberately not reused here \u2014 it carries ``pull_request``/``issue`` as\n*subjects* of a status answer, whereas this enum has to describe\nportfolio, initiative and service nodes that a status answer never takes\nas its subject but a lineage path routinely crosses.",
+      "enum": [
+        "team",
+        "project",
+        "portfolio",
+        "initiative",
+        "repository",
+        "service",
+        "work_unit",
+        "issue",
+        "pull_request",
+        "dependency"
+      ],
+      "title": "InvestigationSubjectKind",
+      "type": "string"
+    },
+    "RelevanceState": {
+      "description": "Whether a node, path, driver or evidence item is *currently* relevant.",
+      "enum": [
+        "current",
+        "recently_current",
+        "historical_only",
+        "unknown"
+      ],
+      "title": "RelevanceState",
+      "type": "string"
+    },
+    "SourceClass": {
+      "description": "The closed platform vocabulary of investigable source classes.\n\nA *source class* names a kind of platform data an investigation step can\ndraw on. It is deliberately a closed enum rather than an ``OpaqueID``,\nbecause the same token is what ``dev_coverage``'s\n``unavailable_required_sources``/``stale_required_sources`` disclose on a\n**denied** answer (see ``validators.NO_ANSWER_FRAME_FIELD_POLICY``):\nadversarial review round 3 used the free-form ``OpaqueID`` shape to smuggle\na subject-derived identifier (``\"private/Nightfall\"``) out through a frame\nwhose every other field was correctly empty. A closed vocabulary means the\ncoverage counts stay answerable for a denial while carrying nothing a\nproducer chose.\n\nAdding a source class is therefore a deliberate contract change, not an\nincidental string: a new adapter must add its member here (and regenerate\nthe exported schemas) before it can appear on the wire.",
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "SourceClass",
+      "type": "string"
+    },
+    "SubjectCandidate": {
+      "additionalProperties": false,
+      "description": "One candidate canonical subject and why it is a candidate.\n\n``match_signals`` is ``min_length=1``: a ranked candidate with no stated\nsignal is the shape in which a wrong-but-similarly-named project reaches\nrank 1 unexaminably.",
+      "properties": {
+        "candidate_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Candidate Id",
+          "type": "string"
+        },
+        "canonical_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Canonical Id",
+          "type": "string"
+        },
+        "commitment_state": {
+          "$ref": "#/$defs/SubjectCommitmentState"
+        },
+        "display_label": {
+          "maxLength": 256,
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "match_confidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Match Confidence",
+          "type": "number"
+        },
+        "match_rationale": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Match Rationale",
+          "type": "string"
+        },
+        "match_signals": {
+          "items": {
+            "$ref": "#/$defs/SubjectMatchEvidence"
+          },
+          "maxItems": 10,
+          "minItems": 1,
+          "title": "Match Signals",
+          "type": "array"
+        },
+        "rank": {
+          "maximum": 25,
+          "minimum": 1,
+          "title": "Rank",
+          "type": "integer"
+        },
+        "relevance": {
+          "$ref": "#/$defs/RelevanceState"
+        },
+        "subject_kind": {
+          "$ref": "#/$defs/InvestigationSubjectKind"
+        }
+      },
+      "required": [
+        "candidate_id",
+        "rank",
+        "subject_kind",
+        "canonical_id",
+        "display_label",
+        "commitment_state",
+        "match_rationale",
+        "match_signals",
+        "match_confidence",
+        "relevance"
+      ],
+      "title": "SubjectCandidate",
+      "type": "object"
+    },
+    "SubjectCommitmentState": {
+      "description": "Proposed-versus-committed subject state.\n\n``PROPOSED`` is the normal state during discovery, and the correction\naddendum is explicit that *exact subject commitment must not be a\nprerequisite for authorized candidate and context discovery* \u2014 so a\npacket with zero committed subjects and a populated related-context\nsection is legal, and\n``test_chaos_3615_packet_contract.py::\ntest_discovery_without_any_commitment_is_legal`` pins that.",
+      "enum": [
+        "proposed",
+        "committed",
+        "rejected",
+        "ambiguous"
+      ],
+      "title": "SubjectCommitmentState",
+      "type": "string"
+    },
+    "SubjectMatchEvidence": {
+      "additionalProperties": false,
+      "description": "What matched, and what backs the claim that it matched.",
+      "properties": {
+        "evidence_ref_ids": {
+          "items": {
+            "maxLength": 44,
+            "minLength": 44,
+            "pattern": "^ev1_[0-9a-f]{40}$",
+            "type": "string"
+          },
+          "maxItems": 10,
+          "title": "Evidence Ref Ids",
+          "type": "array"
+        },
+        "matched_text": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Matched Text",
+          "type": "string"
+        },
+        "signal": {
+          "$ref": "#/$defs/SubjectMatchSignal"
+        },
+        "source_class": {
+          "$ref": "#/$defs/SourceClass"
+        }
+      },
+      "required": [
+        "signal",
+        "matched_text",
+        "source_class"
+      ],
+      "title": "SubjectMatchEvidence",
+      "type": "object"
+    },
+    "SubjectMatchSignal": {
+      "description": "What actually caused a candidate to match the question's reference.\n\nThis is the anti-drift vocabulary for fault mode\n``wrong_but_similar_subject_ranked_first``: a candidate cannot be\ncommitted on ``FUZZY_LABEL`` alone, because a similarly-named project is\nexactly what fuzzy label matching returns.",
+      "enum": [
+        "exact_canonical_id",
+        "exact_display_name",
+        "alias",
+        "acronym",
+        "previous_name",
+        "provider_identifier",
+        "conversational_reference",
+        "surface_context_reference",
+        "fuzzy_label"
+      ],
+      "title": "SubjectMatchSignal",
+      "type": "string"
+    },
+    "TruncationReason": {
+      "enum": [
+        "path_budget",
+        "node_budget",
+        "cohort_budget",
+        "evidence_budget",
+        "time_budget",
+        "authorization_filter",
+        "source_unavailable"
+      ],
+      "title": "TruncationReason",
+      "type": "string"
+    },
+    "UnresolvedMention": {
+      "additionalProperties": false,
+      "description": "A reference in the question that discovery could not resolve.",
+      "properties": {
+        "candidate_ids": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+            "type": "string"
+          },
+          "maxItems": 25,
+          "title": "Candidate Ids",
+          "type": "array"
+        },
+        "mention_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Mention Id",
+          "type": "string"
+        },
+        "mention_text": {
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Mention Text",
+          "type": "string"
+        },
+        "reason": {
+          "$ref": "#/$defs/UnresolvedMentionReason"
+        }
+      },
+      "required": [
+        "mention_id",
+        "mention_text",
+        "reason"
+      ],
+      "title": "UnresolvedMention",
+      "type": "object"
+    },
+    "UnresolvedMentionReason": {
+      "enum": [
+        "no_candidate",
+        "multiple_candidates",
+        "authorization_filtered",
+        "out_of_scope"
+      ],
+      "title": "UnresolvedMentionReason",
+      "type": "string"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1/ask_dev_subject_discovery.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Candidate subjects, what was committed, and what stayed unresolved.\n\nCommitment is *not* a prerequisite for the rest of the packet: a\ndiscovery section with zero committed subjects is legal and is exercised\nby a positive fixture, because the correction addendum forbids requiring\nexact subject commitment before authorized context discovery.",
+  "properties": {
+    "authorization_filtered_count": {
+      "minimum": 0,
+      "title": "Authorization Filtered Count",
+      "type": "integer"
+    },
+    "candidates": {
+      "items": {
+        "$ref": "#/$defs/SubjectCandidate"
+      },
+      "maxItems": 25,
+      "title": "Candidates",
+      "type": "array"
+    },
+    "candidates_truncated": {
+      "title": "Candidates Truncated",
+      "type": "boolean"
+    },
+    "committed_subject_ids": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+        "type": "string"
+      },
+      "maxItems": 25,
+      "title": "Committed Subject Ids",
+      "type": "array"
+    },
+    "schema_version": {
+      "const": "ask_dev_subject_discovery.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "truncation_reason": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TruncationReason"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "unresolved_mentions": {
+      "items": {
+        "$ref": "#/$defs/UnresolvedMention"
+      },
+      "maxItems": 10,
+      "title": "Unresolved Mentions",
+      "type": "array"
+    }
+  },
+  "required": [
+    "schema_version",
+    "authorization_filtered_count",
+    "candidates_truncated"
+  ],
+  "title": "SubjectDiscovery",
+  "type": "object"
+}

--- a/docs-data/ia/contribute.tsv
+++ b/docs-data/ia/contribute.tsv
@@ -10,6 +10,7 @@ con-contracts	con-arch	/contribute/architecture/contracts/	Stable contracts and 
 con-ask-dev-v2	con-arch	/contribute/architecture/ask-dev-contracts-v2/	Ask Dev v2 contracts (Wave 3.1)	architecture	true	public	planned	false	
 con-ask-dev-preflight	con-arch	/contribute/architecture/ask-dev-subject-preflight/	Ask Dev subject preflight	architecture	true	public	planned	false	
 con-ask-dev-role-readiness	con-arch	/contribute/architecture/ask-dev-role-readiness/	Ask Dev role readiness	architecture	true	public	planned	false	
+con-ask-dev-investigation-packet	con-arch	/contribute/architecture/ask-dev-investigation-packet/	Ask Dev investigation packet	architecture	true	public	planned	false	
 con-dev	contribute	/contribute/development/	Develop and test	landing	true	public	planned	false	
 con-commands	con-dev	/contribute/development/commands/	Common development commands	task-guide	true	public	planned	false	
 con-tests	con-dev	/contribute/development/testing/	Testing layers and local validation	task-guide	true	public	planned	false	

--- a/docs/contribute/architecture/ask-dev-investigation-packet.md
+++ b/docs/contribute/architecture/ask-dev-investigation-packet.md
@@ -190,14 +190,31 @@ fails if any registered fault mode has no injection case.
 
 ## What this contract cannot check
 
-Three limits are worth stating explicitly, because a reader who believes
-the contract covers them will stop looking.
+Four limits are worth stating explicitly, because a reader who believes the
+contract covers them will stop looking.
 
+- **The generated JSON Schema is structural only.** Pydantic emits
+  `required`/`type`/`enum`/`pattern`/`minItems` and nothing else, so none of
+  the cross-field rules above survive into the schema. Measured, not
+  estimated: **3 of 41** negative fixtures are caught by the schema and 38
+  are not — a consumer that schema-validates and stops would accept a packet
+  that commits to the wrong subject on a fuzzy match, routes a path through
+  an unauthorized entity, or promotes a symptom to principal driver. The
+  canonical validator is the Python model; `manifest.json`'s
+  `validation_policy` says so in the artifact tree itself, and
+  `test_chaos_3615_schema_validator_differential.py` runs both
+  implementations over every fixture and pins exactly which each one catches.
+  Hand-encoding the rules into JSON Schema was rejected: it would be the
+  duplicate schema definition the corrective plan forbids, and a second
+  hand-written implementation is precisely the divergence that test exists
+  to detect.
 - **Authorization is producer-declared.** `authorized_entity_ids` comes from
-  the arm, so the guard proves the traversal was consistent with the claim,
-  not that the claim is true. An arm that declared the whole organization
-  authorized would pass. `ZERO_UNAUTHORIZED_RESULTS` must therefore also be
-  scored against a real authorization oracle in CHAOS-3616.
+  the arm, so the guard proves the packet is internally consistent with its
+  own claim, not that the claim is true. An arm that declared the whole
+  organization authorized would pass. `ZERO_UNAUTHORIZED_RESULTS` must
+  therefore also be scored against a real authorization oracle in
+  CHAOS-3616. The check does cover the *whole* packet — subjects, cohort,
+  drivers, evidence and surface refs, not only lineage.
 - **Evidence closure is closure within the packet.** Whether a handle would
   verify against `EvidenceHandleService` is a runtime, org-scoped question;
   the grammar pins the handle's shape and dereferencing pins its validity.

--- a/docs/contribute/architecture/ask-dev-investigation-packet.md
+++ b/docs/contribute/architecture/ask-dev-investigation-packet.md
@@ -1,0 +1,244 @@
+---
+page_id: con-ask-dev-investigation-packet
+summary: The backend-neutral ask_dev_investigation_packet.v1 contract, its question/scoring/fault registries, and the cross-repository ownership map.
+content_type: architecture
+owner: engineering
+source_of_truth:
+  - src/dev_health_ops/api/dev/investigation_contract/
+  - contracts/ask-dev-investigation/v1/
+  - scripts/verify_chaos_3615_fault_mode_guards.py
+  - Correction Addendum -- Graph-assisted Ask Dev intelligence, ambiguity and driver lineage (Linear, project Context Fabric)
+applicability: current
+lifecycle: active
+---
+
+# Ask Dev investigation packet (`ask_dev_investigation_packet.v1`)
+
+CHAOS-3615 freezes one bounded, backend-neutral investigation contract and
+the evaluation framework that goes with it, **before** either arm of the
+corrected CHAOS-3614 trial is implemented. The point is narrow and worth
+stating plainly: if the contract is written after the arms, whichever arm is
+built first defines the questions, the output shape, and the definition of
+success — and the comparison is decided before it is run.
+{: .fc-page-lede }
+
+This page explains what the packet is, what it deliberately is not, how a
+future native arm (CHAOS-3618) and a future graph-assisted arm (CHAOS-3617)
+must use it, and which repository owns which part of it.
+
+## Governing rule
+
+> The graph determines what is relevant; canonical services determine what is
+> measurable; Ask Dev explains what the combined evidence means.
+
+Every design decision below follows from that split. An investigation may
+propose that a dependency stall is the principal driver of a project's
+delay. It may not decide that the project is 40% complete, that a team is
+understaffed, or that a release is ready — those are canonical measurements,
+and the packet carries only references to them, tagged with how they were
+obtained.
+
+## What the packet is, and is not
+
+A packet is an **investigation result**: what was looked for, what was
+found, how well it is supported, and what could not be established. It is
+consumed by the server-owned Ask Dev frame, which synthesizes the answer.
+
+It is explicitly **not** a final user answer, a dashboard response, a
+graph-native query response, an LLM reasoning trace, or arbitrary traversal
+output. Two of those are prevented structurally rather than by convention:
+
+- there is no prose field anywhere on the contract that an assistant would
+  speak — every text field is a bounded rationale, limitation or summary
+  attached to a specific structured claim;
+- a packet whose outcome is `supported` must assert at least one principal
+  or contributing driver, so "here are some links, you work it out" is not a
+  representable success.
+
+## Sections
+
+| Section | Contract | What it carries |
+| --- | --- | --- |
+| Analytical job | `ask_dev_analytical_job.v1` | Normalized job, question family, comparison shape, bounded time context and slice, safe surface/conversation references, interpretation limits |
+| Subject discovery | `ask_dev_subject_discovery.v1` | Ranked candidates with match signals and rationale, proposed vs committed state, unresolved mentions, authorization-filtered count |
+| Comparison cohort | `ask_dev_comparison_cohort.v1` | Members with inclusion basis and rationale, explicit exclusions with reasons, supported comparison dimensions, completeness and uncertainty |
+| Related context | `ask_dev_related_context.v1` | Canonical related entities, bounded lineage paths with per-hop direction and type, the authorized entity set, truncation state |
+| Driver analysis | `ask_dev_driver_analysis.v1` | Driver candidates with symptom-vs-driver role, standing, measured/source-asserted/inferred basis, supporting paths and evidence, conflicts, exclusion reasons |
+| Evidence and coverage | `ask_dev_evidence_coverage.v1` | The evidence index, source health, missing sources, conflicts, limitations, clarification needs |
+| Versions | `ask_dev_investigation_versions.v1` | Schema, query, ranking and projection versions, per-source contract versions, and **optional** trial metadata |
+
+## The five properties that are load-bearing
+
+### 1. Backend neutrality
+
+No graph backend, graph query language, or graph-store concept appears
+anywhere on the wire. Arm identity lives in `TrialMetadata`, which is an
+*optional* field: a native packet is complete without it, no consumer may
+branch on it, and no field anywhere is mandatory for one arm only.
+
+This is checked against the **generated artifacts** — schemas, every
+fixture, every registry file — rather than against the Python source, since
+the artifacts are what a consumer reads. A neutral source that generated a
+leaky schema would pass a source-only scan.
+
+### 2. Commitment is not a prerequisite for discovery
+
+"What teams are currently struggling?" names no subject. An arm that
+requires a committed subject before it will investigate cannot answer that
+family at all, so the contract permits a packet with zero committed
+subjects and a fully populated related-context and driver section. A golden
+variant exercises exactly that.
+
+For the same reason the analytical job carries a `job_uncertainty` of
+`broad_with_uncertainty` or `ambiguous`, with declared interpretation
+limitations. Nothing requires a pre-enumerated intent; what is required is
+that the arm say what it decided the question meant.
+
+### 3. No person is ever a subject
+
+Person-level productivity, health, workload and staffing ranking is
+prohibited, and the prohibition is structural in two independent places:
+`InvestigationSubjectKind` has no person member, and `ComparisonDimension`
+has no per-person axis. A validator could be routed around by a future
+producer; an absent enum member cannot be.
+
+### 4. Missing staffing data qualifies, it never disqualifies
+
+A capacity or staffing driver must carry a `StaffingQualification`, and when
+its denominator is partial or absent the claim may not be presented as
+`measured_certain`. It may still be made, at `qualified` or `uncertain`
+confidence — a golden variant pins that, because a guard that quietly turned
+"qualify" into "refuse" would pass every negative test while making the
+capacity families unanswerable.
+
+### 5. No disclosure field has a reassuring default
+
+Every boolean and every `*_count` on the contract is required with no
+default. The convenient defaults here are all the flattering ones —
+`authorization_filtered_count = 0`, `truncated = False` — so a producer that
+forgot the field would be indistinguishable from one that had nothing to
+disclose. A test derives this from the models themselves rather than from a
+hand-maintained list, so a disclosure field added later cannot dodge it.
+
+## Current versus historical slices
+
+`SLICE_BOUNDARIES` declares what each slice needs. The current slice needs
+no as-of instant and consults no edge-validity interval; it is deliberately
+the slice CHAOS-3569 does not block, because the corrective plan forbids
+blocking current-intelligence discovery on historical-edge modelling.
+
+The historical and current-vs-historical slices need both. CHAOS-3569
+(native historical edge validity) is open, so rows whose edges carry no
+validity interval cannot have their as-of state reconstructed. The ruling is
+that such rows are **NOT COMPARABLE, not blockers**: the packet declares
+`not_comparable_missing_edge_validity`, discloses a
+`historical_slice_not_comparable` limitation, and stays a valid, supported
+investigation. The trial scores that row NOT COMPARABLE rather than failing
+it.
+
+## Registries
+
+Four registries ship as machine-readable JSON under
+`contracts/ask-dev-investigation/v1/registries/`, so CHAOS-3616 can consume
+them without importing Python.
+
+- **Question families** (10). Each declares exact and natural variants,
+  required source classes, required packet sections, applicable scoring
+  dimensions, a staffing-denominator policy and prohibited reductions. The
+  floors — one exact variant, two natural variants, two source classes, two
+  sections, three dimensions — are what make "a family is never one metric
+  and never one prompt" checkable rather than aspirational.
+- **Scoring dimensions** (28). Each names the packet fields it reads and the
+  fault modes it can fail. `reported_per_question_family` and
+  `aggregate_prohibited` are `Literal[True]`, so "do not collapse these into
+  one aggregate score" cannot be flipped by a value change.
+- **Fault modes** (11). The corrective plan's own named bad behaviours. Each
+  says whether the contract rejects it (`contract_validator`, naming the
+  exact validator), whether the field grammar rejects it (`required_field`),
+  or whether it is an oracle judgment CHAOS-3616 must score — and names the
+  test that proves it.
+- **Trial allowlists.** The source classes an arm may draw on with a stated
+  reason for each; the twelve closed technical relationship types with their
+  canonical orientation; the slice boundaries.
+
+The relationship allowlist bounds traversal and gives "a relationship is
+reversed" a definition. It is deliberately **not** a requirement to
+pre-model every human question: these are technical edges between canonical
+entities (a PR implements an issue; a project depends on a service). "Why is
+ACR still not finished?" is answered by composing those edges with canonical
+measurements, not by adding a `why_is_it_not_finished` edge type.
+
+## How the fault-mode guards are proved
+
+`tests/api/dev/test_chaos_3615_fault_modes.py` feeds each validator an
+arm-shaped bad packet — a payload an implementation could plausibly emit,
+differing from the golden only in the behaviour under test — and asserts
+both that it is rejected and that the rejection message came from the
+*named* guard.
+
+That alone would not prove the guard is load-bearing: a payload can be
+caught incidentally by an unrelated field constraint while the real guard is
+missing, and the test would still be green.
+`scripts/verify_chaos_3615_fault_mode_guards.py` closes that gap by
+inverting the experiment. For each of the eleven fault modes it runs a
+subprocess that removes exactly one guard — deleting a single
+`model_validator` and rebuilding the affected schemas, or giving the
+disclosure field the default it does not have — and requires the bad packet
+to then be **accepted**. A guard whose removal changes nothing is not the
+guard the registry claims it is. The script is wired into the suite and
+fails if any registered fault mode has no injection case.
+
+## How a future arm must use this
+
+Both arms are out of scope for CHAOS-3615. When they are authorized:
+
+1. **Emit this packet, unchanged.** An arm that needs a field the contract
+   does not have raises a contract change, not a private extension —
+   `extra="forbid"` makes the private extension impossible anyway.
+2. **Put arm identity in `versions.trial` and nowhere else.** If a consumer
+   would behave differently knowing which arm produced a packet, the
+   comparison is already compromised.
+3. **Draw only on allowlisted sources and relationship types.** Both
+   allowlists are closed; widening either is a reviewed contract change.
+4. **Let canonical services own every measurement.** The graph proposes;
+   `assertion_basis` records which service measured what, and only
+   `measured` may be presented as certain.
+5. **Regenerate artifacts, never hand-edit them.** `python -m
+   dev_health_ops.api.dev.investigation_contract.export write`; the `check`
+   mode compares the whole artifact set and is a test.
+
+## Cross-repository ownership map
+
+| Repository | Owns | Consumes | Rationale |
+| --- | --- | --- | --- |
+| `dev-health-ops` | The contract, its generated artifacts, all four registries, the fixtures and the fault-mode guards. Both future arms and their producers. | Its own `dev_evidence_ref.v1` / `EvidenceHandle` vocabulary, `SourceClass`, `SourceRequirementState`. | The packet is produced by Ask Dev's own investigation path, which is Python and lives here. A graph-assisted arm would use a Python graph library, which is also here. |
+| `dev-health-acr` | Nothing in this contract. | Nothing from it. | ACR's `AGENTS.md` bans Python runtime and contract-checking code outright, and separately bans adding a graph database during SVS. Its `evidence_ref.v1` is a *different* contract from ops' `dev_evidence_ref.v1` despite the similar name; ops imports nothing from ACR's contract tree. |
+| `dev-health-web` | Nothing. | Nothing. | The packet is an internal trial artifact and is never served to a client. No user-visible Ask Dev behaviour changes in this issue. |
+
+### Why the packet does not live under `contracts/ask-dev/v2`
+
+`contracts/ask-dev/v2` is reserved for wire contracts served to real
+clients, and is consumed by web's contract sync. Filing an internal trial
+artifact there would misrepresent it and would put CHAOS-3616 iterations on
+the critical path of a web contract regeneration. The packet gets its own
+root, `contracts/ask-dev-investigation/v1`, with its own exporter instance
+and its own manifest. A test asserts the two registries do not overlap.
+
+### If a Go or TypeScript consumer ever needs this
+
+None does today, so no unused generated types are shipped — a generated type
+nobody compiles is a maintenance cost with no drift-detection value. The
+established vendoring pattern, should one appear, is web's
+`scripts/sync-acr-contracts.mjs`: copy from a pinned source commit, keep an
+explicit path closure, digest every file, and assert currency in CI. This
+packet's exporter already emits the manifest half of that (a sha256 per
+artifact), so a future consumer vendors against the manifest rather than
+re-deriving the schema.
+
+## Out of scope for CHAOS-3615
+
+No Graphiti or other graph-backend implementation. No native comparison arm.
+No trial run, corpus or oracle. No user-visible Ask Dev change. No graph
+data exposed through ACR or MCP. No projection, retention or graph-store
+migration. No corrected ADR. CHAOS-3616 through CHAOS-3621 remain
+unauthorized and must not be self-started from this contract.

--- a/docs/contribute/architecture/ask-dev-investigation-packet.md
+++ b/docs/contribute/architecture/ask-dev-investigation-packet.md
@@ -188,6 +188,26 @@ to then be **accepted**. A guard whose removal changes nothing is not the
 guard the registry claims it is. The script is wired into the suite and
 fails if any registered fault mode has no injection case.
 
+## What this contract cannot check
+
+Three limits are worth stating explicitly, because a reader who believes
+the contract covers them will stop looking.
+
+- **Authorization is producer-declared.** `authorized_entity_ids` comes from
+  the arm, so the guard proves the traversal was consistent with the claim,
+  not that the claim is true. An arm that declared the whole organization
+  authorized would pass. `ZERO_UNAUTHORIZED_RESULTS` must therefore also be
+  scored against a real authorization oracle in CHAOS-3616.
+- **Evidence closure is closure within the packet.** Whether a handle would
+  verify against `EvidenceHandleService` is a runtime, org-scoped question;
+  the grammar pins the handle's shape and dereferencing pins its validity.
+- **Relevance is not correctness.** The contract can require that a cohort
+  member state a basis and a rationale, and that a driver carry lineage and
+  evidence. Whether the member actually belongs, or the driver actually
+  drives, is an oracle judgment — which is exactly why the fault-mode
+  registry distinguishes `contract_validator` from `oracle_judgment` rather
+  than claiming everything is enforced here.
+
 ## How a future arm must use this
 
 Both arms are out of scope for CHAOS-3615. When they are authorized:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -244,6 +244,7 @@ nav:
           - Ask Dev v2 contracts: contribute/architecture/ask-dev-contracts-v2.md
           - Ask Dev subject preflight: contribute/architecture/ask-dev-subject-preflight.md
           - Ask Dev role readiness: contribute/architecture/ask-dev-role-readiness.md
+          - Ask Dev investigation packet: contribute/architecture/ask-dev-investigation-packet.md
       - Develop and test:
           - contribute/development/index.md
           - Commands: contribute/development/commands.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,17 @@ dev = [
   # CHAOS-3034 compatibility probe only. Production Python code must enqueue
   # through the worker_job_outbox fallback unless a compatible client ships.
   "riverqueue==0.7.0",
+  # CHAOS-3615: the differential oracle between the canonical Pydantic
+  # contract and its generated Draft 2020-12 schemas
+  # (tests/api/dev/test_chaos_3615_schema_validator_differential.py). Test
+  # scope only -- no src/ module imports it, because the exporter must stay
+  # runnable without dev extras.
+  "jsonschema>=4.20.0",
+  # Declared rather than left to `mypy --install-types`: the gate's mypy
+  # stage auto-installs stubs, so a missing declaration passes the gate and
+  # then blocks the pre-commit hook (which runs plain `mypy`). Same pattern
+  # as pandas-stubs / types-grpcio above.
+  "types-jsonschema>=4.20.0",
 ]
 enterprise-sso = ["signxml>=3.0.0"]
 

--- a/scripts/verify_chaos_3615_fault_mode_guards.py
+++ b/scripts/verify_chaos_3615_fault_mode_guards.py
@@ -1,0 +1,328 @@
+"""Fault injection proof: every CHAOS-3615 guard is load-bearing.
+
+``tests/api/dev/test_chaos_3615_fault_modes.py`` proves each arm-shaped bad
+packet is *rejected*. That, on its own, is not proof that the named guard is
+what rejects it — a payload could be caught incidentally by an unrelated
+field constraint and the test would still be green with the real guard
+missing. This script closes that gap the only way it can be closed: it
+**removes the named validator and watches the bad packet be accepted.**
+
+For each of the eleven named fault modes it runs one subprocess that:
+
+1. validates the arm-shaped payload against the pristine contract and
+   requires a rejection (baseline);
+2. neutralizes exactly one guard — deleting a single ``model_validator``
+   from ``__pydantic_decorators__`` and rebuilding the affected models, or,
+   for the required-field fault, giving the disclosure field the flattering
+   default it does not have;
+3. validates the same payload again and requires it to be **accepted**.
+
+A guard whose removal changes nothing is not the guard the fault-mode
+registry claims it is, and the script fails.
+
+Subprocess isolation is not decoration: step 2 mutates class-level pydantic
+state, and doing that inside the test process would corrupt every later
+test in the session.
+
+Run it directly::
+
+    python scripts/verify_chaos_3615_fault_mode_guards.py
+
+Exit code 0 means every named guard was observed failing. Any other exit
+code names the case that did not behave as claimed. The script also fails
+if the case table does not cover every fault mode in
+``FAULT_MODE_REGISTRY`` — a fault mode with no injection case would
+otherwise be an unmeasured coverage claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from pydantic import BaseModel, ValidationError
+
+from dev_health_ops.api.dev.investigation_contract import (
+    ALL_FAULT_MODE_IDS,
+    INVESTIGATION_CONTRACT_MODELS,
+    FaultModeID,
+)
+from dev_health_ops.api.dev.investigation_contract import packet as packet_module
+from dev_health_ops.api.dev.investigation_contract.fixtures import negative_fixtures
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class GuardCase(NamedTuple):
+    """One fault mode, and the single guard claimed to reject it."""
+
+    fault_mode: FaultModeID
+    contract: str
+    fixture_label: str
+    #: The class whose validator (or field) is neutralized.
+    target_model: str
+    #: A ``model_validator`` to delete, or ``None`` for a required-field case.
+    validator: str | None
+    #: For required-field cases: the field to give a flattering default, and
+    #: the value a forgetful producer would have inherited.
+    defaulted_field: tuple[str, Any] | None
+
+
+_F = FaultModeID
+
+CASES: tuple[GuardCase, ...] = (
+    GuardCase(
+        _F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,
+        "ask_dev_subject_discovery.v1",
+        "commitment_on_fuzzy_label_alone",
+        "SubjectDiscovery",
+        "validate_commitment_is_evidenced",
+        None,
+    ),
+    GuardCase(
+        _F.ORGANIZATION_WIDENING_AFTER_UNRESOLVED_REFERENCE,
+        "ask_dev_investigation_packet.v1",
+        "organization_widening_after_unresolved_reference",
+        "AskDevInvestigationPacket",
+        "validate_no_unsafe_organization_widening",
+        None,
+    ),
+    GuardCase(
+        _F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,
+        "ask_dev_evidence_coverage.v1",
+        "evidence_supporting_nothing",
+        "InvestigationEvidenceEntry",
+        "validate_supports_something",
+        None,
+    ),
+    GuardCase(
+        _F.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER,
+        "ask_dev_driver_analysis.v1",
+        "symptom_promoted_to_principal_driver",
+        "DriverCandidate",
+        "validate_principal_standing_is_earned",
+        None,
+    ),
+    GuardCase(
+        _F.STAFFING_CERTAINTY_WITHOUT_ALLOCATION_EVIDENCE,
+        "ask_dev_driver_analysis.v1",
+        "staffing_certainty_without_denominator",
+        "DriverCandidate",
+        "validate_staffing_claims_are_qualified",
+        None,
+    ),
+    GuardCase(
+        _F.UNRELATED_COHORT_MEMBER,
+        "ask_dev_comparison_cohort.v1",
+        "unrelated_member_without_inclusion_evidence",
+        "CohortMember",
+        "validate_inclusion_is_evidenced",
+        None,
+    ),
+    GuardCase(
+        _F.REVERSED_RELATIONSHIP_DIRECTION,
+        "ask_dev_related_context.v1",
+        "reversed_relationship_direction",
+        "LineageHop",
+        "validate_direction_matches_allowlist",
+        None,
+    ),
+    GuardCase(
+        _F.PATH_CROSSES_UNAUTHORIZED_ENTITY,
+        "ask_dev_related_context.v1",
+        "path_crosses_unauthorized_entity",
+        "RelatedContext",
+        "validate_paths_stay_inside_authorized_set",
+        None,
+    ),
+    GuardCase(
+        _F.DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT,
+        "ask_dev_investigation_packet.v1",
+        "dashboard_redirect_without_direct_judgment",
+        "AskDevInvestigationPacket",
+        "validate_supported_outcome_asserts_a_judgment",
+        None,
+    ),
+    GuardCase(
+        _F.ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS,
+        "ask_dev_subject_discovery.v1",
+        "absent_truncation_disclosure_field",
+        "SubjectDiscovery",
+        None,
+        ("candidates_truncated", False),
+    ),
+    GuardCase(
+        _F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS,
+        "ask_dev_comparison_cohort.v1",
+        "comparison_claimed_without_dimensions",
+        "ComparisonCohort",
+        "validate_comparison_is_not_vacuous",
+        None,
+    ),
+)
+
+
+def _case_by_name(name: str) -> GuardCase:
+    for case in CASES:
+        if str(case.fault_mode) == name:
+            return case
+    raise SystemExit(f"unknown case {name}")
+
+
+def _fixture(contract: str, label: str) -> dict[str, Any]:
+    for case_label, payload in negative_fixtures()[contract]:
+        if case_label == label:
+            return payload
+    raise SystemExit(f"no negative fixture {contract}/{label}")
+
+
+def _contract_models() -> list[type[BaseModel]]:
+    models: list[type[BaseModel]] = []
+    for name in dir(packet_module):
+        candidate = getattr(packet_module, name)
+        if (
+            isinstance(candidate, type)
+            and issubclass(candidate, BaseModel)
+            and candidate.__module__ == packet_module.__name__
+        ):
+            models.append(candidate)
+    return models
+
+
+def _rebuild_all() -> None:
+    """Regenerate every core schema so a neutralized guard really is gone.
+
+    Several passes because a parent's schema embeds its children's: one pass
+    would leave an outer model still validating against the pristine inner
+    schema, which would make the injection look like a no-op and produce a
+    false 'guard is not load-bearing' verdict. Six passes comfortably
+    exceeds the deepest nesting in the contract (packet -> coverage -> entry
+    -> evidence ref).
+    """
+
+    models = _contract_models()
+    for _ in range(6):
+        for model in models:
+            model.model_rebuild(force=True)
+
+
+def _neutralize(case: GuardCase) -> None:
+    model = getattr(packet_module, case.target_model)
+    if case.validator is not None:
+        validators = model.__pydantic_decorators__.model_validators
+        if case.validator not in validators:
+            raise SystemExit(
+                f"{case.target_model} has no model validator named "
+                f"{case.validator}; the fault-mode registry names a guard "
+                "that does not exist"
+            )
+        del validators[case.validator]
+    else:
+        assert case.defaulted_field is not None
+        field_name, default = case.defaulted_field
+        field = model.model_fields[field_name]
+        if not field.is_required():
+            raise SystemExit(
+                f"{case.target_model}.{field_name} already has a default, so "
+                "this injection proves nothing"
+            )
+        field.default = default
+        field.default_factory = None
+    _rebuild_all()
+
+
+def _validates(contract: str, payload: dict[str, Any]) -> tuple[bool, str]:
+    model = INVESTIGATION_CONTRACT_MODELS[contract]
+    try:
+        model.model_validate(payload)
+    except ValidationError as error:
+        first = error.errors()[0]
+        return False, f"{'.'.join(str(p) for p in first['loc'])}: {first['msg']}"
+    return True, ""
+
+
+def _run_case(name: str) -> int:
+    case = _case_by_name(name)
+    payload = _fixture(case.contract, case.fixture_label)
+
+    accepted, detail = _validates(case.contract, payload)
+    if accepted:
+        print(
+            f"FAIL {name}: the arm-shaped payload validates against the "
+            "pristine contract; there is no guard here at all"
+        )
+        return 1
+    print(f"  baseline REJECTED  <- {detail}")
+
+    injection = (
+        f"validator {case.target_model}.{case.validator}"
+        if case.validator is not None
+        else f"default on {case.target_model}."
+        f"{case.defaulted_field[0] if case.defaulted_field else '?'}"
+    )
+    _neutralize(case)
+
+    accepted, detail = _validates(case.contract, payload)
+    if not accepted:
+        print(
+            f"FAIL {name}: with {injection} removed the payload is STILL "
+            f"rejected ({detail}); the registry names a guard that is not "
+            "what actually rejects this fault"
+        )
+        return 1
+    print(f"  neutralised ACCEPTED <- removed {injection}")
+    print(f"OK   {name}")
+    return 0
+
+
+def _run_all() -> int:
+    covered = {case.fault_mode for case in CASES}
+    missing = sorted(str(item) for item in set(ALL_FAULT_MODE_IDS) - covered)
+    if missing:
+        print(
+            "FAIL: fault modes with no injection case, so their guards are "
+            f"unproved: {missing}"
+        )
+        return 1
+    if len(covered) != len(CASES):
+        print("FAIL: the case table lists a fault mode twice")
+        return 1
+
+    failures: list[str] = []
+    for case in CASES:
+        name = str(case.fault_mode)
+        print(f"\n=== {name} ===")
+        completed = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve()), "--case", name],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        sys.stdout.write(completed.stdout)
+        if completed.returncode != 0:
+            sys.stderr.write(completed.stderr)
+            failures.append(name)
+    print("\n" + "=" * 70)
+    if failures:
+        print(f"GUARD PROOF FAILED for {len(failures)} case(s): {failures}")
+        return 1
+    print(
+        f"GUARD PROOF PASSED: {len(CASES)}/{len(CASES)} named guards observed failing"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--case", default=None, help="run a single fault mode")
+    args = parser.parse_args()
+    if args.case is not None:
+        return _run_case(args.case)
+    return _run_all()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_chaos_3615_fault_mode_guards.py
+++ b/scripts/verify_chaos_3615_fault_mode_guards.py
@@ -47,8 +47,10 @@ from pydantic import BaseModel, ValidationError
 
 from dev_health_ops.api.dev.investigation_contract import (
     ALL_FAULT_MODE_IDS,
+    FAULT_MODE_REGISTRY,
     INVESTIGATION_CONTRACT_MODELS,
     FaultModeID,
+    RejectingMechanism,
 )
 from dev_health_ops.api.dev.investigation_contract import packet as packet_module
 from dev_health_ops.api.dev.investigation_contract.fixtures import negative_fixtures
@@ -278,6 +280,59 @@ def _run_case(name: str) -> int:
     return 0
 
 
+def _cross_check_against_registry() -> list[str]:
+    """Every case must name exactly the guard the registry names.
+
+    Adversarial review round 1, finding M8. The case table duplicated the
+    model and validator names by hand and only the *set of fault ids* was
+    checked, so a validator renamed in the registry would leave this script
+    neutralizing a stale mapping and still printing GUARD PROOF PASSED — a
+    green proof of the wrong thing, which is worse than no proof.
+    """
+
+    problems: list[str] = []
+    for case in CASES:
+        fault = FAULT_MODE_REGISTRY[case.fault_mode]
+        mechanism = fault.rejecting_mechanism
+        if mechanism is RejectingMechanism.CONTRACT_VALIDATOR:
+            reference = fault.validator_reference
+            if reference is None:
+                problems.append(
+                    f"{case.fault_mode}: registry claims a contract validator "
+                    "but names none"
+                )
+                continue
+            if case.validator is None:
+                problems.append(
+                    f"{case.fault_mode}: registry names validator "
+                    f"{reference.model_name}.{reference.validator_name} but the "
+                    "case injects a field default instead"
+                )
+                continue
+            if (case.target_model, case.validator) != (
+                reference.model_name,
+                reference.validator_name,
+            ):
+                problems.append(
+                    f"{case.fault_mode}: case neutralizes "
+                    f"{case.target_model}.{case.validator} but the registry "
+                    f"names {reference.model_name}.{reference.validator_name}"
+                )
+        elif mechanism is RejectingMechanism.REQUIRED_FIELD:
+            if case.validator is not None or case.defaulted_field is None:
+                problems.append(
+                    f"{case.fault_mode}: registry says the field grammar "
+                    "rejects this, so the case must inject a field default"
+                )
+        else:
+            problems.append(
+                f"{case.fault_mode}: rejecting mechanism {mechanism} has no "
+                "injection semantics; an oracle-judged fault must not claim a "
+                "contract-level proof"
+            )
+    return problems
+
+
 def _run_all() -> int:
     covered = {case.fault_mode for case in CASES}
     missing = sorted(str(item) for item in set(ALL_FAULT_MODE_IDS) - covered)
@@ -289,6 +344,12 @@ def _run_all() -> int:
         return 1
     if len(covered) != len(CASES):
         print("FAIL: the case table lists a fault mode twice")
+        return 1
+    drift = _cross_check_against_registry()
+    if drift:
+        print("FAIL: injection cases have drifted from the fault-mode registry:")
+        for problem in drift:
+            print(f"  - {problem}")
         return 1
 
     failures: list[str] = []

--- a/src/dev_health_ops/api/dev/investigation_contract/__init__.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/__init__.py
@@ -1,0 +1,266 @@
+"""CHAOS-3615: the backend-neutral Ask Dev investigation-packet contract.
+
+``ask_dev_investigation_packet.v1`` is the **shared, frozen wire shape** that
+every arm of the corrected CHAOS-3614 trial must emit — the current/native
+arm (CHAOS-3618) and the future graph-assisted arm (CHAOS-3617) alike — so
+that neither arm can define its own questions, its own output shape, or its
+own definition of success after seeing the other's results.
+
+Three properties are load-bearing and are enforced by tests, not by
+convention:
+
+1. **Backend neutrality.** No graph-backend vocabulary appears anywhere on
+   the wire. Arm identity lives in :class:`TrialMetadata`, which is an
+   *optional* field of :class:`InvestigationVersions` — evaluation metadata,
+   never product truth. See
+   ``tests/api/dev/test_chaos_3615_backend_neutrality.py``.
+2. **A packet is an investigation result, not an answer.** It carries what
+   was discovered and how well it is supported. It never carries prose an
+   assistant would speak, a dashboard redirect, a graph-native query
+   response, or an LLM reasoning trace.
+3. **The graph proposes; canonical services verify.** Every measurable claim
+   carries an :class:`AssertionBasis` (measured / source-asserted / inferred)
+   and, for the measured case, real evidence handles minted by
+   ``evidence_service.EvidenceHandleService`` — the *existing* evidence
+   identity scheme (``EvidenceHandle``/``DevEvidenceRefV2``), deliberately
+   not a parallel one.
+
+Artifact root: ``contracts/ask-dev-investigation/v1`` — deliberately its own
+tree rather than a member of ``CONTRACT_MODELS_V2``, because
+``contracts/ask-dev/v2`` is reserved for wire contracts served to real
+clients (``scripts/acceptance/corpus/receipt.py:6-7``) and this packet is
+never client-served.
+
+Architecture write-up, including the cross-repository ownership map:
+``docs/contribute/architecture/ask-dev-investigation-packet.md``.
+"""
+
+from __future__ import annotations
+
+from .allowlists import (
+    ALL_ANALYTICAL_SLICES,
+    SLICE_BOUNDARIES,
+    TRIAL_SOURCE_ALLOWLIST,
+    TRIAL_SOURCE_RATIONALE,
+    SliceBoundary,
+    validate_slice_boundaries,
+    validate_trial_source_allowlist,
+)
+from .packet import (
+    INVESTIGATION_CONTRACT_MODELS,
+    AnalyticalJob,
+    AskDevInvestigationPacket,
+    BoundedTimeContext,
+    ClarificationNeed,
+    CohortExclusion,
+    CohortMember,
+    ComparisonCohort,
+    DriverAnalysis,
+    DriverCandidate,
+    EvidenceCoverage,
+    InvestigationEvidenceEntry,
+    InvestigationVersions,
+    LineageHop,
+    LineagePath,
+    MissingSource,
+    PacketLimitation,
+    RelatedContext,
+    RelatedEntity,
+    SourceConflict,
+    SourceContractVersion,
+    SourceHealthObservation,
+    StaffingQualification,
+    SubjectCandidate,
+    SubjectDiscovery,
+    SubjectMatchEvidence,
+    SurfaceContextRef,
+    TrialMetadata,
+    UnresolvedMention,
+)
+from .question_families import (
+    ALL_PROHIBITED_REDUCTIONS,
+    ALL_QUESTION_FAMILY_IDS,
+    MANDATORY_PROHIBITED_REDUCTIONS,
+    QUESTION_FAMILY_REGISTRY,
+    ProhibitedReduction,
+    QuestionFamily,
+    QuestionFamilyID,
+    QuestionVariant,
+    QuestionVariantKind,
+    StaffingDenominatorPolicy,
+    validate_question_family_registry,
+)
+from .relationships import (
+    ALL_RELATIONSHIP_TYPES,
+    RELATIONSHIP_ALLOWLIST,
+    EntityPair,
+    RelationshipOrientation,
+    RelationshipType,
+    validate_relationship_allowlist,
+)
+from .scoring import (
+    ALL_FAULT_MODE_IDS,
+    ALL_SCORING_DIMENSION_IDS,
+    FAULT_MODE_REGISTRY,
+    SCORING_DIMENSION_REGISTRY,
+    DimensionPolarity,
+    FaultMode,
+    FaultModeID,
+    MeasurementKind,
+    RejectingMechanism,
+    ScoringDimension,
+    ScoringDimensionID,
+    ValidatorReference,
+    validate_scoring_registry,
+)
+from .vocabulary import (
+    ALL_ASSERTION_BASES,
+    ALL_COMPARISON_DIMENSIONS,
+    ALL_COMPARISON_SHAPES,
+    ALL_DRIVER_CATEGORIES,
+    ALL_DRIVER_ROLES,
+    ALL_DRIVER_STANDINGS,
+    ALL_INVESTIGATION_OUTCOMES,
+    ALL_INVESTIGATION_SUBJECT_KINDS,
+    ALL_PACKET_SECTIONS,
+    ALL_STAFFING_DENOMINATOR_STATES,
+    ALL_TRUNCATION_REASONS,
+    AnalyticalSlice,
+    AssertionBasis,
+    ClarificationNeedKind,
+    CohortCompleteness,
+    CohortEvidenceClassification,
+    CohortExclusionReason,
+    CohortInclusionBasis,
+    ComparisonDimension,
+    ComparisonShape,
+    ConfidenceQualifier,
+    ConflictResolution,
+    DriverCategory,
+    DriverExclusionReason,
+    DriverRole,
+    DriverStanding,
+    HistoricalComparability,
+    InvestigationOutcome,
+    InvestigationSubjectKind,
+    JobUncertainty,
+    PacketLimitationKind,
+    PacketSection,
+    RelationshipDirection,
+    RelevanceState,
+    StaffingDenominatorState,
+    SubjectCommitmentState,
+    SubjectMatchSignal,
+    SurfaceKind,
+    TruncationReason,
+    UnresolvedMentionReason,
+)
+
+__all__ = [
+    "ALL_ANALYTICAL_SLICES",
+    "ALL_ASSERTION_BASES",
+    "ALL_COMPARISON_DIMENSIONS",
+    "ALL_COMPARISON_SHAPES",
+    "ALL_DRIVER_CATEGORIES",
+    "ALL_DRIVER_ROLES",
+    "ALL_DRIVER_STANDINGS",
+    "ALL_FAULT_MODE_IDS",
+    "ALL_INVESTIGATION_OUTCOMES",
+    "ALL_INVESTIGATION_SUBJECT_KINDS",
+    "ALL_PACKET_SECTIONS",
+    "ALL_PROHIBITED_REDUCTIONS",
+    "ALL_QUESTION_FAMILY_IDS",
+    "ALL_RELATIONSHIP_TYPES",
+    "ALL_SCORING_DIMENSION_IDS",
+    "ALL_STAFFING_DENOMINATOR_STATES",
+    "ALL_TRUNCATION_REASONS",
+    "FAULT_MODE_REGISTRY",
+    "INVESTIGATION_CONTRACT_MODELS",
+    "MANDATORY_PROHIBITED_REDUCTIONS",
+    "QUESTION_FAMILY_REGISTRY",
+    "RELATIONSHIP_ALLOWLIST",
+    "SCORING_DIMENSION_REGISTRY",
+    "SLICE_BOUNDARIES",
+    "TRIAL_SOURCE_ALLOWLIST",
+    "TRIAL_SOURCE_RATIONALE",
+    "AnalyticalJob",
+    "AnalyticalSlice",
+    "AskDevInvestigationPacket",
+    "AssertionBasis",
+    "BoundedTimeContext",
+    "ClarificationNeed",
+    "ClarificationNeedKind",
+    "CohortCompleteness",
+    "CohortEvidenceClassification",
+    "CohortExclusion",
+    "CohortExclusionReason",
+    "CohortInclusionBasis",
+    "CohortMember",
+    "ComparisonCohort",
+    "ComparisonDimension",
+    "ComparisonShape",
+    "ConfidenceQualifier",
+    "ConflictResolution",
+    "DimensionPolarity",
+    "DriverAnalysis",
+    "DriverCandidate",
+    "DriverCategory",
+    "DriverExclusionReason",
+    "DriverRole",
+    "DriverStanding",
+    "EntityPair",
+    "EvidenceCoverage",
+    "FaultMode",
+    "FaultModeID",
+    "HistoricalComparability",
+    "InvestigationEvidenceEntry",
+    "InvestigationOutcome",
+    "InvestigationSubjectKind",
+    "InvestigationVersions",
+    "JobUncertainty",
+    "LineageHop",
+    "LineagePath",
+    "MeasurementKind",
+    "MissingSource",
+    "PacketLimitation",
+    "PacketLimitationKind",
+    "PacketSection",
+    "ProhibitedReduction",
+    "QuestionFamily",
+    "QuestionFamilyID",
+    "QuestionVariant",
+    "QuestionVariantKind",
+    "RejectingMechanism",
+    "RelatedContext",
+    "RelatedEntity",
+    "RelationshipDirection",
+    "RelationshipOrientation",
+    "RelationshipType",
+    "RelevanceState",
+    "ScoringDimension",
+    "ScoringDimensionID",
+    "SliceBoundary",
+    "SourceConflict",
+    "SourceContractVersion",
+    "SourceHealthObservation",
+    "StaffingDenominatorPolicy",
+    "StaffingDenominatorState",
+    "StaffingQualification",
+    "SubjectCandidate",
+    "SubjectCommitmentState",
+    "SubjectDiscovery",
+    "SubjectMatchEvidence",
+    "SubjectMatchSignal",
+    "SurfaceContextRef",
+    "SurfaceKind",
+    "TrialMetadata",
+    "TruncationReason",
+    "UnresolvedMention",
+    "UnresolvedMentionReason",
+    "ValidatorReference",
+    "validate_question_family_registry",
+    "validate_relationship_allowlist",
+    "validate_scoring_registry",
+    "validate_slice_boundaries",
+    "validate_trial_source_allowlist",
+]

--- a/src/dev_health_ops/api/dev/investigation_contract/allowlists.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/allowlists.py
@@ -1,0 +1,283 @@
+"""Trial source allowlist and current-versus-historical slice boundaries.
+
+CHAOS-3615 deliverables 9 and 10.
+
+The **source allowlist** names which of the platform's ``SourceClass``
+members an investigation arm may draw on during the corrected trial, and why
+each one is in. It is a strict subset of ``SourceClass``: the enum carries
+members that exist for the Ask Dev *answer* path and have no role in
+subject/cohort/lineage/driver discovery, and quietly permitting them would
+let an arm claim coverage from a source the trial never intended to score.
+``TEMPORAL_CONTEXT`` is excluded for a different reason — it is CHAOS-3567's
+deliberately inert flag-off stub, and pulling it into this allowlist would
+make it non-inert by the back door.
+
+The **slice boundaries** say what "current" and "historical" each require of
+edge validity, and record the CHAOS-3569 consequence explicitly: native
+historical edge validity is not implemented, so a historical or
+current-vs-historical slice that needs as-of traversal over gapped rows is
+``NOT COMPARABLE``. Per the corrective plan that is a *reporting* state, not
+a blocker — the packet stays valid, the trial row is scored NOT COMPARABLE
+rather than failed, and the arm must disclose the limitation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal
+
+from dev_health_ops.api.dev.contracts import Label, LongText, ShortText
+from dev_health_ops.api.dev.contracts_v2.base import ContractModelV2, SourceClass
+
+from .vocabulary import (
+    ALL_ANALYTICAL_SLICES,
+    AnalyticalSlice,
+    HistoricalComparability,
+)
+
+__all__ = [
+    "ALL_ANALYTICAL_SLICES",
+    "SLICE_BOUNDARIES",
+    "TRIAL_SOURCE_ALLOWLIST",
+    "TRIAL_SOURCE_RATIONALE",
+    "SliceBoundary",
+    "validate_slice_boundaries",
+    "validate_trial_source_allowlist",
+]
+
+
+#: The source classes an investigation arm may draw on during the trial.
+#:
+#: Ordered as declared on ``SourceClass`` so the exported schemas and the
+#: registry documentation stay byte-stable.
+TRIAL_SOURCE_ALLOWLIST: tuple[SourceClass, ...] = (
+    SourceClass.STATUS_CHANGE,
+    SourceClass.WORK_ITEM,
+    SourceClass.WORK_GRAPH,
+    SourceClass.PULL_REQUEST,
+    SourceClass.CODE_CHANGE,
+    SourceClass.REVIEW,
+    SourceClass.CI_RUN,
+    SourceClass.TEST_REPORT,
+    SourceClass.DEPLOYMENT,
+    SourceClass.INCIDENT,
+    SourceClass.OPERATIONAL_CONTROL,
+    SourceClass.SOURCE_HEALTH,
+    SourceClass.COGNITIVE_LOAD,
+    SourceClass.INVESTMENT_ALLOCATION,
+    SourceClass.HEALTH_PROFILE,
+    SourceClass.DEFICIENCY_INVENTORY,
+)
+
+#: Why each allowed source is in the trial. Totality against
+#: :data:`TRIAL_SOURCE_ALLOWLIST` is enforced by
+#: :func:`validate_trial_source_allowlist`, so a source added to the
+#: allowlist without a stated reason is an import-time failure.
+TRIAL_SOURCE_RATIONALE: Mapping[SourceClass, str] = {
+    SourceClass.STATUS_CHANGE: (
+        "declared status and its transitions -- the 'declared' half of the "
+        "declared-versus-actual family"
+    ),
+    SourceClass.WORK_ITEM: (
+        "canonical units of work; the substrate for delivery pressure, scope "
+        "change and blocked-by lineage"
+    ),
+    SourceClass.WORK_GRAPH: (
+        "canonical entity identity and membership -- how a candidate subject "
+        "becomes a canonical ID at all"
+    ),
+    SourceClass.PULL_REQUEST: (
+        "implementing changes; the 'actual delivery evidence' half of the "
+        "declared-versus-actual family"
+    ),
+    SourceClass.CODE_CHANGE: "change volume and locality behind delivery pressure",
+    SourceClass.REVIEW: "review pressure, and the cycled-in-review colloquial family",
+    SourceClass.CI_RUN: "readiness evidence for declared-complete claims",
+    SourceClass.TEST_REPORT: "readiness evidence for declared-complete claims",
+    SourceClass.DEPLOYMENT: "release evidence for declared-complete claims",
+    SourceClass.INCIDENT: "operational pressure and its driver lineage",
+    SourceClass.OPERATIONAL_CONTROL: (
+        "operational readiness controls behind operational-deficiency drivers"
+    ),
+    SourceClass.SOURCE_HEALTH: (
+        "source availability and freshness -- required to distinguish 'no "
+        "signal' from 'no data'"
+    ),
+    SourceClass.COGNITIVE_LOAD: (
+        "team-level interruption/context-spread/review-request rollups behind "
+        "the struggling-teams family. Team-level only: this source class also "
+        "backs per-developer rollups, which the packet cannot express because "
+        "no person subject kind exists"
+    ),
+    SourceClass.INVESTMENT_ALLOCATION: (
+        "investment mix pressure, and the nearest available proxy for a "
+        "capacity denominator"
+    ),
+    SourceClass.HEALTH_PROFILE: (
+        "code-owned health-rule findings; a derived judgment over other "
+        "sources, never a primary source of its own"
+    ),
+    SourceClass.DEFICIENCY_INVENTORY: (
+        "operational-deficiency inventory behind readiness and operational "
+        "pressure judgments"
+    ),
+}
+
+
+class SliceBoundary(ContractModelV2):
+    """What one analytical slice requires, and what it cannot yet deliver."""
+
+    schema_version: Literal["ask_dev_slice_boundary.v1"]
+    slice_id: AnalyticalSlice
+    title: Label
+    definition: LongText
+    requires_as_of: bool
+    requires_edge_validity: bool
+    permitted_comparability: tuple[HistoricalComparability, ...]
+    known_gap: ShortText | None
+
+
+SLICE_BOUNDARIES: Mapping[AnalyticalSlice, SliceBoundary] = {
+    AnalyticalSlice.CURRENT: SliceBoundary(
+        schema_version="ask_dev_slice_boundary.v1",
+        slice_id=AnalyticalSlice.CURRENT,
+        title="Current",
+        definition=(
+            "Entities, relationships and evidence that are valid now. The "
+            "investigation reads the live projection: no as-of timestamp is "
+            "supplied and no edge-validity interval is consulted. This is the "
+            "slice every 'what is happening / what is going sideways / who "
+            "needs attention' question runs in, and it is deliberately the "
+            "slice that CHAOS-3569 does not block."
+        ),
+        requires_as_of=False,
+        requires_edge_validity=False,
+        permitted_comparability=(HistoricalComparability.NOT_APPLICABLE,),
+        known_gap=None,
+    ),
+    AnalyticalSlice.HISTORICAL: SliceBoundary(
+        schema_version="ask_dev_slice_boundary.v1",
+        slice_id=AnalyticalSlice.HISTORICAL,
+        title="Historical",
+        definition=(
+            "The state as of a supplied past instant. Requires an as-of "
+            "timestamp and requires every traversed edge to carry a validity "
+            "interval covering that instant, so that relationships which did "
+            "not exist then are not reported as if they did."
+        ),
+        requires_as_of=True,
+        requires_edge_validity=True,
+        permitted_comparability=(
+            HistoricalComparability.COMPARABLE,
+            HistoricalComparability.NOT_COMPARABLE_MISSING_EDGE_VALIDITY,
+            HistoricalComparability.NOT_COMPARABLE_MISSING_BASELINE,
+        ),
+        known_gap=(
+            "CHAOS-3569 (native historical edge validity) is open. Rows whose "
+            "edges lack a validity interval are reported NOT COMPARABLE and "
+            "excluded from historical scoring -- they are not trial failures "
+            "and they do not block the current slice."
+        ),
+    ),
+    AnalyticalSlice.CURRENT_VS_HISTORICAL: SliceBoundary(
+        schema_version="ask_dev_slice_boundary.v1",
+        slice_id=AnalyticalSlice.CURRENT_VS_HISTORICAL,
+        title="Current versus historical",
+        definition=(
+            "A change question: the current state compared against the state "
+            "as of a supplied past instant. Inherits every requirement of the "
+            "historical slice, plus a baseline that must itself be "
+            "reconstructable -- a comparison against a baseline that cannot "
+            "be rebuilt is NOT COMPARABLE rather than a zero delta."
+        ),
+        requires_as_of=True,
+        requires_edge_validity=True,
+        permitted_comparability=(
+            HistoricalComparability.COMPARABLE,
+            HistoricalComparability.NOT_COMPARABLE_MISSING_EDGE_VALIDITY,
+            HistoricalComparability.NOT_COMPARABLE_MISSING_BASELINE,
+        ),
+        known_gap=(
+            "CHAOS-3569 as above, plus: a missing baseline must be reported "
+            "NOT_COMPARABLE_MISSING_BASELINE and never silently rendered as "
+            "'no change'."
+        ),
+    ),
+}
+
+
+def validate_trial_source_allowlist() -> None:
+    """Raise unless the source allowlist is a sane, fully-justified subset."""
+
+    allowlist = set(TRIAL_SOURCE_ALLOWLIST)
+    if len(TRIAL_SOURCE_ALLOWLIST) != len(allowlist):
+        raise RuntimeError("trial source allowlist repeats a source class")
+    platform_sources = set(SourceClass.__members__.values())
+    outside = sorted(str(item) for item in allowlist - platform_sources)
+    if outside:
+        raise RuntimeError(f"trial source allowlist names unknown sources: {outside}")
+    unjustified = sorted(str(item) for item in allowlist - set(TRIAL_SOURCE_RATIONALE))
+    if unjustified:
+        raise RuntimeError(
+            f"trial source allowlist entries have no stated rationale: {unjustified}"
+        )
+    orphaned = sorted(str(item) for item in set(TRIAL_SOURCE_RATIONALE) - allowlist)
+    if orphaned:
+        raise RuntimeError(
+            f"trial source rationale names non-allowlisted sources: {orphaned}"
+        )
+    if SourceClass.TEMPORAL_CONTEXT in allowlist:
+        # CHAOS-3567 shipped this member deliberately inert. Allowlisting it
+        # here would make it reachable without any of the plan/step wiring
+        # that inertness guard proves absent.
+        raise RuntimeError(
+            "SourceClass.TEMPORAL_CONTEXT is CHAOS-3567's inert stub and must "
+            "not be allowlisted for the trial"
+        )
+
+
+def validate_slice_boundaries() -> None:
+    """Raise unless every analytical slice has a coherent declared boundary."""
+
+    if set(SLICE_BOUNDARIES) != set(ALL_ANALYTICAL_SLICES):
+        missing = sorted(
+            str(item) for item in set(ALL_ANALYTICAL_SLICES) - set(SLICE_BOUNDARIES)
+        )
+        extra = sorted(
+            str(item) for item in set(SLICE_BOUNDARIES) - set(ALL_ANALYTICAL_SLICES)
+        )
+        raise RuntimeError(
+            f"slice boundaries are not total; missing={missing}, extra={extra}"
+        )
+    for slice_id, boundary in SLICE_BOUNDARIES.items():
+        if boundary.slice_id is not slice_id:
+            raise RuntimeError(
+                f"slice boundary key {slice_id} is filed under {boundary.slice_id}"
+            )
+        if not boundary.permitted_comparability:
+            raise RuntimeError(f"slice {slice_id} permits no comparability state")
+        if boundary.requires_edge_validity and not boundary.known_gap:
+            # Every slice that needs edge validity today runs into CHAOS-3569.
+            # Dropping the gap note would let a future edit quietly imply the
+            # historical slice is fully supported.
+            raise RuntimeError(
+                f"slice {slice_id} requires edge validity but declares no "
+                "known gap; CHAOS-3569 is open and must stay disclosed"
+            )
+        applicable = HistoricalComparability.NOT_APPLICABLE
+        if boundary.requires_as_of and applicable in boundary.permitted_comparability:
+            raise RuntimeError(
+                f"slice {slice_id} requires an as-of instant, so "
+                "'not_applicable' comparability is not a legal state for it"
+            )
+        if not boundary.requires_as_of and boundary.permitted_comparability != (
+            applicable,
+        ):
+            raise RuntimeError(
+                f"slice {slice_id} needs no as-of instant, so 'not_applicable' "
+                "is its only legal comparability state"
+            )
+
+
+validate_trial_source_allowlist()
+validate_slice_boundaries()

--- a/src/dev_health_ops/api/dev/investigation_contract/export.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/export.py
@@ -253,6 +253,38 @@ def expected_artifacts() -> dict[str, str]:
     manifest = {
         "schema_version": "ask_dev_investigation_contract_manifest.v1",
         "compatibility": "internal-trial-artifact-not-client-served",
+        # Adversarial review round 1, finding H1. Pydantic emits structural
+        # JSON Schema only: required/type/enum/pattern/length. None of this
+        # contract's cross-field rules -- commitment evidence, authorization
+        # scope, symptom-vs-driver standing, evidence closure, family
+        # obligations -- survive into the emitted schema, so a consumer that
+        # schema-validates and stops accepts almost every arm-shaped bad
+        # packet in examples/negative. Saying so here, in the artifact a
+        # consumer actually reads, rather than leaving it to be discovered.
+        #
+        # The split is measured by execution, not asserted: see
+        # tests/api/dev/test_chaos_3615_schema_validator_differential.py,
+        # which runs every negative fixture through a real JSON Schema
+        # validator AND the Python model and pins exactly which fixtures each
+        # one catches.
+        "validation_policy": {
+            "canonical_validator": (
+                "dev_health_ops.api.dev.investigation_contract.packet"
+                ".INVESTIGATION_CONTRACT_MODELS"
+            ),
+            "json_schema_scope": "structural_only",
+            "schema_only_validation_is_sufficient": False,
+            "note": (
+                "The generated JSON Schemas describe field shape, not the "
+                "contract's semantics. A packet that validates against the "
+                "schema alone has not been checked for authorization scope, "
+                "evidence closure, driver standing, family obligations, "
+                "historical comparability or any other cross-field rule. Any "
+                "consumer -- including a future non-Python arm -- must run "
+                "the canonical validator or reimplement these rules and prove "
+                "equivalence against examples/negative."
+            ),
+        },
         "contracts": manifest_entries,
         "registries": registry_entries,
     }

--- a/src/dev_health_ops/api/dev/investigation_contract/export.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/export.py
@@ -1,0 +1,315 @@
+"""Generate or verify the checked-in investigation-contract artifacts.
+
+CHAOS-3615 deliverables 2, 5 and 6.
+
+The third instance of the repository's established exporter pattern (after
+``export_contracts`` for ``contracts/ask-dev/v1`` and ``export_contracts_v2``
+for ``contracts/ask-dev/v2``), writing to its own root,
+``contracts/ask-dev-investigation/v1``.
+
+**Why its own root rather than a new entry in ``CONTRACT_MODELS_V2``.**
+``contracts/ask-dev/v2`` is reserved for wire contracts served to real
+clients — ``scripts/acceptance/corpus/receipt.py:6-7`` says so explicitly,
+and ``dev-health-web``'s contract sync reads that tree. The investigation
+packet is an internal trial artifact that is never client-served, and
+filing it under the client tree would both misrepresent it and put a
+CHAOS-3616 iteration on the critical path of a web contract regen.
+
+**What is exported.** Draft 2020-12 JSON Schema per contract; the positive
+golden; the anti-drift positive variants; every arm-shaped negative fixture;
+the four registries (question families, scoring dimensions, fault modes,
+source/relationship allowlists and slice boundaries) as machine-readable
+JSON so CHAOS-3616 can consume them without importing Python; and a manifest
+with a sha256 for every file.
+
+``check`` mode is the drift gate: it compares the *full* artifact set, so a
+stale file, a missing file and an unexpected extra file are all failures.
+``_validate_fixtures`` runs first in both modes, and hard-fails unless every
+registered contract has a positive fixture and at least one negative fixture
+that genuinely fails validation — a negative fixture that quietly started
+passing is the exact shape of a guard that has stopped guarding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from .allowlists import (
+    SLICE_BOUNDARIES,
+    TRIAL_SOURCE_ALLOWLIST,
+    TRIAL_SOURCE_RATIONALE,
+)
+from .fixtures import (
+    negative_fixtures,
+    positive_fixtures,
+    positive_variant_fixtures,
+)
+from .packet import INVESTIGATION_CONTRACT_MODELS
+from .question_families import (
+    ALL_QUESTION_FAMILY_IDS,
+    MANDATORY_PROHIBITED_REDUCTIONS,
+    QUESTION_FAMILY_REGISTRY,
+)
+from .relationships import ALL_RELATIONSHIP_TYPES, RELATIONSHIP_ALLOWLIST
+from .scoring import (
+    ALL_FAULT_MODE_IDS,
+    ALL_SCORING_DIMENSION_IDS,
+    FAULT_MODE_REGISTRY,
+    SCORING_DIMENSION_REGISTRY,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+ARTIFACT_ROOT = REPOSITORY_ROOT / "contracts" / "ask-dev-investigation" / "v1"
+
+SCHEMA_ID_PREFIX = "https://api.fullchaos.dev/contracts/ask-dev-investigation/v1"
+
+__all__ = [
+    "ARTIFACT_ROOT",
+    "check_artifacts",
+    "expected_artifacts",
+    "main",
+    "write_artifacts",
+]
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True) + "\n"
+
+
+def _sha256(contents: str) -> str:
+    return hashlib.sha256(contents.encode("utf-8")).hexdigest()
+
+
+def _schema(name: str) -> dict[str, Any]:
+    schema = INVESTIGATION_CONTRACT_MODELS[name].model_json_schema(mode="validation")
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": f"{SCHEMA_ID_PREFIX}/{name}.schema.json",
+        **schema,
+    }
+
+
+def _validate_positive_variants() -> None:
+    variants = positive_variant_fixtures()
+    unregistered = sorted(set(variants) - set(INVESTIGATION_CONTRACT_MODELS))
+    if unregistered:
+        raise RuntimeError(
+            f"positive variants name unregistered contracts: {unregistered}"
+        )
+    for name, cases in variants.items():
+        if not cases:
+            raise RuntimeError(f"{name} declares an empty positive variant list")
+        labels = [label for label, _ in cases]
+        if len(labels) != len(set(labels)):
+            raise RuntimeError(f"{name} has duplicate positive variant labels")
+        for label, payload in cases:
+            if not label:
+                raise RuntimeError(f"{name} has an unlabelled positive variant")
+            INVESTIGATION_CONTRACT_MODELS[name].model_validate(payload)
+
+
+def _validate_fixtures() -> None:
+    positives = positive_fixtures()
+    negatives = negative_fixtures()
+    if set(positives) != set(INVESTIGATION_CONTRACT_MODELS):
+        raise RuntimeError("positive fixture coverage does not match contract registry")
+    if set(negatives) != set(INVESTIGATION_CONTRACT_MODELS):
+        raise RuntimeError("negative fixture coverage does not match contract registry")
+    for name, payload in positives.items():
+        INVESTIGATION_CONTRACT_MODELS[name].model_validate(payload)
+    _validate_positive_variants()
+    for name, cases in negatives.items():
+        if not cases:
+            raise RuntimeError(f"{name} has no negative fixture")
+        labels = [label for label, _ in cases]
+        if len(labels) != len(set(labels)):
+            raise RuntimeError(f"{name} has duplicate negative fixture labels")
+        for label, payload in cases:
+            try:
+                INVESTIGATION_CONTRACT_MODELS[name].model_validate(payload)
+            except ValidationError:
+                continue
+            raise RuntimeError(
+                f"negative fixture unexpectedly passed: {name}/{label}; a "
+                "negative fixture that validates is a guard that has stopped "
+                "guarding"
+            )
+
+
+def _registry_artifacts() -> dict[str, Any]:
+    """The four registries, as JSON a non-Python consumer can read."""
+
+    question_families = {
+        "schema_version": "ask_dev_question_family_registry.v1",
+        "mandatory_prohibited_reductions": [
+            str(item) for item in MANDATORY_PROHIBITED_REDUCTIONS
+        ],
+        "families": [
+            QUESTION_FAMILY_REGISTRY[family_id].model_dump(mode="json")
+            for family_id in ALL_QUESTION_FAMILY_IDS
+        ],
+    }
+    scoring = {
+        "schema_version": "ask_dev_scoring_registry.v1",
+        "aggregate_score_prohibited": True,
+        "reporting_shape": "per_question_family_x_per_dimension",
+        "dimensions": [
+            SCORING_DIMENSION_REGISTRY[dimension_id].model_dump(mode="json")
+            for dimension_id in ALL_SCORING_DIMENSION_IDS
+        ],
+    }
+    fault_modes = {
+        "schema_version": "ask_dev_fault_mode_registry.v1",
+        "fault_modes": [
+            FAULT_MODE_REGISTRY[fault_id].model_dump(mode="json")
+            for fault_id in ALL_FAULT_MODE_IDS
+        ],
+    }
+    allowlists = {
+        "schema_version": "ask_dev_trial_allowlists.v1",
+        "source_classes": [
+            {"source_class": str(item), "rationale": TRIAL_SOURCE_RATIONALE[item]}
+            for item in TRIAL_SOURCE_ALLOWLIST
+        ],
+        "relationship_types": [
+            RELATIONSHIP_ALLOWLIST[relationship].model_dump(mode="json")
+            for relationship in ALL_RELATIONSHIP_TYPES
+        ],
+        "slice_boundaries": [
+            boundary.model_dump(mode="json") for boundary in SLICE_BOUNDARIES.values()
+        ],
+    }
+    return {
+        "registries/question_families.json": question_families,
+        "registries/scoring_dimensions.json": scoring,
+        "registries/fault_modes.json": fault_modes,
+        "registries/trial_allowlists.json": allowlists,
+    }
+
+
+def expected_artifacts() -> dict[str, str]:
+    _validate_fixtures()
+    artifacts: dict[str, str] = {}
+    manifest_entries: list[dict[str, Any]] = []
+    positives = positive_fixtures()
+    negatives = negative_fixtures()
+    variants = positive_variant_fixtures()
+    for name in INVESTIGATION_CONTRACT_MODELS:
+        schema_path = f"schemas/{name}.schema.json"
+        positive_path = f"examples/positive/{name}.json"
+        schema_contents = _json(_schema(name))
+        positive_contents = _json(positives[name])
+        artifacts[schema_path] = schema_contents
+        artifacts[positive_path] = positive_contents
+        variant_entries = []
+        for label, payload in variants.get(name, []):
+            variant_path = f"examples/positive/{name}.{label}.json"
+            if variant_path in artifacts:
+                raise RuntimeError(f"positive variant path collides: {variant_path}")
+            variant_contents = _json(payload)
+            artifacts[variant_path] = variant_contents
+            variant_entries.append(
+                {
+                    "case": label,
+                    "path": variant_path,
+                    "sha256": _sha256(variant_contents),
+                }
+            )
+        negative_entries = []
+        for label, payload in negatives[name]:
+            negative_path = f"examples/negative/{name}.{label}.json"
+            negative_contents = _json(payload)
+            artifacts[negative_path] = negative_contents
+            negative_entries.append(
+                {
+                    "case": label,
+                    "path": negative_path,
+                    "sha256": _sha256(negative_contents),
+                }
+            )
+        manifest_entries.append(
+            {
+                "schema_version": name,
+                "schema": {"path": schema_path, "sha256": _sha256(schema_contents)},
+                "positive": {
+                    "path": positive_path,
+                    "sha256": _sha256(positive_contents),
+                },
+                "positive_variants": variant_entries,
+                "negative": negative_entries,
+            }
+        )
+    registry_entries = []
+    for path, payload in _registry_artifacts().items():
+        contents = _json(payload)
+        artifacts[path] = contents
+        registry_entries.append({"path": path, "sha256": _sha256(contents)})
+    manifest = {
+        "schema_version": "ask_dev_investigation_contract_manifest.v1",
+        "compatibility": "internal-trial-artifact-not-client-served",
+        "contracts": manifest_entries,
+        "registries": registry_entries,
+    }
+    artifacts["manifest.json"] = _json(manifest)
+    return artifacts
+
+
+def _current_artifact_paths() -> set[str]:
+    if not ARTIFACT_ROOT.exists():
+        return set()
+    return {
+        str(path.relative_to(ARTIFACT_ROOT))
+        for path in ARTIFACT_ROOT.rglob("*")
+        if path.is_file()
+    }
+
+
+def write_artifacts(artifacts: dict[str, str]) -> None:
+    ARTIFACT_ROOT.mkdir(parents=True, exist_ok=True)
+    for relative_path, contents in artifacts.items():
+        destination = ARTIFACT_ROOT / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(contents, encoding="utf-8")
+    for stale in _current_artifact_paths() - set(artifacts):
+        (ARTIFACT_ROOT / stale).unlink()
+
+
+def check_artifacts(artifacts: dict[str, str]) -> None:
+    actual_paths = _current_artifact_paths()
+    expected_paths = set(artifacts)
+    if actual_paths != expected_paths:
+        missing = sorted(expected_paths - actual_paths)
+        stale = sorted(actual_paths - expected_paths)
+        raise RuntimeError(
+            f"contract artifact set drifted; missing={missing}, stale={stale}"
+        )
+    drifted = [
+        relative_path
+        for relative_path, expected in artifacts.items()
+        if (ARTIFACT_ROOT / relative_path).read_text(encoding="utf-8") != expected
+    ]
+    if drifted:
+        raise RuntimeError(f"contract artifacts drifted: {sorted(drifted)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("write", "check"))
+    args = parser.parse_args()
+    artifacts = expected_artifacts()
+    if args.mode == "write":
+        write_artifacts(artifacts)
+        print(f"wrote {len(artifacts)} Ask Dev investigation contract artifacts")
+    else:
+        check_artifacts(artifacts)
+        print(f"verified {len(artifacts)} Ask Dev investigation contract artifacts")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dev_health_ops/api/dev/investigation_contract/fixtures.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/fixtures.py
@@ -125,6 +125,7 @@ def _analytical_job() -> dict[str, Any]:
             "analytical_slice": "current",
             "as_of": None,
             "historical_comparability": "not_applicable",
+            "edge_validity_basis": "not_required",
         },
         "surface_context_refs": [
             {
@@ -348,7 +349,13 @@ def _related_context() -> dict[str, Any]:
                 "source_health": "available_current",
             },
         ],
-        "authorized_entity_ids": [SUBJECT, TEAM, SERVICE, DEPENDENCY],
+        # The packet-wide authorization envelope: every entity named
+        # ANYWHERE in the packet must appear here, not just the ones on a
+        # lineage path (adversarial review round 1, finding H2). DECOY is a
+        # ranked-then-rejected candidate the caller could see, so it belongs
+        # in the set; a candidate the caller may not see is filtered out and
+        # counted, never listed.
+        "authorized_entity_ids": [SUBJECT, DECOY, TEAM, SERVICE, DEPENDENCY],
         "authorization_filtered_count": 0,
         "entities_truncated": False,
         "paths_truncated": False,
@@ -509,6 +516,24 @@ def _evidence_coverage() -> dict[str, Any]:
                 "detail": None,
             },
             {
+                "source_class": "work_item",
+                "state": "available_current",
+                "observed_at": NOW,
+                "detail": None,
+            },
+            {
+                "source_class": "status_change",
+                "state": "available_current",
+                "observed_at": NOW,
+                "detail": None,
+            },
+            {
+                "source_class": "pull_request",
+                "state": "available_current",
+                "observed_at": NOW,
+                "detail": None,
+            },
+            {
                 "source_class": "deployment",
                 "state": "available_stale",
                 "observed_at": NOW,
@@ -658,6 +683,7 @@ def _not_comparable_historical_packet() -> dict[str, Any]:
         "analytical_slice": "current_vs_historical",
         "as_of": AS_OF,
         "historical_comparability": "not_comparable_missing_edge_validity",
+        "edge_validity_basis": "unavailable",
     }
     packet["evidence_coverage"]["limitations"].append(
         {
@@ -684,7 +710,19 @@ def _qualified_capacity_packet() -> dict[str, Any]:
     """
 
     packet = _packet()
-    packet["analytical_job"]["question_family"] = "project_capacity"
+    # staffing_language rather than project_capacity: this variant keeps the
+    # golden's singular-subject shape, and project_capacity is a cohort family
+    # (the family-obligation validator rejects the mismatch, which is the
+    # point of that guard).
+    packet["analytical_job"]["question_family"] = "staffing_language"
+    packet["evidence_coverage"]["source_health"].append(
+        {
+            "source_class": "cognitive_load",
+            "state": "available_current",
+            "observed_at": NOW,
+            "detail": None,
+        }
+    )
     packet["driver_analysis"]["candidates"][1] = {
         "driver_id": DRIVER_REVIEW,
         "category": "capacity_or_staffing",
@@ -791,6 +829,14 @@ def _needs_clarification_packet() -> dict[str, Any]:
         candidate["standing"] = "candidate_only"
         candidate["exclusion_reason"] = None
     packet["driver_analysis"]["principal_driver_ids"] = []
+    packet["evidence_coverage"]["source_health"].append(
+        {
+            "source_class": "source_health",
+            "state": "available_current",
+            "observed_at": NOW,
+            "detail": "Source availability was checked before widening.",
+        }
+    )
     packet["evidence_coverage"]["clarification_needs"] = [
         {
             "kind": "ambiguous_subject",
@@ -1150,6 +1196,7 @@ def _fault_historical_slice_without_as_of() -> dict[str, Any]:
     job = _analytical_job()
     job["time_context"]["analytical_slice"] = "historical"
     job["time_context"]["historical_comparability"] = "comparable"
+    job["time_context"]["edge_validity_basis"] = "observed_intervals"
     return job
 
 
@@ -1211,6 +1258,125 @@ def _fault_coverage_unknown_extra_field() -> dict[str, Any]:
     return coverage
 
 
+# --- Round-1 adversarial review: one negative per newly closed hole ------
+
+
+def _fault_unauthorized_cohort_member() -> dict[str, Any]:
+    """FAULT (H2): a cohort member outside the authorized entity set."""
+
+    packet = _packet()
+    packet["comparison_cohort"]["members"][0]["canonical_id"] = "proj_private_other_org"
+    packet["driver_analysis"]["candidates"][0]["affected_subject_ids"] = [SERVICE]
+    packet["driver_analysis"]["candidates"][1]["affected_subject_ids"] = [TEAM]
+    packet["driver_analysis"]["candidates"][2]["affected_subject_ids"] = [TEAM]
+    packet["evidence_coverage"]["evidence_index"][0]["supports_subject_ids"] = []
+    packet["evidence_coverage"]["evidence_index"][0]["supports_entity_ids"] = [TEAM]
+    return packet
+
+
+def _fault_unauthorized_evidence_entity() -> dict[str, Any]:
+    """FAULT (H2): indexed evidence naming an entity the caller cannot see."""
+
+    packet = _packet()
+    entry = packet["evidence_coverage"]["evidence_index"][1]
+    entry["evidence"]["entity_id"] = "dep_private_other_org"
+    return packet
+
+
+def _fault_non_allowlisted_source() -> dict[str, Any]:
+    """FAULT (H3): coverage claimed from CHAOS-3567's inert temporal stub."""
+
+    packet = _packet()
+    packet["evidence_coverage"]["source_health"].append(
+        {
+            "source_class": "temporal_context",
+            "state": "available_current",
+            "observed_at": NOW,
+            "detail": None,
+        }
+    )
+    return packet
+
+
+def _fault_family_shape_mismatch() -> dict[str, Any]:
+    """FAULT (H4): claiming a cohort family while answering a single subject."""
+
+    packet = _packet()
+    packet["analytical_job"]["question_family"] = "struggling_teams"
+    return packet
+
+
+def _fault_family_required_source_unaccounted() -> dict[str, Any]:
+    """FAULT (H4): a required source neither observed nor declared missing."""
+
+    packet = _packet()
+    packet["evidence_coverage"]["source_health"] = [
+        item
+        for item in packet["evidence_coverage"]["source_health"]
+        if item["source_class"] != "deployment"
+    ]
+    packet["evidence_coverage"]["limitations"] = [
+        limitation
+        for limitation in packet["evidence_coverage"]["limitations"]
+        if limitation["kind"] != "stale_source"
+    ]
+    return packet
+
+
+def _fault_path_never_reaches_entity() -> dict[str, Any]:
+    """FAULT (M5): a real path cited by an entity it never touches."""
+
+    context = _related_context()
+    context["entities"][1]["supporting_path_ids"] = [PATH_OWNERSHIP]
+    return context
+
+
+def _fault_source_both_observed_and_missing() -> dict[str, Any]:
+    """FAULT (M6): contradictory coverage claims for the same source."""
+
+    coverage = _evidence_coverage()
+    coverage["missing_sources"].append(
+        {
+            "source_class": "work_graph",
+            "state": "unavailable",
+            "impact": "Reported unavailable while also reported available_current.",
+        }
+    )
+    return coverage
+
+
+def _fault_comparable_history_without_edge_validity() -> dict[str, Any]:
+    """FAULT (M7): a historical comparison read off the live projection."""
+
+    job = _analytical_job()
+    job["time_context"] = {
+        "start": AS_OF,
+        "end": WINDOW_END,
+        "timezone": "America/Los_Angeles",
+        "analytical_slice": "historical",
+        "as_of": AS_OF,
+        "historical_comparability": "comparable",
+        "edge_validity_basis": "not_required",
+    }
+    return job
+
+
+def _fault_unavailable_edge_validity_claimed_comparable() -> dict[str, Any]:
+    """FAULT (M7): CHAOS-3569 state relabelled as a softer non-comparability."""
+
+    job = _analytical_job()
+    job["time_context"] = {
+        "start": AS_OF,
+        "end": WINDOW_END,
+        "timezone": "America/Los_Angeles",
+        "analytical_slice": "historical",
+        "as_of": AS_OF,
+        "historical_comparability": "not_comparable_missing_baseline",
+        "edge_validity_basis": "unavailable",
+    }
+    return job
+
+
 def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
     """Arm-shaped payloads that MUST fail validation, keyed by contract.
 
@@ -1245,6 +1411,23 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
                 "not_comparable_slice_undisclosed",
                 _fault_undisclosed_not_comparable_slice(),
             ),
+            (
+                "cohort_member_outside_authorized_set",
+                _fault_unauthorized_cohort_member(),
+            ),
+            (
+                "evidence_entity_outside_authorized_set",
+                _fault_unauthorized_evidence_entity(),
+            ),
+            (
+                "source_class_off_the_trial_allowlist",
+                _fault_non_allowlisted_source(),
+            ),
+            ("question_family_shape_mismatch", _fault_family_shape_mismatch()),
+            (
+                "family_required_source_unaccounted",
+                _fault_family_required_source_unaccounted(),
+            ),
         ],
         "ask_dev_analytical_job.v1": [
             (
@@ -1253,6 +1436,14 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
             ),
             ("current_slice_carrying_as_of", _fault_current_slice_with_as_of()),
             ("historical_slice_without_as_of", _fault_historical_slice_without_as_of()),
+            (
+                "comparable_history_without_edge_validity",
+                _fault_comparable_history_without_edge_validity(),
+            ),
+            (
+                "unavailable_edge_validity_mislabelled",
+                _fault_unavailable_edge_validity_claimed_comparable(),
+            ),
         ],
         "ask_dev_subject_discovery.v1": [
             ("commitment_on_fuzzy_label_alone", _fault_commitment_on_fuzzy_label()),
@@ -1276,6 +1467,10 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
             ("path_crosses_unauthorized_entity", _fault_unauthorized_path_entity()),
             ("disconnected_path_presented_as_chain", _fault_disconnected_path()),
             ("entity_citing_undeclared_path", _fault_context_entity_without_path()),
+            (
+                "path_cited_but_never_reaching_entity",
+                _fault_path_never_reaches_entity(),
+            ),
         ],
         "ask_dev_driver_analysis.v1": [
             (
@@ -1316,6 +1511,10 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
             (
                 "graph_native_field_smuggled_as_extra",
                 _fault_coverage_unknown_extra_field(),
+            ),
+            (
+                "source_both_observed_and_missing",
+                _fault_source_both_observed_and_missing(),
             ),
         ],
         "ask_dev_investigation_versions.v1": [

--- a/src/dev_health_ops/api/dev/investigation_contract/fixtures.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/fixtures.py
@@ -1,0 +1,1328 @@
+"""Golden positive and negative fixtures for the investigation packet.
+
+CHAOS-3615 deliverables 3 and 4.
+
+Every payload is a plain JSON-serializable ``dict``, never a constructed
+model — the exporter and the test suite both validate them through
+``INVESTIGATION_CONTRACT_MODELS[name].model_validate(payload)``, which is the
+only way a fixture can prove the *wire* shape rather than the Python one.
+Same convention as ``contract_fixtures_v2``.
+
+The positive fixtures are all slices of **one coherent investigation**: "Why
+is the Nightfall Migration still not finished?", answered against a team, a
+service, a shared dependency and a review backlog. Deriving each section
+fixture from the same scenario rather than authoring eight unrelated
+examples means the section goldens cannot drift apart from the packet
+golden — the packet embeds the very dicts the section fixtures export.
+
+The negative fixtures are **arm-shaped**, not syntax errors. Each one is a
+packet an implementation could plausibly emit — a symptom promoted to
+principal driver, a cohort member with no stated basis, a lineage hop
+pointing the wrong way — because a validator that only rejects malformed
+JSON proves nothing about the behaviours this contract exists to prevent.
+Every one of the eleven named fault modes appears here and is exercised by
+``tests/api/dev/test_chaos_3615_fault_modes.py``.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+NOW = "2026-08-08T12:00:00Z"
+WINDOW_START = "2026-07-09T00:00:00Z"
+WINDOW_END = "2026-08-08T00:00:00Z"
+AS_OF = "2026-05-08T00:00:00Z"
+
+ORG = "org_fullchaos"
+PACKET_ID = "6f1c2a80-3d4e-4b71-9c8a-2e5f7d90ab13"
+
+SUBJECT = "proj_nightfall_migration"
+DECOY = "proj_nightfall"
+TEAM = "team_platform"
+SERVICE = "svc_auth_gateway"
+DEPENDENCY = "dep_authlib"
+
+PATH_OWNERSHIP = "path_ownership"
+PATH_DEPENDENCY = "path_dependency"
+
+DRIVER_DEPENDENCY = "drv_dependency_stall"
+DRIVER_REVIEW = "drv_review_backlog"
+DRIVER_CYCLE_TIME = "drv_cycle_time_rising"
+
+EV_SUBJECT = "ev1_" + "a1" * 20
+EV_DEPENDENCY = "ev1_" + "b2" * 20
+EV_REVIEW = "ev1_" + "c3" * 20
+EV_CYCLE_TIME = "ev1_" + "d4" * 20
+
+__all__ = [
+    "negative_fixtures",
+    "positive_fixtures",
+    "positive_variant_fixtures",
+]
+
+
+# --------------------------------------------------------------------------
+# Shared building blocks
+# --------------------------------------------------------------------------
+
+
+def _evidence_ref(
+    handle: str,
+    *,
+    source_system: str,
+    entity_type: str,
+    entity_id: str,
+    display_label: str,
+    citation_text: str,
+) -> dict[str, Any]:
+    """A real ``dev_evidence_ref.v1`` body, reusing the existing vocabulary.
+
+    Deliberately the platform's own evidence ref rather than a
+    packet-specific one: a handle in this index has to be the same handle
+    ``EvidenceHandleService.verify`` would accept, or packet evidence would
+    be unverifiable against the service that issues it.
+    """
+
+    return {
+        "schema_version": "dev_evidence_ref.v1",
+        "evidence_ref_id": handle,
+        "source_system": source_system,
+        "source_version": "work_graph.v1",
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "display_label": display_label,
+        "link": {
+            "internal_path": f"/work/{entity_type}/{entity_id}",
+            "source_url": None,
+        },
+        "observed_at": NOW,
+        "freshness": "fresh",
+        "provenance": "Canonical work graph projection",
+        "confidence": 1.0,
+        "citation_text": citation_text,
+        "repository_ids": [],
+        "valid_entity_ids": [],
+        "flags": {},
+    }
+
+
+def _analytical_job() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_analytical_job.v1",
+        "job_id": "job_nightfall_status",
+        "question_family": "project_status_drivers",
+        "job_uncertainty": "precise",
+        "job_statement": (
+            "Report the current delivery status of the Nightfall Migration "
+            "project and identify its principal current drivers."
+        ),
+        "comparison_shape": "singular_subject",
+        "time_context": {
+            "start": WINDOW_START,
+            "end": WINDOW_END,
+            "timezone": "America/Los_Angeles",
+            "analytical_slice": "current",
+            "as_of": None,
+            "historical_comparability": "not_applicable",
+        },
+        "surface_context_refs": [
+            {
+                "surface_kind": "project_page",
+                "surface_id": "surface_project_overview",
+                "entity_kind": "project",
+                "entity_id": SUBJECT,
+            }
+        ],
+        "conversation_reference_ids": ["conv_2026_08_08_a"],
+        "interpretation_limitations": [],
+    }
+
+
+def _subject_discovery() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_subject_discovery.v1",
+        "candidates": [
+            {
+                "candidate_id": "cand_1",
+                "rank": 1,
+                "subject_kind": "project",
+                "canonical_id": SUBJECT,
+                "display_label": "Nightfall Migration",
+                "commitment_state": "committed",
+                "match_rationale": (
+                    "The question's phrase 'the Nightfall migration' matches "
+                    "this project's registered display name exactly, and the "
+                    "surface the question was asked from is this project's "
+                    "overview page."
+                ),
+                "match_signals": [
+                    {
+                        "signal": "exact_display_name",
+                        "matched_text": "Nightfall Migration",
+                        "source_class": "work_graph",
+                        "evidence_ref_ids": [EV_SUBJECT],
+                    },
+                    {
+                        "signal": "surface_context_reference",
+                        "matched_text": "surface_project_overview",
+                        "source_class": "work_graph",
+                        "evidence_ref_ids": [],
+                    },
+                ],
+                "match_confidence": 0.97,
+                "relevance": "current",
+            },
+            {
+                "candidate_id": "cand_2",
+                "rank": 2,
+                "subject_kind": "project",
+                "canonical_id": DECOY,
+                "display_label": "Nightfall",
+                "commitment_state": "rejected",
+                "match_rationale": (
+                    "A similarly named archived project. Retained as a ranked "
+                    "candidate so the near-miss is visible rather than "
+                    "silently discarded."
+                ),
+                "match_signals": [
+                    {
+                        "signal": "fuzzy_label",
+                        "matched_text": "Nightfall",
+                        "source_class": "work_graph",
+                        "evidence_ref_ids": [],
+                    }
+                ],
+                "match_confidence": 0.41,
+                "relevance": "historical_only",
+            },
+        ],
+        "unresolved_mentions": [],
+        "committed_subject_ids": [SUBJECT],
+        "authorization_filtered_count": 0,
+        "candidates_truncated": False,
+        "truncation_reason": None,
+    }
+
+
+def _comparison_cohort() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_comparison_cohort.v1",
+        "cohort_id": "cohort_nightfall_singular",
+        "comparison_shape": "singular_subject",
+        "members": [
+            {
+                "subject_kind": "project",
+                "canonical_id": SUBJECT,
+                "display_label": "Nightfall Migration",
+                "inclusion_basis": ["explicitly_named"],
+                "inclusion_rationale": (
+                    "The question names this project directly; it is the sole "
+                    "subject rather than a member of a comparison set."
+                ),
+                "inclusion_evidence_ids": [],
+                "inclusion_evidence_classification": "explicitly_named_by_question",
+                "relevance": "current",
+            }
+        ],
+        "exclusions": [
+            {
+                "subject_kind": "project",
+                "canonical_id": DECOY,
+                "reason": "ambiguous_identity",
+                "rationale": (
+                    "Archived project with a near-identical name; excluded so "
+                    "the near-miss is recorded rather than silently dropped."
+                ),
+            }
+        ],
+        "supported_comparison_dimensions": [],
+        "completeness": "complete",
+        "truncation_reason": None,
+        "cohort_uncertainty": None,
+        "authorization_filtered_count": 0,
+    }
+
+
+def _related_context() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_related_context.v1",
+        "entities": [
+            {
+                "entity_id": TEAM,
+                "entity_kind": "team",
+                "display_label": "Platform",
+                "inclusion_reason": (
+                    "Owns the project; the team whose review capacity gates "
+                    "the remaining work."
+                ),
+                "supporting_path_ids": [PATH_OWNERSHIP],
+                "relevance": "current",
+                "observed_at": NOW,
+            },
+            {
+                "entity_id": SERVICE,
+                "entity_kind": "service",
+                "display_label": "Auth Gateway",
+                "inclusion_reason": (
+                    "The project's remaining work all lands in this service."
+                ),
+                "supporting_path_ids": [PATH_DEPENDENCY],
+                "relevance": "current",
+                "observed_at": NOW,
+            },
+            {
+                "entity_id": DEPENDENCY,
+                "entity_kind": "dependency",
+                "display_label": "authlib",
+                "inclusion_reason": (
+                    "Shared dependency the gateway is blocked behind; the "
+                    "terminal node of the driver's lineage."
+                ),
+                "supporting_path_ids": [PATH_DEPENDENCY],
+                "relevance": "current",
+                "observed_at": NOW,
+            },
+        ],
+        "paths": [
+            {
+                "path_id": PATH_OWNERSHIP,
+                "origin_entity_id": SUBJECT,
+                "terminal_entity_id": TEAM,
+                "hops": [
+                    {
+                        "source_entity_id": SUBJECT,
+                        "source_entity_kind": "project",
+                        "relationship": "owned_by_team",
+                        "direction": "forward",
+                        "target_entity_id": TEAM,
+                        "target_entity_kind": "team",
+                        "observed_at": NOW,
+                        "relevance": "current",
+                    }
+                ],
+                "inclusion_reason": (
+                    "Establishes which team's review capacity applies to the "
+                    "project's outstanding changes."
+                ),
+                "relevance": "current",
+                "evidence_ref_ids": [EV_REVIEW],
+                "truncated": False,
+                "truncation_reason": None,
+                "source_health": "available_current",
+            },
+            {
+                "path_id": PATH_DEPENDENCY,
+                "origin_entity_id": SUBJECT,
+                "terminal_entity_id": DEPENDENCY,
+                "hops": [
+                    {
+                        "source_entity_id": SUBJECT,
+                        "source_entity_kind": "project",
+                        "relationship": "depends_on",
+                        "direction": "forward",
+                        "target_entity_id": SERVICE,
+                        "target_entity_kind": "service",
+                        "observed_at": NOW,
+                        "relevance": "current",
+                    },
+                    {
+                        "source_entity_id": SERVICE,
+                        "source_entity_kind": "service",
+                        "relationship": "depends_on",
+                        "direction": "forward",
+                        "target_entity_id": DEPENDENCY,
+                        "target_entity_kind": "dependency",
+                        "observed_at": NOW,
+                        "relevance": "current",
+                    },
+                ],
+                "inclusion_reason": (
+                    "The two-hop chain from the project to the stalled shared "
+                    "dependency; the mechanism behind the principal driver."
+                ),
+                "relevance": "current",
+                "evidence_ref_ids": [EV_DEPENDENCY],
+                "truncated": False,
+                "truncation_reason": None,
+                "source_health": "available_current",
+            },
+        ],
+        "authorized_entity_ids": [SUBJECT, TEAM, SERVICE, DEPENDENCY],
+        "authorization_filtered_count": 0,
+        "entities_truncated": False,
+        "paths_truncated": False,
+        "truncation_reason": None,
+    }
+
+
+def _driver_analysis() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_driver_analysis.v1",
+        "candidates": [
+            {
+                "driver_id": DRIVER_DEPENDENCY,
+                "category": "dependency_pressure",
+                "summary": (
+                    "The migration's remaining work is blocked behind an "
+                    "unreleased authlib change the gateway depends on."
+                ),
+                "affected_subject_ids": [SUBJECT, SERVICE],
+                "role": "driver",
+                "standing": "principal_driver",
+                "assertion_basis": "measured",
+                "confidence_qualifier": "measured_certain",
+                "supporting_path_ids": [PATH_DEPENDENCY],
+                "supporting_evidence_ids": [EV_DEPENDENCY],
+                "conflicting_evidence_ids": [],
+                "conflict_note": None,
+                "relevance": "current",
+                "exclusion_reason": None,
+                "staffing_qualification": None,
+            },
+            {
+                "driver_id": DRIVER_REVIEW,
+                "category": "review_pressure",
+                "summary": (
+                    "The owning team's review queue has grown faster than it "
+                    "is being drained, extending the tail of every change."
+                ),
+                "affected_subject_ids": [SUBJECT, TEAM],
+                "role": "driver",
+                "standing": "contributing_driver",
+                "assertion_basis": "measured",
+                "confidence_qualifier": "qualified",
+                "supporting_path_ids": [PATH_OWNERSHIP],
+                "supporting_evidence_ids": [EV_REVIEW],
+                "conflicting_evidence_ids": [],
+                "conflict_note": None,
+                "relevance": "current",
+                "exclusion_reason": None,
+                "staffing_qualification": None,
+            },
+            {
+                "driver_id": DRIVER_CYCLE_TIME,
+                "category": "delivery_pressure",
+                "summary": (
+                    "Median cycle time on the project has risen over the window."
+                ),
+                "affected_subject_ids": [SUBJECT],
+                "role": "symptom",
+                "standing": "excluded",
+                "assertion_basis": "measured",
+                "confidence_qualifier": "qualified",
+                "supporting_path_ids": [],
+                "supporting_evidence_ids": [EV_CYCLE_TIME],
+                "conflicting_evidence_ids": [],
+                "conflict_note": None,
+                "relevance": "current",
+                "exclusion_reason": "symptom_of_another_candidate",
+                "staffing_qualification": None,
+            },
+        ],
+        "principal_driver_ids": [DRIVER_DEPENDENCY],
+        "candidates_truncated": False,
+        "truncation_reason": None,
+    }
+
+
+def _evidence_coverage() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_evidence_coverage.v1",
+        "evidence_index": [
+            {
+                "evidence": _evidence_ref(
+                    EV_SUBJECT,
+                    source_system="work_graph",
+                    entity_type="project",
+                    entity_id=SUBJECT,
+                    display_label="Nightfall Migration registration",
+                    citation_text="Project registered under this display name.",
+                ),
+                "source_class": "work_graph",
+                "supports_path_ids": [],
+                "supports_entity_ids": [],
+                "supports_driver_ids": [],
+                "supports_subject_ids": [SUBJECT],
+                "relevance": "current",
+            },
+            {
+                "evidence": _evidence_ref(
+                    EV_DEPENDENCY,
+                    source_system="work_graph",
+                    entity_type="dependency",
+                    entity_id=DEPENDENCY,
+                    display_label="authlib release status",
+                    citation_text="Dependency has no released version carrying the change.",
+                ),
+                "source_class": "work_graph",
+                "supports_path_ids": [PATH_DEPENDENCY],
+                "supports_entity_ids": [SERVICE, DEPENDENCY],
+                "supports_driver_ids": [DRIVER_DEPENDENCY],
+                "supports_subject_ids": [],
+                "relevance": "current",
+            },
+            {
+                "evidence": _evidence_ref(
+                    EV_REVIEW,
+                    source_system="review",
+                    entity_type="team",
+                    entity_id=TEAM,
+                    display_label="Platform review queue",
+                    citation_text="Open review count exceeded the drain rate for the window.",
+                ),
+                "source_class": "review",
+                "supports_path_ids": [PATH_OWNERSHIP],
+                "supports_entity_ids": [TEAM],
+                "supports_driver_ids": [DRIVER_REVIEW],
+                "supports_subject_ids": [],
+                "relevance": "current",
+            },
+            {
+                "evidence": _evidence_ref(
+                    EV_CYCLE_TIME,
+                    source_system="work_item",
+                    entity_type="project",
+                    entity_id=SUBJECT,
+                    display_label="Cycle time p50",
+                    citation_text="Median cycle time rose over the window.",
+                ),
+                "source_class": "work_item",
+                "supports_path_ids": [],
+                "supports_entity_ids": [],
+                "supports_driver_ids": [DRIVER_CYCLE_TIME],
+                "supports_subject_ids": [],
+                "relevance": "current",
+            },
+        ],
+        "source_health": [
+            {
+                "source_class": "work_graph",
+                "state": "available_current",
+                "observed_at": NOW,
+                "detail": None,
+            },
+            {
+                "source_class": "review",
+                "state": "available_current",
+                "observed_at": NOW,
+                "detail": None,
+            },
+            {
+                "source_class": "deployment",
+                "state": "available_stale",
+                "observed_at": NOW,
+                "detail": "Last deployment sync completed 31 hours ago.",
+            },
+        ],
+        "missing_sources": [
+            {
+                "source_class": "investment_allocation",
+                "state": "unconfigured",
+                "impact": (
+                    "No allocation denominator is available, so no staffing "
+                    "claim is made about this project."
+                ),
+            }
+        ],
+        "conflicts": [],
+        "limitations": [
+            {
+                "kind": "missing_source",
+                "detail": (
+                    "Investment allocation is unconfigured for this "
+                    "organization; capacity statements are out of scope for "
+                    "this packet."
+                ),
+            },
+            {
+                "kind": "stale_source",
+                "detail": (
+                    "Deployment evidence is 31 hours old; a release landing "
+                    "since then would not be reflected."
+                ),
+            },
+        ],
+        "clarification_needs": [],
+        "authorization_filtered_count": 0,
+        "evidence_truncated": False,
+        "truncation_reason": None,
+    }
+
+
+def _versions() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_investigation_versions.v1",
+        "packet_schema_version": "ask_dev_investigation_packet.v1",
+        "query_version": "ask_dev_investigation_queries.v1",
+        "ranking_version": "ask_dev_investigation_ranking.v1",
+        "projection_version": "work_graph_projection.v1",
+        "source_contract_versions": [
+            {"source_class": "work_graph", "contract_version": "work_graph.v1"},
+            {"source_class": "review", "contract_version": "review_metrics.v1"},
+            {"source_class": "work_item", "contract_version": "work_item.v1"},
+        ],
+        "corpus_version": None,
+        "trial": None,
+    }
+
+
+def _packet() -> dict[str, Any]:
+    return {
+        "schema_version": "ask_dev_investigation_packet.v1",
+        "packet_id": PACKET_ID,
+        "organization_id": ORG,
+        "produced_at": NOW,
+        "outcome": "supported",
+        "analytical_job": _analytical_job(),
+        "subject_discovery": _subject_discovery(),
+        "comparison_cohort": _comparison_cohort(),
+        "related_context": _related_context(),
+        "driver_analysis": _driver_analysis(),
+        "evidence_coverage": _evidence_coverage(),
+        "versions": _versions(),
+    }
+
+
+def positive_fixtures() -> dict[str, dict[str, Any]]:
+    """One golden per registered contract, all slices of the same scenario."""
+
+    packet = _packet()
+    return {
+        "ask_dev_investigation_packet.v1": packet,
+        "ask_dev_analytical_job.v1": deepcopy(packet["analytical_job"]),
+        "ask_dev_subject_discovery.v1": deepcopy(packet["subject_discovery"]),
+        "ask_dev_comparison_cohort.v1": deepcopy(packet["comparison_cohort"]),
+        "ask_dev_related_context.v1": deepcopy(packet["related_context"]),
+        "ask_dev_driver_analysis.v1": deepcopy(packet["driver_analysis"]),
+        "ask_dev_evidence_coverage.v1": deepcopy(packet["evidence_coverage"]),
+        "ask_dev_investigation_versions.v1": deepcopy(packet["versions"]),
+    }
+
+
+# --------------------------------------------------------------------------
+# Positive variants: the anti-drift rules, as packets that must VALIDATE
+# --------------------------------------------------------------------------
+
+
+def _discovery_without_commitment_packet() -> dict[str, Any]:
+    """Context discovery with no committed subject at all.
+
+    The correction addendum forbids requiring exact subject commitment
+    before authorized candidate and context discovery. This variant is the
+    positive control for that rule: a full related-context and driver
+    section with every candidate merely ``PROPOSED``.
+    """
+
+    packet = _packet()
+    for candidate in packet["subject_discovery"]["candidates"]:
+        candidate["commitment_state"] = "proposed"
+    packet["subject_discovery"]["committed_subject_ids"] = []
+    packet["outcome"] = "supported_with_gaps"
+    packet["evidence_coverage"]["limitations"].append(
+        {
+            "kind": "interpretation_uncertainty",
+            "detail": (
+                "The subject was not committed; findings are reported against "
+                "the top-ranked candidate and remain provisional."
+            ),
+        }
+    )
+    packet["analytical_job"]["job_uncertainty"] = "broad_with_uncertainty"
+    packet["analytical_job"]["interpretation_limitations"] = [
+        {
+            "kind": "interpretation_uncertainty",
+            "detail": (
+                "The question named a project ambiguously; the job was widened "
+                "to 'status and drivers of the best-matching project'."
+            ),
+        }
+    ]
+    return packet
+
+
+def _not_comparable_historical_packet() -> dict[str, Any]:
+    """A historical slice CHAOS-3569 cannot reconstruct — still SUPPORTED.
+
+    The corrective plan's ruling in fixture form: gapped historical rows are
+    NOT COMPARABLE, not blockers. This packet declares
+    ``not_comparable_missing_edge_validity``, discloses the limitation, and
+    remains a valid, supported investigation.
+    """
+
+    packet = _packet()
+    packet["analytical_job"]["time_context"] = {
+        "start": AS_OF,
+        "end": WINDOW_END,
+        "timezone": "America/Los_Angeles",
+        "analytical_slice": "current_vs_historical",
+        "as_of": AS_OF,
+        "historical_comparability": "not_comparable_missing_edge_validity",
+    }
+    packet["evidence_coverage"]["limitations"].append(
+        {
+            "kind": "historical_slice_not_comparable",
+            "detail": (
+                "Relationship edges carry no validity interval, so the as-of "
+                "state cannot be reconstructed; the historical half of this "
+                "comparison is reported NOT COMPARABLE rather than as no "
+                "change."
+            ),
+        }
+    )
+    return packet
+
+
+def _qualified_capacity_packet() -> dict[str, Any]:
+    """A capacity claim with no allocation denominator — qualified, not killed.
+
+    The mirror image of the staffing fault mode, and the reason it needs a
+    positive control: a missing denominator must *reduce confidence*, not
+    make capacity questions unsupported. This packet asserts a capacity
+    driver at ``QUALIFIED`` confidence with ``denominator_absent`` and is
+    valid.
+    """
+
+    packet = _packet()
+    packet["analytical_job"]["question_family"] = "project_capacity"
+    packet["driver_analysis"]["candidates"][1] = {
+        "driver_id": DRIVER_REVIEW,
+        "category": "capacity_or_staffing",
+        "summary": (
+            "The owning team appears capacity-constrained relative to the "
+            "outstanding work, inferred from review queue growth and work in "
+            "progress rather than from an allocation denominator."
+        ),
+        "affected_subject_ids": [SUBJECT, TEAM],
+        "role": "driver",
+        "standing": "contributing_driver",
+        "assertion_basis": "inferred",
+        "confidence_qualifier": "qualified",
+        "supporting_path_ids": [PATH_OWNERSHIP],
+        "supporting_evidence_ids": [EV_REVIEW],
+        "conflicting_evidence_ids": [],
+        "conflict_note": None,
+        "relevance": "current",
+        "exclusion_reason": None,
+        "staffing_qualification": {
+            "denominator_state": "denominator_absent",
+            "denominator_source_classes": [],
+            "qualification_note": (
+                "No allocation or headcount denominator is configured. The "
+                "capacity judgment is inferred from queue growth and WIP and "
+                "is reported as qualified rather than withheld."
+            ),
+        },
+    }
+    packet["evidence_coverage"]["limitations"].append(
+        {
+            "kind": "absent_staffing_denominator",
+            "detail": (
+                "No allocation denominator exists for this organization; the "
+                "capacity statement is qualified accordingly and is not a "
+                "measured claim."
+            ),
+        }
+    )
+    return packet
+
+
+def _needs_clarification_packet() -> dict[str, Any]:
+    """The safe no-match/clarification shape, including the one legal widening.
+
+    Organization scope with an unresolved mention is legal in exactly one
+    case — when the packet is *asking* rather than answering. This variant
+    is that case, and it is the positive control paired with
+    ``organization_widening_after_unresolved_reference``.
+    """
+
+    packet = _packet()
+    packet["outcome"] = "needs_clarification"
+    packet["analytical_job"]["question_family"] = "clarification_and_no_match"
+    packet["analytical_job"]["comparison_shape"] = "organization_wide"
+    packet["analytical_job"]["job_uncertainty"] = "ambiguous"
+    packet["analytical_job"]["job_statement"] = (
+        "Report what is going sideways; no subject was named."
+    )
+    packet["analytical_job"]["interpretation_limitations"] = [
+        {
+            "kind": "interpretation_uncertainty",
+            "detail": "The question named no subject and no time context.",
+        }
+    ]
+    packet["subject_discovery"]["candidates"][0]["commitment_state"] = "ambiguous"
+    packet["subject_discovery"]["committed_subject_ids"] = []
+    packet["subject_discovery"]["unresolved_mentions"] = [
+        {
+            "mention_id": "mention_1",
+            "mention_text": "the nightfall thing",
+            "reason": "multiple_candidates",
+            "candidate_ids": ["cand_1", "cand_2"],
+        }
+    ]
+    packet["comparison_cohort"]["comparison_shape"] = "organization_wide"
+    packet["comparison_cohort"]["members"] = [
+        {
+            "subject_kind": "project",
+            "canonical_id": SUBJECT,
+            "display_label": "Nightfall Migration",
+            "inclusion_basis": ["explicitly_named"],
+            "inclusion_rationale": "One of two candidates for the named reference.",
+            "inclusion_evidence_ids": [],
+            "inclusion_evidence_classification": "explicitly_named_by_question",
+            "relevance": "current",
+        },
+        {
+            "subject_kind": "project",
+            "canonical_id": DECOY,
+            "display_label": "Nightfall",
+            "inclusion_basis": ["explicitly_named"],
+            "inclusion_rationale": "The other candidate for the named reference.",
+            "inclusion_evidence_ids": [],
+            "inclusion_evidence_classification": "explicitly_named_by_question",
+            "relevance": "historical_only",
+        },
+    ]
+    packet["comparison_cohort"]["exclusions"] = []
+    packet["comparison_cohort"]["supported_comparison_dimensions"] = [
+        "delivery_throughput"
+    ]
+    for candidate in packet["driver_analysis"]["candidates"]:
+        candidate["standing"] = "candidate_only"
+        candidate["exclusion_reason"] = None
+    packet["driver_analysis"]["principal_driver_ids"] = []
+    packet["evidence_coverage"]["clarification_needs"] = [
+        {
+            "kind": "ambiguous_subject",
+            "prompt": (
+                "Two projects match 'nightfall'. Did you mean the Nightfall "
+                "Migration, or the archived Nightfall project?"
+            ),
+            "candidate_ids": ["cand_1", "cand_2"],
+        }
+    ]
+    return packet
+
+
+def _trial_metadata_packet() -> dict[str, Any]:
+    """The same packet with trial metadata attached.
+
+    Proves arm identity is *addable* without being required, and that no
+    other field changes when it is present — the structural meaning of "arm
+    identity is evaluation metadata, not product truth".
+    """
+
+    packet = _packet()
+    packet["versions"]["trial"] = {
+        "arm_id": "arm_under_test",
+        "producer_id": "investigation_arm.v1",
+        "fixture_version": "chaos_3616_corpus.v1",
+        "run_id": "0f9d3c21-7b45-4c8e-9a10-5d6e7f801234",
+    }
+    packet["versions"]["corpus_version"] = "chaos_3616_corpus.v1"
+    return packet
+
+
+def positive_variant_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
+    """Extra packets that MUST validate — the anti-drift positive controls.
+
+    Every named anti-drift rule that could be "enforced" by simply making
+    the legitimate case impossible has a variant here. A contract that
+    rejected the bad shape *and* the good one would pass every negative
+    test while being useless.
+    """
+
+    return {
+        "ask_dev_investigation_packet.v1": [
+            ("discovery_without_commitment", _discovery_without_commitment_packet()),
+            ("not_comparable_historical_slice", _not_comparable_historical_packet()),
+            ("qualified_capacity_without_denominator", _qualified_capacity_packet()),
+            ("needs_clarification_with_widening", _needs_clarification_packet()),
+            ("trial_metadata_present", _trial_metadata_packet()),
+        ]
+    }
+
+
+# --------------------------------------------------------------------------
+# Negative fixtures: arm-shaped bad packets, one per named fault mode
+# --------------------------------------------------------------------------
+
+
+def _fault_commitment_on_fuzzy_label() -> dict[str, Any]:
+    """FAULT: wrong but similarly named subject ranked and committed first."""
+
+    discovery = _subject_discovery()
+    top = discovery["candidates"][0]
+    top["canonical_id"] = DECOY
+    top["display_label"] = "Nightfall"
+    top["match_signals"] = [
+        {
+            "signal": "fuzzy_label",
+            "matched_text": "Nightfall",
+            "source_class": "work_graph",
+            "evidence_ref_ids": [],
+        }
+    ]
+    discovery["candidates"][1]["canonical_id"] = SUBJECT
+    discovery["candidates"][1]["display_label"] = "Nightfall Migration"
+    discovery["committed_subject_ids"] = [DECOY]
+    return discovery
+
+
+def _fault_committed_below_rank_one() -> dict[str, Any]:
+    """FAULT: the committed subject is not the one the arm ranked first."""
+
+    discovery = _subject_discovery()
+    discovery["candidates"][0]["commitment_state"] = "proposed"
+    discovery["candidates"][1]["commitment_state"] = "committed"
+    discovery["candidates"][1]["match_signals"] = [
+        {
+            "signal": "exact_display_name",
+            "matched_text": "Nightfall",
+            "source_class": "work_graph",
+            "evidence_ref_ids": [],
+        }
+    ]
+    discovery["committed_subject_ids"] = [DECOY]
+    return discovery
+
+
+def _fault_ranks_out_of_order() -> dict[str, Any]:
+    discovery = _subject_discovery()
+    discovery["candidates"][0]["rank"] = 2
+    discovery["candidates"][1]["rank"] = 1
+    return discovery
+
+
+def _fault_missing_truncation_flag() -> dict[str, Any]:
+    """FAULT: an absent required disclosure field, silently defaulting."""
+
+    discovery = _subject_discovery()
+    del discovery["candidates_truncated"]
+    return discovery
+
+
+def _fault_organization_widening() -> dict[str, Any]:
+    """FAULT: org-wide sweep after an unresolved named reference."""
+
+    packet = _needs_clarification_packet()
+    packet["outcome"] = "supported"
+    packet["evidence_coverage"]["clarification_needs"] = []
+    packet["driver_analysis"]["candidates"][0]["standing"] = "principal_driver"
+    packet["driver_analysis"]["principal_driver_ids"] = [DRIVER_DEPENDENCY]
+    return packet
+
+
+def _fault_evidence_supports_nothing() -> dict[str, Any]:
+    """FAULT: high-volume evidence attached to nothing, displacing lineage."""
+
+    coverage = _evidence_coverage()
+    coverage["evidence_index"].append(
+        {
+            "evidence": _evidence_ref(
+                "ev1_" + "e5" * 20,
+                source_system="code_change",
+                entity_type="repository",
+                entity_id="repo_dev_health",
+                display_label="Recent commits",
+                citation_text="1,482 commits in the window.",
+            ),
+            "source_class": "code_change",
+            "supports_path_ids": [],
+            "supports_entity_ids": [],
+            "supports_driver_ids": [],
+            "supports_subject_ids": [],
+            "relevance": "current",
+        }
+    )
+    return coverage
+
+
+def _fault_dangling_evidence_citation() -> dict[str, Any]:
+    """FAULT: a driver cites evidence that is nowhere in the index."""
+
+    packet = _packet()
+    packet["driver_analysis"]["candidates"][0]["supporting_evidence_ids"] = [
+        "ev1_" + "f6" * 20
+    ]
+    return packet
+
+
+def _fault_symptom_as_principal_driver() -> dict[str, Any]:
+    """FAULT: a symptom promoted to principal driver with no lineage."""
+
+    analysis = _driver_analysis()
+    symptom = analysis["candidates"][2]
+    symptom["standing"] = "principal_driver"
+    symptom["exclusion_reason"] = None
+    analysis["principal_driver_ids"] = [DRIVER_DEPENDENCY, DRIVER_CYCLE_TIME]
+    return analysis
+
+
+def _fault_principal_driver_without_path() -> dict[str, Any]:
+    """FAULT: a real driver promoted to principal with no supporting path."""
+
+    analysis = _driver_analysis()
+    analysis["candidates"][0]["supporting_path_ids"] = []
+    return analysis
+
+
+def _fault_historical_driver_as_principal() -> dict[str, Any]:
+    analysis = _driver_analysis()
+    analysis["candidates"][0]["relevance"] = "historical_only"
+    return analysis
+
+
+def _fault_certain_staffing_without_denominator() -> dict[str, Any]:
+    """FAULT: a staffing claim presented as certain with no denominator."""
+
+    analysis = _driver_analysis()
+    analysis["candidates"][1] = {
+        "driver_id": DRIVER_REVIEW,
+        "category": "capacity_or_staffing",
+        "summary": "The team is understaffed for the remaining work.",
+        "affected_subject_ids": [SUBJECT, TEAM],
+        "role": "driver",
+        "standing": "contributing_driver",
+        "assertion_basis": "measured",
+        "confidence_qualifier": "measured_certain",
+        "supporting_path_ids": [PATH_OWNERSHIP],
+        "supporting_evidence_ids": [EV_REVIEW],
+        "conflicting_evidence_ids": [],
+        "conflict_note": None,
+        "relevance": "current",
+        "exclusion_reason": None,
+        "staffing_qualification": {
+            "denominator_state": "denominator_absent",
+            "denominator_source_classes": [],
+            "qualification_note": "No allocation data.",
+        },
+    }
+    return analysis
+
+
+def _fault_staffing_claim_without_qualification() -> dict[str, Any]:
+    """FAULT: a capacity driver that says nothing about its denominator."""
+
+    analysis = _driver_analysis()
+    analysis["candidates"][1]["category"] = "capacity_or_staffing"
+    analysis["candidates"][1]["staffing_qualification"] = None
+    return analysis
+
+
+def _fault_unrelated_cohort_member() -> dict[str, Any]:
+    """FAULT: a cohort member with neither evidence nor a classification."""
+
+    cohort = _comparison_cohort()
+    cohort["comparison_shape"] = "discovered_cohort"
+    cohort["supported_comparison_dimensions"] = ["delivery_throughput"]
+    cohort["members"].append(
+        {
+            "subject_kind": "project",
+            "canonical_id": "proj_unrelated_billing",
+            "display_label": "Billing Revamp",
+            "inclusion_basis": ["comparable_delivery_profile"],
+            "inclusion_rationale": "Also a project.",
+            "inclusion_evidence_ids": [],
+            "inclusion_evidence_classification": None,
+            "relevance": "current",
+        }
+    )
+    return cohort
+
+
+def _fault_cohort_without_comparison_dimensions() -> dict[str, Any]:
+    """FAULT: a cohort claiming comparison while declaring no dimension."""
+
+    cohort = _comparison_cohort()
+    cohort["comparison_shape"] = "discovered_cohort"
+    cohort["members"].append(
+        {
+            "subject_kind": "project",
+            "canonical_id": "proj_atlas",
+            "display_label": "Atlas",
+            "inclusion_basis": ["shared_dependency"],
+            "inclusion_rationale": "Depends on the same stalled dependency.",
+            "inclusion_evidence_ids": [EV_DEPENDENCY],
+            "inclusion_evidence_classification": None,
+            "relevance": "current",
+        }
+    )
+    cohort["supported_comparison_dimensions"] = []
+    return cohort
+
+
+def _fault_cohort_truncated_without_reason() -> dict[str, Any]:
+    cohort = _comparison_cohort()
+    cohort["completeness"] = "truncated"
+    return cohort
+
+
+def _fault_reversed_relationship() -> dict[str, Any]:
+    """FAULT: 'project owns team' emitted as a forward ownership edge."""
+
+    context = _related_context()
+    hop = context["paths"][0]["hops"][0]
+    hop["source_entity_id"] = TEAM
+    hop["source_entity_kind"] = "team"
+    hop["target_entity_id"] = SUBJECT
+    hop["target_entity_kind"] = "project"
+    context["paths"][0]["origin_entity_id"] = TEAM
+    context["paths"][0]["terminal_entity_id"] = SUBJECT
+    return context
+
+
+def _fault_unauthorized_path_entity() -> dict[str, Any]:
+    """FAULT: a lineage path routed through an entity outside the authorized set."""
+
+    context = _related_context()
+    context["authorized_entity_ids"] = [SUBJECT, TEAM, SERVICE]
+    return context
+
+
+def _fault_disconnected_path() -> dict[str, Any]:
+    context = _related_context()
+    context["paths"][1]["hops"][1]["source_entity_id"] = "svc_unrelated"
+    context["paths"][1]["hops"][1]["source_entity_kind"] = "service"
+    context["authorized_entity_ids"].append("svc_unrelated")
+    return context
+
+
+def _fault_dashboard_redirect_as_answer() -> dict[str, Any]:
+    """FAULT: SUPPORTED with evidence and surfaces but no asserted driver."""
+
+    packet = _packet()
+    for candidate in packet["driver_analysis"]["candidates"]:
+        candidate["standing"] = "candidate_only"
+        candidate["exclusion_reason"] = None
+    packet["driver_analysis"]["principal_driver_ids"] = []
+    return packet
+
+
+def _fault_no_match_without_explanation() -> dict[str, Any]:
+    """FAULT: a silent no-match — the privileged default wearing a label."""
+
+    packet = _packet()
+    packet["outcome"] = "no_match"
+    for candidate in packet["subject_discovery"]["candidates"]:
+        candidate["commitment_state"] = "proposed"
+    packet["subject_discovery"]["committed_subject_ids"] = []
+    for candidate in packet["driver_analysis"]["candidates"]:
+        candidate["standing"] = "candidate_only"
+        candidate["exclusion_reason"] = None
+    packet["driver_analysis"]["principal_driver_ids"] = []
+    packet["evidence_coverage"]["limitations"] = []
+    packet["evidence_coverage"]["missing_sources"] = []
+    packet["evidence_coverage"]["clarification_needs"] = []
+    return packet
+
+
+def _fault_undisclosed_authorization_filtering() -> dict[str, Any]:
+    packet = _packet()
+    packet["related_context"]["authorization_filtered_count"] = 4
+    return packet
+
+
+def _fault_undisclosed_not_comparable_slice() -> dict[str, Any]:
+    packet = _not_comparable_historical_packet()
+    packet["evidence_coverage"]["limitations"] = [
+        limitation
+        for limitation in packet["evidence_coverage"]["limitations"]
+        if limitation["kind"] != "historical_slice_not_comparable"
+    ]
+    return packet
+
+
+def _fault_uncertain_job_without_limitations() -> dict[str, Any]:
+    job = _analytical_job()
+    job["job_uncertainty"] = "broad_with_uncertainty"
+    job["interpretation_limitations"] = []
+    return job
+
+
+def _fault_current_slice_with_as_of() -> dict[str, Any]:
+    job = _analytical_job()
+    job["time_context"]["as_of"] = AS_OF
+    return job
+
+
+def _fault_historical_slice_without_as_of() -> dict[str, Any]:
+    job = _analytical_job()
+    job["time_context"]["analytical_slice"] = "historical"
+    job["time_context"]["historical_comparability"] = "comparable"
+    return job
+
+
+def _fault_coverage_missing_source_undisclosed() -> dict[str, Any]:
+    coverage = _evidence_coverage()
+    coverage["limitations"] = [
+        limitation
+        for limitation in coverage["limitations"]
+        if limitation["kind"] != "missing_source"
+    ]
+    return coverage
+
+
+def _fault_coverage_conflict_not_indexed() -> dict[str, Any]:
+    coverage = _evidence_coverage()
+    coverage["conflicts"] = [
+        {
+            "conflict_id": "conflict_1",
+            "evidence_ref_ids": ["ev1_" + "07" * 20, "ev1_" + "08" * 20],
+            "description": "Two sources disagree on the release state.",
+            "resolution": "unresolved",
+        }
+    ]
+    coverage["limitations"].append(
+        {"kind": "conflicting_evidence", "detail": "Release state disputed."}
+    )
+    return coverage
+
+
+def _fault_versions_without_source_contracts() -> dict[str, Any]:
+    versions = _versions()
+    versions["source_contract_versions"] = []
+    return versions
+
+
+def _fault_versions_duplicate_source_contract() -> dict[str, Any]:
+    versions = _versions()
+    versions["source_contract_versions"].append(
+        {"source_class": "work_graph", "contract_version": "work_graph.v2"}
+    )
+    return versions
+
+
+def _fault_analysis_principal_list_mismatch() -> dict[str, Any]:
+    analysis = _driver_analysis()
+    analysis["principal_driver_ids"] = []
+    return analysis
+
+
+def _fault_context_entity_without_path() -> dict[str, Any]:
+    context = _related_context()
+    context["entities"][0]["supporting_path_ids"] = ["path_never_declared"]
+    return context
+
+
+def _fault_coverage_unknown_extra_field() -> dict[str, Any]:
+    coverage = _evidence_coverage()
+    coverage["graph_node_ids"] = ["4:8a1f:12"]
+    return coverage
+
+
+def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
+    """Arm-shaped payloads that MUST fail validation, keyed by contract.
+
+    Labels are the fault, not the mechanism, so a reader scanning the
+    exported artifact tree sees what the contract refuses rather than which
+    validator happens to refuse it.
+    """
+
+    return {
+        "ask_dev_investigation_packet.v1": [
+            (
+                "organization_widening_after_unresolved_reference",
+                _fault_organization_widening(),
+            ),
+            (
+                "dashboard_redirect_without_direct_judgment",
+                _fault_dashboard_redirect_as_answer(),
+            ),
+            (
+                "evidence_citation_absent_from_index",
+                _fault_dangling_evidence_citation(),
+            ),
+            (
+                "no_match_without_limitation_or_clarification",
+                _fault_no_match_without_explanation(),
+            ),
+            (
+                "authorization_filtering_undisclosed",
+                _fault_undisclosed_authorization_filtering(),
+            ),
+            (
+                "not_comparable_slice_undisclosed",
+                _fault_undisclosed_not_comparable_slice(),
+            ),
+        ],
+        "ask_dev_analytical_job.v1": [
+            (
+                "uncertain_job_without_limitations",
+                _fault_uncertain_job_without_limitations(),
+            ),
+            ("current_slice_carrying_as_of", _fault_current_slice_with_as_of()),
+            ("historical_slice_without_as_of", _fault_historical_slice_without_as_of()),
+        ],
+        "ask_dev_subject_discovery.v1": [
+            ("commitment_on_fuzzy_label_alone", _fault_commitment_on_fuzzy_label()),
+            ("commitment_below_rank_one", _fault_committed_below_rank_one()),
+            ("candidate_ranks_out_of_order", _fault_ranks_out_of_order()),
+            ("absent_truncation_disclosure_field", _fault_missing_truncation_flag()),
+        ],
+        "ask_dev_comparison_cohort.v1": [
+            (
+                "unrelated_member_without_inclusion_evidence",
+                _fault_unrelated_cohort_member(),
+            ),
+            (
+                "comparison_claimed_without_dimensions",
+                _fault_cohort_without_comparison_dimensions(),
+            ),
+            ("truncated_without_reason", _fault_cohort_truncated_without_reason()),
+        ],
+        "ask_dev_related_context.v1": [
+            ("reversed_relationship_direction", _fault_reversed_relationship()),
+            ("path_crosses_unauthorized_entity", _fault_unauthorized_path_entity()),
+            ("disconnected_path_presented_as_chain", _fault_disconnected_path()),
+            ("entity_citing_undeclared_path", _fault_context_entity_without_path()),
+        ],
+        "ask_dev_driver_analysis.v1": [
+            (
+                "symptom_promoted_to_principal_driver",
+                _fault_symptom_as_principal_driver(),
+            ),
+            (
+                "principal_driver_without_supporting_path",
+                _fault_principal_driver_without_path(),
+            ),
+            (
+                "historical_driver_promoted_to_principal",
+                _fault_historical_driver_as_principal(),
+            ),
+            (
+                "staffing_certainty_without_denominator",
+                _fault_certain_staffing_without_denominator(),
+            ),
+            (
+                "capacity_driver_without_staffing_qualification",
+                _fault_staffing_claim_without_qualification(),
+            ),
+            (
+                "principal_list_contradicts_standings",
+                _fault_analysis_principal_list_mismatch(),
+            ),
+        ],
+        "ask_dev_evidence_coverage.v1": [
+            ("evidence_supporting_nothing", _fault_evidence_supports_nothing()),
+            (
+                "missing_source_undisclosed",
+                _fault_coverage_missing_source_undisclosed(),
+            ),
+            (
+                "conflict_citing_unindexed_evidence",
+                _fault_coverage_conflict_not_indexed(),
+            ),
+            (
+                "graph_native_field_smuggled_as_extra",
+                _fault_coverage_unknown_extra_field(),
+            ),
+        ],
+        "ask_dev_investigation_versions.v1": [
+            ("no_source_contract_versions", _fault_versions_without_source_contracts()),
+            (
+                "duplicate_source_contract_version",
+                _fault_versions_duplicate_source_contract(),
+            ),
+        ],
+    }

--- a/src/dev_health_ops/api/dev/investigation_contract/packet.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/packet.py
@@ -560,8 +560,7 @@ class ComparisonCohort(ContractModelV2):
         if self.comparison_shape is ComparisonShape.SINGULAR_SUBJECT:
             if len(self.members) > 1:
                 raise ValueError(
-                    "a singular-subject shape cannot carry more than one "
-                    "cohort member"
+                    "a singular-subject shape cannot carry more than one cohort member"
                 )
             return self
         if self.comparison_shape in COHORT_BEARING_SHAPES:
@@ -586,9 +585,7 @@ class ComparisonCohort(ContractModelV2):
         )
         uncertain = self.completeness is CohortCompleteness.BEST_EFFORT_UNCERTAIN
         if uncertain and self.cohort_uncertainty is None:
-            raise ValueError(
-                "a best-effort cohort must say what it is uncertain about"
-            )
+            raise ValueError("a best-effort cohort must say what it is uncertain about")
         if not uncertain and self.cohort_uncertainty is not None:
             raise ValueError(
                 "cohort_uncertainty is only meaningful on a best-effort cohort"
@@ -765,6 +762,16 @@ class RelatedContext(ContractModelV2):
         restricted entity still discloses that the entity exists and that it
         connects two things the caller can see — which is the leak, even
         when its own record is never returned.
+
+        **What this cannot check, stated plainly.** ``authorized_entity_ids``
+        is declared by the producer, so this validator proves *internal
+        consistency* — the packet did not traverse anything it did not also
+        claim was authorized — and not that the claim is true. An arm that
+        listed the whole organization as authorized would pass here. That
+        residual is why ``ZERO_UNAUTHORIZED_RESULTS`` is scored by CHAOS-3616
+        against a real authorization oracle as well as by this check, and
+        why the honest description of this guard is "makes an unauthorized
+        traversal impossible to hide", not "makes it impossible".
         """
 
         authorized = set(self.authorized_entity_ids)
@@ -875,8 +882,7 @@ class DriverCandidate(ContractModelV2):
                 )
             if not self.supporting_evidence_ids:
                 raise ValueError(
-                    f"driver {self.driver_id} is principal with no supporting "
-                    "evidence"
+                    f"driver {self.driver_id} is principal with no supporting evidence"
                 )
             if self.relevance not in CURRENTLY_RELEVANT_STATES:
                 raise ValueError(
@@ -1328,6 +1334,14 @@ class AskDevInvestigationPacket(ContractModelV2):
         on the index's own ``supports_*`` fields — stops an evidence dump
         from claiming attachment to paths, entities, drivers or subjects the
         packet never declared.
+
+        **What this cannot check.** Closure is checked *within the packet*.
+        Whether a handle would actually verify against
+        ``evidence_service.EvidenceHandleService`` is a runtime,
+        org-scoped question a static contract cannot answer — the grammar
+        pins the handle's shape, and dereferencing pins its validity. A
+        packet that passes here can still cite a handle that no longer
+        resolves.
         """
 
         indexed = {
@@ -1354,9 +1368,7 @@ class AskDevInvestigationPacket(ContractModelV2):
 
         known_paths = {path.path_id for path in self.related_context.paths}
         known_entities = {entity.entity_id for entity in self.related_context.entities}
-        known_drivers = {
-            driver.driver_id for driver in self.driver_analysis.candidates
-        }
+        known_drivers = {driver.driver_id for driver in self.driver_analysis.candidates}
         known_subjects = {
             candidate.canonical_id for candidate in self.subject_discovery.candidates
         } | {member.canonical_id for member in self.comparison_cohort.members}
@@ -1380,10 +1392,7 @@ class AskDevInvestigationPacket(ContractModelV2):
     def validate_drivers_reference_declared_material(self) -> Self:
         known_paths = {path.path_id for path in self.related_context.paths}
         known_subjects = (
-            {
-                candidate.canonical_id
-                for candidate in self.subject_discovery.candidates
-            }
+            {candidate.canonical_id for candidate in self.subject_discovery.candidates}
             | {member.canonical_id for member in self.comparison_cohort.members}
             | {entity.entity_id for entity in self.related_context.entities}
         )
@@ -1446,14 +1455,11 @@ class AskDevInvestigationPacket(ContractModelV2):
         if self.outcome is InvestigationOutcome.NEEDS_CLARIFICATION:
             if not self.evidence_coverage.clarification_needs:
                 raise ValueError(
-                    "a needs-clarification outcome must record what it needs "
-                    "clarified"
+                    "a needs-clarification outcome must record what it needs clarified"
                 )
         if self.outcome is InvestigationOutcome.NO_MATCH:
             if self.subject_discovery.committed_subject_ids:
-                raise ValueError(
-                    "a no-match outcome cannot also commit to a subject"
-                )
+                raise ValueError("a no-match outcome cannot also commit to a subject")
             if not (
                 self.evidence_coverage.clarification_needs
                 or self.evidence_coverage.limitations

--- a/src/dev_health_ops/api/dev/investigation_contract/packet.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/packet.py
@@ -52,7 +52,8 @@ from dev_health_ops.api.dev.contracts_v2.base import (
 )
 from dev_health_ops.api.dev.contracts_v2.embedded import DevEvidenceRefV2
 
-from .question_families import QuestionFamilyID
+from .allowlists import SLICE_BOUNDARIES, TRIAL_SOURCE_ALLOWLIST
+from .question_families import QUESTION_FAMILY_REGISTRY, QuestionFamilyID
 from .relationships import RELATIONSHIP_ALLOWLIST, RelationshipType
 from .vocabulary import (
     ASSERTED_DRIVER_STANDINGS,
@@ -79,11 +80,13 @@ from .vocabulary import (
     DriverExclusionReason,
     DriverRole,
     DriverStanding,
+    EdgeValidityBasis,
     HistoricalComparability,
     InvestigationOutcome,
     InvestigationSubjectKind,
     JobUncertainty,
     PacketLimitationKind,
+    PacketSection,
     RelationshipDirection,
     RelevanceState,
     StaffingDenominatorState,
@@ -125,6 +128,16 @@ __all__ = [
     "TrialMetadata",
     "UnresolvedMention",
 ]
+
+
+def _path_entity_ids(path: LineagePath) -> set[str]:
+    """Every entity a path touches, endpoints and intermediates alike."""
+
+    touched: set[str] = {path.origin_entity_id, path.terminal_entity_id}
+    for hop in path.hops:
+        touched.add(hop.source_entity_id)
+        touched.add(hop.target_entity_id)
+    return touched
 
 
 def _require_truncation_reason(
@@ -200,6 +213,7 @@ class BoundedTimeContext(ContractModelV2):
     analytical_slice: AnalyticalSlice
     as_of: AwareDatetime | None = None
     historical_comparability: HistoricalComparability
+    edge_validity_basis: EdgeValidityBasis
 
     @model_validator(mode="after")
     def validate_window_and_slice(self) -> Self:
@@ -217,6 +231,11 @@ class BoundedTimeContext(ContractModelV2):
                     "the current slice's only legal comparability state is "
                     "'not_applicable'"
                 )
+            if self.edge_validity_basis is not EdgeValidityBasis.NOT_REQUIRED:
+                raise ValueError(
+                    "the current slice reads the live projection, so its only "
+                    "legal edge_validity_basis is 'not_required'"
+                )
             return self
         if self.as_of is None:
             raise ValueError(
@@ -227,6 +246,52 @@ class BoundedTimeContext(ContractModelV2):
             raise ValueError(
                 f"the {self.analytical_slice} slice must state whether it is "
                 "comparable; 'not_applicable' is reserved for the current slice"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_comparability_is_backed_by_edge_validity(self) -> Self:
+        """A historical comparison must have actually had edge validity.
+
+        Adversarial review round 1, finding M7. ``SLICE_BOUNDARIES`` declared
+        that historical slices require edge validity, but nothing on the wire
+        recorded whether the arm had it — so a packet could read the *live*
+        projection, label the slice ``COMPARABLE``, and emit a confident and
+        entirely false delta. The declaration was a comment; this makes it a
+        constraint.
+
+        The three rules are the contrapositives of each other: a slice that
+        needs edge validity may not claim it was ``NOT_REQUIRED``; only
+        ``OBSERVED_INTERVALS`` may back ``COMPARABLE``; and ``UNAVAILABLE`` —
+        the CHAOS-3569 state — forces the matching not-comparable reason
+        rather than a vaguer one.
+        """
+
+        boundary = SLICE_BOUNDARIES[self.analytical_slice]
+        if not boundary.requires_edge_validity:
+            return self
+        if self.edge_validity_basis is EdgeValidityBasis.NOT_REQUIRED:
+            raise ValueError(
+                f"the {self.analytical_slice} slice requires edge validity, so "
+                "'not_required' is not a legal edge_validity_basis for it"
+            )
+        comparable = self.historical_comparability is HistoricalComparability.COMPARABLE
+        observed = self.edge_validity_basis is EdgeValidityBasis.OBSERVED_INTERVALS
+        if comparable and not observed:
+            raise ValueError(
+                f"the {self.analytical_slice} slice claims COMPARABLE on an "
+                f"edge_validity_basis of {self.edge_validity_basis}; without "
+                "observed validity intervals the as-of state was not "
+                "reconstructed and any delta is fabricated"
+            )
+        if self.edge_validity_basis is EdgeValidityBasis.UNAVAILABLE and (
+            self.historical_comparability
+            is not HistoricalComparability.NOT_COMPARABLE_MISSING_EDGE_VALIDITY
+        ):
+            raise ValueError(
+                "edge validity is unavailable, so the comparability state must "
+                "be 'not_comparable_missing_edge_validity' (the CHAOS-3569 "
+                f"state), not {self.historical_comparability}"
             )
         return self
 
@@ -743,13 +808,34 @@ class RelatedContext(ContractModelV2):
 
     @model_validator(mode="after")
     def validate_entities_are_reachable(self) -> Self:
-        known_paths = {path.path_id for path in self.paths}
+        """Cited paths must exist **and** must actually reach the entity.
+
+        Adversarial review round 1, finding M5. The original check only
+        rejected dangling path ids, so an entity could cite a real path that
+        terminates somewhere else entirely — the Auth Gateway service citing
+        the project-owns-team path — and the packet would present two
+        unrelated true facts as a single line of reasoning. Existence is not
+        attachment.
+        """
+
+        by_id = {path.path_id: path for path in self.paths}
         for entity in self.entities:
-            dangling = sorted(set(entity.supporting_path_ids) - known_paths)
+            dangling = sorted(set(entity.supporting_path_ids) - set(by_id))
             if dangling:
                 raise ValueError(
                     f"related entity {entity.entity_id} cites paths that were "
                     f"never declared: {dangling}"
+                )
+            unreached = sorted(
+                path_id
+                for path_id in entity.supporting_path_ids
+                if entity.entity_id not in _path_entity_ids(by_id[path_id])
+            )
+            if unreached:
+                raise ValueError(
+                    f"related entity {entity.entity_id} cites paths that never "
+                    f"reach it: {unreached}; a path that does not touch the "
+                    "entity is not why the entity is here"
                 )
         return self
 
@@ -1178,6 +1264,21 @@ class EvidenceCoverage(ContractModelV2):
                 "limitations repeats a kind; one disclosure per kind keeps the "
                 "list a real summary rather than a pile"
             )
+        contradictory = sorted(
+            str(item) for item in set(health_classes) & set(missing_classes)
+        )
+        if contradictory:
+            # Adversarial review round 1, finding M6. Uniqueness was checked
+            # *within* each list but never *between* them, so a producer could
+            # report work_graph as available_current in source_health and
+            # unavailable in missing_sources at the same time -- and then pick
+            # whichever reading flattered its coverage score.
+            raise ValueError(
+                "these source classes are reported both as observed and as "
+                f"missing: {contradictory}; a source cannot be simultaneously "
+                "available and absent, and a consumer cannot know which "
+                "coverage claim to score"
+            )
         return self
 
     @model_validator(mode="after")
@@ -1290,6 +1391,180 @@ class AskDevInvestigationPacket(ContractModelV2):
                 f"({self.comparison_cohort.comparison_shape}) contradicts the "
                 f"job's ({self.analytical_job.comparison_shape})"
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_every_entity_is_authorized(self) -> Self:
+        """The authorization envelope covers the **whole packet**, not one section.
+
+        Adversarial review round 1, finding H2. ``RelatedContext``'s own guard
+        checks the entities and hop endpoints it owns, and nothing else — so a
+        cohort member, a subject candidate, a driver's affected subject or an
+        indexed evidence item could name an entity outside the authorized set
+        and the packet still validated. Every one of those is a label or an
+        identifier reaching a consumer, which is the leak; scoping the check
+        to lineage only protected the least likely route.
+
+        Residual, unchanged and still worth repeating: the authorized set is
+        producer-declared, so this proves the packet is internally consistent
+        with its own claim, not that the claim is true. See
+        ``RelatedContext.validate_paths_stay_inside_authorized_set``.
+        """
+
+        authorized = set(self.related_context.authorized_entity_ids)
+        offenders: dict[str, set[str]] = {}
+
+        def flag(where: str, entity_id: str) -> None:
+            if entity_id not in authorized:
+                offenders.setdefault(where, set()).add(entity_id)
+
+        for candidate in self.subject_discovery.candidates:
+            flag("subject_discovery.candidates", candidate.canonical_id)
+        for member in self.comparison_cohort.members:
+            flag("comparison_cohort.members", member.canonical_id)
+        for exclusion in self.comparison_cohort.exclusions:
+            flag("comparison_cohort.exclusions", exclusion.canonical_id)
+        for driver in self.driver_analysis.candidates:
+            for subject_id in driver.affected_subject_ids:
+                flag("driver_analysis.affected_subject_ids", subject_id)
+        for entry in self.evidence_coverage.evidence_index:
+            flag("evidence_coverage.evidence_index", entry.evidence.entity_id)
+        for ref in self.analytical_job.surface_context_refs:
+            if ref.entity_id is not None:
+                flag("analytical_job.surface_context_refs", ref.entity_id)
+
+        if offenders:
+            detail = "; ".join(
+                f"{where}: {sorted(ids)}" for where, ids in sorted(offenders.items())
+            )
+            raise ValueError(
+                "these entities appear in the packet but not in "
+                f"related_context.authorized_entity_ids -- {detail}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_sources_are_allowlisted(self) -> Self:
+        """Every source class named anywhere must be on the trial allowlist.
+
+        Adversarial review round 1, finding H3. ``TRIAL_SOURCE_ALLOWLIST``
+        deliberately excludes ``SourceClass.TEMPORAL_CONTEXT`` — CHAOS-3567's
+        inert stub — but the packet's ``source_class`` fields were typed as
+        the full platform enum and no validator consulted the allowlist, so
+        an arm could claim coverage from a source the trial does not score
+        and that has no adapter behind it at all.
+
+        Enforced rather than narrowed at the type level on purpose: the field
+        type stays ``SourceClass`` so the packet keeps speaking the platform's
+        vocabulary, and the *trial's* bound stays visible as a rule that can
+        be relaxed for a later trial without a wire change.
+        """
+
+        allowed = set(TRIAL_SOURCE_ALLOWLIST)
+        offenders: dict[str, set[str]] = {}
+
+        def flag(where: str, source_class: SourceClass) -> None:
+            if source_class not in allowed:
+                offenders.setdefault(where, set()).add(str(source_class))
+
+        for candidate in self.subject_discovery.candidates:
+            for signal in candidate.match_signals:
+                flag("subject_discovery.match_signals", signal.source_class)
+        for driver in self.driver_analysis.candidates:
+            if driver.staffing_qualification is not None:
+                for (
+                    source_class
+                ) in driver.staffing_qualification.denominator_source_classes:
+                    flag("driver_analysis.staffing_qualification", source_class)
+        for entry in self.evidence_coverage.evidence_index:
+            flag("evidence_coverage.evidence_index", entry.source_class)
+        for observation in self.evidence_coverage.source_health:
+            flag("evidence_coverage.source_health", observation.source_class)
+        for missing in self.evidence_coverage.missing_sources:
+            flag("evidence_coverage.missing_sources", missing.source_class)
+        for version in self.versions.source_contract_versions:
+            flag("versions.source_contract_versions", version.source_class)
+
+        if offenders:
+            detail = "; ".join(
+                f"{where}: {sorted(names)}"
+                for where, names in sorted(offenders.items())
+            )
+            raise ValueError(
+                f"these source classes are not on the trial allowlist -- {detail}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_question_family_obligations(self) -> Self:
+        """The declared family's obligations bind the packet that claims it.
+
+        Adversarial review round 1, finding H4. The family registry described
+        what each family requires — permitted comparison shapes, source
+        classes, populated sections — and nothing checked any of it, so an
+        arm could label a discovered-cohort investigation
+        ``project_status_drivers`` (the family with the loosest evidence
+        requirements), skip the work, and still land in the per-family
+        scoring table under a family it never actually answered. That
+        corrupts exactly the report CHAOS-3616 exists to produce.
+
+        Required sources are satisfied by being *accounted for*, not by being
+        present: an arm that could not read deployments may declare that in
+        ``missing_sources``. What it may not do is stay silent, which is the
+        difference between a disclosed gap and an undisclosed one.
+        """
+
+        family = QUESTION_FAMILY_REGISTRY[self.analytical_job.question_family]
+
+        shape = self.analytical_job.comparison_shape
+        if shape not in family.permitted_comparison_shapes:
+            permitted = sorted(str(item) for item in family.permitted_comparison_shapes)
+            raise ValueError(
+                f"family {family.family_id} does not permit the "
+                f"{shape} comparison shape (permitted: {permitted}); a packet "
+                "cannot claim a family whose shape it does not answer"
+            )
+
+        accounted = (
+            {entry.source_class for entry in self.evidence_coverage.evidence_index}
+            | {item.source_class for item in self.evidence_coverage.source_health}
+            | {item.source_class for item in self.evidence_coverage.missing_sources}
+        )
+        unaccounted = sorted(
+            str(item) for item in set(family.required_source_classes) - accounted
+        )
+        if unaccounted:
+            raise ValueError(
+                f"family {family.family_id} requires source classes that this "
+                f"packet neither observed nor declared missing: {unaccounted}"
+            )
+
+        populated = {
+            PacketSection.ANALYTICAL_JOB: True,
+            PacketSection.SUBJECT_DISCOVERY: bool(self.subject_discovery.candidates),
+            PacketSection.COMPARISON_COHORT: bool(self.comparison_cohort.members),
+            PacketSection.RELATED_CONTEXT: bool(self.related_context.entities),
+            PacketSection.DRIVER_ANALYSIS: bool(self.driver_analysis.candidates),
+            PacketSection.EVIDENCE_COVERAGE: bool(
+                self.evidence_coverage.evidence_index
+            ),
+            PacketSection.VERSIONS: True,
+        }
+        # Only a packet that claims to have answered owes the full section
+        # set. A clarification or no-match packet legitimately has no cohort
+        # and no drivers -- requiring them would force an arm to invent both
+        # rather than admit it could not resolve the subject.
+        if self.outcome in SUPPORTED_OUTCOMES:
+            empty = sorted(
+                str(section)
+                for section in family.required_packet_sections
+                if not populated[section]
+            )
+            if empty:
+                raise ValueError(
+                    f"family {family.family_id} requires these packet sections "
+                    f"to be populated, and they are empty: {empty}"
+                )
         return self
 
     @model_validator(mode="after")

--- a/src/dev_health_ops/api/dev/investigation_contract/packet.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/packet.py
@@ -1,0 +1,1578 @@
+"""``ask_dev_investigation_packet.v1`` — the frozen investigation contract.
+
+CHAOS-3615 deliverables 1 and 12.
+
+Every model here is a ``ContractModelV2``: ``extra="forbid"`` and
+``frozen=True``, exactly like the Ask Dev v2 wire contracts, so an arm
+cannot smuggle a backend-specific field through as an extra key and cannot
+mutate a packet after it has been produced.
+
+Two conventions run through the whole module and are worth stating once.
+
+**No reassuring default.** Every disclosure field —
+``authorization_filtered_count``, every ``*_truncated`` flag,
+``completeness`` — is required with no default. The tempting defaults are
+all the flattering ones (nothing was filtered, nothing was truncated), and a
+producer that forgets the field would then look exactly like one that had
+nothing to disclose. Omission is a validation error instead. Pinned by
+``test_chaos_3615_fault_modes.py::test_disclosure_fields_have_no_reassuring_default``.
+
+**Truncation and filtering are always paired with a reason.** A ``True``
+truncation flag without a ``TruncationReason``, or a non-zero
+authorization-filtered count without a matching limitation, is rejected —
+partial results that do not say why they are partial are indistinguishable
+from complete ones.
+
+The evidence vocabulary is deliberately *not* new: handles are
+``EvidenceHandle`` (``ev1_`` + 40 hex, minted and verified by
+``evidence_service.EvidenceHandleService``) and indexed items embed a real
+``DevEvidenceRefV2``. A parallel evidence-identity scheme would have made
+packet evidence unverifiable against the service that issues it.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from dev_health_ops.api.dev.contracts import (
+    Label,
+    OpaqueID,
+    ShortText,
+    TimezoneName,
+)
+from dev_health_ops.api.dev.contracts_v2.base import (
+    ContractModelV2,
+    EvidenceHandle,
+    PlatformVersionToken,
+    ServerHandle,
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.embedded import DevEvidenceRefV2
+
+from .question_families import QuestionFamilyID
+from .relationships import RELATIONSHIP_ALLOWLIST, RelationshipType
+from .vocabulary import (
+    ASSERTED_DRIVER_STANDINGS,
+    COHORT_BEARING_SHAPES,
+    CURRENTLY_RELEVANT_STATES,
+    NOT_COMPARABLE_STATES,
+    SUBJECT_CLARIFICATION_KINDS,
+    SUPPORTED_OUTCOMES,
+    UNCERTAIN_JOB_STATES,
+    UNQUALIFIED_DENOMINATOR_STATES,
+    WEAK_SUBJECT_MATCH_SIGNALS,
+    AnalyticalSlice,
+    AssertionBasis,
+    ClarificationNeedKind,
+    CohortCompleteness,
+    CohortEvidenceClassification,
+    CohortExclusionReason,
+    CohortInclusionBasis,
+    ComparisonDimension,
+    ComparisonShape,
+    ConfidenceQualifier,
+    ConflictResolution,
+    DriverCategory,
+    DriverExclusionReason,
+    DriverRole,
+    DriverStanding,
+    HistoricalComparability,
+    InvestigationOutcome,
+    InvestigationSubjectKind,
+    JobUncertainty,
+    PacketLimitationKind,
+    RelationshipDirection,
+    RelevanceState,
+    StaffingDenominatorState,
+    SubjectCommitmentState,
+    SubjectMatchSignal,
+    SurfaceKind,
+    TruncationReason,
+    UnresolvedMentionReason,
+)
+
+__all__ = [
+    "INVESTIGATION_CONTRACT_MODELS",
+    "AnalyticalJob",
+    "AskDevInvestigationPacket",
+    "BoundedTimeContext",
+    "ClarificationNeed",
+    "CohortExclusion",
+    "CohortMember",
+    "ComparisonCohort",
+    "DriverAnalysis",
+    "DriverCandidate",
+    "EvidenceCoverage",
+    "InvestigationEvidenceEntry",
+    "InvestigationVersions",
+    "LineageHop",
+    "LineagePath",
+    "MissingSource",
+    "PacketLimitation",
+    "RelatedContext",
+    "RelatedEntity",
+    "SourceConflict",
+    "SourceContractVersion",
+    "SourceHealthObservation",
+    "StaffingQualification",
+    "SubjectCandidate",
+    "SubjectDiscovery",
+    "SubjectMatchEvidence",
+    "SurfaceContextRef",
+    "TrialMetadata",
+    "UnresolvedMention",
+]
+
+
+def _require_truncation_reason(
+    truncated: bool, reason: TruncationReason | None, field: str
+) -> None:
+    """Raise unless a truncation flag and its reason agree.
+
+    Shared by every section that can truncate. Both directions are errors: a
+    flag without a reason hides *why* the result is partial; a reason
+    without a flag means a consumer counting truncations would miss it.
+    """
+
+    if truncated and reason is None:
+        raise ValueError(
+            f"{field} is truncated but declares no truncation_reason; a "
+            "partial result that does not say why is indistinguishable from "
+            "a complete one"
+        )
+    if not truncated and reason is not None:
+        raise ValueError(
+            f"{field} declares a truncation_reason but is not marked truncated"
+        )
+
+
+# --------------------------------------------------------------------------
+# Analytical job
+# --------------------------------------------------------------------------
+
+
+class PacketLimitation(ContractModelV2):
+    """One safe, closed-vocabulary limitation the packet is disclosing."""
+
+    kind: PacketLimitationKind
+    detail: ShortText
+
+
+class ClarificationNeed(ContractModelV2):
+    """A question the investigation needs answered before it can proceed."""
+
+    kind: ClarificationNeedKind
+    prompt: ShortText
+    candidate_ids: tuple[OpaqueID, ...] = Field(default_factory=tuple, max_length=10)
+
+
+class SurfaceContextRef(ContractModelV2):
+    """A safe reference to the surface or conversation the question came from.
+
+    Deliberately three closed/opaque fields and no URL: see
+    ``vocabulary.SurfaceKind``.
+    """
+
+    surface_kind: SurfaceKind
+    surface_id: OpaqueID
+    entity_kind: InvestigationSubjectKind | None = None
+    entity_id: OpaqueID | None = None
+
+    @model_validator(mode="after")
+    def validate_entity_reference_is_complete(self) -> Self:
+        if (self.entity_kind is None) != (self.entity_id is None):
+            raise ValueError(
+                "a surface entity reference needs both entity_kind and "
+                "entity_id, or neither"
+            )
+        return self
+
+
+class BoundedTimeContext(ContractModelV2):
+    """The bounded time window, and which slice of history it addresses."""
+
+    start: AwareDatetime
+    end: AwareDatetime
+    timezone: TimezoneName
+    analytical_slice: AnalyticalSlice
+    as_of: AwareDatetime | None = None
+    historical_comparability: HistoricalComparability
+
+    @model_validator(mode="after")
+    def validate_window_and_slice(self) -> Self:
+        if self.end <= self.start:
+            raise ValueError("time context end must be strictly after start")
+        current = self.analytical_slice is AnalyticalSlice.CURRENT
+        if current:
+            if self.as_of is not None:
+                raise ValueError("the current slice must not carry an as_of instant")
+            if (
+                self.historical_comparability
+                is not HistoricalComparability.NOT_APPLICABLE
+            ):
+                raise ValueError(
+                    "the current slice's only legal comparability state is "
+                    "'not_applicable'"
+                )
+            return self
+        if self.as_of is None:
+            raise ValueError(
+                f"the {self.analytical_slice} slice requires an as_of instant; "
+                "without one an as-of traversal cannot be reconstructed"
+            )
+        if self.historical_comparability is HistoricalComparability.NOT_APPLICABLE:
+            raise ValueError(
+                f"the {self.analytical_slice} slice must state whether it is "
+                "comparable; 'not_applicable' is reserved for the current slice"
+            )
+        return self
+
+
+class AnalyticalJob(ContractModelV2):
+    """The normalized analytical job, with its uncertainty stated.
+
+    ``job_uncertainty`` is what keeps this contract from requiring a
+    pre-enumerated intent: an arm may declare a broad job it is uncertain
+    about and still investigate, provided it says so. The
+    ``question_family`` is a *family*, not an enumerated intent — ten of
+    them cover the whole trial, and one of them is "clarification and safe
+    no-match".
+    """
+
+    schema_version: Literal["ask_dev_analytical_job.v1"]
+    job_id: OpaqueID
+    question_family: QuestionFamilyID
+    job_uncertainty: JobUncertainty
+    job_statement: ShortText
+    comparison_shape: ComparisonShape
+    time_context: BoundedTimeContext
+    surface_context_refs: tuple[SurfaceContextRef, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    conversation_reference_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    interpretation_limitations: tuple[PacketLimitation, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+
+    @model_validator(mode="after")
+    def validate_uncertainty_is_disclosed(self) -> Self:
+        """An uncertain job must say what it is uncertain about.
+
+        Without this, ``BROAD_WITH_UNCERTAINTY`` would be a free pass: an
+        arm could label every job broad, investigate whatever it liked, and
+        never be accountable for the interpretation it actually chose.
+        """
+
+        if (
+            self.job_uncertainty in UNCERTAIN_JOB_STATES
+            and not self.interpretation_limitations
+        ):
+            raise ValueError(
+                f"a {self.job_uncertainty} analytical job must declare at "
+                "least one interpretation limitation"
+            )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Subject discovery
+# --------------------------------------------------------------------------
+
+
+class SubjectMatchEvidence(ContractModelV2):
+    """What matched, and what backs the claim that it matched."""
+
+    signal: SubjectMatchSignal
+    matched_text: ShortText
+    source_class: SourceClass
+    evidence_ref_ids: tuple[EvidenceHandle, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+
+
+class SubjectCandidate(ContractModelV2):
+    """One candidate canonical subject and why it is a candidate.
+
+    ``match_signals`` is ``min_length=1``: a ranked candidate with no stated
+    signal is the shape in which a wrong-but-similarly-named project reaches
+    rank 1 unexaminably.
+    """
+
+    candidate_id: OpaqueID
+    rank: int = Field(ge=1, le=25)
+    subject_kind: InvestigationSubjectKind
+    canonical_id: OpaqueID
+    display_label: Label
+    commitment_state: SubjectCommitmentState
+    match_rationale: ShortText
+    match_signals: tuple[SubjectMatchEvidence, ...] = Field(min_length=1, max_length=10)
+    match_confidence: float = Field(ge=0, le=1)
+    relevance: RelevanceState
+
+
+class UnresolvedMention(ContractModelV2):
+    """A reference in the question that discovery could not resolve."""
+
+    mention_id: OpaqueID
+    mention_text: ShortText
+    reason: UnresolvedMentionReason
+    candidate_ids: tuple[OpaqueID, ...] = Field(default_factory=tuple, max_length=25)
+
+
+class SubjectDiscovery(ContractModelV2):
+    """Candidate subjects, what was committed, and what stayed unresolved.
+
+    Commitment is *not* a prerequisite for the rest of the packet: a
+    discovery section with zero committed subjects is legal and is exercised
+    by a positive fixture, because the correction addendum forbids requiring
+    exact subject commitment before authorized context discovery.
+    """
+
+    schema_version: Literal["ask_dev_subject_discovery.v1"]
+    candidates: tuple[SubjectCandidate, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    unresolved_mentions: tuple[UnresolvedMention, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    committed_subject_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    authorization_filtered_count: int = Field(ge=0)
+    candidates_truncated: bool
+    truncation_reason: TruncationReason | None = None
+
+    @model_validator(mode="after")
+    def validate_candidate_ranking(self) -> Self:
+        """Ranks are 1..n, unique, and in declaration order.
+
+        Declaration order matters because top-1 and top-3 are scored
+        dimensions: a producer that emitted ranks out of order would make
+        "the rank-1 candidate" ambiguous between position and label.
+        """
+
+        expected = tuple(range(1, len(self.candidates) + 1))
+        actual = tuple(candidate.rank for candidate in self.candidates)
+        if actual != expected:
+            raise ValueError(
+                f"candidate ranks must be 1..n in declaration order; got {actual}"
+            )
+        candidate_ids = [candidate.candidate_id for candidate in self.candidates]
+        if len(set(candidate_ids)) != len(candidate_ids):
+            raise ValueError("candidate_id values must be unique")
+        return self
+
+    @model_validator(mode="after")
+    def validate_commitment_is_evidenced(self) -> Self:
+        """Committed subjects agree with their candidates, and are earned.
+
+        Three rules, all aimed at the same fault shape — a wrong but
+        similarly named subject silently becoming *the* subject:
+
+        1. ``committed_subject_ids`` is exactly the set of candidates in the
+           ``COMMITTED`` state, in both directions. A commitment recorded in
+           one place and not the other is a producer bug that would show up
+           downstream as a subject nobody can trace.
+        2. A committed candidate's signals may not be *only* weak ones.
+           Fuzzy label matching is exactly what returns "Nightfall" for
+           "Nightfall Migration"; committing on it alone is the fault.
+        3. A committed candidate must be ranked first. Committing to
+           something the arm itself ranked below another candidate, with no
+           clarification, is the same fault wearing a different hat.
+        """
+
+        committed = {
+            candidate.canonical_id
+            for candidate in self.candidates
+            if candidate.commitment_state is SubjectCommitmentState.COMMITTED
+        }
+        declared = set(self.committed_subject_ids)
+        if committed != declared:
+            raise ValueError(
+                "committed_subject_ids must be exactly the canonical ids of "
+                f"COMMITTED candidates; committed={sorted(committed)}, "
+                f"declared={sorted(declared)}"
+            )
+        if len(self.committed_subject_ids) != len(declared):
+            raise ValueError("committed_subject_ids must not repeat a subject")
+        for candidate in self.candidates:
+            if candidate.commitment_state is not SubjectCommitmentState.COMMITTED:
+                continue
+            signals = {signal.signal for signal in candidate.match_signals}
+            if signals <= WEAK_SUBJECT_MATCH_SIGNALS:
+                raise ValueError(
+                    f"candidate {candidate.candidate_id} is committed on weak "
+                    f"signals alone ({sorted(str(item) for item in signals)}); "
+                    "a fuzzy label match is what returns a similarly named "
+                    "subject, so it cannot carry a commitment by itself"
+                )
+            if candidate.rank != 1:
+                raise ValueError(
+                    f"candidate {candidate.candidate_id} is committed at rank "
+                    f"{candidate.rank}; committing to a candidate the "
+                    "investigation itself ranked below another, without "
+                    "clarification, is an unexaminable subject choice"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_unresolved_mentions_reference_declared_candidates(self) -> Self:
+        known = {candidate.candidate_id for candidate in self.candidates}
+        for mention in self.unresolved_mentions:
+            dangling = sorted(set(mention.candidate_ids) - known)
+            if dangling:
+                raise ValueError(
+                    f"unresolved mention {mention.mention_id} names candidate "
+                    f"ids that were never declared: {dangling}"
+                )
+            if (
+                mention.reason is UnresolvedMentionReason.MULTIPLE_CANDIDATES
+                and len(mention.candidate_ids) < 2
+            ):
+                raise ValueError(
+                    f"unresolved mention {mention.mention_id} claims multiple "
+                    "candidates but names fewer than two"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_truncation_disclosure(self) -> Self:
+        _require_truncation_reason(
+            self.candidates_truncated, self.truncation_reason, "subject_discovery"
+        )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Comparison cohort
+# --------------------------------------------------------------------------
+
+
+class CohortMember(ContractModelV2):
+    """A subject in the comparison cohort, with its inclusion justified."""
+
+    subject_kind: InvestigationSubjectKind
+    canonical_id: OpaqueID
+    display_label: Label
+    inclusion_basis: tuple[CohortInclusionBasis, ...] = Field(
+        min_length=1, max_length=5
+    )
+    inclusion_rationale: ShortText
+    inclusion_evidence_ids: tuple[EvidenceHandle, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    inclusion_evidence_classification: CohortEvidenceClassification | None = None
+    relevance: RelevanceState
+
+    @model_validator(mode="after")
+    def validate_inclusion_is_evidenced(self) -> Self:
+        """Evidence handles XOR an explicit no-evidence classification.
+
+        The same F10 pattern as ``DevMetricRefV2`` and ``DeficiencyFinding``.
+        "Neither" is the fault shape: a cohort member with no evidence and
+        no stated reason for having none is exactly how an unrelated project
+        joins a comparison unnoticed. "Both" is rejected too, because a
+        classification exists only to explain an *absence*.
+        """
+
+        has_evidence = bool(self.inclusion_evidence_ids)
+        has_classification = self.inclusion_evidence_classification is not None
+        if has_evidence and has_classification:
+            raise ValueError(
+                f"cohort member {self.canonical_id} carries evidence and an "
+                "inclusion_evidence_classification; the classification exists "
+                "only for the no-evidence case"
+            )
+        if not has_evidence and not has_classification:
+            raise ValueError(
+                f"cohort member {self.canonical_id} carries neither evidence "
+                "nor an explicit no-evidence classification; an unjustified "
+                "member is an unrelated member nobody can spot"
+            )
+        if len(set(self.inclusion_basis)) != len(self.inclusion_basis):
+            raise ValueError(
+                f"cohort member {self.canonical_id} repeats an inclusion basis"
+            )
+        return self
+
+
+class CohortExclusion(ContractModelV2):
+    """A subject considered for the cohort and deliberately left out."""
+
+    subject_kind: InvestigationSubjectKind
+    canonical_id: OpaqueID
+    reason: CohortExclusionReason
+    rationale: ShortText
+
+
+class ComparisonCohort(ContractModelV2):
+    """The comparison cohort, its exclusions, and how complete it is."""
+
+    schema_version: Literal["ask_dev_comparison_cohort.v1"]
+    cohort_id: OpaqueID
+    comparison_shape: ComparisonShape
+    members: tuple[CohortMember, ...] = Field(default_factory=tuple, max_length=50)
+    exclusions: tuple[CohortExclusion, ...] = Field(
+        default_factory=tuple, max_length=50
+    )
+    supported_comparison_dimensions: tuple[ComparisonDimension, ...] = Field(
+        default_factory=tuple, max_length=12
+    )
+    completeness: CohortCompleteness
+    truncation_reason: TruncationReason | None = None
+    cohort_uncertainty: ShortText | None = None
+    authorization_filtered_count: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_membership_is_coherent(self) -> Self:
+        member_ids = [member.canonical_id for member in self.members]
+        if len(set(member_ids)) != len(member_ids):
+            raise ValueError("cohort members must be unique by canonical_id")
+        excluded_ids = [exclusion.canonical_id for exclusion in self.exclusions]
+        if len(set(excluded_ids)) != len(excluded_ids):
+            raise ValueError("cohort exclusions must be unique by canonical_id")
+        both = sorted(set(member_ids) & set(excluded_ids))
+        if both:
+            raise ValueError(f"subjects are both included and excluded: {both}")
+        if len(set(self.supported_comparison_dimensions)) != len(
+            self.supported_comparison_dimensions
+        ):
+            raise ValueError("supported_comparison_dimensions repeats a dimension")
+        return self
+
+    @model_validator(mode="after")
+    def validate_comparison_is_not_vacuous(self) -> Self:
+        """A cohort that claims to compare must be able to.
+
+        Two members and at least one declared dimension. Without the
+        dimension the cohort is a list the reader has to compare themselves;
+        without the second member there is nothing to compare at all. Both
+        are well-formed shapes that would score as "comparison supported"
+        while supporting no comparison — the wildcard/optional-field
+        vacuity fault, in its cohort-shaped form.
+        """
+
+        if self.comparison_shape is ComparisonShape.SINGULAR_SUBJECT:
+            if len(self.members) > 1:
+                raise ValueError(
+                    "a singular-subject shape cannot carry more than one "
+                    "cohort member"
+                )
+            return self
+        if self.comparison_shape in COHORT_BEARING_SHAPES:
+            if len(self.members) < 2:
+                raise ValueError(
+                    f"a {self.comparison_shape} cohort needs at least two "
+                    f"members to compare; got {len(self.members)}"
+                )
+            if not self.supported_comparison_dimensions:
+                raise ValueError(
+                    f"a {self.comparison_shape} cohort declares no supported "
+                    "comparison dimension, so it supports no comparison"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_completeness_disclosure(self) -> Self:
+        _require_truncation_reason(
+            self.completeness is CohortCompleteness.TRUNCATED,
+            self.truncation_reason,
+            "comparison_cohort",
+        )
+        uncertain = self.completeness is CohortCompleteness.BEST_EFFORT_UNCERTAIN
+        if uncertain and self.cohort_uncertainty is None:
+            raise ValueError(
+                "a best-effort cohort must say what it is uncertain about"
+            )
+        if not uncertain and self.cohort_uncertainty is not None:
+            raise ValueError(
+                "cohort_uncertainty is only meaningful on a best-effort cohort"
+            )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Related context and lineage
+# --------------------------------------------------------------------------
+
+
+class LineageHop(ContractModelV2):
+    """One traversed edge.
+
+    ``source_entity_id`` is always the entity traversal started from and
+    ``target_entity_id`` the entity it arrived at; ``direction`` says whether
+    that traversal followed the relationship's canonical orientation or ran
+    against it. Separating traversal order from canonical orientation is
+    what makes a reversed relationship detectable at all — with a single
+    combined field, "team owns project" and "project owned by team" are the
+    same bytes.
+    """
+
+    source_entity_id: OpaqueID
+    source_entity_kind: InvestigationSubjectKind
+    relationship: RelationshipType
+    direction: RelationshipDirection
+    target_entity_id: OpaqueID
+    target_entity_kind: InvestigationSubjectKind
+    observed_at: AwareDatetime | None = None
+    relevance: RelevanceState
+
+    @model_validator(mode="after")
+    def validate_direction_matches_allowlist(self) -> Self:
+        """The endpoint kinds must match the declared canonical orientation."""
+
+        orientation = RELATIONSHIP_ALLOWLIST[self.relationship]
+        if self.direction is RelationshipDirection.FORWARD:
+            source_kind, target_kind = self.source_entity_kind, self.target_entity_kind
+        else:
+            source_kind, target_kind = self.target_entity_kind, self.source_entity_kind
+        if not orientation.permits(source_kind, target_kind):
+            raise ValueError(
+                f"hop {self.source_entity_id} -[{self.relationship}/"
+                f"{self.direction}]-> {self.target_entity_id} contradicts the "
+                f"canonical orientation ({orientation.canonical_reading}); "
+                f"{source_kind} -> {target_kind} is not a declared ordering"
+            )
+        if self.source_entity_id == self.target_entity_id:
+            raise ValueError(
+                f"hop on {self.source_entity_id} points at itself; a self-loop "
+                "explains nothing and inflates path recall"
+            )
+        return self
+
+
+class LineagePath(ContractModelV2):
+    """A bounded chain of hops, and why it was included."""
+
+    path_id: OpaqueID
+    origin_entity_id: OpaqueID
+    terminal_entity_id: OpaqueID
+    hops: tuple[LineageHop, ...] = Field(min_length=1, max_length=6)
+    inclusion_reason: ShortText
+    relevance: RelevanceState
+    evidence_ref_ids: tuple[EvidenceHandle, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    truncated: bool
+    truncation_reason: TruncationReason | None = None
+    source_health: SourceRequirementState
+
+    @model_validator(mode="after")
+    def validate_path_is_connected(self) -> Self:
+        """Hops chain end-to-end and match the declared endpoints.
+
+        A "path" whose hops do not actually join is two unrelated facts
+        presented as a causal chain, which is how a plausible but false
+        lineage gets built out of true edges.
+        """
+
+        first, last = self.hops[0], self.hops[-1]
+        if first.source_entity_id != self.origin_entity_id:
+            raise ValueError(
+                f"path {self.path_id} declares origin {self.origin_entity_id} "
+                f"but its first hop starts at {first.source_entity_id}"
+            )
+        if last.target_entity_id != self.terminal_entity_id:
+            raise ValueError(
+                f"path {self.path_id} declares terminal "
+                f"{self.terminal_entity_id} but its last hop ends at "
+                f"{last.target_entity_id}"
+            )
+        for index in range(len(self.hops) - 1):
+            current, following = self.hops[index], self.hops[index + 1]
+            if current.target_entity_id != following.source_entity_id:
+                raise ValueError(
+                    f"path {self.path_id} is not connected: hop {index} ends "
+                    f"at {current.target_entity_id} but hop {index + 1} "
+                    f"starts at {following.source_entity_id}"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_truncation_disclosure(self) -> Self:
+        _require_truncation_reason(
+            self.truncated, self.truncation_reason, f"path {self.path_id}"
+        )
+        return self
+
+
+class RelatedEntity(ContractModelV2):
+    """A canonical entity the investigation pulled in, and its justification.
+
+    ``supporting_path_ids`` is ``min_length=1``: an entity nothing connects
+    to the subject is not related context, it is noise that displaces the
+    lineage actually asked for.
+    """
+
+    entity_id: OpaqueID
+    entity_kind: InvestigationSubjectKind
+    display_label: Label
+    inclusion_reason: ShortText
+    supporting_path_ids: tuple[OpaqueID, ...] = Field(min_length=1, max_length=10)
+    relevance: RelevanceState
+    observed_at: AwareDatetime | None = None
+
+
+class RelatedContext(ContractModelV2):
+    """Related entities, the paths that reach them, and the authorized set."""
+
+    schema_version: Literal["ask_dev_related_context.v1"]
+    entities: tuple[RelatedEntity, ...] = Field(default_factory=tuple, max_length=100)
+    paths: tuple[LineagePath, ...] = Field(default_factory=tuple, max_length=100)
+    authorized_entity_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=500
+    )
+    authorization_filtered_count: int = Field(ge=0)
+    entities_truncated: bool
+    paths_truncated: bool
+    truncation_reason: TruncationReason | None = None
+
+    @model_validator(mode="after")
+    def validate_identifiers_are_unique(self) -> Self:
+        entity_ids = [entity.entity_id for entity in self.entities]
+        if len(set(entity_ids)) != len(entity_ids):
+            raise ValueError("related entities must be unique by entity_id")
+        path_ids = [path.path_id for path in self.paths]
+        if len(set(path_ids)) != len(path_ids):
+            raise ValueError("lineage paths must be unique by path_id")
+        if len(set(self.authorized_entity_ids)) != len(self.authorized_entity_ids):
+            raise ValueError("authorized_entity_ids repeats an entity")
+        return self
+
+    @model_validator(mode="after")
+    def validate_entities_are_reachable(self) -> Self:
+        known_paths = {path.path_id for path in self.paths}
+        for entity in self.entities:
+            dangling = sorted(set(entity.supporting_path_ids) - known_paths)
+            if dangling:
+                raise ValueError(
+                    f"related entity {entity.entity_id} cites paths that were "
+                    f"never declared: {dangling}"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_paths_stay_inside_authorized_set(self) -> Self:
+        """No hop endpoint or related entity may sit outside the authorized set.
+
+        Enforced on *every* endpoint of every hop, not only on the entities
+        the packet returns as results. A path that merely routes through a
+        restricted entity still discloses that the entity exists and that it
+        connects two things the caller can see — which is the leak, even
+        when its own record is never returned.
+        """
+
+        authorized = set(self.authorized_entity_ids)
+        offenders: set[str] = set()
+        for path in self.paths:
+            for hop in path.hops:
+                for entity_id in (hop.source_entity_id, hop.target_entity_id):
+                    if entity_id not in authorized:
+                        offenders.add(entity_id)
+        for entity in self.entities:
+            if entity.entity_id not in authorized:
+                offenders.add(entity.entity_id)
+        if offenders:
+            raise ValueError(
+                "related context crosses entities outside the authorized set: "
+                f"{sorted(offenders)}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_truncation_disclosure(self) -> Self:
+        _require_truncation_reason(
+            self.entities_truncated or self.paths_truncated,
+            self.truncation_reason,
+            "related_context",
+        )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Driver candidates
+# --------------------------------------------------------------------------
+
+
+class StaffingQualification(ContractModelV2):
+    """How much allocation evidence stands behind a capacity claim."""
+
+    denominator_state: StaffingDenominatorState
+    denominator_source_classes: tuple[SourceClass, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    qualification_note: ShortText
+
+    @model_validator(mode="after")
+    def validate_available_denominator_names_its_sources(self) -> Self:
+        if (
+            self.denominator_state
+            is StaffingDenominatorState.ALLOCATION_EVIDENCE_AVAILABLE
+            and not self.denominator_source_classes
+        ):
+            raise ValueError(
+                "a staffing denominator claimed available must name the source "
+                "classes it came from"
+            )
+        return self
+
+
+class DriverCandidate(ContractModelV2):
+    """A candidate driver, its standing, and everything that standing rests on."""
+
+    driver_id: OpaqueID
+    category: DriverCategory
+    summary: ShortText
+    affected_subject_ids: tuple[OpaqueID, ...] = Field(min_length=1, max_length=50)
+    role: DriverRole
+    standing: DriverStanding
+    assertion_basis: AssertionBasis
+    confidence_qualifier: ConfidenceQualifier
+    supporting_path_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=20
+    )
+    supporting_evidence_ids: tuple[EvidenceHandle, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    conflicting_evidence_ids: tuple[EvidenceHandle, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    conflict_note: ShortText | None = None
+    relevance: RelevanceState
+    exclusion_reason: DriverExclusionReason | None = None
+    staffing_qualification: StaffingQualification | None = None
+
+    @model_validator(mode="after")
+    def validate_principal_standing_is_earned(self) -> Self:
+        """Principal standing requires a driver, a path, evidence and currency.
+
+        This is the whole symptom-as-driver guard. "Cycle time is up" is a
+        real observation and a legitimate ``SYMPTOM`` candidate; what it may
+        not be is the principal driver, and what no candidate may be is
+        principal without lineage explaining the mechanism, evidence
+        supporting it, and current relevance. Contributing standing is held
+        to the same requirements at a lower bar (path or evidence, not
+        necessarily both) because a contributing driver is still an
+        assertion the packet is making.
+        """
+
+        if self.standing is DriverStanding.PRINCIPAL_DRIVER:
+            if self.role is not DriverRole.DRIVER:
+                raise ValueError(
+                    f"driver {self.driver_id} is promoted to principal while "
+                    f"classified {self.role}; a symptom is not a driver"
+                )
+            if not self.supporting_path_ids:
+                raise ValueError(
+                    f"driver {self.driver_id} is principal with no supporting "
+                    "relationship path; without lineage there is no mechanism, "
+                    "only a correlation"
+                )
+            if not self.supporting_evidence_ids:
+                raise ValueError(
+                    f"driver {self.driver_id} is principal with no supporting "
+                    "evidence"
+                )
+            if self.relevance not in CURRENTLY_RELEVANT_STATES:
+                raise ValueError(
+                    f"driver {self.driver_id} is principal but its relevance "
+                    f"is {self.relevance}; a historical cause is not a "
+                    "principal current driver"
+                )
+        if self.standing is DriverStanding.CONTRIBUTING_DRIVER:
+            if self.role is DriverRole.SYMPTOM:
+                raise ValueError(
+                    f"driver {self.driver_id} contributes as a driver while "
+                    "classified a symptom"
+                )
+            if not self.supporting_path_ids and not self.supporting_evidence_ids:
+                raise ValueError(
+                    f"driver {self.driver_id} is a contributing driver with "
+                    "neither a supporting path nor supporting evidence"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_exclusion_is_stated(self) -> Self:
+        excluded = self.standing is DriverStanding.EXCLUDED
+        if excluded and self.exclusion_reason is None:
+            raise ValueError(
+                f"driver {self.driver_id} is excluded without a reason; the "
+                "reasons a candidate did not reach principal standing are part "
+                "of the investigation result, not an implementation detail"
+            )
+        if not excluded and self.exclusion_reason is not None:
+            raise ValueError(
+                f"driver {self.driver_id} carries an exclusion_reason while "
+                f"holding {self.standing} standing"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_assertion_basis_matches_support(self) -> Self:
+        if self.assertion_basis is AssertionBasis.MEASURED:
+            if not self.supporting_evidence_ids:
+                raise ValueError(
+                    f"driver {self.driver_id} claims a measured basis with no "
+                    "evidence handle; canonical services mint evidence for "
+                    "what they measure"
+                )
+        elif self.confidence_qualifier is ConfidenceQualifier.MEASURED_CERTAIN:
+            raise ValueError(
+                f"driver {self.driver_id} is {self.assertion_basis} but claims "
+                "measured certainty; only a measured basis may be certain"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_conflicts_are_disclosed(self) -> Self:
+        has_conflict = bool(self.conflicting_evidence_ids)
+        if has_conflict and self.conflict_note is None:
+            raise ValueError(
+                f"driver {self.driver_id} carries conflicting evidence with no "
+                "conflict_note"
+            )
+        if not has_conflict and self.conflict_note is not None:
+            raise ValueError(
+                f"driver {self.driver_id} declares a conflict_note with no "
+                "conflicting evidence"
+            )
+        if has_conflict and self.confidence_qualifier is (
+            ConfidenceQualifier.MEASURED_CERTAIN
+        ):
+            raise ValueError(
+                f"driver {self.driver_id} presents conflicting evidence as "
+                "measured certainty"
+            )
+        overlap = sorted(
+            set(self.supporting_evidence_ids) & set(self.conflicting_evidence_ids)
+        )
+        if overlap:
+            raise ValueError(
+                f"driver {self.driver_id} lists the same evidence as both "
+                f"supporting and conflicting: {overlap}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_staffing_claims_are_qualified(self) -> Self:
+        """Capacity claims must be qualified exactly as far as their evidence.
+
+        Both halves of the correction addendum's staffing rule live here.
+        A capacity/staffing driver must carry a
+        :class:`StaffingQualification` at all — silence about the
+        denominator is the commonest way an unsupported staffing claim
+        reaches an answer. And when that denominator is partial or absent,
+        the claim may not be presented as ``MEASURED_CERTAIN``.
+
+        What this deliberately does **not** do is force such a claim to
+        ``UNSUPPORTED``: ``QUALIFIED`` and ``UNCERTAIN`` are both legal, and
+        ``test_missing_denominator_still_supports_a_qualified_capacity_claim``
+        pins that a missing denominator reduces confidence rather than
+        killing the answer.
+        """
+
+        if self.category is not DriverCategory.CAPACITY_OR_STAFFING:
+            if self.staffing_qualification is not None:
+                raise ValueError(
+                    f"driver {self.driver_id} carries a staffing qualification "
+                    f"while categorised {self.category}"
+                )
+            return self
+        if self.staffing_qualification is None:
+            raise ValueError(
+                f"driver {self.driver_id} is a capacity/staffing driver with no "
+                "staffing_qualification; a staffing claim that says nothing "
+                "about its denominator is an unsupported claim"
+            )
+        weak = (
+            self.staffing_qualification.denominator_state
+            in UNQUALIFIED_DENOMINATOR_STATES
+        )
+        if weak and self.confidence_qualifier is ConfidenceQualifier.MEASURED_CERTAIN:
+            raise ValueError(
+                f"driver {self.driver_id} presents a staffing claim as certain "
+                f"while its denominator is "
+                f"{self.staffing_qualification.denominator_state}"
+            )
+        return self
+
+
+class DriverAnalysis(ContractModelV2):
+    """Every driver candidate, and which of them are principal."""
+
+    schema_version: Literal["ask_dev_driver_analysis.v1"]
+    candidates: tuple[DriverCandidate, ...] = Field(
+        default_factory=tuple, max_length=50
+    )
+    principal_driver_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    candidates_truncated: bool
+    truncation_reason: TruncationReason | None = None
+
+    @model_validator(mode="after")
+    def validate_principal_list_matches_standings(self) -> Self:
+        driver_ids = [candidate.driver_id for candidate in self.candidates]
+        if len(set(driver_ids)) != len(driver_ids):
+            raise ValueError("driver candidates must be unique by driver_id")
+        principal = {
+            candidate.driver_id
+            for candidate in self.candidates
+            if candidate.standing is DriverStanding.PRINCIPAL_DRIVER
+        }
+        declared = set(self.principal_driver_ids)
+        if principal != declared:
+            raise ValueError(
+                "principal_driver_ids must be exactly the candidates holding "
+                f"principal standing; standings={sorted(principal)}, "
+                f"declared={sorted(declared)}"
+            )
+        if len(self.principal_driver_ids) != len(declared):
+            raise ValueError("principal_driver_ids must not repeat a driver")
+        return self
+
+    @model_validator(mode="after")
+    def validate_truncation_disclosure(self) -> Self:
+        _require_truncation_reason(
+            self.candidates_truncated, self.truncation_reason, "driver_analysis"
+        )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Evidence, coverage and limitations
+# --------------------------------------------------------------------------
+
+
+class InvestigationEvidenceEntry(ContractModelV2):
+    """One evidence item, and what in this packet it actually supports."""
+
+    evidence: DevEvidenceRefV2
+    source_class: SourceClass
+    supports_path_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=20
+    )
+    supports_entity_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=20
+    )
+    supports_driver_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=20
+    )
+    supports_subject_ids: tuple[OpaqueID, ...] = Field(
+        default_factory=tuple, max_length=20
+    )
+    relevance: RelevanceState
+
+    @model_validator(mode="after")
+    def validate_supports_something(self) -> Self:
+        """Indexed evidence must support something the packet includes.
+
+        This is the displacement half of evidence closure. An arm with a
+        large, cheap source (commits, comments) can otherwise flood the
+        index with items attached to nothing, burying the lineage that was
+        asked for under material that is individually true and collectively
+        irrelevant.
+        """
+
+        if not (
+            self.supports_path_ids
+            or self.supports_entity_ids
+            or self.supports_driver_ids
+            or self.supports_subject_ids
+        ):
+            raise ValueError(
+                f"evidence {self.evidence.evidence_ref_id} supports nothing in "
+                "this packet; unattached evidence displaces lineage rather "
+                "than adding to it"
+            )
+        return self
+
+
+class SourceHealthObservation(ContractModelV2):
+    """The observed state of one source class during the investigation."""
+
+    source_class: SourceClass
+    state: SourceRequirementState
+    observed_at: AwareDatetime | None = None
+    detail: ShortText | None = None
+
+
+class MissingSource(ContractModelV2):
+    """A source the investigation wanted and did not get."""
+
+    source_class: SourceClass
+    state: SourceRequirementState
+    impact: ShortText
+
+
+class SourceConflict(ContractModelV2):
+    """Two or more evidence items that disagree."""
+
+    conflict_id: OpaqueID
+    evidence_ref_ids: tuple[EvidenceHandle, ...] = Field(min_length=2, max_length=10)
+    description: ShortText
+    resolution: ConflictResolution
+
+
+class EvidenceCoverage(ContractModelV2):
+    """The evidence index, what was missing, and what the packet cannot say."""
+
+    schema_version: Literal["ask_dev_evidence_coverage.v1"]
+    evidence_index: tuple[InvestigationEvidenceEntry, ...] = Field(
+        default_factory=tuple, max_length=200
+    )
+    source_health: tuple[SourceHealthObservation, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    missing_sources: tuple[MissingSource, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    conflicts: tuple[SourceConflict, ...] = Field(default_factory=tuple, max_length=25)
+    limitations: tuple[PacketLimitation, ...] = Field(
+        default_factory=tuple, max_length=25
+    )
+    clarification_needs: tuple[ClarificationNeed, ...] = Field(
+        default_factory=tuple, max_length=10
+    )
+    authorization_filtered_count: int = Field(ge=0)
+    evidence_truncated: bool
+    truncation_reason: TruncationReason | None = None
+
+    @model_validator(mode="after")
+    def validate_index_is_coherent(self) -> Self:
+        handles = [entry.evidence.evidence_ref_id for entry in self.evidence_index]
+        if len(set(handles)) != len(handles):
+            raise ValueError("evidence_index repeats an evidence handle")
+        health_classes = [item.source_class for item in self.source_health]
+        if len(set(health_classes)) != len(health_classes):
+            raise ValueError("source_health declares a source class twice")
+        missing_classes = [item.source_class for item in self.missing_sources]
+        if len(set(missing_classes)) != len(missing_classes):
+            raise ValueError("missing_sources declares a source class twice")
+        conflict_ids = [conflict.conflict_id for conflict in self.conflicts]
+        if len(set(conflict_ids)) != len(conflict_ids):
+            raise ValueError("conflicts must be unique by conflict_id")
+        indexed = set(handles)
+        for conflict in self.conflicts:
+            dangling = sorted(set(conflict.evidence_ref_ids) - indexed)
+            if dangling:
+                raise ValueError(
+                    f"conflict {conflict.conflict_id} cites evidence that is "
+                    f"not in the index: {dangling}"
+                )
+        limitation_kinds = [limitation.kind for limitation in self.limitations]
+        if len(set(limitation_kinds)) != len(limitation_kinds):
+            raise ValueError(
+                "limitations repeats a kind; one disclosure per kind keeps the "
+                "list a real summary rather than a pile"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_disclosures_match_state(self) -> Self:
+        _require_truncation_reason(
+            self.evidence_truncated, self.truncation_reason, "evidence_coverage"
+        )
+        kinds = {limitation.kind for limitation in self.limitations}
+        if self.missing_sources and PacketLimitationKind.MISSING_SOURCE not in kinds:
+            raise ValueError(
+                "missing sources are recorded but no MISSING_SOURCE limitation "
+                "is disclosed"
+            )
+        unresolved = any(
+            conflict.resolution is ConflictResolution.UNRESOLVED
+            for conflict in self.conflicts
+        )
+        if unresolved and PacketLimitationKind.CONFLICTING_EVIDENCE not in kinds:
+            raise ValueError(
+                "an unresolved source conflict is recorded but no "
+                "CONFLICTING_EVIDENCE limitation is disclosed"
+            )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Versions and trial metadata
+# --------------------------------------------------------------------------
+
+
+class SourceContractVersion(ContractModelV2):
+    """Which version of a source's own contract the investigation read."""
+
+    source_class: SourceClass
+    contract_version: PlatformVersionToken
+
+
+class TrialMetadata(ContractModelV2):
+    """Evaluation metadata — never product truth.
+
+    Arm identity lives here and only here, and the field that holds it is
+    optional on :class:`InvestigationVersions`. That is the structural
+    statement of "arm identity should be evaluation metadata": a native
+    packet is complete without it, no consumer may branch on it, and no
+    field anywhere in this contract is mandatory only for one arm.
+    """
+
+    arm_id: OpaqueID
+    producer_id: PlatformVersionToken
+    fixture_version: PlatformVersionToken | None = None
+    run_id: ServerHandle | None = None
+
+
+class InvestigationVersions(ContractModelV2):
+    """Every version an investigation result is reproducible against."""
+
+    schema_version: Literal["ask_dev_investigation_versions.v1"]
+    packet_schema_version: Literal["ask_dev_investigation_packet.v1"]
+    query_version: PlatformVersionToken
+    ranking_version: PlatformVersionToken
+    projection_version: PlatformVersionToken
+    source_contract_versions: tuple[SourceContractVersion, ...] = Field(
+        min_length=1, max_length=25
+    )
+    corpus_version: PlatformVersionToken | None = None
+    trial: TrialMetadata | None = None
+
+    @model_validator(mode="after")
+    def validate_source_contract_versions_are_unique(self) -> Self:
+        classes = [item.source_class for item in self.source_contract_versions]
+        if len(set(classes)) != len(classes):
+            raise ValueError("source_contract_versions declares a source class twice")
+        return self
+
+
+# --------------------------------------------------------------------------
+# The packet
+# --------------------------------------------------------------------------
+
+
+class AskDevInvestigationPacket(ContractModelV2):
+    """A bounded, authorized, backend-neutral investigation result.
+
+    Not a final user answer, not a dashboard response, not a graph-native
+    query response, not an LLM reasoning trace, not arbitrary traversal
+    output. It is the input the Ask Dev frame reasons over, and the artifact
+    both trial arms are scored on.
+    """
+
+    schema_version: Literal["ask_dev_investigation_packet.v1"]
+    packet_id: ServerHandle
+    organization_id: OpaqueID
+    produced_at: AwareDatetime
+    outcome: InvestigationOutcome
+    analytical_job: AnalyticalJob
+    subject_discovery: SubjectDiscovery
+    comparison_cohort: ComparisonCohort
+    related_context: RelatedContext
+    driver_analysis: DriverAnalysis
+    evidence_coverage: EvidenceCoverage
+    versions: InvestigationVersions
+
+    @model_validator(mode="after")
+    def validate_cohort_shape_matches_job(self) -> Self:
+        if self.comparison_cohort.comparison_shape is not (
+            self.analytical_job.comparison_shape
+        ):
+            raise ValueError(
+                "the cohort's comparison_shape "
+                f"({self.comparison_cohort.comparison_shape}) contradicts the "
+                f"job's ({self.analytical_job.comparison_shape})"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_no_unsafe_organization_widening(self) -> Self:
+        """An unresolved reference may not become an organization-wide sweep.
+
+        The named fault: the question mentioned a subject, resolution
+        failed, and the arm answered about everyone instead of asking. The
+        one legitimate way to hold an organization-wide shape with an
+        unresolved mention outstanding is to be *asking* — outcome
+        ``NEEDS_CLARIFICATION`` with a subject clarification recorded.
+        """
+
+        widened = (
+            self.analytical_job.comparison_shape is ComparisonShape.ORGANIZATION_WIDE
+        )
+        if not widened or not self.subject_discovery.unresolved_mentions:
+            return self
+        asking = self.outcome is InvestigationOutcome.NEEDS_CLARIFICATION
+        clarifies_subject = any(
+            need.kind in SUBJECT_CLARIFICATION_KINDS
+            for need in self.evidence_coverage.clarification_needs
+        )
+        if not (asking and clarifies_subject):
+            mentions = sorted(
+                mention.mention_id
+                for mention in self.subject_discovery.unresolved_mentions
+            )
+            raise ValueError(
+                "the investigation widened to organization scope with "
+                f"unresolved subject references outstanding ({mentions}) "
+                "without asking for clarification; widening after a failed "
+                "resolution answers a question nobody asked"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_evidence_closure(self) -> Self:
+        """Every referenced handle is indexed, and every index entry lands.
+
+        The first half stops dangling citations. The second half — checked
+        on the index's own ``supports_*`` fields — stops an evidence dump
+        from claiming attachment to paths, entities, drivers or subjects the
+        packet never declared.
+        """
+
+        indexed = {
+            entry.evidence.evidence_ref_id
+            for entry in self.evidence_coverage.evidence_index
+        }
+        referenced: set[str] = set()
+        for candidate in self.subject_discovery.candidates:
+            for signal in candidate.match_signals:
+                referenced.update(signal.evidence_ref_ids)
+        for member in self.comparison_cohort.members:
+            referenced.update(member.inclusion_evidence_ids)
+        for path in self.related_context.paths:
+            referenced.update(path.evidence_ref_ids)
+        for driver in self.driver_analysis.candidates:
+            referenced.update(driver.supporting_evidence_ids)
+            referenced.update(driver.conflicting_evidence_ids)
+        dangling = sorted(referenced - indexed)
+        if dangling:
+            raise ValueError(
+                "evidence handles are cited but absent from the evidence "
+                f"index: {dangling}"
+            )
+
+        known_paths = {path.path_id for path in self.related_context.paths}
+        known_entities = {entity.entity_id for entity in self.related_context.entities}
+        known_drivers = {
+            driver.driver_id for driver in self.driver_analysis.candidates
+        }
+        known_subjects = {
+            candidate.canonical_id for candidate in self.subject_discovery.candidates
+        } | {member.canonical_id for member in self.comparison_cohort.members}
+        for entry in self.evidence_coverage.evidence_index:
+            handle = entry.evidence.evidence_ref_id
+            for label, cited, known in (
+                ("paths", entry.supports_path_ids, known_paths),
+                ("entities", entry.supports_entity_ids, known_entities),
+                ("drivers", entry.supports_driver_ids, known_drivers),
+                ("subjects", entry.supports_subject_ids, known_subjects),
+            ):
+                unknown = sorted(set(cited) - known)
+                if unknown:
+                    raise ValueError(
+                        f"evidence {handle} claims to support {label} the "
+                        f"packet never declared: {unknown}"
+                    )
+        return self
+
+    @model_validator(mode="after")
+    def validate_drivers_reference_declared_material(self) -> Self:
+        known_paths = {path.path_id for path in self.related_context.paths}
+        known_subjects = (
+            {
+                candidate.canonical_id
+                for candidate in self.subject_discovery.candidates
+            }
+            | {member.canonical_id for member in self.comparison_cohort.members}
+            | {entity.entity_id for entity in self.related_context.entities}
+        )
+        for driver in self.driver_analysis.candidates:
+            dangling_paths = sorted(set(driver.supporting_path_ids) - known_paths)
+            if dangling_paths:
+                raise ValueError(
+                    f"driver {driver.driver_id} cites paths that were never "
+                    f"declared: {dangling_paths}"
+                )
+            dangling_subjects = sorted(
+                set(driver.affected_subject_ids) - known_subjects
+            )
+            if dangling_subjects:
+                raise ValueError(
+                    f"driver {driver.driver_id} affects subjects the packet "
+                    f"never declared: {dangling_subjects}"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_supported_outcome_asserts_a_judgment(self) -> Self:
+        """A supported packet must assert something, not just point at data.
+
+        The structural form of "open the dashboard" is a packet that is
+        perfectly well formed, cites plenty of evidence, and asserts no
+        driver at all — leaving the reader to do the analysis. A supported
+        outcome therefore requires at least one principal or contributing
+        driver, and each of those has already had to earn its standing with
+        lineage and evidence.
+
+        The non-supported outcomes are held to their own floors, so that
+        ``NO_MATCH`` cannot become the silent, privileged default for a
+        packet that simply found nothing to say.
+        """
+
+        asserted = [
+            driver
+            for driver in self.driver_analysis.candidates
+            if driver.standing in ASSERTED_DRIVER_STANDINGS
+        ]
+        if self.outcome in SUPPORTED_OUTCOMES:
+            if not asserted:
+                raise ValueError(
+                    f"outcome {self.outcome} asserts no principal or "
+                    "contributing driver; a packet that only points at "
+                    "evidence has redirected, not answered"
+                )
+            if not self.evidence_coverage.evidence_index:
+                raise ValueError(
+                    f"outcome {self.outcome} carries an empty evidence index"
+                )
+            return self
+        if asserted:
+            raise ValueError(
+                f"outcome {self.outcome} asserts drivers "
+                f"({sorted(driver.driver_id for driver in asserted)}); a "
+                "non-supported investigation must not carry a judgment"
+            )
+        if self.outcome is InvestigationOutcome.NEEDS_CLARIFICATION:
+            if not self.evidence_coverage.clarification_needs:
+                raise ValueError(
+                    "a needs-clarification outcome must record what it needs "
+                    "clarified"
+                )
+        if self.outcome is InvestigationOutcome.NO_MATCH:
+            if self.subject_discovery.committed_subject_ids:
+                raise ValueError(
+                    "a no-match outcome cannot also commit to a subject"
+                )
+            if not (
+                self.evidence_coverage.clarification_needs
+                or self.evidence_coverage.limitations
+            ):
+                raise ValueError(
+                    "a no-match outcome must state a limitation or a "
+                    "clarification need; an unexplained no-match is a silent "
+                    "default wearing an outcome label"
+                )
+        if self.outcome is InvestigationOutcome.UNSUPPORTED:
+            if not self.evidence_coverage.limitations:
+                raise ValueError(
+                    "an unsupported outcome must state why it is unsupported"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_partial_results_are_disclosed(self) -> Self:
+        """Filtering and truncation anywhere must surface as a limitation.
+
+        Each section already pairs its own flag with a reason; this is the
+        packet-level statement, so a consumer reading only ``limitations``
+        cannot mistake a filtered or truncated investigation for a complete
+        one.
+        """
+
+        kinds = {limitation.kind for limitation in self.evidence_coverage.limitations}
+        filtered = (
+            self.subject_discovery.authorization_filtered_count
+            + self.comparison_cohort.authorization_filtered_count
+            + self.related_context.authorization_filtered_count
+            + self.evidence_coverage.authorization_filtered_count
+        )
+        if filtered and PacketLimitationKind.AUTHORIZATION_FILTERED not in kinds:
+            raise ValueError(
+                f"{filtered} results were filtered for authorization but no "
+                "AUTHORIZATION_FILTERED limitation is disclosed"
+            )
+        truncated = any(
+            (
+                self.subject_discovery.candidates_truncated,
+                self.comparison_cohort.completeness is CohortCompleteness.TRUNCATED,
+                self.related_context.entities_truncated,
+                self.related_context.paths_truncated,
+                self.driver_analysis.candidates_truncated,
+                self.evidence_coverage.evidence_truncated,
+                any(path.truncated for path in self.related_context.paths),
+            )
+        )
+        if truncated and PacketLimitationKind.TRUNCATED_TRAVERSAL not in kinds:
+            raise ValueError(
+                "the investigation truncated results but no TRUNCATED_TRAVERSAL "
+                "limitation is disclosed"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_historical_comparability_is_disclosed(self) -> Self:
+        """A not-comparable historical slice must say so — and stays valid.
+
+        CHAOS-3569 leaves historical edge validity unimplemented, so some
+        as-of comparisons cannot be reconstructed. The corrective plan's
+        ruling is that such rows are NOT COMPARABLE rather than failures:
+        this validator therefore requires the *disclosure*, and pointedly
+        does not require the outcome to be downgraded.
+        """
+
+        comparability = self.analytical_job.time_context.historical_comparability
+        if comparability not in NOT_COMPARABLE_STATES:
+            return self
+        kinds = {limitation.kind for limitation in self.evidence_coverage.limitations}
+        job_kinds = {
+            limitation.kind
+            for limitation in self.analytical_job.interpretation_limitations
+        }
+        if PacketLimitationKind.HISTORICAL_SLICE_NOT_COMPARABLE not in (
+            kinds | job_kinds
+        ):
+            raise ValueError(
+                f"the time context is {comparability} but no "
+                "HISTORICAL_SLICE_NOT_COMPARABLE limitation is disclosed"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_staffing_absence_is_disclosed(self) -> Self:
+        weak = [
+            driver
+            for driver in self.driver_analysis.candidates
+            if driver.staffing_qualification is not None
+            and driver.staffing_qualification.denominator_state
+            in UNQUALIFIED_DENOMINATOR_STATES
+        ]
+        if not weak:
+            return self
+        kinds = {limitation.kind for limitation in self.evidence_coverage.limitations}
+        if PacketLimitationKind.ABSENT_STAFFING_DENOMINATOR not in kinds:
+            raise ValueError(
+                "a staffing claim rests on a partial or absent allocation "
+                "denominator but no ABSENT_STAFFING_DENOMINATOR limitation is "
+                "disclosed"
+            )
+        return self
+
+
+#: The exported contract registry: ``schema_version`` -> model.
+#:
+#: Deliberately **not** merged into ``CONTRACT_MODELS_V2``: that registry
+#: backs ``contracts/ask-dev/v2``, which is reserved for wire contracts
+#: served to real clients (``scripts/acceptance/corpus/receipt.py:6-7``).
+#: This packet is an internal trial artifact and gets its own root,
+#: ``contracts/ask-dev-investigation/v1``.
+INVESTIGATION_CONTRACT_MODELS: dict[str, type[ContractModelV2]] = {
+    "ask_dev_investigation_packet.v1": AskDevInvestigationPacket,
+    "ask_dev_analytical_job.v1": AnalyticalJob,
+    "ask_dev_subject_discovery.v1": SubjectDiscovery,
+    "ask_dev_comparison_cohort.v1": ComparisonCohort,
+    "ask_dev_related_context.v1": RelatedContext,
+    "ask_dev_driver_analysis.v1": DriverAnalysis,
+    "ask_dev_evidence_coverage.v1": EvidenceCoverage,
+    "ask_dev_investigation_versions.v1": InvestigationVersions,
+}

--- a/src/dev_health_ops/api/dev/investigation_contract/question_families.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/question_families.py
@@ -1,0 +1,798 @@
+"""The frozen question-family registry for the corrected trial (CHAOS-3615).
+
+Ten families, each with *exact* variants (the phrasing the corrective plan
+and the correction addendum use verbatim) and *natural* variants (how the
+question actually arrives — elliptical, colloquial, mid-conversation).
+
+The registry exists to stop two specific drifts, and both are enforced by
+:func:`validate_question_family_registry` at import time rather than by
+review:
+
+* **A family is never one metric and never one prompt.** Every family
+  declares at least one exact and at least two natural variants, at least
+  two source classes, at least two packet sections and at least three
+  scoring dimensions — and every family lists ``SINGLE_DASHBOARD_METRIC``
+  and ``SINGLE_EXACT_PROMPT`` among its prohibited reductions. An arm that
+  answers "which teams are struggling?" by returning one chart has not
+  answered the family.
+* **Missing staffing denominators qualify, they do not disqualify.** Every
+  family whose questions can turn on capacity carries
+  ``StaffingDenominatorPolicy.QUALIFY_WHEN_ABSENT`` and lists
+  ``AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR`` as a prohibited reduction. The
+  correction addendum is explicit: absent allocation data reduces confidence
+  and requires qualification; it must not make capacity questions
+  unsupported.
+
+``PERSON_LEVEL_RANKING`` is prohibited on **every** family, not only the
+staffing ones. The packet already makes a person subject unrepresentable;
+this is the second, independent statement of the same rule, at the level of
+what may be *asked*.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Literal
+
+from dev_health_ops.api.dev.contracts import Label, LongText, ShortText
+from dev_health_ops.api.dev.contracts_v2.base import ContractModelV2, SourceClass
+
+from .allowlists import TRIAL_SOURCE_ALLOWLIST
+from .scoring import ALL_SCORING_DIMENSION_IDS, ScoringDimensionID
+from .vocabulary import ComparisonShape, PacketSection
+
+__all__ = [
+    "ALL_PROHIBITED_REDUCTIONS",
+    "ALL_QUESTION_FAMILY_IDS",
+    "MANDATORY_PROHIBITED_REDUCTIONS",
+    "QUESTION_FAMILY_REGISTRY",
+    "ProhibitedReduction",
+    "QuestionFamily",
+    "QuestionFamilyID",
+    "QuestionVariant",
+    "QuestionVariantKind",
+    "StaffingDenominatorPolicy",
+    "validate_question_family_registry",
+]
+
+
+class QuestionFamilyID(StrEnum):
+    """The ten frozen families of the corrected trial."""
+
+    STRUGGLING_TEAMS = "struggling_teams"
+    PRESSURE_SIGNALS = "pressure_signals"
+    PROJECT_CAPACITY = "project_capacity"
+    STAFFING_LANGUAGE = "staffing_language"
+    PROJECT_STATUS_DRIVERS = "project_status_drivers"
+    PORTFOLIO_DEPENDENCY_RISK = "portfolio_dependency_risk"
+    DECLARED_VERSUS_ACTUAL = "declared_versus_actual"
+    AMBIGUOUS_IDENTITY = "ambiguous_identity"
+    COLLOQUIAL_FOLLOW_UP = "colloquial_follow_up"
+    CLARIFICATION_AND_NO_MATCH = "clarification_and_no_match"
+
+
+ALL_QUESTION_FAMILY_IDS: tuple[QuestionFamilyID, ...] = (
+    QuestionFamilyID.STRUGGLING_TEAMS,
+    QuestionFamilyID.PRESSURE_SIGNALS,
+    QuestionFamilyID.PROJECT_CAPACITY,
+    QuestionFamilyID.STAFFING_LANGUAGE,
+    QuestionFamilyID.PROJECT_STATUS_DRIVERS,
+    QuestionFamilyID.PORTFOLIO_DEPENDENCY_RISK,
+    QuestionFamilyID.DECLARED_VERSUS_ACTUAL,
+    QuestionFamilyID.AMBIGUOUS_IDENTITY,
+    QuestionFamilyID.COLLOQUIAL_FOLLOW_UP,
+    QuestionFamilyID.CLARIFICATION_AND_NO_MATCH,
+)
+
+
+class QuestionVariantKind(StrEnum):
+    """``EXACT`` is the canonical phrasing; ``NATURAL`` is how it arrives."""
+
+    EXACT = "exact"
+    NATURAL = "natural"
+
+
+class ProhibitedReduction(StrEnum):
+    """Shapes an arm must not collapse a family into."""
+
+    SINGLE_DASHBOARD_METRIC = "single_dashboard_metric"
+    SINGLE_EXACT_PROMPT = "single_exact_prompt"
+    PERSON_LEVEL_RANKING = "person_level_ranking"
+    DASHBOARD_REDIRECT_AS_ANSWER = "dashboard_redirect_as_answer"
+    UNQUALIFIED_STAFFING_CERTAINTY = "unqualified_staffing_certainty"
+    AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR = "auto_unsupported_on_missing_denominator"
+    PRE_ENUMERATED_INTENT_REQUIRED = "pre_enumerated_intent_required"
+
+
+ALL_PROHIBITED_REDUCTIONS: tuple[ProhibitedReduction, ...] = (
+    ProhibitedReduction.SINGLE_DASHBOARD_METRIC,
+    ProhibitedReduction.SINGLE_EXACT_PROMPT,
+    ProhibitedReduction.PERSON_LEVEL_RANKING,
+    ProhibitedReduction.DASHBOARD_REDIRECT_AS_ANSWER,
+    ProhibitedReduction.UNQUALIFIED_STAFFING_CERTAINTY,
+    ProhibitedReduction.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR,
+    ProhibitedReduction.PRE_ENUMERATED_INTENT_REQUIRED,
+)
+
+#: Prohibited on every family without exception. These three are the
+#: registry's own anti-vacuity floor: a family that permitted any of them
+#: could be "supported" by a chart, a single hard-coded prompt, or a
+#: leaderboard of people.
+MANDATORY_PROHIBITED_REDUCTIONS: tuple[ProhibitedReduction, ...] = (
+    ProhibitedReduction.SINGLE_DASHBOARD_METRIC,
+    ProhibitedReduction.SINGLE_EXACT_PROMPT,
+    ProhibitedReduction.PERSON_LEVEL_RANKING,
+)
+
+
+class StaffingDenominatorPolicy(StrEnum):
+    """What a family does when allocation/headcount data is missing."""
+
+    NOT_APPLICABLE = "not_applicable"
+    QUALIFY_WHEN_ABSENT = "qualify_when_absent"
+
+
+class QuestionVariant(ContractModelV2):
+    variant_id: Label
+    kind: QuestionVariantKind
+    text: ShortText
+
+
+class QuestionFamily(ContractModelV2):
+    """One frozen question family and everything an arm owes it."""
+
+    schema_version: Literal["ask_dev_question_family.v1"]
+    family_id: QuestionFamilyID
+    title: Label
+    analytical_job_statement: LongText
+    exact_variants: tuple[QuestionVariant, ...]
+    natural_variants: tuple[QuestionVariant, ...]
+    permitted_comparison_shapes: tuple[ComparisonShape, ...]
+    required_source_classes: tuple[SourceClass, ...]
+    required_packet_sections: tuple[PacketSection, ...]
+    scoring_dimension_ids: tuple[ScoringDimensionID, ...]
+    staffing_denominator_policy: StaffingDenominatorPolicy
+    prohibited_reductions: tuple[ProhibitedReduction, ...]
+
+
+def _variants(
+    family_id: QuestionFamilyID,
+    kind: QuestionVariantKind,
+    texts: tuple[str, ...],
+) -> tuple[QuestionVariant, ...]:
+    prefix = "e" if kind is QuestionVariantKind.EXACT else "n"
+    return tuple(
+        QuestionVariant(
+            variant_id=f"{family_id.value}.{prefix}{index + 1}",
+            kind=kind,
+            text=text,
+        )
+        for index, text in enumerate(texts)
+    )
+
+
+def _family(
+    family_id: QuestionFamilyID,
+    title: str,
+    analytical_job_statement: str,
+    exact: tuple[str, ...],
+    natural: tuple[str, ...],
+    shapes: tuple[ComparisonShape, ...],
+    sources: tuple[SourceClass, ...],
+    sections: tuple[PacketSection, ...],
+    dimensions: tuple[ScoringDimensionID, ...],
+    staffing_policy: StaffingDenominatorPolicy,
+    extra_prohibitions: tuple[ProhibitedReduction, ...] = (),
+) -> QuestionFamily:
+    return QuestionFamily(
+        schema_version="ask_dev_question_family.v1",
+        family_id=family_id,
+        title=title,
+        analytical_job_statement=analytical_job_statement,
+        exact_variants=_variants(family_id, QuestionVariantKind.EXACT, exact),
+        natural_variants=_variants(family_id, QuestionVariantKind.NATURAL, natural),
+        permitted_comparison_shapes=shapes,
+        required_source_classes=sources,
+        required_packet_sections=sections,
+        scoring_dimension_ids=dimensions,
+        staffing_denominator_policy=staffing_policy,
+        prohibited_reductions=MANDATORY_PROHIBITED_REDUCTIONS + extra_prohibitions,
+    )
+
+
+_ID = QuestionFamilyID
+_SC = SourceClass
+_S = PacketSection
+_D = ScoringDimensionID
+_R = ProhibitedReduction
+_SHAPE = ComparisonShape
+_STAFF = StaffingDenominatorPolicy
+
+#: Dimensions every family is scored on. Kept small on purpose: a family's
+#: own list adds what is specific to it, and the union is what CHAOS-3616
+#: reports per family x per dimension.
+_UNIVERSAL_DIMENSIONS: tuple[ScoringDimensionID, ...] = (
+    _D.EVIDENCE_CLOSURE,
+    _D.USEFUL_UNCERTAINTY_BEHAVIOUR,
+    _D.ZERO_UNAUTHORIZED_RESULTS,
+    _D.ZERO_PERSON_LEVEL_RANKING,
+    _D.ZERO_GRAPH_NATIVE_SURFACE_LEAKAGE,
+)
+
+
+QUESTION_FAMILY_REGISTRY: Mapping[QuestionFamilyID, QuestionFamily] = {
+    _ID.STRUGGLING_TEAMS: _family(
+        _ID.STRUGGLING_TEAMS,
+        "Struggling teams and teams needing attention",
+        "Identify which teams are currently under strain and explain why, "
+        "from cross-source evidence rather than a single health chart. The "
+        "subject set is discovered, not supplied: the question names no team, "
+        "so an arm that requires a committed subject before it will "
+        "investigate cannot answer this family at all.",
+        (
+            "What teams are currently struggling, and why?",
+            "Which teams need attention right now?",
+        ),
+        (
+            "who's having a rough time at the moment?",
+            "any teams we should be worried about?",
+            "where are things not going well?",
+        ),
+        (_SHAPE.DISCOVERED_COHORT, _SHAPE.PORTFOLIO_WIDE),
+        (
+            _SC.WORK_ITEM,
+            _SC.REVIEW,
+            _SC.COGNITIVE_LOAD,
+            _SC.HEALTH_PROFILE,
+            _SC.INCIDENT,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.COMPARISON_COHORT,
+            _S.RELATED_CONTEXT,
+            _S.DRIVER_ANALYSIS,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.COHORT_PRECISION,
+            _D.COHORT_RECALL,
+            _D.COHORT_INCLUSION_EXPLAINABILITY,
+            _D.PRINCIPAL_DRIVER_PRECISION,
+            _D.PRINCIPAL_DRIVER_RECALL,
+            _D.SYMPTOM_VERSUS_DRIVER_DISTINCTION,
+            _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+            _D.CROSS_SOURCE_ASSOCIATION,
+        ),
+        _STAFF.QUALIFY_WHEN_ABSENT,
+        (
+            _R.DASHBOARD_REDIRECT_AS_ANSWER,
+            _R.PRE_ENUMERATED_INTENT_REQUIRED,
+            _R.UNQUALIFIED_STAFFING_CERTAINTY,
+            _R.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR,
+        ),
+    ),
+    _ID.PRESSURE_SIGNALS: _family(
+        _ID.PRESSURE_SIGNALS,
+        "Delivery, operational, review, dependency and investment pressure",
+        "Locate where pressure is concentrated and of what kind. Five "
+        "distinct pressure classes, deliberately in one family: an arm that "
+        "can only see delivery pressure will score well on a delivery-only "
+        "family and badly here, which is the point.",
+        (
+            "Which teams need attention because of delivery, operational, "
+            "review, dependency, or investment pressure?",
+            "Where is delivery pressure highest right now?",
+        ),
+        (
+            "what's under the most pressure?",
+            "where are we bottlenecked?",
+            "who's drowning in reviews?",
+        ),
+        (_SHAPE.DISCOVERED_COHORT, _SHAPE.PORTFOLIO_WIDE, _SHAPE.EXPLICIT_COHORT),
+        (
+            _SC.WORK_ITEM,
+            _SC.PULL_REQUEST,
+            _SC.REVIEW,
+            _SC.INCIDENT,
+            _SC.INVESTMENT_ALLOCATION,
+            _SC.DEFICIENCY_INVENTORY,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.COMPARISON_COHORT,
+            _S.RELATED_CONTEXT,
+            _S.DRIVER_ANALYSIS,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.COHORT_PRECISION,
+            _D.COHORT_RECALL,
+            _D.RELEVANT_RELATIONSHIP_RECALL,
+            _D.PRINCIPAL_DRIVER_PRECISION,
+            _D.SYMPTOM_VERSUS_DRIVER_DISTINCTION,
+            _D.COMPARATIVE_JUDGMENT_SUPPORT,
+            _D.CROSS_SOURCE_ASSOCIATION,
+        ),
+        _STAFF.QUALIFY_WHEN_ABSENT,
+        (
+            _R.DASHBOARD_REDIRECT_AS_ANSWER,
+            _R.UNQUALIFIED_STAFFING_CERTAINTY,
+            _R.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR,
+        ),
+    ),
+    _ID.PROJECT_CAPACITY: _family(
+        _ID.PROJECT_CAPACITY,
+        "Project capacity constraints and lightly loaded projects",
+        "Judge which projects look capacity-constrained and which look "
+        "unusually lightly loaded relative to demand. Both directions are in "
+        "scope: an arm that only ever reports overload is not measuring "
+        "capacity, it is measuring activity.",
+        (
+            "Which projects appear capacity-constrained, understaffed, "
+            "overstaffed, or unusually lightly loaded relative to demand?",
+            "Which projects are capacity-constrained right now?",
+        ),
+        (
+            "what are we under-resourcing?",
+            "anything that looks over-provisioned?",
+            "where do we have slack?",
+        ),
+        (_SHAPE.DISCOVERED_COHORT, _SHAPE.PORTFOLIO_WIDE, _SHAPE.EXPLICIT_COHORT),
+        (
+            _SC.WORK_ITEM,
+            _SC.INVESTMENT_ALLOCATION,
+            _SC.COGNITIVE_LOAD,
+            _SC.WORK_GRAPH,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.COMPARISON_COHORT,
+            _S.DRIVER_ANALYSIS,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.COHORT_PRECISION,
+            _D.COHORT_RECALL,
+            _D.COMPARATIVE_JUDGMENT_SUPPORT,
+            _D.ZERO_UNSUPPORTED_STAFFING_CERTAINTY,
+            _D.UNSUPPORTED_ATTRIBUTION_RATE,
+            _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+        ),
+        _STAFF.QUALIFY_WHEN_ABSENT,
+        (
+            _R.UNQUALIFIED_STAFFING_CERTAINTY,
+            _R.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR,
+            _R.DASHBOARD_REDIRECT_AS_ANSWER,
+        ),
+    ),
+    _ID.STAFFING_LANGUAGE: _family(
+        _ID.STAFFING_LANGUAGE,
+        "Understaffed and overstaffed language with qualified evidence",
+        "Answer questions phrased in staffing language without inventing a "
+        "staffing denominator the platform does not have. The correct "
+        "behaviour when allocation data is absent is a qualified answer that "
+        "says what it is inferring from -- not silence, and not certainty.",
+        (
+            "Which projects are understaffed?",
+            "Is this project overstaffed for what it is being asked to deliver?",
+        ),
+        (
+            "do we have enough people on this?",
+            "are we spreading ourselves too thin here?",
+            "is anyone sitting idle on that project?",
+        ),
+        (_SHAPE.SINGULAR_SUBJECT, _SHAPE.EXPLICIT_COHORT, _SHAPE.DISCOVERED_COHORT),
+        (
+            _SC.INVESTMENT_ALLOCATION,
+            _SC.WORK_ITEM,
+            _SC.COGNITIVE_LOAD,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.DRIVER_ANALYSIS,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.ZERO_UNSUPPORTED_STAFFING_CERTAINTY,
+            _D.UNSUPPORTED_ATTRIBUTION_RATE,
+            _D.SUBJECT_TOP_1,
+            _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+        ),
+        _STAFF.QUALIFY_WHEN_ABSENT,
+        (
+            _R.UNQUALIFIED_STAFFING_CERTAINTY,
+            _R.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR,
+        ),
+    ),
+    _ID.PROJECT_STATUS_DRIVERS: _family(
+        _ID.PROJECT_STATUS_DRIVERS,
+        "Project status and principal current drivers",
+        "State where a named project actually stands and what is principally "
+        "driving that, distinguishing drivers from symptoms and current "
+        "causes from historical ones.",
+        (
+            "What is the actual status of Project XYZ, and what are the "
+            "principal current drivers?",
+            "Why is ACR still not finished?",
+        ),
+        (
+            "what's the deal with the auth work?",
+            "where did that project get to?",
+            "what's holding it up?",
+        ),
+        (_SHAPE.SINGULAR_SUBJECT,),
+        (
+            _SC.STATUS_CHANGE,
+            _SC.WORK_ITEM,
+            _SC.PULL_REQUEST,
+            _SC.REVIEW,
+            _SC.DEPLOYMENT,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.RELATED_CONTEXT,
+            _S.DRIVER_ANALYSIS,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.SUBJECT_TOP_1,
+            _D.SUBJECT_TOP_3,
+            _D.PRINCIPAL_DRIVER_PRECISION,
+            _D.PRINCIPAL_DRIVER_RECALL,
+            _D.SYMPTOM_VERSUS_DRIVER_DISTINCTION,
+            _D.LINEAGE_PATH_PRECISION,
+            _D.LINEAGE_DIRECTION_CORRECTNESS,
+            _D.CURRENT_RELEVANCE,
+            _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+        ),
+        _STAFF.QUALIFY_WHEN_ABSENT,
+        (
+            _R.DASHBOARD_REDIRECT_AS_ANSWER,
+            _R.UNQUALIFIED_STAFFING_CERTAINTY,
+            _R.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR,
+        ),
+    ),
+    _ID.PORTFOLIO_DEPENDENCY_RISK: _family(
+        _ID.PORTFOLIO_DEPENDENCY_RISK,
+        "Portfolio and shared-dependency risk",
+        "Find projects exposed through a dependency they share with "
+        "something already in trouble. This family is the clearest test of "
+        "whether relationship traversal adds anything: the answer is not "
+        "visible in any single project's own metrics.",
+        (
+            "Which projects are at risk because of shared dependencies?",
+            "What else is exposed if this dependency slips?",
+        ),
+        (
+            "what else does that break?",
+            "who else is on the hook for this?",
+            "if that library is stuck, what else is stuck?",
+        ),
+        (_SHAPE.DISCOVERED_COHORT, _SHAPE.PORTFOLIO_WIDE),
+        (
+            _SC.WORK_GRAPH,
+            _SC.WORK_ITEM,
+            _SC.DEPLOYMENT,
+            _SC.INCIDENT,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.COMPARISON_COHORT,
+            _S.RELATED_CONTEXT,
+            _S.DRIVER_ANALYSIS,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.RELEVANT_ENTITY_RECALL,
+            _D.RELEVANT_RELATIONSHIP_RECALL,
+            _D.LINEAGE_PATH_PRECISION,
+            _D.LINEAGE_DIRECTION_CORRECTNESS,
+            _D.COHORT_PRECISION,
+            _D.COHORT_RECALL,
+            _D.CROSS_SOURCE_ASSOCIATION,
+        ),
+        _STAFF.NOT_APPLICABLE,
+        (_R.DASHBOARD_REDIRECT_AS_ANSWER,),
+    ),
+    _ID.DECLARED_VERSUS_ACTUAL: _family(
+        _ID.DECLARED_VERSUS_ACTUAL,
+        "Declared status versus actual delivery and readiness evidence",
+        "Find work declared complete that lacks the delivery, release, "
+        "documentation or operational evidence completion would imply. "
+        "Requires both halves -- the declaration and the evidence -- from "
+        "different source classes, by construction.",
+        (
+            "Which declared-complete projects lack delivery, release, "
+            "documentation, or operational evidence?",
+            "Is this actually done?",
+        ),
+        (
+            "is that really finished?",
+            "did that ever actually ship?",
+            "anything marked done that isn't?",
+        ),
+        (_SHAPE.SINGULAR_SUBJECT, _SHAPE.DISCOVERED_COHORT, _SHAPE.PORTFOLIO_WIDE),
+        (
+            _SC.STATUS_CHANGE,
+            _SC.PULL_REQUEST,
+            _SC.DEPLOYMENT,
+            _SC.CI_RUN,
+            _SC.TEST_REPORT,
+            _SC.DEFICIENCY_INVENTORY,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.RELATED_CONTEXT,
+            _S.DRIVER_ANALYSIS,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.CROSS_SOURCE_ASSOCIATION,
+            _D.PRINCIPAL_DRIVER_PRECISION,
+            _D.UNSUPPORTED_ATTRIBUTION_RATE,
+            _D.CURRENT_RELEVANCE,
+            _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+        ),
+        _STAFF.NOT_APPLICABLE,
+        (_R.DASHBOARD_REDIRECT_AS_ANSWER,),
+    ),
+    _ID.AMBIGUOUS_IDENTITY: _family(
+        _ID.AMBIGUOUS_IDENTITY,
+        "Ambiguous aliases, acronyms and renamed entities",
+        "Resolve a reference that is not the canonical name -- an acronym, "
+        "an old name, a provider key, a nickname -- to the right canonical "
+        "subject, or say honestly that it is ambiguous. The failure to score "
+        "hardest is confident resolution to the wrong similarly-named thing.",
+        (
+            "What about the auth work?",
+            "How is ACR doing?",
+        ),
+        (
+            "how's the thing we used to call Northstar going?",
+            "status on DHO?",
+            "what happened to the payments rewrite?",
+        ),
+        (_SHAPE.SINGULAR_SUBJECT, _SHAPE.EXPLICIT_COHORT),
+        (
+            _SC.WORK_GRAPH,
+            _SC.WORK_ITEM,
+            _SC.STATUS_CHANGE,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.SUBJECT_TOP_1,
+            _D.SUBJECT_TOP_3,
+            _D.ALIAS_ACRONYM_RENAME_RESOLUTION,
+            _D.CLARIFICATION_CANDIDATE_PRECISION,
+            _D.NO_UNSAFE_ORGANIZATION_WIDENING,
+        ),
+        _STAFF.NOT_APPLICABLE,
+        (_R.PRE_ENUMERATED_INTENT_REQUIRED,),
+    ),
+    _ID.COLLOQUIAL_FOLLOW_UP: _family(
+        _ID.COLLOQUIAL_FOLLOW_UP,
+        "Colloquial references and conversational follow-ups",
+        "Resolve a reference that only makes sense against the conversation "
+        "or the surface the user is on. 'What about the other project we "
+        "discussed?' has no answer without context and must not be answered "
+        "by guessing.",
+        (
+            "What about the other project we discussed?",
+            "What happened with the project that kept cycling in review?",
+        ),
+        (
+            "and the other one?",
+            "what about that thing from earlier?",
+            "same question for the second team",
+        ),
+        (_SHAPE.SINGULAR_SUBJECT, _SHAPE.EXPLICIT_COHORT),
+        (
+            _SC.WORK_GRAPH,
+            _SC.REVIEW,
+            _SC.WORK_ITEM,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.CONVERSATIONAL_REFERENCE_RESOLUTION,
+            _D.SUBJECT_TOP_1,
+            _D.CLARIFICATION_CANDIDATE_PRECISION,
+            _D.NO_UNSAFE_ORGANIZATION_WIDENING,
+        ),
+        _STAFF.NOT_APPLICABLE,
+        (_R.PRE_ENUMERATED_INTENT_REQUIRED,),
+    ),
+    _ID.CLARIFICATION_AND_NO_MATCH: _family(
+        _ID.CLARIFICATION_AND_NO_MATCH,
+        "Clarification and safe no-match behaviour",
+        "Behave well when the question cannot be answered as asked: ask a "
+        "useful clarifying question with a short, plausible candidate list, "
+        "or say there is no match. Never widen to the whole organization, "
+        "and never manufacture a subject.",
+        (
+            "What is going sideways?",
+            "How is Atlas doing?",
+        ),
+        (
+            "what about that other team, the new one?",
+            "how's the project going",
+            "give me the update",
+        ),
+        (_SHAPE.SINGULAR_SUBJECT, _SHAPE.DISCOVERED_COHORT),
+        (
+            _SC.WORK_GRAPH,
+            _SC.SOURCE_HEALTH,
+        ),
+        (
+            _S.ANALYTICAL_JOB,
+            _S.SUBJECT_DISCOVERY,
+            _S.EVIDENCE_COVERAGE,
+        ),
+        _UNIVERSAL_DIMENSIONS
+        + (
+            _D.CLARIFICATION_CANDIDATE_PRECISION,
+            _D.NO_UNSAFE_ORGANIZATION_WIDENING,
+            _D.SUBJECT_TOP_3,
+        ),
+        _STAFF.NOT_APPLICABLE,
+        (_R.PRE_ENUMERATED_INTENT_REQUIRED,),
+    ),
+}
+
+#: Minimum shape of a family. Below any of these it stops being a family and
+#: becomes a prompt with a metric attached.
+_MIN_EXACT_VARIANTS = 1
+_MIN_NATURAL_VARIANTS = 2
+_MIN_SOURCE_CLASSES = 2
+_MIN_PACKET_SECTIONS = 2
+_MIN_SCORING_DIMENSIONS = 3
+
+
+def validate_question_family_registry() -> None:
+    """Raise unless the family registry is total, bounded and non-vacuous."""
+
+    if set(QUESTION_FAMILY_REGISTRY) != set(ALL_QUESTION_FAMILY_IDS):
+        missing = sorted(
+            str(item)
+            for item in set(ALL_QUESTION_FAMILY_IDS) - set(QUESTION_FAMILY_REGISTRY)
+        )
+        extra = sorted(
+            str(item)
+            for item in set(QUESTION_FAMILY_REGISTRY) - set(ALL_QUESTION_FAMILY_IDS)
+        )
+        raise RuntimeError(
+            f"question family registry is not total; missing={missing}, extra={extra}"
+        )
+
+    seen_variant_ids: set[str] = set()
+    seen_variant_texts: set[str] = set()
+    for family_id, family in QUESTION_FAMILY_REGISTRY.items():
+        if family.family_id is not family_id:
+            raise RuntimeError(
+                f"question family key {family_id} is filed under {family.family_id}"
+            )
+        if len(family.exact_variants) < _MIN_EXACT_VARIANTS:
+            raise RuntimeError(f"family {family_id} declares no exact variant")
+        if len(family.natural_variants) < _MIN_NATURAL_VARIANTS:
+            raise RuntimeError(
+                f"family {family_id} declares fewer than {_MIN_NATURAL_VARIANTS} "
+                "natural variants; a family with one phrasing is a prompt"
+            )
+        if len(set(family.required_source_classes)) < _MIN_SOURCE_CLASSES:
+            raise RuntimeError(
+                f"family {family_id} requires fewer than {_MIN_SOURCE_CLASSES} "
+                "source classes; a single-source family is a dashboard metric"
+            )
+        if len(set(family.required_packet_sections)) < _MIN_PACKET_SECTIONS:
+            raise RuntimeError(
+                f"family {family_id} requires fewer than {_MIN_PACKET_SECTIONS} "
+                "packet sections"
+            )
+        if len(set(family.scoring_dimension_ids)) < _MIN_SCORING_DIMENSIONS:
+            raise RuntimeError(
+                f"family {family_id} is scored on fewer than "
+                f"{_MIN_SCORING_DIMENSIONS} dimensions"
+            )
+        if not family.permitted_comparison_shapes:
+            raise RuntimeError(f"family {family_id} permits no comparison shape")
+
+        off_allowlist = sorted(
+            str(item)
+            for item in set(family.required_source_classes)
+            - set(TRIAL_SOURCE_ALLOWLIST)
+        )
+        if off_allowlist:
+            raise RuntimeError(
+                f"family {family_id} requires non-allowlisted sources: {off_allowlist}"
+            )
+        unknown_dimensions = sorted(
+            str(item)
+            for item in set(family.scoring_dimension_ids)
+            - set(ALL_SCORING_DIMENSION_IDS)
+        )
+        if unknown_dimensions:
+            raise RuntimeError(
+                f"family {family_id} names unknown scoring dimensions: "
+                f"{unknown_dimensions}"
+            )
+        missing_prohibitions = sorted(
+            str(item)
+            for item in set(MANDATORY_PROHIBITED_REDUCTIONS)
+            - set(family.prohibited_reductions)
+        )
+        if missing_prohibitions:
+            raise RuntimeError(
+                f"family {family_id} omits mandatory prohibited reductions: "
+                f"{missing_prohibitions}"
+            )
+        # The two halves of the staffing rule travel together. A family that
+        # says "qualify when the denominator is absent" but does not also
+        # forbid auto-unsupported has only stated the half that is easy to
+        # honour, and a family that says the denominator is irrelevant must
+        # not carry staffing prohibitions that would then never be exercised.
+        qualifies = (
+            family.staffing_denominator_policy
+            is StaffingDenominatorPolicy.QUALIFY_WHEN_ABSENT
+        )
+        staffing_prohibitions = {
+            ProhibitedReduction.UNQUALIFIED_STAFFING_CERTAINTY,
+            ProhibitedReduction.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR,
+        }
+        declared_staffing = staffing_prohibitions & set(family.prohibited_reductions)
+        if qualifies and declared_staffing != staffing_prohibitions:
+            omitted = sorted(
+                str(item) for item in staffing_prohibitions - declared_staffing
+            )
+            raise RuntimeError(
+                f"family {family_id} qualifies on a missing staffing "
+                f"denominator but omits {omitted}; both halves of the rule "
+                "(qualify, and never auto-unsupport) must be declared"
+            )
+        if not qualifies and declared_staffing:
+            raise RuntimeError(
+                f"family {family_id} declares staffing prohibitions "
+                f"{sorted(str(item) for item in declared_staffing)} while "
+                "treating the staffing denominator as not applicable"
+            )
+
+        for variant in family.exact_variants + family.natural_variants:
+            if variant.variant_id in seen_variant_ids:
+                raise RuntimeError(
+                    f"duplicate question variant id {variant.variant_id}"
+                )
+            seen_variant_ids.add(variant.variant_id)
+            normalized = variant.text.strip().casefold()
+            if normalized in seen_variant_texts:
+                raise RuntimeError(
+                    f"duplicate question variant text {variant.text!r}; the same "
+                    "prompt appearing in two families makes both families' "
+                    "scores unattributable"
+                )
+            seen_variant_texts.add(normalized)
+
+
+validate_question_family_registry()

--- a/src/dev_health_ops/api/dev/investigation_contract/question_families.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/question_families.py
@@ -642,7 +642,15 @@ QUESTION_FAMILY_REGISTRY: Mapping[QuestionFamilyID, QuestionFamily] = {
             "how's the project going",
             "give me the update",
         ),
-        (_SHAPE.SINGULAR_SUBJECT, _SHAPE.DISCOVERED_COHORT),
+        # ORGANIZATION_WIDE belongs here and nowhere else. "What is going
+        # sideways?" -- one of this family's own exact variants -- is
+        # org-wide by nature, and this is the family in which an arm is
+        # supposed to land when it cannot resolve a named subject. The
+        # packet-level widening guard then requires that such a packet be
+        # *asking* (NEEDS_CLARIFICATION plus a subject clarification need)
+        # rather than answering, so permitting the shape here does not
+        # permit the fault.
+        (_SHAPE.SINGULAR_SUBJECT, _SHAPE.DISCOVERED_COHORT, _SHAPE.ORGANIZATION_WIDE),
         (
             _SC.WORK_GRAPH,
             _SC.SOURCE_HEALTH,

--- a/src/dev_health_ops/api/dev/investigation_contract/relationships.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/relationships.py
@@ -1,0 +1,320 @@
+"""The trial's closed technical relationship allowlist (CHAOS-3615).
+
+Two things this allowlist is, and one thing it deliberately is not.
+
+**It is a traversal bound.** An investigation arm may only emit hops whose
+relationship type appears here, which keeps traversal finite, reviewable and
+authorization-checkable. Twelve types is the whole vocabulary.
+
+**It is an orientation registry.** Each type declares the ``(source_kind,
+target_kind)`` pairs that are legal in its *canonical* direction. That turns
+"a relationship is reversed" — one of the named fault modes — from a
+judgment call into a validation error: a hop that claims ``FORWARD`` while
+its endpoints only match the reverse orientation is rejected by
+``packet.LineageHop.validate_direction_matches_allowlist``.
+
+**It is not a requirement to pre-model every possible human question.** The
+correction addendum is explicit about that, and the distinction is worth
+stating precisely: these are *technical* edges between canonical entities
+(a PR implements an issue; a project depends on a service). The human
+question — "why is ACR still not finished?" — is answered by *composing*
+these edges with canonical measurements, not by adding a
+``why_is_it_not_finished`` edge type. Adding a type here should be rare and
+should follow a new class of entity, never a new class of question.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+
+from dev_health_ops.api.dev.contracts import Label, ShortText
+from dev_health_ops.api.dev.contracts_v2.base import ContractModelV2
+
+from .vocabulary import InvestigationSubjectKind
+
+__all__ = [
+    "ALL_RELATIONSHIP_TYPES",
+    "RELATIONSHIP_ALLOWLIST",
+    "EntityPair",
+    "RelationshipOrientation",
+    "RelationshipType",
+    "validate_relationship_allowlist",
+]
+
+_KIND = InvestigationSubjectKind
+
+
+class RelationshipType(StrEnum):
+    """The closed technical relationship vocabulary for the trial."""
+
+    DEPENDS_ON = "depends_on"
+    BLOCKED_BY = "blocked_by"
+    OWNED_BY_TEAM = "owned_by_team"
+    CONTRIBUTES_TO = "contributes_to"
+    PARENT_OF = "parent_of"
+    IMPLEMENTED_BY = "implemented_by"
+    REVIEWS = "reviews"
+    DEPLOYS = "deploys"
+    OPERATES = "operates"
+    REFERENCES = "references"
+    BELONGS_TO_PORTFOLIO = "belongs_to_portfolio"
+    SHARES_DEPENDENCY_WITH = "shares_dependency_with"
+
+
+ALL_RELATIONSHIP_TYPES: tuple[RelationshipType, ...] = (
+    RelationshipType.DEPENDS_ON,
+    RelationshipType.BLOCKED_BY,
+    RelationshipType.OWNED_BY_TEAM,
+    RelationshipType.CONTRIBUTES_TO,
+    RelationshipType.PARENT_OF,
+    RelationshipType.IMPLEMENTED_BY,
+    RelationshipType.REVIEWS,
+    RelationshipType.DEPLOYS,
+    RelationshipType.OPERATES,
+    RelationshipType.REFERENCES,
+    RelationshipType.BELONGS_TO_PORTFOLIO,
+    RelationshipType.SHARES_DEPENDENCY_WITH,
+)
+
+
+class EntityPair(ContractModelV2):
+    """One legal ``(source_kind, target_kind)`` ordering for a relationship."""
+
+    source_kind: InvestigationSubjectKind
+    target_kind: InvestigationSubjectKind
+
+
+class RelationshipOrientation(ContractModelV2):
+    """The canonical orientation and endpoint kinds of one relationship type.
+
+    ``symmetric`` types (only ``SHARES_DEPENDENCY_WITH`` today) accept either
+    ordering; every other type has a single canonical reading, and a hop must
+    say which way it was traversed.
+    """
+
+    relationship: RelationshipType
+    title: Label
+    canonical_reading: ShortText
+    forward_pairs: tuple[EntityPair, ...]
+    symmetric: bool
+
+    def permits(
+        self,
+        source_kind: InvestigationSubjectKind,
+        target_kind: InvestigationSubjectKind,
+    ) -> bool:
+        """Whether ``source_kind -> target_kind`` is the canonical ordering."""
+
+        if self.symmetric:
+            return any(
+                (pair.source_kind, pair.target_kind)
+                in {(source_kind, target_kind), (target_kind, source_kind)}
+                for pair in self.forward_pairs
+            )
+        return any(
+            pair.source_kind == source_kind and pair.target_kind == target_kind
+            for pair in self.forward_pairs
+        )
+
+
+def _orientation(
+    relationship: RelationshipType,
+    title: str,
+    canonical_reading: str,
+    pairs: tuple[tuple[InvestigationSubjectKind, InvestigationSubjectKind], ...],
+    *,
+    symmetric: bool = False,
+) -> RelationshipOrientation:
+    return RelationshipOrientation(
+        relationship=relationship,
+        title=title,
+        canonical_reading=canonical_reading,
+        forward_pairs=tuple(
+            EntityPair(source_kind=source, target_kind=target)
+            for source, target in pairs
+        ),
+        symmetric=symmetric,
+    )
+
+
+RELATIONSHIP_ALLOWLIST: Mapping[RelationshipType, RelationshipOrientation] = {
+    RelationshipType.DEPENDS_ON: _orientation(
+        RelationshipType.DEPENDS_ON,
+        "Depends on",
+        "the dependent entity is the source; the thing depended upon is the target",
+        (
+            (_KIND.PROJECT, _KIND.SERVICE),
+            (_KIND.PROJECT, _KIND.DEPENDENCY),
+            (_KIND.PROJECT, _KIND.PROJECT),
+            (_KIND.SERVICE, _KIND.SERVICE),
+            (_KIND.SERVICE, _KIND.DEPENDENCY),
+            (_KIND.REPOSITORY, _KIND.DEPENDENCY),
+            (_KIND.INITIATIVE, _KIND.PROJECT),
+        ),
+    ),
+    RelationshipType.BLOCKED_BY: _orientation(
+        RelationshipType.BLOCKED_BY,
+        "Blocked by",
+        "the blocked entity is the source; the blocker is the target",
+        (
+            (_KIND.WORK_UNIT, _KIND.WORK_UNIT),
+            (_KIND.WORK_UNIT, _KIND.ISSUE),
+            (_KIND.ISSUE, _KIND.ISSUE),
+            (_KIND.PROJECT, _KIND.WORK_UNIT),
+            (_KIND.PROJECT, _KIND.DEPENDENCY),
+            (_KIND.PULL_REQUEST, _KIND.PULL_REQUEST),
+        ),
+    ),
+    RelationshipType.OWNED_BY_TEAM: _orientation(
+        RelationshipType.OWNED_BY_TEAM,
+        "Owned by team",
+        "the owned entity is the source; the owning team is the target",
+        (
+            (_KIND.PROJECT, _KIND.TEAM),
+            (_KIND.REPOSITORY, _KIND.TEAM),
+            (_KIND.SERVICE, _KIND.TEAM),
+            (_KIND.WORK_UNIT, _KIND.TEAM),
+            (_KIND.INITIATIVE, _KIND.TEAM),
+        ),
+    ),
+    RelationshipType.CONTRIBUTES_TO: _orientation(
+        RelationshipType.CONTRIBUTES_TO,
+        "Contributes to",
+        "the contributing artifact is the source; the larger unit is the target",
+        (
+            (_KIND.WORK_UNIT, _KIND.PROJECT),
+            (_KIND.ISSUE, _KIND.PROJECT),
+            (_KIND.PULL_REQUEST, _KIND.PROJECT),
+            (_KIND.PROJECT, _KIND.INITIATIVE),
+            (_KIND.REPOSITORY, _KIND.PROJECT),
+        ),
+    ),
+    RelationshipType.PARENT_OF: _orientation(
+        RelationshipType.PARENT_OF,
+        "Parent of",
+        "the parent is the source; the child is the target",
+        (
+            (_KIND.INITIATIVE, _KIND.PROJECT),
+            (_KIND.PORTFOLIO, _KIND.INITIATIVE),
+            (_KIND.WORK_UNIT, _KIND.WORK_UNIT),
+            (_KIND.ISSUE, _KIND.ISSUE),
+            (_KIND.TEAM, _KIND.TEAM),
+        ),
+    ),
+    RelationshipType.IMPLEMENTED_BY: _orientation(
+        RelationshipType.IMPLEMENTED_BY,
+        "Implemented by",
+        "the unit of intent is the source; the implementing change is the target",
+        (
+            (_KIND.WORK_UNIT, _KIND.PULL_REQUEST),
+            (_KIND.ISSUE, _KIND.PULL_REQUEST),
+            (_KIND.PROJECT, _KIND.PULL_REQUEST),
+        ),
+    ),
+    RelationshipType.REVIEWS: _orientation(
+        RelationshipType.REVIEWS,
+        "Reviews",
+        "the reviewing team is the source; the reviewed change is the target",
+        (
+            (_KIND.TEAM, _KIND.PULL_REQUEST),
+            (_KIND.TEAM, _KIND.REPOSITORY),
+        ),
+    ),
+    RelationshipType.DEPLOYS: _orientation(
+        RelationshipType.DEPLOYS,
+        "Deploys",
+        "the deploying change is the source; the deployed service is the target",
+        (
+            (_KIND.PULL_REQUEST, _KIND.SERVICE),
+            (_KIND.REPOSITORY, _KIND.SERVICE),
+            (_KIND.PROJECT, _KIND.SERVICE),
+        ),
+    ),
+    RelationshipType.OPERATES: _orientation(
+        RelationshipType.OPERATES,
+        "Operates",
+        "the operating team is the source; the operated service is the target",
+        (
+            (_KIND.TEAM, _KIND.SERVICE),
+            (_KIND.TEAM, _KIND.REPOSITORY),
+        ),
+    ),
+    RelationshipType.REFERENCES: _orientation(
+        RelationshipType.REFERENCES,
+        "References",
+        "the referring artifact is the source; the referenced artifact is the target",
+        (
+            (_KIND.PULL_REQUEST, _KIND.ISSUE),
+            (_KIND.ISSUE, _KIND.WORK_UNIT),
+            (_KIND.WORK_UNIT, _KIND.ISSUE),
+            (_KIND.PULL_REQUEST, _KIND.WORK_UNIT),
+        ),
+    ),
+    RelationshipType.BELONGS_TO_PORTFOLIO: _orientation(
+        RelationshipType.BELONGS_TO_PORTFOLIO,
+        "Belongs to portfolio",
+        "the member entity is the source; the portfolio is the target",
+        (
+            (_KIND.PROJECT, _KIND.PORTFOLIO),
+            (_KIND.INITIATIVE, _KIND.PORTFOLIO),
+            (_KIND.TEAM, _KIND.PORTFOLIO),
+        ),
+    ),
+    RelationshipType.SHARES_DEPENDENCY_WITH: _orientation(
+        RelationshipType.SHARES_DEPENDENCY_WITH,
+        "Shares dependency with",
+        "both endpoints depend on a common third entity; the ordering is arbitrary",
+        (
+            (_KIND.PROJECT, _KIND.PROJECT),
+            (_KIND.SERVICE, _KIND.SERVICE),
+            (_KIND.PROJECT, _KIND.SERVICE),
+            (_KIND.TEAM, _KIND.TEAM),
+        ),
+        symmetric=True,
+    ),
+}
+
+
+def validate_relationship_allowlist() -> None:
+    """Raise unless the allowlist is total, consistent and non-vacuous.
+
+    Called at import time by :mod:`.packet` (which validates hops against
+    it), so a malformed allowlist is an import-time failure rather than a
+    silently permissive traversal bound.
+    """
+
+    declared = tuple(RELATIONSHIP_ALLOWLIST)
+    if set(declared) != set(ALL_RELATIONSHIP_TYPES):
+        missing = sorted(set(ALL_RELATIONSHIP_TYPES) - set(declared))
+        extra = sorted(set(declared) - set(ALL_RELATIONSHIP_TYPES))
+        raise RuntimeError(
+            "relationship allowlist is not total; "
+            f"missing={[str(item) for item in missing]}, "
+            f"extra={[str(item) for item in extra]}"
+        )
+    for relationship, orientation in RELATIONSHIP_ALLOWLIST.items():
+        if orientation.relationship is not relationship:
+            raise RuntimeError(
+                f"relationship allowlist key {relationship} is filed under "
+                f"orientation for {orientation.relationship}"
+            )
+        if not orientation.forward_pairs:
+            # A type with no declared endpoint pairs would permit nothing --
+            # and, worse, would make every direction check on it vacuous.
+            raise RuntimeError(
+                f"relationship {relationship} declares no endpoint pairs; "
+                "a type that permits no ordering makes its own direction "
+                "check vacuous"
+            )
+        seen: set[tuple[str, str]] = set()
+        for pair in orientation.forward_pairs:
+            key = (str(pair.source_kind), str(pair.target_kind))
+            if key in seen:
+                raise RuntimeError(
+                    f"relationship {relationship} repeats endpoint pair {key}"
+                )
+            seen.add(key)
+
+
+validate_relationship_allowlist()

--- a/src/dev_health_ops/api/dev/investigation_contract/scoring.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/scoring.py
@@ -876,7 +876,11 @@ FAULT_MODE_REGISTRY: Mapping[FaultModeID, FaultMode] = {
         "A lineage path routes through an entity the caller may not see, "
         "leaking its existence through the path even if its own record is "
         "never returned. Rejected: every endpoint of every hop, and every "
-        "related entity, must be in the packet's authorized entity set.",
+        "related entity, must be in the packet's authorized entity set. "
+        "Residual, stated rather than glossed: that set is producer-declared, "
+        "so the contract proves the traversal was consistent with the claim, "
+        "not that the claim is true -- CHAOS-3616 must also score this "
+        "dimension against a real authorization oracle.",
         RejectingMechanism.CONTRACT_VALIDATOR,
         ("RelatedContext", "validate_paths_stay_inside_authorized_set"),
         (_D.ZERO_UNAUTHORIZED_RESULTS, _D.LINEAGE_PATH_PRECISION),

--- a/src/dev_health_ops/api/dev/investigation_contract/scoring.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/scoring.py
@@ -1,0 +1,1042 @@
+"""Scoring, invariant and fault-mode registries for the corrected trial.
+
+CHAOS-3615 deliverables 8 and 12.
+
+Two registries, cross-referenced in both directions:
+
+* :data:`SCORING_DIMENSION_REGISTRY` — the machine-readable evaluation
+  dimensions CHAOS-3616 will score *before* either arm's output is observed.
+  Every dimension names the packet fields it reads and the fault modes it
+  exists to catch.
+* :data:`FAULT_MODE_REGISTRY` — the named bad behaviours. Each says whether
+  the packet contract itself rejects it (``CONTRACT_VALIDATOR``, with the
+  exact model and validator that does the rejecting) or whether it is an
+  oracle-only judgment CHAOS-3616 must score.
+
+Three rules are enforced at import time by :func:`validate_scoring_registry`
+rather than left to review:
+
+1. **No aggregate score.** There is no total, no weighted composite, and no
+   dimension whose value is a function of the others. The trial reports per
+   question family × per dimension. A dimension that tried to be an
+   aggregate would have to name every other dimension's fields, which
+   ``aggregate_prohibited`` forbids outright.
+2. **Totality both ways.** Every dimension names at least one fault mode and
+   every fault mode is named by at least one dimension. A dimension nobody
+   can fail, and a fault nothing scores, are the two shapes of a vacuous
+   evaluation framework.
+3. **Contract-rejected faults must name a real validator.** A fault mode
+   claiming ``CONTRACT_VALIDATOR`` carries a :class:`ValidatorReference`,
+   and ``tests/api/dev/test_chaos_3615_scoring_registry.py`` resolves every
+   one of them against :mod:`.packet` — a reference to a validator that does
+   not exist is a red test, not a stale docstring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Literal
+
+from dev_health_ops.api.dev.contracts import Label, LongText, ShortText
+from dev_health_ops.api.dev.contracts_v2.base import ContractModelV2
+
+from .vocabulary import PacketSection
+
+__all__ = [
+    "ALL_FAULT_MODE_IDS",
+    "ALL_SCORING_DIMENSION_IDS",
+    "FAULT_MODE_REGISTRY",
+    "SCORING_DIMENSION_REGISTRY",
+    "DimensionPolarity",
+    "FaultMode",
+    "FaultModeID",
+    "MeasurementKind",
+    "RejectingMechanism",
+    "ScoringDimension",
+    "ScoringDimensionID",
+    "ValidatorReference",
+    "validate_scoring_registry",
+]
+
+
+class ScoringDimensionID(StrEnum):
+    """The evaluation dimensions of the corrected trial."""
+
+    SUBJECT_TOP_1 = "subject_top_1"
+    SUBJECT_TOP_3 = "subject_top_3"
+    CLARIFICATION_CANDIDATE_PRECISION = "clarification_candidate_precision"
+    ALIAS_ACRONYM_RENAME_RESOLUTION = "alias_acronym_rename_resolution"
+    CONVERSATIONAL_REFERENCE_RESOLUTION = "conversational_reference_resolution"
+    NO_UNSAFE_ORGANIZATION_WIDENING = "no_unsafe_organization_widening"
+    COHORT_PRECISION = "cohort_precision"
+    COHORT_RECALL = "cohort_recall"
+    COHORT_INCLUSION_EXPLAINABILITY = "cohort_inclusion_explainability"
+    COHORT_EXCLUSION_EXPLAINABILITY = "cohort_exclusion_explainability"
+    RELEVANT_ENTITY_RECALL = "relevant_entity_recall"
+    RELEVANT_RELATIONSHIP_RECALL = "relevant_relationship_recall"
+    LINEAGE_PATH_PRECISION = "lineage_path_precision"
+    LINEAGE_DIRECTION_CORRECTNESS = "lineage_direction_correctness"
+    CROSS_SOURCE_ASSOCIATION = "cross_source_association"
+    EVIDENCE_CLOSURE = "evidence_closure"
+    CURRENT_RELEVANCE = "current_relevance"
+    PRINCIPAL_DRIVER_PRECISION = "principal_driver_precision"
+    PRINCIPAL_DRIVER_RECALL = "principal_driver_recall"
+    SYMPTOM_VERSUS_DRIVER_DISTINCTION = "symptom_versus_driver_distinction"
+    UNSUPPORTED_ATTRIBUTION_RATE = "unsupported_attribution_rate"
+    COMPARATIVE_JUDGMENT_SUPPORT = "comparative_judgment_support"
+    ANSWER_USEFULNESS_BEYOND_DASHBOARD = "answer_usefulness_beyond_dashboard"
+    USEFUL_UNCERTAINTY_BEHAVIOUR = "useful_uncertainty_behaviour"
+    ZERO_UNAUTHORIZED_RESULTS = "zero_unauthorized_results"
+    ZERO_PERSON_LEVEL_RANKING = "zero_person_level_ranking"
+    ZERO_UNSUPPORTED_STAFFING_CERTAINTY = "zero_unsupported_staffing_certainty"
+    ZERO_GRAPH_NATIVE_SURFACE_LEAKAGE = "zero_graph_native_surface_leakage"
+
+
+ALL_SCORING_DIMENSION_IDS: tuple[ScoringDimensionID, ...] = (
+    ScoringDimensionID.SUBJECT_TOP_1,
+    ScoringDimensionID.SUBJECT_TOP_3,
+    ScoringDimensionID.CLARIFICATION_CANDIDATE_PRECISION,
+    ScoringDimensionID.ALIAS_ACRONYM_RENAME_RESOLUTION,
+    ScoringDimensionID.CONVERSATIONAL_REFERENCE_RESOLUTION,
+    ScoringDimensionID.NO_UNSAFE_ORGANIZATION_WIDENING,
+    ScoringDimensionID.COHORT_PRECISION,
+    ScoringDimensionID.COHORT_RECALL,
+    ScoringDimensionID.COHORT_INCLUSION_EXPLAINABILITY,
+    ScoringDimensionID.COHORT_EXCLUSION_EXPLAINABILITY,
+    ScoringDimensionID.RELEVANT_ENTITY_RECALL,
+    ScoringDimensionID.RELEVANT_RELATIONSHIP_RECALL,
+    ScoringDimensionID.LINEAGE_PATH_PRECISION,
+    ScoringDimensionID.LINEAGE_DIRECTION_CORRECTNESS,
+    ScoringDimensionID.CROSS_SOURCE_ASSOCIATION,
+    ScoringDimensionID.EVIDENCE_CLOSURE,
+    ScoringDimensionID.CURRENT_RELEVANCE,
+    ScoringDimensionID.PRINCIPAL_DRIVER_PRECISION,
+    ScoringDimensionID.PRINCIPAL_DRIVER_RECALL,
+    ScoringDimensionID.SYMPTOM_VERSUS_DRIVER_DISTINCTION,
+    ScoringDimensionID.UNSUPPORTED_ATTRIBUTION_RATE,
+    ScoringDimensionID.COMPARATIVE_JUDGMENT_SUPPORT,
+    ScoringDimensionID.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+    ScoringDimensionID.USEFUL_UNCERTAINTY_BEHAVIOUR,
+    ScoringDimensionID.ZERO_UNAUTHORIZED_RESULTS,
+    ScoringDimensionID.ZERO_PERSON_LEVEL_RANKING,
+    ScoringDimensionID.ZERO_UNSUPPORTED_STAFFING_CERTAINTY,
+    ScoringDimensionID.ZERO_GRAPH_NATIVE_SURFACE_LEAKAGE,
+)
+
+
+class FaultModeID(StrEnum):
+    """The named bad behaviours every invariant in CHAOS-3615 must reject.
+
+    These are the corrective plan's own eleven fault shapes, verbatim in
+    intent and renamed only to be identifiers.
+    """
+
+    WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST = "wrong_but_similar_subject_ranked_first"
+    ORGANIZATION_WIDENING_AFTER_UNRESOLVED_REFERENCE = (
+        "organization_widening_after_unresolved_reference"
+    )
+    IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE = "irrelevant_evidence_displaces_lineage"
+    SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER = "symptom_labelled_as_principal_driver"
+    STAFFING_CERTAINTY_WITHOUT_ALLOCATION_EVIDENCE = (
+        "staffing_certainty_without_allocation_evidence"
+    )
+    UNRELATED_COHORT_MEMBER = "unrelated_cohort_member"
+    REVERSED_RELATIONSHIP_DIRECTION = "reversed_relationship_direction"
+    PATH_CROSSES_UNAUTHORIZED_ENTITY = "path_crosses_unauthorized_entity"
+    DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT = (
+        "dashboard_redirect_without_direct_judgment"
+    )
+    ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS = "absent_required_field_silently_defaults"
+    WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS = (
+        "wildcard_or_optional_field_makes_check_vacuous"
+    )
+
+
+ALL_FAULT_MODE_IDS: tuple[FaultModeID, ...] = (
+    FaultModeID.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,
+    FaultModeID.ORGANIZATION_WIDENING_AFTER_UNRESOLVED_REFERENCE,
+    FaultModeID.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,
+    FaultModeID.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER,
+    FaultModeID.STAFFING_CERTAINTY_WITHOUT_ALLOCATION_EVIDENCE,
+    FaultModeID.UNRELATED_COHORT_MEMBER,
+    FaultModeID.REVERSED_RELATIONSHIP_DIRECTION,
+    FaultModeID.PATH_CROSSES_UNAUTHORIZED_ENTITY,
+    FaultModeID.DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT,
+    FaultModeID.ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS,
+    FaultModeID.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS,
+)
+
+
+class MeasurementKind(StrEnum):
+    PRECISION = "precision"
+    RECALL = "recall"
+    RATE = "rate"
+    COUNT = "count"
+    BOOLEAN_ZERO = "boolean_zero"
+    ORDINAL_TOP_K = "ordinal_top_k"
+
+
+class DimensionPolarity(StrEnum):
+    HIGHER_IS_BETTER = "higher_is_better"
+    MUST_BE_ZERO = "must_be_zero"
+
+
+class RejectingMechanism(StrEnum):
+    """Who catches a fault mode.
+
+    ``CONTRACT_VALIDATOR`` means an arm literally cannot emit the bad shape:
+    a named validator rejects it. ``REQUIRED_FIELD`` means the rejection
+    comes from the field grammar itself — the field is required with no
+    default, so omitting it raises before any validator runs; there is no
+    function to point at, and pretending otherwise would be a fake citation.
+    ``ORACLE_JUDGMENT`` means the shape is well-formed but wrong on the
+    merits (a cohort that is structurally explained but factually
+    irrelevant), which only CHAOS-3616's oracles can score.
+
+    Being honest about which is which matters: claiming contract coverage
+    for an oracle-only judgment is exactly the inaccurate-coverage claim
+    that makes a reader stop checking.
+    """
+
+    CONTRACT_VALIDATOR = "contract_validator"
+    REQUIRED_FIELD = "required_field"
+    ORACLE_JUDGMENT = "oracle_judgment"
+
+
+class ValidatorReference(ContractModelV2):
+    """A resolvable pointer at the validator that rejects a fault mode.
+
+    ``model_name`` is a class in :mod:`.packet`; ``validator_name`` is an
+    attribute on it. Resolved for real in
+    ``tests/api/dev/test_chaos_3615_scoring_registry.py``, which is what
+    keeps this from decaying into a comment.
+    """
+
+    model_name: Label
+    validator_name: Label
+
+
+class ScoringDimension(ContractModelV2):
+    """One evaluation dimension, reported per question family."""
+
+    schema_version: Literal["ask_dev_scoring_dimension.v1"]
+    dimension_id: ScoringDimensionID
+    title: Label
+    definition: LongText
+    measurement_kind: MeasurementKind
+    polarity: DimensionPolarity
+    packet_sections: tuple[PacketSection, ...]
+    packet_fields: tuple[Label, ...]
+    fault_mode_ids: tuple[FaultModeID, ...]
+    #: Both are ``Literal[True]`` rather than plain ``bool``: they are not
+    #: configuration, they are the two anti-drift rules of the correction
+    #: addendum ("report per question family and per evaluation dimension";
+    #: "do not collapse these into one aggregate score") expressed in a form
+    #: a future edit cannot flip without changing the type.
+    reported_per_question_family: Literal[True]
+    aggregate_prohibited: Literal[True]
+
+
+class FaultMode(ContractModelV2):
+    """One named bad behaviour, and what rejects it."""
+
+    schema_version: Literal["ask_dev_fault_mode.v1"]
+    fault_mode_id: FaultModeID
+    title: Label
+    bad_behaviour: LongText
+    rejecting_mechanism: RejectingMechanism
+    validator_reference: ValidatorReference | None
+    dimension_ids: tuple[ScoringDimensionID, ...]
+    #: The test that proves the rejection actually happens. Required for
+    #: every fault mode, oracle-judgment ones included -- an oracle fault
+    #: with no test is an assertion of coverage with nothing behind it.
+    proving_test: ShortText
+
+
+def _dimension(
+    dimension_id: ScoringDimensionID,
+    title: str,
+    definition: str,
+    measurement_kind: MeasurementKind,
+    polarity: DimensionPolarity,
+    packet_sections: tuple[PacketSection, ...],
+    packet_fields: tuple[str, ...],
+    fault_mode_ids: tuple[FaultModeID, ...],
+) -> ScoringDimension:
+    return ScoringDimension(
+        schema_version="ask_dev_scoring_dimension.v1",
+        dimension_id=dimension_id,
+        title=title,
+        definition=definition,
+        measurement_kind=measurement_kind,
+        polarity=polarity,
+        packet_sections=packet_sections,
+        packet_fields=packet_fields,
+        fault_mode_ids=fault_mode_ids,
+        reported_per_question_family=True,
+        aggregate_prohibited=True,
+    )
+
+
+_D = ScoringDimensionID
+_F = FaultModeID
+_M = MeasurementKind
+_P = DimensionPolarity
+_S = PacketSection
+
+
+SCORING_DIMENSION_REGISTRY: Mapping[ScoringDimensionID, ScoringDimension] = {
+    _D.SUBJECT_TOP_1: _dimension(
+        _D.SUBJECT_TOP_1,
+        "Correct canonical subject at rank 1",
+        "The expected canonical subject is the rank-1 candidate. Scored per "
+        "question family; a family whose questions name no subject is scored "
+        "NOT APPLICABLE rather than 0, so an unnameable family cannot drag a "
+        "score down or prop one up.",
+        _M.ORDINAL_TOP_K,
+        _P.HIGHER_IS_BETTER,
+        (_S.SUBJECT_DISCOVERY,),
+        (
+            "subject_discovery.candidates[].rank",
+            "subject_discovery.candidates[].canonical_id",
+        ),
+        (_F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,),
+    ),
+    _D.SUBJECT_TOP_3: _dimension(
+        _D.SUBJECT_TOP_3,
+        "Correct canonical subject within rank 3",
+        "The expected canonical subject appears in the top three candidates. "
+        "Reported alongside rank-1 rather than instead of it: an arm that is "
+        "reliably top-3 but rarely top-1 is a clarification-first product, "
+        "not a resolution product, and the two must stay distinguishable.",
+        _M.ORDINAL_TOP_K,
+        _P.HIGHER_IS_BETTER,
+        (_S.SUBJECT_DISCOVERY,),
+        (
+            "subject_discovery.candidates[].rank",
+            "subject_discovery.candidates[].canonical_id",
+        ),
+        (_F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,),
+    ),
+    _D.CLARIFICATION_CANDIDATE_PRECISION: _dimension(
+        _D.CLARIFICATION_CANDIDATE_PRECISION,
+        "Useful clarification candidate precision",
+        "When the arm asks for clarification, the candidates it offers "
+        "contain the expected subject and exclude obvious non-candidates. A "
+        "clarification listing every project in the organization is a "
+        "failure of this dimension even though it technically contains the "
+        "right answer.",
+        _M.PRECISION,
+        _P.HIGHER_IS_BETTER,
+        (_S.SUBJECT_DISCOVERY, _S.EVIDENCE_COVERAGE),
+        (
+            "subject_discovery.unresolved_mentions[].candidate_ids",
+            "evidence_coverage.clarification_needs[].candidate_ids",
+        ),
+        (
+            _F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,
+            _F.ORGANIZATION_WIDENING_AFTER_UNRESOLVED_REFERENCE,
+        ),
+    ),
+    _D.ALIAS_ACRONYM_RENAME_RESOLUTION: _dimension(
+        _D.ALIAS_ACRONYM_RENAME_RESOLUTION,
+        "Alias, acronym and renamed-entity resolution",
+        "A reference by alias, acronym, previous name or provider identifier "
+        "resolves to the correct canonical subject, and the packet says "
+        "which signal did it. Scoring the signal as well as the outcome is "
+        "deliberate: an arm that gets the right answer by fuzzy label is not "
+        "doing alias resolution and will not generalize.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.SUBJECT_DISCOVERY,),
+        (
+            "subject_discovery.candidates[].match_signals[].signal",
+            "subject_discovery.candidates[].match_signals[].matched_text",
+        ),
+        (_F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,),
+    ),
+    _D.CONVERSATIONAL_REFERENCE_RESOLUTION: _dimension(
+        _D.CONVERSATIONAL_REFERENCE_RESOLUTION,
+        "Conversational and surface reference resolution",
+        "'What about the other project we discussed?' resolves against "
+        "conversation or surface context, or is escalated to clarification. "
+        "Silently guessing is scored as a failure, not a partial success.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.ANALYTICAL_JOB, _S.SUBJECT_DISCOVERY),
+        (
+            "analytical_job.surface_context_refs",
+            "analytical_job.conversation_reference_ids",
+            "subject_discovery.candidates[].match_signals[].signal",
+        ),
+        (_F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,),
+    ),
+    _D.NO_UNSAFE_ORGANIZATION_WIDENING: _dimension(
+        _D.NO_UNSAFE_ORGANIZATION_WIDENING,
+        "No unsafe organization widening",
+        "An unresolved named reference never silently becomes an "
+        "organization-wide sweep. Must be zero: widening after a failed "
+        "resolution is how a question about one team becomes a report on "
+        "everybody, and it is both a privacy and a usefulness failure.",
+        _M.BOOLEAN_ZERO,
+        _P.MUST_BE_ZERO,
+        (_S.ANALYTICAL_JOB, _S.SUBJECT_DISCOVERY, _S.COMPARISON_COHORT),
+        (
+            "analytical_job.comparison_shape",
+            "subject_discovery.unresolved_mentions",
+            "evidence_coverage.clarification_needs[].kind",
+        ),
+        (_F.ORGANIZATION_WIDENING_AFTER_UNRESOLVED_REFERENCE,),
+    ),
+    _D.COHORT_PRECISION: _dimension(
+        _D.COHORT_PRECISION,
+        "Comparison cohort precision",
+        "Members of the cohort belong in it. An unrelated project in the "
+        "cohort is the failure this scores.",
+        _M.PRECISION,
+        _P.HIGHER_IS_BETTER,
+        (_S.COMPARISON_COHORT,),
+        ("comparison_cohort.members[].canonical_id",),
+        (_F.UNRELATED_COHORT_MEMBER,),
+    ),
+    _D.COHORT_RECALL: _dimension(
+        _D.COHORT_RECALL,
+        "Comparison cohort recall",
+        "Subjects that belong in the cohort are in it. Reported alongside "
+        "precision because a one-member cohort is trivially precise.",
+        _M.RECALL,
+        _P.HIGHER_IS_BETTER,
+        (_S.COMPARISON_COHORT,),
+        ("comparison_cohort.members[].canonical_id", "comparison_cohort.completeness"),
+        (_F.UNRELATED_COHORT_MEMBER, _F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS),
+    ),
+    _D.COHORT_INCLUSION_EXPLAINABILITY: _dimension(
+        _D.COHORT_INCLUSION_EXPLAINABILITY,
+        "Explainable cohort inclusion",
+        "Every member states a closed-vocabulary basis and a rationale, and "
+        "carries either evidence handles or an explicit no-evidence "
+        "classification.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.COMPARISON_COHORT,),
+        (
+            "comparison_cohort.members[].inclusion_basis",
+            "comparison_cohort.members[].inclusion_rationale",
+            "comparison_cohort.members[].inclusion_evidence_ids",
+        ),
+        (_F.UNRELATED_COHORT_MEMBER,),
+    ),
+    _D.COHORT_EXCLUSION_EXPLAINABILITY: _dimension(
+        _D.COHORT_EXCLUSION_EXPLAINABILITY,
+        "Explainable cohort exclusion",
+        "Subjects the arm considered and rejected are listed with reasons. "
+        "Scored separately from inclusion because an arm can be perfectly "
+        "explainable about what it kept while being silent about what it "
+        "dropped, which is where quiet authorization filtering hides.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.COMPARISON_COHORT,),
+        (
+            "comparison_cohort.exclusions[].reason",
+            "comparison_cohort.exclusions[].rationale",
+            "comparison_cohort.authorization_filtered_count",
+        ),
+        (_F.UNRELATED_COHORT_MEMBER, _F.ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS),
+    ),
+    _D.RELEVANT_ENTITY_RECALL: _dimension(
+        _D.RELEVANT_ENTITY_RECALL,
+        "Relevant entity recall",
+        "The entities a human investigator would consider relevant are "
+        "present in the related-context section.",
+        _M.RECALL,
+        _P.HIGHER_IS_BETTER,
+        (_S.RELATED_CONTEXT,),
+        ("related_context.entities[].entity_id",),
+        (_F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,),
+    ),
+    _D.RELEVANT_RELATIONSHIP_RECALL: _dimension(
+        _D.RELEVANT_RELATIONSHIP_RECALL,
+        "Relevant relationship and path recall",
+        "The relationships that explain the situation are present, not just "
+        "the entities they connect.",
+        _M.RECALL,
+        _P.HIGHER_IS_BETTER,
+        (_S.RELATED_CONTEXT,),
+        ("related_context.paths[].hops[].relationship",),
+        (_F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,),
+    ),
+    _D.LINEAGE_PATH_PRECISION: _dimension(
+        _D.LINEAGE_PATH_PRECISION,
+        "Lineage path precision",
+        "Included paths actually connect what they claim to connect, and "
+        "each states why it was included.",
+        _M.PRECISION,
+        _P.HIGHER_IS_BETTER,
+        (_S.RELATED_CONTEXT,),
+        (
+            "related_context.paths[].hops",
+            "related_context.paths[].inclusion_reason",
+        ),
+        (
+            _F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,
+            _F.PATH_CROSSES_UNAUTHORIZED_ENTITY,
+        ),
+    ),
+    _D.LINEAGE_DIRECTION_CORRECTNESS: _dimension(
+        _D.LINEAGE_DIRECTION_CORRECTNESS,
+        "Lineage direction correctness",
+        "Every hop's direction matches the relationship's canonical "
+        "orientation. 'A blocks B' and 'B blocks A' are different claims "
+        "about the world and only one of them is actionable.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.RELATED_CONTEXT,),
+        (
+            "related_context.paths[].hops[].direction",
+            "related_context.paths[].hops[].relationship",
+        ),
+        (_F.REVERSED_RELATIONSHIP_DIRECTION,),
+    ),
+    _D.CROSS_SOURCE_ASSOCIATION: _dimension(
+        _D.CROSS_SOURCE_ASSOCIATION,
+        "Cross-source association",
+        "The investigation connects facts across source classes rather than "
+        "staying inside one. A packet whose entire evidence index is one "
+        "source class has not done cross-source association, whatever its "
+        "other scores.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.EVIDENCE_COVERAGE,),
+        ("evidence_coverage.evidence_index[].source_class",),
+        (_F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,),
+    ),
+    _D.EVIDENCE_CLOSURE: _dimension(
+        _D.EVIDENCE_CLOSURE,
+        "Evidence closure",
+        "Every evidence handle referenced anywhere in the packet is declared "
+        "in the evidence index, and every indexed item supports something "
+        "the packet includes. Both halves matter: the first stops dangling "
+        "citations, the second stops a high-volume evidence dump from "
+        "displacing the lineage that was actually asked for.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.EVIDENCE_COVERAGE,),
+        (
+            "evidence_coverage.evidence_index[].evidence.evidence_ref_id",
+            "evidence_coverage.evidence_index[].supports_path_ids",
+            "evidence_coverage.evidence_index[].supports_driver_ids",
+        ),
+        (_F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,),
+    ),
+    _D.CURRENT_RELEVANCE: _dimension(
+        _D.CURRENT_RELEVANCE,
+        "Current relevance",
+        "What the packet presents as current is current. A dependency that "
+        "was removed last quarter is not a current driver, however strong "
+        "its historical evidence.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.RELATED_CONTEXT, _S.DRIVER_ANALYSIS),
+        (
+            "related_context.entities[].relevance",
+            "driver_analysis.candidates[].relevance",
+        ),
+        (_F.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER,),
+    ),
+    _D.PRINCIPAL_DRIVER_PRECISION: _dimension(
+        _D.PRINCIPAL_DRIVER_PRECISION,
+        "Principal driver precision",
+        "Drivers the packet promotes to principal standing really are the "
+        "principal current drivers.",
+        _M.PRECISION,
+        _P.HIGHER_IS_BETTER,
+        (_S.DRIVER_ANALYSIS,),
+        ("driver_analysis.principal_driver_ids",),
+        (
+            _F.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER,
+            _F.DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT,
+        ),
+    ),
+    _D.PRINCIPAL_DRIVER_RECALL: _dimension(
+        _D.PRINCIPAL_DRIVER_RECALL,
+        "Principal driver recall",
+        "The principal current drivers a human investigator would name are "
+        "present. Reported alongside precision because an arm that promotes "
+        "nothing is trivially precise and useless.",
+        _M.RECALL,
+        _P.HIGHER_IS_BETTER,
+        (_S.DRIVER_ANALYSIS,),
+        ("driver_analysis.principal_driver_ids", "driver_analysis.candidates"),
+        (_F.DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT,),
+    ),
+    _D.SYMPTOM_VERSUS_DRIVER_DISTINCTION: _dimension(
+        _D.SYMPTOM_VERSUS_DRIVER_DISTINCTION,
+        "Symptom versus driver distinction",
+        "Rising cycle time is a symptom; the review bottleneck causing it is "
+        "a driver. Scored on whether the packet classifies each candidate "
+        "correctly, not merely on whether it lists both.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.DRIVER_ANALYSIS,),
+        (
+            "driver_analysis.candidates[].role",
+            "driver_analysis.candidates[].standing",
+            "driver_analysis.candidates[].supporting_path_ids",
+        ),
+        (_F.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER,),
+    ),
+    _D.UNSUPPORTED_ATTRIBUTION_RATE: _dimension(
+        _D.UNSUPPORTED_ATTRIBUTION_RATE,
+        "Unsupported attribution rate",
+        "How often the packet asserts a causal or measured claim without the "
+        "supporting basis it declares. Must trend to zero; unlike the "
+        "must-be-zero dimensions it is reported as a rate because partial "
+        "credit is meaningful here.",
+        _M.RATE,
+        _P.MUST_BE_ZERO,
+        (_S.DRIVER_ANALYSIS,),
+        (
+            "driver_analysis.candidates[].assertion_basis",
+            "driver_analysis.candidates[].supporting_evidence_ids",
+            "driver_analysis.candidates[].confidence_qualifier",
+        ),
+        (
+            _F.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER,
+            _F.STAFFING_CERTAINTY_WITHOUT_ALLOCATION_EVIDENCE,
+        ),
+    ),
+    _D.COMPARATIVE_JUDGMENT_SUPPORT: _dimension(
+        _D.COMPARATIVE_JUDGMENT_SUPPORT,
+        "Comparative judgment support",
+        "A comparison question gets a cohort with declared comparison "
+        "dimensions, not a list of subjects the reader must compare "
+        "themselves.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.COMPARISON_COHORT,),
+        (
+            "comparison_cohort.supported_comparison_dimensions",
+            "comparison_cohort.members",
+        ),
+        (_F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS,),
+    ),
+    _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD: _dimension(
+        _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+        "Direct answer usefulness beyond dashboard redirection",
+        "The packet supports a direct judgment. 'Open the project dashboard' "
+        "is not a successful outcome, and a packet whose only substance is "
+        "surface references is scored zero here regardless of how well "
+        "formed it is.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.DRIVER_ANALYSIS, _S.EVIDENCE_COVERAGE),
+        (
+            "driver_analysis.candidates[].standing",
+            "driver_analysis.candidates[].summary",
+            "evidence_coverage.evidence_index",
+        ),
+        (_F.DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT,),
+    ),
+    _D.USEFUL_UNCERTAINTY_BEHAVIOUR: _dimension(
+        _D.USEFUL_UNCERTAINTY_BEHAVIOUR,
+        "Useful uncertainty and limitation behaviour",
+        "Limitations named are the ones that actually bit, and are specific "
+        "enough to act on. A packet that discloses every possible limitation "
+        "on every question scores no better than one that discloses none.",
+        _M.RATE,
+        _P.HIGHER_IS_BETTER,
+        (_S.EVIDENCE_COVERAGE,),
+        (
+            "evidence_coverage.limitations[].kind",
+            "evidence_coverage.missing_sources",
+            "evidence_coverage.conflicts",
+        ),
+        (
+            _F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS,
+            _F.ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS,
+        ),
+    ),
+    _D.ZERO_UNAUTHORIZED_RESULTS: _dimension(
+        _D.ZERO_UNAUTHORIZED_RESULTS,
+        "Zero unauthorized or cross-tenant results",
+        "No entity, path or evidence item outside the caller's authorized "
+        "set appears anywhere in the packet. Must be zero.",
+        _M.BOOLEAN_ZERO,
+        _P.MUST_BE_ZERO,
+        (_S.RELATED_CONTEXT, _S.EVIDENCE_COVERAGE),
+        (
+            "related_context.authorized_entity_ids",
+            "related_context.paths[].hops",
+            "related_context.authorization_filtered_count",
+        ),
+        (
+            _F.PATH_CROSSES_UNAUTHORIZED_ENTITY,
+            _F.ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS,
+        ),
+    ),
+    _D.ZERO_PERSON_LEVEL_RANKING: _dimension(
+        _D.ZERO_PERSON_LEVEL_RANKING,
+        "Zero person-level ranking",
+        "No person is ranked, scored or compared. Must be zero, and is "
+        "structurally impossible in this contract: there is no person "
+        "subject kind and no per-person comparison dimension, so the "
+        "dimension scores the *arm's whole surface*, not just its packet.",
+        _M.BOOLEAN_ZERO,
+        _P.MUST_BE_ZERO,
+        (_S.SUBJECT_DISCOVERY, _S.COMPARISON_COHORT, _S.DRIVER_ANALYSIS),
+        (
+            "subject_discovery.candidates[].subject_kind",
+            "comparison_cohort.supported_comparison_dimensions",
+        ),
+        (_F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS,),
+    ),
+    _D.ZERO_UNSUPPORTED_STAFFING_CERTAINTY: _dimension(
+        _D.ZERO_UNSUPPORTED_STAFFING_CERTAINTY,
+        "Zero unsupported staffing certainty",
+        "No staffing or capacity claim is presented as certain without "
+        "allocation evidence. Must be zero. The converse is explicitly not "
+        "scored here: a missing denominator must reduce confidence, never "
+        "make the question unsupported.",
+        _M.BOOLEAN_ZERO,
+        _P.MUST_BE_ZERO,
+        (_S.DRIVER_ANALYSIS,),
+        (
+            "driver_analysis.candidates[].staffing_qualification",
+            "driver_analysis.candidates[].confidence_qualifier",
+        ),
+        (_F.STAFFING_CERTAINTY_WITHOUT_ALLOCATION_EVIDENCE,),
+    ),
+    _D.ZERO_GRAPH_NATIVE_SURFACE_LEAKAGE: _dimension(
+        _D.ZERO_GRAPH_NATIVE_SURFACE_LEAKAGE,
+        "Zero graph-native surface leakage",
+        "No backend identity, query language, node identifier or traversal "
+        "syntax reaches the packet. Must be zero. Enforced structurally by "
+        "the contract's own vocabulary and checked against the generated "
+        "schemas, not merely reviewed.",
+        _M.BOOLEAN_ZERO,
+        _P.MUST_BE_ZERO,
+        (_S.VERSIONS, _S.RELATED_CONTEXT),
+        ("versions.trial", "related_context.paths[].hops[].relationship"),
+        (_F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS,),
+    ),
+}
+
+
+def _fault(
+    fault_mode_id: FaultModeID,
+    title: str,
+    bad_behaviour: str,
+    mechanism: RejectingMechanism,
+    validator: tuple[str, str] | None,
+    dimension_ids: tuple[ScoringDimensionID, ...],
+    proving_test: str,
+) -> FaultMode:
+    return FaultMode(
+        schema_version="ask_dev_fault_mode.v1",
+        fault_mode_id=fault_mode_id,
+        title=title,
+        bad_behaviour=bad_behaviour,
+        rejecting_mechanism=mechanism,
+        validator_reference=(
+            None
+            if validator is None
+            else ValidatorReference(
+                model_name=validator[0], validator_name=validator[1]
+            )
+        ),
+        dimension_ids=dimension_ids,
+        proving_test=proving_test,
+    )
+
+
+_TESTS = "tests/api/dev/test_chaos_3615_fault_modes.py"
+
+FAULT_MODE_REGISTRY: Mapping[FaultModeID, FaultMode] = {
+    _F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST: _fault(
+        _F.WRONG_BUT_SIMILAR_SUBJECT_RANKED_FIRST,
+        "A wrong but similarly named subject ranks above the correct target",
+        "An arm commits to 'Nightfall' when the question meant 'Nightfall "
+        "Migration', on the strength of a fuzzy label match alone. The "
+        "contract cannot know which is correct -- that is the oracle's job -- "
+        "but it can refuse the shape that makes the mistake invisible: a "
+        "committed subject whose every match signal is fuzzy, or a ranked "
+        "candidate with no stated signal at all.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("SubjectDiscovery", "validate_commitment_is_evidenced"),
+        (
+            _D.SUBJECT_TOP_1,
+            _D.SUBJECT_TOP_3,
+            _D.ALIAS_ACRONYM_RENAME_RESOLUTION,
+            _D.CLARIFICATION_CANDIDATE_PRECISION,
+            _D.CONVERSATIONAL_REFERENCE_RESOLUTION,
+        ),
+        f"{_TESTS}::test_commitment_on_fuzzy_label_alone_is_rejected",
+    ),
+    _F.ORGANIZATION_WIDENING_AFTER_UNRESOLVED_REFERENCE: _fault(
+        _F.ORGANIZATION_WIDENING_AFTER_UNRESOLVED_REFERENCE,
+        "Organization-wide widening after an unresolved named reference",
+        "The question named a subject, resolution failed, and the arm "
+        "answered about the whole organization instead of asking. Rejected "
+        "unless the packet's outcome is NEEDS_CLARIFICATION and it carries a "
+        "subject clarification need.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("AskDevInvestigationPacket", "validate_no_unsafe_organization_widening"),
+        (
+            _D.NO_UNSAFE_ORGANIZATION_WIDENING,
+            _D.CLARIFICATION_CANDIDATE_PRECISION,
+        ),
+        f"{_TESTS}::test_organization_widening_after_unresolved_mention_is_rejected",
+    ),
+    _F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE: _fault(
+        _F.IRRELEVANT_EVIDENCE_DISPLACES_LINEAGE,
+        "Irrelevant high-volume evidence displaces the expected lineage",
+        "An arm floods the evidence index with whatever it had most of -- "
+        "commits, comments -- none of it attached to any included entity, "
+        "path or driver, burying the lineage that was actually asked for. "
+        "Rejected in both directions: an indexed item that supports nothing, "
+        "and a referenced handle that is not indexed.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("InvestigationEvidenceEntry", "validate_supports_something"),
+        (
+            _D.EVIDENCE_CLOSURE,
+            _D.RELEVANT_ENTITY_RECALL,
+            _D.RELEVANT_RELATIONSHIP_RECALL,
+            _D.LINEAGE_PATH_PRECISION,
+            _D.CROSS_SOURCE_ASSOCIATION,
+        ),
+        f"{_TESTS}::test_evidence_that_supports_nothing_is_rejected",
+    ),
+    _F.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER: _fault(
+        _F.SYMPTOM_LABELLED_AS_PRINCIPAL_DRIVER,
+        "A symptom is labelled the principal driver without supporting paths",
+        "'Cycle time is up' promoted to principal driver with no lineage "
+        "explaining why. Rejected: principal standing requires the DRIVER "
+        "role, at least one supporting path, at least one evidence handle, "
+        "and current relevance.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("DriverCandidate", "validate_principal_standing_is_earned"),
+        (
+            _D.SYMPTOM_VERSUS_DRIVER_DISTINCTION,
+            _D.PRINCIPAL_DRIVER_PRECISION,
+            _D.UNSUPPORTED_ATTRIBUTION_RATE,
+            _D.CURRENT_RELEVANCE,
+        ),
+        f"{_TESTS}::test_symptom_promoted_to_principal_driver_is_rejected",
+    ),
+    _F.STAFFING_CERTAINTY_WITHOUT_ALLOCATION_EVIDENCE: _fault(
+        _F.STAFFING_CERTAINTY_WITHOUT_ALLOCATION_EVIDENCE,
+        "A staffing claim is presented as certain without allocation evidence",
+        "'This project is understaffed' asserted as measured fact with no "
+        "allocation denominator. Rejected. The mirror-image drift is "
+        "rejected too, by a positive test: a missing denominator with a "
+        "QUALIFIED confidence qualifier is a legal, useful packet -- missing "
+        "staffing data reduces confidence, it does not make the question "
+        "unsupported.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("DriverCandidate", "validate_staffing_claims_are_qualified"),
+        (
+            _D.ZERO_UNSUPPORTED_STAFFING_CERTAINTY,
+            _D.UNSUPPORTED_ATTRIBUTION_RATE,
+        ),
+        f"{_TESTS}::test_certain_staffing_claim_without_denominator_is_rejected",
+    ),
+    _F.UNRELATED_COHORT_MEMBER: _fault(
+        _F.UNRELATED_COHORT_MEMBER,
+        "The cohort includes an unrelated project",
+        "A cohort member with no stated inclusion basis, no rationale, or "
+        "neither evidence nor an explicit no-evidence classification. "
+        "Whether a *well-explained* member is factually relevant remains an "
+        "oracle judgment; what the contract removes is the ability to add "
+        "one silently.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("CohortMember", "validate_inclusion_is_evidenced"),
+        (
+            _D.COHORT_PRECISION,
+            _D.COHORT_RECALL,
+            _D.COHORT_INCLUSION_EXPLAINABILITY,
+            _D.COHORT_EXCLUSION_EXPLAINABILITY,
+        ),
+        f"{_TESTS}::test_cohort_member_without_inclusion_evidence_is_rejected",
+    ),
+    _F.REVERSED_RELATIONSHIP_DIRECTION: _fault(
+        _F.REVERSED_RELATIONSHIP_DIRECTION,
+        "A relationship is reversed",
+        "'Team owns project' emitted as 'project owns team', or a blocked-by "
+        "edge pointing the wrong way. Rejected against the relationship "
+        "allowlist's declared canonical orientation.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("LineageHop", "validate_direction_matches_allowlist"),
+        (_D.LINEAGE_DIRECTION_CORRECTNESS, _D.LINEAGE_PATH_PRECISION),
+        f"{_TESTS}::test_reversed_relationship_direction_is_rejected",
+    ),
+    _F.PATH_CROSSES_UNAUTHORIZED_ENTITY: _fault(
+        _F.PATH_CROSSES_UNAUTHORIZED_ENTITY,
+        "A path crosses an unauthorized entity",
+        "A lineage path routes through an entity the caller may not see, "
+        "leaking its existence through the path even if its own record is "
+        "never returned. Rejected: every endpoint of every hop, and every "
+        "related entity, must be in the packet's authorized entity set.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("RelatedContext", "validate_paths_stay_inside_authorized_set"),
+        (_D.ZERO_UNAUTHORIZED_RESULTS, _D.LINEAGE_PATH_PRECISION),
+        f"{_TESTS}::test_path_through_unauthorized_entity_is_rejected",
+    ),
+    _F.DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT: _fault(
+        _F.DASHBOARD_REDIRECT_WITHOUT_DIRECT_JUDGMENT,
+        "Dashboard redirection appears without a direct judgment",
+        "A packet claims SUPPORTED while carrying no asserted driver at all "
+        "-- the structural form of 'here are some links, you work it out'. "
+        "Rejected: a supported outcome requires at least one principal or "
+        "contributing driver, each of which must itself be path- and "
+        "evidence-backed.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("AskDevInvestigationPacket", "validate_supported_outcome_asserts_a_judgment"),
+        (
+            _D.ANSWER_USEFULNESS_BEYOND_DASHBOARD,
+            _D.PRINCIPAL_DRIVER_PRECISION,
+            _D.PRINCIPAL_DRIVER_RECALL,
+        ),
+        f"{_TESTS}::test_supported_outcome_without_any_asserted_driver_is_rejected",
+    ),
+    _F.ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS: _fault(
+        _F.ABSENT_REQUIRED_FIELD_SILENTLY_DEFAULTS,
+        "An absent required field silently defaults to a privileged value",
+        "The dangerous defaults are all the reassuring ones: "
+        "authorization_filtered_count = 0, truncated = False. Each would let "
+        "an arm that filtered or truncated look like one that did not. Every "
+        "such field on this contract is required with no default, so "
+        "omitting it is a validation error rather than a comforting zero.",
+        RejectingMechanism.REQUIRED_FIELD,
+        None,
+        (
+            _D.COHORT_EXCLUSION_EXPLAINABILITY,
+            _D.ZERO_UNAUTHORIZED_RESULTS,
+            _D.USEFUL_UNCERTAINTY_BEHAVIOUR,
+        ),
+        f"{_TESTS}::test_disclosure_fields_have_no_reassuring_default",
+    ),
+    _F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS: _fault(
+        _F.WILDCARD_OR_OPTIONAL_FIELD_MAKES_CHECK_VACUOUS,
+        "A wildcard or optional field makes a check vacuous",
+        "A cohort that claims to compare while declaring zero comparison "
+        "dimensions; a question family reduced to one prompt and one metric; "
+        "a scoring dimension no fault mode can fail. Each is well-formed and "
+        "proves nothing. Rejected at the contract layer for cohorts and at "
+        "the registry layer for families and dimensions.",
+        RejectingMechanism.CONTRACT_VALIDATOR,
+        ("ComparisonCohort", "validate_comparison_is_not_vacuous"),
+        (
+            _D.COMPARATIVE_JUDGMENT_SUPPORT,
+            _D.COHORT_RECALL,
+            _D.USEFUL_UNCERTAINTY_BEHAVIOUR,
+            _D.ZERO_PERSON_LEVEL_RANKING,
+            _D.ZERO_GRAPH_NATIVE_SURFACE_LEAKAGE,
+        ),
+        f"{_TESTS}::test_cohort_claiming_comparison_without_dimensions_is_rejected",
+    ),
+}
+
+
+def validate_scoring_registry() -> None:
+    """Raise unless both registries are total, cross-referenced and non-vacuous."""
+
+    if set(SCORING_DIMENSION_REGISTRY) != set(ALL_SCORING_DIMENSION_IDS):
+        missing = sorted(
+            str(item)
+            for item in set(ALL_SCORING_DIMENSION_IDS) - set(SCORING_DIMENSION_REGISTRY)
+        )
+        extra = sorted(
+            str(item)
+            for item in set(SCORING_DIMENSION_REGISTRY) - set(ALL_SCORING_DIMENSION_IDS)
+        )
+        raise RuntimeError(
+            f"scoring dimension registry is not total; missing={missing}, extra={extra}"
+        )
+    if set(FAULT_MODE_REGISTRY) != set(ALL_FAULT_MODE_IDS):
+        missing = sorted(
+            str(item) for item in set(ALL_FAULT_MODE_IDS) - set(FAULT_MODE_REGISTRY)
+        )
+        extra = sorted(
+            str(item) for item in set(FAULT_MODE_REGISTRY) - set(ALL_FAULT_MODE_IDS)
+        )
+        raise RuntimeError(
+            f"fault mode registry is not total; missing={missing}, extra={extra}"
+        )
+
+    cited_faults: set[FaultModeID] = set()
+    for dimension_id, dimension in SCORING_DIMENSION_REGISTRY.items():
+        if dimension.dimension_id is not dimension_id:
+            raise RuntimeError(
+                f"scoring dimension key {dimension_id} is filed under "
+                f"{dimension.dimension_id}"
+            )
+        if not dimension.fault_mode_ids:
+            raise RuntimeError(
+                f"scoring dimension {dimension_id} names no fault mode; a "
+                "dimension nothing can fail is a vacuous dimension"
+            )
+        if not dimension.packet_fields or not dimension.packet_sections:
+            raise RuntimeError(
+                f"scoring dimension {dimension_id} names no packet field or "
+                "section, so nothing in a packet could ever be read to score it"
+            )
+        unknown = sorted(
+            str(item)
+            for item in set(dimension.fault_mode_ids) - set(ALL_FAULT_MODE_IDS)
+        )
+        if unknown:
+            raise RuntimeError(
+                f"scoring dimension {dimension_id} names unknown fault modes: {unknown}"
+            )
+        cited_faults.update(dimension.fault_mode_ids)
+
+    uncited = sorted(str(item) for item in set(ALL_FAULT_MODE_IDS) - cited_faults)
+    if uncited:
+        raise RuntimeError(
+            f"fault modes no scoring dimension measures: {uncited}; a fault "
+            "nothing scores is an unmeasured claim of coverage"
+        )
+
+    cited_dimensions: set[ScoringDimensionID] = set()
+    for fault_mode_id, fault in FAULT_MODE_REGISTRY.items():
+        if fault.fault_mode_id is not fault_mode_id:
+            raise RuntimeError(
+                f"fault mode key {fault_mode_id} is filed under {fault.fault_mode_id}"
+            )
+        if not fault.dimension_ids:
+            raise RuntimeError(f"fault mode {fault_mode_id} names no scoring dimension")
+        unknown_dimensions = sorted(
+            str(item)
+            for item in set(fault.dimension_ids) - set(ALL_SCORING_DIMENSION_IDS)
+        )
+        if unknown_dimensions:
+            raise RuntimeError(
+                f"fault mode {fault_mode_id} names unknown dimensions: "
+                f"{unknown_dimensions}"
+            )
+        contract_rejected = (
+            fault.rejecting_mechanism is RejectingMechanism.CONTRACT_VALIDATOR
+        )
+        if contract_rejected and fault.validator_reference is None:
+            raise RuntimeError(
+                f"fault mode {fault_mode_id} claims contract rejection but "
+                "names no validator; an unnamed validator is an unverifiable "
+                "coverage claim"
+            )
+        if not contract_rejected and fault.validator_reference is not None:
+            raise RuntimeError(
+                f"fault mode {fault_mode_id} is rejected by "
+                f"{fault.rejecting_mechanism}, which has no validator "
+                "function to name -- a reference here would be a fake citation"
+            )
+        cited_dimensions.update(fault.dimension_ids)
+
+    unmeasured = sorted(
+        str(item) for item in set(ALL_SCORING_DIMENSION_IDS) - cited_dimensions
+    )
+    if unmeasured:
+        raise RuntimeError(f"scoring dimensions no fault mode exercises: {unmeasured}")
+
+
+validate_scoring_registry()

--- a/src/dev_health_ops/api/dev/investigation_contract/vocabulary.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/vocabulary.py
@@ -47,6 +47,7 @@ __all__ = [
     "ALL_DRIVER_EXCLUSION_REASONS",
     "ALL_DRIVER_ROLES",
     "ALL_DRIVER_STANDINGS",
+    "ALL_EDGE_VALIDITY_BASES",
     "ALL_HISTORICAL_COMPARABILITY_STATES",
     "ALL_INVESTIGATION_OUTCOMES",
     "ALL_INVESTIGATION_SUBJECT_KINDS",
@@ -76,6 +77,7 @@ __all__ = [
     "DriverExclusionReason",
     "DriverRole",
     "DriverStanding",
+    "EdgeValidityBasis",
     "HistoricalComparability",
     "InvestigationOutcome",
     "InvestigationSubjectKind",
@@ -265,6 +267,34 @@ NOT_COMPARABLE_STATES: frozenset[HistoricalComparability] = frozenset(
         HistoricalComparability.NOT_COMPARABLE_MISSING_EDGE_VALIDITY,
         HistoricalComparability.NOT_COMPARABLE_MISSING_BASELINE,
     }
+)
+
+
+class EdgeValidityBasis(StrEnum):
+    """What backs a slice's claim that its relationships were valid *then*.
+
+    Added after adversarial review round 1 (finding M7). ``SLICE_BOUNDARIES``
+    declared that historical slices require edge validity, but nothing on the
+    wire recorded whether an arm actually had it — so a packet could label a
+    historical slice ``COMPARABLE`` while having read the live projection,
+    producing a confident and entirely false delta.
+
+    ``NOT_REQUIRED`` is the current slice. ``OBSERVED_INTERVALS`` means every
+    traversed edge carried a validity interval covering the as-of instant, and
+    is the only basis on which a historical slice may be ``COMPARABLE``.
+    ``UNAVAILABLE`` is the CHAOS-3569 state and forces
+    ``NOT_COMPARABLE_MISSING_EDGE_VALIDITY``.
+    """
+
+    NOT_REQUIRED = "not_required"
+    OBSERVED_INTERVALS = "observed_intervals"
+    UNAVAILABLE = "unavailable"
+
+
+ALL_EDGE_VALIDITY_BASES: tuple[EdgeValidityBasis, ...] = (
+    EdgeValidityBasis.NOT_REQUIRED,
+    EdgeValidityBasis.OBSERVED_INTERVALS,
+    EdgeValidityBasis.UNAVAILABLE,
 )
 
 

--- a/src/dev_health_ops/api/dev/investigation_contract/vocabulary.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/vocabulary.py
@@ -1,0 +1,823 @@
+"""Closed vocabularies for ``ask_dev_investigation_packet.v1`` (CHAOS-3615).
+
+Every enum here is **closed** and every one is paired with an explicit
+``ALL_*`` tuple literal. The tuple is not a convenience: totality tests
+iterate it (rather than the enum object) because CodeQL's
+``py/non-iterable-in-for-loop`` false-positives on ``(str, Enum)`` mixins —
+the same reason ``contracts_v2`` publishes ``DEFICIENCY_CATEGORIES`` and
+``investigation_plans`` publishes its literal matrices. ``ALL_*`` is proved
+exhaustive against ``__members__`` in
+``tests/api/dev/test_chaos_3615_vocabulary_totality.py``, so a member added
+without updating the tuple is a red test, not a silent gap.
+
+Three absences are deliberate and load-bearing:
+
+* :class:`InvestigationSubjectKind` has **no person member**. Person-level
+  productivity, health, workload and staffing ranking is prohibited by the
+  correction addendum, and the cleanest enforcement is to make a person
+  subject *unrepresentable* rather than to police it with a validator that a
+  future producer could route around.
+* :class:`ComparisonDimension` carries no per-person dimension, for the same
+  reason: a cohort can be compared on delivery, review, dependency,
+  operational, investment and coverage axes, never on the individuals
+  inside it.
+* No enum anywhere in this package names a graph backend, a graph query
+  language, or a graph-store concept. The packet is backend-neutral by
+  construction; ``tests/api/dev/test_chaos_3615_backend_neutrality.py``
+  scans the *generated schemas* (not just the source) to keep it that way.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = [
+    "ALL_ANALYTICAL_SLICES",
+    "ALL_ASSERTION_BASES",
+    "ALL_CLARIFICATION_NEED_KINDS",
+    "ALL_COHORT_COMPLETENESS_STATES",
+    "ALL_COHORT_EVIDENCE_CLASSIFICATIONS",
+    "ALL_COHORT_EXCLUSION_REASONS",
+    "ALL_COHORT_INCLUSION_BASES",
+    "ALL_COMPARISON_DIMENSIONS",
+    "ALL_COMPARISON_SHAPES",
+    "ALL_CONFIDENCE_QUALIFIERS",
+    "ALL_CONFLICT_RESOLUTIONS",
+    "ALL_DRIVER_CATEGORIES",
+    "ALL_DRIVER_EXCLUSION_REASONS",
+    "ALL_DRIVER_ROLES",
+    "ALL_DRIVER_STANDINGS",
+    "ALL_HISTORICAL_COMPARABILITY_STATES",
+    "ALL_INVESTIGATION_OUTCOMES",
+    "ALL_INVESTIGATION_SUBJECT_KINDS",
+    "ALL_JOB_UNCERTAINTIES",
+    "ALL_PACKET_LIMITATION_KINDS",
+    "ALL_PACKET_SECTIONS",
+    "ALL_RELATIONSHIP_DIRECTIONS",
+    "ALL_RELEVANCE_STATES",
+    "ALL_STAFFING_DENOMINATOR_STATES",
+    "ALL_SUBJECT_COMMITMENT_STATES",
+    "ALL_SUBJECT_MATCH_SIGNALS",
+    "ALL_SURFACE_KINDS",
+    "ALL_TRUNCATION_REASONS",
+    "ALL_UNRESOLVED_MENTION_REASONS",
+    "AnalyticalSlice",
+    "AssertionBasis",
+    "ClarificationNeedKind",
+    "CohortCompleteness",
+    "CohortEvidenceClassification",
+    "CohortExclusionReason",
+    "CohortInclusionBasis",
+    "ComparisonDimension",
+    "ComparisonShape",
+    "ConfidenceQualifier",
+    "ConflictResolution",
+    "DriverCategory",
+    "DriverExclusionReason",
+    "DriverRole",
+    "DriverStanding",
+    "HistoricalComparability",
+    "InvestigationOutcome",
+    "InvestigationSubjectKind",
+    "JobUncertainty",
+    "PacketLimitationKind",
+    "PacketSection",
+    "RelationshipDirection",
+    "RelevanceState",
+    "StaffingDenominatorState",
+    "SubjectCommitmentState",
+    "SubjectMatchSignal",
+    "SurfaceKind",
+    "TruncationReason",
+    "UnresolvedMentionReason",
+]
+
+
+class InvestigationSubjectKind(StrEnum):
+    """What an investigation may take as a subject, cohort member or node.
+
+    A superset of the *organizational* kinds an Ask Dev question can name,
+    and a strict subset of "anything in the work graph": there is no person
+    kind, by design (see the module docstring). ``EntityKind``
+    (``contracts_v2.base``) is the answer-frame subject vocabulary and is
+    deliberately not reused here — it carries ``pull_request``/``issue`` as
+    *subjects* of a status answer, whereas this enum has to describe
+    portfolio, initiative and service nodes that a status answer never takes
+    as its subject but a lineage path routinely crosses.
+    """
+
+    TEAM = "team"
+    PROJECT = "project"
+    PORTFOLIO = "portfolio"
+    INITIATIVE = "initiative"
+    REPOSITORY = "repository"
+    SERVICE = "service"
+    WORK_UNIT = "work_unit"
+    ISSUE = "issue"
+    PULL_REQUEST = "pull_request"
+    DEPENDENCY = "dependency"
+
+
+ALL_INVESTIGATION_SUBJECT_KINDS: tuple[InvestigationSubjectKind, ...] = (
+    InvestigationSubjectKind.TEAM,
+    InvestigationSubjectKind.PROJECT,
+    InvestigationSubjectKind.PORTFOLIO,
+    InvestigationSubjectKind.INITIATIVE,
+    InvestigationSubjectKind.REPOSITORY,
+    InvestigationSubjectKind.SERVICE,
+    InvestigationSubjectKind.WORK_UNIT,
+    InvestigationSubjectKind.ISSUE,
+    InvestigationSubjectKind.PULL_REQUEST,
+    InvestigationSubjectKind.DEPENDENCY,
+)
+
+
+class SubjectCommitmentState(StrEnum):
+    """Proposed-versus-committed subject state.
+
+    ``PROPOSED`` is the normal state during discovery, and the correction
+    addendum is explicit that *exact subject commitment must not be a
+    prerequisite for authorized candidate and context discovery* — so a
+    packet with zero committed subjects and a populated related-context
+    section is legal, and
+    ``test_chaos_3615_packet_contract.py::
+    test_discovery_without_any_commitment_is_legal`` pins that.
+    """
+
+    PROPOSED = "proposed"
+    COMMITTED = "committed"
+    REJECTED = "rejected"
+    AMBIGUOUS = "ambiguous"
+
+
+ALL_SUBJECT_COMMITMENT_STATES: tuple[SubjectCommitmentState, ...] = (
+    SubjectCommitmentState.PROPOSED,
+    SubjectCommitmentState.COMMITTED,
+    SubjectCommitmentState.REJECTED,
+    SubjectCommitmentState.AMBIGUOUS,
+)
+
+
+class SubjectMatchSignal(StrEnum):
+    """What actually caused a candidate to match the question's reference.
+
+    This is the anti-drift vocabulary for fault mode
+    ``wrong_but_similar_subject_ranked_first``: a candidate cannot be
+    committed on ``FUZZY_LABEL`` alone, because a similarly-named project is
+    exactly what fuzzy label matching returns.
+    """
+
+    EXACT_CANONICAL_ID = "exact_canonical_id"
+    EXACT_DISPLAY_NAME = "exact_display_name"
+    ALIAS = "alias"
+    ACRONYM = "acronym"
+    PREVIOUS_NAME = "previous_name"
+    PROVIDER_IDENTIFIER = "provider_identifier"
+    CONVERSATIONAL_REFERENCE = "conversational_reference"
+    SURFACE_CONTEXT_REFERENCE = "surface_context_reference"
+    FUZZY_LABEL = "fuzzy_label"
+
+
+ALL_SUBJECT_MATCH_SIGNALS: tuple[SubjectMatchSignal, ...] = (
+    SubjectMatchSignal.EXACT_CANONICAL_ID,
+    SubjectMatchSignal.EXACT_DISPLAY_NAME,
+    SubjectMatchSignal.ALIAS,
+    SubjectMatchSignal.ACRONYM,
+    SubjectMatchSignal.PREVIOUS_NAME,
+    SubjectMatchSignal.PROVIDER_IDENTIFIER,
+    SubjectMatchSignal.CONVERSATIONAL_REFERENCE,
+    SubjectMatchSignal.SURFACE_CONTEXT_REFERENCE,
+    SubjectMatchSignal.FUZZY_LABEL,
+)
+
+#: Signals too weak to justify committing a subject on their own. A
+#: ``COMMITTED`` candidate whose every signal is in this set is rejected by
+#: ``SubjectDiscovery.validate_commitment_requires_a_strong_signal``.
+WEAK_SUBJECT_MATCH_SIGNALS: frozenset[SubjectMatchSignal] = frozenset(
+    {SubjectMatchSignal.FUZZY_LABEL}
+)
+
+
+class UnresolvedMentionReason(StrEnum):
+    NO_CANDIDATE = "no_candidate"
+    MULTIPLE_CANDIDATES = "multiple_candidates"
+    AUTHORIZATION_FILTERED = "authorization_filtered"
+    OUT_OF_SCOPE = "out_of_scope"
+
+
+ALL_UNRESOLVED_MENTION_REASONS: tuple[UnresolvedMentionReason, ...] = (
+    UnresolvedMentionReason.NO_CANDIDATE,
+    UnresolvedMentionReason.MULTIPLE_CANDIDATES,
+    UnresolvedMentionReason.AUTHORIZATION_FILTERED,
+    UnresolvedMentionReason.OUT_OF_SCOPE,
+)
+
+
+class AnalyticalSlice(StrEnum):
+    """Current-versus-historical slice of the investigation.
+
+    Slice boundaries, and what each slice requires of edge validity, are
+    declared once in :mod:`.allowlists` (``SLICE_BOUNDARIES``).
+    """
+
+    CURRENT = "current"
+    HISTORICAL = "historical"
+    CURRENT_VS_HISTORICAL = "current_vs_historical"
+
+
+ALL_ANALYTICAL_SLICES: tuple[AnalyticalSlice, ...] = (
+    AnalyticalSlice.CURRENT,
+    AnalyticalSlice.HISTORICAL,
+    AnalyticalSlice.CURRENT_VS_HISTORICAL,
+)
+
+
+class HistoricalComparability(StrEnum):
+    """Whether a historical slice can be fairly compared at all.
+
+    ``NOT_COMPARABLE_MISSING_EDGE_VALIDITY`` is the CHAOS-3569 state: native
+    historical edge validity is not implemented, so as-of traversal cannot
+    be reconstructed for those rows. The correction plan is explicit that
+    such rows are **NOT COMPARABLE, not blockers** — a packet that declares
+    this state is still a *valid* packet and may still be ``SUPPORTED``
+    (pinned by ``test_not_comparable_historical_slice_is_valid_and_
+    supported``). What it may not do is stay silent: the packet must also
+    carry a ``HISTORICAL_SLICE_NOT_COMPARABLE`` limitation.
+    """
+
+    NOT_APPLICABLE = "not_applicable"
+    COMPARABLE = "comparable"
+    NOT_COMPARABLE_MISSING_EDGE_VALIDITY = "not_comparable_missing_edge_validity"
+    NOT_COMPARABLE_MISSING_BASELINE = "not_comparable_missing_baseline"
+
+
+ALL_HISTORICAL_COMPARABILITY_STATES: tuple[HistoricalComparability, ...] = (
+    HistoricalComparability.NOT_APPLICABLE,
+    HistoricalComparability.COMPARABLE,
+    HistoricalComparability.NOT_COMPARABLE_MISSING_EDGE_VALIDITY,
+    HistoricalComparability.NOT_COMPARABLE_MISSING_BASELINE,
+)
+
+#: The comparability states that oblige the packet to disclose a
+#: ``HISTORICAL_SLICE_NOT_COMPARABLE`` limitation.
+NOT_COMPARABLE_STATES: frozenset[HistoricalComparability] = frozenset(
+    {
+        HistoricalComparability.NOT_COMPARABLE_MISSING_EDGE_VALIDITY,
+        HistoricalComparability.NOT_COMPARABLE_MISSING_BASELINE,
+    }
+)
+
+
+class ComparisonShape(StrEnum):
+    """The requested comparison or singular-subject shape."""
+
+    SINGULAR_SUBJECT = "singular_subject"
+    EXPLICIT_COHORT = "explicit_cohort"
+    DISCOVERED_COHORT = "discovered_cohort"
+    PORTFOLIO_WIDE = "portfolio_wide"
+    ORGANIZATION_WIDE = "organization_wide"
+
+
+ALL_COMPARISON_SHAPES: tuple[ComparisonShape, ...] = (
+    ComparisonShape.SINGULAR_SUBJECT,
+    ComparisonShape.EXPLICIT_COHORT,
+    ComparisonShape.DISCOVERED_COHORT,
+    ComparisonShape.PORTFOLIO_WIDE,
+    ComparisonShape.ORGANIZATION_WIDE,
+)
+
+#: Shapes that carry a real cohort (two or more members and at least one
+#: declared comparison dimension). ``SINGULAR_SUBJECT`` is the exception.
+COHORT_BEARING_SHAPES: frozenset[ComparisonShape] = frozenset(
+    {
+        ComparisonShape.EXPLICIT_COHORT,
+        ComparisonShape.DISCOVERED_COHORT,
+        ComparisonShape.PORTFOLIO_WIDE,
+        ComparisonShape.ORGANIZATION_WIDE,
+    }
+)
+
+
+class JobUncertainty(StrEnum):
+    """How precisely the analytical job could be interpreted.
+
+    ``BROAD_WITH_UNCERTAINTY`` exists because the correction addendum bans
+    requiring a fully pre-enumerated intent before investigation may begin:
+    "what is going sideways?" is a legitimate job whose subject set is
+    discovered, not declared. A broad or ambiguous job must carry at least
+    one interpretation limitation, which is what stops the state from being
+    a free pass.
+    """
+
+    PRECISE = "precise"
+    BROAD_WITH_UNCERTAINTY = "broad_with_uncertainty"
+    AMBIGUOUS = "ambiguous"
+
+
+ALL_JOB_UNCERTAINTIES: tuple[JobUncertainty, ...] = (
+    JobUncertainty.PRECISE,
+    JobUncertainty.BROAD_WITH_UNCERTAINTY,
+    JobUncertainty.AMBIGUOUS,
+)
+
+#: Uncertainty states that oblige the job to declare its limitations.
+UNCERTAIN_JOB_STATES: frozenset[JobUncertainty] = frozenset(
+    {JobUncertainty.BROAD_WITH_UNCERTAINTY, JobUncertainty.AMBIGUOUS}
+)
+
+
+class SurfaceKind(StrEnum):
+    """Safe surface/conversation context references.
+
+    Closed rather than free text on purpose: a surface reference is the one
+    field on an investigation packet whose natural implementation is "paste
+    the URL the user was looking at", and a URL is both an unbounded
+    disclosure channel and the exact shape of a dashboard redirect.
+    """
+
+    DASHBOARD = "dashboard"
+    PROJECT_PAGE = "project_page"
+    TEAM_PAGE = "team_page"
+    PORTFOLIO_PAGE = "portfolio_page"
+    REPORT = "report"
+    CONVERSATION = "conversation"
+
+
+ALL_SURFACE_KINDS: tuple[SurfaceKind, ...] = (
+    SurfaceKind.DASHBOARD,
+    SurfaceKind.PROJECT_PAGE,
+    SurfaceKind.TEAM_PAGE,
+    SurfaceKind.PORTFOLIO_PAGE,
+    SurfaceKind.REPORT,
+    SurfaceKind.CONVERSATION,
+)
+
+
+class CohortInclusionBasis(StrEnum):
+    """Why a subject is in the comparison cohort.
+
+    There is deliberately no ``unspecified`` member and the field is
+    ``min_length=1``: "an unrelated project appears in the cohort" is a named
+    fault mode, and the cheapest way for an arm to commit it is to include a
+    member with no stated basis at all.
+    """
+
+    EXPLICITLY_NAMED = "explicitly_named"
+    SHARED_DEPENDENCY = "shared_dependency"
+    SHARED_TEAM_OWNERSHIP = "shared_team_ownership"
+    SAME_PORTFOLIO = "same_portfolio"
+    SAME_INITIATIVE = "same_initiative"
+    COMPARABLE_DELIVERY_PROFILE = "comparable_delivery_profile"
+    PEER_OF_NAMED_SUBJECT = "peer_of_named_subject"
+
+
+ALL_COHORT_INCLUSION_BASES: tuple[CohortInclusionBasis, ...] = (
+    CohortInclusionBasis.EXPLICITLY_NAMED,
+    CohortInclusionBasis.SHARED_DEPENDENCY,
+    CohortInclusionBasis.SHARED_TEAM_OWNERSHIP,
+    CohortInclusionBasis.SAME_PORTFOLIO,
+    CohortInclusionBasis.SAME_INITIATIVE,
+    CohortInclusionBasis.COMPARABLE_DELIVERY_PROFILE,
+    CohortInclusionBasis.PEER_OF_NAMED_SUBJECT,
+)
+
+
+class CohortEvidenceClassification(StrEnum):
+    """Closed reasons a cohort member may carry no evidence handle.
+
+    The same "evidence refs XOR an explicit no-evidence classification —
+    never both, never neither" pattern as
+    ``contracts_v2.embedded.MetricEvidenceClassification`` and
+    ``contracts_v2.deficiency.DeficiencyEvidenceClassification``, applied to
+    cohort membership here.
+    """
+
+    EXPLICITLY_NAMED_BY_QUESTION = "explicitly_named_by_question"
+    CANONICAL_REGISTRY_MEMBERSHIP = "canonical_registry_membership"
+
+
+ALL_COHORT_EVIDENCE_CLASSIFICATIONS: tuple[CohortEvidenceClassification, ...] = (
+    CohortEvidenceClassification.EXPLICITLY_NAMED_BY_QUESTION,
+    CohortEvidenceClassification.CANONICAL_REGISTRY_MEMBERSHIP,
+)
+
+
+class CohortExclusionReason(StrEnum):
+    OUT_OF_AUTHORIZED_SCOPE = "out_of_authorized_scope"
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+    NOT_COMPARABLE_SLICE = "not_comparable_slice"
+    ARCHIVED_OR_INACTIVE = "archived_or_inactive"
+    TRUNCATION_BUDGET = "truncation_budget"
+    AMBIGUOUS_IDENTITY = "ambiguous_identity"
+    EXCLUDED_BY_QUESTION = "excluded_by_question"
+
+
+ALL_COHORT_EXCLUSION_REASONS: tuple[CohortExclusionReason, ...] = (
+    CohortExclusionReason.OUT_OF_AUTHORIZED_SCOPE,
+    CohortExclusionReason.INSUFFICIENT_EVIDENCE,
+    CohortExclusionReason.NOT_COMPARABLE_SLICE,
+    CohortExclusionReason.ARCHIVED_OR_INACTIVE,
+    CohortExclusionReason.TRUNCATION_BUDGET,
+    CohortExclusionReason.AMBIGUOUS_IDENTITY,
+    CohortExclusionReason.EXCLUDED_BY_QUESTION,
+)
+
+
+class CohortCompleteness(StrEnum):
+    COMPLETE = "complete"
+    TRUNCATED = "truncated"
+    BEST_EFFORT_UNCERTAIN = "best_effort_uncertain"
+
+
+ALL_COHORT_COMPLETENESS_STATES: tuple[CohortCompleteness, ...] = (
+    CohortCompleteness.COMPLETE,
+    CohortCompleteness.TRUNCATED,
+    CohortCompleteness.BEST_EFFORT_UNCERTAIN,
+)
+
+
+class ComparisonDimension(StrEnum):
+    """Axes a cohort may be compared on.
+
+    Every member is a *unit-of-work or system* axis. None is per-person, and
+    none may be derived per-person: person-level productivity, workload and
+    staffing ranking is prohibited outright, and this enum is one of the two
+    structural places that ban is enforced (the other being the absence of a
+    person member on :class:`InvestigationSubjectKind`).
+    """
+
+    DELIVERY_THROUGHPUT = "delivery_throughput"
+    CYCLE_TIME = "cycle_time"
+    REVIEW_LOAD = "review_load"
+    WORK_IN_PROGRESS = "work_in_progress"
+    DEPENDENCY_EXPOSURE = "dependency_exposure"
+    INCIDENT_LOAD = "incident_load"
+    DEPLOYMENT_FREQUENCY = "deployment_frequency"
+    INVESTMENT_MIX = "investment_mix"
+    OPEN_DEFICIENCY_COUNT = "open_deficiency_count"
+    STATUS_DECLARATION_GAP = "status_declaration_gap"
+    CAPACITY_LOAD_RATIO = "capacity_load_ratio"
+    DATA_COVERAGE = "data_coverage"
+
+
+ALL_COMPARISON_DIMENSIONS: tuple[ComparisonDimension, ...] = (
+    ComparisonDimension.DELIVERY_THROUGHPUT,
+    ComparisonDimension.CYCLE_TIME,
+    ComparisonDimension.REVIEW_LOAD,
+    ComparisonDimension.WORK_IN_PROGRESS,
+    ComparisonDimension.DEPENDENCY_EXPOSURE,
+    ComparisonDimension.INCIDENT_LOAD,
+    ComparisonDimension.DEPLOYMENT_FREQUENCY,
+    ComparisonDimension.INVESTMENT_MIX,
+    ComparisonDimension.OPEN_DEFICIENCY_COUNT,
+    ComparisonDimension.STATUS_DECLARATION_GAP,
+    ComparisonDimension.CAPACITY_LOAD_RATIO,
+    ComparisonDimension.DATA_COVERAGE,
+)
+
+
+class RelationshipDirection(StrEnum):
+    """Which way a hop was traversed relative to the relationship's own
+    canonical orientation (declared in :mod:`.relationships`).
+
+    A hop that claims ``FORWARD`` while its endpoint kinds match only the
+    reverse orientation is exactly the named "a relationship is reversed"
+    fault, and is rejected by ``LineageHop.validate_direction_matches_
+    allowlist``.
+    """
+
+    FORWARD = "forward"
+    REVERSE = "reverse"
+
+
+ALL_RELATIONSHIP_DIRECTIONS: tuple[RelationshipDirection, ...] = (
+    RelationshipDirection.FORWARD,
+    RelationshipDirection.REVERSE,
+)
+
+
+class RelevanceState(StrEnum):
+    """Whether a node, path, driver or evidence item is *currently* relevant."""
+
+    CURRENT = "current"
+    RECENTLY_CURRENT = "recently_current"
+    HISTORICAL_ONLY = "historical_only"
+    UNKNOWN = "unknown"
+
+
+ALL_RELEVANCE_STATES: tuple[RelevanceState, ...] = (
+    RelevanceState.CURRENT,
+    RelevanceState.RECENTLY_CURRENT,
+    RelevanceState.HISTORICAL_ONLY,
+    RelevanceState.UNKNOWN,
+)
+
+#: The relevance states a *principal* driver may hold. A driver whose only
+#: support is historical cannot be the principal current driver.
+CURRENTLY_RELEVANT_STATES: frozenset[RelevanceState] = frozenset(
+    {RelevanceState.CURRENT, RelevanceState.RECENTLY_CURRENT}
+)
+
+
+class AssertionBasis(StrEnum):
+    """Measured, source-asserted and inferred distinctions.
+
+    The governing rule is "the graph determines what is relevant; canonical
+    services determine what is measurable". ``MEASURED`` therefore means a
+    canonical Ops service produced the number and minted evidence for it;
+    ``SOURCE_ASSERTED`` means a provider (or a human in a provider field)
+    said so; ``INFERRED`` means the investigation concluded it. Only
+    ``MEASURED`` may be presented as certain.
+    """
+
+    MEASURED = "measured"
+    SOURCE_ASSERTED = "source_asserted"
+    INFERRED = "inferred"
+
+
+ALL_ASSERTION_BASES: tuple[AssertionBasis, ...] = (
+    AssertionBasis.MEASURED,
+    AssertionBasis.SOURCE_ASSERTED,
+    AssertionBasis.INFERRED,
+)
+
+
+class ConfidenceQualifier(StrEnum):
+    MEASURED_CERTAIN = "measured_certain"
+    QUALIFIED = "qualified"
+    UNCERTAIN = "uncertain"
+    UNSUPPORTED = "unsupported"
+
+
+ALL_CONFIDENCE_QUALIFIERS: tuple[ConfidenceQualifier, ...] = (
+    ConfidenceQualifier.MEASURED_CERTAIN,
+    ConfidenceQualifier.QUALIFIED,
+    ConfidenceQualifier.UNCERTAIN,
+    ConfidenceQualifier.UNSUPPORTED,
+)
+
+
+class DriverRole(StrEnum):
+    """Symptom-versus-driver classification.
+
+    ``CONTEXTUAL_CORRELATE`` is the honest third option: something that moved
+    at the same time and is worth reporting but is neither the cause nor a
+    consequence. Collapsing it into ``DRIVER`` is precisely how unsupported
+    attribution enters an answer.
+    """
+
+    DRIVER = "driver"
+    SYMPTOM = "symptom"
+    CONTEXTUAL_CORRELATE = "contextual_correlate"
+
+
+ALL_DRIVER_ROLES: tuple[DriverRole, ...] = (
+    DriverRole.DRIVER,
+    DriverRole.SYMPTOM,
+    DriverRole.CONTEXTUAL_CORRELATE,
+)
+
+
+class DriverStanding(StrEnum):
+    PRINCIPAL_DRIVER = "principal_driver"
+    CONTRIBUTING_DRIVER = "contributing_driver"
+    CANDIDATE_ONLY = "candidate_only"
+    EXCLUDED = "excluded"
+
+
+ALL_DRIVER_STANDINGS: tuple[DriverStanding, ...] = (
+    DriverStanding.PRINCIPAL_DRIVER,
+    DriverStanding.CONTRIBUTING_DRIVER,
+    DriverStanding.CANDIDATE_ONLY,
+    DriverStanding.EXCLUDED,
+)
+
+#: Standings that constitute a *judgment* the packet is asserting, as
+#: opposed to a candidate it merely surfaced. A ``SUPPORTED`` packet must
+#: carry at least one of these — that is the structural difference between
+#: an investigation result and a dashboard redirect.
+ASSERTED_DRIVER_STANDINGS: frozenset[DriverStanding] = frozenset(
+    {DriverStanding.PRINCIPAL_DRIVER, DriverStanding.CONTRIBUTING_DRIVER}
+)
+
+
+class DriverCategory(StrEnum):
+    DELIVERY_PRESSURE = "delivery_pressure"
+    REVIEW_PRESSURE = "review_pressure"
+    OPERATIONAL_PRESSURE = "operational_pressure"
+    DEPENDENCY_PRESSURE = "dependency_pressure"
+    INVESTMENT_MIX = "investment_mix"
+    CAPACITY_OR_STAFFING = "capacity_or_staffing"
+    SCOPE_CHANGE = "scope_change"
+    QUALITY_OR_DEFECT = "quality_or_defect"
+    EXTERNAL_BLOCKER = "external_blocker"
+    DATA_COVERAGE = "data_coverage"
+
+
+ALL_DRIVER_CATEGORIES: tuple[DriverCategory, ...] = (
+    DriverCategory.DELIVERY_PRESSURE,
+    DriverCategory.REVIEW_PRESSURE,
+    DriverCategory.OPERATIONAL_PRESSURE,
+    DriverCategory.DEPENDENCY_PRESSURE,
+    DriverCategory.INVESTMENT_MIX,
+    DriverCategory.CAPACITY_OR_STAFFING,
+    DriverCategory.SCOPE_CHANGE,
+    DriverCategory.QUALITY_OR_DEFECT,
+    DriverCategory.EXTERNAL_BLOCKER,
+    DriverCategory.DATA_COVERAGE,
+)
+
+
+class DriverExclusionReason(StrEnum):
+    """Why a candidate did not reach principal-driver standing."""
+
+    NO_SUPPORTING_PATH = "no_supporting_path"
+    EVIDENCE_CONFLICT_UNRESOLVED = "evidence_conflict_unresolved"
+    NOT_CURRENTLY_RELEVANT = "not_currently_relevant"
+    SYMPTOM_OF_ANOTHER_CANDIDATE = "symptom_of_another_candidate"
+    UNAUTHORIZED_EVIDENCE = "unauthorized_evidence"
+    INSUFFICIENT_MEASUREMENT = "insufficient_measurement"
+
+
+ALL_DRIVER_EXCLUSION_REASONS: tuple[DriverExclusionReason, ...] = (
+    DriverExclusionReason.NO_SUPPORTING_PATH,
+    DriverExclusionReason.EVIDENCE_CONFLICT_UNRESOLVED,
+    DriverExclusionReason.NOT_CURRENTLY_RELEVANT,
+    DriverExclusionReason.SYMPTOM_OF_ANOTHER_CANDIDATE,
+    DriverExclusionReason.UNAUTHORIZED_EVIDENCE,
+    DriverExclusionReason.INSUFFICIENT_MEASUREMENT,
+)
+
+
+class StaffingDenominatorState(StrEnum):
+    """How much allocation evidence backs a capacity/staffing claim.
+
+    The correction addendum is explicit on both halves of this: a missing
+    denominator must **reduce confidence and require qualification**, and it
+    must **not automatically make capacity questions unsupported**. Both
+    halves are pinned by tests — ``DENOMINATOR_ABSENT`` with a
+    ``MEASURED_CERTAIN`` qualifier is rejected, and ``DENOMINATOR_ABSENT``
+    with a ``QUALIFIED`` qualifier is accepted.
+    """
+
+    ALLOCATION_EVIDENCE_AVAILABLE = "allocation_evidence_available"
+    PARTIAL_ALLOCATION_EVIDENCE = "partial_allocation_evidence"
+    DENOMINATOR_ABSENT = "denominator_absent"
+
+
+ALL_STAFFING_DENOMINATOR_STATES: tuple[StaffingDenominatorState, ...] = (
+    StaffingDenominatorState.ALLOCATION_EVIDENCE_AVAILABLE,
+    StaffingDenominatorState.PARTIAL_ALLOCATION_EVIDENCE,
+    StaffingDenominatorState.DENOMINATOR_ABSENT,
+)
+
+#: Denominator states that forbid presenting a staffing claim as certain.
+UNQUALIFIED_DENOMINATOR_STATES: frozenset[StaffingDenominatorState] = frozenset(
+    {
+        StaffingDenominatorState.PARTIAL_ALLOCATION_EVIDENCE,
+        StaffingDenominatorState.DENOMINATOR_ABSENT,
+    }
+)
+
+
+class TruncationReason(StrEnum):
+    PATH_BUDGET = "path_budget"
+    NODE_BUDGET = "node_budget"
+    COHORT_BUDGET = "cohort_budget"
+    EVIDENCE_BUDGET = "evidence_budget"
+    TIME_BUDGET = "time_budget"
+    AUTHORIZATION_FILTER = "authorization_filter"
+    SOURCE_UNAVAILABLE = "source_unavailable"
+
+
+ALL_TRUNCATION_REASONS: tuple[TruncationReason, ...] = (
+    TruncationReason.PATH_BUDGET,
+    TruncationReason.NODE_BUDGET,
+    TruncationReason.COHORT_BUDGET,
+    TruncationReason.EVIDENCE_BUDGET,
+    TruncationReason.TIME_BUDGET,
+    TruncationReason.AUTHORIZATION_FILTER,
+    TruncationReason.SOURCE_UNAVAILABLE,
+)
+
+
+class ConflictResolution(StrEnum):
+    UNRESOLVED = "unresolved"
+    RESOLVED_BY_PRECEDENCE = "resolved_by_precedence"
+    RESOLVED_BY_RECENCY = "resolved_by_recency"
+    DEFERRED_TO_CANONICAL_SERVICE = "deferred_to_canonical_service"
+
+
+ALL_CONFLICT_RESOLUTIONS: tuple[ConflictResolution, ...] = (
+    ConflictResolution.UNRESOLVED,
+    ConflictResolution.RESOLVED_BY_PRECEDENCE,
+    ConflictResolution.RESOLVED_BY_RECENCY,
+    ConflictResolution.DEFERRED_TO_CANONICAL_SERVICE,
+)
+
+
+class ClarificationNeedKind(StrEnum):
+    AMBIGUOUS_SUBJECT = "ambiguous_subject"
+    MISSING_TIME_CONTEXT = "missing_time_context"
+    MISSING_COMPARISON_BASIS = "missing_comparison_basis"
+    UNRESOLVED_CONVERSATIONAL_REFERENCE = "unresolved_conversational_reference"
+    UNSUPPORTED_BY_AVAILABLE_SOURCES = "unsupported_by_available_sources"
+
+
+ALL_CLARIFICATION_NEED_KINDS: tuple[ClarificationNeedKind, ...] = (
+    ClarificationNeedKind.AMBIGUOUS_SUBJECT,
+    ClarificationNeedKind.MISSING_TIME_CONTEXT,
+    ClarificationNeedKind.MISSING_COMPARISON_BASIS,
+    ClarificationNeedKind.UNRESOLVED_CONVERSATIONAL_REFERENCE,
+    ClarificationNeedKind.UNSUPPORTED_BY_AVAILABLE_SOURCES,
+)
+
+#: Clarification kinds that answer an *unresolved subject reference*. One of
+#: these must be present before a packet may widen to organization scope.
+SUBJECT_CLARIFICATION_KINDS: frozenset[ClarificationNeedKind] = frozenset(
+    {
+        ClarificationNeedKind.AMBIGUOUS_SUBJECT,
+        ClarificationNeedKind.UNRESOLVED_CONVERSATIONAL_REFERENCE,
+    }
+)
+
+
+class PacketLimitationKind(StrEnum):
+    MISSING_SOURCE = "missing_source"
+    STALE_SOURCE = "stale_source"
+    CONFLICTING_EVIDENCE = "conflicting_evidence"
+    AUTHORIZATION_FILTERED = "authorization_filtered"
+    TRUNCATED_TRAVERSAL = "truncated_traversal"
+    ABSENT_STAFFING_DENOMINATOR = "absent_staffing_denominator"
+    HISTORICAL_SLICE_NOT_COMPARABLE = "historical_slice_not_comparable"
+    INTERPRETATION_UNCERTAINTY = "interpretation_uncertainty"
+
+
+ALL_PACKET_LIMITATION_KINDS: tuple[PacketLimitationKind, ...] = (
+    PacketLimitationKind.MISSING_SOURCE,
+    PacketLimitationKind.STALE_SOURCE,
+    PacketLimitationKind.CONFLICTING_EVIDENCE,
+    PacketLimitationKind.AUTHORIZATION_FILTERED,
+    PacketLimitationKind.TRUNCATED_TRAVERSAL,
+    PacketLimitationKind.ABSENT_STAFFING_DENOMINATOR,
+    PacketLimitationKind.HISTORICAL_SLICE_NOT_COMPARABLE,
+    PacketLimitationKind.INTERPRETATION_UNCERTAINTY,
+)
+
+
+class InvestigationOutcome(StrEnum):
+    """What the investigation concluded — *not* what the user is told.
+
+    Deliberately distinct from ``contracts_v2.base.PublicOutcome``: that
+    enum is the public answer-envelope vocabulary of an Ask Dev answer, and
+    reusing it here would make the packet look like an answer. A packet is
+    an input to the Ask Dev frame, never a substitute for it.
+    """
+
+    SUPPORTED = "supported"
+    SUPPORTED_WITH_GAPS = "supported_with_gaps"
+    NEEDS_CLARIFICATION = "needs_clarification"
+    NO_MATCH = "no_match"
+    UNSUPPORTED = "unsupported"
+
+
+ALL_INVESTIGATION_OUTCOMES: tuple[InvestigationOutcome, ...] = (
+    InvestigationOutcome.SUPPORTED,
+    InvestigationOutcome.SUPPORTED_WITH_GAPS,
+    InvestigationOutcome.NEEDS_CLARIFICATION,
+    InvestigationOutcome.NO_MATCH,
+    InvestigationOutcome.UNSUPPORTED,
+)
+
+#: Outcomes that assert the investigation reached a usable judgment.
+SUPPORTED_OUTCOMES: frozenset[InvestigationOutcome] = frozenset(
+    {InvestigationOutcome.SUPPORTED, InvestigationOutcome.SUPPORTED_WITH_GAPS}
+)
+
+
+class PacketSection(StrEnum):
+    """Named sections of the packet, for the question-family registry.
+
+    A family declares which sections it *requires* an arm to populate, which
+    is how "this family is not reducible to one dashboard metric" becomes a
+    machine-checkable statement rather than a comment.
+    """
+
+    ANALYTICAL_JOB = "analytical_job"
+    SUBJECT_DISCOVERY = "subject_discovery"
+    COMPARISON_COHORT = "comparison_cohort"
+    RELATED_CONTEXT = "related_context"
+    DRIVER_ANALYSIS = "driver_analysis"
+    EVIDENCE_COVERAGE = "evidence_coverage"
+    VERSIONS = "versions"
+
+
+ALL_PACKET_SECTIONS: tuple[PacketSection, ...] = (
+    PacketSection.ANALYTICAL_JOB,
+    PacketSection.SUBJECT_DISCOVERY,
+    PacketSection.COMPARISON_COHORT,
+    PacketSection.RELATED_CONTEXT,
+    PacketSection.DRIVER_ANALYSIS,
+    PacketSection.EVIDENCE_COVERAGE,
+    PacketSection.VERSIONS,
+)

--- a/tests/api/dev/test_chaos_3615_fault_modes.py
+++ b/tests/api/dev/test_chaos_3615_fault_modes.py
@@ -30,6 +30,7 @@ would fail if the guard were gone".
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -37,6 +38,7 @@ from pydantic import BaseModel, ValidationError
 
 from dev_health_ops.api.dev.investigation_contract import (
     INVESTIGATION_CONTRACT_MODELS,
+    AnalyticalJob,
     AskDevInvestigationPacket,
     ComparisonCohort,
     DriverAnalysis,
@@ -582,6 +584,153 @@ def test_trial_metadata_is_optional_and_changes_nothing_else() -> None:
         "the trial-metadata variant differs from the golden in fields other "
         "than versions.trial/corpus_version, so arm identity is not isolated"
     )
+
+
+# --------------------------------------------------------------------------
+# Round-1 adversarial review: holes found by attacking the first draft
+#
+# Each of these was a packet the first version of the contract ACCEPTED. They
+# are kept as tests rather than folded into the sections above because the
+# named eleven fault shapes came from the corrective plan, while these came
+# from an adversary reading the implementation — a different provenance, and
+# a different thing to keep honest.
+# --------------------------------------------------------------------------
+
+
+def test_cohort_member_outside_the_authorized_set_is_rejected() -> None:
+    """H2. Authorization covered lineage only; a cohort member walked past it."""
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "cohort_member_outside_authorized_set"),
+        "not in related_context.authorized_entity_ids",
+    )
+
+
+def test_evidence_naming_an_unauthorized_entity_is_rejected() -> None:
+    """H2. An indexed evidence item is a label reaching a consumer too."""
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "evidence_entity_outside_authorized_set"),
+        "not in related_context.authorized_entity_ids",
+    )
+
+
+def test_source_class_off_the_trial_allowlist_is_rejected() -> None:
+    """H3. CHAOS-3567's inert temporal stub was claimable as coverage."""
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "source_class_off_the_trial_allowlist"),
+        "not on the trial allowlist",
+    )
+
+
+def test_question_family_shape_mismatch_is_rejected() -> None:
+    """H4. Family was metadata: an arm could claim the easiest one and skip its work."""
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "question_family_shape_mismatch"),
+        "does not permit the singular_subject comparison shape",
+    )
+
+
+def test_family_required_source_neither_observed_nor_declared_missing() -> None:
+    """H4. A required source may be absent — it may not be unmentioned."""
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "family_required_source_unaccounted"),
+        "neither observed nor declared missing",
+    )
+
+
+def test_declaring_a_required_source_missing_is_still_legal() -> None:
+    """Positive control for the family-obligation guard.
+
+    The golden declares ``investment_allocation`` unconfigured and is
+    accepted. If the guard had required every source to be *present*, an arm
+    would be pushed to fabricate coverage rather than disclose the gap —
+    the opposite of what the rule is for.
+    """
+
+    from dev_health_ops.api.dev.investigation_contract.fixtures import (
+        positive_fixtures,
+    )
+
+    packet = AskDevInvestigationPacket.model_validate(positive_fixtures()[PACKET])
+    assert any(
+        missing.source_class == "investment_allocation"
+        for missing in packet.evidence_coverage.missing_sources
+    )
+
+
+def test_path_cited_by_an_entity_it_never_reaches_is_rejected() -> None:
+    """M5. Existence is not attachment: the path terminated somewhere else."""
+
+    _rejects(
+        RelatedContext,
+        _negative("ask_dev_related_context.v1", "path_cited_but_never_reaching_entity"),
+        "cites paths that never reach it",
+    )
+
+
+def test_source_reported_both_observed_and_missing_is_rejected() -> None:
+    """M6. Two contradictory coverage claims, whichever flatters the score."""
+
+    _rejects(
+        EvidenceCoverage,
+        _negative("ask_dev_evidence_coverage.v1", "source_both_observed_and_missing"),
+        "both as observed and as missing",
+    )
+
+
+def test_comparable_history_without_edge_validity_is_rejected() -> None:
+    """M7. A historical delta computed off the live projection is fabricated."""
+
+    _rejects(
+        AnalyticalJob,
+        _negative(
+            "ask_dev_analytical_job.v1", "comparable_history_without_edge_validity"
+        ),
+        "is not a legal edge_validity_basis",
+    )
+
+
+def test_unavailable_edge_validity_must_use_the_chaos_3569_state() -> None:
+    """M7. The gap may not be relabelled as a vaguer non-comparability."""
+
+    _rejects(
+        AnalyticalJob,
+        _negative("ask_dev_analytical_job.v1", "unavailable_edge_validity_mislabelled"),
+        "not_comparable_missing_edge_validity",
+    )
+
+
+def test_observed_edge_intervals_still_permit_a_comparable_history() -> None:
+    """Positive control for the edge-validity guard.
+
+    An arm that genuinely reconstructed the as-of state must still be able
+    to say so, or the rule would permanently ban the capability CHAOS-3569
+    exists to deliver.
+    """
+
+    from dev_health_ops.api.dev.investigation_contract.fixtures import (
+        positive_fixtures,
+    )
+
+    job = deepcopy(positive_fixtures()["ask_dev_analytical_job.v1"])
+    job["time_context"] = {
+        **job["time_context"],
+        "analytical_slice": "historical",
+        "as_of": "2026-05-08T00:00:00Z",
+        "historical_comparability": "comparable",
+        "edge_validity_basis": "observed_intervals",
+    }
+    parsed = AnalyticalJob.model_validate(job)
+    assert parsed.time_context.historical_comparability == "comparable"
 
 
 @pytest.mark.parametrize("contract", sorted(INVESTIGATION_CONTRACT_MODELS))

--- a/tests/api/dev/test_chaos_3615_fault_modes.py
+++ b/tests/api/dev/test_chaos_3615_fault_modes.py
@@ -1,0 +1,599 @@
+"""CHAOS-3615: every named fault mode, proved rejected by the contract.
+
+The corrective plan names eleven fault shapes and requires, for each, a test
+proving the contract catches *that* defect. A golden-response test is
+explicitly not sufficient — so every test here feeds the validator an
+**arm-shaped bad packet**: a payload an implementation could plausibly emit,
+differing from the golden only in the behaviour under test.
+
+Two properties make these tests non-vacuous, and both are asserted rather
+than assumed:
+
+1. **The rejection comes from the named guard.** Each test asserts on a
+   phrase unique to the validator the fault-mode registry names, not merely
+   that "something raised". A payload rejected by an unrelated field error
+   would otherwise read as coverage while the real guard was missing.
+2. **The legitimate case still validates.** Every rule that could be
+   "enforced" by making the good case impossible has a positive control
+   here — a missing staffing denominator that is qualified rather than
+   killed, discovery with nothing committed, a not-comparable historical
+   slice that is still a supported investigation. A contract that rejected
+   both shapes would pass every negative test and be useless.
+
+The guards' *load-bearing-ness* — that removing a validator makes its bad
+packet validate — is proved separately and permanently by
+``scripts/verify_chaos_3615_fault_mode_guards.py``, which neutralizes each
+named validator in a subprocess and asserts the arm-shaped payload is then
+accepted. That script is what turns "this test passes" into "this test
+would fail if the guard were gone".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from dev_health_ops.api.dev.investigation_contract import (
+    INVESTIGATION_CONTRACT_MODELS,
+    AskDevInvestigationPacket,
+    ComparisonCohort,
+    DriverAnalysis,
+    EvidenceCoverage,
+    InvestigationOutcome,
+    RelatedContext,
+    SubjectDiscovery,
+)
+from dev_health_ops.api.dev.investigation_contract.fixtures import (
+    negative_fixtures,
+    positive_variant_fixtures,
+)
+
+PACKET = "ask_dev_investigation_packet.v1"
+
+
+def _negative(contract: str, label: str) -> dict[str, Any]:
+    for case_label, payload in negative_fixtures()[contract]:
+        if case_label == label:
+            return payload
+    raise AssertionError(f"no negative fixture {contract}/{label}")
+
+
+def _variant(label: str) -> dict[str, Any]:
+    for case_label, payload in positive_variant_fixtures()[PACKET]:
+        if case_label == label:
+            return payload
+    raise AssertionError(f"no positive variant {label}")
+
+
+def _rejects(
+    model: type[BaseModel], payload: dict[str, Any], expected_phrase: str
+) -> None:
+    """Assert the payload is rejected, and that the named guard rejected it."""
+
+    with pytest.raises(ValidationError) as caught:
+        model.model_validate(payload)
+    message = str(caught.value)
+    assert expected_phrase in message, (
+        f"{model.__name__} rejected the payload, but not for the reason under "
+        f"test. Expected a message containing {expected_phrase!r}; got:\n{message}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Fault 1: a wrong but similarly named subject ranks (and commits) first
+# --------------------------------------------------------------------------
+
+
+def test_commitment_on_fuzzy_label_alone_is_rejected() -> None:
+    _rejects(
+        SubjectDiscovery,
+        _negative("ask_dev_subject_discovery.v1", "commitment_on_fuzzy_label_alone"),
+        "committed on weak signals alone",
+    )
+
+
+def test_commitment_below_rank_one_is_rejected() -> None:
+    """The same fault wearing a different hat: commit to the runner-up.
+
+    Distinct from the fuzzy-label case because the signal here is strong —
+    an exact display-name match on the *wrong* project. What makes it a
+    fault is that the arm itself ranked something else higher and committed
+    anyway, with no clarification.
+    """
+
+    _rejects(
+        SubjectDiscovery,
+        _negative("ask_dev_subject_discovery.v1", "commitment_below_rank_one"),
+        "is committed at rank",
+    )
+
+
+def test_candidate_ranks_out_of_order_are_rejected() -> None:
+    _rejects(
+        SubjectDiscovery,
+        _negative("ask_dev_subject_discovery.v1", "candidate_ranks_out_of_order"),
+        "candidate ranks must be 1..n in declaration order",
+    )
+
+
+# --------------------------------------------------------------------------
+# Fault 2: organization widening after an unresolved named reference
+# --------------------------------------------------------------------------
+
+
+def test_organization_widening_after_unresolved_mention_is_rejected() -> None:
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "organization_widening_after_unresolved_reference"),
+        "widened to organization scope",
+    )
+
+
+def test_organization_scope_is_legal_when_the_packet_is_asking() -> None:
+    """Positive control for the widening guard.
+
+    Organization scope with an unresolved mention outstanding is legitimate
+    in exactly one case — the packet is asking for clarification rather than
+    answering. If this validated nothing, the widening guard could have been
+    implemented as "never allow organization scope", which would ban a
+    correct behaviour.
+    """
+
+    packet = AskDevInvestigationPacket.model_validate(
+        _variant("needs_clarification_with_widening")
+    )
+    assert packet.outcome is InvestigationOutcome.NEEDS_CLARIFICATION
+    assert packet.subject_discovery.unresolved_mentions
+    assert packet.evidence_coverage.clarification_needs
+
+
+# --------------------------------------------------------------------------
+# Fault 3: irrelevant high-volume evidence displaces the expected lineage
+# --------------------------------------------------------------------------
+
+
+def test_evidence_that_supports_nothing_is_rejected() -> None:
+    _rejects(
+        EvidenceCoverage,
+        _negative("ask_dev_evidence_coverage.v1", "evidence_supporting_nothing"),
+        "supports nothing in this packet",
+    )
+
+
+def test_evidence_cited_but_not_indexed_is_rejected() -> None:
+    """The other half of evidence closure: a citation with nothing behind it."""
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "evidence_citation_absent_from_index"),
+        "cited but absent from the evidence",
+    )
+
+
+# --------------------------------------------------------------------------
+# Fault 4: a symptom labelled the principal driver without supporting paths
+# --------------------------------------------------------------------------
+
+
+def test_symptom_promoted_to_principal_driver_is_rejected() -> None:
+    _rejects(
+        DriverAnalysis,
+        _negative("ask_dev_driver_analysis.v1", "symptom_promoted_to_principal_driver"),
+        "a symptom is not a driver",
+    )
+
+
+def test_principal_driver_without_supporting_path_is_rejected() -> None:
+    _rejects(
+        DriverAnalysis,
+        _negative(
+            "ask_dev_driver_analysis.v1", "principal_driver_without_supporting_path"
+        ),
+        "no supporting relationship path",
+    )
+
+
+def test_historical_driver_promoted_to_principal_is_rejected() -> None:
+    _rejects(
+        DriverAnalysis,
+        _negative(
+            "ask_dev_driver_analysis.v1", "historical_driver_promoted_to_principal"
+        ),
+        "not a principal current driver",
+    )
+
+
+def test_symptom_remains_a_legitimate_candidate() -> None:
+    """Positive control: symptoms are reportable, just not promotable.
+
+    The golden carries a rising-cycle-time candidate classified ``symptom``
+    and excluded from principal standing with a stated reason. If the guard
+    had been implemented as "reject symptoms", the packet would lose the
+    observation that makes the driver legible.
+    """
+
+    from dev_health_ops.api.dev.investigation_contract.fixtures import (
+        positive_fixtures,
+    )
+
+    analysis = DriverAnalysis.model_validate(
+        positive_fixtures()["ask_dev_driver_analysis.v1"]
+    )
+    symptoms = [
+        candidate for candidate in analysis.candidates if candidate.role == "symptom"
+    ]
+    assert symptoms, "the golden must keep a symptom candidate to be meaningful"
+    assert all(candidate.exclusion_reason is not None for candidate in symptoms)
+
+
+# --------------------------------------------------------------------------
+# Fault 5: a staffing claim presented as certain without allocation evidence
+# --------------------------------------------------------------------------
+
+
+def test_certain_staffing_claim_without_denominator_is_rejected() -> None:
+    _rejects(
+        DriverAnalysis,
+        _negative(
+            "ask_dev_driver_analysis.v1", "staffing_certainty_without_denominator"
+        ),
+        "presents a staffing claim as certain",
+    )
+
+
+def test_capacity_driver_without_any_staffing_qualification_is_rejected() -> None:
+    _rejects(
+        DriverAnalysis,
+        _negative(
+            "ask_dev_driver_analysis.v1",
+            "capacity_driver_without_staffing_qualification",
+        ),
+        "says nothing about its denominator",
+    )
+
+
+def test_missing_denominator_still_supports_a_qualified_capacity_claim() -> None:
+    """Positive control, and the anti-drift rule that matters most here.
+
+    The correction addendum requires that missing staffing data *reduce
+    confidence* rather than make capacity questions unsupported. This packet
+    asserts a capacity driver with ``denominator_absent`` at ``qualified``
+    confidence and must validate — otherwise the staffing guard would have
+    silently converted "qualify" into "refuse".
+    """
+
+    packet = AskDevInvestigationPacket.model_validate(
+        _variant("qualified_capacity_without_denominator")
+    )
+    capacity = [
+        candidate
+        for candidate in packet.driver_analysis.candidates
+        if candidate.staffing_qualification is not None
+    ]
+    assert capacity, "the variant must actually carry a capacity claim"
+    assert all(
+        candidate.staffing_qualification is not None
+        and candidate.staffing_qualification.denominator_state == "denominator_absent"
+        for candidate in capacity
+    )
+    assert packet.outcome in {
+        InvestigationOutcome.SUPPORTED,
+        InvestigationOutcome.SUPPORTED_WITH_GAPS,
+    }
+
+
+# --------------------------------------------------------------------------
+# Fault 6: the cohort includes an unrelated project
+# --------------------------------------------------------------------------
+
+
+def test_cohort_member_without_inclusion_evidence_is_rejected() -> None:
+    _rejects(
+        ComparisonCohort,
+        _negative(
+            "ask_dev_comparison_cohort.v1",
+            "unrelated_member_without_inclusion_evidence",
+        ),
+        "neither evidence nor an explicit no-evidence classification",
+    )
+
+
+# --------------------------------------------------------------------------
+# Fault 7: a relationship is reversed
+# --------------------------------------------------------------------------
+
+
+def test_reversed_relationship_direction_is_rejected() -> None:
+    _rejects(
+        RelatedContext,
+        _negative("ask_dev_related_context.v1", "reversed_relationship_direction"),
+        "contradicts the canonical orientation",
+    )
+
+
+def test_disconnected_path_presented_as_a_chain_is_rejected() -> None:
+    """A path whose hops do not join is a false lineage built of true edges."""
+
+    _rejects(
+        RelatedContext,
+        _negative("ask_dev_related_context.v1", "disconnected_path_presented_as_chain"),
+        "is not connected",
+    )
+
+
+# --------------------------------------------------------------------------
+# Fault 8: a path crosses an unauthorized entity
+# --------------------------------------------------------------------------
+
+
+def test_path_through_unauthorized_entity_is_rejected() -> None:
+    """The unauthorized entity is an *intermediate* node, not a result.
+
+    Deliberately so: the fixture drops only the terminal dependency from the
+    authorized set while every returned entity record stays visible. A guard
+    that checked returned entities alone would pass this payload and still
+    leak the existence of a restricted node through the path that crosses
+    it.
+    """
+
+    _rejects(
+        RelatedContext,
+        _negative("ask_dev_related_context.v1", "path_crosses_unauthorized_entity"),
+        "outside the authorized set",
+    )
+
+
+# --------------------------------------------------------------------------
+# Fault 9: dashboard redirection without a direct judgment
+# --------------------------------------------------------------------------
+
+
+def test_supported_outcome_without_any_asserted_driver_is_rejected() -> None:
+    """The structural form of "here are some links, you work it out".
+
+    The payload is well formed, carries a full evidence index, a populated
+    lineage section and surface references — everything except a judgment.
+    """
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "dashboard_redirect_without_direct_judgment"),
+        "has redirected, not answered",
+    )
+
+
+def test_no_match_without_limitation_or_clarification_is_rejected() -> None:
+    """ "No match" may not become the silent, privileged default."""
+
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "no_match_without_limitation_or_clarification"),
+        "silent default wearing an outcome label",
+    )
+
+
+# --------------------------------------------------------------------------
+# Fault 10: an absent required field silently defaults to a privileged value
+# --------------------------------------------------------------------------
+
+
+def test_absent_truncation_flag_is_rejected_rather_than_defaulted() -> None:
+    _rejects(
+        SubjectDiscovery,
+        _negative("ask_dev_subject_discovery.v1", "absent_truncation_disclosure_field"),
+        "candidates_truncated",
+    )
+
+
+def test_disclosure_fields_have_no_reassuring_default() -> None:
+    """No boolean or count field anywhere in the contract may be optional.
+
+    Derived from the models themselves rather than from a hand-maintained
+    list, so a disclosure field added later cannot dodge the rule by simply
+    not being written down here. Every ``bool`` and every ``*_count`` on
+    every contract model is a disclosure — "was anything hidden from you",
+    "was this truncated", "how many results were filtered" — and each has
+    exactly one comfortable default that a forgetful producer would inherit.
+    """
+
+    from dev_health_ops.api.dev.investigation_contract import packet as packet_module
+
+    checked = 0
+    offenders: list[str] = []
+    for name in dir(packet_module):
+        model = getattr(packet_module, name)
+        if not (isinstance(model, type) and issubclass(model, BaseModel)):
+            continue
+        if model.__module__ != packet_module.__name__:
+            continue
+        for field_name, field in model.model_fields.items():
+            is_flag = field.annotation is bool
+            is_count = field_name.endswith("_count")
+            if not (is_flag or is_count):
+                continue
+            checked += 1
+            if not field.is_required():
+                offenders.append(f"{name}.{field_name}")
+    assert checked >= 8, (
+        "expected the contract to carry several boolean/count disclosure "
+        f"fields; only found {checked}, which suggests this test is scanning "
+        "the wrong models"
+    )
+    assert not offenders, (
+        "these disclosure fields would silently default to the flattering "
+        f"value if a producer omitted them: {sorted(offenders)}"
+    )
+
+
+def test_non_boolean_disclosure_fields_are_also_required() -> None:
+    """The disclosures whose privileged default is not ``False`` or ``0``."""
+
+    from dev_health_ops.api.dev.investigation_contract.packet import (
+        BoundedTimeContext,
+        LineagePath,
+    )
+
+    pinned: tuple[tuple[type[BaseModel], str], ...] = (
+        (ComparisonCohort, "completeness"),
+        (LineagePath, "source_health"),
+        (BoundedTimeContext, "historical_comparability"),
+        (BoundedTimeContext, "analytical_slice"),
+        (AskDevInvestigationPacket, "outcome"),
+    )
+    for model, field_name in pinned:
+        assert model.model_fields[field_name].is_required(), (
+            f"{model.__name__}.{field_name} must be required; its most "
+            "convenient default is also its most flattering one"
+        )
+
+
+# --------------------------------------------------------------------------
+# Fault 11: a wildcard or optional field makes the check vacuous
+# --------------------------------------------------------------------------
+
+
+def test_cohort_claiming_comparison_without_dimensions_is_rejected() -> None:
+    """A cohort that supports no comparison cannot claim to be one."""
+
+    _rejects(
+        ComparisonCohort,
+        _negative(
+            "ask_dev_comparison_cohort.v1", "comparison_claimed_without_dimensions"
+        ),
+        "declares no supported comparison dimension",
+    )
+
+
+def test_identifier_grammar_admits_no_wildcard_token() -> None:
+    """``*`` cannot appear in any identifier this contract accepts.
+
+    The cheapest way to make an authorization or cohort check vacuous is an
+    identifier that means "all of them". ``OpaqueID``'s grammar excludes the
+    character outright, so the class of attack is closed rather than
+    policed; this test pins that the grammar has not been loosened.
+    """
+
+    packet = _variant("trial_metadata_present")
+    wildcarded = {
+        **packet,
+        "organization_id": "*",
+    }
+    _rejects(AskDevInvestigationPacket, wildcarded, "organization_id")
+
+
+def test_truncation_without_a_reason_is_rejected() -> None:
+    _rejects(
+        ComparisonCohort,
+        _negative("ask_dev_comparison_cohort.v1", "truncated_without_reason"),
+        "declares no truncation_reason",
+    )
+
+
+# --------------------------------------------------------------------------
+# Anti-drift positive controls for the remaining named rules
+# --------------------------------------------------------------------------
+
+
+def test_discovery_without_any_commitment_is_legal() -> None:
+    """Exact subject commitment is not a prerequisite for discovery.
+
+    A packet with every candidate merely ``proposed`` — no committed
+    subject at all — still carries a full related-context and driver
+    section, and validates. This is the correction addendum's rule stated as
+    a fixture: an arm that refused to investigate before committing could
+    not answer the struggling-teams family at all.
+    """
+
+    packet = AskDevInvestigationPacket.model_validate(
+        _variant("discovery_without_commitment")
+    )
+    assert packet.subject_discovery.committed_subject_ids == ()
+    assert packet.subject_discovery.candidates
+    assert packet.related_context.paths
+    assert packet.driver_analysis.principal_driver_ids
+
+
+def test_not_comparable_historical_slice_is_valid_and_supported() -> None:
+    """CHAOS-3569-gapped history is NOT COMPARABLE, not a blocker.
+
+    The packet declares ``not_comparable_missing_edge_validity``, discloses
+    the limitation, and stays a supported investigation. A contract that
+    downgraded the outcome here would turn an open dependency into a
+    permanent trial failure.
+    """
+
+    packet = AskDevInvestigationPacket.model_validate(
+        _variant("not_comparable_historical_slice")
+    )
+    assert (
+        packet.analytical_job.time_context.historical_comparability
+        == "not_comparable_missing_edge_validity"
+    )
+    assert packet.outcome is InvestigationOutcome.SUPPORTED
+    assert any(
+        limitation.kind == "historical_slice_not_comparable"
+        for limitation in packet.evidence_coverage.limitations
+    )
+
+
+def test_not_comparable_slice_must_still_be_disclosed() -> None:
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "not_comparable_slice_undisclosed"),
+        "HISTORICAL_SLICE_NOT_COMPARABLE limitation is disclosed",
+    )
+
+
+def test_authorization_filtering_must_be_disclosed() -> None:
+    _rejects(
+        AskDevInvestigationPacket,
+        _negative(PACKET, "authorization_filtering_undisclosed"),
+        "AUTHORIZATION_FILTERED limitation is disclosed",
+    )
+
+
+def test_trial_metadata_is_optional_and_changes_nothing_else() -> None:
+    """Arm identity is evaluation metadata, not product truth.
+
+    The golden validates without ``versions.trial`` at all; the variant adds
+    it and nothing else. If any other field were required to change when an
+    arm identified itself, the contract would be coupling consumers to the
+    arm.
+    """
+
+    from dev_health_ops.api.dev.investigation_contract.fixtures import (
+        positive_fixtures,
+    )
+
+    plain = positive_fixtures()[PACKET]
+    assert plain["versions"]["trial"] is None
+    AskDevInvestigationPacket.model_validate(plain)
+
+    with_trial = _variant("trial_metadata_present")
+    packet = AskDevInvestigationPacket.model_validate(with_trial)
+    assert packet.versions.trial is not None
+
+    stripped = {**with_trial, "versions": {**with_trial["versions"]}}
+    stripped["versions"]["trial"] = None
+    stripped["versions"]["corpus_version"] = None
+    assert stripped == plain, (
+        "the trial-metadata variant differs from the golden in fields other "
+        "than versions.trial/corpus_version, so arm identity is not isolated"
+    )
+
+
+@pytest.mark.parametrize("contract", sorted(INVESTIGATION_CONTRACT_MODELS))
+def test_every_contract_has_a_negative_fixture_that_actually_fails(
+    contract: str,
+) -> None:
+    """A negative fixture that quietly starts passing is a dead guard."""
+
+    cases = negative_fixtures()[contract]
+    assert cases, f"{contract} has no negative fixture"
+    model = INVESTIGATION_CONTRACT_MODELS[contract]
+    for label, payload in cases:
+        with pytest.raises(ValidationError):
+            model.model_validate(payload)
+        assert label, f"{contract} has an unlabelled negative fixture"

--- a/tests/api/dev/test_chaos_3615_investigation_contract.py
+++ b/tests/api/dev/test_chaos_3615_investigation_contract.py
@@ -1,0 +1,252 @@
+"""CHAOS-3615: artifact drift, fixture coverage and backend neutrality.
+
+Three things this module holds the contract to.
+
+**Drift.** ``check`` mode compares the whole artifact set — contents,
+missing files and unexpected extra files — so a schema regenerated without
+committing, a fixture edited by hand, or a contract removed without
+regenerating are all red here rather than discovered by CHAOS-3616.
+
+**Coverage.** Every registered contract has a positive golden and at least
+one negative fixture, and the negatives genuinely fail. The exporter already
+refuses to write otherwise; this asserts it independently, because a gate
+that only ever runs inside the thing it gates proves less than it appears
+to.
+
+**Backend neutrality.** The wire must name no graph backend, no graph query
+language and no graph-store concept. Asserted against the *generated
+artifacts* — the schemas, every fixture and every registry file — rather
+than against the Python source, because the artifacts are what a consumer
+actually reads, and a neutral source that generated a leaky schema would
+pass a source-only scan.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.api.dev.investigation_contract import (
+    INVESTIGATION_CONTRACT_MODELS,
+)
+from dev_health_ops.api.dev.investigation_contract.export import (
+    ARTIFACT_ROOT,
+    check_artifacts,
+    expected_artifacts,
+)
+from dev_health_ops.api.dev.investigation_contract.fixtures import (
+    negative_fixtures,
+    positive_fixtures,
+    positive_variant_fixtures,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+#: Tokens that must never reach the wire. Graph backends, graph query
+#: languages and graph-native surface concepts. ``graph`` itself is
+#: deliberately absent: ``SourceClass.WORK_GRAPH`` is a platform concept
+#: that predates this work and banning the substring would flag it.
+BANNED_WIRE_TOKENS: tuple[str, ...] = (
+    "graphiti",
+    "neo4j",
+    "falkor",
+    "kuzu",
+    "nebula",
+    "arangodb",
+    "janusgraph",
+    "tigergraph",
+    "memgraph",
+    "dgraph",
+    "neptune",
+    "cypher",
+    "gremlin",
+    "sparql",
+    "bolt://",
+    "graph_store",
+    "episodic",
+    "group_id",
+    "graph_query",
+    "traversal_query",
+)
+
+
+def test_checked_in_artifacts_match_the_contract_source() -> None:
+    """The drift gate. Regenerate with ``python -m ...export write``."""
+
+    check_artifacts(expected_artifacts())
+
+
+def test_artifact_root_is_not_the_client_served_tree() -> None:
+    """This packet is an internal trial artifact and must stay out of v2.
+
+    ``contracts/ask-dev/v2`` is reserved for wire contracts served to real
+    clients and is consumed by ``dev-health-web``'s contract sync. Filing an
+    internal trial artifact there would both misrepresent it and put
+    CHAOS-3616 iterations on the critical path of a web contract regen.
+    """
+
+    assert (
+        ARTIFACT_ROOT == REPOSITORY_ROOT / "contracts" / "ask-dev-investigation" / "v1"
+    )
+    assert ARTIFACT_ROOT.is_dir()
+
+    from dev_health_ops.api.dev.contracts_v2 import CONTRACT_MODELS_V2
+
+    overlap = sorted(set(INVESTIGATION_CONTRACT_MODELS) & set(CONTRACT_MODELS_V2))
+    assert not overlap, (
+        f"investigation contracts registered in the client-served v2 registry: {overlap}"
+    )
+
+
+def test_manifest_covers_every_artifact_with_a_digest() -> None:
+    manifest = json.loads((ARTIFACT_ROOT / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "ask_dev_investigation_contract_manifest.v1"
+    listed = {entry["schema_version"] for entry in manifest["contracts"]}
+    assert listed == set(INVESTIGATION_CONTRACT_MODELS)
+    for entry in manifest["contracts"]:
+        assert len(entry["schema"]["sha256"]) == 64
+        assert len(entry["positive"]["sha256"]) == 64
+        assert entry["negative"], f"{entry['schema_version']} has no negative fixture"
+        for negative in entry["negative"]:
+            assert len(negative["sha256"]) == 64
+    assert manifest["registries"], "the registries must be exported for CHAOS-3616"
+    for registry in manifest["registries"]:
+        assert (ARTIFACT_ROOT / registry["path"]).is_file()
+        assert len(registry["sha256"]) == 64
+
+
+@pytest.mark.parametrize("contract", sorted(INVESTIGATION_CONTRACT_MODELS))
+def test_positive_golden_validates(contract: str) -> None:
+    INVESTIGATION_CONTRACT_MODELS[contract].model_validate(
+        positive_fixtures()[contract]
+    )
+
+
+def test_fixture_coverage_matches_the_registry_exactly() -> None:
+    assert set(positive_fixtures()) == set(INVESTIGATION_CONTRACT_MODELS)
+    assert set(negative_fixtures()) == set(INVESTIGATION_CONTRACT_MODELS)
+    unregistered = set(positive_variant_fixtures()) - set(INVESTIGATION_CONTRACT_MODELS)
+    assert not unregistered
+
+
+def test_every_registered_contract_declares_its_schema_version() -> None:
+    """No contract may be identified by position or by convention alone."""
+
+    for name, model in INVESTIGATION_CONTRACT_MODELS.items():
+        field = model.model_fields["schema_version"]
+        assert field.is_required(), f"{name} lets schema_version default"
+        schema = model.model_json_schema(mode="validation")
+        assert schema["properties"]["schema_version"]["const"] == name
+
+
+def test_section_goldens_are_the_packet_goldens() -> None:
+    """The section fixtures are slices of the packet, not parallel authorings.
+
+    Eight independently authored examples would drift; this asserts they
+    cannot, because each section golden is byte-identical to the
+    corresponding section of the packet golden.
+    """
+
+    positives = positive_fixtures()
+    packet = positives["ask_dev_investigation_packet.v1"]
+    for section, contract in (
+        ("analytical_job", "ask_dev_analytical_job.v1"),
+        ("subject_discovery", "ask_dev_subject_discovery.v1"),
+        ("comparison_cohort", "ask_dev_comparison_cohort.v1"),
+        ("related_context", "ask_dev_related_context.v1"),
+        ("driver_analysis", "ask_dev_driver_analysis.v1"),
+        ("evidence_coverage", "ask_dev_evidence_coverage.v1"),
+        ("versions", "ask_dev_investigation_versions.v1"),
+    ):
+        assert packet[section] == positives[contract], (
+            f"the {contract} golden has drifted from the packet's {section}"
+        )
+
+
+def _artifact_files() -> list[Path]:
+    return sorted(path for path in ARTIFACT_ROOT.rglob("*.json") if path.is_file())
+
+
+def test_generated_artifacts_name_no_graph_backend() -> None:
+    """Zero graph-backend vocabulary anywhere on the wire.
+
+    Scans every generated file, not a sampled subset: schemas carry field
+    names and enum values, fixtures carry the values a producer would emit,
+    and the registries carry the prose CHAOS-3616 will read. A leak in any
+    of them is a leak.
+    """
+
+    files = _artifact_files()
+    assert len(files) >= 20, (
+        f"only {len(files)} artifacts found under {ARTIFACT_ROOT}; this scan "
+        "would pass vacuously"
+    )
+    offenders: list[str] = []
+    for path in files:
+        text = path.read_text(encoding="utf-8").casefold()
+        for token in BANNED_WIRE_TOKENS:
+            if token in text:
+                offenders.append(f"{path.relative_to(ARTIFACT_ROOT)}: {token}")
+    assert not offenders, f"graph-native vocabulary reached the wire: {offenders}"
+
+
+def test_the_neutrality_scan_can_actually_fail() -> None:
+    """Anti-vacuity control for the scan above.
+
+    A scan whose token list never matches anything is indistinguishable from
+    a scan that is looking in the wrong place. This plants one banned token
+    in a copy of a real artifact's text and requires the same predicate to
+    catch it.
+    """
+
+    sample = (ARTIFACT_ROOT / "manifest.json").read_text(encoding="utf-8")
+    planted = (sample + '\n{"backend": "neo4j"}\n').casefold()
+    assert any(token in planted for token in BANNED_WIRE_TOKENS)
+
+
+def test_no_contract_field_names_a_person_subject() -> None:
+    """Person-level ranking is unrepresentable, not merely prohibited.
+
+    Checked against the generated schemas so it covers every enum the wire
+    admits: if a ``person``/``individual``/``developer`` subject kind or
+    comparison dimension were ever added, it would show up here before any
+    producer could emit one.
+    """
+
+    banned = ("person", "individual", "developer", "headcount_rank", "contributor_rank")
+    offenders: list[str] = []
+    for path in sorted((ARTIFACT_ROOT / "schemas").glob("*.json")):
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        for definition in schema.get("$defs", {}).values():
+            for value in definition.get("enum", []):
+                if any(token in str(value).casefold() for token in banned):
+                    offenders.append(f"{path.name}: {value}")
+    assert not offenders, f"person-level vocabulary on the wire: {offenders}"
+
+
+def test_every_named_guard_is_load_bearing() -> None:
+    """Run the fault-injection proof: remove each guard, watch the fault land.
+
+    Shelled out rather than inlined because the proof mutates class-level
+    pydantic state, which would corrupt every later test in the session.
+    The script's own exit code is the assertion; its stdout is attached on
+    failure so a red run names the case that stopped being load-bearing.
+    """
+
+    script = REPOSITORY_ROOT / "scripts" / "verify_chaos_3615_fault_mode_guards.py"
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPOSITORY_ROOT,
+    )
+    assert completed.returncode == 0, (
+        "at least one named guard is not what rejects its fault:\n"
+        f"{completed.stdout}\n{completed.stderr}"
+    )
+    assert "GUARD PROOF PASSED" in completed.stdout

--- a/tests/api/dev/test_chaos_3615_registries.py
+++ b/tests/api/dev/test_chaos_3615_registries.py
@@ -418,6 +418,32 @@ def test_current_slice_is_not_blocked_by_the_historical_gap() -> None:
     assert current.known_gap is None
 
 
+def test_architecture_doc_counts_match_the_registries() -> None:
+    """The doc states registry sizes in prose; prose rots silently.
+
+    Every count the architecture page asserts is re-derived here, so adding
+    a family or a fault mode without updating the page turns red instead of
+    leaving a confidently wrong number in the docs.
+    """
+
+    page = (
+        REPOSITORY_ROOT
+        / "docs"
+        / "contribute"
+        / "architecture"
+        / "ask-dev-investigation-packet.md"
+    ).read_text(encoding="utf-8")
+    claims = (
+        (f"**Question families** ({len(ALL_QUESTION_FAMILY_IDS)})", "families"),
+        (f"**Scoring dimensions** ({len(ALL_SCORING_DIMENSION_IDS)})", "dimensions"),
+        (f"**Fault modes** ({len(ALL_FAULT_MODE_IDS)})", "fault modes"),
+    )
+    for claim, what in claims:
+        assert claim in page, f"the architecture page's {what} count is stale"
+    assert len(ALL_RELATIONSHIP_TYPES) == 12
+    assert "twelve closed technical relationship types" in page
+
+
 def test_historical_slices_declare_the_open_gap() -> None:
     for slice_id in (AnalyticalSlice.HISTORICAL, AnalyticalSlice.CURRENT_VS_HISTORICAL):
         boundary = SLICE_BOUNDARIES[slice_id]

--- a/tests/api/dev/test_chaos_3615_registries.py
+++ b/tests/api/dev/test_chaos_3615_registries.py
@@ -1,0 +1,426 @@
+"""CHAOS-3615: totality and anti-vacuity of the four frozen registries.
+
+The question families, the scoring dimensions, the fault modes and the trial
+allowlists are the part of this issue CHAOS-3616 will actually consume, and
+they are the part that fails silently if it is wrong: a family nobody scores,
+a dimension no fault can fail, a fault mode whose "validator" does not exist.
+Each of those is well formed and proves nothing, so each is asserted here.
+
+Closed vocabularies are iterated through their ``ALL_*`` literal tuples
+rather than through the enum objects — CodeQL's
+``py/non-iterable-in-for-loop`` false-positives on ``(str, Enum)`` mixins,
+which is why the repository publishes literal registries in the first place.
+The tuples are proved exhaustive against ``__members__`` below, so the
+indirection cannot hide a member.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.investigation_contract import (
+    ALL_ANALYTICAL_SLICES,
+    ALL_ASSERTION_BASES,
+    ALL_COMPARISON_DIMENSIONS,
+    ALL_COMPARISON_SHAPES,
+    ALL_DRIVER_CATEGORIES,
+    ALL_DRIVER_ROLES,
+    ALL_DRIVER_STANDINGS,
+    ALL_FAULT_MODE_IDS,
+    ALL_INVESTIGATION_OUTCOMES,
+    ALL_INVESTIGATION_SUBJECT_KINDS,
+    ALL_PACKET_SECTIONS,
+    ALL_PROHIBITED_REDUCTIONS,
+    ALL_QUESTION_FAMILY_IDS,
+    ALL_RELATIONSHIP_TYPES,
+    ALL_SCORING_DIMENSION_IDS,
+    ALL_STAFFING_DENOMINATOR_STATES,
+    ALL_TRUNCATION_REASONS,
+    FAULT_MODE_REGISTRY,
+    MANDATORY_PROHIBITED_REDUCTIONS,
+    QUESTION_FAMILY_REGISTRY,
+    RELATIONSHIP_ALLOWLIST,
+    SCORING_DIMENSION_REGISTRY,
+    SLICE_BOUNDARIES,
+    TRIAL_SOURCE_ALLOWLIST,
+    AnalyticalSlice,
+    AssertionBasis,
+    ComparisonDimension,
+    ComparisonShape,
+    DriverCategory,
+    DriverRole,
+    DriverStanding,
+    FaultModeID,
+    InvestigationOutcome,
+    InvestigationSubjectKind,
+    PacketSection,
+    ProhibitedReduction,
+    QuestionFamilyID,
+    RejectingMechanism,
+    RelationshipType,
+    ScoringDimensionID,
+    StaffingDenominatorPolicy,
+    StaffingDenominatorState,
+    TruncationReason,
+    validate_question_family_registry,
+    validate_relationship_allowlist,
+    validate_scoring_registry,
+    validate_slice_boundaries,
+    validate_trial_source_allowlist,
+)
+from dev_health_ops.api.dev.investigation_contract import packet as packet_module
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+FAULT_MODE_TEST_FILE = "tests/api/dev/test_chaos_3615_fault_modes.py"
+
+#: ``(literal tuple, enum)`` for every closed vocabulary this package owns.
+_TOTALITY_TABLE: tuple[tuple[tuple[StrEnum, ...], type[StrEnum]], ...] = (
+    (ALL_INVESTIGATION_SUBJECT_KINDS, InvestigationSubjectKind),
+    (ALL_COMPARISON_SHAPES, ComparisonShape),
+    (ALL_COMPARISON_DIMENSIONS, ComparisonDimension),
+    (ALL_ANALYTICAL_SLICES, AnalyticalSlice),
+    (ALL_ASSERTION_BASES, AssertionBasis),
+    (ALL_DRIVER_ROLES, DriverRole),
+    (ALL_DRIVER_STANDINGS, DriverStanding),
+    (ALL_DRIVER_CATEGORIES, DriverCategory),
+    (ALL_STAFFING_DENOMINATOR_STATES, StaffingDenominatorState),
+    (ALL_TRUNCATION_REASONS, TruncationReason),
+    (ALL_INVESTIGATION_OUTCOMES, InvestigationOutcome),
+    (ALL_PACKET_SECTIONS, PacketSection),
+    (ALL_RELATIONSHIP_TYPES, RelationshipType),
+    (ALL_QUESTION_FAMILY_IDS, QuestionFamilyID),
+    (ALL_SCORING_DIMENSION_IDS, ScoringDimensionID),
+    (ALL_FAULT_MODE_IDS, FaultModeID),
+    (ALL_PROHIBITED_REDUCTIONS, ProhibitedReduction),
+)
+
+
+# --------------------------------------------------------------------------
+# Closed vocabularies
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("literal", "enum"),
+    _TOTALITY_TABLE,
+    ids=[enum.__name__ for _, enum in _TOTALITY_TABLE],
+)
+def test_literal_tuple_is_exhaustive(
+    literal: tuple[StrEnum, ...], enum: type[StrEnum]
+) -> None:
+    """A member added without updating its ``ALL_*`` tuple is a red test."""
+
+    members = set(enum.__members__.values())
+    assert set(literal) == members, (
+        f"{enum.__name__} literal tuple is out of sync with its members; "
+        f"missing={sorted(str(item) for item in members - set(literal))}, "
+        f"extra={sorted(str(item) for item in set(literal) - members)}"
+    )
+    assert len(literal) == len(set(literal)), f"{enum.__name__} tuple repeats a member"
+
+
+def test_no_person_subject_kind_exists() -> None:
+    """Person-level ranking is banned by making it unrepresentable.
+
+    A validator forbidding person subjects could be routed around by a
+    future producer; an enum with no person member cannot be. This is the
+    structural half of the ban — the wire-level half is asserted in
+    ``test_chaos_3615_investigation_contract.py``.
+    """
+
+    banned = ("person", "user", "individual", "developer", "employee")
+    for kind in ALL_INVESTIGATION_SUBJECT_KINDS:
+        assert not any(token in str(kind) for token in banned), (
+            f"InvestigationSubjectKind.{kind} makes a person a subject"
+        )
+    for dimension in ALL_COMPARISON_DIMENSIONS:
+        assert not any(token in str(dimension) for token in banned), (
+            f"ComparisonDimension.{dimension} compares people"
+        )
+
+
+# --------------------------------------------------------------------------
+# Question families
+# --------------------------------------------------------------------------
+
+
+def test_question_family_registry_validates() -> None:
+    validate_question_family_registry()
+
+
+def test_every_family_is_registered_once() -> None:
+    assert set(QUESTION_FAMILY_REGISTRY) == set(ALL_QUESTION_FAMILY_IDS)
+    assert len(ALL_QUESTION_FAMILY_IDS) == 10
+
+
+@pytest.mark.parametrize("family_id", ALL_QUESTION_FAMILY_IDS, ids=str)
+def test_family_is_not_one_metric_and_not_one_prompt(
+    family_id: QuestionFamilyID,
+) -> None:
+    """The registry's whole anti-reduction rule, per family.
+
+    One exact phrasing is enough to pin what the family *is*; two natural
+    variants are the minimum that shows it survives rephrasing. Two source
+    classes is the line between an investigation and a dashboard metric, and
+    three scoring dimensions the line between an evaluation and a pass/fail.
+    """
+
+    family = QUESTION_FAMILY_REGISTRY[family_id]
+    assert len(family.exact_variants) >= 1
+    assert len(family.natural_variants) >= 2
+    assert len(set(family.required_source_classes)) >= 2
+    assert len(set(family.required_packet_sections)) >= 2
+    assert len(set(family.scoring_dimension_ids)) >= 3
+    assert set(MANDATORY_PROHIBITED_REDUCTIONS) <= set(family.prohibited_reductions)
+    assert family.permitted_comparison_shapes
+
+
+@pytest.mark.parametrize("family_id", ALL_QUESTION_FAMILY_IDS, ids=str)
+def test_family_sources_are_allowlisted(family_id: QuestionFamilyID) -> None:
+    family = QUESTION_FAMILY_REGISTRY[family_id]
+    assert set(family.required_source_classes) <= set(TRIAL_SOURCE_ALLOWLIST)
+
+
+def test_question_variants_are_globally_unique() -> None:
+    """The same prompt in two families would make both scores unattributable."""
+
+    ids: list[str] = []
+    texts: list[str] = []
+    for family in QUESTION_FAMILY_REGISTRY.values():
+        for variant in family.exact_variants + family.natural_variants:
+            ids.append(variant.variant_id)
+            texts.append(variant.text.strip().casefold())
+    assert len(set(ids)) == len(ids)
+    assert len(set(texts)) == len(texts)
+
+
+def test_capacity_families_qualify_rather_than_refuse() -> None:
+    """Missing staffing data reduces confidence; it never disqualifies.
+
+    Both halves are asserted, because a registry that declared only the
+    first would be honoured by an arm that answered "unsupported" to every
+    capacity question.
+    """
+
+    qualifying = [
+        family
+        for family in QUESTION_FAMILY_REGISTRY.values()
+        if family.staffing_denominator_policy
+        is StaffingDenominatorPolicy.QUALIFY_WHEN_ABSENT
+    ]
+    assert qualifying, "no family qualifies on a missing denominator"
+    for family in qualifying:
+        assert (
+            ProhibitedReduction.AUTO_UNSUPPORTED_ON_MISSING_DENOMINATOR
+            in family.prohibited_reductions
+        )
+        assert (
+            ProhibitedReduction.UNQUALIFIED_STAFFING_CERTAINTY
+            in family.prohibited_reductions
+        )
+
+
+def test_every_family_prohibits_person_level_ranking() -> None:
+    for family in QUESTION_FAMILY_REGISTRY.values():
+        assert ProhibitedReduction.PERSON_LEVEL_RANKING in family.prohibited_reductions
+
+
+def test_a_family_exists_for_clarification_and_no_match() -> None:
+    """Safe no-match behaviour is a scored family, not an error path."""
+
+    family = QUESTION_FAMILY_REGISTRY[QuestionFamilyID.CLARIFICATION_AND_NO_MATCH]
+    assert ScoringDimensionID.NO_UNSAFE_ORGANIZATION_WIDENING in (
+        family.scoring_dimension_ids
+    )
+    assert ScoringDimensionID.CLARIFICATION_CANDIDATE_PRECISION in (
+        family.scoring_dimension_ids
+    )
+
+
+# --------------------------------------------------------------------------
+# Scoring dimensions and fault modes
+# --------------------------------------------------------------------------
+
+
+def test_scoring_registry_validates() -> None:
+    validate_scoring_registry()
+
+
+def test_no_aggregate_score_is_expressible() -> None:
+    """The correction addendum's "do not collapse into one score", asserted.
+
+    ``reported_per_question_family`` and ``aggregate_prohibited`` are
+    ``Literal[True]`` on the model, so this cannot be flipped by a value
+    change — only by a type change, which is a visible contract edit.
+    """
+
+    for dimension in SCORING_DIMENSION_REGISTRY.values():
+        assert dimension.reported_per_question_family is True
+        assert dimension.aggregate_prohibited is True
+    names = {str(dimension_id) for dimension_id in ALL_SCORING_DIMENSION_IDS}
+    assert not any(
+        token in name
+        for name in names
+        for token in ("overall", "aggregate", "total_score", "composite")
+    )
+
+
+def test_every_dimension_names_a_fault_it_can_fail() -> None:
+    for dimension_id, dimension in SCORING_DIMENSION_REGISTRY.items():
+        assert dimension.fault_mode_ids, f"{dimension_id} can never fail"
+        assert set(dimension.fault_mode_ids) <= set(ALL_FAULT_MODE_IDS)
+        assert dimension.packet_fields, f"{dimension_id} reads no packet field"
+        assert dimension.packet_sections, f"{dimension_id} reads no packet section"
+
+
+def test_every_fault_mode_is_measured_by_a_dimension() -> None:
+    measured: set[FaultModeID] = set()
+    for dimension in SCORING_DIMENSION_REGISTRY.values():
+        measured.update(dimension.fault_mode_ids)
+    unmeasured = sorted(str(item) for item in set(ALL_FAULT_MODE_IDS) - measured)
+    assert not unmeasured, f"fault modes nothing scores: {unmeasured}"
+
+
+def test_the_eleven_named_fault_shapes_are_all_registered() -> None:
+    """The corrective plan's own list, pinned as an exact count and set."""
+
+    assert len(ALL_FAULT_MODE_IDS) == 11
+    assert set(FAULT_MODE_REGISTRY) == set(ALL_FAULT_MODE_IDS)
+
+
+@pytest.mark.parametrize("fault_id", ALL_FAULT_MODE_IDS, ids=str)
+def test_contract_rejected_fault_names_a_validator_that_exists(
+    fault_id: FaultModeID,
+) -> None:
+    """A validator reference that does not resolve is a fake citation.
+
+    Resolved against the real module, so a validator renamed during a
+    refactor turns the registry red rather than leaving behind a plausible
+    docstring pointing at nothing.
+    """
+
+    fault = FAULT_MODE_REGISTRY[fault_id]
+    if fault.rejecting_mechanism is not RejectingMechanism.CONTRACT_VALIDATOR:
+        assert fault.validator_reference is None
+        return
+    reference = fault.validator_reference
+    assert reference is not None
+    model = getattr(packet_module, reference.model_name, None)
+    assert model is not None, (
+        f"{fault_id} names model {reference.model_name}, which does not exist"
+    )
+    validators = model.__pydantic_decorators__.model_validators
+    assert reference.validator_name in validators, (
+        f"{fault_id} names validator {reference.model_name}."
+        f"{reference.validator_name}, which is not a model validator on it; "
+        f"available: {sorted(validators)}"
+    )
+
+
+@pytest.mark.parametrize("fault_id", ALL_FAULT_MODE_IDS, ids=str)
+def test_every_fault_mode_names_a_test_that_exists(fault_id: FaultModeID) -> None:
+    """The proving test must be real, in the file the registry names.
+
+    Without this, ``proving_test`` would be a coverage claim with nothing
+    behind it — precisely the failure the corrective plan calls out.
+    """
+
+    fault = FAULT_MODE_REGISTRY[fault_id]
+    path_part, _, test_name = fault.proving_test.partition("::")
+    assert path_part == FAULT_MODE_TEST_FILE, (
+        f"{fault_id} points at {path_part}, not the fault-mode test module"
+    )
+    assert test_name, f"{fault_id} names no test function"
+    source = (REPOSITORY_ROOT / path_part).read_text(encoding="utf-8")
+    assert re.search(rf"^def {re.escape(test_name)}\(", source, re.MULTILINE), (
+        f"{fault_id} names {test_name}, which is not defined in {path_part}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Trial allowlists and slice boundaries
+# --------------------------------------------------------------------------
+
+
+def test_trial_source_allowlist_validates() -> None:
+    validate_trial_source_allowlist()
+
+
+def test_trial_source_allowlist_is_a_strict_subset_of_the_platform() -> None:
+    """A trial allowlist equal to the whole enum would bound nothing."""
+
+    allowlist = set(TRIAL_SOURCE_ALLOWLIST)
+    platform = set(SourceClass.__members__.values())
+    assert allowlist < platform
+    assert SourceClass.TEMPORAL_CONTEXT not in allowlist, (
+        "CHAOS-3567's TEMPORAL_CONTEXT stub is deliberately inert and must "
+        "not be reachable through this allowlist"
+    )
+
+
+def test_relationship_allowlist_validates() -> None:
+    validate_relationship_allowlist()
+
+
+def test_relationship_allowlist_is_bounded_and_oriented() -> None:
+    assert set(RELATIONSHIP_ALLOWLIST) == set(ALL_RELATIONSHIP_TYPES)
+    for relationship, orientation in RELATIONSHIP_ALLOWLIST.items():
+        assert orientation.forward_pairs, f"{relationship} permits no ordering"
+        assert orientation.canonical_reading
+
+
+def test_asymmetric_relationships_reject_the_reverse_ordering() -> None:
+    """The orientation registry is what makes 'reversed' detectable.
+
+    An allowlist whose every entry permitted both orderings would satisfy
+    every direction check trivially. This asserts at least one asymmetric
+    type genuinely refuses its reverse — the property the reversed-hop guard
+    depends on.
+    """
+
+    asymmetric = [
+        orientation
+        for orientation in RELATIONSHIP_ALLOWLIST.values()
+        if not orientation.symmetric
+    ]
+    assert asymmetric
+    proved = 0
+    for orientation in asymmetric:
+        for pair in orientation.forward_pairs:
+            if pair.source_kind == pair.target_kind:
+                continue
+            assert orientation.permits(pair.source_kind, pair.target_kind)
+            if not orientation.permits(pair.target_kind, pair.source_kind):
+                proved += 1
+    assert proved, "no asymmetric relationship actually refuses its reverse"
+
+
+def test_slice_boundaries_validate() -> None:
+    validate_slice_boundaries()
+
+
+def test_current_slice_is_not_blocked_by_the_historical_gap() -> None:
+    """CHAOS-3569 constrains history only; current intelligence proceeds.
+
+    The corrective plan forbids blocking current-intelligence discovery on
+    historical-edge modelling, and this is that rule as an assertion about
+    the declared boundaries.
+    """
+
+    current = SLICE_BOUNDARIES[AnalyticalSlice.CURRENT]
+    assert current.requires_as_of is False
+    assert current.requires_edge_validity is False
+    assert current.known_gap is None
+
+
+def test_historical_slices_declare_the_open_gap() -> None:
+    for slice_id in (AnalyticalSlice.HISTORICAL, AnalyticalSlice.CURRENT_VS_HISTORICAL):
+        boundary = SLICE_BOUNDARIES[slice_id]
+        assert boundary.requires_edge_validity is True
+        assert boundary.known_gap is not None
+        assert "CHAOS-3569" in boundary.known_gap

--- a/tests/api/dev/test_chaos_3615_schema_validator_differential.py
+++ b/tests/api/dev/test_chaos_3615_schema_validator_differential.py
@@ -1,0 +1,259 @@
+"""CHAOS-3615: what the generated JSON Schema actually catches, measured.
+
+Adversarial review round 1, finding H1. The contract has two
+implementations of the same rules — the canonical Pydantic models, and the
+Draft 2020-12 schemas generated from them — and no type checker, linter or
+code index can tell you whether they agree. Only running both over the same
+inputs can, so that is what this module does: every negative fixture goes
+through a real JSON Schema validator *and* the Python model, and the split
+is pinned.
+
+The answer is uncomfortable and is the point of writing it down. Pydantic
+emits structural constraints only (``required``/``type``/``enum``/
+``pattern``/``minItems``), so **3 of 41** arm-shaped bad packets are caught
+by the schema and **38 are not**. A consumer that schema-validates and stops
+would accept a packet that commits to the wrong subject on a fuzzy match,
+routes a path through an unauthorized entity, promotes a symptom to
+principal driver, or claims a historical comparison it never reconstructed.
+
+Two things follow, and both are enforced here rather than trusted:
+
+* the canonical validator is the Python model, and the manifest says so in
+  the artifact tree a consumer reads;
+* the exact set of schema-catchable fixtures is pinned, so a fixture
+  quietly changing category — or a schema regeneration that silently drops
+  a structural constraint — is a red test, not a discovery made later by
+  CHAOS-3616.
+
+Encoding the cross-field rules into JSON Schema by hand was rejected: the
+corrective plan requires one canonical source of truth and forbids
+hand-maintained duplicate schema definitions, and a second hand-written
+implementation of these validators would be exactly the divergence this
+module exists to detect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+from pydantic import ValidationError
+
+from dev_health_ops.api.dev.investigation_contract import (
+    INVESTIGATION_CONTRACT_MODELS,
+)
+from dev_health_ops.api.dev.investigation_contract.export import ARTIFACT_ROOT
+from dev_health_ops.api.dev.investigation_contract.fixtures import (
+    negative_fixtures,
+    positive_fixtures,
+    positive_variant_fixtures,
+)
+
+#: The only negative fixtures the emitted JSON Schema is able to reject, and
+#: the structural keyword that does it. Everything else in
+#: ``examples/negative`` is semantic and reaches the wire unchallenged
+#: without the canonical validator.
+SCHEMA_CATCHABLE: dict[str, str] = {
+    "ask_dev_subject_discovery.v1::absent_truncation_disclosure_field": "required",
+    "ask_dev_investigation_versions.v1::no_source_contract_versions": "minItems",
+    "ask_dev_evidence_coverage.v1::graph_native_field_smuggled_as_extra": (
+        "additionalProperties"
+    ),
+}
+
+
+def _schema(contract: str) -> dict[str, Any]:
+    path = ARTIFACT_ROOT / "schemas" / f"{contract}.schema.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _schema_rejects(contract: str, payload: dict[str, Any]) -> bool:
+    try:
+        jsonschema.validate(payload, _schema(contract))
+    except jsonschema.ValidationError:
+        return True
+    return False
+
+
+def _model_rejects(contract: str, payload: dict[str, Any]) -> bool:
+    try:
+        INVESTIGATION_CONTRACT_MODELS[contract].model_validate(payload)
+    except ValidationError:
+        return True
+    return False
+
+
+def _all_negative_cases() -> list[tuple[str, str, dict[str, Any]]]:
+    return [
+        (contract, label, payload)
+        for contract, cases in sorted(negative_fixtures().items())
+        for label, payload in cases
+    ]
+
+
+def test_every_negative_fixture_is_caught_by_the_canonical_validator() -> None:
+    """The floor. A fixture caught by neither would be a hole in both."""
+
+    escaped = [
+        f"{contract}::{label}"
+        for contract, label, payload in _all_negative_cases()
+        if not _model_rejects(contract, payload)
+    ]
+    assert not escaped, f"negative fixtures no validator rejects: {escaped}"
+
+
+def test_the_schema_catchable_set_is_exactly_as_pinned() -> None:
+    """Measured by execution, not asserted from the shape of the schema.
+
+    A fixture moving in or out of this set means either the schema gained or
+    lost a structural constraint, or a fixture stopped exercising the
+    semantic rule it was written for. Both are worth a red test.
+    """
+
+    measured = {
+        f"{contract}::{label}"
+        for contract, label, payload in _all_negative_cases()
+        if _schema_rejects(contract, payload)
+    }
+    pinned = set(SCHEMA_CATCHABLE)
+    assert measured == pinned, (
+        "the JSON Schema's real coverage has drifted from the pinned set; "
+        f"newly caught={sorted(measured - pinned)}, "
+        f"no longer caught={sorted(pinned - measured)}"
+    )
+
+
+def test_the_schema_misses_the_overwhelming_majority_of_semantic_faults() -> None:
+    """The claim the manifest makes, restated as an assertion.
+
+    Not decoration: if a future change made the schema catch most faults,
+    the manifest's ``schema_only_validation_is_sufficient: false`` would be
+    needlessly alarming, and if it caught fewer, the gap would be wider than
+    documented. Either way the artifact tree's own statement should be
+    re-derived rather than trusted.
+    """
+
+    total = len(_all_negative_cases())
+    caught = len(SCHEMA_CATCHABLE)
+    assert total >= 20, f"only {total} negative fixtures; this ratio is not meaningful"
+    assert caught * 4 < total, (
+        f"the schema now catches {caught}/{total} negatives; if schema-only "
+        "validation has become close to sufficient, revisit the manifest's "
+        "validation_policy rather than leaving it overstated"
+    )
+
+
+@pytest.mark.parametrize(
+    ("contract", "label"),
+    sorted((key.split("::")[0], key.split("::")[1]) for key in SCHEMA_CATCHABLE),
+)
+def test_structurally_catchable_fixtures_are_caught_by_both(
+    contract: str, label: str
+) -> None:
+    """Where the two implementations agree, they must agree completely."""
+
+    payload = next(
+        fixture
+        for fixture_contract, fixture_label, fixture in _all_negative_cases()
+        if (fixture_contract, fixture_label) == (contract, label)
+        for _ in (0,)
+        for fixture in (fixture,)
+    )
+    assert _schema_rejects(contract, payload)
+    assert _model_rejects(contract, payload)
+
+
+@pytest.mark.parametrize("contract", sorted(INVESTIGATION_CONTRACT_MODELS))
+def test_positive_goldens_validate_against_the_generated_schema(
+    contract: str,
+) -> None:
+    """The agreement direction that must be total.
+
+    The two implementations may disagree about what to *reject* — that is
+    the measured gap above — but a packet the canonical validator accepts
+    must never fail its own generated schema. That would mean the schema
+    describes something the producer cannot emit, which is a real drift bug
+    rather than a known limitation.
+    """
+
+    jsonschema.validate(positive_fixtures()[contract], _schema(contract))
+
+
+def test_positive_variants_validate_against_the_generated_schema() -> None:
+    for contract, cases in positive_variant_fixtures().items():
+        for label, payload in cases:
+            try:
+                jsonschema.validate(payload, _schema(contract))
+            except jsonschema.ValidationError as error:  # pragma: no cover - failure
+                raise AssertionError(
+                    f"positive variant {contract}/{label} fails its own "
+                    f"generated schema: {error.message}"
+                ) from error
+
+
+def test_manifest_declares_the_schema_is_not_sufficient_on_its_own() -> None:
+    manifest = json.loads((ARTIFACT_ROOT / "manifest.json").read_text(encoding="utf-8"))
+    policy = manifest["validation_policy"]
+    assert policy["schema_only_validation_is_sufficient"] is False
+    assert policy["json_schema_scope"] == "structural_only"
+    assert "INVESTIGATION_CONTRACT_MODELS" in policy["canonical_validator"]
+
+
+def test_schemas_carry_no_hand_written_cross_field_rules() -> None:
+    """No duplicate semantic implementation crept into the emitted schemas.
+
+    The corrective plan forbids hand-maintained duplicate schema
+    definitions. ``anyOf`` is permitted because Pydantic emits it for
+    nullable unions; the composition keywords that would encode a *rule*
+    are not.
+    """
+
+    banned = {"allOf", "oneOf", "if", "then", "else", "dependentRequired"}
+    offenders: list[str] = []
+
+    def walk(node: object, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in banned:
+                    offenders.append(f"{path}/{key}")
+                walk(value, f"{path}/{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{path}[{index}]")
+
+    for path in sorted((ARTIFACT_ROOT / "schemas").glob("*.json")):
+        walk(json.loads(path.read_text(encoding="utf-8")), path.name)
+    assert not offenders, (
+        "generated schemas contain composition keywords, which means a "
+        f"second implementation of the rules has appeared: {offenders}"
+    )
+
+
+def test_artifact_root_exists_and_is_populated() -> None:
+    assert (ARTIFACT_ROOT / "schemas").is_dir()
+    assert len(list((ARTIFACT_ROOT / "schemas").glob("*.json"))) == len(
+        INVESTIGATION_CONTRACT_MODELS
+    )
+
+
+def test_no_negative_fixture_directory_drift() -> None:
+    """Every negative fixture on disk corresponds to a declared case."""
+
+    on_disk = {
+        path.stem for path in (ARTIFACT_ROOT / "examples" / "negative").glob("*.json")
+    }
+    declared = {f"{contract}.{label}" for contract, label, _ in _all_negative_cases()}
+    assert on_disk == declared, (
+        f"stale={sorted(on_disk - declared)}, missing={sorted(declared - on_disk)}"
+    )
+
+
+def test_repository_root_resolves(tmp_path: Path) -> None:
+    """Guards the path arithmetic this whole module depends on."""
+
+    assert ARTIFACT_ROOT.name == "v1"
+    assert ARTIFACT_ROOT.parent.name == "ask-dev-investigation"
+    assert tmp_path.exists()

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -27,6 +27,18 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 from dev_health_ops.api.dev import contracts_v2 as v2
+
+# CHAOS-3615: imported for its side effect on the class hierarchy, not for a
+# name. `_all_v2_contract_models()` discovers models by walking
+# `ContractModelV2.__subclasses__()`, which only sees the investigation-packet
+# models once their module has been imported -- and `_NON_HANDLE_IDENTIFIER_
+# REASONS` classifies 33 of their fields. Without this import the reasons
+# table names fields Python has never heard of and the closure assertion
+# `set(_NON_HANDLE_IDENTIFIER_REASONS) <= known` fails whenever this module
+# runs alone. Relying on another test module's collection to make this pass
+# was an order-dependent green: `pytest tests/api/dev/test_contracts_v2.py`
+# on its own went 1 failed, 274 passed.
+from dev_health_ops.api.dev import investigation_contract as _investigation_contract
 from dev_health_ops.api.dev.contract_fixtures import (
     TEAM_ID,
     committed_team_commit,
@@ -2204,6 +2216,10 @@ def test_round2_v1_projection_of_a_no_answer_outcome_carries_no_frame_text() -> 
 
 
 def _all_v2_contract_models() -> list[type[v2.ContractModelV2]]:
+    # Touch the investigation-contract package so its ContractModelV2
+    # subclasses are registered before the walk below, and so the import
+    # above cannot be pruned as unused.
+    assert _investigation_contract.INVESTIGATION_CONTRACT_MODELS
     found: set[type[v2.ContractModelV2]] = set()
     stack: list[type[v2.ContractModelV2]] = [v2.ContractModelV2]
     while stack:

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -1727,6 +1727,69 @@ _NON_HANDLE_IDENTIFIER_REASONS: dict[str, str] = {
     # -- same category as HealthRuleFinding.subject_id above: names a real
     # project entity.
     "DevPortfolioProjectStatusV2.project_id": "provider entity key",
+    # CHAOS-3615 ask_dev_investigation_packet.v1
+    # (api.dev.investigation_contract) -- same situation as the CHAOS-3302
+    # and CHAOS-3305 blocks above, one step further out: these models
+    # subclass ContractModelV2 (deliberately, to inherit extra="forbid" +
+    # frozen=True and the shared scalar vocabulary) so this reflection sweep
+    # reaches them, but they are NOT part of the no-answer-projection model
+    # space at all. The packet is an internal trial artifact with its own
+    # registry (INVESTIGATION_CONTRACT_MODELS) and its own artifact root
+    # (contracts/ask-dev-investigation/v1); it is never registered in
+    # CONTRACT_MODELS_V2, never served to a client, and unreachable from a
+    # DevAnswerV2 in any outcome -- asserted by
+    # test_chaos_3615_investigation_contract.py::
+    # test_artifact_root_is_not_the_client_served_tree.
+    #
+    # Canonical entity keys: name real platform records (projects, teams,
+    # services, dependencies, repositories), the same category as
+    # DevEntityRefV2.entity_id above.
+    "AskDevInvestigationPacket.organization_id": "provider entity key",
+    "CohortExclusion.canonical_id": "provider entity key",
+    "CohortMember.canonical_id": "provider entity key",
+    "DriverCandidate.affected_subject_ids": "provider entity key",
+    "InvestigationEvidenceEntry.supports_entity_ids": "provider entity key",
+    "InvestigationEvidenceEntry.supports_subject_ids": "provider entity key",
+    "LineageHop.source_entity_id": "provider entity key",
+    "LineageHop.target_entity_id": "provider entity key",
+    "LineagePath.origin_entity_id": "provider entity key",
+    "LineagePath.terminal_entity_id": "provider entity key",
+    "RelatedContext.authorized_entity_ids": "provider entity key",
+    "RelatedEntity.entity_id": "provider entity key",
+    "SubjectCandidate.canonical_id": "provider entity key",
+    "SubjectDiscovery.committed_subject_ids": "provider entity key",
+    "SurfaceContextRef.entity_id": "provider entity key",
+    # Intra-document reference keys: scoped to one packet, meaningless
+    # outside it. Each is cross-checked against the packet's own declared
+    # material by AskDevInvestigationPacket.validate_evidence_closure /
+    # .validate_drivers_reference_declared_material, so a dangling one is a
+    # validation error rather than a free-text cell.
+    "AnalyticalJob.job_id": "intra-document key",
+    "ClarificationNeed.candidate_ids": "intra-document key",
+    "ComparisonCohort.cohort_id": "intra-document key",
+    "DriverAnalysis.principal_driver_ids": "intra-document key",
+    "DriverCandidate.driver_id": "intra-document key",
+    "DriverCandidate.supporting_path_ids": "intra-document key",
+    "InvestigationEvidenceEntry.supports_driver_ids": "intra-document key",
+    "InvestigationEvidenceEntry.supports_path_ids": "intra-document key",
+    "LineagePath.path_id": "intra-document key",
+    "RelatedEntity.supporting_path_ids": "intra-document key",
+    "SourceConflict.conflict_id": "intra-document key",
+    "SubjectCandidate.candidate_id": "intra-document key",
+    "UnresolvedMention.candidate_ids": "intra-document key",
+    "UnresolvedMention.mention_id": "intra-document key",
+    # Server-owned surface and conversation correlation keys, supplied by the
+    # Ask Dev request path rather than by the investigation.
+    "AnalyticalJob.conversation_reference_ids": "server-owned correlation key",
+    "SurfaceContextRef.surface_id": "server-owned correlation key",
+    # Evaluation-only. TrialMetadata is an optional field of
+    # InvestigationVersions and exists so arm identity is trial metadata
+    # rather than product truth; it is never populated on a product path.
+    "TrialMetadata.arm_id": "trial evaluation metadata",
+    # Registry entry, not a wire document: QuestionVariant instances live in
+    # the frozen question-family registry, whose ids are asserted globally
+    # unique by test_chaos_3615_registries.py.
+    "QuestionVariant.variant_id": "registry token",
 }
 
 


### PR DESCRIPTION
CHAOS-3615 freezes one bounded, backend-neutral investigation contract and the
evaluation framework around it, **before** either arm of the corrected
CHAOS-3614 trial exists. That ordering is the whole point: if the contract is
written after the arms, whichever arm lands first defines the questions, the
output shape and the definition of success, and the comparison is decided
before it is run.

**Contracts only. No arm implementation, no trial, no user-visible change.**

## Deliverables

| # | Deliverable | Where |
| --- | --- | --- |
| 1 | Backend-neutral versioned packet contract | `src/dev_health_ops/api/dev/investigation_contract/packet.py` — `ask_dev_investigation_packet.v1` + 7 section contracts |
| 2 | Canonical JSON Schema + source representation | `contracts/ask-dev-investigation/v1/schemas/` (8), generated by `investigation_contract/export.py` |
| 3 | Golden positive fixtures | 8 goldens + 5 anti-drift positive variants |
| 4 | Negative mutation fixtures | 41 arm-shaped negatives, exporter-enforced |
| 5 | Generated/verified consumer types | Python only today; the vendoring path for a future Go/TS consumer is documented rather than shipped unused (see ownership map) |
| 6 | Contract parity and drift tests | `check_artifacts()` compares the whole artifact set; sha256 per file in `manifest.json`; plus a schema-vs-validator differential oracle |
| 7 | Question-family registry | `question_families.py` — 10 families, exact + natural variants |
| 8 | Scoring/invariant registry | `scoring.py` — 28 dimensions, no aggregate score |
| 9 | Trial source + relationship allowlists | `allowlists.py` (16 sources, each justified), `relationships.py` (12 oriented types) |
| 10 | Current-vs-historical slice boundaries | `allowlists.py::SLICE_BOUNDARIES` |
| 11 | Cross-repository ownership map | `docs/contribute/architecture/ask-dev-investigation-packet.md` |
| 12 | Fault-mode tests for every validator | `tests/api/dev/test_chaos_3615_fault_modes.py` + `scripts/verify_chaos_3615_fault_mode_guards.py` |
| 13 | Documentation of the contract and how arms use it | same architecture page |
| 14 | Linear update | owned by the orchestrator |
| 15 | No arm implementation | scope proof below |

## Why the negative fixtures are the interesting part

A golden-response test is explicitly not sufficient here, so each of the
eleven named fault shapes gets an **arm-shaped bad packet** — a payload an
implementation could plausibly emit, differing from the golden only in the
behaviour under test — and a test asserting both that it is rejected and that
the message came from the *named* guard.

That still would not prove the guard is load-bearing: a payload can be caught
incidentally by an unrelated field constraint while the real guard is missing,
and the test stays green. `scripts/verify_chaos_3615_fault_mode_guards.py`
inverts the experiment — it removes exactly one guard (deletes a
`model_validator` and rebuilds the schemas, or gives the disclosure field the
default it does not have) and requires the bad packet to then be **accepted**.

```
GUARD PROOF PASSED: 11/11 named guards observed failing
```

It is wired into the suite as a test and hard-fails if any registered fault
mode has no injection case, so a fault mode cannot be added as an unmeasured
coverage claim.

## Anti-drift rules are positive fixtures, not prose

Each rule that could be "enforced" by making the legitimate case impossible
has a golden variant that must validate:

- **discovery without commitment** — zero committed subjects, full lineage and
  driver sections. Exact subject commitment is not a prerequisite.
- **not-comparable historical slice** — CHAOS-3569-gapped edges, declared
  `not_comparable_missing_edge_validity`, limitation disclosed, and still
  `supported`. NOT COMPARABLE, not a blocker.
- **qualified capacity without a denominator** — `denominator_absent` at
  `qualified` confidence. Missing staffing data reduces confidence; it never
  makes the question unsupported.
- **needs-clarification with widening** — the one legal organization-wide
  shape: when the packet is asking, not answering.
- **trial metadata present** — arm identity added and *nothing else changes*,
  asserted by diffing the variant against the golden.

Person-level ranking is banned structurally rather than by validator:
`InvestigationSubjectKind` has no person member and `ComparisonDimension` has
no per-person axis, checked in the source and again in the generated schemas.


## Adversarial review round 1 — 8 findings, all reproduced, all closed

Codex (`gpt-5.6-luna -e xhigh`) returned 4 high and 4 medium. **Every one was
reproduced against the shipped contract before any fix**, via a repro harness
that fed each exploit to the real validator. **7 of the 8 were live exploits:
a packet the contract ACCEPTED and should have refused.** None was refuted.

Two first-pass detectors of mine printed REFUTED for H1 and M8; both were
**detector bugs** (a substring search matching `not` inside `annotation`, and
one matching a docstring mention). Corrected and confirmed by execution before
either was touched.

| # | Sev | Repro against the shipped contract | Fix |
| --- | --- | --- | --- |
| H1 | high | Real `jsonschema` run: **38 of 41 negatives PASS the generated schema** while Python rejects them | Not by hand-writing rules into JSON Schema — that is the duplicate schema definition the plan forbids. `manifest.json` gains a `validation_policy` (canonical validator named; `schema_only_validation_is_sufficient: false`), and a differential-oracle module runs **both** implementations over every fixture and pins the exact 3-of-41 split |
| H2 | high | Cohort member, indexed-evidence entity and subject candidate each set outside `authorized_entity_ids` → all three ACCEPTED | `validate_every_entity_is_authorized` now covers subjects, cohort, exclusions, driver affected subjects, evidence and surface refs |
| H3 | high | `temporal_context` (CHAOS-3567's inert stub) claimed as coverage → ACCEPTED | `validate_sources_are_allowlisted` |
| H4 | high | Family flipped to `struggling_teams` while keeping `singular_subject` → ACCEPTED | Binds permitted shape, required sources and required sections. Required sources are satisfied by being observed **or** declared missing — an arm must disclose a gap, never fabricate coverage |
| M5 | med | Auth Gateway citing `path_ownership`, which terminates at the team → ACCEPTED | Existence is not attachment: a cited path must reach the entity |
| M6 | med | `work_graph` reported `available_current` **and** `unavailable` → ACCEPTED | The two lists must be disjoint |
| M7 | med | `historical` + `comparable` with no edge-validity concept in the contract → ACCEPTED | New `EdgeValidityBasis`; `COMPARABLE` requires `observed_intervals`, `unavailable` forces the CHAOS-3569 state. A delta computed off the live projection is fabricated |
| M8 | med | Guard script imported `ALL_FAULT_MODE_IDS` only — a renamed validator would leave `GUARD PROOF PASSED` on a stale mapping | `_cross_check_against_registry()` |

Shipped with the fixes: **10 new negative fixtures** (one per closed hole) and
**3 new positive controls**, so no fix bans the legitimate case — a genuinely
reconstructed history can still be `comparable`, a required source can still
be declared missing, and a symptom is still a reportable candidate.

## Verification

```
bash ci/local_validate.sh
   ✔  lint: ruff format --check
   ✔  lint: ruff check
   ✔  typecheck: mypy                       (whole tree, literal `mypy .`)
   ✔  ch-scratch-create (ci_local_validate_38153a8f9d1f)
   ✔  ch-migrate (upgrade + status --check)
   ✔  unit suite (FULL, not subset)         13545 passed, 245 skipped, 1 xfailed in 160.21s
   ✔  argMax live-exec proof (real engine)
   ✔  declared-state-history live tests (real engine)   13 passed
   ✔  migration 075 reconcile live tests (real engine)   2 passed

GATE PASSED. safe to push.
```

Focused runs:

| Command | Result |
| --- | --- |
| `pytest tests/api/dev/test_chaos_3615_fault_modes.py` | 50 passed |
| `pytest tests/api/dev/test_chaos_3615_registries.py` | 80 passed |
| `pytest tests/api/dev/test_chaos_3615_investigation_contract.py` | 18 passed |
| `pytest tests/api/dev/test_chaos_3615_schema_validator_differential.py` | 20 passed |
| `pytest tests/docs` | 113 passed (nav + IA row wired) |
| `python scripts/verify_chaos_3615_fault_mode_guards.py` | 11/11 guards observed failing |
| `python -m dev_health_ops.api.dev.investigation_contract.export check` | 58 artifacts verified |

**RED-first evidence.** All ten named validators short-circuited with
`return self`, fault-mode module re-run:

```
21 failed, 18 passed
FAILED ...::test_commitment_on_fuzzy_label_alone_is_rejected
FAILED ...::test_organization_widening_after_unresolved_mention_is_rejected
FAILED ...::test_evidence_that_supports_nothing_is_rejected
FAILED ...::test_symptom_promoted_to_principal_driver_is_rejected
FAILED ...::test_certain_staffing_claim_without_denominator_is_rejected
FAILED ...::test_cohort_member_without_inclusion_evidence_is_rejected
FAILED ...::test_reversed_relationship_direction_is_rejected
FAILED ...::test_path_through_unauthorized_entity_is_rejected
FAILED ...::test_supported_outcome_without_any_asserted_driver_is_rejected
FAILED ...::test_cohort_claiming_comparison_without_dimensions_is_rejected
FAILED ...::test_no_match_without_limitation_or_clarification_is_rejected
(+ 10 more, incl. the per-contract negative-fixture sweep)
```

Restored → 39 passed, verified by re-running the suite rather than by a `git`
check.

## What this contract cannot check

Stated in the validator docstrings, the fault-mode registry and the
architecture page, because an inaccurate coverage claim is worse than an
admitted gap:

0. **The generated JSON Schema is structural only** — measured at 3 of 41
   negatives caught. The canonical validator is the Python model, and the
   manifest says so in the artifact tree itself.
1. `authorized_entity_ids` is producer-declared — the guard proves the packet
   is internally consistent with its own claim, not that the claim is true.
   CHAOS-3616 must also score `ZERO_UNAUTHORIZED_RESULTS` against a real
   authorization oracle.
2. Evidence closure is closure *within* the packet; whether a handle verifies
   against `EvidenceHandleService` is a runtime, org-scoped question.
3. Relevance is not correctness — hence `contract_validator` vs
   `oracle_judgment` on every fault mode.

## Scope proof

- No Graphiti (or any graph backend) implementation, client or dependency.
- No native comparison arm; no trial run, corpus or oracle.
- No user-visible Ask Dev behaviour changed — nothing imports this package yet.
- No structured data converted to prose; the contract carries structured
  fields end to end.
- Wire contract is backend-neutral, asserted against the generated artifacts.
- No downstream issue self-authorized (CHAOS-3616…3621 untouched).
- `trials/chaos_3499/` untouched. `contracts/ask-dev/v1` and `.../v2` untouched
  — a test asserts the two registries do not overlap.
- No existing test weakened, and exactly **four** pre-existing files are
  touched — everything else in the diff is new:
  - `mkdocs.yml` and `docs-data/ia/contribute.tsv` — one added line each, both
    required by the docs gate (a page in neither is a gate failure).
  - `pyproject.toml` — `jsonschema` + `types-jsonschema` in the **dev** extra
    only, for the differential oracle. No `src/` module imports either, so the
    exporter stays runnable without dev extras. The stub is declared rather
    than left to `mypy --install-types`, which auto-installs during the gate
    and then blocks the pre-commit hook's plain `mypy`.
  - `uv.lock` — deliberately **not** regenerated for the dev-extra addition.
    The ops dependency model is pip + `pyproject.toml`, and no CI job or gate
    stage resolves with `--locked`/`--frozen` (grep confirms the only frozen
    lockfile in the repo is a pnpm one in a web workflow). Regenerating it
    here would add a 300 KB diff that nothing verifies.
  - `tests/api/dev/test_contracts_v2.py` —
    `test_round4_every_v2_identifier_is_classified` walks every
    `ContractModelV2` subclass via `__subclasses__()`, so the new models are
    swept the moment both modules are collected in one process. It failed the
    full gate with 33 unclassified identifiers while every targeted run was
    green — the order-dependent failure AGENTS.md warns a per-file run hides.
    Extending the classification table is that guard's designed extension
    point ("a new identifier field fails here until it is … named above with
    a reason") and is what CHAOS-3302, CHAOS-3305 and CHAOS-3393 each did. **No
    assertion, threshold or exemption was loosened** — 33 rows added, with
    reasons, in four categories. Independent fix-verify then caught the
    other half of that guard: those 33 rows name models that only exist once
    `investigation_contract` is imported, so `pytest
    tests/api/dev/test_contracts_v2.py` **alone** went `1 failed, 274 passed`
    on the closure assertion while the full suite was green — an
    order-dependent green riding on another module's collection. Fixed with
    an explicit import; standalone is now `275 passed`.

## Deviation from the brief, flagged before implementing

The brief asked for `design/CHAOS-3615-…md`. Commit `4749f4490` ("move design
doc off design/") **deleted** `design/CHAOS-3567-…md` under the ruling
"decisions go to a Linear project doc, repo docs are for architecture", and no
`design/` tree exists on this branch. Deliverables 11 and 13 are a contract
explanation and an ownership map — architecture, not a decision record — so
they live at `docs/contribute/architecture/ask-dev-investigation-packet.md`
beside the existing `ask-dev-contracts-v2` page. Raised with the orchestrator
with this evidence before the doc was written.
