### PR TITLE
CHAOS-3646 follow-up: make the no-residue property mint-then-authorize depends on actually true

### DIFF
--- a/docs/contribute/architecture/graph-evidence-admission.md
+++ b/docs/contribute/architecture/graph-evidence-admission.md
@@ -65,8 +65,8 @@ graph traversal ──emits──▶ EvidenceCandidate      (a POINTER: no handl
                        1. entitlement
                        2. scope resolution, re-resolved PER CANDIDATE
                        3. resolve  → the SOURCE's own record
-                       4. authorize→ the existing _authorize_expansion
-                       5. mint     → the existing _to_ref / signer.issue
+                       4. mint     → the existing _to_ref / signer.issue
+                       5. authorize→ the existing _authorize_expansion
                                   │
                     ┌─────────────┴─────────────┐
                     ▼                           ▼
@@ -141,10 +141,19 @@ Per candidate, in order:
 3. **Resolve** through the resolver for `candidate.source_system`. No
    resolver → refuse. `None` → refuse.
 4. **Mint** the ref with the existing `self._to_ref(...)`, over the **record
-   the source returned**, with `valid_entity_ids` from *this* resolution.
-   Because the mint is over the returned record, a candidate that pointed at
-   one record and got another back still yields a truthful handle: the handle
-   describes what the source actually had.
+   the source returned**. Because the mint is over the returned record, a
+   candidate that pointed at one record and got another back still yields a
+   truthful handle: the handle describes what the source actually had.
+
+   `valid_entity_ids` is minted as **the record's own entity**, and that one
+   choice is what makes the next step real. `search` mints with the whole
+   authorized set, which makes step 5's containment check compare a set to
+   itself — harmless there, because an adapter is handed the scope and returns
+   records within it. On the admission path the same tautology would leave the
+   record's own entity unchecked, and a resolver bug would admit a record about
+   an entity the principal cannot see. Narrowing the minted set turns the
+   existing, unmodified check into the admission path's entity authorization,
+   with no second authorization surface written anywhere.
 5. **Authorize** with the existing `self._authorize_expansion(...)`,
    unmodified and uncopied. It runs the signature check, the
    `valid_entity_ids ⊆ allowed` check, and the separate repository-scope
@@ -153,9 +162,34 @@ Per candidate, in order:
 
 Order matters and is deliberate: **mint then authorize**, so authorization
 runs against the same object the caller would receive, through the same code
-path expansion uses. Authorizing a candidate and then minting would be a
-second, parallel authorization surface — which is exactly the class of defect
-the trial keeps finding.
+path expansion uses. Authorizing a candidate and then minting would authorize
+a *pre-mint representation* and then hope the mint preserved it — a second,
+parallel authorization surface, which is exactly the class of defect the
+trial keeps finding.
+
+### The property mint-then-authorize depends on
+
+**The mint must leave no residue.** A refused candidate is minted and then
+thrown away, so the ordering is only safe if minting creates nothing that
+outlives the call — no registry entry, no store write, no counter, nothing a
+later caller could present. Were that false, a refusal would still have
+*created* something.
+
+The production signer has the property: `EvidenceReferenceSigner.issue` is a
+pure HMAC over `_payload` with no persistence of any kind, and `_to_ref`
+around it only constructs a model. This is asserted on the object's own state
+rather than read off the source
+(`test_the_production_signer_mints_without_persisting_anything`), so a later
+edit that adds a cache fails.
+
+Recorded because the trial's own signer got it wrong first: an earlier
+`CorpusEvidenceSigner` cached every issued payload so `verify` could compare
+against it, which left a verifiable handle behind for every *refused*
+candidate. It is now stateless, verifying as a pure function of the world.
+The planted caching mint is kept as a test, and it immediately earned its
+place — it exposed that the first version of the residue assertion used a
+*shallow* state snapshot, which shares nested containers with the live object
+and therefore could not fail.
 
 ### 4. Refusal uses the vocabulary that already exists
 
@@ -226,9 +260,26 @@ still bites, and a planted single-field mutation is the test that proves it.
   own path rather than through the graph's copy of it. Nothing here is
   evidence about how a `native_evidence` adapter would resolve a locator, and
   the records artifact says so.
-* **The mint substitution the corpus forces.** `world.evidence_handle(slug)`
-  is the corpus's sole mint and the frozen authorization oracle audits against
-  it, so the trial's canonical service signs with the world's mint rather than
-  the platform HMAC — exactly as `world.py:158` already documents for the
-  corpus. That is a property of the corpus, not of the admission path, and it
-  is recorded rather than glossed.
+* **The mint substitution the corpus forces — and its CHAOS-3633 lineage.**
+  `world.evidence_handle(slug)` is the corpus's sole mint and the frozen
+  authorization oracle audits cited handles against it, so the trial's
+  canonical service signs with the world's mint rather than the platform
+  HMAC. `world.py:158` already documents the substitution and why the corpus
+  cannot key the platform HMAC.
+
+  These are **one story, not two**. CHAOS-3633 is the platform-side defect:
+  `EvidenceReferenceSigner._payload` identifies a record by `(org,
+  source_system, source_version, entity_type, entity_id, repositories)`, and
+  `entity_id` on the wire is the entity the evidence is *about* — so two
+  distinct records of one kind about one entity mint the SAME handle. The
+  graph arm already works around it on its own side
+  (`packet_builder._mint_handle` signs over the record's canonical id, and
+  says so), and the corpus works around it on the other side by deriving a
+  handle from the slug. This lane's `EvidenceCandidate.locator` is the third
+  appearance of the same distinction: the source's record identity is not the
+  entity the record is about.
+
+  A future reader should see that the corpus mint stops being a substitution
+  when CHAOS-3633 lands — the ticket carries the removal steps, and this
+  design needs no change when they are taken, because it never depends on
+  *which* mint the service holds, only that the service holds it.

--- a/tests/context_fabric/test_chaos_3646_evidence_admission.py
+++ b/tests/context_fabric/test_chaos_3646_evidence_admission.py
@@ -9,9 +9,11 @@ proving nothing about it.
 from __future__ import annotations
 
 import asyncio
+import copy
 import dataclasses
 import json
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -44,6 +46,7 @@ from trials.chaos_3646.canonical import (
     CorpusCandidateResolver,
     CorpusScopeAuthorizer,
     corpus_evidence_service,
+    record_for,
 )
 
 SECRET = "chaos-3646-test-signing-secret-not-a-real-key-at-all"
@@ -629,3 +632,141 @@ def test_the_rendered_result_agrees_with_the_records() -> None:
                 f"{case_id}/{column}: the table says {cell!r}, the records "
                 f"say {recorded_verdict!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Mint-then-authorize depends on the mint leaving no residue
+# ---------------------------------------------------------------------------
+
+
+def test_the_production_signer_mints_without_persisting_anything() -> None:
+    """``admit`` mints BEFORE it authorizes, so a refused candidate is minted
+    and thrown away. The whole ordering is only safe because the mint creates
+    nothing that outlives the call.
+
+    ``EvidenceReferenceSigner.issue`` is a pure HMAC over ``_payload``: no
+    registry, no store, no counter. Asserted on the object's own state rather
+    than read off the source, so a later edit that adds a cache fails here.
+    """
+
+    from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
+
+    signer = EvidenceReferenceSigner(SECRET)
+    # deepcopy, NOT dict(vars(...)): a shallow snapshot shares every nested
+    # container with the live object, so a mint that appends to a cache
+    # mutates the 'before' picture too and the comparison cannot fail.
+    # The planted caching mint below found exactly that hole in the first
+    # version of this assertion.
+    before = copy.deepcopy(vars(signer))
+    record = EvidenceRecord(
+        source_system="s",
+        source_version="v",
+        entity_type="work_item",
+        entity_id="proj_identity_rewrite",
+        display_label="l",
+        observed_at=datetime(2026, 7, 1, tzinfo=UTC),
+        freshness=FreshnessState.FRESH,
+        provenance="p",
+        confidence=1.0,
+    )
+    first = signer.issue(ORG, record)
+    second = signer.issue(ORG, record)
+    assert first == second, "the mint must be a pure function of its inputs"
+    assert vars(signer) == before, (
+        "issue() mutated the signer. admit() mints before it authorizes, so "
+        "state added here is residue a REFUSED candidate leaves behind"
+    )
+
+
+def test_a_refused_candidate_leaves_no_verifiable_residue() -> None:
+    """The property stated end to end, over a candidate refused AFTER minting.
+
+    The lying resolver returns a record about an entity outside the grant, so
+    admission mints the ref and then refuses it. Nothing about that mint may
+    survive: the handle must not become verifiable, and the service must
+    behave identically afterwards.
+    """
+
+    class Lying:
+        source_system = ARM_SOURCE_SYSTEM
+
+        async def resolve(self, *, org_id, scope, candidate):
+            return EvidenceRecord(
+                source_system=ARM_SOURCE_SYSTEM,
+                source_version="test",
+                entity_type="work_item",
+                entity_id="proj_quarry",
+                display_label="smuggled",
+                observed_at=datetime(2026, 7, 1, tzinfo=UTC),
+                freshness=FreshnessState.FRESH,
+                provenance="test",
+                confidence=1.0,
+                internal_path="wg_identity_rewrite",
+            )
+
+    signer = _signer()
+    # deepcopy, NOT dict(vars(...)): a shallow snapshot shares every nested
+    # container with the live object, so a mint that appends to a cache
+    # mutates the 'before' picture too and the comparison cannot fail.
+    # The planted caching mint below found exactly that hole in the first
+    # version of this assertion.
+    before = copy.deepcopy(vars(signer))
+    service = EvidenceService(
+        entitlement=_AlwaysEntitled(),
+        authorizer=CorpusScopeAuthorizer(principal_id=PRINCIPAL),
+        signer=signer,
+        native_adapters=(),
+        candidate_resolvers=(Lying(),),
+    )
+    (refused,) = _admit(service, _candidate("wg_identity_rewrite")).admissions
+    assert refused.evidence is None
+
+    assert vars(signer) == before, "the refused candidate left state on the signer"
+    # And the handle it would have carried does not verify against the
+    # identity the resolver claimed, because nothing recorded that claim.
+    forged = SimpleNamespace(
+        evidence_ref_id=world.evidence_handle("wg_identity_rewrite"),
+        source_system=ARM_SOURCE_SYSTEM,
+        source_version="test",
+        entity_type="work_item",
+        entity_id="proj_quarry",
+        repository_ids=(),
+    )
+    assert signer.verify(ORG, forged) is False
+
+
+def test_the_residue_check_is_observed_failing_on_a_caching_mint() -> None:
+    """The guard, watched failing on the implementation it replaced.
+
+    ``CorpusEvidenceSigner`` used to cache every issued payload so ``verify``
+    could compare against it. That made a refused candidate leave a verifiable
+    handle behind in the harness -- the exact residue mint-then-authorize
+    forbids. Re-planted here so the two tests above are known to be capable of
+    catching it, rather than merely passing beside it.
+    """
+
+    from trials.chaos_3646.canonical import CorpusEvidenceSigner
+
+    class CachingSigner(CorpusEvidenceSigner):
+        def __init__(self, secret: str) -> None:
+            super().__init__(secret)
+            self._issued: dict[str, bytes] = {}
+
+        def issue(self, org_id: str, record: EvidenceRecord) -> str:
+            handle = super().issue(org_id, record)
+            self._issued[handle] = self._payload(org_id, record)
+            return handle
+
+    signer = CachingSigner(SECRET)
+    # deepcopy, NOT dict(vars(...)): a shallow snapshot shares every nested
+    # container with the live object, so a mint that appends to a cache
+    # mutates the 'before' picture too and the comparison cannot fail.
+    # The planted caching mint below found exactly that hole in the first
+    # version of this assertion.
+    before = copy.deepcopy(vars(signer))
+    record = world.EVIDENCE_BY_SLUG["wg_identity_rewrite"]
+    signer.issue(ORG, record_for(record))
+    assert vars(signer) != before, (
+        "the planted caching mint did NOT leave residue, so the residue "
+        "assertions above cannot be trusted to catch one"
+    )

--- a/trials/chaos_3646/README.md
+++ b/trials/chaos_3646/README.md
@@ -121,18 +121,41 @@ not a graph-versus-native difference: both arms run the same extraction.
 2. **Not evidence about real sources.** The resolver reads the CHAOS-3616
    world. No `native_evidence` ClickHouse adapter is exercised, so nothing
    here says how a real source resolves a locator.
-3. **Not evidence about the platform mint.** `world.evidence_handle(slug)` is
-   the corpus's sole mint and the frozen authorization oracle audits against
-   it, so the trial's service signs with the world's mint rather than the
-   platform HMAC. Property of the corpus (`world.py:158` documents why),
-   not of the admission path.
+3. **Not evidence about the platform mint — and it is the CHAOS-3633 story,
+   not a separate one.** `world.evidence_handle(slug)` is the corpus's sole
+   mint and the frozen authorization oracle audits cited handles against it,
+   so the trial's service signs with the world's mint rather than the platform
+   HMAC. `world.py:158` documents the substitution and why the corpus cannot
+   key the platform HMAC.
+
+   The reason it cannot is CHAOS-3633: `EvidenceReferenceSigner._payload`
+   identifies a record by `(org, source_system, source_version, entity_type,
+   entity_id, repositories)`, and `entity_id` on the wire is the entity the
+   evidence is *about*, so two distinct records of one kind about one entity
+   mint the same handle. Three places in this tree already work around that
+   single defect — the arm signs over the record's canonical id
+   (`packet_builder._mint_handle`), the corpus derives its handle from the
+   slug (`world.py:158`), and this lane's `EvidenceCandidate.locator` keeps
+   the source's record identity separate from the entity. Same story, three
+   costumes. When CHAOS-3633 lands, the corpus mint stops being a
+   substitution; the admission path needs no change, because it never depends
+   on *which* mint the service holds, only that the service holds it.
 4. **Not deployed subject extraction.** Production `extract_mentions` only
    recognises a name adjacent to a kind noun, which reaches zero of these
    cases. The sweep adds an untyped capitalized-span backstop, clearly marked
    in `sweep.py`, which is NOT production code and is not claimed as any
    arm's capability. Every one of the 17 reached cases is a case the deployed
    extraction would not reach.
-5. **Not a rendered-prose measurement.** The frozen
+5. **Not a comparison with the native arm, in any direction.** There is no
+   native column here and there must not be one. The CHAOS-3619 trial's
+   native scored column is produced by `FakePlanExecutorRuntime` — the test
+   double the orchestrator harness supplies — so it describes a canned status
+   result rather than production data, and it covers one case. Every score in
+   this artifact is a **graph final answer measured against the frozen
+   oracles**, never against native. A reader who sets these numbers beside
+   the trial's native column is comparing an oracle verdict with a fake
+   runtime's output.
+6. **Not a rendered-prose measurement.** The frozen
    `answer_usefulness_beyond_dashboard` oracle scores PACKET fields
    (`driver_analysis.candidates[].standing`, `.summary`,
    `evidence_coverage.evidence_index`). What changed is that those packets now

--- a/trials/chaos_3646/README.md
+++ b/trials/chaos_3646/README.md
@@ -141,11 +141,22 @@ not a graph-versus-native difference: both arms run the same extraction.
    substitution; the admission path needs no change, because it never depends
    on *which* mint the service holds, only that the service holds it.
 4. **Not deployed subject extraction.** Production `extract_mentions` only
-   recognises a name adjacent to a kind noun, which reaches zero of these
+   recognises a name adjacent to a kind noun, which reaches **zero** of these
    cases. The sweep adds an untyped capitalized-span backstop, clearly marked
    in `sweep.py`, which is NOT production code and is not claimed as any
    arm's capability. Every one of the 17 reached cases is a case the deployed
    extraction would not reach.
+
+   **Re-verified on the post-CHAOS-3648 base rather than carried forward.**
+   CHAOS-3648 (#1622, unflagged) improved extraction recall on colloquial
+   singular-subject questions, so this claim had to be re-measured rather than
+   repeated; production extraction alone still reaches 0 of 41. The two are
+   disjoint by construction: 3648 recognises lowercase *definite descriptions*
+   ("the payroll migration"), while every case this sweep reaches is unlocked
+   by a capitalized proper name with no kind noun ("do we have enough people
+   on Lattice Search?"). The backstop is therefore still doing distinct work,
+   and the sweep's seeds and scores are byte-identical across that base
+   change.
 5. **Not a comparison with the native arm, in any direction.** There is no
    native column here and there must not be one. The CHAOS-3619 trial's
    native scored column is produced by `FakePlanExecutorRuntime` — the test

--- a/trials/chaos_3646/canonical.py
+++ b/trials/chaos_3646/canonical.py
@@ -62,6 +62,7 @@ __all__ = [
     "CorpusEvidenceSigner",
     "CorpusScopeAuthorizer",
     "corpus_evidence_service",
+    "record_for",
 ]
 
 #: Stamped on every admitted ref. Names the world and its version, so a
@@ -89,22 +90,32 @@ _KIND_BY_WORLD_KIND = {
 class CorpusEvidenceSigner(EvidenceReferenceSigner):
     """The world's mint, wearing the platform signer's interface.
 
-    ``issue`` returns ``world.evidence_handle(slug)`` for a record the corpus
-    resolver produced, and remembers the identity it issued over. ``verify``
-    then answers the question the HMAC answers -- "was this handle issued for
-    exactly this identity, in this org" -- by comparing the remembered
-    payload rather than by recomputing a key it cannot hold.
+    ``issue`` returns ``world.evidence_handle(slug)``: the corpus's sole mint
+    (``world.py:158``, which documents why the corpus cannot key the platform
+    HMAC), and the mint the FROZEN authorization oracle audits cited handles
+    against.
 
-    Not a weakening of verification: the payload compared is
-    ``EvidenceReferenceSigner._payload``'s own bytes, so a ref whose identity
-    fields were altered after minting fails here exactly as it would fail an
-    HMAC check. What is lost is only the ability to verify a handle this
-    process did not issue, which no admission round needs.
+    **Stateless, and that is load-bearing rather than tidy.** The admission
+    path mints BEFORE it authorizes, so a refused candidate is minted and then
+    thrown away. The whole design rests on that mint leaving no residue --
+    otherwise a refusal would still have created something, somewhere, that a
+    later caller could present. The production ``EvidenceReferenceSigner`` has
+    that property for free (``issue`` is a pure HMAC over
+    ``_payload``; no persistence, no registry). An earlier version of THIS
+    class did not: it cached every issued payload in a dict so ``verify``
+    could compare against it, which meant every refused candidate left a
+    verifiable handle behind in the trial harness. That is exactly the residue
+    the property forbids, so the cache is gone.
+
+    ``verify`` is now a pure function of the world instead. The handle names
+    the record (``world.EVIDENCE_BY_HANDLE``), the record determines the
+    identity through the SAME construction the resolver uses
+    (:func:`record_for`), and the comparison is
+    ``EvidenceReferenceSigner._payload``'s own bytes. A ref whose identity
+    fields were altered after minting therefore fails here exactly as it would
+    fail an HMAC check -- and unlike the cached version, it fails whether or
+    not this process happened to mint it.
     """
-
-    def __init__(self, secret: str | bytes) -> None:
-        super().__init__(secret)
-        self._issued: dict[str, bytes] = {}
 
     def issue(self, org_id: str, record: EvidenceRecord) -> str:
         slug = record.internal_path
@@ -114,13 +125,53 @@ class CorpusEvidenceSigner(EvidenceReferenceSigner):
                 "which the resolver must carry on EvidenceRecord.internal_path; "
                 f"got {record!r}"
             )
-        handle = world.evidence_handle(slug)
-        self._issued[handle] = self._payload(org_id, record)
-        return handle
+        return world.evidence_handle(slug)
 
     def verify(self, org_id: str, evidence: SignedIdentity) -> bool:
-        expected = self._issued.get(evidence.evidence_ref_id)
-        return expected is not None and expected == self._payload(org_id, evidence)
+        record = world.EVIDENCE_BY_HANDLE.get(evidence.evidence_ref_id)
+        if record is None or record.tenant_id != org_id:
+            return False
+        return self._payload(org_id, record_for(record)) == self._payload(
+            org_id, evidence
+        )
+
+
+def record_for(
+    evidence: world.WorldEvidence, source_system: str = ARM_SOURCE_SYSTEM
+) -> EvidenceRecord:
+    """The canonical ``EvidenceRecord`` for one world record.
+
+    One construction, called by the resolver when it resolves and by the
+    signer when it verifies. Two copies would be a differential-oracle problem
+    in miniature: verification would be comparing against a second opinion
+    about what the world holds, and the day the two drifted, ``verify`` would
+    start rejecting refs the resolver had just produced.
+    """
+
+    return EvidenceRecord(
+        source_system=source_system,
+        source_version=CORPUS_SOURCE_VERSION,
+        # Every field comes from the WORLD's record, never from the candidate.
+        # That is the whole point of resolution: the arm said where to look,
+        # and the source said what is there.
+        entity_type=evidence.source_class.value,
+        entity_id=evidence.entity_id,
+        display_label=evidence.display_label,
+        observed_at=evidence.observed_at.astimezone(UTC),
+        freshness=FreshnessState.FRESH,
+        provenance=f"canonical record admitted from {evidence.source_class.value}",
+        confidence=1.0,
+        repository_ids=(),
+        raw_excerpt=evidence.citation_text,
+        # The world's own trust level, carried as a flag rather than as a
+        # refusal. ``_to_ref`` already stamps ``untrusted_content`` on every
+        # ref; this says the SOURCE also considers the content unverified,
+        # which is a different claim.
+        uncertain=evidence.trust is not world.TrustLevel.CANONICAL,
+        # Carries the slug to the mint. Not emitted on the ref:
+        # ``_safe_link`` ignores a path that does not start with "/".
+        internal_path=evidence.slug,
+    )
 
 
 @dataclass(frozen=True)
@@ -215,30 +266,7 @@ class CorpusCandidateResolver:
             return None
         if evidence.state is not world.EvidenceState.ACTIVE:
             return None
-        return EvidenceRecord(
-            source_system=self.source_system,
-            source_version=CORPUS_SOURCE_VERSION,
-            # Every field below comes from the WORLD's record, never from the
-            # candidate. That is the whole point of resolution: the arm said
-            # where to look, and the source said what is there.
-            entity_type=evidence.source_class.value,
-            entity_id=evidence.entity_id,
-            display_label=evidence.display_label,
-            observed_at=evidence.observed_at.astimezone(UTC),
-            freshness=FreshnessState.FRESH,
-            provenance=f"canonical record admitted from {evidence.source_class.value}",
-            confidence=1.0,
-            repository_ids=(),
-            raw_excerpt=evidence.citation_text,
-            # The world's own trust level, carried as a flag rather than as a
-            # refusal. ``_to_ref`` already stamps ``untrusted_content`` on
-            # every ref; this says the SOURCE also considers the content
-            # unverified, which is a different claim.
-            uncertain=evidence.trust is not world.TrustLevel.CANONICAL,
-            # Carries the slug to the mint. Not emitted on the ref:
-            # ``_safe_link`` ignores a path that does not start with "/".
-            internal_path=evidence.slug,
-        )
+        return record_for(evidence, self.source_system)
 
 
 class _AlwaysEntitled:

--- a/trials/chaos_3646/results/admission-records.json
+++ b/trials/chaos_3646/results/admission-records.json
@@ -1025,7 +1025,7 @@
   ],
   "provenance": {
     "corpus_version": "ask_dev_investigation_corpus.v1",
-    "lane_commit": "666552db832a1ad43b4d5b32a18899caa8427c9d",
+    "lane_commit": "b2e8e906fd76fcd027fe96bf6a2399367f7b9568",
     "tree_clean": true
   },
   "schema_version": "chaos_3646_admission_records.v1"

--- a/trials/chaos_3646/results/admission-records.json
+++ b/trials/chaos_3646/results/admission-records.json
@@ -1025,7 +1025,7 @@
   ],
   "provenance": {
     "corpus_version": "ask_dev_investigation_corpus.v1",
-    "lane_commit": "6117cdd1c108a915d19c8a2ca31f92f1577364e6",
+    "lane_commit": "666552db832a1ad43b4d5b32a18899caa8427c9d",
     "tree_clean": true
   },
   "schema_version": "chaos_3646_admission_records.v1"

--- a/trials/chaos_3646/results/admission-records.json
+++ b/trials/chaos_3646/results/admission-records.json
@@ -1025,8 +1025,8 @@
   ],
   "provenance": {
     "corpus_version": "ask_dev_investigation_corpus.v1",
-    "lane_commit": "fbd27a1abb6d4a5b9712ee9660785f892f4b15b8",
-    "tree_clean": true
+    "lane_commit": "be04ccefd48b835a40f31ee6ef5ac58eb5eb4e28",
+    "tree_clean": false
   },
   "schema_version": "chaos_3646_admission_records.v1"
 }

