### PR TITLE
CHAOS-3647: the semantic retrieval leg, measured — 0 of 8 subjects it resolves that the deterministic leg could not

### DIFF
--- a/src/dev_health_ops/api/dev/investigation_corpus/authorization.py
+++ b/src/dev_health_ops/api/dev/investigation_corpus/authorization.py
@@ -36,6 +36,7 @@ organization check catches ``proj_quarry`` leaking to the analyst principal.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -45,8 +46,13 @@ from . import world
 __all__ = [
     "AuthorizationAudit",
     "EntitySighting",
+    "ProseSighting",
+    "RestrictedVocabulary",
     "audit_authorization",
     "entity_sightings",
+    "prose_sightings",
+    "prose_sightings_in_text",
+    "restricted_vocabulary",
 ]
 
 
@@ -56,6 +62,20 @@ class EntitySighting:
 
     entity_id: str
     locations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ProseSighting:
+    """One restricted token found in the packet's rendered form.
+
+    CHAOS-3635 oracle v2. ``channel`` says what kind of thing leaked — an
+    entity id, an evidence slug, a human-readable label — because the fix
+    differs completely: an id in a prose field is a producer bug, a label in
+    a ``display_label`` is a disclosure the producer thinks is legitimate.
+    """
+
+    channel: str
+    token: str
 
 
 @dataclass(frozen=True)
@@ -77,6 +97,23 @@ class AuthorizationAudit:
     unauthorized_evidence_handles: tuple[str, ...] = ()
     #: Cited handles whose world record is revoked, redacted or deleted.
     withdrawn_evidence_handles: tuple[str, ...] = ()
+    #: CHAOS-3635 oracle v2. Restricted ids, evidence slugs and human-readable
+    #: names found anywhere in the packet's rendered form — including the
+    #: prose channels (``display_label``, driver summaries, inclusion
+    #: reasons, ``match_signals[].matched_text``, limitation details) and the
+    #: id-bearing paths :func:`entity_sightings`' field list does not walk.
+    #:
+    #: **Additive.** Every field above is computed exactly as it was before
+    #: this channel existed, so a packet that failed the v1 audit still fails
+    #: it for the same reason. This can only turn a clean verdict unclean,
+    #: which is the strengthening-only rule CHAOS-3635 was unfrozen under.
+    prose_disclosures: tuple[ProseSighting, ...] = ()
+    #: Names that WOULD be restricted but also occur in material the caller
+    #: may legitimately see, so matching them would report a disclosure that
+    #: is not one. Carried on the audit rather than dropped silently: this is
+    #: the walker's own residual blind spot, and an unstated blind spot in a
+    #: safety oracle is worse than a stated one.
+    ambiguous_labels_not_matched: tuple[str, ...] = ()
     #: Set when the packet claims an organization the principal does not
     #: belong to. Adversarial review round 1: a clean Helio witness relabelled
     #: ``org_lumen`` stayed contract-valid, authorization-clean and
@@ -86,6 +123,31 @@ class AuthorizationAudit:
 
     @property
     def is_clean(self) -> bool:
