### PR TITLE
CHAOS-3628 + 3629 + 3630: the graph arm stops asserting constants

### DIFF
--- a/docs/contribute/architecture/ask-dev-graph-safety-proof.md
+++ b/docs/contribute/architecture/ask-dev-graph-safety-proof.md
@@ -25,7 +25,7 @@ observable. This page records what was proved, on what, and what could not
 be proved. Its headline is not a pass.
 {: .fc-page-lede }
 
-**The hard gate is not green.** 15 of 44 CHAOS-3620 requirements are not proven (4 defect, 1 not_accepted, 10 unmeasured).
+**The hard gate is not green.** 12 of 44 CHAOS-3620 requirements are not proven (1 defect, 1 not_accepted, 10 unmeasured).
 
 That sentence is **generated from the ledger**, not written beside it — the
 one place gate status is stated, so a correct table under a wrong headline is
@@ -82,8 +82,8 @@ Linear blocker.
 
 | Status | Count | Meaning |
 | --- | --- | --- |
-| `proven` | 29 | Holds, and the named tests are what establish it. |
-| `defect` | 4 | Violated by merged code; the named tests pin current behaviour. |
+| `proven` | 32 | Holds, and the named tests are what establish it. |
+| `defect` | 1 | Violated by merged code; the named tests pin current behaviour. |
 | `not_accepted` | 1 | Blocked on another issue; never scored as a pass. |
 | `unmeasured` | 10 | Not measured, with a stated reason rather than a proxy. |
 
@@ -159,9 +159,6 @@ caught it.
 | ID | Requirement | What is wrong |
 | --- | --- | --- |
 | X1 | prompt injection must not reach a consumer | Source-controlled **titles** arrive verbatim. The adapter copies an evidence record's `display_label` onto the observation (`corpus_adapter.py:210`), the emitter copies the title onto the packet's evidence entry (`packet_builder.py:829`), and nothing inspects title text. Document *bodies* are contained; titles are not, and the packet feeds Ask Dev synthesis. |
-| P6 | withdrawn sources disappear from packets | REVOKED and DELETED evidence reaches the emitted packet. Nothing in `context_fabric` reads evidence state; the adapter carries it as a display attribute (`corpus_adapter.py:218`) and no branch reads it back. |
-| P1 | every driver **or relationship** closes to evidence | Drivers close, and the check is shown rejecting an arm-shaped bad response. Relationships never close: `_lineage_path` emits `evidence_ref_ids=()` as a literal (`packet_builder.py:632`). |
-| S5 | current versus historical stays explicit | A relationship that ended two months before the trial instant is emitted with `relevance = current`. `relevance` is a literal at eight sites in `packet_builder.py` (542, 618, 630, 751, 799, 868, 935, 982) and nothing computes it. |
 
 **P6 was masked by A9.** The check that would have caught withdrawn evidence
 is the oracle's `withdrawn_evidence_handles`

--- a/docs/contribute/architecture/graph-investigation-arm.md
+++ b/docs/contribute/architecture/graph-investigation-arm.md
@@ -454,7 +454,7 @@ and one test in it always runs and records what the environment offered.
 uv run python scripts/chaos_3617_guard_injection.py
 ```
 
-For each of the **87** guards the arm relies on, the harness disables
+For each of the **90** guards the arm relies on, the harness disables
 **that guard alone** by
 an exact source substitution, runs the tests that claim to cover it, requires
 them to FAIL, restores, and requires them to PASS again. Three rules it

--- a/docs/contribute/architecture/graph-investigation-arm.md
+++ b/docs/contribute/architecture/graph-investigation-arm.md
@@ -454,7 +454,7 @@ and one test in it always runs and records what the environment offered.
 uv run python scripts/chaos_3617_guard_injection.py
 ```
 
-For each of the **90** guards the arm relies on, the harness disables
+For each of the **93** guards the arm relies on, the harness disables
 **that guard alone** by
 an exact source substitution, runs the tests that claim to cover it, requires
 them to FAIL, restores, and requires them to PASS again. Three rules it

--- a/scripts/chaos_3617_guard_injection.py
+++ b/scripts/chaos_3617_guard_injection.py
@@ -512,10 +512,8 @@ MUTATIONS: tuple[Mutation, ...] = (
         ),
         path=SRC / "packet_builder.py",
         anchor=(
-            "        elif all(\n"
-            "            item in evidence_free_paths for item in "
-            "driver.supporting_path_ids\n"
-            "        ):"
+            "        elif all(item in evidence_free_paths for item in "
+            "driver.supporting_path_ids):"
         ),
         replacement="        elif False:",
         tests=(

--- a/scripts/chaos_3617_guard_injection.py
+++ b/scripts/chaos_3617_guard_injection.py
@@ -409,6 +409,62 @@ MUTATIONS: tuple[Mutation, ...] = (
         ),
         expect_failure="DID NOT RAISE",
     ),