--- a/trials/chaos_3646/results/admission-records.json
+++ b/trials/chaos_3646/results/admission-records.json
@@ -1025,8 +1025,8 @@
   ],
   "provenance": {
     "corpus_version": "ask_dev_investigation_corpus.v1",
-    "lane_commit": "be04ccefd48b835a40f31ee6ef5ac58eb5eb4e28",
-    "tree_clean": false
+    "lane_commit": "6117cdd1c108a915d19c8a2ca31f92f1577364e6",
+    "tree_clean": true
   },
   "schema_version": "chaos_3646_admission_records.v1"
 }


### PR DESCRIPTION
# CHAOS-3646 follow-up — the review conditions, and one defect they exposed

Follow-up to #1624 (squash-merged as `74eb8e0bf`). Rebased onto the current
feature tip (`4f5e28c4f`, post-CHAOS-3648), which turned out to matter — see
the last section.

## 1. The condition on mint-then-authorize, confirmed — and found false in my own harness

The order was approved on condition that `_to_ref` be side-effect-free, so a
refused candidate leaves no minted residue anywhere. **Confirmed for
production**: `EvidenceReferenceSigner.issue` is a pure HMAC over `_payload`
with no persistence, and `_to_ref` around it only constructs a model.

**Found FALSE for this trial's own signer.** `CorpusEvidenceSigner` cached
every issued payload in a dict so `verify()` could compare against it. Because
`admit()` mints *before* it authorizes, every **refused** candidate therefore
left a verifiable handle behind in the harness — precisely the residue the
property forbids, in the one place nobody would have looked. The condition was
worth asking for.