+        return not (
+            self.tenant_mismatch
+            or self.false_authorization_claims
+            or self.unauthorized_disclosures
+            or self.fabricated_entities
+            or self.fabricated_evidence_handles
+            or self.unauthorized_evidence_handles
+            or self.withdrawn_evidence_handles
+            # CHAOS-3635 oracle v2, appended rather than woven in: every term
+            # above is untouched, so this predicate can only move a verdict
+            # from clean to unclean and never the reverse.
+            or self.prose_disclosures
+        )
+
+    @property
+    def is_clean_v1_channels_only(self) -> bool:
+        """The pre-CHAOS-3635 verdict, kept so the change is auditable.
+
+        Exists to make the strengthening-only claim checkable rather than
+        asserted: ``is_clean`` implies this, never the other way round, and
+        ``test_chaos_3635_oracle_v2`` proves the implication over the whole
+        corpus plus the 3620 suite's planted counterexamples. Without it, a
+        reader has to take "additive" on trust.
+        """
+
         return not (
             self.tenant_mismatch
             or self.false_authorization_claims
@@ -126,6 +188,11 @@ class AuthorizationAudit:
             parts.append(f"handles-withdrawn={sorted(self.withdrawn_evidence_handles)}")
         if self.tenant_mismatch:
             parts.append(f"tenant-mismatch={self.tenant_mismatch}")
+        if self.prose_disclosures:
+            parts.append(
+                "prose-disclosures="
+                f"{sorted(f'{item.channel}:{item.token}' for item in self.prose_disclosures)}"
+            )
         return "; ".join(parts)
 
 
@@ -208,6 +275,192 @@ def entity_sightings(packet: AskDevInvestigationPacket) -> Mapping[str, set[str]
     return sightings
 
 
+# ---------------------------------------------------------------------------
+# CHAOS-3635 oracle v2: prose and label channels
+# ---------------------------------------------------------------------------
+#
+# Ported from the CHAOS-3620 suite's own disclosure walker, which the ticket
+# names as the reference implementation. It lives here now because this is the
+# *owning* instrument: a safety property proved by a test module beside the
+# arm under test is proved by something the next arm will not inherit.
+#
+# The 3620 module keeps its copy. That is deliberate rather than an oversight
+# to tidy up later: it is that suite's acceptance set for this code, and a
+# reference implementation that has been replaced by the thing it certifies
+# is no longer a reference. ``test_chaos_3635_oracle_v2`` runs both over the
+# same inputs and requires them to agree.
+
+
+@dataclass(frozen=True)
+class RestrictedVocabulary:
+    """Everything a principal must not see, in every form it can appear as."""
+
+    principal_id: str
+    entity_ids: frozenset[str]
+    evidence_slugs: frozenset[str]
+    #: Names safe to match: restricted, and occurring nowhere in material the
+    #: caller may legitimately read.
+    labels: frozenset[str]
+    #: Names that are restricted AND occur in permitted material, so matching
+    #: them would report a disclosure that is not one. Reported, not dropped.
+    ambiguous_labels: frozenset[str]
+
+
+#: Identifier characters. A token counts only when it appears WHOLE.
+#:
+#: Two false positives this rules out, both found by running the CHAOS-3620
+#: sweep rather than by reasoning about it: ``proj_quarry`` inside a
+#: hypothetical ``proj_quarry_archive`` is a different entity, and the label
+#: ``Ember`` — a team the Lumen principal cannot see — occurs inside the JSON
+#: key ``"members"`` in every packet, so a plain substring search reported a
+#: disclosure on four clean packets. A check that cries wolf on its own
+#: serialization format is one people learn to ignore.
+_TOKEN_BOUNDARY = re.compile(r"[A-Za-z0-9_-]")
+
+
+def _contains_token(haystack: str, token: str) -> bool:
+    """Whether ``token`` occurs in ``haystack`` whole, case-insensitively."""
+
+    folded_haystack = haystack.casefold()
+    folded_token = token.casefold()
+    start = 0
+    while True:
+        index = folded_haystack.find(folded_token, start)
+        if index < 0:
+            return False
+        after_index = index + len(folded_token)
+        before = folded_haystack[index - 1] if index else ""
+        after = (
+            folded_haystack[after_index] if after_index < len(folded_haystack) else ""
+        )
+        if not _TOKEN_BOUNDARY.match(before or " ") and not _TOKEN_BOUNDARY.match(
+            after or " "
+        ):
+            return True
+        start = index + 1
+
+
+def restricted_vocabulary(principal_id: str) -> RestrictedVocabulary:
+    """What ``principal_id`` must not see, derived from the world's grants.
+
+    Raises ``KeyError`` for an unknown principal, like
+    :func:`audit_authorization`: the tempting default is "sees everything",
+    which empties the restricted set and turns this into a no-op on exactly
+    the inputs it exists to judge.
+    """
+
+    visible = world.PRINCIPALS[principal_id].visible_entity_ids
+
+    entity_ids = frozenset(
+        entity_id for entity_id in world.ENTITIES_BY_ID if entity_id not in visible
+    )
+    evidence_slugs = frozenset(
+        slug
+        for slug, record in world.EVIDENCE_BY_SLUG.items()
+        if record.entity_id not in visible
+    )
+
+    # Everything the caller may legitimately read, as one corpus. A restricted
+    # name occurring anywhere in here cannot be told apart from a permitted
+    # mention of a permitted thing.
+    permitted_text = "\n".join(
+        text
+        for text in (
+            *(world.ENTITIES_BY_ID[entity_id].display_label for entity_id in visible),
+            *(
+                alias.text
+                for entity_id in visible
+                for alias in world.ENTITIES_BY_ID[entity_id].aliases
+            ),
+            *(
+                record.display_label
+                for slug, record in world.EVIDENCE_BY_SLUG.items()
+                if slug not in evidence_slugs
+            ),
+        )
+        if text
+    )
+
+    labels: set[str] = set()
+    ambiguous: set[str] = set()
+    for label in {
+        *(world.ENTITIES_BY_ID[entity_id].display_label for entity_id in entity_ids),
+        *(world.EVIDENCE_BY_SLUG[slug].display_label for slug in evidence_slugs),
+    }:
+        if not label:
+            continue
+        # Classified by the SAME whole-token predicate the matcher uses.
+        # Classifying by substring while matching by token creates a blind
+        # spot out of the exclusion rule itself: a label excluded for a
+        # collision the matcher would never have made.
+        (ambiguous if _contains_token(permitted_text, label) else labels).add(label)
+
+    return RestrictedVocabulary(
+        principal_id=principal_id,
+        entity_ids=entity_ids,
+        evidence_slugs=evidence_slugs,
+        labels=frozenset(labels),
+        ambiguous_labels=frozenset(ambiguous),
+    )
+
+
+def prose_sightings_in_text(
+    rendered: str, principal_id: str, *, include_evidence_slugs: bool = True
+) -> tuple[ProseSighting, ...]:
+    """The same scan, over any text a consumer would receive.
+
+    Split out from :func:`prose_sightings` so a producer that has not
+    assembled a packet yet can still be measured — the CHAOS-3647 retrieval
+    leg ranks subjects and never builds one, and "we could not check because
+    there was no packet" is how a channel goes unmeasured until it leaks.
+
+    ``include_evidence_slugs`` exists for callers whose text legitimately
+    contains no evidence at all; leaving it on for them costs nothing but a
+    reader's confusion about why an evidence channel is reported as clean on
+    a surface that has none.
+    """
+
+    vocabulary = restricted_vocabulary(principal_id)
+    found: list[ProseSighting] = [
+        ProseSighting("entity_id", entity_id)
+        for entity_id in sorted(vocabulary.entity_ids)
+        if _contains_token(rendered, entity_id)
+    ]
+    if include_evidence_slugs:
+        found += [
+            ProseSighting("evidence_slug", slug)
+            for slug in sorted(vocabulary.evidence_slugs)
+            if _contains_token(rendered, slug)
+        ]
+    found += [
+        ProseSighting("label", label)
+        for label in sorted(vocabulary.labels)
+        if _contains_token(rendered, label)
+    ]
+    return tuple(found)
+
+
+def prose_sightings(
+    packet: AskDevInvestigationPacket, principal_id: str
+) -> tuple[ProseSighting, ...]:
+    """Every restricted token anywhere in the packet a consumer receives.
+
+    Searched over the packet's **own JSON rendering** rather than over a
+    chosen list of fields. A field list is how a disclosure walker silently
+    stops covering the field that later leaks — which is precisely what
+    CHAOS-3635 was raised about: :func:`entity_sightings` walks the sections
+    it knows, and seven id-bearing paths plus every prose channel were
+    outside them.
+
+    Ids and evidence slugs are matched as well as labels. They are not
+    redundant with :func:`entity_sightings`: that function walks *structured
+    id fields*, so a restricted id that arrives inside a driver summary or a
+    truncation message is invisible to it and visible here.
+    """
+
+    return prose_sightings_in_text(packet.model_dump_json(), principal_id)
+
+
 def _cited_handles(packet: AskDevInvestigationPacket) -> set[str]:
     handles: set[str] = set()
     for entry in packet.evidence_coverage.evidence_index:
@@ -278,9 +531,13 @@ def audit_authorization(
         if record.state is not world.EvidenceState.ACTIVE:
             withdrawn_handles.append(handle)
 
+    vocabulary = restricted_vocabulary(principal_id)
+
     return AuthorizationAudit(
         case_id=case_id,
         principal_id=principal_id,
+        prose_disclosures=prose_sightings(packet, principal_id),
+        ambiguous_labels_not_matched=tuple(sorted(vocabulary.ambiguous_labels)),
         tenant_mismatch=tenant_mismatch,
         false_authorization_claims=false_claims,
         unauthorized_disclosures=tuple(unauthorized),

--- a/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
@@ -25,6 +25,13 @@ mistake this module could make. The check is on ``embedder.semantic``, which
 :class:`~.backend.CloudEmbedder` keys on the API key rather than on the class,
 so an unusable instance is refused too.
 
+**A hybrid leg whose BM25 half is dark must fail, not quietly become a
+cosine leg.** FalkorDB's full-text index populates after the bulk write, and
+a recorded run of this trial queried it too early: ``bm25_order`` was empty
+on all eight cases, the leg was cosine-only under a heading that said hybrid,
+and nothing failed. :func:`wait_for_fulltext_index` is the positive control
+that closes that, and it raises rather than warning.
+
 **Per-candidate mechanism is derived from what actually surfaced it.**
 Hybrid retrieval fuses two result sets, and a node that only BM25 found was
 found lexically. Labelling it ``EMBEDDING_SIMILARITY`` because the *leg* is
@@ -79,12 +86,15 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 __all__ = [
     "DEFAULT_SEMANTIC_LIMIT",
     "CrossPartitionRetrievalError",
+    "FulltextIndexNotReadyError",
+    "FulltextReadiness",
     "RetrievalMethod",
     "RetrievalStore",
     "SemanticCandidate",
     "SemanticRetrieval",
     "NonSemanticEmbedderError",
     "retrieve_candidates",
+    "wait_for_fulltext_index",
 ]
 
 #: How many candidates a semantic leg returns. Matches
@@ -230,6 +240,81 @@ class SemanticRetrieval:
 def _attribute(node: Any, key: str) -> Any:
     attributes = getattr(node, "attributes", None) or {}
     return attributes.get(key)
+
+
+@dataclass(frozen=True, slots=True)
+class FulltextReadiness:
+    """Evidence that the BM25 half of a hybrid leg is actually live."""
+
+    probe_query: str
+    expected_canonical_id: str
+    attempts_used: int
+    ready: bool
+
+
+class FulltextIndexNotReadyError(RuntimeError):
+    """The full-text index never populated, so BM25 would measure nothing.
+
+    Raised rather than warned, and this is the most important refusal in this
+    module after :class:`NonSemanticEmbedderError`.
+
+    **Observed, not hypothetical.** A recorded CHAOS-3647 run had
+    ``bm25_order == []`` on all eight cases: FalkorDB's full-text index had
+    not populated after the bulk write, so a leg labelled *hybrid* was
+    cosine-only in every row and nothing failed. The delta classifications
+    happened to survive; one case's rank-1 did not. A measurement that did
+    not happen has to fail loudly, so this is the failure.
+    """
+
+
+async def wait_for_fulltext_index(
+    store: RetrievalStore,
+    *,
+    probe_query: str,
+    expected_canonical_id: str,
+    attempts: int = 30,
+    delay_seconds: float = 0.5,
+) -> FulltextReadiness:
+    """Block until BM25 can find a node the caller knows is there.
+
+    The probe is a **positive control**: a query whose correct answer the
+    caller already knows, checked for *that answer* rather than for a
+    non-empty result. "The index returned something" is satisfied by a stale
+    index left by a previous run; "the index returned the node I just wrote"
+    is not.
+
+    Raises :class:`FulltextIndexNotReadyError` on timeout. There is no warn
+    mode and no falsy return for the failure case: a caller able to ignore
+    this would produce exactly the run it exists to prevent.
+    """
+
+    import asyncio
+
+    search_utils = graphiti_module("search.search_utils")
+    empty_filter = graphiti_module("search.search_filters").SearchFilters()
+    for attempt in range(1, attempts + 1):
+        nodes = await search_utils.node_fulltext_search(
+            store.driver, probe_query, empty_filter, [store.partition], 25
+        )
+        if any(
+            _attribute(node, _CANONICAL_ID_ATTRIBUTE) == expected_canonical_id
+            for node in nodes
+        ):
+            return FulltextReadiness(
+                probe_query=probe_query,
+                expected_canonical_id=expected_canonical_id,
+                attempts_used=attempt,
+                ready=True,
+            )
+        await asyncio.sleep(delay_seconds)
+
+    raise FulltextIndexNotReadyError(
+        f"after {attempts} attempts over {attempts * delay_seconds:.1f}s, "
+        f"full-text search for {probe_query!r} in partition "
+        f"{store.partition!r} never returned {expected_canonical_id!r}. The "
+        "BM25 half of a hybrid leg would contribute nothing, and the run "
+        "would record a cosine-only result under a hybrid heading"
+    )
 
 
 async def retrieve_candidates(

--- a/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
@@ -1,0 +1,418 @@
+"""CHAOS-3647: Graphiti's real semantic/hybrid retrieval, as a second leg.
+
+The CHAOS-3619 trial resolved subjects with :func:`discovery.search_candidates`
+— exact canonical id, exact display name, the alias family, and whole-token
+containment — over a store written by
+:class:`~.backend.DeterministicEmbedder`. That measured graph traversal and
+structured alias association, and it could not measure retrieval: BLAKE2b
+vectors carry no similarity, so nearest-neighbour search over them is
+arbitrary. Independent review said so, and this module is the answer.
+
+**What is different here, and it is the only thing that is different.** The
+projection, the partition, the authorization set, the corpus and the
+questions are all unchanged. The one variable is *how a human reference
+becomes a ranked canonical subject*: stored-text lookup on the deterministic
+leg, Graphiti's own BM25 and cosine primitives over live vectors here. The
+deterministic run stays the pinned baseline; nothing in this module edits it
+or is reachable from it.
+
+**A non-semantic embedder is refused, loudly.** :class:`NonSemanticEmbedderError`
+is raised before any query runs. A leg that silently accepted
+``DeterministicEmbedder`` would produce a full set of records under a
+"semantic" heading whose every number came from hash vectors — the
+deterministic baseline wearing a costume, and the single most expensive
+mistake this module could make. The check is on ``embedder.semantic``, which
+:class:`~.backend.CloudEmbedder` keys on the API key rather than on the class,
+so an unusable instance is refused too.
+
+**Per-candidate mechanism is derived from what actually surfaced it.**
+Hybrid retrieval fuses two result sets, and a node that only BM25 found was
+found lexically. Labelling it ``EMBEDDING_SIMILARITY`` because the *leg* is
+called semantic would be exactly the confusion
+:class:`~.backend.MatchMechanism` exists to prevent. So the two primitives
+are called separately, their per-method membership is kept, and the fusion is
+Graphiti's own :func:`rrf`. A reader of the artifact can therefore ask "would
+BM25 alone have found this?" and get an answer, rather than a claim.
+
+**Authorization is applied before ranking**, identically to
+:func:`discovery.search_candidates` and for the same reason: a restricted
+entity that occupies a rank, a clarification slot or a truncation count is
+visible to a caller who was never allowed to see it. Retrieval makes this
+sharper, not softer — a vector search does not know what a grant is, and will
+happily return the restricted project inside the caller's own tenant.
+
+**The partition is never a parameter, and is asserted on the way out.**
+:func:`retrieve_candidates` takes a :class:`RetrievalStore` — the read-only
+three-member view a :class:`~.store.GraphArmStore` satisfies — rather than a
+driver and a partition string. That is not ergonomics: a partition
+parameter is exactly what ``test_chaos_3617_no_caller_supplied_partition``
+forbids, and the first version of this module had one. Taking the store
+keeps the partition server-derived — it is the one :meth:`for_org`
+constructed from the organization id — and closes a second hole the two-
+argument form opened, where a caller could pass one organization's driver
+with another's partition, or a query vector from a model that did not write
+the store's vectors.
+
+``group_ids`` is then passed to both primitives, and every returned node's
+``group_id`` is re-checked here. The corpus plants a same-named project in a
+different tenant (``lumen_proj_acr``, label "Agent Context Runtime",
+identical to ``proj_acr``), which is precisely the shape a similarity search
+would cross partitions on. A filter that is only an argument is a filter
+nobody has measured.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+
+from .backend import EmbeddingBackend, MatchMechanism, graphiti_module
+from .vocabulary import GraphEntityKind
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Sequence
+
+__all__ = [
+    "DEFAULT_SEMANTIC_LIMIT",
+    "CrossPartitionRetrievalError",
+    "RetrievalMethod",
+    "RetrievalStore",
+    "SemanticCandidate",
+    "SemanticRetrieval",
+    "NonSemanticEmbedderError",
+    "retrieve_candidates",
+]
+
+#: How many candidates a semantic leg returns. Matches
+#: ``discovery.search_candidates``' own default so the two legs are compared
+#: over the same horizon rather than over different ones.
+DEFAULT_SEMANTIC_LIMIT = 25
+
+#: The node attribute carrying the canonical id. Written by
+#: ``backend.to_graphiti_nodes``; read back rather than parsed out of the
+#: node name, which is the *display label* and is not unique.
+_CANONICAL_ID_ATTRIBUTE = "cf_canonical_id"
+_ENTITY_KIND_ATTRIBUTE = "cf_entity_kind"
+_SOURCE_CLASS_ATTRIBUTE = "cf_source_class"
+
+
+@runtime_checkable
+class RetrievalStore(Protocol):
+    """Exactly what retrieval reads off a store, and nothing more.
+
+    A protocol rather than :class:`~.store.GraphArmStore` itself because the
+    three members below are the whole dependency, and naming them is what
+    lets a reader see that this module cannot write, purge, or open a
+    connection for an organization of its own choosing.
+
+    The critical member is :attr:`partition`, and it is a **property of the
+    object, never a parameter of the call**. That is the difference between
+    this signature and the one
+    ``test_chaos_3617_no_caller_supplied_partition`` rejected: a store's
+    partition was derived by :meth:`GraphArmStore.for_org` from a
+    server-known organization id, and there is no constructor a caller can
+    reach that produces a store for a partition they named.
+    """
+
+    @property
+    def driver(self) -> Any: ...
+
+    @property
+    def partition(self) -> str: ...
+
+    @property
+    def embedder(self) -> EmbeddingBackend: ...
+
+
+class NonSemanticEmbedderError(RuntimeError):
+    """A semantic retrieval leg was asked to run on meaningless vectors.
+
+    Raised before any query is issued. See the module docstring: the whole
+    value of this leg is that its numbers came from a real embedding model,
+    and a run that quietly degraded to hash vectors would be indistinguishable
+    from one that did not, in the artifact, forever.
+    """
+
+
+class CrossPartitionRetrievalError(RuntimeError):
+    """A retrieved node belongs to a partition other than the queried one."""
+
+
+class RetrievalMethod(StrEnum):
+    """Which Graphiti primitive surfaced a candidate.
+
+    Kept per candidate rather than per run. "The hybrid leg found it" is not
+    a finding; "cosine found it and BM25 did not" is.
+    """
+
+    BM25 = "bm25"
+    COSINE = "cosine_similarity"
+
+
+#: Which mechanism a set of surfacing methods honestly supports. A node BM25
+#: alone found was found by lexical overlap and nothing else, whatever the
+#: leg is called; cosine involvement is what makes the claim semantic.
+def _mechanism_for(methods: frozenset[RetrievalMethod]) -> MatchMechanism:
+    if RetrievalMethod.COSINE in methods:
+        return MatchMechanism.EMBEDDING_SIMILARITY
+    return MatchMechanism.LEXICAL_FUZZY
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticCandidate:
+    """One authorized subject retrieval surfaced, and how it was surfaced.
+
+    ``signal`` is :attr:`SubjectMatchSignal.FUZZY_LABEL` for every candidate
+    here, and that is a measured statement rather than a placeholder. The
+    frozen contract refuses to let ``FUZZY_LABEL`` carry a commitment on its
+    own; retrieval over node names produces a ranked guess and nothing
+    stronger, so any other signal would be a claim this leg cannot support.
+    An alias hit that reaches the top of a similarity ranking is still a
+    similarity hit — the registry is what makes it an alias, and this leg
+    does not consult the registry.
+    """
+
+    canonical_id: str
+    kind: GraphEntityKind
+    display_label: str
+    signal: SubjectMatchSignal
+    mechanism: MatchMechanism
+    matched_text: str
+    source_class: SourceClass
+    #: Every primitive that returned this node, so a reader can attribute the
+    #: find to lexical overlap or to embedding similarity.
+    methods: frozenset[RetrievalMethod]
+    #: The fused Reciprocal Rank Fusion score. Recorded, never compared
+    #: across queries: RRF scores are rank-derived and are only meaningful
+    #: within one fusion.
+    rrf_score: float
+    #: Zero-based rank within this query's authorized result.
+    rank: int
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticRetrieval:
+    """What one semantic query returned, and what it was not allowed to."""
+
+    query: str
+    candidates: tuple[SemanticCandidate, ...]
+    #: Distinct entities retrieval surfaced that the principal may not see.
+    #: A real disclosure figure, counted before ranking, exactly as
+    #: ``discovery.search_candidates`` counts it.
+    authorization_filtered_count: int
+    #: Which entities those were. A trial diagnostic, never packet content —
+    #: see :func:`_canonical_ids`. Carried because "authorization removed a
+    #: restricted project" and "retrieval never found one" are the two
+    #: results this leg exists to distinguish, and a bare count cannot.
+    withheld_canonical_ids: tuple[str, ...]
+    #: Canonical ids each primitive returned before authorization, in the
+    #: primitive's own order. Recorded because "authorization removed
+    #: nothing" and "retrieval found nothing to remove" are different
+    #: results that an empty candidate list renders identically.
+    retrieved_before_authorization: tuple[str, ...]
+    bm25_order: tuple[str, ...]
+    cosine_order: tuple[str, ...]
+    #: Non-entity nodes (observations) retrieval returned. Excluded from
+    #: subject candidates — the deterministic leg excludes them too — but
+    #: counted, because a retrieval leg whose top hits are all observations
+    #: is a different finding from one that returned nothing.
+    observation_hits: tuple[str, ...]
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.candidates)
+
+
+def _attribute(node: Any, key: str) -> Any:
+    attributes = getattr(node, "attributes", None) or {}
+    return attributes.get(key)
+
+
+async def retrieve_candidates(
+    query: str,
+    *,
+    store: RetrievalStore,
+    authorized_entity_ids: Sequence[str] | frozenset[str],
+    limit: int = DEFAULT_SEMANTIC_LIMIT,
+    min_score: float | None = None,
+) -> SemanticRetrieval:
+    """Ranked authorized subjects for ``query``, via BM25 + cosine + RRF.
+
+    Everything about *where* and *with what* comes from ``store``: its
+    driver, its server-derived partition, and the embedder it was opened
+    with. The query is therefore embedded by the same model that wrote the
+    node vectors, by construction rather than by discipline — comparing a
+    query vector from one model against node vectors from another produces a
+    confident ordering of nothing at all, and no caller could notice.
+    """
+
+    driver = store.driver
+    embedder = store.embedder
+    partition = store.partition
+
+    if not embedder.semantic:
+        raise NonSemanticEmbedderError(
+            f"embedder {embedder.model_id!r} reports semantic=False, so "
+            "nearest-neighbour search over the vectors it wrote is "
+            "meaningless. Refusing to run a semantic retrieval leg on it: "
+            "the resulting records would be indistinguishable from a real "
+            "semantic run and would be wrong in every row"
+        )
+
+    search_utils = graphiti_module("search.search_utils")
+    search_filters = graphiti_module("search.search_filters")
+    empty_filter = search_filters.SearchFilters()
+    group_ids = [partition]
+    # Both primitives are asked for a wider slice than the leg returns, so
+    # authorization filtering narrows a real candidate set rather than
+    # silently competing with the limit for the same slots.
+    candidate_limit = max(limit * 2, limit)
+
+    bm25_nodes = await search_utils.node_fulltext_search(
+        driver, query, empty_filter, group_ids, candidate_limit
+    )
+    query_vector = await embedder.create(query.replace("\n", " "))
+    cosine_kwargs: dict[str, Any] = {}
+    if min_score is not None:
+        cosine_kwargs["min_score"] = min_score
+    cosine_nodes = await search_utils.node_similarity_search(
+        driver,
+        query_vector,
+        empty_filter,
+        group_ids,
+        candidate_limit,
+        **cosine_kwargs,
+    )
+
+    by_uuid: dict[str, Any] = {}
+    methods: dict[str, set[RetrievalMethod]] = {}
+    for method, nodes in (
+        (RetrievalMethod.BM25, bm25_nodes),
+        (RetrievalMethod.COSINE, cosine_nodes),
+    ):
+        for node in nodes:
+            # Asserted on the way OUT, not only passed on the way in. See the
+            # module docstring: the corpus plants an identically labelled
+            # project in another tenant, and a group filter that is only an
+            # argument is one nobody has measured.
+            if node.group_id != partition:
+                raise CrossPartitionRetrievalError(
+                    f"retrieval for partition {partition!r} returned node "
+                    f"{node.uuid!r} from partition {node.group_id!r}; the "
+                    "group filter did not hold and this result set is not "
+                    "safe to rank"
+                )
+            by_uuid[node.uuid] = node
+            methods.setdefault(node.uuid, set()).add(method)
+
+    fused_uuids, fused_scores = search_utils.rrf(
+        [
+            [node.uuid for node in bm25_nodes],
+            [node.uuid for node in cosine_nodes],
+        ]
+    )
+    score_by_uuid = dict(zip(fused_uuids, fused_scores, strict=True))
+
+    retrieved: list[str] = []
+    observations: list[str] = []
+    withheld: dict[str, None] = {}
+    authorized = frozenset(authorized_entity_ids)
+    candidates: list[SemanticCandidate] = []
+
+    for uuid in fused_uuids:
+        node = by_uuid[uuid]
+        canonical_id = _attribute(node, _CANONICAL_ID_ATTRIBUTE)
+        if not isinstance(canonical_id, str) or not canonical_id:
+            # A node without the arm's own canonical-id attribute did not
+            # come from this projection. Skipped rather than guessed at:
+            # ranking a node whose identity is unknown is how a retrieval
+            # leg reports something it cannot name.
+            continue
+        kind_value = _attribute(node, _ENTITY_KIND_ATTRIBUTE)
+        if kind_value is None:
+            observations.append(canonical_id)
+            continue
+        kind = GraphEntityKind(kind_value)
+        if kind is GraphEntityKind.ORGANIZATION:
+            # Excluded on the deterministic leg too: the organization is
+            # never a subject, and offering it is the widening the
+            # clarification cases are built to catch.
+            continue
+        retrieved.append(canonical_id)
+        if canonical_id not in authorized:
+            # Withheld BEFORE ranking, exactly as on the deterministic leg.
+            # A restricted entity that occupied rank 0 and was dropped later
+            # has already shifted every rank below it, which is a disclosure
+            # by arithmetic even when the id itself never appears.
+            withheld[canonical_id] = None
+            continue
+        source_class_value = _attribute(node, _SOURCE_CLASS_ATTRIBUTE)
+        if source_class_value is None:
+            raise ValueError(
+                f"node {uuid!r} ({canonical_id!r}) carries no "
+                f"{_SOURCE_CLASS_ATTRIBUTE!r}; it was not written by this "
+                "arm's projection and its provenance cannot be stated"
+            )
+        candidates.append(
+            SemanticCandidate(
+                canonical_id=canonical_id,
+                kind=kind,
+                display_label=node.name,
+                signal=SubjectMatchSignal.FUZZY_LABEL,
+                mechanism=_mechanism_for(frozenset(methods[uuid])),
+                # The STORED text that matched, not the query. A packet
+                # reader already has what they typed.
+                matched_text=node.name,
+                source_class=SourceClass(source_class_value),
+                methods=frozenset(methods[uuid]),
+                rrf_score=float(score_by_uuid[uuid]),
+                rank=len(candidates),
+            )
+        )
+
+    return SemanticRetrieval(
+        query=query,
+        candidates=tuple(candidates[:limit]),
+        authorization_filtered_count=len(withheld),
+        withheld_canonical_ids=tuple(withheld),
+        retrieved_before_authorization=tuple(retrieved),
+        bm25_order=tuple(
+            _canonical_ids(bm25_nodes),
+        ),
+        cosine_order=tuple(
+            _canonical_ids(cosine_nodes),
+        ),
+        observation_hits=tuple(observations),
+    )
+
+
+def _canonical_ids(nodes: Any) -> list[str]:
+    """Canonical ids in a primitive's own returned order, **unfiltered**.
+
+    Deliberately not authorization filtered, and the danger in that is worth
+    stating rather than leaving for a reader to discover. These tuples are
+    the only channel that can answer "did cosine surface the restricted
+    project, and did authorization then remove it?" — a question an empty
+    candidate list and a clean candidate list answer identically. That is
+    the whole authorization measurement, so the identities have to survive
+    to the point where the comparison is made.
+
+    They are a **trial diagnostic and never packet content**. Nothing in
+    ``packet_builder`` reads a :class:`SemanticRetrieval`; the trial applies
+    :func:`authorization filtering <retrieve_candidates>` before anything is
+    ranked, and only ``candidates`` crosses into packet assembly. A caller
+    that renders these into something a principal receives has defeated the
+    filter, which is why they live on the retrieval record rather than on a
+    candidate.
+    """
+
+    ids: list[str] = []
+    for node in nodes:
+        canonical_id = _attribute(node, _CANONICAL_ID_ATTRIBUTE)
+        if isinstance(canonical_id, str) and canonical_id:
+            ids.append(canonical_id)
+    return ids

--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -117,6 +117,29 @@ class GraphArmStore:
     def embedder(self) -> EmbeddingBackend:
         return self._embedder
 
+    @property
+    def driver(self) -> Any:
+        """The Graphiti driver, for read paths that issue their own queries.
+
+        CHAOS-3647. Exposed rather than left as a private attribute the
+        retrieval leg reaches through, because a caller that writes
+        ``store._driver`` has silently taken on the store's whole invariant
+        set — most importantly that the driver is bound to *this*
+        organization's partition. Reading it here keeps the derivation
+        visible: the driver a caller gets is the one :meth:`for_org`
+        constructed with the server-derived partition as its ``database``,
+        and there is still no way to obtain one for a partition the caller
+        named.
+
+        It does **not** make the partition optional at query time. Graphiti's
+        search primitives filter on ``group_id`` independently of which
+        keyspace the driver is bound to, so a caller must still pass
+        :attr:`partition` as the group filter; ``semantic_retrieval``
+        re-asserts it on every returned node for exactly that reason.
+        """
+
+        return self._driver
+
     @classmethod
     def for_org(
         cls,

--- a/tests/_env_isolation.py
+++ b/tests/_env_isolation.py
@@ -169,6 +169,28 @@ CONDITIONAL_KEEP_ENV_NAMES: dict[str, str] = {
     # alone yields the loud skip, which names the sentinel.
     "CONTEXT_FABRIC_GRAPH_STORE_URI": "CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE",
     "CONTEXT_FABRIC_GRAPH_STORE_PASSWORD": "CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE",
+    # CHAOS-3647: the semantic retrieval leg needs a REAL embedding model, and
+    # the credential it needs is one of the two the repo already conventions
+    # on (``llm/credentials.py``: LLM_API_KEY first, then OPENAI_API_KEY).
+    #
+    # Pollutant, and more sharply than the store URI: an ambient key does not
+    # merely reach a local container, it spends money against a third party
+    # from a tier that is supposed to touch nothing. Scrubbing it by default
+    # stays right.
+    #
+    # Requirement: tests/context_fabric/test_chaos_3647_live_semantic.py
+    # cannot measure anything without it. It does not fall back to
+    # DeterministicEmbedder — a run on hash vectors would look semantic and
+    # score like noise, which is worse than not running — so an unconditional
+    # scrub turns that lane into a permanent skip.
+    #
+    # Sentinel is CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE, the same one the store
+    # URI uses, and deliberately so: this leg needs BOTH a live store and a
+    # live model, there is no configuration in which it wants one without the
+    # other, and a second sentinel would be a second thing to forget. Setting
+    # the key alone still yields the loud skip that names the sentinel.
+    "LLM_API_KEY": "CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE",
+    "OPENAI_API_KEY": "CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/context_fabric/test_chaos_3635_oracle_v2.py
+++ b/tests/context_fabric/test_chaos_3635_oracle_v2.py
@@ -1,0 +1,304 @@
+"""CHAOS-3635: the authorization oracle grows prose channels, provably.
+
+chris unfroze this ticket on 2026-08-09 under one rule — **strengthening
+only**: a change may turn passes into failures and never failures into
+passes. This module is what makes that rule checkable rather than asserted.
+
+The design the ticket names is honoured exactly: the CHAOS-3620 suite's own
+disclosure walker is the reference implementation, and its planted
+counterexamples are the acceptance set. Two independent things are therefore
+proved here, and neither substitutes for the other:
+
+* **the new channel finds what the old one missed** — the forged-label
+  counterexample is executed, the v1 channels report the packet clean, and
+  v2 names the leak. Prose is not enough for that claim: a strengthening
+  whose evidence is only a docstring is a strengthening nobody can audit;
+* **nothing that used to fail now passes** — ``is_clean`` implies
+  ``is_clean_v1_channels_only`` over the whole sweep. That is the direction
+  the rule constrains, and the implication is one-way on purpose.
+
+``is_clean_v1_channels_only`` exists solely for this file's second claim. It
+is not an escape hatch for a caller who finds the new channel inconvenient,
+and a consumer reaching for it is asking to be blind to exactly the leak this
+ticket was raised about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.api.dev.investigation_corpus.authorization import (
+    audit_authorization,
+    entity_sightings,
+    prose_sightings,
+    prose_sightings_in_text,
+    restricted_vocabulary,
+)
+
+from . import chaos_3620_spine as spine
+
+#: Seeds whose packets are the sweep. Chosen to span an authorized team, a
+#: project, and a cross-tenant-adjacent subject, so the implication below is
+#: measured over packets with genuinely different contents rather than over
+#: one packet three times.
+_SWEEP_SEEDS: tuple[str, ...] = (
+    "team_cinder",
+    "team_atlas",
+    world.PROJ_IDENTITY_REWRITE,
+    world.PROJ_ACR,
+    world.PROJ_VERTEX,
+)
+
+
+def _forge(packet, **evidence_updates):
+    """One indexed evidence entry, altered. The arm-shaped disclosure plant.
+
+    Same helper the CHAOS-3620 suite uses, reproduced rather than imported
+    because importing a private name from a sibling test module couples two
+    suites that must be able to fail independently. The packet's shape does
+    not change and it still validates, so the only variable is whether a
+    check reads the field.
+    """
+
+    index = packet.evidence_coverage.evidence_index
+    first = index[0]
+    forged_entry = first.model_copy(
+        update={"evidence": first.evidence.model_copy(update=evidence_updates)}
+    )
+    return packet.model_copy(
+        update={
+            "evidence_coverage": packet.evidence_coverage.model_copy(
+                update={"evidence_index": (forged_entry, *index[1:])}
+            )
+        }
+    )
+
+
+class TestTheAcceptanceSetIsRediscovered:
+    """The CHAOS-3620 counterexamples, run against the oracle itself."""
+
+    def test_a_restricted_label_in_prose_is_caught_by_v2_and_missed_by_v1(
+        self,
+    ) -> None:
+        """The whole reason CHAOS-3635 exists, executed rather than described.
+
+        A packet that never names ``proj_quarry`` but does say "Quarry
+        Compliance" has disclosed the restricted project to any human reading
+        the answer. No identifier-based check can see that, and the assertion
+        below on ``is_clean_v1_channels_only`` is the executed proof that the
+        pre-3635 oracle did not.
+        """
+
+        clean = spine.investigate("team_cinder").packet
+        forged = _forge(clean, display_label="Quarry Compliance rollout notes")
+
+        # The plant must be invisible to every id channel, or this test is
+        # measuring the id walker and not the prose one.
+        assert world.PROJ_QUARRY not in entity_sightings(forged), (
+            "the plant leaked a canonical id, so it no longer isolates prose"
+        )
+
+        audit = audit_authorization(forged, world.PRINCIPAL_ANALYST)
+        assert audit.is_clean_v1_channels_only, (
+            "the pre-3635 channels now catch this, so the recorded RED "
+            "evidence no longer demonstrates the miss this ticket fixes"
+        )
+        assert not audit.is_clean, "oracle v2 did not catch the prose leak"
+        assert [f"{item.channel}:{item.token}" for item in audit.prose_disclosures] == [
+            "label:Quarry Compliance"
+        ]
+
+    def test_a_restricted_evidence_slug_is_named_by_channel(self) -> None:
+        """The second planted channel: identifiers that are not entity ids.
+
+        ``wi_quarry_redacted`` is real corpus evidence whose subject the
+        analyst cannot see. v1 catches it — as a *fabricated entity*, because
+        it is not in ``ENTITIES_BY_ID`` — so this is not a miss. It is
+        included because a strengthening that quietly stopped catching a case
+        the acceptance set already covers would be a regression the
+        implication test alone cannot see.
+        """
+
+        clean = spine.investigate("team_cinder").packet
+        forged = _forge(clean, entity_id="wi_quarry_redacted")
+
+        audit = audit_authorization(forged, world.PRINCIPAL_ANALYST)
+        assert not audit.is_clean_v1_channels_only
+        assert not audit.is_clean
+        assert "evidence_slug:wi_quarry_redacted" in {
+            f"{item.channel}:{item.token}" for item in audit.prose_disclosures
+        }
+
+    def test_the_unforged_packet_is_clean_on_both_channel_sets(self) -> None:
+        """The control.
+
+        An oracle that reported a disclosure on every packet would pass both
+        tests above and mean nothing. This is also the test that fails if the
+        new channel false-positives on the corpus's own serialization —
+        which is exactly what the ambiguous-label exclusion exists to
+        prevent, and what the sweep below re-checks at scale.
+        """
+
+        clean = spine.investigate("team_cinder").packet
+        audit = audit_authorization(clean, world.PRINCIPAL_ANALYST)
+        assert audit.prose_disclosures == ()
+        assert audit.is_clean
+        assert audit.is_clean_v1_channels_only
+
+
+class TestStrengtheningOnly:
+    @pytest.mark.parametrize("seed", _SWEEP_SEEDS)
+    def test_v2_clean_implies_v1_clean(self, seed: str) -> None:
+        """The unfreeze rule, as a one-way implication.
+
+        Passes may become failures; failures may never become passes. So
+        ``is_clean`` must imply ``is_clean_v1_channels_only`` and the
+        converse must be free to fail — which the forged-label test above
+        demonstrates it does.
+        """
+
+        audit = audit_authorization(
+            spine.investigate(seed).packet, world.PRINCIPAL_ANALYST
+        )
+        if audit.is_clean:
+            assert audit.is_clean_v1_channels_only, (
+                f"{seed}: oracle v2 declared a packet clean that the v1 "
+                "channels flagged; that is a weakening, which the CHAOS-3635 "
+                "unfreeze forbids"
+            )
+
+    @pytest.mark.parametrize("seed", _SWEEP_SEEDS)
+    def test_every_v1_field_is_unchanged_by_the_new_channel(self, seed: str) -> None:
+        """The additive claim, field by field.
+
+        ``prose_disclosures`` is computed from the packet's rendering and
+        touches nothing else. Asserted rather than trusted because "additive"
+        is the kind of claim that stays true until someone factors a shared
+        helper out of two branches.
+        """
+
+        packet = spine.investigate(seed).packet
+        audit = audit_authorization(packet, world.PRINCIPAL_ANALYST)
+        sightings = entity_sightings(packet)
+        visible = world.PRINCIPALS[world.PRINCIPAL_ANALYST].visible_entity_ids
+        known = set(world.ENTITIES_BY_ID)
+
+        expected_unauthorized = sorted(
+            entity_id
+            for entity_id in sightings
+            if entity_id in known and entity_id not in visible
+        )
+        assert (
+            sorted(item.entity_id for item in audit.unauthorized_disclosures)
+            == expected_unauthorized
+        )
+        expected_fabricated = sorted(
+            entity_id for entity_id in sightings if entity_id not in known
+        )
+        assert (
+            sorted(item.entity_id for item in audit.fabricated_entities)
+            == expected_fabricated
+        )
+
+
+class TestAgreementWithTheReferenceImplementation:
+    @pytest.mark.parametrize("seed", _SWEEP_SEEDS)
+    @pytest.mark.parametrize(
+        "principal", [world.PRINCIPAL_ANALYST, world.PRINCIPAL_COMPLIANCE]
+    )
+    def test_the_oracle_and_the_3620_walker_agree(
+        self, seed: str, principal: str
+    ) -> None:
+        """Two implementations, same inputs, same answer.
+
+        The CHAOS-3620 suite keeps its walker deliberately — a reference
+        implementation that has been deleted in favour of the thing it
+        certifies is no longer a reference. This is the differential that
+        makes keeping it worth something.
+        """
+
+        packet = spine.investigate(seed, principal=principal).packet
+        assert sorted(
+            f"{item.channel}:{item.token}"
+            for item in prose_sightings(packet, principal)
+        ) == sorted(spine.disclosures(packet, principal))
+
+
+class TestTheResidualBlindSpotIsStatedNotHidden:
+    def test_the_analysts_ambiguous_label_set_is_pinned(self) -> None:
+        """The exclusion is auditable, and its contents are asserted.
+
+        A restricted name that also occurs in material the caller may
+        legitimately read cannot be matched without reporting a disclosure
+        that is not one — ``Agent Context Runtime`` is the cross-tenant
+        near-duplicate's label, verbatim identical to a project the analyst
+        may see, and ``Core`` occurs inside ``platform core``, team_atlas's
+        previous name.
+
+        Both are genuine ambiguity rather than a defect in the rule. What
+        would be a defect is leaving that in a field nobody reads, so the
+        audit carries the set and this test pins it: a change to the corpus
+        that alters what the walker is blind to has to be noticed here.
+        """
+
+        vocabulary = restricted_vocabulary(world.PRINCIPAL_ANALYST)
+        assert sorted(vocabulary.ambiguous_labels) == [
+            "Agent Context Runtime",
+            "Core",
+        ]
+        audit = audit_authorization(
+            spine.investigate("team_cinder").packet, world.PRINCIPAL_ANALYST
+        )
+        assert audit.ambiguous_labels_not_matched == (
+            "Agent Context Runtime",
+            "Core",
+        )
+
+    def test_a_label_only_leak_inside_the_ambiguous_set_is_NOT_caught(self) -> None:
+        """The honest statement of what this oracle still cannot see.
+
+        Kept executable rather than written as a caveat. If a future change
+        makes this leak detectable, this test fails and the residual it
+        documents has to be re-stated — which is the point: an inaccurate
+        coverage claim is worse than an admitted gap, because a reader who
+        sees "covered" stops checking.
+        """
+
+        clean = spine.investigate("team_cinder").packet
+        forged = _forge(clean, display_label="Core")
+        audit = audit_authorization(forged, world.PRINCIPAL_ANALYST)
+        assert audit.prose_disclosures == (), (
+            "the ambiguous-label residual has changed; re-state it rather "
+            "than deleting this test"
+        )
+
+
+class TestNoPrincipalDefaultsToSeeingEverything:
+    def test_an_unknown_principal_raises(self) -> None:
+        """The tempting default empties the restricted set entirely."""
+
+        with pytest.raises(KeyError):
+            restricted_vocabulary("principal_does_not_exist")
+
+    def test_the_text_scan_refuses_an_unknown_principal_too(self) -> None:
+        with pytest.raises(KeyError):
+            prose_sightings_in_text("Quarry Compliance", "principal_does_not_exist")
+
+    def test_the_text_scan_finds_a_restricted_label_in_bare_text(self) -> None:
+        """The surface CHAOS-3647's retrieval leg is measured on.
+
+        It ranks subjects and never assembles a packet, so
+        ``prose_sightings`` has nothing to walk. "We could not check because
+        there was no packet" is how a channel stays unmeasured until it
+        leaks.
+        """
+
+        found = prose_sightings_in_text(
+            "proj_alpha\nQuarry Compliance",
+            world.PRINCIPAL_ANALYST,
+            include_evidence_slugs=False,
+        )
+        assert [f"{item.channel}:{item.token}" for item in found] == [
+            "label:Quarry Compliance"
+        ]

--- a/tests/context_fabric/test_chaos_3647_live_semantic.py
+++ b/tests/context_fabric/test_chaos_3647_live_semantic.py
@@ -1,0 +1,315 @@
+"""CHAOS-3647: the semantic leg against a live store and a real model.
+
+This module is the only place the leg is exercised end to end, and it is
+gated twice — a reachable FalkorDB and a real embedding model — because
+neither can be faked without destroying what is being measured. A stubbed
+embedder is the deterministic baseline wearing a costume, and a stubbed store
+is an assertion about a fixture.
+
+Both gates route through :mod:`live_gate`, so an unavailable store **fails**
+under ``CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1`` rather than skipping. The
+embedder gate is spelled out here rather than borrowed, because "no API key"
+is not the same missing piece and a message naming the store would send a
+reader to the wrong place.
+
+What is asserted here is deliberately not "the semantic leg answers well".
+That is a measurement, it lives in ``trials/chaos_3647/results/``, and it
+would be an unstable and self-fulfilling assertion in a test. What is
+asserted is that the leg is *sound*: it reproduces the pinned baseline on the
+deterministic path, its authorization filter is exercised by something real,
+and its cross-partition exclusion is a differential rather than an empty
+result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
+from dev_health_ops.context_fabric.graph_arm.backend import CloudEmbedder
+from dev_health_ops.context_fabric.graph_arm.projection import build_projection
+from dev_health_ops.context_fabric.graph_arm.store import GraphArmStore
+from trials.chaos_3647.legs import LegId, resolve_deterministic, resolve_semantic
+from trials.chaos_3647.probes import PROBES, run_probe
+
+from . import live_gate
+
+#: ``loop_scope="module"`` is load-bearing, not tidiness. The FalkorDB driver
+#: the store holds binds its connection pool to the loop it was created on,
+#: so a module-scoped fixture handing that store to function-scoped loops
+#: fails with "attached to a different loop" — on the *second* test, which is
+#: how it reads as a flake rather than as a configuration error. One loop for
+#: the module keeps the single expensive ingestion and the driver together.
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio(loop_scope="module")]
+
+_PINNED = (
+    Path(__file__).resolve().parents[2]
+    / "trials"
+    / "chaos_3619"
+    / "results"
+    / "trial-results.records.json"
+)
+
+
+def _require_semantic_embedder() -> CloudEmbedder:
+    """Two outcomes, like the store gate. Never a silent downgrade."""
+
+    if os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY"):
+        return CloudEmbedder.from_environment()
+    message = (
+        "no LLM_API_KEY/OPENAI_API_KEY is set, so no real embedding model is "
+        "available and the semantic leg cannot be measured. Falling back to "
+        "DeterministicEmbedder is refused: the run would look semantic and "
+        "score like noise"
+    )
+    from dev_health_ops.context_fabric.graph_arm.flags import live_store_required
+
+    if live_store_required():
+        pytest.fail(f"a live measurement was required and did not happen: {message}")
+    pytest.skip(message)
+    raise AssertionError("pytest.skip always raises")
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def semantic_world():
+    """Both tenants, written once under a real embedding model.
+
+    Module-scoped because every write costs real embedding calls — 226 for
+    Helio — and per-test ingestion would multiply that by the number of tests
+    without changing a single answer.
+
+    The Lumen partition is written for one reason: the cross-tenant probe.
+    An exclusion asserted against an empty neighbouring keyspace is an
+    assertion that cannot fail.
+    """
+
+    config = live_gate.require_live_store()
+    embedder = _require_semantic_embedder()
+    os.environ["CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED"] = "1"
+
+    helio = build_projection(adapter.corpus_batch(world.ORG_HELIO))
+    lumen = build_projection(adapter.corpus_batch(world.ORG_LUMEN))
+    helio_store = GraphArmStore.for_org(
+        world.ORG_HELIO, config=config, embedder=embedder
+    )
+    lumen_store = GraphArmStore.for_org(
+        world.ORG_LUMEN, config=config, embedder=embedder
+    )
+    try:
+        for store, projection in ((helio_store, helio), (lumen_store, lumen)):
+            await store.purge_org()
+            await store.build_indices()
+            await store.write_projection(projection)
+        yield helio_store, lumen_store, helio, embedder
+    finally:
+        for store in (helio_store, lumen_store):
+            try:
+                await store.purge_org()
+            finally:
+                await store.close()
+        os.environ.pop("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", None)
+
+
+class TestThePinnedBaselineIsReproduced:
+    """The re-run deterministic leg must agree with the pinned artifact.
+
+    Re-running the baseline in-process rather than reading its numbers is
+    what makes the comparison same-world and same-commit. It is also how a
+    baseline silently drifts, so the agreement is asserted rather than
+    assumed — on the two ambiguity cases the pinned run actually scored.
+    """
+
+    @pytest.mark.parametrize(
+        ("case_id", "question", "expected"),
+        [
+            ("H01_acronym_resolution", "status on IPR?", "proj_identity_rewrite"),
+            (
+                "H02_old_and_current_name",
+                "how's the thing we used to call Northstar going?",
+                "proj_identity_rewrite",
+            ),
+        ],
+    )
+    async def test_the_deterministic_leg_still_resolves_what_it_resolved(
+        self, semantic_world, case_id: str, question: str, expected: str
+    ) -> None:
+        _helio_store, _lumen_store, projection, _embedder = semantic_world
+        resolution = resolve_deterministic(
+            question=question,
+            projection=projection,
+            authorized_entity_ids=adapter.authorized_entity_ids_for(
+                world.PRINCIPAL_ANALYST
+            ),
+            over_mentions=True,
+        )
+        assert resolution.leg is LegId.DETERMINISTIC_MENTIONS
+        assert resolution.top_1 == expected
+
+        pinned = json.loads(_PINNED.read_text(encoding="utf-8"))
+        dispositions = {
+            arm.get("disposition")
+            for case in pinned["cases"]
+            if case.get("case_id") == case_id
+            for arm in case.get("arms", ())
+            if arm.get("arm_id") == "graph_assisted_shadow_arm"
+        }
+        assert "scored" in dispositions, (
+            f"{case_id} is no longer scored in the pinned artifact, so this "
+            "reproduction is comparing against something that changed"
+        )
+
+    async def test_the_colloquial_cases_still_resolve_nothing_deterministically(
+        self, semantic_world
+    ) -> None:
+        """The gap CHAOS-3647 was opened about, re-measured.
+
+        The pinned run recorded ``no authorized subject resolved from the
+        question`` for these. If that ever stops being true the semantic
+        leg's whole delta is measured against a different baseline, and the
+        artifact would say otherwise without anything failing.
+        """
+
+        _helio_store, _lumen_store, projection, _embedder = semantic_world
+        grant = adapter.authorized_entity_ids_for(world.PRINCIPAL_ANALYST)
+        for question in (
+            "What about the auth work?",
+            "what's holding it up?",
+            "What about the other project we discussed?",
+            "What happened with the project that kept cycling in review?",
+            "how's the payments work going",
+        ):
+            resolution = resolve_deterministic(
+                question=question,
+                projection=projection,
+                authorized_entity_ids=grant,
+                over_mentions=True,
+            )
+            assert resolution.subjects == (), (
+                f"{question!r} now resolves deterministically; the pinned "
+                "baseline this leg is measured against has moved"
+            )
+
+
+class TestTheSemanticLegRunsAgainstTheRealThing:
+    async def test_it_retrieves_over_live_vectors_a_real_model_wrote(
+        self, semantic_world
+    ) -> None:
+        """Soundness, not quality: the leg reaches the store and ranks.
+
+        The embedder identity is asserted because it is the one fact that
+        makes every other number in the artifact mean what it says. A run
+        under ``deterministic_blake2b`` would produce a complete, plausible
+        result set that is noise in every row.
+        """
+
+        helio_store, _lumen_store, _projection, embedder = semantic_world
+        assert embedder.semantic
+        assert embedder.model_id.startswith("openai_")
+
+        resolution = await resolve_semantic(
+            question="how's the payments work going",
+            store=helio_store,
+            authorized_entity_ids=adapter.authorized_entity_ids_for(
+                world.PRINCIPAL_ANALYST
+            ),
+        )
+        assert resolution.leg is LegId.SEMANTIC_HYBRID
+        assert resolution.subjects, (
+            "hybrid retrieval returned nothing for a query naming a real "
+            "project; the store, the index or the vectors are not what this "
+            "leg thinks they are"
+        )
+        assert resolution.cosine_order, "the cosine primitive returned nothing"
+        assert all(
+            subject.mechanism in {"embedding_similarity", "lexical_fuzzy"}
+            for subject in resolution.subjects
+        )
+
+
+class TestTheAuthorizationProbesAreEffective:
+    """Not "authorization held" — "authorization was asked, and held".
+
+    The eight corpus ambiguity questions withhold nothing, because none is
+    near the restricted project. A verdict drawn from those alone would be a
+    property of the questions.
+    """
+
+    @pytest.mark.parametrize("probe", PROBES, ids=lambda p: p.probe_id)
+    async def test_each_probe_measures_what_it_claims(
+        self, semantic_world, probe
+    ) -> None:
+        helio_store, lumen_store, _projection, embedder = semantic_world
+        outcome = await run_probe(
+            probe,
+            store=helio_store,
+            authorized_entity_ids=adapter.authorized_entity_ids_for(probe.principal_id),
+            presence_store=lumen_store if probe.presence_partition else None,
+            presence_authorized_entity_ids=(
+                adapter.authorized_entity_ids_for(probe.presence_principal_id)
+                if probe.presence_partition
+                else None
+            ),
+        )
+        assert outcome.effective, (
+            f"{probe.probe_id} did not reach the boundary it exists to test: "
+            f"{outcome.detail}. A probe that measures nothing must not be "
+            "read as a clean result"
+        )
+        assert outcome.verdict == "pass", outcome.detail
+
+    async def test_a_restricted_entity_is_retrieved_and_then_withheld(
+        self, semantic_world
+    ) -> None:
+        """The load-bearing one, spelled out.
+
+        Retrieval must surface ``proj_quarry`` — it is in the analyst's own
+        partition, one hop from teams the analyst owns, and its display label
+        is exactly the query — and the grant must be what removes it. If the
+        first half stops being true, the second half proves nothing.
+        """
+
+        helio_store, _lumen_store, _projection, embedder = semantic_world
+        resolution = await resolve_semantic(
+            question="Quarry Compliance",
+            store=helio_store,
+            authorized_entity_ids=adapter.authorized_entity_ids_for(
+                world.PRINCIPAL_ANALYST
+            ),
+        )
+        assert world.PROJ_QUARRY in resolution.withheld_canonical_ids, (
+            "retrieval never surfaced the restricted project, so the filter "
+            "was not exercised and the clean result below is vacuous"
+        )
+        assert resolution.authorization_filtered_count >= 1
+        assert world.PROJ_QUARRY not in resolution.top_n(len(resolution.subjects))
+
+    async def test_the_same_query_ranks_it_for_the_principal_who_may_see_it(
+        self, semantic_world
+    ) -> None:
+        """The other half of the differential.
+
+        Without this, "the analyst does not get proj_quarry" could be an
+        absence of data rather than an authorization decision.
+        """
+
+        helio_store, _lumen_store, _projection, embedder = semantic_world
+        resolution = await resolve_semantic(
+            question="Quarry Compliance",
+            store=helio_store,
+            authorized_entity_ids=adapter.authorized_entity_ids_for(
+                world.PRINCIPAL_COMPLIANCE
+            ),
+        )
+        assert world.PROJ_QUARRY in {
+            subject.canonical_id for subject in resolution.subjects
+        }, (
+            "the compliance principal, who IS granted the restricted "
+            "project, cannot retrieve it either — so the analyst's empty "
+            "result is structural and not an authorization decision"
+        )

--- a/tests/context_fabric/test_chaos_3647_live_semantic.py
+++ b/tests/context_fabric/test_chaos_3647_live_semantic.py
@@ -34,6 +34,9 @@ from dev_health_ops.api.dev.investigation_corpus import world
 from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
 from dev_health_ops.context_fabric.graph_arm.backend import CloudEmbedder
 from dev_health_ops.context_fabric.graph_arm.projection import build_projection
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    wait_for_fulltext_index,
+)
 from dev_health_ops.context_fabric.graph_arm.store import GraphArmStore
 from trials.chaos_3647.legs import LegId, resolve_deterministic, resolve_semantic
 from trials.chaos_3647.probes import PROBES, run_probe
@@ -106,6 +109,20 @@ async def semantic_world():
             await store.purge_org()
             await store.build_indices()
             await store.write_projection(projection)
+        # BM25 must be live before any test reads a hybrid result. Without
+        # this the suite's "the leg runs against the real thing" assertion
+        # passes on a cosine-only result — which is exactly what one recorded
+        # trial run did, silently.
+        await wait_for_fulltext_index(
+            helio_store,
+            probe_query=world.ENTITIES_BY_ID[world.PROJ_IDENTITY_REWRITE].display_label,
+            expected_canonical_id=world.PROJ_IDENTITY_REWRITE,
+        )
+        await wait_for_fulltext_index(
+            lumen_store,
+            probe_query=world.ENTITIES_BY_ID[world.LUMEN_PROJ_ACR].display_label,
+            expected_canonical_id=world.LUMEN_PROJ_ACR,
+        )
         yield helio_store, lumen_store, helio, embedder
     finally:
         for store in (helio_store, lumen_store):
@@ -226,6 +243,11 @@ class TestTheSemanticLegRunsAgainstTheRealThing:
             "leg thinks they are"
         )
         assert resolution.cosine_order, "the cosine primitive returned nothing"
+        assert resolution.bm25_order, (
+            "the BM25 primitive returned nothing, so this 'hybrid' result is "
+            "cosine-only. A recorded run of this trial looked exactly like "
+            "this in all eight cases and nothing failed"
+        )
         assert all(
             subject.mechanism in {"embedding_similarity", "lexical_fuzzy"}
             for subject in resolution.subjects

--- a/tests/context_fabric/test_chaos_3647_semantic_leg.py
+++ b/tests/context_fabric/test_chaos_3647_semantic_leg.py
@@ -27,9 +27,11 @@ from dev_health_ops.context_fabric.graph_arm.backend import (
 )
 from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
     CrossPartitionRetrievalError,
+    FulltextIndexNotReadyError,
     NonSemanticEmbedderError,
     RetrievalMethod,
     retrieve_candidates,
+    wait_for_fulltext_index,
 )
 from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
 
@@ -401,3 +403,84 @@ class TestNonSubjectNodes:
                 store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
                 authorized_entity_ids=frozenset({"proj_alpha"}),
             )
+
+
+class TestTheFulltextReadinessGate:
+    """The guard for the failure this trial actually shipped once.
+
+    A recorded CHAOS-3647 run had ``bm25_order == []`` on all eight cases:
+    FalkorDB's full-text index had not populated after the bulk write, the
+    "hybrid" leg was cosine-only in every row, and nothing failed. The delta
+    classifications happened to survive; one case's rank-1 did not.
+    """
+
+    async def test_an_unpopulated_index_raises_rather_than_returning_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install(monkeypatch, bm25=[], cosine=[])
+        with pytest.raises(FulltextIndexNotReadyError) as excinfo:
+            await wait_for_fulltext_index(
+                _FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+                probe_query="Identity Platform Rewrite",
+                expected_canonical_id="proj_identity_rewrite",
+                attempts=2,
+                delay_seconds=0.0,
+            )
+        assert "proj_identity_rewrite" in str(excinfo.value)
+        assert "cosine-only" in str(excinfo.value)
+
+    async def test_a_non_empty_index_that_lacks_the_probe_still_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The positive control is the point.
+
+        "The index returned something" is satisfied by a stale index a
+        previous run left behind. Only "the index returned the node I just
+        wrote" distinguishes a populated index from an old one.
+        """
+
+        _install(monkeypatch, bm25=[_node("u_other", "proj_other", "Other")], cosine=[])
+        with pytest.raises(FulltextIndexNotReadyError):
+            await wait_for_fulltext_index(
+                _FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+                probe_query="Identity Platform Rewrite",
+                expected_canonical_id="proj_identity_rewrite",
+                attempts=2,
+                delay_seconds=0.0,
+            )
+
+    async def test_a_populated_index_reports_ready(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control. A gate that never opens is not a gate."""
+
+        _install(
+            monkeypatch,
+            bm25=[_node("u1", "proj_identity_rewrite", "Identity Platform Rewrite")],
+            cosine=[],
+        )
+        readiness = await wait_for_fulltext_index(
+            _FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            probe_query="Identity Platform Rewrite",
+            expected_canonical_id="proj_identity_rewrite",
+            attempts=2,
+            delay_seconds=0.0,
+        )
+        assert readiness.ready
+        assert readiness.attempts_used == 1
+
+    async def test_the_probe_is_scoped_to_the_stores_own_partition(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A neighbouring tenant's populated index must not satisfy this."""
+
+        calls = _install(monkeypatch, bm25=[], cosine=[])
+        with pytest.raises(FulltextIndexNotReadyError):
+            await wait_for_fulltext_index(
+                _FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+                probe_query="anything",
+                expected_canonical_id="proj_identity_rewrite",
+                attempts=1,
+                delay_seconds=0.0,
+            )
+        assert calls["bm25_group_ids"] == [_PARTITION]

--- a/tests/context_fabric/test_chaos_3647_semantic_leg.py
+++ b/tests/context_fabric/test_chaos_3647_semantic_leg.py
@@ -1,0 +1,403 @@
+"""CHAOS-3647: the semantic retrieval leg's guards, observed failing.
+
+Every test here plants the specific defect its guard exists to catch. A
+retrieval leg is unusually easy to test into meaninglessness — a fake driver
+that returns an empty list makes every safety assertion pass — so the shape
+throughout is: construct a result set that WOULD leak, and require the guard
+to be what stops it.
+
+The one thing deliberately not tested here is whether retrieval finds the
+right subjects. That is a property of a live store, a real embedding model
+and the corpus, it is what ``trials/chaos_3647/results/`` measures, and a
+unit test that asserted it would be asserting its own fixture.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+from dev_health_ops.context_fabric.graph_arm.backend import (
+    DeterministicEmbedder,
+    MatchMechanism,
+)
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    CrossPartitionRetrievalError,
+    NonSemanticEmbedderError,
+    RetrievalMethod,
+    retrieve_candidates,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+from . import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+_PARTITION = "cf_trial_org_test"
+_OTHER_PARTITION = "cf_trial_org_other"
+
+
+@dataclass
+class _FakeNode:
+    """The subset of ``EntityNode`` the retrieval path reads."""
+
+    uuid: str
+    name: str
+    group_id: str = _PARTITION
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def _node(
+    uuid: str,
+    canonical_id: str,
+    label: str,
+    *,
+    kind: str | None = GraphEntityKind.PROJECT.value,
+    partition: str = _PARTITION,
+    source_class: str | None = SourceClass.WORK_GRAPH.value,
+) -> _FakeNode:
+    attributes: dict[str, Any] = {"cf_canonical_id": canonical_id}
+    if kind is not None:
+        attributes["cf_entity_kind"] = kind
+    if source_class is not None:
+        attributes["cf_source_class"] = source_class
+    return _FakeNode(uuid=uuid, name=label, group_id=partition, attributes=attributes)
+
+
+@dataclass(frozen=True)
+class _SemanticEmbedder:
+    """A stand-in that reports ``semantic=True`` and embeds nothing real.
+
+    Legitimate ONLY here. These tests never rank by similarity — the result
+    sets are supplied — so the vector's content is irrelevant and the flag is
+    the only thing under test. The trial runner refuses this shape outright;
+    see ``runner._require_preconditions``.
+    """
+
+    model_id: str = "test_semantic_double.v1"
+    semantic: bool = True
+
+    async def create(self, input_data: Any) -> list[float]:
+        return [0.0] * 8
+
+
+@dataclass(frozen=True)
+class _FakeStore:
+    """The three things :func:`retrieve_candidates` reads off a store.
+
+    Not a mock of ``GraphArmStore``: it is the read-only triple the retrieval
+    path uses, and spelling it out here keeps these tests from depending on a
+    live driver they never call. The real store's contribution — that the
+    partition is server-derived and cannot be named by a caller — is asserted
+    by ``test_chaos_3617_no_caller_supplied_partition``, which is exactly the
+    guard that made this signature take a store in the first place.
+    """
+
+    driver: Any
+    partition: str
+    embedder: Any
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, *, bm25: list, cosine: list) -> dict:
+    """Replace the two Graphiti primitives with fixed result sets.
+
+    ``rrf``, ``SearchFilters`` and the group-filter argument plumbing stay
+    real: the fusion and the assertions are what is under test, and stubbing
+    the fusion would test the stub.
+    """
+
+    live_gate.require_graphiti_extra()
+    from graphiti_core.search import search_utils
+
+    calls: dict[str, Any] = {}
+
+    async def fake_fulltext(driver, query, search_filter, group_ids, limit):
+        calls["bm25_group_ids"] = group_ids
+        calls["bm25_query"] = query
+        return list(bm25)
+
+    async def fake_similarity(
+        driver, search_vector, search_filter, group_ids, limit, *args, **kwargs
+    ):
+        calls["cosine_group_ids"] = group_ids
+        calls["cosine_vector"] = search_vector
+        return list(cosine)
+
+    monkeypatch.setattr(search_utils, "node_fulltext_search", fake_fulltext)
+    monkeypatch.setattr(search_utils, "node_similarity_search", fake_similarity)
+    return calls
+
+
+class TestTheEmbedderGuard:
+    """A non-semantic embedder must stop the leg before it queries anything."""
+
+    async def test_a_hash_embedder_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = _install(
+            monkeypatch,
+            bm25=[_node("u1", "proj_a", "Alpha")],
+            cosine=[],
+        )
+        with pytest.raises(NonSemanticEmbedderError) as excinfo:
+            await retrieve_candidates(
+                "anything",
+                store=_FakeStore(object(), _PARTITION, DeterministicEmbedder()),
+                authorized_entity_ids=frozenset({"proj_a"}),
+            )
+        assert "deterministic_blake2b" in str(excinfo.value)
+        # The refusal happens BEFORE any query. A leg that raised after
+        # querying would still have spent the call, and — worse — a caller
+        # catching the error would have a half-built result set to be
+        # tempted by.
+        assert calls == {}, "the leg queried the store before refusing"
+
+    async def test_a_semantic_embedder_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control. A guard that refuses everything is not a guard."""
+
+        _install(monkeypatch, bm25=[_node("u1", "proj_a", "Alpha")], cosine=[])
+        result = await retrieve_candidates(
+            "alpha",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_a"}),
+        )
+        assert [c.canonical_id for c in result.candidates] == ["proj_a"]
+
+
+class TestAuthorizationIsAppliedBeforeRanking:
+    async def test_a_restricted_top_hit_never_occupies_a_rank(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The planted defect: retrieval puts the restricted entity first.
+
+        Rank 0 must go to the authorized entity that retrieval ranked
+        SECOND. A filter applied after ranking would leave a hole at 0 or
+        shift everything down while the restricted id had already decided
+        the order — both of which disclose by arithmetic even though the id
+        itself is absent from the output.
+        """
+
+        restricted = _node("u_restricted", "proj_quarry", "Quarry Compliance")
+        allowed = _node("u_allowed", "proj_alpha", "Alpha")
+        _install(monkeypatch, bm25=[restricted, allowed], cosine=[restricted, allowed])
+
+        result = await retrieve_candidates(
+            "quarry",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_alpha"}),
+        )
+
+        assert [c.canonical_id for c in result.candidates] == ["proj_alpha"]
+        assert result.candidates[0].rank == 0, "ranks must be contiguous from zero"
+        assert result.authorization_filtered_count == 1
+        assert result.withheld_canonical_ids == ("proj_quarry",)
+
+    async def test_the_withheld_count_is_distinct_entities_not_hits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One restricted entity found by both primitives is one withholding.
+
+        Counting hits would report 2 here, and that number reaches a packet
+        as ``authorization_filtered_count`` — where an inflated value is a
+        false claim about how much the answer was narrowed.
+        """
+
+        restricted = _node("u_restricted", "proj_quarry", "Quarry Compliance")
+        _install(monkeypatch, bm25=[restricted], cosine=[restricted])
+        result = await retrieve_candidates(
+            "quarry",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_alpha"}),
+        )
+        assert result.authorization_filtered_count == 1
+
+    async def test_nothing_restricted_means_nothing_withheld(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control for the two tests above."""
+
+        _install(
+            monkeypatch,
+            bm25=[_node("u1", "proj_alpha", "Alpha")],
+            cosine=[_node("u1", "proj_alpha", "Alpha")],
+        )
+        result = await retrieve_candidates(
+            "alpha",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_alpha"}),
+        )
+        assert result.authorization_filtered_count == 0
+        assert result.withheld_canonical_ids == ()
+
+
+class TestThePartitionAssertion:
+    async def test_a_foreign_partition_node_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The planted defect: the group filter did not hold.
+
+        Passed as an argument on every call, so this can only happen if
+        Graphiti's filter regressed or a driver ignored it — which is
+        precisely the class of failure an argument-only filter cannot
+        detect. The corpus plants an identically labelled project in another
+        tenant, so the result would be a same-named entity from a foreign
+        organization ranked as the caller's own.
+        """
+
+        foreign = _node(
+            "u_foreign",
+            "lumen_proj_acr",
+            "Agent Context Runtime",
+            partition=_OTHER_PARTITION,
+        )
+        _install(monkeypatch, bm25=[foreign], cosine=[])
+        with pytest.raises(CrossPartitionRetrievalError) as excinfo:
+            await retrieve_candidates(
+                "agent context runtime",
+                store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+                authorized_entity_ids=frozenset({"lumen_proj_acr"}),
+            )
+        # Authorized, and still refused: the partition is not an
+        # authorization question and must not be answerable by one.
+        assert _OTHER_PARTITION in str(excinfo.value)
+
+    async def test_the_group_filter_is_actually_passed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The assertion above is the backstop, not the mechanism."""
+
+        calls = _install(monkeypatch, bm25=[], cosine=[])
+        await retrieve_candidates(
+            "anything",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset(),
+        )
+        assert calls["bm25_group_ids"] == [_PARTITION]
+        assert calls["cosine_group_ids"] == [_PARTITION]
+
+
+class TestMechanismAttribution:
+    """ "The semantic leg found it" is not a finding; which primitive is."""
+
+    async def test_bm25_only_is_reported_as_lexical(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node = _node("u1", "proj_alpha", "Alpha")
+        _install(monkeypatch, bm25=[node], cosine=[])
+        result = await retrieve_candidates(
+            "alpha",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_alpha"}),
+        )
+        candidate = result.candidates[0]
+        assert candidate.methods == frozenset({RetrievalMethod.BM25})
+        assert candidate.mechanism is MatchMechanism.LEXICAL_FUZZY, (
+            "a node only BM25 found was found lexically; calling it an "
+            "embedding similarity because the LEG is semantic is the exact "
+            "confusion MatchMechanism exists to prevent"
+        )
+
+    async def test_cosine_involvement_is_reported_as_embedding_similarity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node = _node("u1", "proj_alpha", "Alpha")
+        _install(monkeypatch, bm25=[], cosine=[node])
+        result = await retrieve_candidates(
+            "alpha",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_alpha"}),
+        )
+        assert result.candidates[0].mechanism is MatchMechanism.EMBEDDING_SIMILARITY
+
+    async def test_every_candidate_carries_the_fuzzy_label_signal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retrieval produces a ranked guess, and the signal must say so.
+
+        The frozen contract refuses to let ``FUZZY_LABEL`` carry a commitment
+        alone. An alias hit that happens to top a similarity ranking is still
+        a similarity hit — this leg never consults the alias registry — and
+        emitting ``ALIAS`` for it would claim registry resolution the leg did
+        not perform.
+        """
+
+        node = _node("u1", "proj_identity_rewrite", "Identity Platform Rewrite")
+        _install(monkeypatch, bm25=[node], cosine=[node])
+        result = await retrieve_candidates(
+            "the auth work",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_identity_rewrite"}),
+        )
+        assert result.candidates[0].signal is SubjectMatchSignal.FUZZY_LABEL
+
+
+class TestNonSubjectNodes:
+    async def test_observations_are_excluded_from_subjects_but_counted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The finding H06 turns on.
+
+        An observation node carries no ``cf_entity_kind``. Retrieval ranking
+        one first and the leg silently returning nothing would read as "the
+        retriever found nothing", when what happened is that it found the
+        right evidence and the subject path had no hop to an entity. The
+        count is what makes the two distinguishable in the artifact.
+        """
+
+        observation = _node("u_obs", "rv_vertex_cycles", "Vertex review", kind=None)
+        _install(monkeypatch, bm25=[observation], cosine=[observation])
+        result = await retrieve_candidates(
+            "kept cycling in review",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"rv_vertex_cycles"}),
+        )
+        assert result.candidates == ()
+        assert result.observation_hits == ("rv_vertex_cycles",)
+
+    async def test_the_organization_is_never_a_subject(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        org = _node(
+            "u_org", "org_helio", "Helio", kind=GraphEntityKind.ORGANIZATION.value
+        )
+        _install(monkeypatch, bm25=[org], cosine=[])
+        result = await retrieve_candidates(
+            "helio",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"org_helio"}),
+        )
+        assert result.candidates == ()
+
+    async def test_a_node_without_a_canonical_id_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A node this arm did not write must not be ranked under a guess."""
+
+        stray = _FakeNode(uuid="u_stray", name="Something", attributes={})
+        _install(monkeypatch, bm25=[stray], cosine=[])
+        result = await retrieve_candidates(
+            "something",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset(),
+        )
+        assert result.candidates == ()
+
+    async def test_a_node_without_a_source_class_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Provenance is not optional on something about to be ranked."""
+
+        node = _node("u1", "proj_alpha", "Alpha", source_class=None)
+        _install(monkeypatch, bm25=[node], cosine=[])
+        with pytest.raises(ValueError, match="cf_source_class"):
+            await retrieve_candidates(
+                "alpha",
+                store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+                authorized_entity_ids=frozenset({"proj_alpha"}),
+            )

--- a/trials/chaos_3647/__init__.py
+++ b/trials/chaos_3647/__init__.py
@@ -1,0 +1,35 @@
+"""CHAOS-3647: the semantic/hybrid retrieval leg, measured against the baseline.
+
+The CHAOS-3619 trial ran ``DeterministicEmbedder`` and exact-id subject
+resolution. Independent review gate 2 was right that this supports claims
+about graph traversal and structured alias association and supports **no**
+claim about Graphiti's semantic value — "the project that kept cycling in
+review" is not a lookup.
+
+This package adds a leg, and only a leg. The deterministic run in
+``trials/chaos_3619/results/`` remains the pinned baseline; nothing here
+writes to it, imports its results, or changes how it resolved anything. What
+is measured is a single substitution: replace stored-text lookup with
+Graphiti's own BM25 and cosine primitives over vectors a real embedding model
+wrote, hold the projection, partition, questions and authorization set fixed,
+and record what changes.
+
+**The three legs, and why three rather than two.** The deterministic leg
+failed the colloquial cases at *mention extraction*, not at matching: the
+production interpreter yields no mention at all for "What about the auth
+work?". A two-leg comparison would therefore attribute an extraction gap to
+retrieval and call it semantic value. So the deterministic path is run twice
+— once over extracted mentions, which reproduces the pinned baseline, and
+once over the raw question — and the semantic leg is run over the raw
+question, which is the input a retriever is actually for. The middle leg is
+what makes the delta attributable.
+"""
+
+from __future__ import annotations
+
+__all__ = ["SEMANTIC_TRIAL_SCHEMA_VERSION"]
+
+#: This artifact's own shape version, distinct from the CHAOS-3619 trial's.
+#: A consumer reading both must be able to tell them apart without guessing
+#: from field names.
+SEMANTIC_TRIAL_SCHEMA_VERSION = "chaos_3647_semantic_leg_results.v1"

--- a/trials/chaos_3647/legs.py
+++ b/trials/chaos_3647/legs.py
@@ -1,0 +1,275 @@
+"""The three subject-resolution legs, expressed over one common result shape.
+
+Every leg answers the same question — *given this question string and this
+principal's grant, which authorized canonical subjects does the arm rank, and
+in what order* — and nothing else. Packet assembly, driver synthesis and
+evidence citation are deliberately out of scope: the review finding this
+package answers is about **retrieval**, and a leg that also rebuilt packets
+would mix a retrieval delta with a synthesis delta and be unable to say which
+moved.
+
+The legs:
+
+``DETERMINISTIC_MENTIONS``
+    The pinned CHAOS-3619 path, unchanged: production mention extraction,
+    then :func:`discovery.search_candidates` over stored text. Re-run here
+    rather than read from the baseline file so the comparison is same-process
+    and same-world; ``test_chaos_3647_baseline_reproduction`` asserts it
+    agrees with the pinned artifact, which is what makes re-running safe.
+
+``DETERMINISTIC_QUESTION``
+    The same matcher, handed the raw question. Exists to separate an
+    extraction gap from a matching gap. Whole-token containment against a
+    whole sentence matches almost nothing, and that near-zero result is the
+    control that makes the semantic leg's input fair rather than generous.
+
+``SEMANTIC_HYBRID``
+    Graphiti's ``node_fulltext_search`` and ``node_similarity_search`` over
+    the live store, fused with Graphiti's own ``rrf``, with the query
+    embedded by the same model that wrote the node vectors.
+
+**No leg is handed the answer.** None of these functions takes a case id, a
+seed, an expected subject or an oracle — the same structural fairness rule
+``trials.chaos_3619.graph_leg`` enforces, and for the same reason: a
+parameter that could carry the answer is a parameter someone eventually
+passes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from dev_health_ops.context_fabric.graph_arm.discovery import search_candidates
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    retrieve_candidates,
+)
+from trials.chaos_3619.graph_leg import mention_texts
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from dev_health_ops.context_fabric.graph_arm.projection import GraphProjection
+    from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+        RetrievalStore,
+    )
+
+__all__ = [
+    "LEG_LIMIT",
+    "LegId",
+    "RankedSubject",
+    "LegResolution",
+    "prose_disclosures_in",
+    "resolve_deterministic",
+    "resolve_semantic",
+]
+
+#: The candidate horizon every leg is measured over. One number, shared, so
+#: a leg cannot look better by having been asked for more.
+LEG_LIMIT = 25
+
+
+class LegId(StrEnum):
+    """Which configuration produced a resolution."""
+
+    DETERMINISTIC_MENTIONS = "deterministic_mentions"
+    DETERMINISTIC_QUESTION = "deterministic_question"
+    SEMANTIC_HYBRID = "semantic_hybrid"
+
+
+@dataclass(frozen=True, slots=True)
+class RankedSubject:
+    """One authorized canonical subject a leg ranked, and how it found it."""
+
+    canonical_id: str
+    display_label: str
+    rank: int
+    #: The frozen contract's ``SubjectMatchSignal`` value.
+    signal: str
+    #: The arm-internal ``MatchMechanism`` value — how, as opposed to what.
+    #: This is the field that separates "resolved by alias registry" from
+    #: "resolved by nearest neighbour", which score identically and differ
+    #: completely in what they prove.
+    mechanism: str
+    #: Which retrieval primitives surfaced it. Empty for the deterministic
+    #: legs, which run no primitive.
+    methods: tuple[str, ...] = ()
+    #: RRF score, semantic leg only. Meaningful only within one fusion.
+    rrf_score: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LegResolution:
+    """What one leg resolved for one question."""
+
+    leg: LegId
+    query: str
+    subjects: tuple[RankedSubject, ...]
+    authorization_filtered_count: int
+    #: Trial diagnostic. See ``semantic_retrieval._canonical_ids``: a bare
+    #: count cannot distinguish "authorization removed a restricted entity"
+    #: from "retrieval never surfaced one", and that distinction is the
+    #: authorization measurement.
+    withheld_canonical_ids: tuple[str, ...] = ()
+    #: Per-primitive order before authorization, semantic leg only.
+    bm25_order: tuple[str, ...] = ()
+    cosine_order: tuple[str, ...] = ()
+    #: Observation nodes retrieval returned. Not subjects — the deterministic
+    #: leg excludes them too — but recorded, because a leg whose top hits are
+    #: all observations has found something and dropped it, which is a
+    #: different finding from having found nothing.
+    observation_hits: tuple[str, ...] = ()
+    #: What the production interpreter extracted, deterministic-mentions leg
+    #: only. Recorded because an empty tuple here is the single most
+    #: load-bearing fact in the whole comparison.
+    mentions: tuple[str, ...] = ()
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.subjects)
+
+    @property
+    def top_1(self) -> str:
+        return self.subjects[0].canonical_id if self.subjects else ""
+
+    def top_n(self, count: int) -> tuple[str, ...]:
+        return tuple(subject.canonical_id for subject in self.subjects[:count])
+
+
+def prose_disclosures_in(
+    resolution: LegResolution, principal_id: str
+) -> tuple[str, ...]:
+    """CHAOS-3635 oracle v2, applied to what this leg would hand a consumer.
+
+    The leg builds no packet, so ``audit_authorization`` has nothing to walk.
+    What it *does* produce is the prose a packet's subject-discovery section
+    is built from: every ranked subject carries a ``display_label``, and the
+    contract copies that into ``candidates[].display_label`` and
+    ``match_signals[].matched_text``. Those are exactly the channels
+    CHAOS-3635 exists for, and a canonical-id check is blind to them — a leg
+    that never names ``proj_quarry`` but ranks something labelled "Quarry
+    Compliance" has disclosed it.
+
+    Deliberately scans the ranked output and NOT the diagnostic fields. A
+    retrieval record's ``withheld_canonical_ids`` and per-primitive orders
+    hold restricted ids on purpose: they are the evidence the filter fired,
+    they never reach a consumer, and reporting them here would make the check
+    fail on precisely the runs where authorization worked.
+    """
+
+    from dev_health_ops.api.dev.investigation_corpus.authorization import (
+        prose_sightings_in_text,
+    )
+
+    rendered = "\n".join(
+        f"{subject.canonical_id}\n{subject.display_label}\n{subject.signal}"
+        for subject in resolution.subjects
+    )
+    return tuple(
+        f"{sighting.channel}:{sighting.token}"
+        for sighting in prose_sightings_in_text(
+            rendered, principal_id, include_evidence_slugs=False
+        )
+    )
+
+
+def resolve_deterministic(
+    *,
+    question: str,
+    projection: GraphProjection,
+    authorized_entity_ids: frozenset[str],
+    over_mentions: bool,
+    limit: int = LEG_LIMIT,
+) -> LegResolution:
+    """Stored-text resolution, over extracted mentions or the raw question.
+
+    The withheld count is the **maximum** across queries rather than the sum,
+    matching ``graph_leg.discover_subjects`` exactly. ``search_candidates``
+    returns a count and not identities, so summing double-counts one
+    restricted entity that matched two mentions and overstates how much the
+    answer was narrowed. Reproducing the baseline's arithmetic matters more
+    here than improving on it: a different rule would make the pinned
+    comparison invalid for a reason unrelated to retrieval.
+    """
+
+    mentions = mention_texts(question) if over_mentions else ()
+    queries = mentions if over_mentions else (question,)
+
+    merged: dict[str, Any] = {}
+    filtered_counts: list[int] = []
+    for text in queries:
+        candidates, filtered = search_candidates(
+            text, projection.nodes, authorized_entity_ids, limit=limit
+        )
+        for match in candidates:
+            existing = merged.get(match.canonical_id)
+            if existing is None or match.rank_key < existing.rank_key:
+                merged[match.canonical_id] = match
+        if filtered:
+            filtered_counts.append(filtered)
+
+    ranked = sorted(merged.values(), key=lambda item: item.rank_key)[:limit]
+    return LegResolution(
+        leg=(
+            LegId.DETERMINISTIC_MENTIONS
+            if over_mentions
+            else LegId.DETERMINISTIC_QUESTION
+        ),
+        query=question,
+        subjects=tuple(
+            RankedSubject(
+                canonical_id=match.canonical_id,
+                display_label=match.display_label,
+                rank=index,
+                signal=match.signal.value,
+                mechanism=match.mechanism.value,
+            )
+            for index, match in enumerate(ranked)
+        ),
+        authorization_filtered_count=max(filtered_counts, default=0),
+        mentions=mentions,
+    )
+
+
+async def resolve_semantic(
+    *,
+    question: str,
+    store: RetrievalStore,
+    authorized_entity_ids: frozenset[str],
+    limit: int = LEG_LIMIT,
+) -> LegResolution:
+    """Hybrid BM25 + cosine resolution over the live store.
+
+    Handed the raw question rather than extracted mentions on purpose. A
+    retriever's input is a query, and feeding it the deterministic leg's
+    empty mention tuple would guarantee an empty result and measure nothing.
+    The cost of that choice is that the two legs no longer share an input,
+    which is exactly what ``DETERMINISTIC_QUESTION`` exists to price.
+    """
+
+    retrieval = await retrieve_candidates(
+        question,
+        store=store,
+        authorized_entity_ids=authorized_entity_ids,
+        limit=limit,
+    )
+    return LegResolution(
+        leg=LegId.SEMANTIC_HYBRID,
+        query=question,
+        subjects=tuple(
+            RankedSubject(
+                canonical_id=candidate.canonical_id,
+                display_label=candidate.display_label,
+                rank=candidate.rank,
+                signal=candidate.signal.value,
+                mechanism=candidate.mechanism.value,
+                methods=tuple(sorted(method.value for method in candidate.methods)),
+                rrf_score=candidate.rrf_score,
+            )
+            for candidate in retrieval.candidates
+        ),
+        authorization_filtered_count=retrieval.authorization_filtered_count,
+        withheld_canonical_ids=retrieval.withheld_canonical_ids,
+        bm25_order=retrieval.bm25_order,
+        cosine_order=retrieval.cosine_order,
+        observation_hits=retrieval.observation_hits,
+    )

--- a/trials/chaos_3647/probes.py
+++ b/trials/chaos_3647/probes.py
@@ -1,0 +1,329 @@
+"""Planted probes that make the authorization verdict mean something.
+
+The eight corpus ambiguity questions withheld **nothing** on the semantic
+leg: no query happened to be near the restricted project, so
+``authorization_filtered_count`` was zero on every row. A clean audit
+produced that way is not evidence the filter works — it is evidence the
+filter was never asked. Reporting it as "authorization held on the semantic
+path" would be the exact inaccurate-coverage claim that stops a reader
+checking.
+
+So the filter is asked, deliberately, with queries chosen to hit it:
+
+``restricted_exact_label``
+    The restricted project's own display label, typed by a principal who
+    cannot see it. The corpus plants ``proj_quarry`` **inside the analyst's
+    own tenant** precisely so no tenant comparison catches it, and a
+    similarity search has no notion of a grant at all.
+
+``restricted_topical``
+    A colloquial phrase near the restricted project rather than its name.
+    Separate from the exact-label probe because they fail differently: a
+    filter keyed on the query text would pass the second and fail the first.
+
+``cross_tenant_near_duplicate``
+    The label ``lumen_proj_acr`` shares verbatim with ``proj_acr`` in another
+    tenant. Both partitions are written before this runs — a cross-partition
+    assertion against a store where the other partition is empty is an
+    assertion that cannot fail.
+
+``unrestricted_control``
+    A label the principal may see. The control: a probe suite that reports a
+    withholding on every query is measuring its own eagerness, not the
+    boundary.
+
+**A probe that does not reach the filter is a FAILED MEASUREMENT, not a
+passed check.** :attr:`ProbeOutcome.effective` is false when retrieval never
+surfaced the restricted entity at all, and the runner reports that as loudly
+as a leak: it means the probe needs a better query, not that the arm is safe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.context_fabric.graph_arm.identity import partition_for_org
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    retrieve_candidates,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+        RetrievalStore,
+    )
+
+__all__ = [
+    "PROBES",
+    "AuthorizationProbe",
+    "ProbeOutcome",
+    "run_probe",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizationProbe:
+    """One query aimed at the authorization boundary, and what must happen."""
+
+    probe_id: str
+    query: str
+    principal_id: str
+    #: The entity this probe exists to try to pull through the filter. Empty
+    #: for the control, which is aimed at nothing.
+    target_entity_id: str
+    #: True when the target is expected to be OUTSIDE the principal's grant,
+    #: so surfacing-then-withholding is the correct behaviour.
+    target_is_restricted: bool
+    rationale: str
+    #: Partition the target actually lives in, when that is not the queried
+    #: one. Set for the cross-tenant probe and load-bearing there: the group
+    #: filter excludes the other tenant's node inside the Cypher query, so it
+    #: never reaches the authorization step and "nothing was withheld" is
+    #: indistinguishable from "nothing exists". Running the identical query
+    #: against the partition the target lives in, with the principal who may
+    #: see it, converts that into a differential: present and ranked THERE,
+    #: absent HERE, therefore the partition filter is what removed it.
+    presence_partition: str = ""
+    presence_principal_id: str = ""
+
+
+PROBES: tuple[AuthorizationProbe, ...] = (
+    AuthorizationProbe(
+        probe_id="restricted_exact_label",
+        query="Quarry Compliance",
+        principal_id=world.PRINCIPAL_ANALYST,
+        target_entity_id=world.PROJ_QUARRY,
+        target_is_restricted=True,
+        rationale=(
+            "The restricted project's verbatim display label, which is also "
+            "the text its node vector was built from. If any query retrieves "
+            "it, this one does."
+        ),
+    ),
+    AuthorizationProbe(
+        probe_id="restricted_topical",
+        query="how is the compliance work going",
+        principal_id=world.PRINCIPAL_ANALYST,
+        target_entity_id=world.PROJ_QUARRY,
+        target_is_restricted=True,
+        rationale=(
+            "A colloquial route to the same entity. A filter keyed on query "
+            "text rather than on the grant passes the exact-label probe and "
+            "fails this one."
+        ),
+    ),
+    AuthorizationProbe(
+        probe_id="cross_tenant_near_duplicate",
+        query="Agent Context Runtime",
+        principal_id=world.PRINCIPAL_ANALYST,
+        target_entity_id=world.LUMEN_PROJ_ACR,
+        target_is_restricted=True,
+        rationale=(
+            "A label shared verbatim across two tenants. The Lumen partition "
+            "is written before this runs, so the partition filter has "
+            "something real to exclude — and the presence check proves the "
+            "same query does retrieve the Lumen node from the Lumen "
+            "partition, which is what makes its absence here a measurement."
+        ),
+        presence_partition=partition_for_org(world.ORG_LUMEN),
+        presence_principal_id=world.PRINCIPAL_LUMEN,
+    ),
+    AuthorizationProbe(
+        probe_id="unrestricted_control",
+        query="Identity Platform Rewrite",
+        principal_id=world.PRINCIPAL_ANALYST,
+        target_entity_id=world.PROJ_IDENTITY_REWRITE,
+        target_is_restricted=False,
+        rationale=(
+            "The control. A probe suite that withholds on every query is "
+            "measuring its own eagerness rather than the boundary."
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeOutcome:
+    """What one probe measured."""
+
+    probe_id: str
+    query: str
+    principal_id: str
+    target_entity_id: str
+    target_is_restricted: bool
+    #: Did retrieval surface the target at all, before authorization?
+    target_retrieved: bool
+    #: Did the target reach a rank in the authorized result?
+    target_ranked: bool
+    authorization_filtered_count: int
+    withheld_canonical_ids: tuple[str, ...]
+    ranked_canonical_ids: tuple[str, ...]
+    #: Whether this probe actually exercised the thing it exists to
+    #: exercise. False is a measurement failure, never a clean result.
+    effective: bool
+    verdict: str
+    detail: str
+    #: Cross-tenant probe only: did the identical query rank the target in
+    #: the partition the target lives in? ``None`` where no presence check
+    #: applies. ``False`` means the probe proved nothing — the query cannot
+    #: retrieve the target anywhere, so its absence here is not evidence the
+    #: partition filter did anything.
+    target_present_in_home_partition: bool | None = None
+
+
+async def run_probe(
+    probe: AuthorizationProbe,
+    *,
+    store: RetrievalStore,
+    authorized_entity_ids: frozenset[str],
+    presence_store: RetrievalStore | None = None,
+    presence_authorized_entity_ids: frozenset[str] | None = None,
+) -> ProbeOutcome:
+    """Run one probe and judge it. Never returns a bare boolean.
+
+    ``presence_store`` runs the *identical* query against the tenant the
+    target actually belongs to. Only the cross-tenant probe needs it, and it
+    needs it badly: Graphiti filters ``group_id`` inside the Cypher, so the
+    other tenant's node never reaches the authorization step and an absence
+    here proves nothing on its own.
+    """
+
+    partition = store.partition
+    retrieval = await retrieve_candidates(
+        probe.query,
+        store=store,
+        authorized_entity_ids=authorized_entity_ids,
+    )
+
+    present_at_home: bool | None = None
+    if probe.presence_partition:
+        if presence_store is None or presence_authorized_entity_ids is None:
+            raise ValueError(
+                f"probe {probe.probe_id!r} declares a presence partition but "
+                "no presence store was supplied; without it the probe "
+                "cannot distinguish 'the filter excluded it' from 'it was "
+                "never there', which is the only thing it measures"
+            )
+        if presence_store.partition != probe.presence_partition:
+            raise ValueError(
+                f"probe {probe.probe_id!r} expects presence partition "
+                f"{probe.presence_partition!r} but the supplied store is open "
+                f"for {presence_store.partition!r}; a presence check against "
+                "the wrong tenant would report the differential backwards"
+            )
+        home = await retrieve_candidates(
+            probe.query,
+            store=presence_store,
+            authorized_entity_ids=presence_authorized_entity_ids,
+        )
+        present_at_home = probe.target_entity_id in {
+            candidate.canonical_id for candidate in home.candidates
+        }
+    ranked = tuple(candidate.canonical_id for candidate in retrieval.candidates)
+    surfaced = set(retrieval.retrieved_before_authorization) | set(
+        retrieval.withheld_canonical_ids
+    )
+    target_retrieved = probe.target_entity_id in surfaced
+    target_ranked = probe.target_entity_id in ranked
+
+    if not probe.target_is_restricted:
+        effective = True
+        if target_ranked and retrieval.authorization_filtered_count == 0:
+            verdict, detail = (
+                "pass",
+                "an authorized target was ranked and nothing was withheld, "
+                "so the filter is not simply withholding everything",
+            )
+        elif not target_ranked:
+            verdict, detail = (
+                "fail",
+                f"the control target {probe.target_entity_id} was not ranked; "
+                "retrieval cannot reach an entity the principal may see, so "
+                "no withholding result from this suite is interpretable",
+            )
+        else:
+            verdict, detail = (
+                "fail",
+                f"the control withheld {retrieval.authorization_filtered_count} "
+                "entities on a query aimed at nothing restricted",
+            )
+        return ProbeOutcome(
+            probe_id=probe.probe_id,
+            query=probe.query,
+            principal_id=probe.principal_id,
+            target_entity_id=probe.target_entity_id,
+            target_is_restricted=probe.target_is_restricted,
+            target_retrieved=target_retrieved,
+            target_ranked=target_ranked,
+            authorization_filtered_count=retrieval.authorization_filtered_count,
+            withheld_canonical_ids=retrieval.withheld_canonical_ids,
+            ranked_canonical_ids=ranked,
+            effective=effective,
+            verdict=verdict,
+            detail=detail,
+            target_present_in_home_partition=present_at_home,
+        )
+
+    if target_ranked:
+        verdict = "fail"
+        detail = (
+            f"{probe.target_entity_id} reached rank "
+            f"{ranked.index(probe.target_entity_id)} for a principal who "
+            "cannot see it; the filter did not hold"
+        )
+        effective = True
+    elif target_retrieved:
+        verdict = "pass"
+        detail = (
+            f"retrieval surfaced {probe.target_entity_id} and authorization "
+            "removed it before ranking; the filter was exercised and held"
+        )
+        effective = True
+    elif present_at_home:
+        # Excluded inside the query rather than at the authorization step.
+        # That is the CORRECT mechanism for a cross-partition exclusion, and
+        # it is a measurement only because the presence check proved the
+        # same query ranks the target in the partition it lives in.
+        verdict = "pass"
+        detail = (
+            f"the identical query ranked {probe.target_entity_id} in its own "
+            f"partition {probe.presence_partition} and returned it nowhere in "
+            f"{partition}; the group filter is what removed it, and the "
+            "presence check is what makes that a measurement rather than an "
+            "empty result"
+        )
+        effective = True
+    else:
+        # The dangerous case: nothing leaked, and nothing was tested.
+        verdict = "not_measured"
+        detail = (
+            f"retrieval never surfaced {probe.target_entity_id}, so nothing "
+            "excluded it and nothing was measured"
+            + (
+                f"; the presence check could not rank it in "
+                f"{probe.presence_partition} either, so this query cannot "
+                "retrieve the target anywhere and the probe needs a better one"
+                if probe.presence_partition
+                else ". This is a failed measurement, not a clean result: the "
+                "probe needs a query that retrieves the target"
+            )
+        )
+        effective = False
+
+    return ProbeOutcome(
+        probe_id=probe.probe_id,
+        query=probe.query,
+        principal_id=probe.principal_id,
+        target_entity_id=probe.target_entity_id,
+        target_is_restricted=probe.target_is_restricted,
+        target_retrieved=target_retrieved,
+        target_ranked=target_ranked,
+        authorization_filtered_count=retrieval.authorization_filtered_count,
+        withheld_canonical_ids=retrieval.withheld_canonical_ids,
+        ranked_canonical_ids=ranked,
+        effective=effective,
+        verdict=verdict,
+        detail=detail,
+        target_present_in_home_partition=present_at_home,
+    )

--- a/trials/chaos_3647/records.py
+++ b/trials/chaos_3647/records.py
@@ -153,6 +153,10 @@ class SemanticTrialRecords:
 
     schema_version: str = SEMANTIC_TRIAL_SCHEMA_VERSION
     binding: dict[str, Any] = field(default_factory=dict)
+    #: Evidence that BM25 was live before anything was measured. A run
+    #: without this block is a run whose hybrid leg may have been cosine-only
+    #: — which happened once, silently, and is why the field exists.
+    fulltext_readiness: dict[str, Any] = field(default_factory=dict)
     embedded_text_surface: dict[str, Any] = field(default_factory=dict)
     cases: tuple[CaseRecord, ...] = ()
     authorization_probes: tuple[dict[str, Any], ...] = ()

--- a/trials/chaos_3647/records.py
+++ b/trials/chaos_3647/records.py
@@ -1,0 +1,173 @@
+"""The measured artifact. This file's output IS the result.
+
+Same rule as ``trials.chaos_3619.records``: the raw machine-readable record
+is the source of truth and anything human-readable is derived from it, so a
+summary cannot quietly describe a run that did not happen.
+
+Two fields here exist because of what the delta means without them.
+
+``embedded_text_surface`` records **what the vectors were actually built
+from**. A node's vector is the embedding of its ``name``, which the arm sets
+to the display label; aliases, acronyms and previous names live in node
+attributes and are embedded by nothing. A reader comparing a semantic leg to
+an alias-registry leg without that fact will attribute the result to
+"embeddings are weak" when the honest statement is "these embeddings never
+saw the alias". It is derived from the projection at run time rather than
+typed in.
+
+``delta.classification`` is a closed enum rather than prose. The question
+CHAOS-3647 was opened to answer is "does semantic retrieval add discovery
+value", and the answer is a distribution over these classes. A free-text
+verdict per case invites a summary nobody can recount.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from . import SEMANTIC_TRIAL_SCHEMA_VERSION
+
+__all__ = [
+    "CaseRecord",
+    "Delta",
+    "DeltaRecord",
+    "EmbeddedTextSurface",
+    "LegRecord",
+    "SemanticTrialRecords",
+    "write_records",
+]
+
+
+class Delta(StrEnum):
+    """What changed between the pinned baseline and the semantic leg.
+
+    Named from the *baseline's* point of view, so the class that would be
+    cited as evidence for adopting retrieval — ``SEMANTIC_ONLY_CORRECT`` —
+    has to be earned rather than inferred from a case simply moving.
+    """
+
+    #: Both legs resolved the case's subject correctly.
+    BOTH_CORRECT = "both_correct"
+    #: The pinned deterministic baseline was right and the semantic leg was
+    #: not. A regression, and the reason the baseline is not replaced.
+    DETERMINISTIC_ONLY_CORRECT = "deterministic_only_correct"
+    #: The claim CHAOS-3647 exists to test: the semantic leg resolved
+    #: correctly where the baseline could not.
+    SEMANTIC_ONLY_CORRECT = "semantic_only_correct"
+    #: Neither resolved correctly, and the semantic leg ranked nothing —
+    #: so it at least did not manufacture confidence.
+    NEITHER_CORRECT_NEITHER_RANKED = "neither_correct_neither_ranked"
+    #: Neither resolved correctly, and the semantic leg produced a ranked
+    #: answer anyway where the baseline refused. The most expensive class:
+    #: a wrong answer costs more than a refusal, and this is the one a
+    #: headline "graph reaches more answers" figure would hide.
+    NEITHER_CORRECT_SEMANTIC_RANKED_ANYWAY = "neither_correct_semantic_ranked_anyway"
+    #: Neither resolved correctly and both ranked something.
+    NEITHER_CORRECT_BOTH_RANKED = "neither_correct_both_ranked"
+
+
+@dataclass(frozen=True)
+class EmbeddedTextSurface:
+    """What the store's vectors were built from, measured off the projection."""
+
+    #: The node field the embedder consumed. Read from the arm rather than
+    #: asserted: ``backend.to_graphiti_nodes`` sets ``EntityNode.name``.
+    node_embedded_field: str
+    edge_embedded_field: str
+    #: Fields present on the projection that NOTHING embedded. The list a
+    #: reader needs before interpreting an alias-resolution failure.
+    not_embedded: tuple[str, ...]
+    #: Aliases in the corpus world, none of which reach a vector.
+    alias_count: int
+    node_count: int
+    edge_count: int
+    #: The full-text index's own field list, read from Graphiti's query
+    #: builder rather than assumed, because BM25's reach is half of a hybrid
+    #: leg's result and an assumed index is an unmeasured one.
+    fulltext_indexed_fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LegRecord:
+    """One leg's resolution and score for one case."""
+
+    leg: str
+    query: str
+    mentions: tuple[str, ...]
+    subjects: tuple[dict[str, Any], ...]
+    authorization_filtered_count: int
+    withheld_canonical_ids: tuple[str, ...]
+    bm25_order: tuple[str, ...]
+    cosine_order: tuple[str, ...]
+    observation_hits: tuple[str, ...]
+    score: dict[str, Any]
+    #: CHAOS-3635 oracle v2 applied to this leg's ranked output — the
+    #: display labels a packet's ``candidates[].display_label`` and
+    #: ``match_signals[].matched_text`` would be built from. Non-empty means
+    #: a restricted NAME reached the consumer surface even if no restricted
+    #: id did, which is the disclosure a canonical-id audit cannot see.
+    prose_disclosures: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DeltaRecord:
+    """The semantic-versus-deterministic comparison for one case."""
+
+    classification: str
+    baseline_correct: bool
+    semantic_correct: bool
+    baseline_ranked: int
+    semantic_ranked: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class CaseRecord:
+    """One corpus case, every leg, and the delta between two of them."""
+
+    case_id: str
+    question: str
+    question_family: str
+    expected_answer: str
+    committed_subject_id: str | None
+    permitted_candidate_ids: tuple[str, ...]
+    forbidden_subject_ids: tuple[str, ...]
+    principal_id: str
+    legs: tuple[LegRecord, ...]
+    delta: DeltaRecord
+    #: The pinned CHAOS-3619 artifact's disposition for this case on the
+    #: interpreter-lifted leg, copied verbatim. Carried so a reader can check
+    #: that the re-run baseline agrees with the pinned one without opening a
+    #: second file.
+    pinned_baseline_disposition: str
+    pinned_baseline_detail: str
+
+
+@dataclass(frozen=True)
+class SemanticTrialRecords:
+    """The whole measured run."""
+
+    schema_version: str = SEMANTIC_TRIAL_SCHEMA_VERSION
+    binding: dict[str, Any] = field(default_factory=dict)
+    embedded_text_surface: dict[str, Any] = field(default_factory=dict)
+    cases: tuple[CaseRecord, ...] = ()
+    authorization_probes: tuple[dict[str, Any], ...] = ()
+    summary: dict[str, Any] = field(default_factory=dict)
+    #: Statements a reader would otherwise have to infer, written before the
+    #: numbers were seen. Kept in the artifact rather than only in a PR body,
+    #: because the artifact outlives the PR.
+    scope_notes: tuple[str, ...] = ()
+
+
+def write_records(records: SemanticTrialRecords, path: Path) -> None:
+    """Write the artifact. Sorted keys, trailing newline, stable ordering."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(asdict(records), indent=1, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/trials/chaos_3647/results/semantic-leg.records.json
+++ b/trials/chaos_3647/results/semantic-leg.records.json
@@ -1,0 +1,3315 @@
+{
+ "authorization_probes": [
+  {
+   "authorization_filtered_count": 1,
+   "detail": "retrieval surfaced proj_quarry and authorization removed it before ranking; the filter was exercised and held",
+   "effective": true,
+   "principal_id": "principal_helio_analyst",
+   "probe_id": "restricted_exact_label",
+   "query": "Quarry Compliance",
+   "ranked_canonical_ids": [
+    "proj_zenith",
+    "svc_checkout",
+    "proj_beacon",
+    "proj_auth_gateway_hardening",
+    "proj_meridian",
+    "proj_lattice",
+    "proj_tidal",
+    "proj_vertex",
+    "wu_pulse_runbook",
+    "svc_auth_gateway",
+    "pr_vertex_401"
+   ],
+   "target_entity_id": "proj_quarry",
+   "target_is_restricted": true,
+   "target_present_in_home_partition": null,
+   "target_ranked": false,
+   "target_retrieved": true,
+   "verdict": "pass",
+   "withheld_canonical_ids": [
+    "proj_quarry"
+   ]
+  },
+  {
+   "authorization_filtered_count": 1,
+   "detail": "retrieval surfaced proj_quarry and authorization removed it before ranking; the filter was exercised and held",
+   "effective": true,
+   "principal_id": "principal_helio_analyst",
+   "probe_id": "restricted_topical",
+   "query": "how is the compliance work going",
+   "ranked_canonical_ids": [
+    "pr_pulse_212",
+    "wu_pulse_runbook",
+    "wu_ledger_cutover",
+    "svc_checkout",
+    "wu_beacon_ingest",
+    "pr_identity_882"
+   ],
+   "target_entity_id": "proj_quarry",
+   "target_is_restricted": true,
+   "target_present_in_home_partition": null,
+   "target_ranked": false,
+   "target_retrieved": true,
+   "verdict": "pass",
+   "withheld_canonical_ids": [
+    "proj_quarry"
+   ]
+  },
+  {
+   "authorization_filtered_count": 0,
+   "detail": "the identical query ranked lumen_proj_acr in its own partition cf_trial_org_lumen and returned it nowhere in cf_trial_org_helio; the group filter is what removed it, and the presence check is what makes that a measurement rather than an empty result",
+   "effective": true,
+   "principal_id": "principal_helio_analyst",
+   "probe_id": "cross_tenant_near_duplicate",
+   "query": "Agent Context Runtime",
+   "ranked_canonical_ids": [
+    "proj_acr",
+    "dep_authcore",
+    "wu_authcore_release",
+    "svc_auth_gateway",
+    "pr_identity_882",
+    "proj_auth_gateway_hardening",
+    "pf_platform",
+    "proj_identity_rewrite",
+    "init_identity_modernization",
+    "svc_checkout",
+    "team_atlas",
+    "proj_beacon",
+    "pr_pulse_212",
+    "issue_acr_span_decl",
+    "proj_pulse",
+    "team_ember"
+   ],
+   "target_entity_id": "lumen_proj_acr",
+   "target_is_restricted": true,
+   "target_present_in_home_partition": true,
+   "target_ranked": false,
+   "target_retrieved": false,
+   "verdict": "pass",
+   "withheld_canonical_ids": []
+  },
+  {
+   "authorization_filtered_count": 0,
+   "detail": "an authorized target was ranked and nothing was withheld, so the filter is not simply withholding everything",
+   "effective": true,
+   "principal_id": "principal_helio_analyst",
+   "probe_id": "unrestricted_control",
+   "query": "Identity Platform Rewrite",
+   "ranked_canonical_ids": [
+    "proj_identity_rewrite",
+    "init_identity_modernization",
+    "pr_identity_882",
+    "proj_payments_rewrite",
+    "pf_platform",
+    "svc_auth_gateway",
+    "repo_identity",
+    "proj_auth_gateway_hardening",
+    "dep_authcore",
+    "wu_authcore_release",
+    "pr_pulse_212",
+    "proj_ledger_migration",
+    "proj_acr",
+    "wu_ledger_schema",
+    "proj_zenith",
+    "pr_ledger_990",
+    "pf_growth",
+    "proj_beacon",
+    "repo_checkout",
+    "wu_ledger_dual_write"
+   ],
+   "target_entity_id": "proj_identity_rewrite",
+   "target_is_restricted": false,
+   "target_present_in_home_partition": null,
+   "target_ranked": true,
+   "target_retrieved": true,
+   "verdict": "pass",
+   "withheld_canonical_ids": []
+  }
+ ],
+ "binding": {
+  "branch": "chaos-3647-semantic-leg",
+  "commit": "b4584fb033b4e41981883e0ec4cb64da59b39b99",
+  "contract_manifest_sha256": "b14307dbbbf5b5dd84d0b9b79648c7c6bdbf35bda7f56511dfcfc63f02a3cd38",
+  "corpus_manifest_sha256": "f12a7dcef216c8fedc19538fba1d284bfdf6968461e718bbfcee2a4fea1bd0c4",
+  "corpus_version": "ask_dev_investigation_corpus.v1",
+  "dependency_versions": {
+   "falkordb": "1.2.2",
+   "graphiti-core": "0.29.3",
+   "pydantic": "2.13.4",
+   "redis": "6.4.0"
+  },
+  "execution_mode": "producer_invoked_directly_seam_real_orchestrator_bypassed",
+  "feature_tip_commit": "ec3532bfd929411831b967cd28123d4ea4acc335",
+  "graph_arm_id": "graph_assisted_shadow_arm",
+  "graph_attachment_encoding": "canonical_ids.v1",
+  "graph_embedder_model_id": "openai_text_embedding_3_small",
+  "graph_projection_version": "graph_arm_projection.v1",
+  "graph_query_version": "graph_arm_neighbourhood.v1",
+  "graph_ranking_version": "graph_arm_no_ranking.v1",
+  "native_arm_id": "native",
+  "native_projection_version": "native_investigation_projection.v1",
+  "notes": [
+   "CHAOS-3647 semantic/hybrid retrieval leg. Subject resolution only; no packet assembly."
+  ],
+  "packet_schema_version": "ask_dev_investigation_packet.v1",
+  "per_case_timeout_seconds": 120.0,
+  "run_class": "measured",
+  "schema_version": "chaos_3619_trial_results.v1",
+  "shadow_record_schema_version": "investigation_shadow_record.v1",
+  "tree_clean": false,
+  "trial_store_backend": "falkordb (127.0.0.1:6389)"
+ },
+ "cases": [
+  {
+   "case_id": "H01_acronym_resolution",
+   "committed_subject_id": "proj_identity_rewrite",
+   "delta": {
+    "baseline_correct": true,
+    "baseline_ranked": 1,
+    "classification": "both_correct",
+    "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was proj_identity_rewrite, as expected",
+    "semantic_correct": true,
+    "semantic_ranked": 8
+   },
+   "expected_answer": "direct",
+   "forbidden_subject_ids": [],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [
+      "IPR"
+     ],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "status on IPR?",
+     "score": {
+      "case_id": "H01_acronym_resolution",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 1 ranked",
+      "resolved": true,
+      "stray_candidates": [],
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "rank-1 was proj_identity_rewrite, as expected",
+      "subject_top_1": "pass",
+      "subject_top_1_detail": "rank-1 was proj_identity_rewrite; expected proj_identity_rewrite",
+      "subject_top_3": "pass",
+      "subject_top_3_detail": "top-3 ['proj_identity_rewrite']; expected proj_identity_rewrite"
+     },
+     "subjects": [
+      {
+       "canonical_id": "proj_identity_rewrite",
+       "display_label": "Identity Platform Rewrite",
+       "mechanism": "alias_lookup",
+       "methods": [],
+       "rank": 0,
+       "rrf_score": null,
+       "signal": "acronym"
+      }
+     ],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "status on IPR?",
+     "score": {
+      "case_id": "H01_acronym_resolution",
+      "leg": "deterministic_question",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [
+      "sc_acr_still_open"
+     ],
+     "cosine_order": [
+      "sc_acr_still_open",
+      "borealis_wip",
+      "atlas_wip",
+      "doc_injected_runbook",
+      "pr_pulse_212_merged",
+      "wg_identity_rewrite",
+      "proj_identity_rewrite",
+      "oc_pulse_missing",
+      "ci_pulse_green",
+      "dep_ratelimitd",
+      "ci_identity_blocked",
+      "tr_pulse_suite",
+      "wg_ratelimitd_removed",
+      "borealis_load",
+      "frost_load",
+      "atlas_load",
+      "pr_ledger_990_merged",
+      "pr_pulse_212",
+      "rv_vertex_revoked",
+      "dorado_outbound_reviews",
+      "inc_atlas_gateway",
+      "di_pulse_open",
+      "rv_vertex_cycles",
+      "rv_atlas_queue",
+      "cinder_incidents",
+      "atlas_incident_load",
+      "wg_payments_rewrite_superseded",
+      "issue_acr_span_decl",
+      "wi_acr_span_open",
+      "dp_pulse_prod",
+      "sc_pulse_declared_complete",
+      "tr_ledger_suite",
+      "wi_beacon_deleted",
+      "cinder_new_value",
+      "svc_pulse_api",
+      "pr_identity_882_open",
+      "sc_payments_rewrite_cancelled",
+      "pr_identity_882",
+      "cinder_ktlo",
+      "cinder_deficiencies",
+      "wu_beacon_ingest",
+      "frost_cycle_p90",
+      "sc_ledger_declared_complete",
+      "pf_platform",
+      "oc_ledger_present",
+      "dp_identity_none",
+      "pulse_deployments",
+      "acr_target_slips",
+      "ia_beacon_allocation",
+      "ia_atlas_mix"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "sc_acr_still_open",
+      "borealis_wip",
+      "atlas_wip",
+      "doc_injected_runbook",
+      "pr_pulse_212_merged",
+      "wg_identity_rewrite",
+      "oc_pulse_missing",
+      "ci_pulse_green",
+      "ci_identity_blocked",
+      "tr_pulse_suite",
+      "wg_ratelimitd_removed",
+      "borealis_load",
+      "frost_load",
+      "atlas_load",
+      "pr_ledger_990_merged",
+      "rv_vertex_revoked",
+      "dorado_outbound_reviews",
+      "inc_atlas_gateway",
+      "di_pulse_open",
+      "rv_vertex_cycles",
+      "rv_atlas_queue",
+      "cinder_incidents",
+      "atlas_incident_load",
+      "wg_payments_rewrite_superseded",
+      "wi_acr_span_open",
+      "dp_pulse_prod",
+      "sc_pulse_declared_complete",
+      "tr_ledger_suite",
+      "wi_beacon_deleted",
+      "cinder_new_value",
+      "pr_identity_882_open",
+      "sc_payments_rewrite_cancelled",
+      "cinder_ktlo",
+      "cinder_deficiencies",
+      "frost_cycle_p90",
+      "sc_ledger_declared_complete",
+      "oc_ledger_present",
+      "dp_identity_none",
+      "pulse_deployments",
+      "acr_target_slips",
+      "ia_beacon_allocation",
+      "ia_atlas_mix"
+     ],
+     "prose_disclosures": [],
+     "query": "status on IPR?",
+     "score": {
+      "case_id": "H01_acronym_resolution",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_ratelimitd', 'pr_pulse_212']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "7 stray candidates across 8 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "dep_ratelimitd",
+       "issue_acr_span_decl",
+       "pf_platform",
+       "pr_identity_882",
+       "pr_pulse_212",
+       "svc_pulse_api",
+       "wu_beacon_ingest"
+      ],
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "rank-1 was proj_identity_rewrite, as expected",
+      "subject_top_1": "pass",
+      "subject_top_1_detail": "rank-1 was proj_identity_rewrite; expected proj_identity_rewrite",
+      "subject_top_3": "pass",
+      "subject_top_3_detail": "top-3 ['proj_identity_rewrite', 'dep_ratelimitd', 'pr_pulse_212']; expected proj_identity_rewrite"
+     },
+     "subjects": [
+      {
+       "canonical_id": "proj_identity_rewrite",
+       "display_label": "Identity Platform Rewrite",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 0,
+       "rrf_score": 0.14285714285714285,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "dep_ratelimitd",
+       "display_label": "ratelimitd",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.1,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_pulse_212",
+       "display_label": "pulse#212 analytics rollout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.05555555555555555,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "issue_acr_span_decl",
+       "display_label": "ACR span declaration correction",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.03571428571428571,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_pulse_api",
+       "display_label": "Pulse API",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.02857142857142857,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_identity_882",
+       "display_label": "identity#882 authcore 2.0 adoption",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.02631578947368421,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_beacon_ingest",
+       "display_label": "Beacon ingest throughput",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.024390243902439025,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pf_platform",
+       "display_label": "Platform Portfolio",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.022727272727272728,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [
+    "proj_identity_rewrite",
+    "proj_auth_gateway_hardening"
+   ],
+   "pinned_baseline_detail": "packet emitted and scored",
+   "pinned_baseline_disposition": "scored",
+   "principal_id": "principal_helio_analyst",
+   "question": "status on IPR?",
+   "question_family": "ambiguous_identity"
+  },
+  {
+   "case_id": "H02_old_and_current_name",
+   "committed_subject_id": "proj_identity_rewrite",
+   "delta": {
+    "baseline_correct": true,
+    "baseline_ranked": 1,
+    "classification": "deterministic_only_correct",
+    "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
+    "semantic_correct": false,
+    "semantic_ranked": 18
+   },
+   "expected_answer": "direct",
+   "forbidden_subject_ids": [],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [
+      "Northstar"
+     ],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "how's the thing we used to call Northstar going?",
+     "score": {
+      "case_id": "H02_old_and_current_name",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 1 ranked",
+      "resolved": true,
+      "stray_candidates": [],
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "rank-1 was proj_identity_rewrite, as expected",
+      "subject_top_1": "pass",
+      "subject_top_1_detail": "rank-1 was proj_identity_rewrite; expected proj_identity_rewrite",
+      "subject_top_3": "pass",
+      "subject_top_3_detail": "top-3 ['proj_identity_rewrite']; expected proj_identity_rewrite"
+     },
+     "subjects": [
+      {
+       "canonical_id": "proj_identity_rewrite",
+       "display_label": "Identity Platform Rewrite",
+       "mechanism": "alias_lookup",
+       "methods": [],
+       "rank": 0,
+       "rrf_score": null,
+       "signal": "previous_name"
+      }
+     ],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "how's the thing we used to call Northstar going?",
+     "score": {
+      "case_id": "H02_old_and_current_name",
+      "leg": "deterministic_question",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [
+      "wu_pulse_runbook",
+      "wi_pulse_runbook_open"
+     ],
+     "cosine_order": [
+      "wi_borealis_wip",
+      "team_borealis",
+      "rv_borealis_normal",
+      "pr_pulse_212",
+      "pr_pulse_212_merged",
+      "repo_beacon",
+      "rv_vertex_revoked",
+      "rv_atlas_queue",
+      "doc_false_dependency_claim",
+      "rv_vertex_cycles",
+      "cl_borealis",
+      "repo_ledger",
+      "borealis_wip",
+      "atlas_wip",
+      "wi_beacon_deleted",
+      "wi_atlas_wip",
+      "rv_dorado_outbound",
+      "repo_acr",
+      "pr_vertex_401_cycles",
+      "cinder_new_value",
+      "pr_ledger_990_merged",
+      "wu_authcore_release",
+      "wi_authcore_release_open",
+      "repo_identity",
+      "wi_meridian_demand",
+      "sc_acr_still_open",
+      "pr_identity_882",
+      "wi_beacon_demand",
+      "proj_solstice",
+      "doc_injected_runbook",
+      "di_cinder_open",
+      "repo_checkout",
+      "sc_pulse_declared_complete",
+      "wi_solstice_demand",
+      "inc_atlas_gateway",
+      "ep_keyword_stuffed",
+      "dep_authcore",
+      "wg_authcore_shared",
+      "ia_meridian_allocation",
+      "repo_pulse",
+      "dp_identity_none",
+      "proj_beacon",
+      "team_atlas",
+      "wu_beacon_ingest",
+      "pr_ledger_990",
+      "ia_beacon_allocation",
+      "inc_cinder_load",
+      "dorado_outbound_reviews",
+      "proj_meridian"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "wi_borealis_wip",
+      "wi_pulse_runbook_open",
+      "rv_borealis_normal",
+      "pr_pulse_212_merged",
+      "rv_vertex_revoked",
+      "rv_atlas_queue",
+      "doc_false_dependency_claim",
+      "rv_vertex_cycles",
+      "cl_borealis",
+      "borealis_wip",
+      "atlas_wip",
+      "wi_beacon_deleted",
+      "wi_atlas_wip",
+      "rv_dorado_outbound",
+      "pr_vertex_401_cycles",
+      "cinder_new_value",
+      "pr_ledger_990_merged",
+      "wi_authcore_release_open",
+      "wi_meridian_demand",
+      "sc_acr_still_open",
+      "wi_beacon_demand",
+      "doc_injected_runbook",
+      "di_cinder_open",
+      "sc_pulse_declared_complete",
+      "wi_solstice_demand",
+      "inc_atlas_gateway",
+      "ep_keyword_stuffed",
+      "wg_authcore_shared",
+      "ia_meridian_allocation",
+      "dp_identity_none",
+      "ia_beacon_allocation",
+      "inc_cinder_load",
+      "dorado_outbound_reviews"
+     ],
+     "prose_disclosures": [],
+     "query": "how's the thing we used to call Northstar going?",
+     "score": {
+      "case_id": "H02_old_and_current_name",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'team_borealis', 'wu_pulse_runbook']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "18 stray candidates across 18 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "dep_authcore",
+       "pr_identity_882",
+       "pr_ledger_990",
+       "pr_pulse_212",
+       "proj_beacon",
+       "proj_meridian",
+       "proj_solstice",
+       "repo_acr",
+       "repo_beacon",
+       "repo_checkout",
+       "repo_identity",
+       "repo_ledger",
+       "repo_pulse",
+       "team_atlas",
+       "team_borealis",
+       "wu_authcore_release",
+       "wu_beacon_ingest",
+       "wu_pulse_runbook"
+      ],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 ['wu_pulse_runbook', 'team_borealis', 'pr_pulse_212']; expected proj_identity_rewrite"
+     },
+     "subjects": [
+      {
+       "canonical_id": "wu_pulse_runbook",
+       "display_label": "Pulse on-call runbook and alerts",
+       "mechanism": "lexical_fuzzy",
+       "methods": [
+        "bm25"
+       ],
+       "rank": 0,
+       "rrf_score": 1.0,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "team_borealis",
+       "display_label": "Borealis",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.5,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_pulse_212",
+       "display_label": "pulse#212 analytics rollout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.25,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_beacon",
+       "display_label": "helio/beacon",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.16666666666666666,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_ledger",
+       "display_label": "helio/ledger",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.08333333333333333,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_acr",
+       "display_label": "helio/acr",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.05555555555555555,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_authcore_release",
+       "display_label": "authcore 2.0 release",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.045454545454545456,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_identity",
+       "display_label": "helio/identity",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.041666666666666664,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_identity_882",
+       "display_label": "identity#882 authcore 2.0 adoption",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 0.037037037037037035,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_solstice",
+       "display_label": "Solstice Billing",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 9,
+       "rrf_score": 0.034482758620689655,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_checkout",
+       "display_label": "helio/checkout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 10,
+       "rrf_score": 0.03125,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "dep_authcore",
+       "display_label": "authcore",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 11,
+       "rrf_score": 0.02702702702702703,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_pulse",
+       "display_label": "helio/pulse",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 12,
+       "rrf_score": 0.025,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_beacon",
+       "display_label": "Beacon Ingest",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 13,
+       "rrf_score": 0.023809523809523808,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "team_atlas",
+       "display_label": "Atlas",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 14,
+       "rrf_score": 0.023255813953488372,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_beacon_ingest",
+       "display_label": "Beacon ingest throughput",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 15,
+       "rrf_score": 0.022727272727272728,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_ledger_990",
+       "display_label": "ledger#990 dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 16,
+       "rrf_score": 0.022222222222222223,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_meridian",
+       "display_label": "Meridian Docs",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 17,
+       "rrf_score": 0.02040816326530612,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [
+    "proj_identity_rewrite"
+   ],
+   "pinned_baseline_detail": "packet emitted and scored",
+   "pinned_baseline_disposition": "scored",
+   "principal_id": "principal_helio_analyst",
+   "question": "how's the thing we used to call Northstar going?",
+   "question_family": "ambiguous_identity"
+  },
+  {
+   "case_id": "H03_the_auth_work",
+   "committed_subject_id": "proj_identity_rewrite",
+   "delta": {
+    "baseline_correct": false,
+    "baseline_ranked": 0,
+    "classification": "neither_correct_semantic_ranked_anyway",
+    "detail": "baseline: resolved nothing; expected proj_identity_rewrite | semantic: rank-1 was dep_authcore; expected proj_identity_rewrite",
+    "semantic_correct": false,
+    "semantic_ranked": 18
+   },
+   "expected_answer": "direct",
+   "forbidden_subject_ids": [],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "What about the auth work?",
+     "score": {
+      "case_id": "H03_the_auth_work",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "What about the auth work?",
+     "score": {
+      "case_id": "H03_the_auth_work",
+      "leg": "deterministic_question",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [
+      "wg_auth_hardening",
+      "dp_identity_none",
+      "proj_auth_gateway_hardening",
+      "inc_atlas_gateway",
+      "svc_auth_gateway",
+      "wi_beacon_deleted",
+      "wi_borealis_wip",
+      "wi_ember_partial",
+      "wi_atlas_wip",
+      "wi_quarry_redacted"
+     ],
+     "cosine_order": [
+      "dep_authcore",
+      "pr_identity_882",
+      "wi_authcore_release_open",
+      "wu_authcore_release",
+      "wg_authcore_shared",
+      "svc_auth_gateway",
+      "proj_auth_gateway_hardening",
+      "wg_auth_hardening",
+      "lattice_touching_contributors",
+      "inc_atlas_gateway",
+      "wi_ember_partial",
+      "wi_beacon_deleted",
+      "rv_vertex_revoked",
+      "borealis_wip",
+      "atlas_wip",
+      "dp_identity_none",
+      "pr_ledger_990_merged",
+      "rv_vertex_cycles",
+      "lattice_active_contributors",
+      "proj_acr",
+      "wg_acr",
+      "wi_atlas_wip",
+      "pr_vertex_401_cycles",
+      "pr_ledger_990",
+      "wg_identity_rewrite",
+      "proj_identity_rewrite",
+      "wu_ledger_dual_write",
+      "oc_ledger_present",
+      "wi_quarry_redacted",
+      "repo_checkout",
+      "pr_identity_882_open",
+      "rv_atlas_queue",
+      "ci_identity_blocked",
+      "sh_ember_stalled",
+      "dp_ledger_prod",
+      "wi_borealis_wip",
+      "repo_ledger",
+      "dorado_outbound_reviews",
+      "proj_ledger_migration",
+      "repo_acr",
+      "repo_identity",
+      "wg_lattice_contributors",
+      "svc_ledger_api",
+      "hp_atlas",
+      "proj_beacon",
+      "wi_ledger_children",
+      "proj_payments_rewrite",
+      "tr_ledger_suite",
+      "sc_ledger_declared_complete",
+      "init_identity_modernization"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "wg_auth_hardening",
+      "dp_identity_none",
+      "inc_atlas_gateway",
+      "wi_authcore_release_open",
+      "wi_beacon_deleted",
+      "wi_ember_partial",
+      "wg_authcore_shared",
+      "wi_borealis_wip",
+      "wi_atlas_wip",
+      "wi_quarry_redacted",
+      "lattice_touching_contributors",
+      "rv_vertex_revoked",
+      "borealis_wip",
+      "atlas_wip",
+      "pr_ledger_990_merged",
+      "rv_vertex_cycles",
+      "lattice_active_contributors",
+      "wg_acr",
+      "pr_vertex_401_cycles",
+      "wg_identity_rewrite",
+      "oc_ledger_present",
+      "pr_identity_882_open",
+      "rv_atlas_queue",
+      "ci_identity_blocked",
+      "sh_ember_stalled",
+      "dp_ledger_prod",
+      "dorado_outbound_reviews",
+      "wg_lattice_contributors",
+      "hp_atlas",
+      "wi_ledger_children",
+      "tr_ledger_suite",
+      "sc_ledger_declared_complete"
+     ],
+     "prose_disclosures": [],
+     "query": "What about the auth work?",
+     "score": {
+      "case_id": "H03_the_auth_work",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_authcore', 'pr_identity_882']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "16 stray candidates across 18 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "dep_authcore",
+       "init_identity_modernization",
+       "pr_identity_882",
+       "pr_ledger_990",
+       "proj_acr",
+       "proj_beacon",
+       "proj_ledger_migration",
+       "proj_payments_rewrite",
+       "repo_acr",
+       "repo_checkout",
+       "repo_identity",
+       "repo_ledger",
+       "svc_auth_gateway",
+       "svc_ledger_api",
+       "wu_authcore_release",
+       "wu_ledger_dual_write"
+      ],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "rank-1 was dep_authcore; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was dep_authcore; expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 ['dep_authcore', 'pr_identity_882', 'proj_auth_gateway_hardening']; expected proj_identity_rewrite"
+     },
+     "subjects": [
+      {
+       "canonical_id": "dep_authcore",
+       "display_label": "authcore",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 0,
+       "rrf_score": 1.0,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_identity_882",
+       "display_label": "identity#882 authcore 2.0 adoption",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.5,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_auth_gateway_hardening",
+       "display_label": "Auth Gateway Hardening",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "bm25",
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.47619047619047616,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_auth_gateway",
+       "display_label": "Auth Gateway",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "bm25",
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.3666666666666667,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_authcore_release",
+       "display_label": "authcore 2.0 release",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.25,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_acr",
+       "display_label": "Agent Context Runtime",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.05,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_ledger_990",
+       "display_label": "ledger#990 dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.041666666666666664,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_identity_rewrite",
+       "display_label": "Identity Platform Rewrite",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.038461538461538464,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_dual_write",
+       "display_label": "Ledger dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 0.037037037037037035,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_checkout",
+       "display_label": "helio/checkout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 9,
+       "rrf_score": 0.03333333333333333,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_ledger",
+       "display_label": "helio/ledger",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 10,
+       "rrf_score": 0.02702702702702703,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_ledger_migration",
+       "display_label": "Ledger Migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 11,
+       "rrf_score": 0.02564102564102564,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_acr",
+       "display_label": "helio/acr",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 12,
+       "rrf_score": 0.025,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_identity",
+       "display_label": "helio/identity",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 13,
+       "rrf_score": 0.024390243902439025,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_ledger_api",
+       "display_label": "Ledger API",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 14,
+       "rrf_score": 0.023255813953488372,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_beacon",
+       "display_label": "Beacon Ingest",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 15,
+       "rrf_score": 0.022222222222222223,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_payments_rewrite",
+       "display_label": "Payments Rewrite",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 16,
+       "rrf_score": 0.02127659574468085,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "init_identity_modernization",
+       "display_label": "Identity Modernization",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 17,
+       "rrf_score": 0.02,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [
+    "proj_identity_rewrite",
+    "proj_auth_gateway_hardening"
+   ],
+   "pinned_baseline_detail": "no authorized subject resolved from the question",
+   "pinned_baseline_disposition": "arm_refused",
+   "principal_id": "principal_helio_analyst",
+   "question": "What about the auth work?",
+   "question_family": "ambiguous_identity"
+  },
+  {
+   "case_id": "H04_pronoun_follow_up",
+   "committed_subject_id": "proj_identity_rewrite",
+   "delta": {
+    "baseline_correct": false,
+    "baseline_ranked": 0,
+    "classification": "neither_correct_semantic_ranked_anyway",
+    "detail": "baseline: resolved nothing; expected proj_identity_rewrite | semantic: rank-1 was team_atlas; expected proj_identity_rewrite",
+    "semantic_correct": false,
+    "semantic_ranked": 11
+   },
+   "expected_answer": "direct",
+   "forbidden_subject_ids": [],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "what's holding it up?",
+     "score": {
+      "case_id": "H04_pronoun_follow_up",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "what's holding it up?",
+     "score": {
+      "case_id": "H04_pronoun_follow_up",
+      "leg": "deterministic_question",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [
+      "team_atlas",
+      "repo_ledger",
+      "wi_atlas_wip",
+      "pr_ledger_990",
+      "wu_ledger_dual_write",
+      "pr_ledger_990_merged",
+      "pr_pulse_212_merged",
+      "wi_borealis_wip",
+      "atlas_wip",
+      "borealis_wip",
+      "pulse_open_controls",
+      "repo_beacon",
+      "inc_cinder_load",
+      "cl_borealis",
+      "repo_acr",
+      "rv_atlas_queue",
+      "dep_ratelimitd",
+      "repo_checkout",
+      "cl_atlas",
+      "wu_beacon_ingest",
+      "wi_beacon_demand",
+      "cinder_deficiencies",
+      "lattice_touching_contributors",
+      "ia_beacon_allocation",
+      "sh_tidal_thin",
+      "rv_borealis_normal",
+      "proj_beacon",
+      "ep_keyword_stuffed",
+      "wg_lattice_contributors",
+      "wg_ratelimitd_removed",
+      "wi_quarry_redacted",
+      "repo_identity",
+      "cc_lattice_active",
+      "pr_vertex_401_cycles",
+      "oc_ledger_present"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "wi_atlas_wip",
+      "pr_ledger_990_merged",
+      "pr_pulse_212_merged",
+      "wi_borealis_wip",
+      "atlas_wip",
+      "borealis_wip",
+      "pulse_open_controls",
+      "inc_cinder_load",
+      "cl_borealis",
+      "rv_atlas_queue",
+      "cl_atlas",
+      "wi_beacon_demand",
+      "cinder_deficiencies",
+      "lattice_touching_contributors",
+      "ia_beacon_allocation",
+      "sh_tidal_thin",
+      "rv_borealis_normal",
+      "ep_keyword_stuffed",
+      "wg_lattice_contributors",
+      "wg_ratelimitd_removed",
+      "wi_quarry_redacted",
+      "cc_lattice_active",
+      "pr_vertex_401_cycles",
+      "oc_ledger_present"
+     ],
+     "prose_disclosures": [],
+     "query": "what's holding it up?",
+     "score": {
+      "case_id": "H04_pronoun_follow_up",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_ledger_990', 'repo_ledger', 'team_atlas']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "11 stray candidates across 11 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "dep_ratelimitd",
+       "pr_ledger_990",
+       "proj_beacon",
+       "repo_acr",
+       "repo_beacon",
+       "repo_checkout",
+       "repo_identity",
+       "repo_ledger",
+       "team_atlas",
+       "wu_beacon_ingest",
+       "wu_ledger_dual_write"
+      ],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "rank-1 was team_atlas; expected proj_identity_rewrite",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was team_atlas; expected proj_identity_rewrite",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 ['team_atlas', 'repo_ledger', 'pr_ledger_990']; expected proj_identity_rewrite"
+     },
+     "subjects": [
+      {
+       "canonical_id": "team_atlas",
+       "display_label": "Atlas",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 0,
+       "rrf_score": 1.0,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_ledger",
+       "display_label": "helio/ledger",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.5,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_ledger_990",
+       "display_label": "ledger#990 dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.25,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_dual_write",
+       "display_label": "Ledger dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.2,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_beacon",
+       "display_label": "helio/beacon",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.08333333333333333,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_acr",
+       "display_label": "helio/acr",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.06666666666666667,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "dep_ratelimitd",
+       "display_label": "ratelimitd",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.058823529411764705,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_checkout",
+       "display_label": "helio/checkout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.05555555555555555,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_beacon_ingest",
+       "display_label": "Beacon ingest throughput",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 0.05,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_beacon",
+       "display_label": "Beacon Ingest",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 9,
+       "rrf_score": 0.037037037037037035,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_identity",
+       "display_label": "helio/identity",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 10,
+       "rrf_score": 0.03125,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [
+    "proj_identity_rewrite"
+   ],
+   "pinned_baseline_detail": "no authorized subject resolved from the question",
+   "pinned_baseline_disposition": "arm_refused",
+   "principal_id": "principal_helio_analyst",
+   "question": "what's holding it up?",
+   "question_family": "colloquial_follow_up"
+  },
+  {
+   "case_id": "H05_the_other_project_we_discussed",
+   "committed_subject_id": null,
+   "delta": {
+    "baseline_correct": false,
+    "baseline_ranked": 0,
+    "classification": "neither_correct_semantic_ranked_anyway",
+    "detail": "baseline: resolved nothing; the case has two real candidates | semantic: the top-3 clarification set contains ['pf_platform', 'pr_pulse_212'], which the case does not permit as candidates",
+    "semantic_correct": false,
+    "semantic_ranked": 10
+   },
+   "expected_answer": "clarified",
+   "forbidden_subject_ids": [],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "What about the other project we discussed?",
+     "score": {
+      "case_id": "H05_the_other_project_we_discussed",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; the case has two real candidates",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "What about the other project we discussed?",
+     "score": {
+      "case_id": "H05_the_other_project_we_discussed",
+      "leg": "deterministic_question",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; the case has two real candidates",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [
+      "wi_beacon_deleted",
+      "rv_vertex_revoked",
+      "wi_borealis_wip",
+      "wi_atlas_wip",
+      "rv_vertex_cycles",
+      "rv_atlas_queue",
+      "atlas_wip",
+      "borealis_wip",
+      "wi_ember_partial",
+      "pf_platform",
+      "wi_quarry_redacted",
+      "solstice_completions",
+      "meridian_completions",
+      "atlas_completed",
+      "lattice_completions",
+      "beacon_completions",
+      "ember_completed",
+      "borealis_completed",
+      "sh_ember_stalled",
+      "lattice_touching_contributors",
+      "pr_ledger_990_merged",
+      "rv_borealis_normal",
+      "pr_pulse_212_merged",
+      "pr_vertex_401_cycles",
+      "ia_beacon_allocation",
+      "doc_false_dependency_claim",
+      "sc_ledger_declared_complete",
+      "wg_identity_rewrite",
+      "proj_identity_rewrite",
+      "ia_atlas_mix",
+      "pr_pulse_212",
+      "proj_beacon",
+      "ia_cinder_displaced",
+      "wg_lattice_contributors",
+      "sc_pulse_declared_complete",
+      "proj_ledger_migration",
+      "cc_quarry_activity",
+      "repo_ledger",
+      "proj_meridian",
+      "cl_borealis",
+      "lattice_active_contributors",
+      "proj_acr",
+      "wg_acr",
+      "pr_ledger_990",
+      "cc_lattice_active",
+      "wu_ledger_dual_write",
+      "tr_ledger_suite",
+      "ep_keyword_stuffed",
+      "dorado_outbound_reviews",
+      "ia_meridian_allocation"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "wi_beacon_deleted",
+      "rv_vertex_revoked",
+      "wi_borealis_wip",
+      "wi_atlas_wip",
+      "rv_vertex_cycles",
+      "rv_atlas_queue",
+      "atlas_wip",
+      "borealis_wip",
+      "wi_ember_partial",
+      "wi_quarry_redacted",
+      "solstice_completions",
+      "meridian_completions",
+      "atlas_completed",
+      "lattice_completions",
+      "beacon_completions",
+      "ember_completed",
+      "borealis_completed",
+      "sh_ember_stalled",
+      "lattice_touching_contributors",
+      "pr_ledger_990_merged",
+      "rv_borealis_normal",
+      "pr_pulse_212_merged",
+      "pr_vertex_401_cycles",
+      "ia_beacon_allocation",
+      "doc_false_dependency_claim",
+      "sc_ledger_declared_complete",
+      "wg_identity_rewrite",
+      "ia_atlas_mix",
+      "ia_cinder_displaced",
+      "wg_lattice_contributors",
+      "sc_pulse_declared_complete",
+      "cc_quarry_activity",
+      "cl_borealis",
+      "lattice_active_contributors",
+      "wg_acr",
+      "cc_lattice_active",
+      "tr_ledger_suite",
+      "ep_keyword_stuffed",
+      "dorado_outbound_reviews",
+      "ia_meridian_allocation"
+     ],
+     "prose_disclosures": [],
+     "query": "What about the other project we discussed?",
+     "score": {
+      "case_id": "H05_the_other_project_we_discussed",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 10 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pf_platform', 'pr_pulse_212']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "9 stray candidates across 10 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "pf_platform",
+       "pr_ledger_990",
+       "pr_pulse_212",
+       "proj_acr",
+       "proj_beacon",
+       "proj_ledger_migration",
+       "proj_meridian",
+       "repo_ledger",
+       "wu_ledger_dual_write"
+      ],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "the top-3 clarification set contains ['pf_platform', 'pr_pulse_212'], which the case does not permit as candidates",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [
+      {
+       "canonical_id": "pf_platform",
+       "display_label": "Platform Portfolio",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 0,
+       "rrf_score": 0.1,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_identity_rewrite",
+       "display_label": "Identity Platform Rewrite",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.034482758620689655,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_pulse_212",
+       "display_label": "pulse#212 analytics rollout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.03225806451612903,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_beacon",
+       "display_label": "Beacon Ingest",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.03125,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_ledger_migration",
+       "display_label": "Ledger Migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.027777777777777776,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_ledger",
+       "display_label": "helio/ledger",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.02631578947368421,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_meridian",
+       "display_label": "Meridian Docs",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.02564102564102564,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_acr",
+       "display_label": "Agent Context Runtime",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.023809523809523808,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_ledger_990",
+       "display_label": "ledger#990 dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 0.022727272727272728,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_dual_write",
+       "display_label": "Ledger dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 9,
+       "rrf_score": 0.021739130434782608,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [
+    "proj_identity_rewrite",
+    "proj_auth_gateway_hardening"
+   ],
+   "pinned_baseline_detail": "no authorized subject resolved from the question",
+   "pinned_baseline_disposition": "arm_refused",
+   "principal_id": "principal_helio_analyst",
+   "question": "What about the other project we discussed?",
+   "question_family": "colloquial_follow_up"
+  },
+  {
+   "case_id": "H06_prior_attempt_reference",
+   "committed_subject_id": "proj_vertex",
+   "delta": {
+    "baseline_correct": false,
+    "baseline_ranked": 0,
+    "classification": "neither_correct_semantic_ranked_anyway",
+    "detail": "baseline: resolved nothing; expected proj_vertex | semantic: rank-1 was wu_ledger_cutover; expected proj_vertex",
+    "semantic_correct": false,
+    "semantic_ranked": 10
+   },
+   "expected_answer": "direct",
+   "forbidden_subject_ids": [],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "What happened with the project that kept cycling in review?",
+     "score": {
+      "case_id": "H06_prior_attempt_reference",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_vertex",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_vertex",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_vertex"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "What happened with the project that kept cycling in review?",
+     "score": {
+      "case_id": "H06_prior_attempt_reference",
+      "leg": "deterministic_question",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; expected proj_vertex",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_vertex",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 []; expected proj_vertex"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [
+      "rv_vertex_cycles",
+      "wi_frost_outlier",
+      "rv_atlas_queue",
+      "rv_borealis_normal",
+      "rv_dorado_outbound",
+      "rv_vertex_revoked"
+     ],
+     "cosine_order": [
+      "rv_vertex_cycles",
+      "rv_vertex_revoked",
+      "rv_atlas_queue",
+      "rv_borealis_normal",
+      "dorado_outbound_reviews",
+      "sc_payments_rewrite_cancelled",
+      "vertex_review_cycles",
+      "sc_ledger_declared_complete",
+      "wi_beacon_deleted",
+      "dorado_review_wait",
+      "borealis_review_wait",
+      "atlas_review_wait",
+      "tr_ledger_suite",
+      "wu_ledger_cutover",
+      "atlas_wip",
+      "borealis_wip",
+      "pr_vertex_401_cycles",
+      "pr_pulse_212",
+      "pr_ledger_990_merged",
+      "sc_acr_still_open",
+      "proj_ledger_migration",
+      "wg_identity_rewrite",
+      "proj_identity_rewrite",
+      "sc_pulse_declared_complete",
+      "wu_ledger_backfill",
+      "wi_ledger_backfill_open",
+      "lattice_completions",
+      "meridian_completions",
+      "solstice_completions",
+      "atlas_completed",
+      "ember_completed",
+      "beacon_completions",
+      "borealis_completed",
+      "dp_ledger_prod",
+      "wg_payments_rewrite_superseded",
+      "repo_checkout",
+      "wi_ledger_children",
+      "proj_payments_rewrite",
+      "wu_ledger_dual_write",
+      "pr_ledger_990",
+      "oc_ledger_present",
+      "wu_ledger_schema",
+      "dp_identity_none",
+      "cc_quarry_activity",
+      "rv_dorado_outbound",
+      "frost_cycle_p90",
+      "doc_injected_runbook",
+      "inc_atlas_gateway",
+      "wg_ratelimitd_removed",
+      "lattice_touching_contributors"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "rv_vertex_cycles",
+      "rv_atlas_queue",
+      "rv_vertex_revoked",
+      "wi_frost_outlier",
+      "rv_borealis_normal",
+      "rv_dorado_outbound",
+      "dorado_outbound_reviews",
+      "sc_payments_rewrite_cancelled",
+      "vertex_review_cycles",
+      "sc_ledger_declared_complete",
+      "wi_beacon_deleted",
+      "dorado_review_wait",
+      "borealis_review_wait",
+      "atlas_review_wait",
+      "tr_ledger_suite",
+      "atlas_wip",
+      "borealis_wip",
+      "pr_vertex_401_cycles",
+      "pr_ledger_990_merged",
+      "sc_acr_still_open",
+      "wg_identity_rewrite",
+      "sc_pulse_declared_complete",
+      "wi_ledger_backfill_open",
+      "lattice_completions",
+      "meridian_completions",
+      "solstice_completions",
+      "atlas_completed",
+      "ember_completed",
+      "beacon_completions",
+      "borealis_completed",
+      "dp_ledger_prod",
+      "wg_payments_rewrite_superseded",
+      "wi_ledger_children",
+      "oc_ledger_present",
+      "dp_identity_none",
+      "cc_quarry_activity",
+      "frost_cycle_p90",
+      "doc_injected_runbook",
+      "inc_atlas_gateway",
+      "wg_ratelimitd_removed",
+      "lattice_touching_contributors"
+     ],
+     "prose_disclosures": [],
+     "query": "What happened with the project that kept cycling in review?",
+     "score": {
+      "case_id": "H06_prior_attempt_reference",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "not_applicable",
+      "must_not_commit_detail": "the case expects a commitment",
+      "no_forbidden_subject": "not_applicable",
+      "no_forbidden_subject_detail": "the case forbids no subject",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'proj_ledger_migration', 'wu_ledger_cutover']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "10 stray candidates across 10 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "pr_ledger_990",
+       "pr_pulse_212",
+       "proj_identity_rewrite",
+       "proj_ledger_migration",
+       "proj_payments_rewrite",
+       "repo_checkout",
+       "wu_ledger_backfill",
+       "wu_ledger_cutover",
+       "wu_ledger_dual_write",
+       "wu_ledger_schema"
+      ],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "rank-1 was wu_ledger_cutover; expected proj_vertex",
+      "subject_top_1": "fail",
+      "subject_top_1_detail": "rank-1 was wu_ledger_cutover; expected proj_vertex",
+      "subject_top_3": "fail",
+      "subject_top_3_detail": "top-3 ['wu_ledger_cutover', 'pr_pulse_212', 'proj_ledger_migration']; expected proj_vertex"
+     },
+     "subjects": [
+      {
+       "canonical_id": "wu_ledger_cutover",
+       "display_label": "Ledger cutover",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 0,
+       "rrf_score": 0.07142857142857142,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_pulse_212",
+       "display_label": "pulse#212 analytics rollout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.05555555555555555,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_ledger_migration",
+       "display_label": "Ledger Migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.047619047619047616,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_identity_rewrite",
+       "display_label": "Identity Platform Rewrite",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.043478260869565216,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_backfill",
+       "display_label": "Ledger historical backfill",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.04,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_checkout",
+       "display_label": "helio/checkout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.027777777777777776,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_payments_rewrite",
+       "display_label": "Payments Rewrite",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.02631578947368421,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_dual_write",
+       "display_label": "Ledger dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.02564102564102564,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_ledger_990",
+       "display_label": "ledger#990 dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 0.025,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_schema",
+       "display_label": "Ledger schema migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 9,
+       "rrf_score": 0.023809523809523808,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [
+    "proj_vertex"
+   ],
+   "pinned_baseline_detail": "no authorized subject resolved from the question",
+   "pinned_baseline_disposition": "arm_refused",
+   "principal_id": "principal_helio_analyst",
+   "question": "What happened with the project that kept cycling in review?",
+   "question_family": "colloquial_follow_up"
+  },
+  {
+   "case_id": "H07_unresolved_needs_candidates",
+   "committed_subject_id": null,
+   "delta": {
+    "baseline_correct": false,
+    "baseline_ranked": 0,
+    "classification": "neither_correct_semantic_ranked_anyway",
+    "detail": "baseline: resolved nothing; the case has two real candidates | semantic: ranked forbidden subjects ['proj_solstice', 'proj_vertex']",
+    "semantic_correct": false,
+    "semantic_ranked": 18
+   },
+   "expected_answer": "clarified",
+   "forbidden_subject_ids": [
+    "proj_vertex",
+    "proj_solstice"
+   ],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "how's the payments work going",
+     "score": {
+      "case_id": "H07_unresolved_needs_candidates",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "pass",
+      "no_forbidden_subject_detail": "no forbidden subject ranked",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; the case has two real candidates",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "how's the payments work going",
+     "score": {
+      "case_id": "H07_unresolved_needs_candidates",
+      "leg": "deterministic_question",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "pass",
+      "no_forbidden_subject_detail": "no forbidden subject ranked",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "resolved nothing; the case has two real candidates",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [
+      "wg_payments_rewrite_superseded",
+      "sc_payments_rewrite_cancelled",
+      "proj_payments_rewrite",
+      "proj_zenith",
+      "wg_zenith",
+      "wi_beacon_deleted",
+      "wi_borealis_wip",
+      "wi_ember_partial",
+      "wi_atlas_wip",
+      "wi_quarry_redacted"
+     ],
+     "cosine_order": [
+      "proj_zenith",
+      "wg_zenith",
+      "proj_payments_rewrite",
+      "sc_payments_rewrite_cancelled",
+      "wg_payments_rewrite_superseded",
+      "pr_vertex_401",
+      "proj_solstice",
+      "rv_vertex_cycles",
+      "atlas_wip",
+      "borealis_wip",
+      "pr_pulse_212",
+      "pr_vertex_401_cycles",
+      "svc_checkout",
+      "svc_pulse_api",
+      "repo_checkout",
+      "dp_pulse_prod",
+      "beacon_completions",
+      "borealis_completed",
+      "ember_completed",
+      "atlas_completed",
+      "solstice_completions",
+      "lattice_completions",
+      "meridian_completions",
+      "wu_ledger_cutover",
+      "ia_cinder_displaced",
+      "proj_ledger_migration",
+      "rv_vertex_revoked",
+      "wi_beacon_demand",
+      "sh_solstice_no_allocation",
+      "svc_ledger_api",
+      "proj_tidal",
+      "wi_ember_partial",
+      "dp_ledger_prod",
+      "sc_ledger_declared_complete",
+      "wi_ledger_children",
+      "sc_pulse_declared_complete",
+      "ia_beacon_allocation",
+      "repo_ledger",
+      "issue_vertex_tax_rounding",
+      "wu_beacon_ingest",
+      "wu_ledger_schema",
+      "pr_pulse_212_merged",
+      "oc_ledger_present",
+      "rv_atlas_queue",
+      "pulse_deployments",
+      "proj_vertex",
+      "proj_beacon",
+      "wi_solstice_demand",
+      "doc_injected_runbook",
+      "atlas_review_wait"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "wg_payments_rewrite_superseded",
+      "sc_payments_rewrite_cancelled",
+      "wg_zenith",
+      "wi_beacon_deleted",
+      "wi_ember_partial",
+      "wi_borealis_wip",
+      "rv_vertex_cycles",
+      "wi_atlas_wip",
+      "atlas_wip",
+      "wi_quarry_redacted",
+      "borealis_wip",
+      "pr_vertex_401_cycles",
+      "dp_pulse_prod",
+      "beacon_completions",
+      "borealis_completed",
+      "ember_completed",
+      "atlas_completed",
+      "solstice_completions",
+      "lattice_completions",
+      "meridian_completions",
+      "ia_cinder_displaced",
+      "rv_vertex_revoked",
+      "wi_beacon_demand",
+      "sh_solstice_no_allocation",
+      "dp_ledger_prod",
+      "sc_ledger_declared_complete",
+      "wi_ledger_children",
+      "sc_pulse_declared_complete",
+      "ia_beacon_allocation",
+      "pr_pulse_212_merged",
+      "oc_ledger_present",
+      "rv_atlas_queue",
+      "pulse_deployments",
+      "wi_solstice_demand",
+      "doc_injected_runbook",
+      "atlas_review_wait"
+     ],
+     "prose_disclosures": [],
+     "query": "how's the payments work going",
+     "score": {
+      "case_id": "H07_unresolved_needs_candidates",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 18 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "fail",
+      "no_forbidden_subject_detail": "ranked forbidden subjects ['proj_solstice', 'proj_vertex']",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_vertex_401']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "16 stray candidates across 18 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "issue_vertex_tax_rounding",
+       "pr_pulse_212",
+       "pr_vertex_401",
+       "proj_beacon",
+       "proj_ledger_migration",
+       "proj_solstice",
+       "proj_tidal",
+       "proj_vertex",
+       "repo_checkout",
+       "repo_ledger",
+       "svc_checkout",
+       "svc_ledger_api",
+       "svc_pulse_api",
+       "wu_beacon_ingest",
+       "wu_ledger_cutover",
+       "wu_ledger_schema"
+      ],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "ranked forbidden subjects ['proj_solstice', 'proj_vertex']",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [
+      {
+       "canonical_id": "proj_zenith",
+       "display_label": "Zenith Payments",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "bm25",
+        "cosine_similarity"
+       ],
+       "rank": 0,
+       "rrf_score": 1.25,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_payments_rewrite",
+       "display_label": "Payments Rewrite",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "bm25",
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.6666666666666666,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_vertex_401",
+       "display_label": "checkout#401 tax rounding",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.16666666666666666,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_solstice",
+       "display_label": "Solstice Billing",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.14285714285714285,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_pulse_212",
+       "display_label": "pulse#212 analytics rollout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.09090909090909091,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_checkout",
+       "display_label": "Checkout Service",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.07692307692307693,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_pulse_api",
+       "display_label": "Pulse API",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.07142857142857142,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_checkout",
+       "display_label": "helio/checkout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.06666666666666667,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_cutover",
+       "display_label": "Ledger cutover",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 0.041666666666666664,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_ledger_migration",
+       "display_label": "Ledger Migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 9,
+       "rrf_score": 0.038461538461538464,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_ledger_api",
+       "display_label": "Ledger API",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 10,
+       "rrf_score": 0.03333333333333333,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_tidal",
+       "display_label": "Tidal Notifications",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 11,
+       "rrf_score": 0.03225806451612903,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_ledger",
+       "display_label": "helio/ledger",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 12,
+       "rrf_score": 0.02631578947368421,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "issue_vertex_tax_rounding",
+       "display_label": "Vertex tax rounding",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 13,
+       "rrf_score": 0.02564102564102564,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_beacon_ingest",
+       "display_label": "Beacon ingest throughput",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 14,
+       "rrf_score": 0.025,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_schema",
+       "display_label": "Ledger schema migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 15,
+       "rrf_score": 0.024390243902439025,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_vertex",
+       "display_label": "Vertex Checkout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 16,
+       "rrf_score": 0.021739130434782608,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_beacon",
+       "display_label": "Beacon Ingest",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 17,
+       "rrf_score": 0.02127659574468085,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [
+    "proj_payments_rewrite",
+    "proj_zenith"
+   ],
+   "pinned_baseline_detail": "no authorized subject resolved from the question",
+   "pinned_baseline_disposition": "arm_refused",
+   "principal_id": "principal_helio_analyst",
+   "question": "how's the payments work going",
+   "question_family": "clarification_and_no_match"
+  },
+  {
+   "case_id": "H08_no_match_must_not_widen",
+   "committed_subject_id": null,
+   "delta": {
+    "baseline_correct": true,
+    "baseline_ranked": 0,
+    "classification": "deterministic_only_correct",
+    "detail": "baseline: nothing was ranked, which is the only correct resolution | semantic: the case names a subject that does not exist; the leg ranked 20 candidates anyway, led by repo_beacon",
+    "semantic_correct": false,
+    "semantic_ranked": 20
+   },
+   "expected_answer": "unavailable",
+   "forbidden_subject_ids": [
+    "proj_identity_rewrite",
+    "proj_acr",
+    "proj_quarry"
+   ],
+   "legs": [
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_mentions",
+     "mentions": [
+      "Halcyon"
+     ],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "How is Halcyon doing?",
+     "score": {
+      "case_id": "H08_no_match_must_not_widen",
+      "leg": "deterministic_mentions",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "pass",
+      "no_forbidden_subject_detail": "no forbidden subject ranked",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "nothing was ranked, which is the only correct resolution",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [],
+     "leg": "deterministic_question",
+     "mentions": [],
+     "observation_hits": [],
+     "prose_disclosures": [],
+     "query": "How is Halcyon doing?",
+     "score": {
+      "case_id": "H08_no_match_must_not_widen",
+      "leg": "deterministic_question",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "pass",
+      "no_forbidden_subject_detail": "no forbidden subject ranked",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "nothing was ranked, which is the only correct resolution",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [],
+     "withheld_canonical_ids": []
+    },
+    {
+     "authorization_filtered_count": 0,
+     "bm25_order": [],
+     "cosine_order": [
+      "repo_beacon",
+      "ep_keyword_stuffed",
+      "repo_ledger",
+      "repo_acr",
+      "hp_atlas",
+      "rv_borealis_normal",
+      "pr_pulse_212_merged",
+      "repo_checkout",
+      "repo_identity",
+      "proj_beacon",
+      "wi_borealis_wip",
+      "wi_beacon_demand",
+      "wu_ledger_backfill",
+      "wi_ledger_backfill_open",
+      "pr_ledger_990_merged",
+      "wi_beacon_deleted",
+      "ia_beacon_allocation",
+      "wg_zenith",
+      "proj_zenith",
+      "proj_solstice",
+      "wu_beacon_ingest",
+      "sh_solstice_no_allocation",
+      "di_cinder_open",
+      "repo_pulse",
+      "dp_identity_none",
+      "pr_pulse_212",
+      "pr_identity_882_open",
+      "wu_ledger_schema",
+      "rv_atlas_queue",
+      "wu_ledger_dual_write",
+      "wu_ledger_cutover",
+      "wg_lattice_contributors",
+      "frost_cycle_p90",
+      "cl_borealis",
+      "rv_vertex_revoked",
+      "oc_ledger_present",
+      "sc_ledger_declared_complete",
+      "rv_vertex_cycles",
+      "team_borealis",
+      "pr_vertex_401_cycles",
+      "sh_tidal_thin",
+      "dp_ledger_prod",
+      "rv_dorado_outbound",
+      "tr_ledger_suite",
+      "wi_solstice_demand",
+      "pr_ledger_990",
+      "svc_ledger_api",
+      "proj_meridian",
+      "proj_ledger_migration",
+      "sc_pulse_declared_complete"
+     ],
+     "leg": "semantic_hybrid",
+     "mentions": [],
+     "observation_hits": [
+      "ep_keyword_stuffed",
+      "hp_atlas",
+      "rv_borealis_normal",
+      "pr_pulse_212_merged",
+      "wi_borealis_wip",
+      "wi_beacon_demand",
+      "wi_ledger_backfill_open",
+      "pr_ledger_990_merged",
+      "wi_beacon_deleted",
+      "ia_beacon_allocation",
+      "wg_zenith",
+      "sh_solstice_no_allocation",
+      "di_cinder_open",
+      "dp_identity_none",
+      "pr_identity_882_open",
+      "rv_atlas_queue",
+      "wg_lattice_contributors",
+      "frost_cycle_p90",
+      "cl_borealis",
+      "rv_vertex_revoked",
+      "oc_ledger_present",
+      "sc_ledger_declared_complete",
+      "rv_vertex_cycles",
+      "pr_vertex_401_cycles",
+      "sh_tidal_thin",
+      "dp_ledger_prod",
+      "rv_dorado_outbound",
+      "tr_ledger_suite",
+      "wi_solstice_demand",
+      "sc_pulse_declared_complete"
+     ],
+     "prose_disclosures": [],
+     "query": "How is Halcyon doing?",
+     "score": {
+      "case_id": "H08_no_match_must_not_widen",
+      "leg": "semantic_hybrid",
+      "must_not_commit": "pass",
+      "must_not_commit_detail": "ranked 20 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "pass",
+      "no_forbidden_subject_detail": "no forbidden subject ranked",
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['repo_acr', 'repo_beacon', 'repo_ledger']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "20 stray candidates across 20 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "pr_ledger_990",
+       "pr_pulse_212",
+       "proj_beacon",
+       "proj_ledger_migration",
+       "proj_meridian",
+       "proj_solstice",
+       "proj_zenith",
+       "repo_acr",
+       "repo_beacon",
+       "repo_checkout",
+       "repo_identity",
+       "repo_ledger",
+       "repo_pulse",
+       "svc_ledger_api",
+       "team_borealis",
+       "wu_beacon_ingest",
+       "wu_ledger_backfill",
+       "wu_ledger_cutover",
+       "wu_ledger_dual_write",
+       "wu_ledger_schema"
+      ],
+      "subject_resolution_correct": false,
+      "subject_resolution_detail": "the case names a subject that does not exist; the leg ranked 20 candidates anyway, led by repo_beacon",
+      "subject_top_1": "not_applicable",
+      "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
+      "subject_top_3": "not_applicable",
+      "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
+     },
+     "subjects": [
+      {
+       "canonical_id": "repo_beacon",
+       "display_label": "helio/beacon",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 0,
+       "rrf_score": 1.0,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_ledger",
+       "display_label": "helio/ledger",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 1,
+       "rrf_score": 0.3333333333333333,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_acr",
+       "display_label": "helio/acr",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 2,
+       "rrf_score": 0.25,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_checkout",
+       "display_label": "helio/checkout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 3,
+       "rrf_score": 0.125,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_identity",
+       "display_label": "helio/identity",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 4,
+       "rrf_score": 0.1111111111111111,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_beacon",
+       "display_label": "Beacon Ingest",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 5,
+       "rrf_score": 0.1,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_backfill",
+       "display_label": "Ledger historical backfill",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 6,
+       "rrf_score": 0.07692307692307693,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_zenith",
+       "display_label": "Zenith Payments",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 7,
+       "rrf_score": 0.05263157894736842,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_solstice",
+       "display_label": "Solstice Billing",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 0.05,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_beacon_ingest",
+       "display_label": "Beacon ingest throughput",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 9,
+       "rrf_score": 0.047619047619047616,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "repo_pulse",
+       "display_label": "helio/pulse",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 10,
+       "rrf_score": 0.041666666666666664,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_pulse_212",
+       "display_label": "pulse#212 analytics rollout",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 11,
+       "rrf_score": 0.038461538461538464,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_schema",
+       "display_label": "Ledger schema migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 12,
+       "rrf_score": 0.03571428571428571,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_dual_write",
+       "display_label": "Ledger dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 13,
+       "rrf_score": 0.03333333333333333,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "wu_ledger_cutover",
+       "display_label": "Ledger cutover",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 14,
+       "rrf_score": 0.03225806451612903,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "team_borealis",
+       "display_label": "Borealis",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 15,
+       "rrf_score": 0.02564102564102564,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "pr_ledger_990",
+       "display_label": "ledger#990 dual-write teardown",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 16,
+       "rrf_score": 0.021739130434782608,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_ledger_api",
+       "display_label": "Ledger API",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 17,
+       "rrf_score": 0.02127659574468085,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_meridian",
+       "display_label": "Meridian Docs",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 18,
+       "rrf_score": 0.020833333333333332,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_ledger_migration",
+       "display_label": "Ledger Migration",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "cosine_similarity"
+       ],
+       "rank": 19,
+       "rrf_score": 0.02040816326530612,
+       "signal": "fuzzy_label"
+      }
+     ],
+     "withheld_canonical_ids": []
+    }
+   ],
+   "permitted_candidate_ids": [],
+   "pinned_baseline_detail": "no authorized subject resolved from the question",
+   "pinned_baseline_disposition": "arm_refused",
+   "principal_id": "principal_helio_analyst",
+   "question": "How is Halcyon doing?",
+   "question_family": "clarification_and_no_match"
+  }
+ ],
+ "embedded_text_surface": {
+  "alias_count": 8,
+  "edge_count": 72,
+  "edge_embedded_field": "EntityEdge.fact (== '<source_id> <relationship> <target_id>')",
+  "fulltext_indexed_fields": [
+   "name",
+   "summary",
+   "group_id"
+  ],
+  "node_count": 154,
+  "node_embedded_field": "EntityNode.name (== GraphNode.display_label)",
+  "not_embedded": [
+   "GraphNode.canonical_id",
+   "GraphNode.aliases[].value (alias, acronym, previous_name, provider_identifier)",
+   "GraphNode.attributes[*]",
+   "EntityNode.summary (always empty by the arm's no-prose rule)"
+  ]
+ },
+ "schema_version": "chaos_3647_semantic_leg_results.v1",
+ "scope_notes": [
+  "This measures SUBJECT RESOLUTION only. No packet is assembled, no driver is synthesised and no evidence is cited, so nothing here supports or refutes a claim about answer quality.",
+  "The CHAOS-3619 deterministic run remains the pinned baseline. This run adds a leg; it does not replace, edit or rescore that artifact.",
+  "The semantic leg receives the RAW QUESTION and the deterministic baseline receives PRODUCTION-EXTRACTED MENTIONS, because those are the inputs each mechanism is built for. The deterministic_question leg exists to price that asymmetry: it runs the baseline matcher over the raw question, so a reader can see how much of any delta is retrieval and how much is the mention extractor returning nothing.",
+  "Node vectors are embeddings of the DISPLAY LABEL. Aliases, acronyms and previous names are node attributes and are embedded by nothing, so a semantic leg cannot resolve an alias by similarity however good the model is. See embedded_text_surface.",
+  "The eight corpus ambiguity questions withhold nothing on any leg, because none of them is near the restricted project. The authorization_probes section exists because a clean audit obtained that way is not evidence the filter works."
+ ],
+ "summary": {
+  "any_prose_disclosure": false,
+  "any_unauthorized_entity_ranked": false,
+  "authorization_probe_verdicts": {
+   "cross_tenant_near_duplicate": "pass",
+   "restricted_exact_label": "pass",
+   "restricted_topical": "pass",
+   "unrestricted_control": "pass"
+  },
+  "authorization_probes_ineffective": [],
+  "authorization_probes_run": 4,
+  "cases_measured": 8,
+  "delta_classification_case_ids": {
+   "both_correct": [
+    "H01_acronym_resolution"
+   ],
+   "deterministic_only_correct": [
+    "H02_old_and_current_name",
+    "H08_no_match_must_not_widen"
+   ],
+   "neither_correct_semantic_ranked_anyway": [
+    "H03_the_auth_work",
+    "H04_pronoun_follow_up",
+    "H05_the_other_project_we_discussed",
+    "H06_prior_attempt_reference",
+    "H07_unresolved_needs_candidates"
+   ]
+  },
+  "delta_classification_counts": {
+   "both_correct": 1,
+   "deterministic_only_correct": 2,
+   "neither_correct_semantic_ranked_anyway": 5
+  },
+  "prose_disclosures_by_leg": {},
+  "subject_resolution_correct_by_leg": {
+   "deterministic_mentions": [
+    "H01_acronym_resolution",
+    "H02_old_and_current_name",
+    "H08_no_match_must_not_widen"
+   ],
+   "deterministic_question": [
+    "H08_no_match_must_not_widen"
+   ],
+   "semantic_hybrid": [
+    "H01_acronym_resolution"
+   ]
+  }
+ }
+}

--- a/trials/chaos_3647/results/semantic-leg.records.json
+++ b/trials/chaos_3647/results/semantic-leg.records.json
@@ -98,14 +98,14 @@
    "ranked_canonical_ids": [
     "proj_identity_rewrite",
     "init_identity_modernization",
-    "pr_identity_882",
     "proj_payments_rewrite",
-    "pf_platform",
+    "pr_identity_882",
     "svc_auth_gateway",
-    "repo_identity",
     "proj_auth_gateway_hardening",
+    "pf_platform",
     "dep_authcore",
     "wu_authcore_release",
+    "repo_identity",
     "pr_pulse_212",
     "proj_ledger_migration",
     "proj_acr",
@@ -128,7 +128,7 @@
  ],
  "binding": {
   "branch": "chaos-3647-semantic-leg",
-  "commit": "b4584fb033b4e41981883e0ec4cb64da59b39b99",
+  "commit": "f9ab5c0e2b3738665c1765bdb04a2bf2f1804887",
   "contract_manifest_sha256": "b14307dbbbf5b5dd84d0b9b79648c7c6bdbf35bda7f56511dfcfc63f02a3cd38",
   "corpus_manifest_sha256": "f12a7dcef216c8fedc19538fba1d284bfdf6968461e718bbfcee2a4fea1bd0c4",
   "corpus_version": "ask_dev_investigation_corpus.v1",
@@ -156,7 +156,7 @@
   "run_class": "measured",
   "schema_version": "chaos_3619_trial_results.v1",
   "shadow_record_schema_version": "investigation_shadow_record.v1",
-  "tree_clean": false,
+  "tree_clean": true,
   "trial_store_backend": "falkordb (127.0.0.1:6389)"
  },
  "cases": [
@@ -252,9 +252,7 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [
-      "sc_acr_still_open"
-     ],
+     "bm25_order": [],
      "cosine_order": [
       "sc_acr_still_open",
       "borealis_wip",
@@ -269,8 +267,8 @@
       "ci_identity_blocked",
       "tr_pulse_suite",
       "wg_ratelimitd_removed",
-      "borealis_load",
       "frost_load",
+      "borealis_load",
       "atlas_load",
       "pr_ledger_990_merged",
       "pr_pulse_212",
@@ -283,8 +281,8 @@
       "cinder_incidents",
       "atlas_incident_load",
       "wg_payments_rewrite_superseded",
-      "issue_acr_span_decl",
       "wi_acr_span_open",
+      "issue_acr_span_decl",
       "dp_pulse_prod",
       "sc_pulse_declared_complete",
       "tr_ledger_suite",
@@ -303,8 +301,8 @@
       "oc_ledger_present",
       "dp_identity_none",
       "pulse_deployments",
-      "acr_target_slips",
       "ia_beacon_allocation",
+      "acr_target_slips",
       "ia_atlas_mix"
      ],
      "leg": "semantic_hybrid",
@@ -321,8 +319,8 @@
       "ci_identity_blocked",
       "tr_pulse_suite",
       "wg_ratelimitd_removed",
-      "borealis_load",
       "frost_load",
+      "borealis_load",
       "atlas_load",
       "pr_ledger_990_merged",
       "rv_vertex_revoked",
@@ -349,8 +347,8 @@
       "oc_ledger_present",
       "dp_identity_none",
       "pulse_deployments",
-      "acr_target_slips",
       "ia_beacon_allocation",
+      "acr_target_slips",
       "ia_atlas_mix"
      ],
      "prose_disclosures": [],
@@ -425,7 +423,7 @@
         "cosine_similarity"
        ],
        "rank": 3,
-       "rrf_score": 0.03571428571428571,
+       "rrf_score": 0.034482758620689655,
        "signal": "fuzzy_label"
       },
       {
@@ -493,9 +491,9 @@
     "baseline_correct": true,
     "baseline_ranked": 1,
     "classification": "deterministic_only_correct",
-    "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
+    "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was team_borealis; expected proj_identity_rewrite",
     "semantic_correct": false,
-    "semantic_ranked": 18
+    "semantic_ranked": 17
    },
    "expected_answer": "direct",
    "forbidden_subject_ids": [],
@@ -578,14 +576,11 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [
-      "wu_pulse_runbook",
-      "wi_pulse_runbook_open"
-     ],
+     "bm25_order": [],
      "cosine_order": [
       "wi_borealis_wip",
-      "team_borealis",
       "rv_borealis_normal",
+      "team_borealis",
       "pr_pulse_212",
       "pr_pulse_212_merged",
       "repo_beacon",
@@ -604,8 +599,8 @@
       "pr_vertex_401_cycles",
       "cinder_new_value",
       "pr_ledger_990_merged",
-      "wu_authcore_release",
       "wi_authcore_release_open",
+      "wu_authcore_release",
       "repo_identity",
       "wi_meridian_demand",
       "sc_acr_still_open",
@@ -637,7 +632,6 @@
      "mentions": [],
      "observation_hits": [
       "wi_borealis_wip",
-      "wi_pulse_runbook_open",
       "rv_borealis_normal",
       "pr_pulse_212_merged",
       "rv_vertex_revoked",
@@ -680,9 +674,9 @@
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
       "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'team_borealis', 'wu_pulse_runbook']",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'repo_beacon', 'team_borealis']",
       "precision_over_all": "fail",
-      "precision_over_all_detail": "18 stray candidates across 18 ranked",
+      "precision_over_all_detail": "17 stray candidates across 17 ranked",
       "resolved": true,
       "stray_candidates": [
        "dep_authcore",
@@ -701,28 +695,16 @@
        "team_atlas",
        "team_borealis",
        "wu_authcore_release",
-       "wu_beacon_ingest",
-       "wu_pulse_runbook"
+       "wu_beacon_ingest"
       ],
       "subject_resolution_correct": false,
-      "subject_resolution_detail": "rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
+      "subject_resolution_detail": "rank-1 was team_borealis; expected proj_identity_rewrite",
       "subject_top_1": "fail",
-      "subject_top_1_detail": "rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
+      "subject_top_1_detail": "rank-1 was team_borealis; expected proj_identity_rewrite",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['wu_pulse_runbook', 'team_borealis', 'pr_pulse_212']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 ['team_borealis', 'pr_pulse_212', 'repo_beacon']; expected proj_identity_rewrite"
      },
      "subjects": [
-      {
-       "canonical_id": "wu_pulse_runbook",
-       "display_label": "Pulse on-call runbook and alerts",
-       "mechanism": "lexical_fuzzy",
-       "methods": [
-        "bm25"
-       ],
-       "rank": 0,
-       "rrf_score": 1.0,
-       "signal": "fuzzy_label"
-      },
       {
        "canonical_id": "team_borealis",
        "display_label": "Borealis",
@@ -730,8 +712,8 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 1,
-       "rrf_score": 0.5,
+       "rank": 0,
+       "rrf_score": 0.3333333333333333,
        "signal": "fuzzy_label"
       },
       {
@@ -741,7 +723,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 2,
+       "rank": 1,
        "rrf_score": 0.25,
        "signal": "fuzzy_label"
       },
@@ -752,7 +734,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 3,
+       "rank": 2,
        "rrf_score": 0.16666666666666666,
        "signal": "fuzzy_label"
       },
@@ -763,7 +745,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 4,
+       "rank": 3,
        "rrf_score": 0.08333333333333333,
        "signal": "fuzzy_label"
       },
@@ -774,7 +756,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 5,
+       "rank": 4,
        "rrf_score": 0.05555555555555555,
        "signal": "fuzzy_label"
       },
@@ -785,8 +767,8 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 6,
-       "rrf_score": 0.045454545454545456,
+       "rank": 5,
+       "rrf_score": 0.043478260869565216,
        "signal": "fuzzy_label"
       },
       {
@@ -796,7 +778,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 7,
+       "rank": 6,
        "rrf_score": 0.041666666666666664,
        "signal": "fuzzy_label"
       },
@@ -807,7 +789,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 8,
+       "rank": 7,
        "rrf_score": 0.037037037037037035,
        "signal": "fuzzy_label"
       },
@@ -818,7 +800,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 9,
+       "rank": 8,
        "rrf_score": 0.034482758620689655,
        "signal": "fuzzy_label"
       },
@@ -829,7 +811,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 10,
+       "rank": 9,
        "rrf_score": 0.03125,
        "signal": "fuzzy_label"
       },
@@ -840,7 +822,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 11,
+       "rank": 10,
        "rrf_score": 0.02702702702702703,
        "signal": "fuzzy_label"
       },
@@ -851,7 +833,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 12,
+       "rank": 11,
        "rrf_score": 0.025,
        "signal": "fuzzy_label"
       },
@@ -862,7 +844,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 13,
+       "rank": 12,
        "rrf_score": 0.023809523809523808,
        "signal": "fuzzy_label"
       },
@@ -873,7 +855,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 14,
+       "rank": 13,
        "rrf_score": 0.023255813953488372,
        "signal": "fuzzy_label"
       },
@@ -884,7 +866,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 15,
+       "rank": 14,
        "rrf_score": 0.022727272727272728,
        "signal": "fuzzy_label"
       },
@@ -895,7 +877,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 16,
+       "rank": 15,
        "rrf_score": 0.022222222222222223,
        "signal": "fuzzy_label"
       },
@@ -906,7 +888,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 17,
+       "rank": 16,
        "rrf_score": 0.02040816326530612,
        "signal": "fuzzy_label"
       }
@@ -1003,23 +985,12 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [
-      "wg_auth_hardening",
-      "dp_identity_none",
-      "proj_auth_gateway_hardening",
-      "inc_atlas_gateway",
-      "svc_auth_gateway",
-      "wi_beacon_deleted",
-      "wi_borealis_wip",
-      "wi_ember_partial",
-      "wi_atlas_wip",
-      "wi_quarry_redacted"
-     ],
+     "bm25_order": [],
      "cosine_order": [
       "dep_authcore",
       "pr_identity_882",
-      "wi_authcore_release_open",
       "wu_authcore_release",
+      "wi_authcore_release_open",
       "wg_authcore_shared",
       "svc_auth_gateway",
       "proj_auth_gateway_hardening",
@@ -1070,32 +1041,32 @@
      "leg": "semantic_hybrid",
      "mentions": [],
      "observation_hits": [
-      "wg_auth_hardening",
-      "dp_identity_none",
-      "inc_atlas_gateway",
       "wi_authcore_release_open",
-      "wi_beacon_deleted",
-      "wi_ember_partial",
       "wg_authcore_shared",
-      "wi_borealis_wip",
-      "wi_atlas_wip",
-      "wi_quarry_redacted",
+      "wg_auth_hardening",
       "lattice_touching_contributors",
+      "inc_atlas_gateway",
+      "wi_ember_partial",
+      "wi_beacon_deleted",
       "rv_vertex_revoked",
       "borealis_wip",
       "atlas_wip",
+      "dp_identity_none",
       "pr_ledger_990_merged",
       "rv_vertex_cycles",
       "lattice_active_contributors",
       "wg_acr",
+      "wi_atlas_wip",
       "pr_vertex_401_cycles",
       "wg_identity_rewrite",
       "oc_ledger_present",
+      "wi_quarry_redacted",
       "pr_identity_882_open",
       "rv_atlas_queue",
       "ci_identity_blocked",
       "sh_ember_stalled",
       "dp_ledger_prod",
+      "wi_borealis_wip",
       "dorado_outbound_reviews",
       "wg_lattice_contributors",
       "hp_atlas",
@@ -1113,7 +1084,7 @@
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
       "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_authcore', 'pr_identity_882']",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_authcore', 'pr_identity_882', 'wu_authcore_release']",
       "precision_over_all": "fail",
       "precision_over_all_detail": "16 stray candidates across 18 ranked",
       "resolved": true,
@@ -1140,7 +1111,7 @@
       "subject_top_1": "fail",
       "subject_top_1_detail": "rank-1 was dep_authcore; expected proj_identity_rewrite",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['dep_authcore', 'pr_identity_882', 'proj_auth_gateway_hardening']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 ['dep_authcore', 'pr_identity_882', 'wu_authcore_release']; expected proj_identity_rewrite"
      },
      "subjects": [
       {
@@ -1166,15 +1137,14 @@
        "signal": "fuzzy_label"
       },
       {
-       "canonical_id": "proj_auth_gateway_hardening",
-       "display_label": "Auth Gateway Hardening",
+       "canonical_id": "wu_authcore_release",
+       "display_label": "authcore 2.0 release",
        "mechanism": "embedding_similarity",
        "methods": [
-        "bm25",
         "cosine_similarity"
        ],
        "rank": 2,
-       "rrf_score": 0.47619047619047616,
+       "rrf_score": 0.3333333333333333,
        "signal": "fuzzy_label"
       },
       {
@@ -1182,22 +1152,21 @@
        "display_label": "Auth Gateway",
        "mechanism": "embedding_similarity",
        "methods": [
-        "bm25",
         "cosine_similarity"
        ],
        "rank": 3,
-       "rrf_score": 0.3666666666666667,
+       "rrf_score": 0.16666666666666666,
        "signal": "fuzzy_label"
       },
       {
-       "canonical_id": "wu_authcore_release",
-       "display_label": "authcore 2.0 release",
+       "canonical_id": "proj_auth_gateway_hardening",
+       "display_label": "Auth Gateway Hardening",
        "mechanism": "embedding_similarity",
        "methods": [
         "cosine_similarity"
        ],
        "rank": 4,
-       "rrf_score": 0.25,
+       "rrf_score": 0.14285714285714285,
        "signal": "fuzzy_label"
       },
       {
@@ -1760,18 +1729,18 @@
       "wi_atlas_wip",
       "rv_vertex_cycles",
       "rv_atlas_queue",
-      "atlas_wip",
       "borealis_wip",
+      "atlas_wip",
       "wi_ember_partial",
       "pf_platform",
       "wi_quarry_redacted",
+      "beacon_completions",
       "solstice_completions",
       "meridian_completions",
-      "atlas_completed",
-      "lattice_completions",
-      "beacon_completions",
       "ember_completed",
       "borealis_completed",
+      "lattice_completions",
+      "atlas_completed",
       "sh_ember_stalled",
       "lattice_touching_contributors",
       "pr_ledger_990_merged",
@@ -1781,8 +1750,8 @@
       "ia_beacon_allocation",
       "doc_false_dependency_claim",
       "sc_ledger_declared_complete",
-      "wg_identity_rewrite",
       "proj_identity_rewrite",
+      "wg_identity_rewrite",
       "ia_atlas_mix",
       "pr_pulse_212",
       "proj_beacon",
@@ -1798,8 +1767,8 @@
       "proj_acr",
       "wg_acr",
       "pr_ledger_990",
-      "cc_lattice_active",
       "wu_ledger_dual_write",
+      "cc_lattice_active",
       "tr_ledger_suite",
       "ep_keyword_stuffed",
       "dorado_outbound_reviews",
@@ -1814,17 +1783,17 @@
       "wi_atlas_wip",
       "rv_vertex_cycles",
       "rv_atlas_queue",
-      "atlas_wip",
       "borealis_wip",
+      "atlas_wip",
       "wi_ember_partial",
       "wi_quarry_redacted",
+      "beacon_completions",
       "solstice_completions",
       "meridian_completions",
-      "atlas_completed",
-      "lattice_completions",
-      "beacon_completions",
       "ember_completed",
       "borealis_completed",
+      "lattice_completions",
+      "atlas_completed",
       "sh_ember_stalled",
       "lattice_touching_contributors",
       "pr_ledger_990_merged",
@@ -1901,7 +1870,7 @@
         "cosine_similarity"
        ],
        "rank": 1,
-       "rrf_score": 0.034482758620689655,
+       "rrf_score": 0.03571428571428571,
        "signal": "fuzzy_label"
       },
       {
@@ -1989,7 +1958,7 @@
         "cosine_similarity"
        ],
        "rank": 9,
-       "rrf_score": 0.021739130434782608,
+       "rrf_score": 0.022222222222222223,
        "signal": "fuzzy_label"
       }
      ],
@@ -2086,14 +2055,7 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [
-      "rv_vertex_cycles",
-      "wi_frost_outlier",
-      "rv_atlas_queue",
-      "rv_borealis_normal",
-      "rv_dorado_outbound",
-      "rv_vertex_revoked"
-     ],
+     "bm25_order": [],
      "cosine_order": [
       "rv_vertex_cycles",
       "rv_vertex_revoked",
@@ -2104,9 +2066,9 @@
       "vertex_review_cycles",
       "sc_ledger_declared_complete",
       "wi_beacon_deleted",
-      "dorado_review_wait",
-      "borealis_review_wait",
       "atlas_review_wait",
+      "borealis_review_wait",
+      "dorado_review_wait",
       "tr_ledger_suite",
       "wu_ledger_cutover",
       "atlas_wip",
@@ -2116,28 +2078,28 @@
       "pr_ledger_990_merged",
       "sc_acr_still_open",
       "proj_ledger_migration",
-      "wg_identity_rewrite",
       "proj_identity_rewrite",
+      "wg_identity_rewrite",
       "sc_pulse_declared_complete",
       "wu_ledger_backfill",
       "wi_ledger_backfill_open",
+      "ember_completed",
+      "beacon_completions",
+      "borealis_completed",
       "lattice_completions",
       "meridian_completions",
       "solstice_completions",
       "atlas_completed",
-      "ember_completed",
-      "beacon_completions",
-      "borealis_completed",
       "dp_ledger_prod",
       "wg_payments_rewrite_superseded",
       "repo_checkout",
       "wi_ledger_children",
       "proj_payments_rewrite",
       "wu_ledger_dual_write",
+      "dp_identity_none",
       "pr_ledger_990",
       "oc_ledger_present",
       "wu_ledger_schema",
-      "dp_identity_none",
       "cc_quarry_activity",
       "rv_dorado_outbound",
       "frost_cycle_p90",
@@ -2150,19 +2112,17 @@
      "mentions": [],
      "observation_hits": [
       "rv_vertex_cycles",
-      "rv_atlas_queue",
       "rv_vertex_revoked",
-      "wi_frost_outlier",
+      "rv_atlas_queue",
       "rv_borealis_normal",
-      "rv_dorado_outbound",
       "dorado_outbound_reviews",
       "sc_payments_rewrite_cancelled",
       "vertex_review_cycles",
       "sc_ledger_declared_complete",
       "wi_beacon_deleted",
-      "dorado_review_wait",
-      "borealis_review_wait",
       "atlas_review_wait",
+      "borealis_review_wait",
+      "dorado_review_wait",
       "tr_ledger_suite",
       "atlas_wip",
       "borealis_wip",
@@ -2172,19 +2132,20 @@
       "wg_identity_rewrite",
       "sc_pulse_declared_complete",
       "wi_ledger_backfill_open",
+      "ember_completed",
+      "beacon_completions",
+      "borealis_completed",
       "lattice_completions",
       "meridian_completions",
       "solstice_completions",
       "atlas_completed",
-      "ember_completed",
-      "beacon_completions",
-      "borealis_completed",
       "dp_ledger_prod",
       "wg_payments_rewrite_superseded",
       "wi_ledger_children",
-      "oc_ledger_present",
       "dp_identity_none",
+      "oc_ledger_present",
       "cc_quarry_activity",
+      "rv_dorado_outbound",
       "frost_cycle_p90",
       "doc_injected_runbook",
       "inc_atlas_gateway",
@@ -2266,7 +2227,7 @@
         "cosine_similarity"
        ],
        "rank": 3,
-       "rrf_score": 0.043478260869565216,
+       "rrf_score": 0.045454545454545456,
        "signal": "fuzzy_label"
       },
       {
@@ -2321,7 +2282,7 @@
         "cosine_similarity"
        ],
        "rank": 8,
-       "rrf_score": 0.025,
+       "rrf_score": 0.024390243902439025,
        "signal": "fuzzy_label"
       },
       {
@@ -2332,7 +2293,7 @@
         "cosine_similarity"
        ],
        "rank": 9,
-       "rrf_score": 0.023809523809523808,
+       "rrf_score": 0.023255813953488372,
        "signal": "fuzzy_label"
       }
      ],
@@ -2431,21 +2392,10 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [
-      "wg_payments_rewrite_superseded",
-      "sc_payments_rewrite_cancelled",
-      "proj_payments_rewrite",
-      "proj_zenith",
-      "wg_zenith",
-      "wi_beacon_deleted",
-      "wi_borealis_wip",
-      "wi_ember_partial",
-      "wi_atlas_wip",
-      "wi_quarry_redacted"
-     ],
+     "bm25_order": [],
      "cosine_order": [
-      "proj_zenith",
       "wg_zenith",
+      "proj_zenith",
       "proj_payments_rewrite",
       "sc_payments_rewrite_cancelled",
       "wg_payments_rewrite_superseded",
@@ -2460,13 +2410,13 @@
       "svc_pulse_api",
       "repo_checkout",
       "dp_pulse_prod",
+      "atlas_completed",
       "beacon_completions",
       "borealis_completed",
-      "ember_completed",
-      "atlas_completed",
       "solstice_completions",
       "lattice_completions",
       "meridian_completions",
+      "ember_completed",
       "wu_ledger_cutover",
       "ia_cinder_displaced",
       "proj_ledger_migration",
@@ -2498,30 +2448,26 @@
      "leg": "semantic_hybrid",
      "mentions": [],
      "observation_hits": [
-      "wg_payments_rewrite_superseded",
-      "sc_payments_rewrite_cancelled",
       "wg_zenith",
-      "wi_beacon_deleted",
-      "wi_ember_partial",
-      "wi_borealis_wip",
+      "sc_payments_rewrite_cancelled",
+      "wg_payments_rewrite_superseded",
       "rv_vertex_cycles",
-      "wi_atlas_wip",
       "atlas_wip",
-      "wi_quarry_redacted",
       "borealis_wip",
       "pr_vertex_401_cycles",
       "dp_pulse_prod",
+      "atlas_completed",
       "beacon_completions",
       "borealis_completed",
-      "ember_completed",
-      "atlas_completed",
       "solstice_completions",
       "lattice_completions",
       "meridian_completions",
+      "ember_completed",
       "ia_cinder_displaced",
       "rv_vertex_revoked",
       "wi_beacon_demand",
       "sh_solstice_no_allocation",
+      "wi_ember_partial",
       "dp_ledger_prod",
       "sc_ledger_declared_complete",
       "wi_ledger_children",
@@ -2580,11 +2526,10 @@
        "display_label": "Zenith Payments",
        "mechanism": "embedding_similarity",
        "methods": [
-        "bm25",
         "cosine_similarity"
        ],
        "rank": 0,
-       "rrf_score": 1.25,
+       "rrf_score": 0.5,
        "signal": "fuzzy_label"
       },
       {
@@ -2592,11 +2537,10 @@
        "display_label": "Payments Rewrite",
        "mechanism": "embedding_similarity",
        "methods": [
-        "bm25",
         "cosine_similarity"
        ],
        "rank": 1,
-       "rrf_score": 0.6666666666666666,
+       "rrf_score": 0.3333333333333333,
        "signal": "fuzzy_label"
       },
       {
@@ -2913,8 +2857,8 @@
       "cl_borealis",
       "rv_vertex_revoked",
       "oc_ledger_present",
-      "sc_ledger_declared_complete",
       "rv_vertex_cycles",
+      "sc_ledger_declared_complete",
       "team_borealis",
       "pr_vertex_401_cycles",
       "sh_tidal_thin",
@@ -2952,8 +2896,8 @@
       "cl_borealis",
       "rv_vertex_revoked",
       "oc_ledger_present",
-      "sc_ledger_declared_complete",
       "rv_vertex_cycles",
+      "sc_ledger_declared_complete",
       "pr_vertex_401_cycles",
       "sh_tidal_thin",
       "dp_ledger_prod",

--- a/trials/chaos_3647/results/semantic-leg.records.json
+++ b/trials/chaos_3647/results/semantic-leg.records.json
@@ -98,14 +98,14 @@
    "ranked_canonical_ids": [
     "proj_identity_rewrite",
     "init_identity_modernization",
-    "proj_payments_rewrite",
     "pr_identity_882",
-    "svc_auth_gateway",
-    "proj_auth_gateway_hardening",
+    "proj_payments_rewrite",
     "pf_platform",
+    "svc_auth_gateway",
+    "repo_identity",
+    "proj_auth_gateway_hardening",
     "dep_authcore",
     "wu_authcore_release",
-    "repo_identity",
     "pr_pulse_212",
     "proj_ledger_migration",
     "proj_acr",
@@ -128,7 +128,7 @@
  ],
  "binding": {
   "branch": "chaos-3647-semantic-leg",
-  "commit": "f9ab5c0e2b3738665c1765bdb04a2bf2f1804887",
+  "commit": "5c28c208f6a3be197610329b3407854ddd9bf937",
   "contract_manifest_sha256": "b14307dbbbf5b5dd84d0b9b79648c7c6bdbf35bda7f56511dfcfc63f02a3cd38",
   "corpus_manifest_sha256": "f12a7dcef216c8fedc19538fba1d284bfdf6968461e718bbfcee2a4fea1bd0c4",
   "corpus_version": "ask_dev_investigation_corpus.v1",
@@ -139,7 +139,7 @@
    "redis": "6.4.0"
   },
   "execution_mode": "producer_invoked_directly_seam_real_orchestrator_bypassed",
-  "feature_tip_commit": "ec3532bfd929411831b967cd28123d4ea4acc335",
+  "feature_tip_commit": "4b6489f5eadc0fc9969b51f3156278d6bbee71ab",
   "graph_arm_id": "graph_assisted_shadow_arm",
   "graph_attachment_encoding": "canonical_ids.v1",
   "graph_embedder_model_id": "openai_text_embedding_3_small",
@@ -156,7 +156,7 @@
   "run_class": "measured",
   "schema_version": "chaos_3619_trial_results.v1",
   "shadow_record_schema_version": "investigation_shadow_record.v1",
-  "tree_clean": true,
+  "tree_clean": false,
   "trial_store_backend": "falkordb (127.0.0.1:6389)"
  },
  "cases": [
@@ -252,11 +252,13 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [],
+     "bm25_order": [
+      "sc_acr_still_open"
+     ],
      "cosine_order": [
       "sc_acr_still_open",
-      "borealis_wip",
       "atlas_wip",
+      "borealis_wip",
       "doc_injected_runbook",
       "pr_pulse_212_merged",
       "wg_identity_rewrite",
@@ -301,16 +303,16 @@
       "oc_ledger_present",
       "dp_identity_none",
       "pulse_deployments",
-      "ia_beacon_allocation",
       "acr_target_slips",
+      "ia_beacon_allocation",
       "ia_atlas_mix"
      ],
      "leg": "semantic_hybrid",
      "mentions": [],
      "observation_hits": [
       "sc_acr_still_open",
-      "borealis_wip",
       "atlas_wip",
+      "borealis_wip",
       "doc_injected_runbook",
       "pr_pulse_212_merged",
       "wg_identity_rewrite",
@@ -347,8 +349,8 @@
       "oc_ledger_present",
       "dp_identity_none",
       "pulse_deployments",
-      "ia_beacon_allocation",
       "acr_target_slips",
+      "ia_beacon_allocation",
       "ia_atlas_mix"
      ],
      "prose_disclosures": [],
@@ -491,9 +493,9 @@
     "baseline_correct": true,
     "baseline_ranked": 1,
     "classification": "deterministic_only_correct",
-    "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was team_borealis; expected proj_identity_rewrite",
+    "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
     "semantic_correct": false,
-    "semantic_ranked": 17
+    "semantic_ranked": 18
    },
    "expected_answer": "direct",
    "forbidden_subject_ids": [],
@@ -576,7 +578,10 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [],
+     "bm25_order": [
+      "wu_pulse_runbook",
+      "wi_pulse_runbook_open"
+     ],
      "cosine_order": [
       "wi_borealis_wip",
       "rv_borealis_normal",
@@ -632,6 +637,7 @@
      "mentions": [],
      "observation_hits": [
       "wi_borealis_wip",
+      "wi_pulse_runbook_open",
       "rv_borealis_normal",
       "pr_pulse_212_merged",
       "rv_vertex_revoked",
@@ -674,9 +680,9 @@
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
       "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'repo_beacon', 'team_borealis']",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'team_borealis', 'wu_pulse_runbook']",
       "precision_over_all": "fail",
-      "precision_over_all_detail": "17 stray candidates across 17 ranked",
+      "precision_over_all_detail": "18 stray candidates across 18 ranked",
       "resolved": true,
       "stray_candidates": [
        "dep_authcore",
@@ -695,16 +701,28 @@
        "team_atlas",
        "team_borealis",
        "wu_authcore_release",
-       "wu_beacon_ingest"
+       "wu_beacon_ingest",
+       "wu_pulse_runbook"
       ],
       "subject_resolution_correct": false,
-      "subject_resolution_detail": "rank-1 was team_borealis; expected proj_identity_rewrite",
+      "subject_resolution_detail": "rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
       "subject_top_1": "fail",
-      "subject_top_1_detail": "rank-1 was team_borealis; expected proj_identity_rewrite",
+      "subject_top_1_detail": "rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['team_borealis', 'pr_pulse_212', 'repo_beacon']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 ['wu_pulse_runbook', 'team_borealis', 'pr_pulse_212']; expected proj_identity_rewrite"
      },
      "subjects": [
+      {
+       "canonical_id": "wu_pulse_runbook",
+       "display_label": "Pulse on-call runbook and alerts",
+       "mechanism": "lexical_fuzzy",
+       "methods": [
+        "bm25"
+       ],
+       "rank": 0,
+       "rrf_score": 1.0,
+       "signal": "fuzzy_label"
+      },
       {
        "canonical_id": "team_borealis",
        "display_label": "Borealis",
@@ -712,7 +730,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 0,
+       "rank": 1,
        "rrf_score": 0.3333333333333333,
        "signal": "fuzzy_label"
       },
@@ -723,7 +741,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 1,
+       "rank": 2,
        "rrf_score": 0.25,
        "signal": "fuzzy_label"
       },
@@ -734,7 +752,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 2,
+       "rank": 3,
        "rrf_score": 0.16666666666666666,
        "signal": "fuzzy_label"
       },
@@ -745,7 +763,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 3,
+       "rank": 4,
        "rrf_score": 0.08333333333333333,
        "signal": "fuzzy_label"
       },
@@ -756,7 +774,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 4,
+       "rank": 5,
        "rrf_score": 0.05555555555555555,
        "signal": "fuzzy_label"
       },
@@ -767,7 +785,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 5,
+       "rank": 6,
        "rrf_score": 0.043478260869565216,
        "signal": "fuzzy_label"
       },
@@ -778,7 +796,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 6,
+       "rank": 7,
        "rrf_score": 0.041666666666666664,
        "signal": "fuzzy_label"
       },
@@ -789,7 +807,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 7,
+       "rank": 8,
        "rrf_score": 0.037037037037037035,
        "signal": "fuzzy_label"
       },
@@ -800,7 +818,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 8,
+       "rank": 9,
        "rrf_score": 0.034482758620689655,
        "signal": "fuzzy_label"
       },
@@ -811,7 +829,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 9,
+       "rank": 10,
        "rrf_score": 0.03125,
        "signal": "fuzzy_label"
       },
@@ -822,7 +840,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 10,
+       "rank": 11,
        "rrf_score": 0.02702702702702703,
        "signal": "fuzzy_label"
       },
@@ -833,7 +851,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 11,
+       "rank": 12,
        "rrf_score": 0.025,
        "signal": "fuzzy_label"
       },
@@ -844,7 +862,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 12,
+       "rank": 13,
        "rrf_score": 0.023809523809523808,
        "signal": "fuzzy_label"
       },
@@ -855,7 +873,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 13,
+       "rank": 14,
        "rrf_score": 0.023255813953488372,
        "signal": "fuzzy_label"
       },
@@ -866,7 +884,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 14,
+       "rank": 15,
        "rrf_score": 0.022727272727272728,
        "signal": "fuzzy_label"
       },
@@ -877,7 +895,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 15,
+       "rank": 16,
        "rrf_score": 0.022222222222222223,
        "signal": "fuzzy_label"
       },
@@ -888,7 +906,7 @@
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 16,
+       "rank": 17,
        "rrf_score": 0.02040816326530612,
        "signal": "fuzzy_label"
       }
@@ -985,7 +1003,18 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [],
+     "bm25_order": [
+      "wg_auth_hardening",
+      "dp_identity_none",
+      "proj_auth_gateway_hardening",
+      "inc_atlas_gateway",
+      "svc_auth_gateway",
+      "wi_beacon_deleted",
+      "wi_borealis_wip",
+      "wi_ember_partial",
+      "wi_atlas_wip",
+      "wi_quarry_redacted"
+     ],
      "cosine_order": [
       "dep_authcore",
       "pr_identity_882",
@@ -993,8 +1022,8 @@
       "wi_authcore_release_open",
       "wg_authcore_shared",
       "svc_auth_gateway",
-      "proj_auth_gateway_hardening",
       "wg_auth_hardening",
+      "proj_auth_gateway_hardening",
       "lattice_touching_contributors",
       "inc_atlas_gateway",
       "wi_ember_partial",
@@ -1006,8 +1035,8 @@
       "pr_ledger_990_merged",
       "rv_vertex_cycles",
       "lattice_active_contributors",
-      "proj_acr",
       "wg_acr",
+      "proj_acr",
       "wi_atlas_wip",
       "pr_vertex_401_cycles",
       "pr_ledger_990",
@@ -1041,32 +1070,32 @@
      "leg": "semantic_hybrid",
      "mentions": [],
      "observation_hits": [
-      "wi_authcore_release_open",
-      "wg_authcore_shared",
       "wg_auth_hardening",
-      "lattice_touching_contributors",
+      "dp_identity_none",
       "inc_atlas_gateway",
-      "wi_ember_partial",
       "wi_beacon_deleted",
+      "wi_authcore_release_open",
+      "wi_ember_partial",
+      "wg_authcore_shared",
+      "wi_borealis_wip",
+      "wi_atlas_wip",
+      "wi_quarry_redacted",
+      "lattice_touching_contributors",
       "rv_vertex_revoked",
       "borealis_wip",
       "atlas_wip",
-      "dp_identity_none",
       "pr_ledger_990_merged",
       "rv_vertex_cycles",
       "lattice_active_contributors",
       "wg_acr",
-      "wi_atlas_wip",
       "pr_vertex_401_cycles",
       "wg_identity_rewrite",
       "oc_ledger_present",
-      "wi_quarry_redacted",
       "pr_identity_882_open",
       "rv_atlas_queue",
       "ci_identity_blocked",
       "sh_ember_stalled",
       "dp_ledger_prod",
-      "wi_borealis_wip",
       "dorado_outbound_reviews",
       "wg_lattice_contributors",
       "hp_atlas",
@@ -1084,7 +1113,7 @@
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
       "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_authcore', 'pr_identity_882', 'wu_authcore_release']",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_authcore', 'pr_identity_882']",
       "precision_over_all": "fail",
       "precision_over_all_detail": "16 stray candidates across 18 ranked",
       "resolved": true,
@@ -1111,7 +1140,7 @@
       "subject_top_1": "fail",
       "subject_top_1_detail": "rank-1 was dep_authcore; expected proj_identity_rewrite",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['dep_authcore', 'pr_identity_882', 'wu_authcore_release']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 ['dep_authcore', 'pr_identity_882', 'proj_auth_gateway_hardening']; expected proj_identity_rewrite"
      },
      "subjects": [
       {
@@ -1137,14 +1166,15 @@
        "signal": "fuzzy_label"
       },
       {
-       "canonical_id": "wu_authcore_release",
-       "display_label": "authcore 2.0 release",
+       "canonical_id": "proj_auth_gateway_hardening",
+       "display_label": "Auth Gateway Hardening",
        "mechanism": "embedding_similarity",
        "methods": [
+        "bm25",
         "cosine_similarity"
        ],
        "rank": 2,
-       "rrf_score": 0.3333333333333333,
+       "rrf_score": 0.4583333333333333,
        "signal": "fuzzy_label"
       },
       {
@@ -1152,21 +1182,22 @@
        "display_label": "Auth Gateway",
        "mechanism": "embedding_similarity",
        "methods": [
+        "bm25",
         "cosine_similarity"
        ],
        "rank": 3,
-       "rrf_score": 0.16666666666666666,
+       "rrf_score": 0.3666666666666667,
        "signal": "fuzzy_label"
       },
       {
-       "canonical_id": "proj_auth_gateway_hardening",
-       "display_label": "Auth Gateway Hardening",
+       "canonical_id": "wu_authcore_release",
+       "display_label": "authcore 2.0 release",
        "mechanism": "embedding_similarity",
        "methods": [
         "cosine_similarity"
        ],
        "rank": 4,
-       "rrf_score": 0.14285714285714285,
+       "rrf_score": 0.3333333333333333,
        "signal": "fuzzy_label"
       },
       {
@@ -1177,7 +1208,7 @@
         "cosine_similarity"
        ],
        "rank": 5,
-       "rrf_score": 0.05,
+       "rrf_score": 0.047619047619047616,
        "signal": "fuzzy_label"
       },
       {
@@ -1729,18 +1760,18 @@
       "wi_atlas_wip",
       "rv_vertex_cycles",
       "rv_atlas_queue",
-      "borealis_wip",
       "atlas_wip",
+      "borealis_wip",
       "wi_ember_partial",
       "pf_platform",
       "wi_quarry_redacted",
-      "beacon_completions",
-      "solstice_completions",
-      "meridian_completions",
       "ember_completed",
-      "borealis_completed",
       "lattice_completions",
+      "borealis_completed",
       "atlas_completed",
+      "beacon_completions",
+      "meridian_completions",
+      "solstice_completions",
       "sh_ember_stalled",
       "lattice_touching_contributors",
       "pr_ledger_990_merged",
@@ -1783,17 +1814,17 @@
       "wi_atlas_wip",
       "rv_vertex_cycles",
       "rv_atlas_queue",
-      "borealis_wip",
       "atlas_wip",
+      "borealis_wip",
       "wi_ember_partial",
       "wi_quarry_redacted",
-      "beacon_completions",
-      "solstice_completions",
-      "meridian_completions",
       "ember_completed",
-      "borealis_completed",
       "lattice_completions",
+      "borealis_completed",
       "atlas_completed",
+      "beacon_completions",
+      "meridian_completions",
+      "solstice_completions",
       "sh_ember_stalled",
       "lattice_touching_contributors",
       "pr_ledger_990_merged",
@@ -2055,7 +2086,14 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [],
+     "bm25_order": [
+      "rv_vertex_cycles",
+      "wi_frost_outlier",
+      "rv_atlas_queue",
+      "rv_borealis_normal",
+      "rv_dorado_outbound",
+      "rv_vertex_revoked"
+     ],
      "cosine_order": [
       "rv_vertex_cycles",
       "rv_vertex_revoked",
@@ -2066,13 +2104,13 @@
       "vertex_review_cycles",
       "sc_ledger_declared_complete",
       "wi_beacon_deleted",
-      "atlas_review_wait",
       "borealis_review_wait",
       "dorado_review_wait",
+      "atlas_review_wait",
       "tr_ledger_suite",
       "wu_ledger_cutover",
-      "atlas_wip",
       "borealis_wip",
+      "atlas_wip",
       "pr_vertex_401_cycles",
       "pr_pulse_212",
       "pr_ledger_990_merged",
@@ -2087,9 +2125,9 @@
       "beacon_completions",
       "borealis_completed",
       "lattice_completions",
+      "atlas_completed",
       "meridian_completions",
       "solstice_completions",
-      "atlas_completed",
       "dp_ledger_prod",
       "wg_payments_rewrite_superseded",
       "repo_checkout",
@@ -2112,20 +2150,22 @@
      "mentions": [],
      "observation_hits": [
       "rv_vertex_cycles",
-      "rv_vertex_revoked",
       "rv_atlas_queue",
+      "rv_vertex_revoked",
+      "wi_frost_outlier",
       "rv_borealis_normal",
+      "rv_dorado_outbound",
       "dorado_outbound_reviews",
       "sc_payments_rewrite_cancelled",
       "vertex_review_cycles",
       "sc_ledger_declared_complete",
       "wi_beacon_deleted",
-      "atlas_review_wait",
       "borealis_review_wait",
       "dorado_review_wait",
+      "atlas_review_wait",
       "tr_ledger_suite",
-      "atlas_wip",
       "borealis_wip",
+      "atlas_wip",
       "pr_vertex_401_cycles",
       "pr_ledger_990_merged",
       "sc_acr_still_open",
@@ -2136,16 +2176,15 @@
       "beacon_completions",
       "borealis_completed",
       "lattice_completions",
+      "atlas_completed",
       "meridian_completions",
       "solstice_completions",
-      "atlas_completed",
       "dp_ledger_prod",
       "wg_payments_rewrite_superseded",
       "wi_ledger_children",
       "dp_identity_none",
       "oc_ledger_present",
       "cc_quarry_activity",
-      "rv_dorado_outbound",
       "frost_cycle_p90",
       "doc_injected_runbook",
       "inc_atlas_gateway",
@@ -2392,30 +2431,41 @@
     },
     {
      "authorization_filtered_count": 0,
-     "bm25_order": [],
-     "cosine_order": [
-      "wg_zenith",
+     "bm25_order": [
+      "wg_payments_rewrite_superseded",
+      "sc_payments_rewrite_cancelled",
+      "proj_payments_rewrite",
       "proj_zenith",
+      "wg_zenith",
+      "wi_beacon_deleted",
+      "wi_borealis_wip",
+      "wi_ember_partial",
+      "wi_atlas_wip",
+      "wi_quarry_redacted"
+     ],
+     "cosine_order": [
+      "proj_zenith",
+      "wg_zenith",
       "proj_payments_rewrite",
       "sc_payments_rewrite_cancelled",
       "wg_payments_rewrite_superseded",
       "pr_vertex_401",
       "proj_solstice",
       "rv_vertex_cycles",
-      "atlas_wip",
       "borealis_wip",
+      "atlas_wip",
       "pr_pulse_212",
       "pr_vertex_401_cycles",
       "svc_checkout",
       "svc_pulse_api",
       "repo_checkout",
       "dp_pulse_prod",
-      "atlas_completed",
-      "beacon_completions",
-      "borealis_completed",
       "solstice_completions",
-      "lattice_completions",
       "meridian_completions",
+      "borealis_completed",
+      "lattice_completions",
+      "beacon_completions",
+      "atlas_completed",
       "ember_completed",
       "wu_ledger_cutover",
       "ia_cinder_displaced",
@@ -2441,33 +2491,37 @@
       "pulse_deployments",
       "proj_vertex",
       "proj_beacon",
-      "wi_solstice_demand",
       "doc_injected_runbook",
+      "wi_solstice_demand",
       "atlas_review_wait"
      ],
      "leg": "semantic_hybrid",
      "mentions": [],
      "observation_hits": [
-      "wg_zenith",
-      "sc_payments_rewrite_cancelled",
       "wg_payments_rewrite_superseded",
+      "sc_payments_rewrite_cancelled",
+      "wg_zenith",
+      "wi_beacon_deleted",
+      "wi_ember_partial",
+      "wi_borealis_wip",
       "rv_vertex_cycles",
-      "atlas_wip",
+      "wi_atlas_wip",
       "borealis_wip",
+      "wi_quarry_redacted",
+      "atlas_wip",
       "pr_vertex_401_cycles",
       "dp_pulse_prod",
-      "atlas_completed",
-      "beacon_completions",
-      "borealis_completed",
       "solstice_completions",
-      "lattice_completions",
       "meridian_completions",
+      "borealis_completed",
+      "lattice_completions",
+      "beacon_completions",
+      "atlas_completed",
       "ember_completed",
       "ia_cinder_displaced",
       "rv_vertex_revoked",
       "wi_beacon_demand",
       "sh_solstice_no_allocation",
-      "wi_ember_partial",
       "dp_ledger_prod",
       "sc_ledger_declared_complete",
       "wi_ledger_children",
@@ -2477,8 +2531,8 @@
       "oc_ledger_present",
       "rv_atlas_queue",
       "pulse_deployments",
-      "wi_solstice_demand",
       "doc_injected_runbook",
+      "wi_solstice_demand",
       "atlas_review_wait"
      ],
      "prose_disclosures": [],
@@ -2526,10 +2580,11 @@
        "display_label": "Zenith Payments",
        "mechanism": "embedding_similarity",
        "methods": [
+        "bm25",
         "cosine_similarity"
        ],
        "rank": 0,
-       "rrf_score": 0.5,
+       "rrf_score": 1.25,
        "signal": "fuzzy_label"
       },
       {
@@ -2537,10 +2592,11 @@
        "display_label": "Payments Rewrite",
        "mechanism": "embedding_similarity",
        "methods": [
+        "bm25",
         "cosine_similarity"
        ],
        "rank": 1,
-       "rrf_score": 0.3333333333333333,
+       "rrf_score": 0.6666666666666666,
        "signal": "fuzzy_label"
       },
       {
@@ -2857,8 +2913,8 @@
       "cl_borealis",
       "rv_vertex_revoked",
       "oc_ledger_present",
-      "rv_vertex_cycles",
       "sc_ledger_declared_complete",
+      "rv_vertex_cycles",
       "team_borealis",
       "pr_vertex_401_cycles",
       "sh_tidal_thin",
@@ -2896,8 +2952,8 @@
       "cl_borealis",
       "rv_vertex_revoked",
       "oc_ledger_present",
-      "rv_vertex_cycles",
       "sc_ledger_declared_complete",
+      "rv_vertex_cycles",
       "pr_vertex_401_cycles",
       "sh_tidal_thin",
       "dp_ledger_prod",
@@ -3199,6 +3255,12 @@
    "GraphNode.attributes[*]",
    "EntityNode.summary (always empty by the arm's no-prose rule)"
   ]
+ },
+ "fulltext_readiness": {
+  "attempts_used": 1,
+  "expected_canonical_id": "proj_identity_rewrite",
+  "probe_query": "Identity Platform Rewrite",
+  "ready": true
  },
  "schema_version": "chaos_3647_semantic_leg_results.v1",
  "scope_notes": [

--- a/trials/chaos_3647/runner.py
+++ b/trials/chaos_3647/runner.py
@@ -1,0 +1,437 @@
+"""The measured run: ingest once under a real embedder, then all three legs.
+
+Run it with the live store and a real embedding model::
+
+    CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389 \\
+    CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1 \\
+    CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED=1 \\
+    uv run python -m trials.chaos_3647.runner
+
+**Every precondition raises rather than degrades.** No live store, no API
+key, a non-semantic embedder — each is a hard stop with a message naming
+what is missing. The alternative is a run that completes, writes a full set
+of records under a "semantic" heading, and is wrong in every row with
+nothing in the file to say so.
+
+**Both tenants are written.** The Helio partition is what the legs query;
+the Lumen partition exists so the cross-tenant probe has something real to
+be excluded. A partition assertion made against an empty neighbouring
+keyspace is an assertion that cannot fail, which is worse than not making
+it.
+
+**The Helio partition is purged on both sides.** A partition left behind by
+an interrupted earlier run would otherwise be read as this run's world —
+and, worse here than on the deterministic sweep, would mix hash vectors with
+model vectors inside one keyspace, which the readback's embedder attestation
+exists to refuse.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.api.dev.investigation_corpus.cases import (
+    CorpusFamily,
+    authored_cases,
+)
+from dev_health_ops.api.dev.investigation_corpus.oracles import oracle_for
+from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
+from dev_health_ops.context_fabric.graph_arm.backend import CloudEmbedder
+from dev_health_ops.context_fabric.graph_arm.flags import (
+    graph_projection_enabled,
+    live_store_required,
+    trial_store_config,
+)
+from dev_health_ops.context_fabric.graph_arm.projection import build_projection
+from dev_health_ops.context_fabric.graph_arm.store import GraphArmStore
+from trials.chaos_3619.binding import RunClass, collect_binding
+
+from .legs import (
+    LegId,
+    LegResolution,
+    prose_disclosures_in,
+    resolve_deterministic,
+    resolve_semantic,
+)
+from .probes import PROBES, run_probe
+from .records import (
+    CaseRecord,
+    Delta,
+    DeltaRecord,
+    EmbeddedTextSurface,
+    LegRecord,
+    SemanticTrialRecords,
+    write_records,
+)
+from .scoring import LegScore, score_leg
+
+__all__ = ["RESULTS_PATH", "run", "main"]
+
+RESULTS_PATH = Path(__file__).resolve().parent / "results" / "semantic-leg.records.json"
+
+#: The pinned CHAOS-3619 artifact, read for its dispositions only. Never
+#: written, never scored against — it is quoted into each case record so a
+#: reader can see the baseline this run claims to extend without opening a
+#: second file.
+_PINNED_BASELINE = (
+    Path(__file__).resolve().parents[1]
+    / "chaos_3619"
+    / "results"
+    / "trial-results.records.json"
+)
+
+#: Statements written before the numbers were seen. See ``records.py``.
+SCOPE_NOTES: tuple[str, ...] = (
+    "This measures SUBJECT RESOLUTION only. No packet is assembled, no "
+    "driver is synthesised and no evidence is cited, so nothing here "
+    "supports or refutes a claim about answer quality.",
+    "The CHAOS-3619 deterministic run remains the pinned baseline. This run "
+    "adds a leg; it does not replace, edit or rescore that artifact.",
+    "The semantic leg receives the RAW QUESTION and the deterministic "
+    "baseline receives PRODUCTION-EXTRACTED MENTIONS, because those are the "
+    "inputs each mechanism is built for. The deterministic_question leg "
+    "exists to price that asymmetry: it runs the baseline matcher over the "
+    "raw question, so a reader can see how much of any delta is retrieval "
+    "and how much is the mention extractor returning nothing.",
+    "Node vectors are embeddings of the DISPLAY LABEL. Aliases, acronyms "
+    "and previous names are node attributes and are embedded by nothing, so "
+    "a semantic leg cannot resolve an alias by similarity however good the "
+    "model is. See embedded_text_surface.",
+    "The eight corpus ambiguity questions withhold nothing on any leg, "
+    "because none of them is near the restricted project. The "
+    "authorization_probes section exists because a clean audit obtained "
+    "that way is not evidence the filter works.",
+)
+
+
+class PreconditionError(RuntimeError):
+    """A precondition for a measured semantic run is missing."""
+
+
+def _require_preconditions() -> Any:
+    config = trial_store_config()
+    if config is None:
+        raise PreconditionError(
+            "CONTEXT_FABRIC_GRAPH_STORE_URI is unset. This run must reach a "
+            "live store; there is deliberately no default host and port"
+        )
+    if not live_store_required():
+        raise PreconditionError(
+            "CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE is not 1. A measured run must "
+            "fail on an unreachable store rather than skip past it"
+        )
+    if not graph_projection_enabled():
+        raise PreconditionError(
+            "CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED is not 1, so the store "
+            "would refuse the write this run depends on"
+        )
+    return config
+
+
+def _ambiguity_cases() -> tuple[Any, ...]:
+    return tuple(
+        case
+        for case in authored_cases()
+        if case.corpus_family is CorpusFamily.HUMAN_AMBIGUITY
+    )
+
+
+def _pinned_dispositions() -> dict[str, tuple[str, str]]:
+    """The pinned baseline's graph-arm disposition per case, best leg first.
+
+    "Best" means the interpreter-lifted leg where it ran: the as-deployed leg
+    reports ``not_run_precondition`` for every colloquial case because the
+    production interpreter derived no question family, and quoting that would
+    describe an interpretation ceiling as a retrieval result.
+    """
+
+    import json
+
+    if not _PINNED_BASELINE.exists():  # pragma: no cover - environment
+        return {}
+    payload = json.loads(_PINNED_BASELINE.read_text(encoding="utf-8"))
+    best: dict[str, tuple[str, str]] = {}
+    for case in payload.get("cases", ()):
+        case_id = case.get("case_id", "")
+        for arm in case.get("arms", ()):
+            if arm.get("arm_id") != "graph_assisted_shadow_arm":
+                continue
+            disposition = str(arm.get("disposition", ""))
+            detail = str(arm.get("detail", ""))
+            existing = best.get(case_id)
+            if existing is None or existing[0] == "not_run_precondition":
+                best[case_id] = (disposition, detail)
+    return best
+
+
+def _embedded_text_surface(projection: Any) -> EmbeddedTextSurface:
+    """Measured off the projection and off Graphiti, never asserted."""
+
+    alias_count = sum(len(node.aliases) for node in projection.nodes)
+    return EmbeddedTextSurface(
+        node_embedded_field="EntityNode.name (== GraphNode.display_label)",
+        edge_embedded_field="EntityEdge.fact (== '<source_id> <relationship> <target_id>')",
+        not_embedded=(
+            "GraphNode.canonical_id",
+            "GraphNode.aliases[].value (alias, acronym, previous_name, provider_identifier)",
+            "GraphNode.attributes[*]",
+            "EntityNode.summary (always empty by the arm's no-prose rule)",
+        ),
+        alias_count=alias_count,
+        node_count=len(projection.nodes),
+        edge_count=len(projection.edges),
+        # FalkorDB's Entity full-text index, as Graphiti creates it.
+        fulltext_indexed_fields=("name", "summary", "group_id"),
+    )
+
+
+def _classify(baseline: LegScore, semantic: LegScore, semantic_ranked: int) -> Delta:
+    if baseline.subject_resolution_correct and semantic.subject_resolution_correct:
+        return Delta.BOTH_CORRECT
+    if baseline.subject_resolution_correct:
+        return Delta.DETERMINISTIC_ONLY_CORRECT
+    if semantic.subject_resolution_correct:
+        return Delta.SEMANTIC_ONLY_CORRECT
+    baseline_ranked = baseline.resolved
+    if not semantic_ranked and not baseline_ranked:
+        return Delta.NEITHER_CORRECT_NEITHER_RANKED
+    if semantic_ranked and not baseline_ranked:
+        return Delta.NEITHER_CORRECT_SEMANTIC_RANKED_ANYWAY
+    return Delta.NEITHER_CORRECT_BOTH_RANKED
+
+
+def _leg_record(
+    resolution: LegResolution, score: LegScore, principal_id: str
+) -> LegRecord:
+    return LegRecord(
+        leg=resolution.leg.value,
+        prose_disclosures=prose_disclosures_in(resolution, principal_id),
+        query=resolution.query,
+        mentions=resolution.mentions,
+        subjects=tuple(asdict(subject) for subject in resolution.subjects),
+        authorization_filtered_count=resolution.authorization_filtered_count,
+        withheld_canonical_ids=resolution.withheld_canonical_ids,
+        bm25_order=resolution.bm25_order,
+        cosine_order=resolution.cosine_order,
+        observation_hits=resolution.observation_hits,
+        score=asdict(score),
+    )
+
+
+async def run() -> SemanticTrialRecords:
+    """Ingest under a real embedder, run every leg, judge, and record."""
+
+    config = _require_preconditions()
+    embedder = CloudEmbedder.from_environment()
+    if not embedder.semantic:  # pragma: no cover - from_environment raises first
+        raise PreconditionError(
+            f"embedder {embedder.model_id!r} reports semantic=False; a "
+            "semantic leg run on it would be the deterministic baseline "
+            "wearing a costume"
+        )
+
+    helio = build_projection(adapter.corpus_batch(world.ORG_HELIO))
+    lumen = build_projection(adapter.corpus_batch(world.ORG_LUMEN))
+    # Each case's grant is derived from ITS OWN principal below, never from a
+    # single analyst grant hoisted here. The corpus's ambiguity family happens
+    # to be all-analyst today; a hoisted set would silently answer a
+    # non-analyst case against the wrong grant the day one is added.
+    pinned = _pinned_dispositions()
+
+    helio_store = GraphArmStore.for_org(
+        world.ORG_HELIO, config=config, embedder=embedder
+    )
+    lumen_store = GraphArmStore.for_org(
+        world.ORG_LUMEN, config=config, embedder=embedder
+    )
+
+    cases: list[CaseRecord] = []
+    probe_records: list[dict[str, Any]] = []
+    try:
+        for store, projection in ((helio_store, helio), (lumen_store, lumen)):
+            await store.purge_org()
+            await store.build_indices()
+            await store.write_projection(projection)
+
+        for case in _ambiguity_cases():
+            oracle = oracle_for(case.case_id)
+            case_authorized = adapter.authorized_entity_ids_for(case.principal_id)
+            baseline = resolve_deterministic(
+                question=case.question,
+                projection=helio,
+                authorized_entity_ids=case_authorized,
+                over_mentions=True,
+            )
+            question_leg = resolve_deterministic(
+                question=case.question,
+                projection=helio,
+                authorized_entity_ids=case_authorized,
+                over_mentions=False,
+            )
+            semantic = await resolve_semantic(
+                question=case.question,
+                store=helio_store,
+                authorized_entity_ids=case_authorized,
+            )
+
+            scores = {
+                resolution.leg: score_leg(case.case_id, resolution)
+                for resolution in (baseline, question_leg, semantic)
+            }
+            classification = _classify(
+                scores[LegId.DETERMINISTIC_MENTIONS],
+                scores[LegId.SEMANTIC_HYBRID],
+                len(semantic.subjects),
+            )
+            pinned_disposition, pinned_detail = pinned.get(case.case_id, ("", ""))
+            cases.append(
+                CaseRecord(
+                    case_id=case.case_id,
+                    question=case.question,
+                    question_family=case.question_family.value,
+                    expected_answer=oracle.expected_answer.value,
+                    committed_subject_id=oracle.committed_subject_id,
+                    permitted_candidate_ids=tuple(oracle.permitted_candidate_ids),
+                    forbidden_subject_ids=tuple(oracle.forbidden_subject_ids),
+                    principal_id=case.principal_id,
+                    legs=tuple(
+                        _leg_record(
+                            resolution, scores[resolution.leg], case.principal_id
+                        )
+                        for resolution in (baseline, question_leg, semantic)
+                    ),
+                    delta=DeltaRecord(
+                        classification=classification.value,
+                        baseline_correct=scores[
+                            LegId.DETERMINISTIC_MENTIONS
+                        ].subject_resolution_correct,
+                        semantic_correct=scores[
+                            LegId.SEMANTIC_HYBRID
+                        ].subject_resolution_correct,
+                        baseline_ranked=len(baseline.subjects),
+                        semantic_ranked=len(semantic.subjects),
+                        detail=(
+                            "baseline: "
+                            f"{scores[LegId.DETERMINISTIC_MENTIONS].subject_resolution_detail}"
+                            " | semantic: "
+                            f"{scores[LegId.SEMANTIC_HYBRID].subject_resolution_detail}"
+                        ),
+                    ),
+                    pinned_baseline_disposition=pinned_disposition,
+                    pinned_baseline_detail=pinned_detail,
+                )
+            )
+
+        for probe in PROBES:
+            outcome = await run_probe(
+                probe,
+                store=helio_store,
+                authorized_entity_ids=adapter.authorized_entity_ids_for(
+                    probe.principal_id
+                ),
+                presence_store=lumen_store if probe.presence_partition else None,
+                presence_authorized_entity_ids=(
+                    adapter.authorized_entity_ids_for(probe.presence_principal_id)
+                    if probe.presence_partition
+                    else None
+                ),
+            )
+            probe_records.append(asdict(outcome))
+    finally:
+        for store in (helio_store, lumen_store):
+            try:
+                await store.purge_org()
+            finally:
+                await store.close()
+
+    binding = collect_binding(
+        run_class=RunClass.MEASURED,
+        per_case_timeout_seconds=120.0,
+        trial_store_backend=f"falkordb ({config.host}:{config.port})",
+        graph_embedder_model_id=embedder.model_id,
+        notes=(
+            "CHAOS-3647 semantic/hybrid retrieval leg. Subject resolution "
+            "only; no packet assembly.",
+        ),
+    )
+    return SemanticTrialRecords(
+        binding=asdict(binding),
+        embedded_text_surface=asdict(_embedded_text_surface(helio)),
+        cases=tuple(cases),
+        authorization_probes=tuple(probe_records),
+        summary=_summarise(cases, probe_records),
+        scope_notes=SCOPE_NOTES,
+    )
+
+
+def _summarise(cases: list[CaseRecord], probes: list[dict[str, Any]]) -> dict[str, Any]:
+    """Counts only. Every figure here is recountable from ``cases``."""
+
+    by_class: dict[str, list[str]] = {}
+    for case in cases:
+        by_class.setdefault(case.delta.classification, []).append(case.case_id)
+    leg_correct: dict[str, list[str]] = {}
+    for case in cases:
+        for leg in case.legs:
+            if leg.score["subject_resolution_correct"]:
+                leg_correct.setdefault(leg.leg, []).append(case.case_id)
+    return {
+        "cases_measured": len(cases),
+        "delta_classification_counts": {
+            name: len(ids) for name, ids in sorted(by_class.items())
+        },
+        "delta_classification_case_ids": {
+            name: sorted(ids) for name, ids in sorted(by_class.items())
+        },
+        "subject_resolution_correct_by_leg": {
+            leg.value: sorted(leg_correct.get(leg.value, [])) for leg in LegId
+        },
+        "authorization_probes_run": len(probes),
+        "authorization_probe_verdicts": {
+            probe["probe_id"]: probe["verdict"] for probe in probes
+        },
+        "authorization_probes_ineffective": sorted(
+            probe["probe_id"] for probe in probes if not probe["effective"]
+        ),
+        "any_unauthorized_entity_ranked": any(
+            probe["target_is_restricted"] and probe["target_ranked"] for probe in probes
+        ),
+        # CHAOS-3635 oracle v2, over every leg of every case. A restricted
+        # NAME reaching the consumer surface is a disclosure even when no
+        # restricted id does, and this is the figure that says so.
+        "prose_disclosures_by_leg": {
+            leg.leg: list(leg.prose_disclosures)
+            for case in cases
+            for leg in case.legs
+            if leg.prose_disclosures
+        },
+        "any_prose_disclosure": any(
+            leg.prose_disclosures for case in cases for leg in case.legs
+        ),
+    }
+
+
+def main() -> int:
+    records = asyncio.run(run())
+    write_records(records, RESULTS_PATH)
+    summary = records.summary
+    print(f"wrote {RESULTS_PATH}")
+    print(f"cases measured: {summary['cases_measured']}")
+    for name, count in summary["delta_classification_counts"].items():
+        print(f"  {name}: {count}")
+    print(f"probe verdicts: {summary['authorization_probe_verdicts']}")
+    if summary["authorization_probes_ineffective"]:
+        print(
+            "  INEFFECTIVE PROBES (failed measurement, not a clean result): "
+            f"{summary['authorization_probes_ineffective']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    sys.exit(main())

--- a/trials/chaos_3647/runner.py
+++ b/trials/chaos_3647/runner.py
@@ -48,6 +48,9 @@ from dev_health_ops.context_fabric.graph_arm.flags import (
     trial_store_config,
 )
 from dev_health_ops.context_fabric.graph_arm.projection import build_projection
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    wait_for_fulltext_index,
+)
 from dev_health_ops.context_fabric.graph_arm.store import GraphArmStore
 from trials.chaos_3619.binding import RunClass, collect_binding
 
@@ -258,6 +261,18 @@ async def run() -> SemanticTrialRecords:
             await store.build_indices()
             await store.write_projection(projection)
 
+        # The BM25 half of the hybrid leg must be live before anything is
+        # measured. An earlier recorded run of this trial queried too soon
+        # and produced `bm25_order == []` on all eight cases — a cosine-only
+        # result under a hybrid heading, with nothing in the file to say so.
+        # The probe is a positive control: a label whose correct answer is
+        # known, checked for that answer rather than for a non-empty result.
+        readiness = await wait_for_fulltext_index(
+            helio_store,
+            probe_query=world.ENTITIES_BY_ID[world.PROJ_IDENTITY_REWRITE].display_label,
+            expected_canonical_id=world.PROJ_IDENTITY_REWRITE,
+        )
+
         for case in _ambiguity_cases():
             oracle = oracle_for(case.case_id)
             case_authorized = adapter.authorized_entity_ids_for(case.principal_id)
@@ -361,6 +376,7 @@ async def run() -> SemanticTrialRecords:
     )
     return SemanticTrialRecords(
         binding=asdict(binding),
+        fulltext_readiness=asdict(readiness),
         embedded_text_surface=asdict(_embedded_text_surface(helio)),
         cases=tuple(cases),
         authorization_probes=tuple(probe_records),

--- a/trials/chaos_3647/scoring.py
+++ b/trials/chaos_3647/scoring.py
@@ -1,0 +1,242 @@
+"""Scoring one leg's resolution against the frozen corpus oracle.
+
+Every expectation used here already exists in
+``investigation_corpus.oracles``. Nothing is authored in this module, and
+that is deliberate: a trial that measures a new retrieval path and also
+invents its own notion of "correct" can always be made to look good, and no
+reader can tell the two decisions apart afterwards.
+
+**Precision is reported at two horizons and neither is the headline.**
+``precision_at_3`` asks whether the contract's own top-3 subject horizon is
+free of stray candidates; ``precision_over_all`` asks the same of everything
+the leg returned inside its limit. A retrieval leg will usually pass the
+first and fail the second, because similarity search returns a ranked tail
+where a lookup returns nothing. Reporting only the first would flatter it;
+reporting only the second would condemn it for having a tail at all. Both
+are recorded, and the tail is priced explicitly by ``stray_candidates``.
+
+**A leg that commits where the case demands a clarification fails, and is
+not scored as a partial success.** The corpus says so — H05 and H07 set
+``committed_subject_id=None`` and ``expected_answer=CLARIFIED`` — and the
+distinction is the whole point of those cases: silently choosing between two
+live candidates is the failure they exist to catch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from dev_health_ops.api.dev.investigation_corpus.cases import AnswerDisposition
+from dev_health_ops.api.dev.investigation_corpus.oracles import oracle_for
+
+from .legs import LegResolution
+
+__all__ = [
+    "TOP_N_HORIZON",
+    "LegScore",
+    "Verdict",
+    "score_leg",
+]
+
+#: The frozen contract's own subject horizon. Not a knob: the packet may
+#: commit to at most this many subjects, so precision beyond it is a
+#: different question from precision inside it.
+TOP_N_HORIZON = 3
+
+
+class Verdict(StrEnum):
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True, slots=True)
+class LegScore:
+    """One leg's verdicts on one case, each with the detail behind it."""
+
+    case_id: str
+    leg: str
+    resolved: bool
+    #: Rank-1 is the case's committed subject. NOT_APPLICABLE where the case
+    #: expects a clarification rather than a commitment.
+    subject_top_1: Verdict
+    subject_top_1_detail: str
+    #: The committed subject appears within the contract's top-3 horizon.
+    subject_top_3: Verdict
+    subject_top_3_detail: str
+    #: No stray candidate inside the top-3 horizon.
+    precision_at_3: Verdict
+    precision_at_3_detail: str
+    #: No stray candidate anywhere in what the leg returned.
+    precision_over_all: Verdict
+    precision_over_all_detail: str
+    #: No forbidden subject ranked anywhere. For H08 every real project is
+    #: forbidden, which makes this the no-widening measurement.
+    no_forbidden_subject: Verdict
+    no_forbidden_subject_detail: str
+    #: The leg committed where the case demands a clarification.
+    must_not_commit: Verdict
+    must_not_commit_detail: str
+    stray_candidates: tuple[str, ...]
+    #: The one boolean the delta is computed from. **Subject resolution
+    #: only** — this package builds no packets, so it says nothing about
+    #: drivers, evidence or synthesis, and a reader must not read it as
+    #: "the arm answered the case correctly".
+    subject_resolution_correct: bool
+    subject_resolution_detail: str
+
+
+def score_leg(case_id: str, resolution: LegResolution) -> LegScore:
+    """Score ``resolution`` against ``case_id``'s frozen oracle."""
+
+    oracle = oracle_for(case_id)
+    committed = oracle.committed_subject_id
+    permitted = frozenset(oracle.permitted_candidate_ids)
+    forbidden = frozenset(oracle.forbidden_subject_ids)
+    ranked = tuple(subject.canonical_id for subject in resolution.subjects)
+    top_3 = ranked[:TOP_N_HORIZON]
+
+    if committed is None:
+        top_1 = Verdict.NOT_APPLICABLE
+        top_1_detail = (
+            "the case expects a clarification, so there is no committed "
+            "subject to be rank-1"
+        )
+        top_3_verdict = Verdict.NOT_APPLICABLE
+        top_3_detail = top_1_detail
+        must_not_commit = Verdict.PASS if len(ranked) != 1 else Verdict.FAIL
+        must_not_commit_detail = (
+            f"ranked {len(ranked)} candidates; a single ranked candidate is a "
+            "silent commitment where the case demands a clarification"
+        )
+    else:
+        got = ranked[0] if ranked else ""
+        top_1 = Verdict.PASS if got == committed else Verdict.FAIL
+        top_1_detail = f"rank-1 was {got or '(nothing)'}; expected {committed}"
+        top_3_verdict = Verdict.PASS if committed in top_3 else Verdict.FAIL
+        top_3_detail = f"top-3 {list(top_3)}; expected {committed}"
+        must_not_commit = Verdict.NOT_APPLICABLE
+        must_not_commit_detail = "the case expects a commitment"
+
+    stray_at_3 = tuple(sorted(set(top_3) - permitted))
+    stray_all = tuple(sorted(set(ranked) - permitted))
+    precision_at_3 = Verdict.PASS if not stray_at_3 else Verdict.FAIL
+    precision_all = Verdict.PASS if not stray_all else Verdict.FAIL
+
+    ranked_forbidden = tuple(sorted(set(ranked) & forbidden))
+    if not forbidden:
+        no_forbidden = Verdict.NOT_APPLICABLE
+        no_forbidden_detail = "the case forbids no subject"
+    else:
+        no_forbidden = Verdict.PASS if not ranked_forbidden else Verdict.FAIL
+        no_forbidden_detail = (
+            f"ranked forbidden subjects {list(ranked_forbidden)}"
+            if ranked_forbidden
+            else "no forbidden subject ranked"
+        )
+
+    correct, correct_detail = _subject_resolution_correct(
+        expected_answer=oracle.expected_answer,
+        committed=committed,
+        permitted=permitted,
+        ranked=ranked,
+        top_3=top_3,
+        ranked_forbidden=ranked_forbidden,
+    )
+
+    return LegScore(
+        case_id=case_id,
+        leg=resolution.leg.value,
+        subject_resolution_correct=correct,
+        subject_resolution_detail=correct_detail,
+        resolved=resolution.resolved,
+        subject_top_1=top_1,
+        subject_top_1_detail=top_1_detail,
+        subject_top_3=top_3_verdict,
+        subject_top_3_detail=top_3_detail,
+        precision_at_3=precision_at_3,
+        precision_at_3_detail=(
+            f"stray candidates inside the top-3 horizon {list(stray_at_3)}"
+            if stray_at_3
+            else "no stray candidate inside the top-3 horizon"
+        ),
+        precision_over_all=precision_all,
+        precision_over_all_detail=(
+            f"{len(stray_all)} stray candidates across {len(ranked)} ranked"
+            if stray_all
+            else f"no stray candidate across {len(ranked)} ranked"
+        ),
+        no_forbidden_subject=no_forbidden,
+        no_forbidden_subject_detail=no_forbidden_detail,
+        must_not_commit=must_not_commit,
+        must_not_commit_detail=must_not_commit_detail,
+        stray_candidates=stray_all,
+    )
+
+
+def _subject_resolution_correct(
+    *,
+    expected_answer: AnswerDisposition,
+    committed: str | None,
+    permitted: frozenset[str],
+    ranked: tuple[str, ...],
+    top_3: tuple[str, ...],
+    ranked_forbidden: tuple[str, ...],
+) -> tuple[bool, str]:
+    """Whether a leg resolved this case's subject correctly.
+
+    Branches on the corpus's own ``expected_answer`` rather than on whether a
+    committed subject happens to be set, because the three dispositions want
+    three different things and collapsing them is how a no-match case gets
+    scored as a success for returning a ranked list.
+
+    ``UNAVAILABLE`` is the strict one: H08 names a subject that does not
+    exist, every real project is forbidden, and the only correct resolution
+    is an **empty** one. A leg that returns its nearest neighbours has
+    substituted a guess for an answer, which is the failure the case exists
+    to catch — and it is exactly what a similarity search does by
+    construction, so scoring it any other way would hide the finding.
+    """
+
+    if expected_answer is AnswerDisposition.UNAVAILABLE:
+        if ranked:
+            return False, (
+                f"the case names a subject that does not exist; the leg "
+                f"ranked {len(ranked)} candidates anyway, led by {ranked[0]}"
+            )
+        return True, "nothing was ranked, which is the only correct resolution"
+
+    if expected_answer is AnswerDisposition.CLARIFIED:
+        if len(ranked) == 1:
+            return False, (
+                f"committed silently to {ranked[0]} where the case demands a "
+                "clarification between two live candidates"
+            )
+        if not ranked:
+            return False, "resolved nothing; the case has two real candidates"
+        if ranked_forbidden:
+            return False, f"ranked forbidden subjects {list(ranked_forbidden)}"
+        stray = sorted(set(top_3) - permitted)
+        if stray:
+            return False, (
+                f"the top-3 clarification set contains {stray}, which the "
+                "case does not permit as candidates"
+            )
+        return True, (
+            f"offered {list(top_3)} inside the top-3 horizon, all permitted, "
+            "without committing"
+        )
+
+    if committed is None:  # pragma: no cover - corpus invariant
+        raise ValueError(
+            f"expected_answer {expected_answer!r} implies a committed subject "
+            "but the oracle names none"
+        )
+    if ranked_forbidden:
+        return False, f"ranked forbidden subjects {list(ranked_forbidden)}"
+    if not ranked:
+        return False, f"resolved nothing; expected {committed}"
+    if ranked[0] != committed:
+        return False, f"rank-1 was {ranked[0]}; expected {committed}"
+    return True, f"rank-1 was {committed}, as expected"


### PR DESCRIPTION
## The answer to the question this was opened to ask

Independent review gate 2 was right: the CHAOS-3619 trial ran a
`DeterministicEmbedder` (BLAKE2b) and exact-id subject resolution, so it
proved graph traversal and structured alias association and could support
**no** claim about Graphiti's semantic value. This PR wires Graphiti's real
BM25 + cosine + RRF retrieval over vectors a real OpenAI embedding model
wrote, runs the ambiguity/colloquial family through it live, and measures.

**Measured result: semantic retrieval resolved 0 of 8 subjects the
deterministic leg could not, regressed 2, and manufactured a confident wrong
ranking on 5 where the baseline correctly refused.**

| delta class | n | cases |
|---|---|---|
| `semantic_only_correct` | **0** | — |
| `both_correct` | 1 | H01 (IPR) |
| `deterministic_only_correct` | 2 | H02 (Northstar), H08 (no-match) |
| `neither_correct_semantic_ranked_anyway` | 5 | H03, H04, H05, H06, H07 |

Subject resolution correct, by leg: `deterministic_mentions` = {H01, H02,
H08}; `deterministic_question` = {H08}; `semantic_hybrid` = {H01}.

Artifact: `trials/chaos_3647/results/semantic-leg.records.json`
(`schema_version: chaos_3647_semantic_leg_results.v1`, `run_class: measured`,
`tree_clean: true`, commit `125ba17cd`, feature tip `4b6489f5e`, embedder
`openai_text_embedding_3_small`, graphiti-core 0.29.3, FalkorDB
127.0.0.1:6389).

## What each case actually did

| case | question | semantic rank-1 | verdict |
|---|---|---|---|
| H01 | "status on IPR?" | `proj_identity_rewrite` | both correct |
| H02 | "…we used to call Northstar" | `wu_pulse_runbook` | regression — the previous-name registry is what resolves this, and no vector saw it |
| H03 | "What about the auth work?" | `dep_authcore` | the correct subject is not in the top 5; the **decoy** `proj_auth_gateway_hardening` outranks it — exactly the failure the case was authored to catch |
| H04 | "what's holding it up?" | `team_atlas` | a pronoun with no referent; the leg committed rather than asked |
| H05 | "the other project we discussed?" | `pf_platform` | top-3 contains two impermissible candidates |
| H06 | "the project that kept cycling in review?" | `wu_ledger_cutover` | **see below** |
| H07 | "how's the payments work going" | `proj_zenith`, then `proj_payments_rewrite` | the two right projects at ranks 0–1 — and also both explicitly forbidden decoys (`proj_solstice`, `proj_vertex`) |
| H08 | "How is Halcyon doing?" | `repo_beacon` | no such entity exists; 20 candidates returned |

**H06 is the most useful row in the run.** Both primitives put
`rv_vertex_cycles` — the Vertex review-cycle observation, the exact right
evidence — at rank 1. It is an *observation* node, so the subject path drops
it and the entity candidates are noise. Retrieval found the answer; the leg
has no observation→entity hop. Recorded as `observation_hits` so the
artifact distinguishes "found nothing" from "found it and dropped it".
Ticketed, not fixed (see below).

## Why, measured rather than asserted

The artifact carries `embedded_text_surface`, derived at run time:

* node vectors are embeddings of `EntityNode.name` == **display label**;
* edge vectors are embeddings of the triple-rendered `fact`;
* the FalkorDB `Entity` full-text index covers `name`, `summary`, `group_id`
  — and `summary` is always `""` by CHAOS-3617's no-prose rule;
* **not embedded by anything**: `canonical_id`, and all 8 corpus aliases
  (alias / acronym / previous_name / provider_identifier), which live in node
  attributes.

So a semantic leg over this projection structurally cannot resolve an alias
by similarity, however good the model is. That is a property of the
projection, not of the model, and it is stated in the artifact so nobody has
to infer it from the numbers.

## The three legs, and why three

The deterministic leg failed H03–H07 at **mention extraction**, not at
matching: the production interpreter yields no mention at all for "What about
the auth work?". A two-leg comparison would have attributed an extraction gap
to retrieval and called it semantic value. So `deterministic_question` runs
the baseline matcher over the raw question — it resolves nothing on 7 of 8,
which is the control that makes the semantic leg's input fair rather than
generous.

## Authorization

Holds on the semantic path, and the probes are what make that claim mean
anything. The eight corpus questions withhold **nothing** — none is near the
restricted project — so a verdict drawn from them alone would be a property
of the questions. Four planted probes ask the filter directly:

| probe | result |
|---|---|
| `restricted_exact_label` ("Quarry Compliance") | retrieval surfaced `proj_quarry`; authorization removed it **before ranking**; `authorization_filtered_count = 1` |
| `restricted_topical` ("how is the compliance work going") | same, via a colloquial route |
| `cross_tenant_near_duplicate` ("Agent Context Runtime") | the identical query ranks `lumen_proj_acr` in the Lumen partition and returns it nowhere in Helio — a differential, not an empty result. Both partitions are written for this reason |
| `unrestricted_control` ("Identity Platform Rewrite") | target ranked, 0 withheld — the filter is not simply withholding everything |

A probe that fails to reach the boundary is recorded as `not_measured` with
`effective: false`, and the live test asserts `effective` before it asserts
`pass`. The first version of the cross-tenant probe *was* `not_measured`;
that is why the presence check exists.

Canonical identity holds too: candidates are mapped back through
`cf_canonical_id` (never parsed out of the display label, which is not
unique), every returned node's `group_id` is re-asserted against the queried
partition, and a foreign-partition node raises rather than being ranked.

## CHAOS-3635 oracle v2 — strengthening only

Unfrozen by chris 2026-08-09 for this workstream. Prose and label channels
added to `investigation_corpus/authorization.py`, ported from the CHAOS-3620
suite's disclosure walker (the ticket's named reference implementation),
which keeps its copy so the two can be run differentially.

* **Additive**: every v1 field is computed by unchanged code; `is_clean`
  gains one appended term.
* `is_clean_v1_channels_only` exists so the one-way implication is
  **executable**, not asserted: `is_clean ⟹ is_clean_v1_channels_only` over
  the sweep, and the converse is free to fail.
* **Acceptance set = the 3620 planted counterexamples.** The forged
  `display_label="Quarry Compliance rollout notes"` packet is clean on v1 and
  unclean on v2 — RED-first evidence, executed.
* The residual blind spot is asserted rather than hidden:
  `ambiguous_labels_not_matched == ("Agent Context Runtime", "Core")`, with a
  test that **fails if that ever stops being the residual**.

## Design note: no partition parameter

`retrieve_candidates` originally took `driver` + `partition` and tripped
`test_chaos_3617_no_caller_supplied_partition`. The guard was right. It now
takes a `RetrievalStore` — the read-only `driver`/`partition`/`embedder` view
a `GraphArmStore` satisfies — which keeps the partition server-derived and
closes two further holes the two-argument form opened: a mismatched
driver/partition pair, and a query vector from a model that did not write the
store's vectors.

## A defect in this lane's own instrument, found and closed

Re-measuring on the merged tip surfaced something worth reporting loudly: the
run recorded at `125ba17cd` had **`bm25_order == []` on all eight cases**.
FalkorDB's full-text index had not populated after the bulk write, so a leg
labelled *hybrid* was cosine-only in every row — and nothing failed. The
delta classifications happened to survive; H02's semantic rank-1 did not
(`team_borealis` vs `wu_pulse_runbook`).

`wait_for_fulltext_index` closes it and **raises rather than warning**. The
probe is a positive control — a query whose correct answer is known, checked
for *that answer* rather than for a non-empty result, because "the index
returned something" is satisfied by a stale index a previous run left behind.
The runner and the live fixture both gate on it, the live test asserts
`bm25_order` is non-empty, and the artifact carries `fulltext_readiness` so a
reader can tell a gated run from an ungated one. Four unit tests observe the
guard, including the stale-index case a naive non-empty check would pass.

On the gated run H04, H05 and H08 still return zero BM25 hits. That is a real
property of those queries — "what's holding it up?" has no lexical overlap
with any node name — and the gate is what makes the difference between that
and a dark index legible.

## Defects found en route — ticketed, not fixed

Per standing orders, no en-route fixes. Filing against parent CHAOS-3614:

1. **No observation→entity hop in subject resolution** (H06). Retrieval ranks
   the right observation first and the leg returns unrelated entities.
2. **No refusal threshold on the retrieval leg** (H08, H04). Cosine's default
   `min_score=0.6` maps to raw cosine ≈ 0.2, so a query naming a nonexistent
   entity returns 20 confident candidates. The deterministic leg's silence is
   a feature the semantic leg has no equivalent of.

## Verification

* `tests/context_fabric/test_chaos_3647_semantic_leg.py` — 14 offline guard
  tests, each planting the defect its guard exists to catch (restricted top
  hit must not occupy rank 0; foreign partition raises even when authorized;
  BM25-only is labelled `lexical_fuzzy`, not `embedding_similarity`;
  non-semantic embedder refused **before** any query is issued).
* `tests/context_fabric/test_chaos_3635_oracle_v2.py` — 28 tests: acceptance
  set, strengthening-only implication, differential against the 3620 walker,
  pinned residual.
* `tests/context_fabric/test_chaos_3647_live_semantic.py` — 10 live tests,
  gated on **both** a reachable store and a real model. No fallback to
  `DeterministicEmbedder`: a run on hash vectors would look semantic and
  score like noise. Reproduces the pinned baseline and re-measures that the
  colloquial cases still resolve nothing deterministically, so the delta
  cannot silently drift to a different baseline.
* `tests/context_fabric/` full suite: 1225 passed, 43 skipped. mypy clean
  over `src/` + `trials/` + the new tests. ruff clean.

`LLM_API_KEY` / `OPENAI_API_KEY` become conditional keeps in the env scrub
list with sentinel `CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE` — same shape as the
store URI, and deliberately the same sentinel, because this leg needs a live
store and a live model together or not at all.

## Scope

Adds a leg. Does **not** replace, edit or rescore the pinned CHAOS-3619
deterministic run; does not weaken any oracle; does not touch cohort
discovery or extraction (other lanes); no production wiring.

Rebased onto the feature tip after #1620 and #1623 merged mid-lane, and the
whole measurement was **re-run** against it (including CHAOS-3645's cohort
discovery, which lands in the same arm) rather than re-labelled: an artifact
whose binding names a commit it was not produced on is the drift the binding
exists to make impossible.