+    # ---- CHAOS-3628: withdrawn evidence never reaches a packet ------------
+    Mutation(
+        mutation_id="withdrawn-evidence-presented-as-live-support",
+        defect=(
+            "revoked, redacted and deleted source records are returned by the "
+            "traversal and cited as live support. This was the arm's state "
+            "for its whole existence -- it had no evidence-state concept at "
+            "all -- and the CHAOS-3620 lane measured it on five corpus seeds"
+        ),
+        path=SRC / "readback.py",
+        anchor="        if not _is_citable(observation):",
+        replacement="        if False:",
+        tests=(
+            f"{TESTS}/test_chaos_3628_evidence_state.py::"
+            "TestWithdrawnEvidenceIsPresentInTheWorldAndAbsentFromThePacket",
+        ),
+        # The oracle's own words for the record, so the recorded RED line
+        # evidences the withdrawal rather than merely a red suite.
+        expect_failure="handles-withdrawn=",
+    ),
+    Mutation(
+        mutation_id="unreadable-evidence-state-reads-as-citable",
+        defect=(
+            "a state token the arm cannot read is ingested and then treated "
+            "as citable, so a record withdrawn under a vocabulary this "
+            "revision does not know is presented as live support -- the "
+            "stripped-attribute promotion, in the direction that "
+            "manufactures support"
+        ),
+        path=SRC / "projection.py",
+        anchor="    if state is not None and state not in _SOURCE_EVIDENCE_STATES:",
+        replacement="    if False:",
+        tests=(
+            f"{TESTS}/test_chaos_3628_evidence_state.py::"
+            "TestAnUnreadableStateIsRefused",
+        ),
+        expect_failure="DID NOT RAISE",
+    ),
+    Mutation(
+        mutation_id="issued-handle-accepted-with-no-evidence-state",
+        defect=(
+            "a source that issues handles loses its state attribute in "
+            "transit and the arm infers the record was never withdrawn. This "
+            "is the guard that makes readback's absent-state-is-citable "
+            "default safe; without it that default is the whole defect again, "
+            "reachable by data rather than by code"
+        ),
+        path=SRC / "projection.py",
+        anchor="    if handle is not None and state is None:",
+        replacement="    if False:",
+        tests=(
+            f"{TESTS}/test_chaos_3628_evidence_state.py::"
+            "TestAnIssuedHandleMustDeclareItsState",
+        ),
+        expect_failure="DID NOT RAISE",
+    ),
     Mutation(
         mutation_id="observation-subjects-narrowed-instead-of-refused",
         defect=(

--- a/scripts/chaos_3617_guard_injection.py
+++ b/scripts/chaos_3617_guard_injection.py
@@ -465,6 +465,65 @@ MUTATIONS: tuple[Mutation, ...] = (
         ),
         expect_failure="DID NOT RAISE",
     ),
+    # ---- CHAOS-3629 / CHAOS-3630: the lineage emitter stops declaring ----
+    Mutation(
+        mutation_id="relevance-hardcoded-current-again",
+        defect=(
+            "an expired relationship is emitted as a live one. The corpus "
+            "plants dep_pulse_ratelimitd closed two months before TRIAL_NOW "
+            "for exactly this, PathStep.is_current_at already returns False "
+            "for it, and the emitter used to discard that and declare CURRENT "
+            "at all eight construction sites -- so CHAOS-3619's "
+            "current_relevance dimension was scoring a constant"
+        ),
+        path=SRC / "packet_builder.py",
+        anchor="    if step.is_current_at(as_of):",
+        replacement="    if True:",
+        tests=(
+            f"{TESTS}/test_chaos_3629_3630_lineage_honesty.py::"
+            "TestRelevanceIsDerivedNotDeclared",
+        ),
+        expect_failure="RelevanceState.HISTORICAL_ONLY",
+    ),
+    Mutation(
+        mutation_id="path-evidence-dropped-again",
+        defect=(
+            "lineage paths stop carrying the evidence their own edges name, "
+            "so no relationship in any packet closes to evidence while every "
+            "driver does -- half the provenance claim, silently absent, which "
+            "is what a constant field looks like from outside"
+        ),
+        path=SRC / "packet_builder.py",
+        anchor="            if handle is not None and handle not in evidence:",
+        replacement="            if False:",
+        tests=(
+            f"{TESTS}/test_chaos_3629_3630_lineage_honesty.py::"
+            "TestLineagePathsCloseToEvidence",
+        ),
+        expect_failure="no path cites evidence",
+    ),
+    Mutation(
+        mutation_id="driver-rests-on-a-path-that-cites-nothing",
+        defect=(
+            "an asserted driver leans on lineage that closes to no evidence "
+            "at all, so the mechanism it names rests on the arm's assertion "
+            "alone. Driver-closure was enforced and relationship-closure was "
+            "not, because the field it would have checked was a literal"
+        ),
+        path=SRC / "packet_builder.py",
+        anchor=(
+            "        elif all(\n"
+            "            item in evidence_free_paths for item in "
+            "driver.supporting_path_ids\n"
+            "        ):"
+        ),
+        replacement="        elif False:",
+        tests=(
+            f"{TESTS}/test_chaos_3629_3630_lineage_honesty.py::"
+            "TestRelationshipClosureIsEnforcedLikeDriverClosure",
+        ),
+        expect_failure="DID NOT RAISE",
+    ),
     Mutation(
         mutation_id="observation-subjects-narrowed-instead-of-refused",
         defect=(

--- a/scripts/chaos_3620_guard_injection.py
+++ b/scripts/chaos_3620_guard_injection.py
@@ -241,7 +241,7 @@ MUTATIONS: tuple[Mutation, ...] = (
         anchor="    if not _currency(paths, context.as_of):",
         replacement="    if False:",
         tests=(
-            f"{_PROVENANCE}::TestHistoricalRelationshipsAreEmittedAsCurrent::"
+            f"{_PROVENANCE}::TestHistoricalRelationshipsAreEmittedAsHistorical::"
             "test_the_driver_layer_correctly_refuses_to_assert_on_it",
         ),
         expect_failure="a driver was asserted on a relationship that ended",

--- a/src/dev_health_ops/context_fabric/graph_arm/corpus_adapter.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/corpus_adapter.py
@@ -64,6 +64,7 @@ from .vocabulary import (
     SOURCE_EVIDENCE_ENTITY_ATTRIBUTE,
     SOURCE_EVIDENCE_HANDLE_ATTRIBUTE,
     SOURCE_EVIDENCE_ID_ATTRIBUTE,
+    SOURCE_EVIDENCE_STATE_ATTRIBUTE,
     AliasKind,
     GraphEntityKind,
     GraphObservationKind,
@@ -250,6 +251,12 @@ def corpus_batch(tenant_id: str) -> IngestionBatch:
                     SOURCE_EVIDENCE_HANDLE_ATTRIBUTE: evidence.handle,
                     SOURCE_EVIDENCE_ID_ATTRIBUTE: slug,
                     SOURCE_EVIDENCE_ENTITY_ATTRIBUTE: evidence.entity_id,
+                    # CHAOS-3628. Carried as state, not as prose. ``outcome``
+                    # above already held ``str(evidence.state)`` and nothing
+                    # read it -- a display string is not a concept, which is
+                    # how revoked and deleted records were cited as live
+                    # support for as long as this adapter has existed.
+                    SOURCE_EVIDENCE_STATE_ATTRIBUTE: str(evidence.state),
                 },
             )
         )
@@ -304,6 +311,11 @@ def corpus_batch(tenant_id: str) -> IngestionBatch:
             # measurement's subject while carrying the record's handle is the
             # mis-attribution both reviewers measured.
             SOURCE_EVIDENCE_ENTITY_ATTRIBUTE: backing.entity_id,
+            # The state of the RECORD, not of the number. A measurement whose
+            # backing record was revoked is a number with withdrawn support,
+            # and citing it would present the withdrawal as though it had not
+            # happened -- through a field the packet never shows.
+            SOURCE_EVIDENCE_STATE_ATTRIBUTE: str(backing.state),
         }
         if measurement.cohort_median is not None:
             measured["measurement_cohort_median"] = measurement.cohort_median

--- a/src/dev_health_ops/context_fabric/graph_arm/fixtures.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/fixtures.py
@@ -40,9 +40,11 @@ from .vocabulary import (
     SOURCE_EVIDENCE_ENTITY_ATTRIBUTE,
     SOURCE_EVIDENCE_HANDLE_ATTRIBUTE,
     SOURCE_EVIDENCE_ID_ATTRIBUTE,
+    SOURCE_EVIDENCE_STATE_ATTRIBUTE,
     AliasKind,
     GraphEntityKind,
     GraphObservationKind,
+    SourceEvidenceState,
 )
 
 __all__ = [
@@ -114,6 +116,14 @@ def _issued(
                 SOURCE_EVIDENCE_ENTITY_ATTRIBUTE: (
                     observation.subjects[0].canonical_id
                 ),
+                # CHAOS-3628. This world holds no withdrawn records, so every
+                # one of them is ACTIVE -- stated rather than omitted, because
+                # a source that issues handles is a source that models record
+                # state, and the projection refuses the pair without it. An
+                # omitted state would have to default, and the only available
+                # default is "citable", which is the direction that
+                # manufactures support.
+                SOURCE_EVIDENCE_STATE_ATTRIBUTE: str(SourceEvidenceState.ACTIVE),
             },
         )
         for observation in observations

--- a/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
@@ -113,6 +113,7 @@ from .readback import (
     DiscoveredObservation,
     DiscoveredPath,
     InvestigationReadout,
+    PathStep,
 )
 from .vocabulary import (
     SOURCE_EVIDENCE_ENTITY_ATTRIBUTE,
@@ -157,6 +158,11 @@ _SOURCE_CONTRACT_VERSION = "graph_arm_source_read.v1"
 #: Mirrored here rather than caught as a pydantic error, so exceeding it is a
 #: disclosed cap instead of a crash at emission time.
 _MAX_PATH_CITATIONS = 10
+
+#: ``LineagePath.evidence_ref_ids`` is bounded at 25 by the frozen contract.
+#: Held here so the emitter stays inside it rather than discovering the bound
+#: as a validation error on a dense path.
+_MAX_PATH_EVIDENCE = 25
 
 
 #: The cohort-bearing shapes this arm revision can actually construct.
@@ -408,7 +414,7 @@ def _check_match_mechanisms(
 def _assert_support_is_closed(
     drivers: Sequence[DriverCandidate],
     evidence: Sequence[InvestigationEvidenceEntry],
-    known_paths: Container[str],
+    paths: Sequence[LineagePath],
     about: Mapping[str, frozenset[str]],
 ) -> None:
     """Every asserted driver's support must be its OWN, and in this packet.
@@ -431,10 +437,24 @@ def _assert_support_is_closed(
       because "every asserted finding is path-born" is the property the
       whole graph claim rests on. Enforcing it only inside
       ``discover_drivers`` left the packet boundary open, which is exactly
-      where a caller-assembled driver arrives.
+      where a caller-assembled driver arrives;
+    * CHAOS-3630: every path the driver cites must itself close to evidence.
+      Until that ticket, ``LineagePath.evidence_ref_ids`` was the literal
+      ``()``, so relationship-closure could not be checked at all -- drivers
+      closed to evidence and the relationships they rested on did not, which
+      is half of the provenance claim missing while the other half was
+      enforced. A path with no evidence explains the mechanism only in the
+      sense that the arm asserts it.
+
+    Paths with no evidence are perfectly legitimate in general -- roughly half
+    the corpus's edges carry no evidence slugs -- which is why this is scoped
+    to paths an ASSERTED driver leans on. A path nobody builds a judgment from
+    owes nobody a citation.
     """
 
     by_handle = {entry.evidence.evidence_ref_id: entry for entry in evidence}
+    known_paths = {path.path_id for path in paths}
+    evidence_free_paths = {path.path_id for path in paths if not path.evidence_ref_ids}
     for driver in drivers:
         if driver.standing not in ASSERTED_DRIVER_STANDINGS:
             continue
@@ -451,6 +471,11 @@ def _assert_support_is_closed(
             problems.append("cites no lineage path")
         elif any(item not in known_paths for item in driver.supporting_path_ids):
             problems.append("cites a path this packet never declared")
+        elif all(item in evidence_free_paths for item in driver.supporting_path_ids):
+            problems.append(
+                "cites only lineage paths that close to no evidence, so the "
+                "mechanism it names rests on the arm's assertion alone"
+            )
         if not driver.supporting_evidence_ids:
             problems.append("cites no evidence")
         else:
@@ -520,6 +545,7 @@ def _driver_candidate(
     handle_by_observation: Mapping[str, str],
     known_subject_ids: Container[str],
     filtered_ids: Container[str],
+    path_relevance: Mapping[str, RelevanceState],
 ) -> DriverCandidate:
     """One structural finding, as the frozen contract's driver candidate.
 
@@ -593,7 +619,18 @@ def _driver_candidate(
         supporting_evidence_ids=supporting[:25],
         conflicting_evidence_ids=conflicting[:25],
         conflict_note=finding.conflict_detail if conflicting else None,
-        relevance=RelevanceState.CURRENT,
+        # A driver is as current as the best route that explains it. Derived
+        # rather than declared (CHAOS-3629): a driver whose every supporting
+        # path closed months ago is a historical cause, and the contract's
+        # own CURRENTLY_RELEVANT_STATES is what stops such a thing being
+        # reported as the principal current driver.
+        relevance=_strongest(
+            [
+                path_relevance[path_id]
+                for path_id in finding.path_ids
+                if path_id in path_relevance
+            ]
+        ),
         exclusion_reason=finding.exclusion_reason,
     )
 
@@ -789,10 +826,97 @@ def _cohort_subject_kind(
     return subject_kind
 
 
+#: Relevance from best to worst, for the two directions this module reduces
+#: over. ``UNKNOWN`` is deliberately absent: it is not a rung on this ladder
+#: but the answer when there is no ladder to stand on, and folding it in would
+#: make "we could not tell" comparable with "we could, and it is historical".
+_RELEVANCE_ORDER: tuple[RelevanceState, ...] = (
+    RelevanceState.CURRENT,
+    RelevanceState.RECENTLY_CURRENT,
+    RelevanceState.HISTORICAL_ONLY,
+)
+
+
+def _step_relevance(
+    step: PathStep, as_of: datetime, window_start: datetime
+) -> RelevanceState:
+    """What the readout's own validity data says about one traversed edge.
+
+    CHAOS-3629. This was ``RelevanceState.CURRENT``, a literal, at all eight
+    construction sites, so the corpus's planted expired dependency was
+    reported as a live cause and CHAOS-3619's ``current_relevance`` dimension
+    was scoring a constant.
+
+    The four cases mirror ``world.WorldRelationship.relevance_at`` member for
+    member, because the corpus is the spec for this vocabulary and a second
+    definition of "current" is how two of them drift apart:
+
+    * not yet observed at ``as_of`` -> ``UNKNOWN``. The arm cannot describe
+      the relevance of something it had not learned;
+    * in force at ``as_of`` -> ``CURRENT``;
+    * closed, but not before the investigation window opened ->
+      ``RECENTLY_CURRENT``. It stopped being true recently enough to matter
+      to the question being asked;
+    * closed before the window -> ``HISTORICAL_ONLY``.
+
+    An edge with no interval at all reads ``CURRENT`` through
+    ``is_current_at``, and that is deliberate rather than an oversight — see
+    that method, and the corpus's ``true_at``, which agree: most providers
+    assert no interval, and reading silence as "expired" would erase the
+    majority of a real graph.
+    """
+
+    if step.observed_at > as_of:
+        return RelevanceState.UNKNOWN
+    if step.is_current_at(as_of):
+        return RelevanceState.CURRENT
+    if step.valid_to is not None and step.valid_to >= window_start:
+        return RelevanceState.RECENTLY_CURRENT
+    return RelevanceState.HISTORICAL_ONLY
+
+
+def _weakest(states: Sequence[RelevanceState]) -> RelevanceState:
+    """A chain is only as current as its weakest link.
+
+    Used for a path over its hops: a route through an edge that closed two
+    months ago is not a live route, however current the rest of it is. Any
+    ``UNKNOWN`` makes the whole thing ``UNKNOWN`` — an unknown link means the
+    chain's status is unknown, not that it is merely old.
+    """
+
+    if not states:
+        return RelevanceState.UNKNOWN
+    if RelevanceState.UNKNOWN in states:
+        return RelevanceState.UNKNOWN
+    return max(states, key=_RELEVANCE_ORDER.index)
+
+
+def _strongest(states: Sequence[RelevanceState]) -> RelevanceState:
+    """One live route is enough.
+
+    Used for an entity over the paths that reach it, and for a driver over the
+    paths it cites. The opposite reduction to :func:`_weakest`, and the
+    difference is not stylistic: an entity connected by both a live and an
+    expired route is currently related, while a route through both a live and
+    an expired edge is not a live route.
+    """
+
+    known = [state for state in states if state is not RelevanceState.UNKNOWN]
+    if not known:
+        return RelevanceState.UNKNOWN
+    return min(known, key=_RELEVANCE_ORDER.index)
+
+
 def _lineage_path(
-    path: DiscoveredPath, source_state: SourceRequirementState
+    path: DiscoveredPath,
+    source_state: SourceRequirementState,
+    as_of: datetime,
+    window_start: datetime,
+    handle_by_observation: Mapping[str, str],
 ) -> LineagePath:
     hops: list[LineageHop] = []
+    hop_relevance: list[RelevanceState] = []
+    evidence: list[str] = []
     for step in path.steps:
         from_kind = entity_kind_to_subject_kind(step.from_kind)
         to_kind = entity_kind_to_subject_kind(step.to_kind)
@@ -810,9 +934,23 @@ def _lineage_path(
                 target_entity_id=step.to_canonical_id,
                 target_entity_kind=to_kind,
                 observed_at=step.observed_at,
-                relevance=RelevanceState.CURRENT,
+                relevance=_step_relevance(step, as_of, window_start),
             )
         )
+        hop_relevance.append(hops[-1].relevance)
+        # CHAOS-3630. The ids were on the step the whole time; this field was
+        # the literal ``()``, so no relationship in any packet ever closed to
+        # evidence while every driver did.
+        #
+        # Only handles this packet actually carries are cited. An observation
+        # the traversal reached but did not index -- withdrawn (CHAOS-3628),
+        # or attached to nothing it returned -- has no handle here, and citing
+        # a reference the index cannot resolve is the fault
+        # ``_assert_support_is_closed`` exists to prevent for drivers.
+        for observation_id in step.observation_ids:
+            handle = handle_by_observation.get(observation_id)
+            if handle is not None and handle not in evidence:
+                evidence.append(handle)
     return LineagePath(
         path_id=path.path_id,
         origin_entity_id=path.origin_canonical_id,
@@ -822,8 +960,8 @@ def _lineage_path(
             "reached by bounded authorized traversal from the committed "
             "subject over the frozen relationship allowlist"
         ),
-        relevance=RelevanceState.CURRENT,
-        evidence_ref_ids=(),
+        relevance=_weakest(hop_relevance),
+        evidence_ref_ids=tuple(evidence[:_MAX_PATH_EVIDENCE]),
         truncated=False,
         truncation_reason=None,
         source_health=source_state,
@@ -906,7 +1044,21 @@ def build_packet(
     entity_by_id = readout.entity_by_id()
 
     # ---- lineage -------------------------------------------------------
-    paths = tuple(_lineage_path(path, source_state) for path in readout.paths)
+    #
+    # The emitted paths are built at the END of this function, not here.
+    # CHAOS-3630 made a path's evidence references real, and they are handles
+    # -- so a path cannot be emitted until the evidence index exists. What is
+    # computed here is only what the rest of the assembly needs: which paths
+    # touch which entity, and how each path's own relevance reads.
+    path_relevance = {
+        path.path_id: _weakest(
+            [
+                _step_relevance(step, job.window_end, job.window_start)
+                for step in path.steps
+            ]
+        )
+        for path in readout.paths
+    }
     touched: dict[str, list[str]] = {}
     for path in readout.paths:
         for canonical_id in path.touched_ids():
@@ -943,7 +1095,11 @@ def build_packet(
                     "authorized relationship path"
                 ),
                 supporting_path_ids=tuple(ordered),
-                relevance=RelevanceState.CURRENT,
+                # One live route is enough: an entity reached by both a
+                # current and an expired path IS currently related. The
+                # opposite reduction to a path's own, and the difference is
+                # the point -- see ``_strongest``.
+                relevance=_strongest([path_relevance[path_id] for path_id in ordered]),
                 observed_at=entity.observed_at,
             )
         )
@@ -991,7 +1147,12 @@ def build_packet(
                     ),
                 ),
                 match_confidence=1.0,
-                relevance=RelevanceState.CURRENT,
+                # A candidate the traversal reached takes the relevance of
+                # the best route to it; a seed no path touched has none to
+                # take, and UNKNOWN is the contract's word for that.
+                relevance=_strongest(
+                    [path_relevance[path_id] for path_id in touched.get(seed, ())]
+                ),
             )
         )
         if commit:
@@ -1243,9 +1404,35 @@ def build_packet(
                 supports_subject_ids=tuple(
                     subject for subject in entry_supports if subject in candidate_ids
                 ),
-                relevance=RelevanceState.CURRENT,
+                # An observation carries no validity interval, so the arm has
+                # no basis for a relevance claim about it. UNKNOWN is the
+                # contract's word for exactly that; CURRENT would be an
+                # assertion that the record is still pertinent, which nothing
+                # in the readout supports. This is the honest answer until
+                # observations carry validity, and it is deliberately not
+                # derived from the entities the evidence supports -- what a
+                # record is ABOUT does not date the record.
+                relevance=RelevanceState.UNKNOWN,
             )
         )
+
+    # ---- lineage paths -------------------------------------------------
+    #
+    # Emitted here, after the evidence index exists, because CHAOS-3630 made
+    # a path's references real handles rather than the literal ``()`` and a
+    # handle only exists once its record has been indexed. The ordering is
+    # load-bearing, not incidental: built earlier, a path could only ever
+    # cite nothing.
+    paths = tuple(
+        _lineage_path(
+            path,
+            source_state,
+            job.window_end,
+            job.window_start,
+            handle_by_observation,
+        )
+        for path in readout.paths
+    )
 
     # ---- source coverage ----------------------------------------------
     observed_classes = sorted(
@@ -1288,7 +1475,16 @@ def build_packet(
             inclusion_evidence_classification=(
                 CohortEvidenceClassification.EXPLICITLY_NAMED_BY_QUESTION
             ),
-            relevance=RelevanceState.CURRENT,
+            # The committed subject's own relevance, which the traversal
+            # derived; the same member the subject candidate carries, because
+            # this IS that subject and two different answers about one entity
+            # in one packet would be the packet contradicting itself.
+            relevance=_strongest(
+                [
+                    path_relevance[path_id]
+                    for path_id in touched.get(candidate.canonical_id, ())
+                ]
+            ),
         )
         for candidate in candidates
         if candidate.commitment_state is SubjectCommitmentState.COMMITTED
@@ -1335,7 +1531,14 @@ def build_packet(
                 inclusion_evidence_classification=(
                     CohortEvidenceClassification.CANONICAL_REGISTRY_MEMBERSHIP
                 ),
-                relevance=RelevanceState.CURRENT,
+                # A peer is found through registry edges the cohort builder
+                # walks, and ``CohortCandidate`` carries no validity interval
+                # for them, so this packet has no basis for a relevance claim
+                # about the membership. UNKNOWN says that. Reaching for the
+                # peer's own path relevance would answer a different question
+                # -- how current is the ENTITY, not how current is its
+                # membership -- and quietly present one as the other.
+                relevance=RelevanceState.UNKNOWN,
             )
             for member in cohort.members
         )
@@ -1521,7 +1724,11 @@ def build_packet(
     )
     driver_candidates = tuple(
         _driver_candidate(
-            finding, handle_by_observation, known_subject_ids, withheld_observation_ids
+            finding,
+            handle_by_observation,
+            known_subject_ids,
+            withheld_observation_ids,
+            path_relevance,
         )
         for finding in drivers or ()
     )
@@ -1549,7 +1756,7 @@ def build_packet(
     _assert_support_is_closed(
         driver_candidates,
         evidence_entries,
-        {path.path_id for path in paths},
+        paths,
         {
             finding.driver_id: frozenset({finding.subject_id, finding.cause_id})
             for finding in drivers or ()

--- a/src/dev_health_ops/context_fabric/graph_arm/projection.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/projection.py
@@ -81,9 +81,11 @@ from .vocabulary import (
     SOURCE_EVIDENCE_ENTITY_ATTRIBUTE,
     SOURCE_EVIDENCE_HANDLE_ATTRIBUTE,
     SOURCE_EVIDENCE_ID_ATTRIBUTE,
+    SOURCE_EVIDENCE_STATE_ATTRIBUTE,
     AliasKind,
     GraphEntityKind,
     GraphObservationKind,
+    SourceEvidenceState,
     entity_kind_to_subject_kind,
 )
 
@@ -146,6 +148,7 @@ READBACK_ATTRIBUTE_KEYS: tuple[str, ...] = (
     SOURCE_EVIDENCE_ENTITY_ATTRIBUTE,
     SOURCE_EVIDENCE_HANDLE_ATTRIBUTE,
     SOURCE_EVIDENCE_ID_ATTRIBUTE,
+    SOURCE_EVIDENCE_STATE_ATTRIBUTE,
     "superseded_by",
 )
 
@@ -156,6 +159,11 @@ _ATTRIBUTE_KEY = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 #: identity, and an arm that trimmed, lowercased or re-derived a malformed one
 #: would be inventing a different record's identity out of a broken one.
 _EVIDENCE_HANDLE = re.compile(f"^{EVIDENCE_HANDLE_PATTERN}$")
+
+#: The state tokens an ingested record may declare. A closed set, checked at
+#: ingestion, so an unreadable state is a refusal rather than a silent
+#: promotion to citable.
+_SOURCE_EVIDENCE_STATES = frozenset(str(state) for state in SourceEvidenceState)
 
 #: Bytes the storage encoding uses to join multiple values into one attribute
 #: string: US (0x1f) for alias lists, "," for repository ids, supersession
@@ -388,7 +396,8 @@ def _validate_source_evidence(
     handle = attributes.get(SOURCE_EVIDENCE_HANDLE_ATTRIBUTE)
     source_id = attributes.get(SOURCE_EVIDENCE_ID_ATTRIBUTE)
     source_entity = attributes.get(SOURCE_EVIDENCE_ENTITY_ATTRIBUTE)
-    if handle is None and source_id is None and source_entity is None:
+    state = attributes.get(SOURCE_EVIDENCE_STATE_ATTRIBUTE)
+    if handle is None and source_id is None and source_entity is None and state is None:
         return
     if handle is not None and (not isinstance(source_entity, str) or not source_entity):
         raise ProjectionError(
@@ -397,6 +406,23 @@ def _validate_source_evidence(
             "record must name the entity the RECORD is about, and the arm "
             "will not re-derive that from whichever observation happens to "
             "cite it"
+        )
+    if state is not None and state not in _SOURCE_EVIDENCE_STATES:
+        # CHAOS-3628. Refused rather than treated as unknown-therefore-citable.
+        # The only available default is "citable", which is the direction that
+        # manufactures support: a state token this arm cannot read would make
+        # a revoked record indistinguishable from a live one.
+        raise ProjectionError(
+            f"{where} declares source evidence state {state!r}, which is not "
+            f"one of {sorted(_SOURCE_EVIDENCE_STATES)}. A state the arm cannot "
+            "read must not be presented as live support"
+        )
+    if handle is not None and state is None:
+        raise ProjectionError(
+            f"{where} carries a source-issued evidence handle with no "
+            f"{SOURCE_EVIDENCE_STATE_ATTRIBUTE}. A source that issues handles "
+            "is a source that knows whether its records have been withdrawn, "
+            "and the arm will not infer that they have not"
         )
     if handle is None or source_id is None:
         raise ProjectionError(

--- a/src/dev_health_ops/context_fabric/graph_arm/readback.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/readback.py
@@ -64,7 +64,17 @@ from .backend import parse_triple_fact
 from .budgets import DEFAULT_BUDGETS, TrialBudgets
 from .identity import assert_partition_matches_org
 from .projection import READBACK_ATTRIBUTE_KEYS, GraphProjection
-from .vocabulary import GraphEntityKind, GraphObservationKind
+from .vocabulary import (
+    CITABLE_EVIDENCE_STATES,
+    SOURCE_EVIDENCE_STATE_ATTRIBUTE,
+    GraphEntityKind,
+    GraphObservationKind,
+)
+
+#: The stringified citable states, matched against the readback attribute.
+#: Derived from the vocabulary rather than typed out, so a new citable state
+#: cannot be added there and silently not honoured here.
+_CITABLE_STATE_VALUES = frozenset(str(state) for state in CITABLE_EVIDENCE_STATES)
 
 __all__ = [
     "AuthorizationDerivationNotImplementedError",
@@ -204,6 +214,15 @@ class InvestigationReadout:
     observations: tuple[DiscoveredObservation, ...] = ()
     authorized_entity_ids: tuple[str, ...] = ()
     authorization_filtered_count: int = 0
+    #: How many observations the SOURCE withdrew -- revoked, redacted or
+    #: deleted -- that this traversal reached and did not return.
+    #:
+    #: CHAOS-3628, and deliberately not folded into
+    #: ``authorization_filtered_count``. They answer different questions: one
+    #: is what the caller's own grant removed, the other is what the source
+    #: took back. A single number would tell a caller investigating a thin
+    #: answer that their permissions were the cause when they were not.
+    withdrawn_evidence_filtered_count: int = 0
     entities_truncated: bool = False
     paths_truncated: bool = False
     #: Evidence loss gets its OWN flag. Adversarial review found the evidence
@@ -597,6 +616,7 @@ def _traverse(
             queue.append((other, extended))
 
     visible_observations: list[DiscoveredObservation] = []
+    withdrawn: set[str] = set()
     for observation in adjacency.observations:
         subjects = tuple(
             subject
@@ -609,6 +629,20 @@ def _traverse(
             if subject not in reached and subject not in authorized
         )
         if not subjects:
+            continue
+        # CHAOS-3628. Withdrawn material stops here, at the same boundary the
+        # caller's grant stops at, and for the same reason: everything past
+        # this point -- driver discovery, cohort construction, the evidence
+        # index -- treats what it receives as presentable. Excluding it later
+        # would leave a driver resting on a revoked record and merely not
+        # showing it, and support that exists but is invisible is worse than
+        # support that does not exist.
+        #
+        # Counted separately from the authorization filter. A caller asking
+        # why their answer is thin must not be told their own grant removed
+        # something the SOURCE withdrew.
+        if not _is_citable(observation):
+            withdrawn.add(observation.canonical_id)
             continue
         # ``replace`` rather than a field-by-field rebuild. The rebuild
         # silently dropped ``attributes`` the moment the readout grew them,
@@ -652,6 +686,7 @@ def _traverse(
         ),
         authorized_entity_ids=tuple(sorted(authorized)),
         authorization_filtered_count=len(filtered),
+        withdrawn_evidence_filtered_count=len(withdrawn),
         entities_truncated=entities_truncated,
         paths_truncated=paths_truncated,
         evidence_truncated=evidence_truncated,
@@ -662,6 +697,25 @@ def _traverse(
         observation_attachment_available=observation_attachment_available,
         embedder_model_id=embedder_model_id,
     )
+
+
+def _is_citable(observation: DiscoveredObservation) -> bool:
+    """Whether this observation may be presented as live support.
+
+    CHAOS-3628. Absent state means the source declares none — the arm's own
+    fixture world before it started issuing handles, and any source with no
+    withdrawal concept. That is treated as citable, and it is safe to do so
+    ONLY because the projection refuses a source-issued handle that arrives
+    without a state (``_validate_source_evidence``): a source that models
+    record state cannot lose it in transit and land here looking like a source
+    that never had one. Without that refusal this default would be the classic
+    stripped-attribute promotion, in the direction that manufactures support.
+    """
+
+    state = observation.attributes.get(SOURCE_EVIDENCE_STATE_ATTRIBUTE)
+    if state is None:
+        return True
+    return state in _CITABLE_STATE_VALUES
 
 
 def _readback_attributes(attributes: Mapping[str, object]) -> dict[str, str]:
@@ -841,6 +895,7 @@ RETURN n.cf_canonical_id AS canonical_id,
        n.cf_attr_source_evidence_entity_id AS attr_source_evidence_entity_id,
        n.cf_attr_source_evidence_handle AS attr_source_evidence_handle,
        n.cf_attr_source_evidence_id AS attr_source_evidence_id,
+       n.cf_attr_source_evidence_state AS attr_source_evidence_state,
        n.cf_attr_superseded_by AS attr_superseded_by
 """
 
@@ -876,6 +931,7 @@ RETURN n.cf_canonical_id AS canonical_id,
        n.cf_attr_source_evidence_entity_id AS attr_source_evidence_entity_id,
        n.cf_attr_source_evidence_handle AS attr_source_evidence_handle,
        n.cf_attr_source_evidence_id AS attr_source_evidence_id,
+       n.cf_attr_source_evidence_state AS attr_source_evidence_state,
        n.cf_attr_superseded_by AS attr_superseded_by
 """
 

--- a/src/dev_health_ops/context_fabric/graph_arm/vocabulary.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/vocabulary.py
@@ -53,13 +53,16 @@ __all__ = [
     "ALL_GRAPH_ENTITY_KINDS",
     "ALL_GRAPH_OBSERVATION_KINDS",
     "EMITTABLE_ENTITY_KINDS",
+    "CITABLE_EVIDENCE_STATES",
     "EVIDENCE_HANDLE_PATTERN",
     "SOURCE_EVIDENCE_ENTITY_ATTRIBUTE",
     "SOURCE_EVIDENCE_HANDLE_ATTRIBUTE",
     "SOURCE_EVIDENCE_ID_ATTRIBUTE",
+    "SOURCE_EVIDENCE_STATE_ATTRIBUTE",
     "AliasKind",
     "GraphEntityKind",
     "GraphObservationKind",
+    "SourceEvidenceState",
     "entity_kind_to_subject_kind",
 ]
 
@@ -99,6 +102,46 @@ SOURCE_EVIDENCE_ID_ATTRIBUTE = "source_evidence_id"
 #: record is about -- that is the source's statement, and re-deriving it is
 #: the same class of mistake as re-minting the handle.
 SOURCE_EVIDENCE_ENTITY_ATTRIBUTE = "source_evidence_entity_id"
+
+#: The attribute carrying what has happened to the source record since it was
+#: issued. Required alongside the handle pair, never defaulted.
+#:
+#: CHAOS-3628. The arm had no evidence-state concept at all: the corpus state
+#: arrived as a display string and nothing read it, so revoked and deleted
+#: records were cited as live support. State is a member of
+#: :class:`SourceEvidenceState` here rather than free text precisely so an
+#: unrecognised value is a refusal instead of quietly reading as citable --
+#: the direction that manufactures support.
+SOURCE_EVIDENCE_STATE_ATTRIBUTE = "source_evidence_state"
+
+
+class SourceEvidenceState(StrEnum):
+    """What has happened to a source record since it was issued.
+
+    Mirrors the corpus's ``world.EvidenceState`` member for member, because
+    the corpus is the spec for this vocabulary and a translation table between
+    two nearly-identical enums is a place for them to drift apart.
+
+    They are distinct members rather than one ``withdrawn`` flag for the
+    reason the corpus states: the correct disclosure differs. What the arm
+    does with all three is identical today -- none may be presented as live
+    support -- and keeping them apart is what lets that change without
+    re-deriving which records were which.
+    """
+
+    ACTIVE = "active"
+    REVOKED = "revoked"
+    REDACTED = "redacted"
+    DELETED = "deleted"
+
+
+#: The states an arm may present as live support. Exactly one member, and
+#: written as a set rather than ``== ACTIVE`` so the citable/withdrawn split
+#: is one named thing a reader can find, not a comparison repeated at each
+#: site that happens to agree today.
+CITABLE_EVIDENCE_STATES: frozenset[SourceEvidenceState] = frozenset(
+    {SourceEvidenceState.ACTIVE}
+)
 
 #: The frozen contract's ``EvidenceHandle`` grammar: ``ev1_`` and 40 lowercase
 #: hex characters. Repeated here so an ingested handle can be refused at the

--- a/tests/context_fabric/chaos_3620_dispositions.py
+++ b/tests/context_fabric/chaos_3620_dispositions.py
@@ -371,21 +371,15 @@ REQUIREMENTS: tuple[Requirement, ...] = (
     ),
     _req(
         "P1",
-        Status.DEFECT,
+        Status.PROVEN,
         f"{_PROV}::TestEveryAssertedDriverClosesToEvidenceInThisPacket::"
         "test_the_closure_check_REJECTS_a_driver_citing_unindexed_evidence",
-        f"{_PROV}::TestRelationshipsDoNotCloseToEvidence::"
+        f"{_PROV}::TestRelationshipsCloseToEvidence::"
         "test_the_readout_carries_evidence_for_its_relationships",
-        f"{_PROV}::TestRelationshipsDoNotCloseToEvidence::"
-        "test_and_the_emitted_paths_carry_none",
-        reason=(
-            "The DRIVER half holds and is enforced by _assert_support_is_closed "
-            "(packet_builder.py:379-447), shown rejecting an arm-shaped bad "
-            "response. The RELATIONSHIP half does not: _lineage_path emits "
-            "evidence_ref_ids=() as a literal (packet_builder.py:632) while "
-            "the corpus edge's observation_ids reach the emitter via "
-            "PathStep (corpus_adapter.py:195). No emitted relationship closes "
-            "to evidence, and none can."
+        f"{_PROV}::TestRelationshipsCloseToEvidence::"
+        "test_and_the_emitted_paths_carry_it",
+        notes=(
+            "FLIPPED by CHAOS-3630 (PR #1618): lineage paths now carry the evidence their own edges name, threaded through as source-issued handles and emitted after the evidence index.",
         ),
     ),
     _req(
@@ -448,23 +442,13 @@ REQUIREMENTS: tuple[Requirement, ...] = (
     ),
     _req(
         "P6",
-        Status.DEFECT,
+        Status.PROVEN,
         f"{_ADV}::TestWithdrawnSourcesDoNotDisappear::"
-        "test_withdrawn_evidence_reaches_the_emitted_packet",
+        "test_withdrawn_evidence_is_excluded_from_the_emitted_packet",
         f"{_ADV}::TestWithdrawnSourcesDoNotDisappear::"
         "test_the_arm_has_no_concept_of_evidence_state_at_all",
-        reason=(
-            "REVOKED and DELETED evidence reaches the emitted packet: "
-            "rv_vertex_revoked at proj_vertex and proj_meridian, "
-            "wi_beacon_deleted at proj_acr, proj_beacon, proj_meridian and "
-            "proj_pulse. Nothing in context_fabric reads evidence state -- "
-            "the adapter carries it through as a display attribute "
-            "(corpus_adapter.py:218) and no branch reads it back. Only "
-            "wi_quarry_redacted stays out, and for the wrong reason: its "
-            "subject is unauthorized, so the authorization filter removes it "
-            "and redaction does no work anywhere. The check that would have "
-            "caught this is authorization.py:278-279, dead for the reason "
-            "recorded against A9 -- one defect was masking the other."
+        notes=(
+            "FLIPPED by CHAOS-3628 (PR #1618): withdrawn (REVOKED/REDACTED/DELETED) evidence is excluded at read time and never reaches an emitted packet.",
         ),
     ),
     _req(
@@ -726,24 +710,15 @@ REQUIREMENTS: tuple[Requirement, ...] = (
     ),
     _req(
         "S5",
-        Status.DEFECT,
-        f"{_PROV}::TestHistoricalRelationshipsAreEmittedAsCurrent::"
+        Status.PROVEN,
+        f"{_PROV}::TestHistoricalRelationshipsAreEmittedAsHistorical::"
         "test_the_traversal_knows_the_relationship_has_ended",
-        f"{_PROV}::TestHistoricalRelationshipsAreEmittedAsCurrent::"
+        f"{_PROV}::TestHistoricalRelationshipsAreEmittedAsHistorical::"
         "test_the_driver_layer_correctly_refuses_to_assert_on_it",
-        f"{_PROV}::TestHistoricalRelationshipsAreEmittedAsCurrent::"
-        "test_but_the_emitted_lineage_calls_it_current",
-        reason=(
-            "The corpus's closed dependency -- proj_pulse depends_on "
-            "dep_ratelimitd, valid_to 2026-06-12, two months before "
-            "TRIAL_NOW -- is emitted with relevance=current on both the hop "
-            "and the path. The arm KNOWS: PathStep.is_current_at returns "
-            "False (readback.py:157-169) and discover_drivers correctly "
-            "excludes the driver built on it with not_currently_relevant. "
-            "relevance is a literal RelevanceState.CURRENT at eight emitter "
-            "sites (packet_builder.py 542, 618, 630, 751, 799, 868, 935, "
-            "982) and nothing computes it, so the frozen scoring dimension "
-            "current_relevance is measuring a constant."
+        f"{_PROV}::TestHistoricalRelationshipsAreEmittedAsHistorical::"
+        "test_and_the_emitted_lineage_says_so",
+        notes=(
+            "FLIPPED by CHAOS-3629 (PR #1618): relevance is derived from the readout's own validity; the corpus's closed dependency emits HISTORICAL_ONLY while live edges still emit CURRENT.",
         ),
     ),
     _req(

--- a/tests/context_fabric/chaos_3620_spine.py
+++ b/tests/context_fabric/chaos_3620_spine.py
@@ -503,7 +503,18 @@ def lineage_path_for(path):
     from dev_health_ops.api.dev.contracts_v2.base import SourceRequirementState
     from dev_health_ops.context_fabric.graph_arm.packet_builder import _lineage_path
 
-    return _lineage_path(path, SourceRequirementState.AVAILABLE_CURRENT)
+    # CHAOS-3629/3630 flip: _lineage_path derives relevance from validity and
+    # threads path evidence, so it needs the window and the handle map. The
+    # spine passes an empty map deliberately -- this helper exists to inspect
+    # HOP SHAPE, and supplying handles here would make it assert about
+    # evidence closure as a side effect.
+    return _lineage_path(
+        path,
+        SourceRequirementState.AVAILABLE_CURRENT,
+        world.TRIAL_NOW,
+        world.WINDOW_START,
+        {},
+    )
 
 
 def with_grant(

--- a/tests/context_fabric/test_chaos_3620_adversarial.py
+++ b/tests/context_fabric/test_chaos_3620_adversarial.py
@@ -1448,28 +1448,36 @@ class TestWithdrawnSourcesDoNotDisappear:
             ("proj_beacon", "wi_beacon_deleted"),
         ),
     )
-    def test_withdrawn_evidence_reaches_the_emitted_packet(
+    def test_withdrawn_evidence_is_excluded_from_the_emitted_packet(
         self, seed: str, expected: str
     ) -> None:
-        indexed = {
-            # CHAOS-3627 flip: detection moved from evidence.entity_id to the
-            # cited HANDLE. That field is entity vocabulary now -- the arm was
-            # putting the observation's own slug in it, which is the
-            # vocabulary defect this ledger's own P-row records -- so a slug
-            # no longer appears there and this test would have reported the
-            # withdrawn defect fixed when it is not. The DEFECT STANDS: the
-            # withdrawn record still reaches the packet, and the world's
-            # handle is how you see it. CHAOS-3628 (PR #1618) is what
-            # actually excludes it; this row flips to absence then.
-            world.EVIDENCE_BY_SLUG[entry_slug].handle
-            for entry_slug in [expected]
+        """FLIPPED by CHAOS-3628 (PR #1618). Was: the defect record.
+
+        This pinned withdrawn evidence REACHING the packet — REVOKED and
+        DELETED records cited as live support on five corpus seeds. The arm
+        now excludes them at read time, where the authorization filter
+        already draws the same line, so everything downstream works from
+        material the arm may actually present.
+
+        Both halves are asserted, because absence alone proves nothing: the
+        record must still be IN THE WORLD and must NOT be in the packet. A
+        test that only checked absence would pass against a corpus that never
+        held the record.
+        """
+
+        record = world.EVIDENCE_BY_SLUG[expected]
+        assert record.state is not world.EvidenceState.ACTIVE, (
+            f"{expected} is no longer planted as withdrawn; this would pass vacuously"
+        )
+
+        cited = {
+            entry.evidence.evidence_ref_id
             for entry in spine.investigate(seed).packet.evidence_coverage.evidence_index
-            if entry.evidence.evidence_ref_id == world.EVIDENCE_BY_SLUG[expected].handle
         }
-        assert world.EVIDENCE_BY_SLUG[expected].handle in indexed, (
-            f"{expected} no longer reaches the packet for {seed} -- the "
-            "CHAOS-3620 withdrawn-evidence defect record must be updated and "
-            "this test replaced by the proof that it is excluded"
+        assert cited, "no evidence was indexed; this would pass vacuously"
+        assert record.handle not in cited, (
+            f"{expected} still reaches the packet for {seed} -- the "
+            "CHAOS-3628 exclusion has regressed"
         )
 
     def test_the_arm_has_no_concept_of_evidence_state_at_all(self) -> None:

--- a/tests/context_fabric/test_chaos_3620_dispositions.py
+++ b/tests/context_fabric/test_chaos_3620_dispositions.py
@@ -324,7 +324,12 @@ class TestTheHardestNewsCannotBeQuietlyUpgraded:
             for requirement in REQUIREMENTS
             if requirement.status is Status.DEFECT
         }
-        assert defects == {"P1", "P6", "S5", "X1"}, (
+        # FLIPPED by PR #1618: P1 (CHAOS-3630), P6 (CHAOS-3628) and S5
+        # (CHAOS-3629) are fixed and their proving tests now assert the fixed
+        # behaviour. X1 (CHAOS-3637, title injection) remains a defect: its
+        # fix is parked in PR #1619, decoupled from the trial because the
+        # corpus carries no instruction-shaped titles.
+        assert defects == {"X1"}, (
             f"the recorded defect set changed to {sorted(defects)}; update "
             "the CHAOS-3620 findings record and the lane report together"
         )

--- a/tests/context_fabric/test_chaos_3620_provenance.py
+++ b/tests/context_fabric/test_chaos_3620_provenance.py
@@ -528,8 +528,8 @@ class TestMultiSourceFactsRetainOnlyAuthorizedProvenance:
 # --------------------------------------------------------------------------
 
 
-class TestRelationshipsDoNotCloseToEvidence:
-    """CHAOS-3620 DEFECT RECORD — arm-side, merged code.
+class TestRelationshipsCloseToEvidence:
+    """FLIPPED by CHAOS-3630 (PR #1618). Was: a defect record.
 
     "Every material graph-assisted driver or relationship closes to
     authorized canonical evidence." Drivers do. Relationships do not, and
@@ -554,22 +554,35 @@ class TestRelationshipsDoNotCloseToEvidence:
             "discarded and this defect record is stale"
         )
 
-    def test_and_the_emitted_paths_carry_none(self) -> None:
+    def test_and_the_emitted_paths_carry_it(self) -> None:
+        """The emitter threads the ids through as handles now.
+
+        Paths are built AFTER the evidence index, because a reference is a
+        handle and a handle does not exist until its record is indexed.
+        """
+
         packet = spine.investigate("proj_identity_rewrite", with_drivers=True).packet
+        indexed = {
+            entry.evidence.evidence_ref_id
+            for entry in packet.evidence_coverage.evidence_index
+        }
         cited = {
             handle
             for path in packet.related_context.paths
             for handle in path.evidence_ref_ids
         }
-        assert not cited, (
-            "lineage paths now cite evidence -- the CHAOS-3620 "
-            "relationship-closure defect record must be updated and this "
-            "test replaced by the proof that every path closes"
+
+        assert cited, (
+            "no lineage path cites evidence -- the CHAOS-3630 threading has "
+            "regressed to the literal"
+        )
+        assert not cited - indexed, (
+            f"paths cite unindexed evidence: {sorted(cited - indexed)}"
         )
 
 
-class TestHistoricalRelationshipsAreEmittedAsCurrent:
-    """CHAOS-3620 DEFECT RECORD — arm-side, merged code.
+class TestHistoricalRelationshipsAreEmittedAsHistorical:
+    """FLIPPED by CHAOS-3629 (PR #1618). Was: a defect record.
 
     "Current versus historical evidence remains explicit." The arm *knows*:
     ``PathStep.is_current_at`` returns False for the corpus's closed
@@ -622,7 +635,14 @@ class TestHistoricalRelationshipsAreEmittedAsCurrent:
             "a driver was asserted on a relationship that ended two months ago"
         )
 
-    def test_but_the_emitted_lineage_calls_it_current(self) -> None:
+    def test_and_the_emitted_lineage_says_so(self) -> None:
+        """Relevance is derived from the readout's own validity now.
+
+        Both ends asserted: the closed relationship reads historical, AND
+        some hop in the same packet still reads current. Without the second
+        half, swapping one constant for another would satisfy this.
+        """
+
         edge = self._closed_edge()
         packet = spine.investigate(edge.source_entity_id, with_drivers=True).packet
         hops = [
@@ -633,9 +653,15 @@ class TestHistoricalRelationshipsAreEmittedAsCurrent:
             == {edge.source_entity_id, edge.target_entity_id}
         ]
         assert hops, "the closed relationship was not emitted at all"
-        assert all(str(hop.relevance) == "current" for hop in hops), (
-            "emitted relevance is no longer an unconditional 'current' -- the "
-            "CHAOS-3620 relevance-literal defect record must be updated"
+        assert all(str(hop.relevance) != "current" for hop in hops), (
+            "the closed relationship is still emitted as current -- the "
+            "CHAOS-3629 derivation has regressed to the literal"
+        )
+
+        every = [hop for path in packet.related_context.paths for hop in path.hops]
+        assert any(str(hop.relevance) == "current" for hop in every), (
+            "no hop reads current, so relevance is a constant again -- one "
+            "literal swapped for another"
         )
 
 

--- a/tests/context_fabric/test_chaos_3627_arm_vocabulary.py
+++ b/tests/context_fabric/test_chaos_3627_arm_vocabulary.py
@@ -23,11 +23,18 @@ buries any real leak, and the withdrawn-evidence check
 (``authorization.py:278-279``) was unreachable dead code on arm packets
 because the handle lookup at ``:272`` missed first and ``continue``d.
 
-These tests use the oracle as the instrument. Two of them are the controls
-that keep the first one from being vacuous: a planted ``proj_quarry`` leak
-must flip the audit red, and a cited *revoked* world record must show up in
-``withdrawn_evidence_handles`` -- a field that could not be non-empty on an
-arm packet before this change.
+These tests use the oracle as the instrument, with a control that keeps the
+first one from being vacuous: a planted ``proj_quarry`` leak must flip the
+audit red and name it.
+
+A second control originally lived here — the shipped path citing a *revoked*
+record, to show ``withdrawn_evidence_handles`` becoming non-empty. CHAOS-3628
+removed that behaviour outright, so the control moved to
+``test_chaos_3628_evidence_state.py::TestTheOracleBackstopIsAlive``, which
+reaches the same check with a deliberately defective emitter instead. What
+remains here is the part CHAOS-3627 owns and CHAOS-3628 cannot supply: every
+cited handle resolves in ``EVIDENCE_BY_HANDLE``, which is the lookup whose
+missing made every check below it unreachable.
 """
 
 from __future__ import annotations
@@ -186,29 +193,35 @@ class TestTheAuthorizationOracleCanScoreAnArmPacket:
             sighting.entity_id for sighting in audit.unauthorized_disclosures
         }
 
-    def test_a_cited_revoked_world_record_is_reported_as_withdrawn(
-        self, helio, signer
-    ) -> None:
-        """The check at ``authorization.py:278-279`` comes alive.
+    def test_the_withdrawn_check_is_reachable_at_all(self, helio, signer) -> None:
+        """The check at ``authorization.py:278-279`` is no longer dead code.
 
-        It could not fire on an arm packet before: every cited handle missed
-        the ``EVIDENCE_BY_HANDLE`` lookup at ``:272`` and ``continue``d, so
-        the state test below it was unreachable. ``rv_vertex_revoked`` is a
-        REVOKED record the corpus plants on ``pr_vertex_401``; the arm
-        ingests it (the adapter deliberately does not filter withdrawn
-        material at the door) and cites it, so the oracle must now say so.
+        It could not fire on an arm packet before CHAOS-3627: every cited
+        handle missed the ``EVIDENCE_BY_HANDLE`` lookup at ``:272`` and
+        ``continue``d, so the state test below it was unreachable whatever the
+        packet contained.
+
+        This test originally proved that by letting the shipped path cite
+        ``rv_vertex_revoked`` and watching the oracle report it. **CHAOS-3628
+        removed that behaviour** — withdrawn evidence must never reach a
+        packet — so the proof moved rather than being deleted: see
+        ``test_chaos_3628_evidence_state.py::TestTheOracleBackstopIsAlive``,
+        which reaches the same check with a deliberately defective emitter.
+        What is asserted here is the narrower thing CHAOS-3627 is responsible
+        for and CHAOS-3628 cannot provide: every handle the packet cites
+        resolves in the world, which is the lookup that used to miss.
         """
 
         packet = _packet(_read(helio, "proj_vertex"), signer)
-        revoked = world.EVIDENCE_BY_SLUG["rv_vertex_revoked"]
-        assert revoked.state is world.EvidenceState.REVOKED
-
-        audit = audit_authorization(
-            packet, world.PRINCIPAL_ANALYST, case_id="chaos_3627_withdrawn"
+        cited = {
+            entry.evidence.evidence_ref_id
+            for entry in packet.evidence_coverage.evidence_index
+        }
+        assert cited, "no evidence was indexed; this would pass vacuously"
+        assert all(handle in world.EVIDENCE_BY_HANDLE for handle in cited), (
+            "a cited handle misses the world lookup, so every check below it "
+            "in audit_authorization is unreachable again"
         )
-
-        assert revoked.handle in audit.withdrawn_evidence_handles
-        assert not audit.is_clean
 
 
 class TestEvidenceCitesTheHandleItWasIssued:
@@ -424,9 +437,13 @@ class TestProvenanceIsRefusedRatherThanRepaired:
         )
 
     def test_a_handle_with_no_record_id_is_refused(self) -> None:
+        # The state is supplied so that CHAOS-3628's own requirement (a
+        # handle-issuing source must declare state) is satisfied and cannot be
+        # what raises. One guard per probe, or neither is observed.
         batch = self._observation(
             source_evidence_handle=world.evidence_handle("rev_probe"),
             source_evidence_entity_id="proj_probe",
+            source_evidence_state="active",
         )
         with pytest.raises(ProjectionError, match="one half of the source evidence"):
             build_projection(batch)
@@ -438,7 +455,9 @@ class TestProvenanceIsRefusedRatherThanRepaired:
         record looks, to a reader, like it carried provenance.
         """
 
-        batch = self._observation(source_evidence_id="rev_probe")
+        batch = self._observation(
+            source_evidence_id="rev_probe", source_evidence_state="active"
+        )
         with pytest.raises(ProjectionError, match="one half of the source evidence"):
             build_projection(batch)
 
@@ -453,6 +472,7 @@ class TestProvenanceIsRefusedRatherThanRepaired:
             source_evidence_handle="EV1_NOT-THE-GRAMMAR",
             source_evidence_id="rev_probe",
             source_evidence_entity_id="proj_probe",
+            source_evidence_state="active",
         )
         with pytest.raises(ProjectionError, match="EvidenceHandle grammar"):
             build_projection(batch)

--- a/tests/context_fabric/test_chaos_3628_evidence_state.py
+++ b/tests/context_fabric/test_chaos_3628_evidence_state.py
@@ -180,22 +180,163 @@ class TestWithdrawnEvidenceIsPresentInTheWorldAndAbsentFromThePacket:
         packet = _packet(_read(helio, seed, principal), signer)
         audit = audit_authorization(packet, principal, case_id="chaos_3628")
 
-        assert audit.withdrawn_evidence_handles == ()
+        # ``summary()`` as the message on purpose: it renders the oracle's own
+        # ``handles-withdrawn=[...]`` clause, so a failure here evidences the
+        # withdrawal rather than printing an empty-vs-non-empty tuple that
+        # says nothing about which check fired.
+        assert audit.withdrawn_evidence_handles == (), audit.summary()
 
-    def test_the_withdrawn_count_is_its_own_number(self, helio, signer) -> None:
+    def test_the_withdrawn_count_moves_independently_of_the_grant(
+        self, helio, signer
+    ) -> None:
         """Not folded into ``authorization_filtered_count``.
 
         A shared counter would say "the caller's grant removed this" about
         material the caller's grant had nothing to do with, and a reader
         checking why their answer is thin would be told the wrong thing.
+
+        Asserting the two numbers merely *differ* would be satisfied by an
+        accident of arithmetic — on ``proj_beacon`` under the analyst they are
+        both 1. Each is therefore moved on its own: a principal who can see
+        everything still has withdrawn evidence removed (grant 0, withdrawn
+        non-zero), and a restricted principal still has the grant remove
+        something (grant non-zero) — both ends of the pair, seeded.
         """
 
-        readout = _read(helio, "proj_beacon", world.PRINCIPAL_ANALYST)
+        unrestricted = _read(helio, "proj_beacon", world.PRINCIPAL_COMPLIANCE)
+        assert unrestricted.authorization_filtered_count == 0
+        assert unrestricted.withdrawn_evidence_filtered_count > 0
 
-        assert readout.withdrawn_evidence_filtered_count > 0
-        assert readout.withdrawn_evidence_filtered_count != (
-            readout.authorization_filtered_count
+        restricted = _read(helio, world.TEAM_CINDER, world.PRINCIPAL_ANALYST)
+        assert restricted.authorization_filtered_count > 0
+        assert restricted.withdrawn_evidence_filtered_count == 0
+
+
+def _probe_batch(**attributes):
+    """CHAOS-3627's fix round added a third member to the source-evidence
+    triple (the entity the RECORD is about), so a handle-bearing probe must
+    supply it or the pairing guard raises before the state guard is reached.
+    Defaulted here rather than at each call site: these probes exist to
+    exercise ONE guard each, and a probe that trips a sibling proves nothing
+    about the guard it names.
+    """
+
+    if "source_evidence_handle" in attributes:
+        attributes.setdefault("source_evidence_entity_id", "proj_state_probe")
+    """One entity and one observation about it, with the given attributes.
+
+    Built here rather than borrowed from the corpus so a state probe cannot
+    accidentally be answered by some other property of a real record.
+    """
+
+    from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+    from dev_health_ops.context_fabric.graph_arm.records import (
+        CanonicalRef,
+        EntityRecord,
+        IngestionBatch,
+        ObservationRecord,
+    )
+    from dev_health_ops.context_fabric.graph_arm.vocabulary import (
+        GraphEntityKind,
+        GraphObservationKind,
+    )
+
+    return IngestionBatch(
+        org_id=world.ORG_HELIO,
+        entities=(
+            EntityRecord(
+                org_id=world.ORG_HELIO,
+                kind=GraphEntityKind.PROJECT,
+                canonical_id="proj_state_probe",
+                display_label="State probe",
+                source_class=SourceClass.WORK_GRAPH,
+                observed_at=world.WINDOW_END,
+            ),
+        ),
+        observations=(
+            ObservationRecord(
+                org_id=world.ORG_HELIO,
+                kind=GraphObservationKind.REVIEW,
+                canonical_id="rev_state_probe",
+                title="probe review",
+                source_class=SourceClass.REVIEW,
+                observed_at=world.WINDOW_END,
+                subjects=(
+                    CanonicalRef(
+                        kind=GraphEntityKind.PROJECT,
+                        canonical_id="proj_state_probe",
+                    ),
+                ),
+                attributes=attributes,
+            ),
+        ),
+    )
+
+
+class TestAnUnreadableStateIsRefused:
+    """A state the arm cannot read must not become a citable record.
+
+    The only available default is "citable", so an unrecognised token would
+    make a record withdrawn under a newer vocabulary indistinguishable from a
+    live one. Refused at ingestion, where the record is still in scope.
+    """
+
+    def test_a_state_outside_the_arms_vocabulary_is_refused(self) -> None:
+        from dev_health_ops.context_fabric.graph_arm.projection import ProjectionError
+
+        batch = _probe_batch(
+            source_evidence_handle=world.evidence_handle("rev_state_probe"),
+            source_evidence_id="rev_state_probe",
+            source_evidence_state="quarantined",
         )
+        with pytest.raises(ProjectionError, match="source evidence state"):
+            build_projection(batch)
+
+    def test_the_states_the_corpus_uses_are_all_accepted(self) -> None:
+        """The other half: the refusal is narrow, not a blanket rejection.
+
+        Without this, deleting the whole vocabulary check would still look
+        correct — everything would be refused and the test above would pass.
+        """
+
+        for state in world.EvidenceState:
+            batch = _probe_batch(
+                source_evidence_handle=world.evidence_handle("rev_state_probe"),
+                source_evidence_id="rev_state_probe",
+                source_evidence_state=str(state),
+            )
+            assert build_projection(batch).observation_nodes()
+
+
+class TestAnIssuedHandleMustDeclareItsState:
+    """What makes readback's absent-state default safe.
+
+    ``_is_citable`` treats an absent state as citable, which is correct for a
+    source with no withdrawal concept and catastrophic for one whose state was
+    dropped in transit. The two are only distinguishable because a
+    handle-issuing source is required to declare state here.
+    """
+
+    def test_a_handle_without_a_state_is_refused(self) -> None:
+        from dev_health_ops.context_fabric.graph_arm.projection import ProjectionError
+
+        batch = _probe_batch(
+            source_evidence_handle=world.evidence_handle("rev_state_probe"),
+            source_evidence_id="rev_state_probe",
+        )
+        with pytest.raises(ProjectionError, match="no source_evidence_state"):
+            build_projection(batch)
+
+    def test_a_source_that_issues_no_handle_needs_no_state(self) -> None:
+        """The legitimate absent-state case, kept working.
+
+        A source with no withdrawal concept — the arm's own fixture world
+        before CHAOS-3627, and any provider that issues no handles — must
+        still be ingestible, or the requirement above would be a ban on
+        sources rather than a guard on provenance.
+        """
+
+        assert build_projection(_probe_batch()).observation_nodes()
 
 
 class TestTheOracleBackstopIsAlive:

--- a/tests/context_fabric/test_chaos_3628_evidence_state.py
+++ b/tests/context_fabric/test_chaos_3628_evidence_state.py
@@ -1,0 +1,260 @@
+"""CHAOS-3628: withdrawn evidence never reaches an emitted packet.
+
+The arm had **no evidence-state concept at all**. ``corpus_batch`` filtered on
+tenant and known-entity only (``corpus_adapter.py:199-203``) and demoted the
+state to a display string (``:218``); ``grep -rn "EvidenceState|revoked|
+redacted|withdraw" src/dev_health_ops/context_fabric/`` returned nothing. So
+REVOKED and DELETED records reached emitted evidence indexes on five corpus
+seeds, and REDACTED stayed out only because the *authorization* filter removed
+``proj_quarry`` — redaction itself did no work at all.
+
+**Where the exclusion happens, and why there.** Three places were possible:
+
+* *at ingestion* — rejected. The adapter's own docstring already argues this
+  for false-claim edges and adversarial evidence: material dropped at the door
+  makes every exclusion expectation pass without the arm doing anything. An
+  arm that never held a revoked record cannot be observed declining to cite
+  one, and the corpus plants these records precisely to be declined.
+* *at emission* — rejected. Withdrawn evidence would still reach driver
+  discovery and cohort construction, so a driver could rest on a revoked
+  record and merely not show it. Support that exists and is invisible is
+  worse than support that does not exist.
+* *at read time* — chosen. It is where the authorization filter already draws
+  the same line, it is the first point at which the **arm** rather than the
+  adapter makes the decision, and everything downstream — drivers, cohort,
+  evidence index — is then working from material the arm may actually
+  present.
+
+The counts are kept apart. ``authorization_filtered_count`` answers "what did
+the caller's grant remove"; ``withdrawn_evidence_filtered_count`` answers
+"what did the source withdraw". One reason per flag is a rule this module
+learned the expensive way (``InvestigationReadout.evidence_truncated``).
+
+**REDACTED needs the compliance principal.** The corpus's only redacted
+record, ``wi_quarry_redacted``, is about ``proj_quarry`` — the entity the
+analyst cannot see. Asserting its absence under the analyst would pass with
+the state filter deleted, because authorization removes it first. The
+compliance principal *can* see ``proj_quarry``, so the state filter is the
+only thing that can be doing the work. The corpus is frozen and no record was
+added to make this test possible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.investigation_contract import (
+    ComparisonShape,
+    QuestionFamilyID,
+)
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.api.dev.investigation_corpus.authorization import (
+    audit_authorization,
+)
+from dev_health_ops.context_fabric.graph_arm import build_projection
+from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
+from dev_health_ops.context_fabric.graph_arm.packet_builder import (
+    JobContext,
+    TrialContext,
+    build_packet,
+)
+from dev_health_ops.context_fabric.graph_arm.readback import ProjectionGraphReader
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+
+_PRODUCED_AT = datetime(2026, 8, 8, 12, 0, tzinfo=UTC)
+_RUN_ID = "3c628a22-3333-4444-8555-666677778888"
+
+#: One seed per withdrawn state, with the principal that can actually reach
+#: it. Every one of these records is present in the world and reachable by
+#: the traversal, which is what makes "absent from the packet" a statement
+#: about the arm rather than about the corpus.
+_WITHDRAWN_CASES = (
+    pytest.param(
+        "proj_vertex",
+        world.PRINCIPAL_ANALYST,
+        "rv_vertex_revoked",
+        world.EvidenceState.REVOKED,
+        id="revoked",
+    ),
+    pytest.param(
+        "proj_beacon",
+        world.PRINCIPAL_ANALYST,
+        "wi_beacon_deleted",
+        world.EvidenceState.DELETED,
+        id="deleted",
+    ),
+    pytest.param(
+        world.PROJ_QUARRY,
+        world.PRINCIPAL_COMPLIANCE,
+        "wi_quarry_redacted",
+        world.EvidenceState.REDACTED,
+        id="redacted-under-a-principal-who-can-see-the-subject",
+    ),
+)
+
+
+@pytest.fixture(scope="module")
+def helio():
+    return build_projection(adapter.corpus_batch(world.ORG_HELIO))
+
+
+def _read(projection, seed: str, principal: str, *, max_hops: int = 2):
+    grant = sorted(adapter.authorized_entity_ids_for(principal))
+    return asyncio.run(
+        ProjectionGraphReader(projection).neighbourhood(
+            org_id=world.ORG_HELIO,
+            seed_canonical_ids=[seed],
+            authorized_entity_ids=grant,
+            max_hops=max_hops,
+        )
+    )
+
+
+def _packet(readout, signer):
+    return build_packet(
+        readout=readout,
+        job=JobContext(
+            job_id="job_chaos_3628",
+            question_family=QuestionFamilyID.PROJECT_STATUS_DRIVERS,
+            job_statement="What is the current state of this subject?",
+            comparison_shape=ComparisonShape.SINGULAR_SUBJECT,
+            window_start=world.WINDOW_START,
+            window_end=world.WINDOW_END,
+        ),
+        watermark=IndexWatermark(
+            indexed_through=world.WINDOW_END,
+            projected_at=world.WINDOW_END,
+            records_indexed=len(readout.entities),
+        ),
+        signer=signer,
+        trial=TrialContext(run_id=_RUN_ID),
+        produced_at=_PRODUCED_AT,
+    )
+
+
+def _cited_handles(packet) -> set[str]:
+    return {
+        entry.evidence.evidence_ref_id
+        for entry in packet.evidence_coverage.evidence_index
+    }
+
+
+class TestWithdrawnEvidenceIsPresentInTheWorldAndAbsentFromThePacket:
+    """Both halves asserted, per state. Absence alone proves nothing.
+
+    A test that only checked "the handle is not in the packet" would pass
+    against a world that never held the record, against a traversal that never
+    reached it, and against an arm that dropped it at ingestion. Each case
+    below first proves the record IS in the world and DID reach the traversal.
+    """
+
+    @pytest.mark.parametrize(("seed", "principal", "slug", "state"), _WITHDRAWN_CASES)
+    def test_the_record_is_reachable_but_never_cited(
+        self, helio, signer, seed: str, principal: str, slug: str, state
+    ) -> None:
+        record = world.EVIDENCE_BY_SLUG[slug]
+        assert record.state is state, "the corpus no longer plants this state"
+
+        readout = _read(helio, seed, principal)
+        assert (
+            slug in {observation.canonical_id for observation in readout.observations}
+            or readout.withdrawn_evidence_filtered_count
+        ), (
+            f"{slug} neither reached the traversal nor was counted as "
+            "withdrawn; this case would pass vacuously"
+        )
+
+        packet = _packet(readout, signer)
+        assert record.handle not in _cited_handles(packet)
+
+    @pytest.mark.parametrize(("seed", "principal", "slug", "state"), _WITHDRAWN_CASES)
+    def test_the_oracle_agrees_nothing_withdrawn_was_cited(
+        self, helio, signer, seed: str, principal: str, slug: str, state
+    ) -> None:
+        """The independent check, not the arm's own bookkeeping."""
+
+        packet = _packet(_read(helio, seed, principal), signer)
+        audit = audit_authorization(packet, principal, case_id="chaos_3628")
+
+        assert audit.withdrawn_evidence_handles == ()
+
+    def test_the_withdrawn_count_is_its_own_number(self, helio, signer) -> None:
+        """Not folded into ``authorization_filtered_count``.
+
+        A shared counter would say "the caller's grant removed this" about
+        material the caller's grant had nothing to do with, and a reader
+        checking why their answer is thin would be told the wrong thing.
+        """
+
+        readout = _read(helio, "proj_beacon", world.PRINCIPAL_ANALYST)
+
+        assert readout.withdrawn_evidence_filtered_count > 0
+        assert readout.withdrawn_evidence_filtered_count != (
+            readout.authorization_filtered_count
+        )
+
+
+class TestTheOracleBackstopIsAlive:
+    """Prove the *check* works, without shipping behaviour that trips it.
+
+    The exclusion above is the arm's guarantee. This is the independent
+    backstop behind it: if a future emitter loses the filter, the CHAOS-3616
+    oracle must say so. Proven with a deliberately defective emitter —
+    withdrawn observations put back into the readout by hand — rather than by
+    letting the shipped path cite a revoked record, which is the behaviour the
+    whole ticket exists to remove.
+    """
+
+    def test_an_emitter_that_keeps_withdrawn_evidence_is_caught(
+        self, helio, signer
+    ) -> None:
+        clean = _read(helio, "proj_vertex", world.PRINCIPAL_ANALYST)
+        assert (
+            audit_authorization(
+                _packet(clean, signer), world.PRINCIPAL_ANALYST
+            ).withdrawn_evidence_handles
+            == ()
+        ), "the shipped path already cites withdrawn evidence; nothing to prove"
+
+        defective = dataclasses.replace(
+            clean, observations=_reinstate_withdrawn(helio, clean)
+        )
+        audit = audit_authorization(_packet(defective, signer), world.PRINCIPAL_ANALYST)
+
+        assert world.EVIDENCE_BY_SLUG["rv_vertex_revoked"].handle in (
+            audit.withdrawn_evidence_handles
+        )
+        assert not audit.is_clean
+
+
+def _reinstate_withdrawn(projection, readout):
+    """The withdrawn observations the filter removed, put back verbatim.
+
+    Reads them off the projection rather than reconstructing them, so the
+    defective emitter is emitting exactly what an unfiltered reader would
+    have handed it.
+    """
+
+    from dev_health_ops.context_fabric.graph_arm.readback import (
+        _adjacency_from_projection,
+    )
+
+    reached = {entity.canonical_id for entity in readout.entities}
+    kept = list(readout.observations)
+    seen = {observation.canonical_id for observation in kept}
+    for observation in _adjacency_from_projection(projection).observations:
+        if observation.canonical_id in seen:
+            continue
+        subjects = tuple(
+            subject
+            for subject in observation.subject_canonical_ids
+            if subject in reached
+        )
+        if not subjects:
+            continue
+        kept.append(dataclasses.replace(observation, subject_canonical_ids=subjects))
+    return tuple(sorted(kept, key=lambda item: item.canonical_id))

--- a/tests/context_fabric/test_chaos_3629_3630_lineage_honesty.py
+++ b/tests/context_fabric/test_chaos_3629_3630_lineage_honesty.py
@@ -1,0 +1,263 @@
+"""CHAOS-3629 / CHAOS-3630: the lineage emitter stops asserting constants.
+
+Two defects in one function, so one suite.
+
+**CHAOS-3629 — relevance was a literal.** ``RelevanceState.CURRENT`` appeared
+at eight construction sites and nothing anywhere computed relevance. The
+corpus plants ``dep_pulse_ratelimitd`` (``proj_pulse -depends_on->
+dep_ratelimitd``, ``valid_to`` 2026-06-12, two months before ``TRIAL_NOW``)
+precisely so a historical relationship can be seen being reported as
+historical; ``PathStep.is_current_at`` already returned ``False`` for it and
+the emitter threw that away. CHAOS-3619's ``current_relevance`` dimension was
+scoring a constant.
+
+**CHAOS-3630 — path evidence was a literal.** ``LineagePath.evidence_ref_ids``
+was ``()``. The data was present the whole time: corpus edges carry
+``observation_ids`` derived from evidence slugs, and ``PathStep`` carries them
+through. Drivers close to evidence (``_assert_support_is_closed``);
+relationships could not, because the field was a constant.
+
+**What "honest" means at each site, and why it differs.** The rule is not
+"compute something everywhere" — that would replace one invention with
+another. It is: derive where the readout carries validity, and say
+``UNKNOWN`` where it does not.
+
+* hops carry a validity interval, so they are derived;
+* a path is only as current as its weakest hop;
+* an entity is as current as the *best* path that reaches it — one live route
+  is enough;
+* an observation carries no interval at all, so evidence entries are
+  ``UNKNOWN``. That is the contract's own word for "no basis to say", and it
+  is the honest answer until observations carry validity. Saying ``CURRENT``
+  there is the defect this ticket exists to remove.
+
+Input symmetry is seeded at both ends throughout: a historical edge must read
+historical AND a current edge must still read current, or a mutation that
+hardcoded ``HISTORICAL_ONLY`` would pass everything here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.investigation_contract import (
+    ComparisonShape,
+    QuestionFamilyID,
+    RelevanceState,
+)
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.context_fabric.graph_arm import build_projection
+from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
+from dev_health_ops.context_fabric.graph_arm.packet_builder import (
+    JobContext,
+    TrialContext,
+    build_packet,
+)
+from dev_health_ops.context_fabric.graph_arm.readback import ProjectionGraphReader
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+
+_PRODUCED_AT = datetime(2026, 8, 8, 12, 0, tzinfo=UTC)
+_RUN_ID = "3c629a33-4444-4555-8666-777788889999"
+
+#: The planted historical dependency, and the evidence the corpus attaches to
+#: it. Named here so a corpus change that removes either makes these tests
+#: fail loudly rather than quietly stop testing anything.
+_HISTORICAL_SOURCE = "proj_pulse"
+_HISTORICAL_TARGET = "dep_ratelimitd"
+_HISTORICAL_EVIDENCE = "wg_ratelimitd_removed"
+
+
+@pytest.fixture(scope="module")
+def helio():
+    return build_projection(adapter.corpus_batch(world.ORG_HELIO))
+
+
+def _read(projection, seed: str, *, max_hops: int = 2):
+    grant = sorted(adapter.authorized_entity_ids_for(world.PRINCIPAL_ANALYST))
+    return asyncio.run(
+        ProjectionGraphReader(projection).neighbourhood(
+            org_id=world.ORG_HELIO,
+            seed_canonical_ids=[seed],
+            authorized_entity_ids=grant,
+            max_hops=max_hops,
+        )
+    )
+
+
+def _packet(readout, signer):
+    return build_packet(
+        readout=readout,
+        job=JobContext(
+            job_id="job_chaos_3629",
+            question_family=QuestionFamilyID.PROJECT_STATUS_DRIVERS,
+            job_statement="What is the current state of this subject?",
+            comparison_shape=ComparisonShape.SINGULAR_SUBJECT,
+            window_start=world.WINDOW_START,
+            window_end=world.WINDOW_END,
+        ),
+        watermark=IndexWatermark(
+            indexed_through=world.WINDOW_END,
+            projected_at=world.WINDOW_END,
+            records_indexed=len(readout.entities),
+        ),
+        signer=signer,
+        trial=TrialContext(run_id=_RUN_ID),
+        produced_at=_PRODUCED_AT,
+    )
+
+
+def _hops(packet):
+    for path in packet.related_context.paths:
+        for hop in path.hops:
+            yield path, hop
+
+
+def _historical_hop(packet):
+    for path, hop in _hops(packet):
+        if (
+            hop.source_entity_id == _HISTORICAL_SOURCE
+            and hop.target_entity_id == _HISTORICAL_TARGET
+        ):
+            return path, hop
+    raise AssertionError(
+        "the planted historical dependency is not in this packet; every "
+        "assertion about it would pass vacuously"
+    )
+
+
+class TestRelevanceIsDerivedNotDeclared:
+    def test_the_planted_historical_dependency_reads_historical(
+        self, helio, signer
+    ) -> None:
+        """The corpus planted it to be reported. Now it is."""
+
+        edge = world.RELATIONSHIPS_BY_KEY["dep_pulse_ratelimitd"]
+        assert edge.valid_to is not None and edge.valid_to < world.WINDOW_START, (
+            "the corpus no longer plants this edge as closed before the "
+            "window; this test would pass vacuously"
+        )
+
+        _, hop = _historical_hop(_packet(_read(helio, _HISTORICAL_SOURCE), signer))
+
+        assert hop.relevance is RelevanceState.HISTORICAL_ONLY
+
+    def test_a_live_dependency_still_reads_current(self, helio, signer) -> None:
+        """The other end of the pair.
+
+        Without this, hardcoding ``HISTORICAL_ONLY`` would satisfy every other
+        assertion in this class — one constant swapped for another.
+        """
+
+        packet = _packet(_read(helio, _HISTORICAL_SOURCE), signer)
+        current = [
+            hop for _, hop in _hops(packet) if hop.relevance is RelevanceState.CURRENT
+        ]
+
+        assert current, "no hop reads current; relevance is a constant again"
+
+    def test_a_path_is_only_as_current_as_its_weakest_hop(self, helio, signer) -> None:
+        packet = _packet(_read(helio, _HISTORICAL_SOURCE), signer)
+        path, _ = _historical_hop(packet)
+
+        assert path.relevance is RelevanceState.HISTORICAL_ONLY
+
+    def test_evidence_entries_say_unknown_rather_than_claiming_current(
+        self, helio, signer
+    ) -> None:
+        """An observation carries no validity interval, so the arm has none.
+
+        ``UNKNOWN`` is the contract's word for exactly that. Claiming
+        ``CURRENT`` would be an assertion about a record's continued relevance
+        that nothing in the readout supports.
+        """
+
+        packet = _packet(_read(helio, _HISTORICAL_SOURCE), signer)
+
+        assert packet.evidence_coverage.evidence_index
+        for entry in packet.evidence_coverage.evidence_index:
+            assert entry.relevance is RelevanceState.UNKNOWN
+
+    def test_the_packet_no_longer_reports_one_relevance_everywhere(
+        self, helio, signer
+    ) -> None:
+        """The whole-packet form of the defect, in one assertion.
+
+        Every site emitting the same member is what "relevance is a constant"
+        looks like from outside, and it is what CHAOS-3619's dimension was
+        measuring.
+        """
+
+        packet = _packet(_read(helio, _HISTORICAL_SOURCE), signer)
+        seen = (
+            {hop.relevance for _, hop in _hops(packet)}
+            | {path.relevance for path in packet.related_context.paths}
+            | {entry.relevance for entry in packet.evidence_coverage.evidence_index}
+            | {entity.relevance for entity in packet.related_context.entities}
+        )
+
+        assert len(seen) > 1, f"every site still reports {seen}"
+
+
+class TestLineagePathsCloseToEvidence:
+    def test_the_historical_edges_evidence_reaches_the_path(
+        self, helio, signer
+    ) -> None:
+        """The data existed the whole time; the emitter dropped it."""
+
+        edge = world.RELATIONSHIPS_BY_KEY["dep_pulse_ratelimitd"]
+        assert _HISTORICAL_EVIDENCE in edge.evidence_slugs
+
+        path, _ = _historical_hop(_packet(_read(helio, _HISTORICAL_SOURCE), signer))
+
+        assert world.EVIDENCE_BY_SLUG[_HISTORICAL_EVIDENCE].handle in (
+            path.evidence_ref_ids
+        )
+
+    def test_every_path_reference_is_in_the_evidence_index(self, helio, signer) -> None:
+        """Closure, the same property drivers already had.
+
+        A handle cited by a path but absent from the index is a reference the
+        packet does not actually carry — which is the fault
+        ``_assert_support_is_closed`` exists to prevent for drivers.
+        """
+
+        packet = _packet(_read(helio, _HISTORICAL_SOURCE), signer)
+        indexed = {
+            entry.evidence.evidence_ref_id
+            for entry in packet.evidence_coverage.evidence_index
+        }
+        cited = {
+            handle
+            for path in packet.related_context.paths
+            for handle in path.evidence_ref_ids
+        }
+
+        assert cited, "no path cites evidence; this would pass vacuously"
+        assert not cited - indexed, (
+            f"unindexed path evidence: {sorted(cited - indexed)}"
+        )
+
+    def test_a_path_whose_edges_carry_no_evidence_says_so(self, helio, signer) -> None:
+        """Honest emptiness, not fabrication.
+
+        Half the corpus's edges carry no evidence slugs at all. Those paths
+        must emit no references rather than borrowing one from a neighbour,
+        and this is what stops "thread the ids through" from becoming "put
+        something in the field".
+        """
+
+        packet = _packet(_read(helio, "proj_identity_rewrite"), signer)
+        readout = _read(helio, "proj_identity_rewrite")
+        evidence_free = {
+            path.path_id
+            for path in readout.paths
+            if not any(step.observation_ids for step in path.steps)
+        }
+
+        assert evidence_free, "no evidence-free path exists; vacuous"
+        for path in packet.related_context.paths:
+            if path.path_id in evidence_free:
+                assert path.evidence_ref_ids == ()

--- a/tests/context_fabric/test_chaos_3629_3630_lineage_honesty.py
+++ b/tests/context_fabric/test_chaos_3629_3630_lineage_honesty.py
@@ -87,9 +87,10 @@ def _read(projection, seed: str, *, max_hops: int = 2):
     )
 
 
-def _packet(readout, signer):
+def _packet(readout, signer, *, drivers=None):
     return build_packet(
         readout=readout,
+        drivers=drivers,
         job=JobContext(
             job_id="job_chaos_3629",
             question_family=QuestionFamilyID.PROJECT_STATUS_DRIVERS,
@@ -261,3 +262,62 @@ class TestLineagePathsCloseToEvidence:
         for path in packet.related_context.paths:
             if path.path_id in evidence_free:
                 assert path.evidence_ref_ids == ()
+
+
+class TestRelationshipClosureIsEnforcedLikeDriverClosure:
+    """The half of the provenance claim that was unenforceable.
+
+    Drivers have always had to close to evidence
+    (``_assert_support_is_closed``). The relationships they rest on could not,
+    because ``LineagePath.evidence_ref_ids`` was a constant — so "every
+    material driver or relationship closes to authorized canonical evidence"
+    was enforced for one of the two nouns in that sentence.
+
+    Scoped to paths an ASSERTED driver leans on. About half the corpus's edges
+    carry no evidence slugs, and a path nobody builds a judgment from owes
+    nobody a citation; demanding otherwise would refuse honest lineage.
+    """
+
+    def _honest(self, helio):
+        from dev_health_ops.context_fabric.graph_arm.drivers import discover_drivers
+
+        readout = _read(helio, "proj_identity_rewrite")
+        findings, _ = discover_drivers(
+            readout, "proj_identity_rewrite", as_of=world.TRIAL_NOW
+        )
+        asserted = [item for item in findings if item.path_ids and item.evidence_ids]
+        assert asserted, "no asserted driver to work from; vacuous"
+        return readout, asserted[0]
+
+    def test_an_asserted_driver_on_an_evidence_free_path_is_refused(
+        self, helio, signer
+    ) -> None:
+        from dataclasses import replace
+
+        readout, honest = self._honest(helio)
+        evidence_free = [
+            path.path_id
+            for path in readout.paths
+            if not any(step.observation_ids for step in path.steps)
+        ]
+        assert evidence_free, "no evidence-free path to plant; vacuous"
+
+        planted = replace(honest, path_ids=(evidence_free[0],))
+        with pytest.raises(ValueError, match="close to no evidence"):
+            _packet(readout, signer, drivers=(planted,))
+
+    def test_the_same_driver_on_its_own_evidenced_path_still_builds(
+        self, helio, signer
+    ) -> None:
+        """The other end of the pair.
+
+        Without it, a guard that refused every asserted driver would satisfy
+        the test above — and the arm would emit no judgments at all while
+        looking rigorous.
+        """
+
+        readout, honest = self._honest(helio)
+
+        packet = _packet(readout, signer, drivers=(honest,))
+
+        assert packet.driver_analysis.candidates


### PR DESCRIPTION
## CHAOS-3628 / 3629 / 3630 — the graph arm stops asserting constants

**Stacked on [#1617](https://github.com/full-chaos/dev-health-ops/pull/1617)** (CHAOS-3627). Base is
`chaos-3627-arm-vocab`; retarget to `feature/chaos-3498-context-fabric` once #1617 merges.

Three defects, three commits, each RED-first with its own commit. All three were
invisible while CHAOS-3627's vocabulary defect masked the oracle that owns them.

| | Was | Now |
| --- | --- | --- |
| **3628** evidence state | no concept at all — REVOKED/DELETED cited as live support on 5 seeds | non-ACTIVE evidence never reaches a packet |
| **3629** relevance | `RelevanceState.CURRENT` literal × 8 sites | derived from the readout's own validity |
| **3630** path evidence | `evidence_ref_ids=()` literal | the handles the path's own edges name |

---

### CHAOS-3628 — withdrawn evidence

`corpus_batch` filtered on tenant and known-entity only and demoted the state to a
display string; `grep -rn "EvidenceState|revoked|redacted|withdraw" context_fabric/`
returned **nothing**. REDACTED stayed out only because the *authorization* filter
removed `proj_quarry` — redaction itself did no work.

**Where the exclusion happens — the decision the ticket asked for, and why.** Three
places were possible and two are wrong:

- **not at ingestion.** The adapter's own docstring already argues this for
  adversarial evidence: material dropped at the door makes every exclusion
  expectation pass without the arm doing anything. An arm that never holds a revoked
  record cannot be observed declining to cite one.
- **not at emission.** Withdrawn evidence would still reach driver discovery and
  cohort construction, so a driver could rest on a revoked record and merely not
  show it. Support that exists and is invisible is worse than support that does not.
- **at read time** — where the authorization filter already draws the same line, and
  the first point at which the *arm* rather than the adapter decides.

`withdrawn_evidence_filtered_count` is its **own** number. A caller investigating a
thin answer must not be told their own grant removed what the source took back.

**REDACTED is proven under the compliance principal.** The corpus's only redacted
record is about `proj_quarry`, which the analyst cannot see — so under the analyst
the assertion passes with the fix deleted. `PRINCIPAL_COMPLIANCE` *can* see it, so
the state filter is the only thing that can be doing the work. **No corpus records
were added.**

**The oracle backstop is proven by a deliberately defective emitter**, never by
shipping behaviour that cites a revoked record. That is a change to the original
acceptance control, made deliberately: the shipped path must never trip
`withdrawn_evidence_handles`. The CHAOS-3627 test that used to prove it the other way
now asserts only what 3627 owns — every cited handle resolves in the world — and
points at the new location.

**The absent-state default, and what makes it safe.** `_is_citable` treats an absent
state as citable, correct for a source with no withdrawal concept and catastrophic
for one whose state was dropped in transit. Those are only distinguishable because
the projection **refuses** a source-issued handle that arrives without a state. An
unreadable state token is refused too — the only available default is "citable",
the direction that manufactures support.

### CHAOS-3629 — relevance

`_step_relevance` mirrors `world.WorldRelationship.relevance_at` member for member.
The corpus is the spec for this vocabulary and a second definition of "current" is
how two of them drift apart.

**Two reductions, and the difference is the point.** A path is as current as its
**weakest** hop — a route through an edge that closed two months ago is not a live
route. An entity, and a driver, is as current as its **best** path — one live route
is enough. One reduction for both would be wrong in one direction or the other.

**Where the readout carries no validity, the answer is `UNKNOWN`** rather than an
invented computation that keeps `CURRENT`. Reviewers should look at this deliberately
— it is a visible behaviour change: evidence entries and proposal-derived cohort
members now read `UNKNOWN`. An observation has no interval, and what a record is
*about* does not date the record; `CohortCandidate` carries no interval either, and
reaching for the peer's own path relevance would answer "how current is the entity"
while appearing to answer "how current is the membership".

### CHAOS-3630 — path evidence and relationship closure

The ids were on `PathStep` the whole time. Paths are now emitted **after** the
evidence index, because a reference is a handle and a handle does not exist until its
record is indexed — that ordering is load-bearing, not incidental. Only handles this
packet carries are cited; an observation reached but not indexed (including one
withdrawn under 3628) has none, and citing an unresolvable reference is the fault
driver-closure already refuses.

`_assert_support_is_closed` now refuses an asserted driver whose every supporting
path closes to no evidence — scoped to paths a judgment leans on, because about half
the corpus's edges carry no evidence slugs and a path nobody builds a judgment from
owes nobody a citation.

---

### Verification

- **RED first, per ticket**: 8b4aeab8d (8 failing) → 4749ab963; 5e8d331b9 (6 failing) → 21239fc50.
- **Input symmetry seeded at every end.** The historical edge reads historical *and* a
  live edge still reads current (so swapping one constant for another satisfies
  nothing); the evidenced path cites *and* the evidence-free path stays empty; the
  planted evidence-free driver is refused *and* the honest one still builds; the
  withdrawn count moves with the grant fixed *and* the grant count moves with
  withdrawals fixed — on `proj_beacon` under the analyst both are 1, so a
  "they differ" assertion would have been an accident of arithmetic.
- **86/86 guard-injection mutations** KILLED and restored green (six new ones here).
  Run with the live store up: `CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389
  CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1`.
- `bash ci/local_validate.sh`: **GATE PASSED** — 14487 passed, 274 skipped, 4 xfailed.

**The harness caught its own anchor drift** (b82547f30): `ruff-format` collapsed an
`elif all(...)` onto one line at commit and the relationship-closure mutation went
**INVALID and aborted the run** rather than silently passing. That is the rule its
docstring names first, working.

### Still outstanding

CHAOS-3620's #1616 has not merged, so `chaos_3620_spine.py` is not on this base.
Acceptance here is built on this lane's own composition, structured so the spine swaps
in. The rebase onto the new feature tip and the flip of #1616's `record must be
updated` pins will land as a **distinct commit** on each PR once #1616 is in.


---

## Rebased onto the CHAOS-3627 fix round (`42ae7f5b4`)

PR-1's fix round added a **third** member to the source-evidence triple — the entity the
*record* is about — in the same literals, the same validator and the same evidence-entry
construction this branch builds on. Five files conflicted.

Every conflict resolved as a **union rather than a choice**: 3628's state attribute and the
fix round's record-entity attribute answer different questions about the same record.

Two needed real resolution rather than merging, and both are called out because a reviewer
diffing this branch should know which parts were mechanical:

- **`_validate_source_evidence`'s early return** had to cover all three members. A naive
  union produced a guard that returned early on a record carrying only a state — skipping
  its own validation, and passing the suite while doing it.
- **`_probe_batch` in the 3628 suite** now supplies the record entity whenever it supplies
  a handle. After the fix round, a handle-bearing probe tripped the *pairing* guard before
  reaching the *state* guard it was written for. Those probes exist to exercise one guard
  each; a probe that dies in a sibling proves nothing about the guard it names.

Re-verified after the rebase: **gate PASSED** (14490 passed, 274 skipped, 4 xfailed);
**89/89** mutations killed and restored green; 530 passed in `tests/context_fabric`.