Fixed by removing the cache. `verify()` is now a pure function of the world:
`EVIDENCE_BY_HANDLE` → the record → `record_for()`, the **same construction the
resolver uses**, so verification cannot drift into a second opinion about what
the world holds. It is also strictly stronger than the cache it replaces — a
ref with altered identity fields now fails whether or not this process minted
it.

Three assertions, one adversarial:

| test | what it observes |
|---|---|
| `test_the_production_signer_mints_without_persisting_anything` | the signer's own state, unchanged across `issue()` — asserted on the object, not read off the source |
| `test_a_refused_candidate_leaves_no_verifiable_residue` | a candidate refused AFTER minting leaves nothing, and its handle does not verify |
| `test_the_residue_check_is_observed_failing_on_a_caching_mint` | the deleted caching mint, re-planted, **must** trip the check |

**The planted mutation immediately earned its place.** It failed — because the
first version of the residue assertion snapshotted state with
`dict(vars(...))`, a *shallow* copy that shares nested containers with the live
object, so a mint appending to a cache mutated the "before" picture too and the
comparison could not fail. Snapshot is now a `deepcopy`. Without the planted
mutation, two green tests would have been sitting beside a hole.

## 2. CHAOS-3633 lineage, connected

Both the brief and the artifact now say the corpus mint substitution and
CHAOS-3633 are **one story**. `_payload` identifies a record by `entity_id` —
the entity the evidence is *about* — so two records of one kind about one
entity mint the same handle. Three places already work around that single
defect: the arm signs over the record's canonical id, the corpus derives its
handle from the slug (`world.py:158`), and this lane's
`EvidenceCandidate.locator` keeps record identity separate from entity. When
CHAOS-3633 lands the corpus mint stops being a substitution, and the admission
path needs no change — it never depends on *which* mint the service holds.

## 3. No native comparison, stated as a boundary

The artifact now says explicitly that there is no native column and must not
be one: the trial's native scored column comes from `FakePlanExecutorRuntime`
over one case, so every score here is a **graph final answer against the frozen
oracles**, never against native.

Also corrected in the brief: the diagram and step 4 still described the
pre-review *authorize-then-mint* order and the pre-narrowing
`valid_entity_ids`. The `valid_entity_ids` narrowing — the same unmodified
check made load-bearing by what is minted into it — is now written out where
the design explains the order, with the both-sides observation it rests on
(refused-for-analyst / admitted-for-a-granted-principal / lying-resolver-refused).

## 4. A stale claim caught by the rebase

CHAOS-3648 (#1622, **unflagged**) improved mention-extraction recall. My
artifact claimed "production `extract_mentions` reaches zero of these cases" —
a claim about an extractor that had just changed, so it could not be carried
forward.

**Re-measured: still 0 of 41.** The two are disjoint by construction — 3648
recognises lowercase *definite descriptions* ("the payroll migration"), while
every case this sweep reaches is unlocked by a capitalized proper name with no
kind noun ("do we have enough people on Lattice Search?"). The sweep's untyped
backstop is therefore still doing distinct work, and seeds and scores are
byte-identical across the base change.

## The measurement is unchanged

Every score is byte-identical to #1624 across both the stateless-signer change
and the rebase; only the provenance line moves. That the numbers did not move
is the point — the signer fix removed residue without touching what was
measured.

`tree_clean=true`, lane commit recorded in
`trials/chaos_3646/results/admission-records.json`.

## Verification

`tests/context_fabric` + `tests/api/dev` + `tests/test_env_isolation_contract.py`:
**4228 passed, 104 skipped, 4 xfailed**. Whole-tree `mypy` clean, `ruff` clean,
`validate_docs_v2_publication.py` clean.

**NOT run, by standing instruction, and therefore not claimed:** the full local
gate, the guard-injection mutation harness, and any review round.

Per team-lead: the offer to re-run on the now-merged CHAOS-3619 runner was
declined — identical verdicts, different seed provenance. This measurement uses
the CHAOS-3620 spine composition (real projection, reader, grant, emitter); the
provenance difference is recorded here rather than spent on a re-run.
