### PR TITLE
CHAOS-3656: make the refusal-cause decomposition mechanism-aware

### DIFF
--- a/tests/context_fabric/test_chaos_3619_refusal_causes.py
+++ b/tests/context_fabric/test_chaos_3619_refusal_causes.py
@@ -14,7 +14,9 @@ import pytest
 
 from trials.chaos_3619.refusal_causes import (
     AUTHORIZATION,
+    COHORT_RESOLVED_POST_3645,
     DIVERGENCE_LEDGER,
+    NO_COHORT_FAMILY_SUPPORT,
     NO_MATCH,
     NO_MENTION,
     PHRASE_EXTRACTED_POST_3648,
@@ -22,10 +24,12 @@ from trials.chaos_3619.refusal_causes import (
     decompose,
 )
 
-#: The CHAOS-3648 entry, read from the ledger rather than restated here: a
-#: test that hardcodes the four case ids would keep passing after someone
-#: edited the ledger, which is the one thing the ledger exists to prevent.
+#: The CHAOS-3648 and CHAOS-3645 entries, read from the ledger rather than
+#: restated here: a test that hardcodes case ids would keep passing after
+#: someone edited the ledger, which is the one thing the ledger exists to
+#: prevent.
 _POST_3648 = next(entry for entry in DIVERGENCE_LEDGER if entry.ticket == "CHAOS-3648")
+_POST_3645 = next(entry for entry in DIVERGENCE_LEDGER if entry.ticket == "CHAOS-3645")
 
 _RECORDS = (
     Path(__file__).resolve().parents[2]
@@ -34,7 +38,15 @@ _RECORDS = (
     / "results"
     / "trial-results.records.json"
 )
+_CONSOLIDATED = (
+    Path(__file__).resolve().parents[2]
+    / "trials"
+    / "chaos_3619"
+    / "results"
+    / "consolidated-post-wave.records.json"
+)
 _LEG_B = "leg_b_job_held_constant"
+_GRAPH_ARM = "graph_assisted_shadow_arm"
 
 
 @pytest.fixture(scope="module")
@@ -56,28 +68,35 @@ class TestTheRefusalsDecomposeByRecordedCause:
             "describing a different run"
         )
 
-    def test_the_dominant_cause_is_absent_subject_extraction(self, causes) -> None:
-        """21 of 26 as recorded -- 17 still absent, 4 ledgered to CHAOS-3648.
+    def test_the_seeded_modes_absent_extraction_cases_still_add_up(
+        self, causes
+    ) -> None:
+        """7 of 26 as recorded through the SEEDED mode -- 3 still absent, 4
+        ledgered to CHAOS-3648.
+
+        Before CHAOS-3656 this category also swallowed 14 ``discovered_cohort``
+        refusals that were never an extraction story at all -- a cohort
+        question carries no subject phrase by design, so counting them here
+        conflated "the seeded path found no phrase" with "no mechanism was
+        even tried yet". Mechanism-aware recomputation moves every one of
+        those 14 into cohort-mode categories (see
+        ``TestTheCohortModeIsDecomposedSeparately``), and what remains here is
+        exactly the non-cohort seeded-mode story: 3 still absent, 4 ledgered.
 
         `mention_texts` runs production `extract_mentions` plus the untyped
         backstop -- the SAME extraction the native interpreter runs. So this
         category is a common-mode limit both arms sit behind, not a graph-arm
         capability gap, and reading it as the latter would attribute a shared
         upstream ceiling to the arm under test.
-
-        Both facts are asserted, with the citation between them, because both
-        are true and each alone misleads. "21" alone describes a ceiling the
-        current code no longer has; "17" alone silently restates the pinned
-        sweep's headline as if it had always been 17.
         """
 
         by_cause = counts(causes)
-        assert by_cause[NO_MENTION] == 17
+        assert by_cause[NO_MENTION] == 3
         assert by_cause[PHRASE_EXTRACTED_POST_3648] == 4
-        assert by_cause[NO_MENTION] + by_cause[PHRASE_EXTRACTED_POST_3648] == 21, (
-            "the recorded sweep's 21 absent-extraction refusals must still "
-            "add up; if they do not, either the ledger or the recomputation "
-            "has stopped describing the pinned run"
+        assert by_cause[NO_MENTION] + by_cause[PHRASE_EXTRACTED_POST_3648] == 7, (
+            "the seeded mode's 7 absent-extraction refusals must still add "
+            "up; if they do not, either the ledger or the recomputation has "
+            "stopped describing the pinned run"
         )
 
     def test_the_ledgered_four_are_exactly_the_cases_chaos_3648_moved(
@@ -123,28 +142,85 @@ class TestTheRefusalsDecomposeByRecordedCause:
         assert counts(causes)[NO_MATCH] == 4
         assert all(c.mentions_extracted > 0 for c in causes if c.category == NO_MATCH)
 
-    def test_no_refusal_is_attributed_to_an_unsupported_shape(self, causes) -> None:
-        """The claim the decomposition must NOT support.
+    def test_no_seeded_mode_refusal_is_cohort_shaped(self, causes) -> None:
+        """The claim the decomposition must NOT support, restated for CHAOS-3656.
 
-        Every `discovered_cohort` case refused, which invites the reading
-        that the arm has no cohort handling. The records do not say that:
-        all 14 refused with no subject phrase extracted, so the arm never
-        reached shape handling at all. Asserted so the convenient story
-        cannot be told from these numbers.
+        A `no_mention_extracted` / `no_authorized_match` category describes a
+        check the SEEDED mode ran. Cohort discovery never runs it -- it reads
+        no question text at all -- so no cohort-shaped refusal may carry
+        either category, or the decomposition would be crediting the seeded
+        mode with having looked at a question it never saw.
         """
 
+        seeded_categories = {NO_MENTION, NO_MATCH}
+        offenders = [
+            c
+            for c in causes
+            if c.comparison_shape == "discovered_cohort"
+            and c.category in seeded_categories
+        ]
+        assert offenders == []
+
+
+class TestTheCohortModeIsDecomposedSeparately:
+    """CHAOS-3656: the arm's second entry mode gets its own recomputation.
+
+    Every `discovered_cohort` case in the CHAOS-3619 frozen pin refused,
+    because the pin predates CHAOS-3645 -- the seeded path is the only one
+    that existed, and a cohort question carries no subject phrase for it to
+    find. Reading that as "the arm cannot do cohorts" was already wrong (the
+    original CHAOS-3619 report says so), and now the decomposition can prove
+    it rather than assert it: recomputing through
+    `discover_cohort_for` -- the SAME mechanism `trials.chaos_3619.sweep`
+    selects for this shape -- shows 13 of the 14 resolving, and the frozen
+    pin's continued refusal for those 13 is exactly what
+    `DIVERGENCE_LEDGER`'s CHAOS-3645 entry now cites.
+    """
+
+    def test_thirteen_of_fourteen_cohort_refusals_are_the_chaos_3645_divergence(
+        self, causes
+    ) -> None:
+        ledgered = {
+            c.case_id for c in causes if c.category == COHORT_RESOLVED_POST_3645
+        }
+        assert ledgered == set(_POST_3645.case_ids)
+        assert len(ledgered) == 13
+        assert _POST_3645.pull_request and _POST_3645.landed_on
+        # The entry's stated cause, checked rather than trusted: the ledger
+        # licenses this category only for cases the live cohort mechanism
+        # actually resolves, so every carrier must be a real cohort case.
+        assert all(
+            c.comparison_shape == "discovered_cohort"
+            for c in causes
+            if c.category == COHORT_RESOLVED_POST_3645
+        )
+
+    def test_the_fourteenth_cohort_case_is_a_named_boundary_not_a_mention_gap(
+        self, causes
+    ) -> None:
+        """T07's family has no subjectless entry -- a decision, not a gap.
+
+        Distinct from the other 13 for a reason that survives CHAOS-3645: its
+        family (`clarification_and_no_match`) is deliberately absent from
+        `FAMILY_CANDIDATE_KINDS`, so it refuses under BOTH mechanisms and is
+        never ledgered -- there is no divergence to admit, because nothing
+        about this case's outcome ever changed.
+        """
+
+        boundary = [c for c in causes if c.category == NO_COHORT_FAMILY_SUPPORT]
+        assert [c.case_id for c in boundary] == ["T07_going_sideways_open_question"]
+        assert boundary[0].comparison_shape == "discovered_cohort"
+        assert boundary[0].mentions_extracted == 0
+
+    def test_the_fourteen_cohort_cases_partition_into_exactly_these_two_categories(
+        self, causes
+    ) -> None:
         cohort = [c for c in causes if c.comparison_shape == "discovered_cohort"]
         assert len(cohort) == 14
-        assert {c.category for c in cohort} == {NO_MENTION}, (
-            "a cohort refusal was attributed to something other than absent "
-            "mention extraction; if that is real the 'no cohort support' "
-            "reading becomes available and must be argued, not assumed"
-        )
-        # CHAOS-3648 moved four singular-subject cases and no cohort case, so
-        # the claim above is unchanged by the ledger rather than merely
-        # surviving it. Stated here because "the shape argument still holds"
-        # is exactly the kind of thing a reader would otherwise assume.
-        assert not (set(_POST_3648.case_ids) & {c.case_id for c in cohort})
+        assert {c.category for c in cohort} == {
+            COHORT_RESOLVED_POST_3645,
+            NO_COHORT_FAMILY_SUPPORT,
+        }
 
 
 class TestTheDecompositionRefusesToDescribeADifferentRun:
@@ -213,6 +289,114 @@ class TestTheDecompositionRefusesToDescribeADifferentRun:
             "reader cannot tell a ledgered case from an unledgered one"
         )
 
+    def test_a_cohort_ledgered_case_diverging_the_other_way_still_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CHAOS-3656's own version of the CHAOS-3648 mirror-image test.
+
+        CHAOS-3645 ledgers "the pin refused it, live cohort discovery now
+        resolves it". The mirror image -- the pin scored it, live cohort
+        discovery now refuses it -- is a recall regression in the very case
+        the ledger names, and must stop the run even though the case id is
+        ledgered, because the ledger licenses a DIRECTION, not a case id.
+
+        The victim, `S06_declared_complete_without_delivery_evidence`, is the
+        one CHAOS-3645 case whose question family
+        (`declared_versus_actual`) no sibling case shares, so patching
+        `discover_cohort_for` for that family alone cannot also mutate a
+        different case's outcome and mask what this test is checking.
+        """
+
+        import json
+
+        from dev_health_ops.api.dev.investigation_contract import QuestionFamilyID
+        from dev_health_ops.context_fabric.graph_arm.cohort_discovery import (
+            UnsupportedCohortFamilyError,
+        )
+        from trials.chaos_3619 import graph_leg
+
+        victim = "S06_declared_complete_without_delivery_evidence"
+        assert victim in _POST_3645.case_ids
+
+        payload = json.loads(_RECORDS.read_text())
+        found = False
+        for case in payload["cases"]:
+            if case["leg"] != _LEG_B or case["case_id"] != victim:
+                continue
+            for arm in case["arms"]:
+                if arm["arm_id"] == _GRAPH_ARM:
+                    arm["disposition"] = "scored"
+                    arm["dimension_outcomes"] = []
+                    found = True
+        assert found, "the ledgered cohort case is absent from the pin"
+        target = tmp_path / "reversed_cohort.records.json"
+        target.write_text(json.dumps(payload))
+
+        real_discover_cohort_for = graph_leg.discover_cohort_for
+
+        def refuse_only_the_victims_family(*, question_family, **kwargs):
+            if question_family is QuestionFamilyID.DECLARED_VERSUS_ACTUAL:
+                raise UnsupportedCohortFamilyError("forced for the regression test")
+            return real_discover_cohort_for(question_family=question_family, **kwargs)
+
+        monkeypatch.setattr(
+            graph_leg, "discover_cohort_for", refuse_only_the_victims_family
+        )
+
+        with pytest.raises(RuntimeError, match="no longer reproduces") as raised:
+            decompose(target, _LEG_B)
+        assert victim in str(raised.value)
+        assert _POST_3645.ticket in str(raised.value), (
+            "the drift message must name the entry it declined to apply, or a "
+            "reader cannot tell a ledgered cohort case from an unledgered one"
+        )
+
+    def test_a_current_cohort_case_regressing_to_refusal_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scenario CHAOS-3656 exists to keep catching, not just admit.
+
+        Making the decomposition mechanism-aware must not turn into "cohort
+        cases never raise": a case the CURRENT tip actually scores (no
+        ledger involved -- `consolidated-post-wave.records.json` already
+        records it as `scored`) whose live cohort recomputation regresses to
+        empty must still be reported as drift.
+        """
+
+        from dev_health_ops.api.dev.investigation_contract import QuestionFamilyID
+        from dev_health_ops.context_fabric.graph_arm.cohort_discovery import (
+            UnsupportedCohortFamilyError,
+        )
+        from trials.chaos_3619 import graph_leg
+
+        victim = "S06_declared_complete_without_delivery_evidence"
+
+        real_discover_cohort_for = graph_leg.discover_cohort_for
+
+        def refuse_only_the_victims_family(*, question_family, **kwargs):
+            if question_family is QuestionFamilyID.DECLARED_VERSUS_ACTUAL:
+                raise UnsupportedCohortFamilyError("forced for the regression test")
+            return real_discover_cohort_for(question_family=question_family, **kwargs)
+
+        monkeypatch.setattr(
+            graph_leg, "discover_cohort_for", refuse_only_the_victims_family
+        )
+
+        with pytest.raises(RuntimeError, match="no longer reproduces") as raised:
+            decompose(_CONSOLIDATED, _LEG_B)
+        assert victim in str(raised.value)
+
+
+#: Every case id any ledger entry names, regardless of mechanism. Used so
+#: "pick an UNLEDGERED refused row" stays true as the ledger grows -- picking
+#: from `_POST_3648.case_ids` alone would, after CHAOS-3656, sometimes land on
+#: a CHAOS-3645 cohort case whose live recomputation already resolves it,
+#: which would make the flip a no-op match instead of the drift this fixture
+#: exists to manufacture.
+_ALL_LEDGERED_IDS = frozenset(
+    case_id for entry in DIVERGENCE_LEDGER for case_id in entry.case_ids
+)
+
 
 def _records_with_disposition_flipped(
     tmp_path: Path, name: str, *, ledgered: bool
@@ -226,7 +410,7 @@ def _records_with_disposition_flipped(
     for case in payload["cases"]:
         if case["leg"] != _LEG_B:
             continue
-        if (case["case_id"] in _POST_3648.case_ids) is not ledgered:
+        if (case["case_id"] in _ALL_LEDGERED_IDS) is not ledgered:
             continue
         for arm in case["arms"]:
             if arm["arm_id"] == "graph_assisted_shadow_arm" and (

--- a/tests/context_fabric/test_chaos_3655_consolidated_artifact.py
+++ b/tests/context_fabric/test_chaos_3655_consolidated_artifact.py
@@ -604,24 +604,40 @@ class TestTheMustBeZeroColumn:
 
 
 class TestTheRecordedFindingStaysTrueOrTheNoteGetsUpdated:
-    def test_the_refusal_decomposition_cannot_describe_this_tip(self) -> None:
-        """CHAOS-3655's finding, held as an executable statement.
+    def test_the_refusal_decomposition_now_describes_this_tip(self) -> None:
+        """CHAOS-3655's finding, repaired by CHAOS-3656 -- held as an
+        executable statement in the other direction.
 
-        `decompose` reconciles recorded dispositions against a live recomputation
-        of subject discovery. The 13 CHAOS-3645 cases score through SUBJECTLESS
-        cohort discovery, so the recomputation still finds no seeds while the
-        records say `scored`, and no ledger entry covers that mechanism.
+        `decompose` used to reconcile every recorded disposition against a
+        recomputation that only knew the SEEDED discovery mechanism. The 13
+        CHAOS-3645 cases score through SUBJECTLESS cohort discovery instead,
+        so that recomputation always found empty seeds while the records said
+        `scored`, and no ledger entry covered the mechanism gap -- CHAOS-3655
+        found the tool blind to the tip it was supposed to describe.
 
-        If this test starts failing, the tool was repaired -- good news that must
-        be reflected in `consolidated-post-wave-note.md` rather than left to make
-        the note quietly wrong.
+        CHAOS-3656 makes the recomputation mechanism-aware: it now follows
+        the SAME shape-based fork `trials.chaos_3619.sweep` does, and
+        `DIVERGENCE_LEDGER` carries a CHAOS-3645 entry for the historical
+        pins that predate the mechanism. This tip decomposes cleanly, and the
+        13 cohort cases contribute no `RefusalCause` at all -- they are
+        scored, not refused. `consolidated-post-wave-note.md` is updated
+        alongside this test rather than left to read as a still-open gap.
         """
 
-        from trials.chaos_3619.refusal_causes import decompose
+        from trials.chaos_3619.refusal_causes import counts, decompose
 
-        with pytest.raises(RuntimeError) as raised:
-            decompose(_CONSOLIDATED, _LEG_B)
-        assert "no longer reproduces the recorded sweep" in str(raised.value)
+        causes = decompose(_CONSOLIDATED, _LEG_B)
+        by_cause = counts(causes)
+        assert "cohort_resolved_post_3645" not in by_cause, (
+            "a scored consolidated-tip cohort case must not need the "
+            "historical-pin ledger entry to decompose; that entry exists for "
+            "records frozen before CHAOS-3645, not for this tip"
+        )
+        cohort_shaped = [c for c in causes if c.comparison_shape == "discovered_cohort"]
+        assert len(cohort_shaped) == 1, (
+            "only T07 (no subjectless entry for its family) should still "
+            "refuse on this tip; the other 13 CHAOS-3645 cases score"
+        )
 
     def test_it_still_describes_the_frozen_run(self) -> None:
         """The other half of the finding: the tool is not simply broken.

--- a/trials/chaos_3619/refusal_causes.py
+++ b/trials/chaos_3619/refusal_causes.py
@@ -9,31 +9,63 @@ facts about the same count. A reader deciding whether refusals are a
 capability gap needs them separated.
 
 **This module does not re-interpret the records; it re-derives the cause from
-the same pure function the sweep called, and then checks itself against the
-records.** ``discover_subjects`` is pure over (question, projection, grant),
-all three of which are frozen, so recomputing it reproduces exactly what the
-sweep saw. :func:`decompose` asserts that: every case whose recomputed seed
-set is empty must be a case the records show as refused, and vice versa. A
-mismatch means the recomputation has drifted from the run and the numbers
-must not be published -- so it raises rather than reporting.
+the same pure functions the sweep called, and then checks itself against the
+records.** The arm has two entry modes, and each case's recorded
+``comparison_shape`` says which one the sweep took -- this is the SAME
+signal ``trials.chaos_3619.sweep`` branches on (see ``_run_graph``), so
+recomputation follows the identical fork rather than guessing from a
+disposition:
+
+* the SEEDED mode (:func:`~.graph_leg.discover_subjects`) for every shape
+  except ``discovered_cohort``: pure over (question, projection, grant), all
+  three of which are frozen, so recomputing it reproduces exactly what the
+  sweep saw.
+* the SUBJECTLESS COHORT mode (:func:`~.graph_leg.discover_cohort_for`,
+  CHAOS-3645) for ``discovered_cohort``: pure over (question family,
+  projection, grant), and deliberately blind to the question text -- a
+  cohort question never carries a subject phrase to extract by design, so
+  recomputing THIS shape through the seeded path would always find empty
+  seeds regardless of what the live mechanism does. That mismatch, unledgered,
+  is exactly the CHAOS-3656 defect: 13 current-tip cohort cases score without
+  a single extracted mention, and a decomposition that only knows the seeded
+  mode reads that as drift.
+
+Both modes feed the same self-check. :func:`decompose` asserts that: every
+case whose recomputed seed set is empty must be a case the records show as
+refused, and vice versa. A mismatch means the recomputation has drifted from
+the run and the numbers must not be published -- so it raises rather than
+reporting. New mechanisms extend the fork above and the mechanism-specific
+claim check in the ledger-admission branch below; they never make the
+seeded path recompute for a shape it no longer owns.
 
 The categories are the ones a reader has to tell apart:
 
 ``authorization`` -- the arm matched entities and the grant withheld them.
     This is the arm's authorization working, and on this corpus it is a
     planted case. It is CORRECT BEHAVIOUR, not a gap, and counting it with
-    the misses would understate the arm.
+    the misses would understate the arm. Shared by both entry modes.
 ``no_mention_extracted`` -- production ``extract_mentions`` (plus the untyped
     backstop) returned no subject phrase at all, so discovery had nothing to
     search for. The graph arm shares this extractor with the native
     interpreter, which is what makes this category a COMMON-MODE limit rather
-    than an arm difference.
+    than an arm difference. SEEDED mode only: a cohort question extracts no
+    mention by design, so this category would misdescribe why it refused.
 ``no_authorized_match`` -- phrases were extracted and none matched an entity
-    the principal may see.
+    the principal may see. SEEDED mode only, for the same reason.
+``no_cohort_family_support`` -- the question family has no subjectless entry
+    at all (:data:`~dev_health_ops.context_fabric.graph_arm.cohort_discovery.FAMILY_CANDIDATE_KINDS`
+    does not name it), so ``discover_cohort_for`` raised
+    ``UnsupportedCohortFamilyError`` before any traversal was attempted. A
+    named capability boundary, not an extraction gap.
+``no_cohort_members_enumerated`` -- the family IS supported, the universe was
+    read, and nothing survived authorization and the shared-basis rule. The
+    cohort mode's analogue of ``no_authorized_match``.
 
-Deliberately NOT a category: "shape unsupported". No refusal records one, and
-inventing it would attribute to the arm's coverage something the records
-attribute to subject resolution.
+Deliberately NOT a category: "shape unsupported" as a synonym for
+``no_mention_extracted``. Every ``discovered_cohort`` refusal used to read
+that way before CHAOS-3645 existed, because the only mode available was the
+seeded one; the four categories above are what replaced that conflation once
+the arm had a second entry mode to actually be unsupported *in*.
 
 The divergence ledger
 ---------------------
@@ -65,7 +97,10 @@ Three properties are load-bearing, and each has a test:
   raise, so acceptance checks the direction rather than the case id alone.
 * **Claim-checked, not asserted.** An entry claiming the extractor now finds a
   phrase is honoured only if the live recomputation actually produces one. An
-  entry whose stated cause stopped being true is drift like any other.
+  entry whose stated cause stopped being true is drift like any other. A
+  cohort-mode entry's claim -- that ``discover_cohort_for`` now resolves a
+  non-empty cohort -- is checked the same way, against that mechanism's own
+  recomputation, never against the seeded path's.
 """
 
 from __future__ import annotations
@@ -74,11 +109,24 @@ import json
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from dev_health_ops.api.dev.investigation_corpus.cases import CorpusCase
+    from dev_health_ops.context_fabric.graph_arm.projection import GraphProjection
 
 __all__ = [
+    "AUTHORIZATION",
+    "COHORT_RESOLVED_POST_3645",
     "DIVERGENCE_LEDGER",
+    "NO_COHORT_FAMILY_SUPPORT",
+    "NO_COHORT_MEMBERS",
+    "NO_MATCH",
+    "NO_MENTION",
+    "PHRASE_EXTRACTED_POST_3648",
     "LedgeredDivergence",
     "RefusalCause",
+    "counts",
     "decompose",
 ]
 
@@ -86,12 +134,40 @@ AUTHORIZATION = "authorization"
 NO_MENTION = "no_mention_extracted"
 NO_MATCH = "no_authorized_match"
 
+#: SEEDED-mode categories above; SUBJECTLESS-COHORT-mode categories below.
+#: ``authorization`` is shared by both modes -- see :func:`decompose`.
+
+#: The family has no subjectless entry at all
+#: (:data:`~dev_health_ops.context_fabric.graph_arm.cohort_discovery.FAMILY_CANDIDATE_KINDS`
+#: does not name it), so ``discover_cohort_for`` raised
+#: ``UnsupportedCohortFamilyError`` before any traversal was attempted. A
+#: named capability boundary the arm decided, not an extraction gap -- the
+#: cohort mode's analogue of a refusal the arm KNOWS it has.
+NO_COHORT_FAMILY_SUPPORT = "no_cohort_family_support"
+
+#: The family IS supported, the universe was read, and nothing survived
+#: authorization and the shared-basis rule. The cohort mode's analogue of
+#: ``no_authorized_match``.
+NO_COHORT_MEMBERS = "no_cohort_members_enumerated"
+
 #: The cause a CHAOS-3648 case carries *now*: the pinned sweep recorded it as
 #: an absent-extraction refusal, and the current extractor resolves a subject
 #: for it. Held as its own category rather than folded into a recomputed
 #: ``no_authorized_match`` so a reader can never mistake the ledgered rows for
 #: rows the pinned sweep measured that way.
 PHRASE_EXTRACTED_POST_3648 = "phrase_extracted_post_3648"
+
+#: The cause a CHAOS-3645 cohort case carries *now*, in a records file frozen
+#: before the subjectless cohort mode existed: the pinned sweep could only
+#: take the seeded path, extracted no mention (cohort questions never carry
+#: one, by design) and refused; the current sweep takes the cohort path and
+#: resolves a non-empty cohort for the same question. Held as its own
+#: category, never folded into ``no_mention_extracted``, for the same reason
+#: :data:`PHRASE_EXTRACTED_POST_3648` is not folded into it either: a reader
+#: comparing categories across records files must be able to tell "the pin
+#: measured this as an extraction gap" apart from "this decomposition is
+#: crediting a mechanism the pin never ran."
+COHORT_RESOLVED_POST_3645 = "cohort_resolved_post_3645"
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,7 +186,56 @@ class LedgeredDivergence:
 
 
 #: APPEND ONLY. Never edit or delete a landed entry -- see the module docstring.
+#: Ordered by landing time: CHAOS-3645 (13:16:52) merged before CHAOS-3648
+#: (13:33:32) on the same date.
 DIVERGENCE_LEDGER: tuple[LedgeredDivergence, ...] = (
+    LedgeredDivergence(
+        ticket="CHAOS-3645",
+        pull_request="#1623",
+        landed_on="2026-08-09",
+        from_category=NO_MENTION,
+        to_category=COHORT_RESOLVED_POST_3645,
+        case_ids=frozenset(
+            {
+                "T01_clearly_struggling_team",
+                "T02_high_wip_without_struggle",
+                "T03_operational_displaces_feature",
+                "T04_review_pressure_across_projects",
+                "T05_stale_source_data",
+                "T06_healthy_despite_noisy_metric",
+                "P01_demand_exceeds_capacity",
+                "P02_critical_path_few_contributors",
+                "P03_lightly_loaded_project",
+                "S03_shared_dependency_portfolio_risk",
+                "S06_declared_complete_without_delivery_evidence",
+                "A03_false_relationship_on_real_entity",
+                "A08_stale_and_truncated_state",
+            }
+        ),
+        rationale=(
+            "CHAOS-3645 (#1623) gave the graph arm a second entry mode --"
+            "subjectless cohort discovery, driven by the analytical job's "
+            "question family and the grant alone, with no question text "
+            "read at all. Before it landed, every discovered_cohort case "
+            "could only take the seeded path, which extracts no mention from "
+            "a cohort question by design (there is no subject phrase in "
+            "'which teams are struggling') and therefore always refused. "
+            "trial-results.records.json (the CHAOS-3619 frozen pin) and "
+            "post-3648-remeasure.records.json were both measured before "
+            "CHAOS-3645 landed and record these 13 cases as arm_refused; "
+            "cohort-families-trial-results.records.json and every "
+            "consolidated-post-wave* artifact were measured after, and "
+            "record them as scored. Neither number is wrong -- each is what "
+            "its tree could do -- and this entry is the citation that keeps "
+            "the pinned records decomposable without crediting them with a "
+            "mechanism they never ran. T07_going_sideways_open_question is "
+            "the corpus's 14th discovered_cohort case and is NOT ledgered "
+            "here: its family (clarification_and_no_match) has no "
+            "subjectless entry in FAMILY_CANDIDATE_KINDS by design, so it "
+            "refuses under both mechanisms and carries "
+            "no_cohort_family_support rather than a ledgered divergence."
+        ),
+    ),
     LedgeredDivergence(
         ticket="CHAOS-3648",
         pull_request="#1622",
@@ -191,12 +316,103 @@ class RefusalCause:
     authorization_filtered_count: int
 
 
+@dataclass(frozen=True, slots=True)
+class _Recomputation:
+    """What recomputing ONE case's discovery, through its own mechanism, found.
+
+    ``mentions`` is always empty for a cohort-mode case: the mechanism never
+    extracts one, and leaving the field populated from the seeded path (as a
+    stray default) would let ``no_mention_extracted`` categorize a cohort
+    refusal by an artifact of a check that never ran for it.
+    """
+
+    empty: bool
+    mentions: tuple[str, ...]
+    authorization_filtered_count: int
+    has_candidates: bool
+    unsupported_family: bool = False
+
+
+def _recompute_seeded(
+    case: CorpusCase, projection: GraphProjection, grant: frozenset[str]
+) -> _Recomputation:
+    """The mode every shape but ``discovered_cohort`` takes."""
+
+    from . import graph_leg
+
+    discovery = graph_leg.discover_subjects(
+        question=case.question,
+        projection=projection,
+        authorized_entity_ids=grant,
+    )
+    mentions = graph_leg.mention_texts(case.question)
+    return _Recomputation(
+        empty=not graph_leg.seeds_from(discovery),
+        mentions=mentions,
+        authorization_filtered_count=discovery.authorization_filtered_count,
+        has_candidates=bool(discovery.candidates),
+    )
+
+
+def _recompute_cohort(
+    case: CorpusCase, projection: GraphProjection, grant: frozenset[str]
+) -> _Recomputation:
+    """The mode ``discovered_cohort`` takes (CHAOS-3645), mirroring the exact
+    branch ``trials.chaos_3619.sweep._run_graph`` selects on comparison shape.
+
+    No mention is ever extracted here -- the mechanism reads the question
+    family and the grant, never the question text -- so this recomputation
+    can never contribute a ``no_mention_extracted`` or ``no_authorized_match``
+    category; those describe a check this mode does not run.
+    """
+
+    from dev_health_ops.api.dev.investigation_corpus import world
+    from dev_health_ops.context_fabric.graph_arm.cohort_discovery import (
+        UnsupportedCohortFamilyError,
+    )
+
+    from . import graph_leg
+
+    try:
+        cohort = graph_leg.discover_cohort_for(
+            question_family=case.question_family,
+            projection=projection,
+            authorized_entity_ids=grant,
+            as_of=world.WINDOW_END,
+        )
+    except UnsupportedCohortFamilyError:
+        # A named capability boundary: this family has no subjectless entry
+        # at all, so no traversal was attempted. Reported as empty (refused)
+        # but flagged so the category below is never confused with an
+        # extraction gap.
+        return _Recomputation(
+            empty=True,
+            mentions=(),
+            authorization_filtered_count=0,
+            has_candidates=False,
+            unsupported_family=True,
+        )
+    return _Recomputation(
+        empty=not graph_leg.cohort_seeds_from(cohort),
+        mentions=(),
+        authorization_filtered_count=cohort.authorization_filtered_count,
+        has_candidates=bool(cohort.proposal.members),
+    )
+
+
 def decompose(records_path: Path, leg: str) -> tuple[RefusalCause, ...]:
     """Every refusal in ``leg``, with its cause, verified against the records.
 
     Raises when the recomputation and the records disagree: a decomposition
     that has drifted from the run it describes is worse than none, because it
     reads as evidence about a sweep it no longer matches.
+
+    Which recomputation a case gets is decided by its OWN comparison shape --
+    the same signal ``trials.chaos_3619.sweep`` forks on -- never by which
+    records file is being checked. A records file frozen before a mechanism
+    existed is expected to disagree with what that mechanism finds today;
+    that disagreement is not drift, it is exactly what a divergence-ledger
+    entry exists to admit.
 
     The single exception is a divergence named in :data:`DIVERGENCE_LEDGER`,
     moving in the direction that entry states, whose stated cause the live
@@ -205,12 +421,12 @@ def decompose(records_path: Path, leg: str) -> tuple[RefusalCause, ...]:
     carries the ledgered category instead of a recomputed one.
     """
 
+    from dev_health_ops.api.dev.investigation_contract import ComparisonShape
     from dev_health_ops.api.dev.investigation_corpus import world
     from dev_health_ops.api.dev.investigation_corpus.cases import authored_cases
     from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
     from dev_health_ops.context_fabric.graph_arm.projection import build_projection
 
-    from . import graph_leg
     from .sweep import GRAPH_ARM_ID
 
     payload = json.loads(records_path.read_text())
@@ -233,29 +449,34 @@ def decompose(records_path: Path, leg: str) -> tuple[RefusalCause, ...]:
     drift: list[str] = []
     for case in authored_cases():
         disposition, shape, family = recorded[case.case_id]
-        discovery = graph_leg.discover_subjects(
-            question=case.question,
-            projection=projection,
-            authorized_entity_ids=grant,
+        is_cohort = case.comparison_shape is ComparisonShape.DISCOVERED_COHORT
+        recomputed = (
+            _recompute_cohort(case, projection, grant)
+            if is_cohort
+            else _recompute_seeded(case, projection, grant)
         )
-        mentions = graph_leg.mention_texts(case.question)
-        empty = not graph_leg.seeds_from(discovery)
+        empty = recomputed.empty
+        mentions = recomputed.mentions
         refused = disposition == "arm_refused"
         if empty != refused:
             entry = _ledger_entry_for(case.case_id)
             # Admitted only in the ledgered direction (the pin refused, the
             # live code now resolves) AND only while the entry's stated cause
-            # still holds. The mirror image -- a case the pin scored that the
-            # live code now refuses -- is a recall regression and must stop
-            # the run even for a ledgered case, which is why this tests the
-            # direction rather than membership alone.
-            if (
-                entry is not None
-                and refused
+            # still holds, checked against the SAME mechanism that produced
+            # ``empty`` above. The mirror image -- a case the pin scored that
+            # the live code now refuses -- is a recall regression and must
+            # stop the run even for a ledgered case, which is why this tests
+            # the direction rather than membership alone.
+            claim_holds = entry is not None and (
+                refused
                 and not empty
                 and entry.from_category == NO_MENTION
-                and mentions
-            ):
+                and (
+                    (entry.to_category == PHRASE_EXTRACTED_POST_3648 and mentions)
+                    or (entry.to_category == COHORT_RESOLVED_POST_3645 and is_cohort)
+                )
+            )
+            if claim_holds and entry is not None:
                 causes.append(
                     RefusalCause(
                         case_id=case.case_id,
@@ -264,7 +485,7 @@ def decompose(records_path: Path, leg: str) -> tuple[RefusalCause, ...]:
                         category=entry.to_category,
                         mentions_extracted=len(mentions),
                         authorization_filtered_count=(
-                            discovery.authorization_filtered_count
+                            recomputed.authorization_filtered_count
                         ),
                     )
                 )
@@ -283,8 +504,15 @@ def decompose(records_path: Path, leg: str) -> tuple[RefusalCause, ...]:
             continue
         if not refused:
             continue
-        if discovery.authorization_filtered_count > 0 and not discovery.candidates:
+        if recomputed.unsupported_family:
+            category = NO_COHORT_FAMILY_SUPPORT
+        elif (
+            recomputed.authorization_filtered_count > 0
+            and not recomputed.has_candidates
+        ):
             category = AUTHORIZATION
+        elif is_cohort:
+            category = NO_COHORT_MEMBERS
         elif not mentions:
             category = NO_MENTION
         else:
@@ -296,7 +524,7 @@ def decompose(records_path: Path, leg: str) -> tuple[RefusalCause, ...]:
                 corpus_family=family,
                 category=category,
                 mentions_extracted=len(mentions),
-                authorization_filtered_count=(discovery.authorization_filtered_count),
+                authorization_filtered_count=recomputed.authorization_filtered_count,
             )
         )
     if drift:

--- a/trials/chaos_3619/results/consolidated-post-wave-note.md
+++ b/trials/chaos_3619/results/consolidated-post-wave-note.md
@@ -193,6 +193,42 @@ the frozen records, which still reconcile. The defect is that the tool CHAOS-361
 analysis depends on can no longer be pointed at the current tree. **Not fixed here** — this lane
 changes no code. Filed as **CHAOS-3656** under CHAOS-3614.
 
+### Addendum, 2026-08-09 — CHAOS-3656 repairs the finding above
+
+**This addendum is additive; nothing above it is edited.** The finding above was true when
+CHAOS-3655 measured it and stays true as a description of that state. It no longer describes
+current `main`.
+
+`trials/chaos_3619/refusal_causes.decompose()` is now mechanism-aware
+(`trials.chaos_3619.refusal_causes`, CHAOS-3656): each case is recomputed through whichever entry
+mode its `comparison_shape` actually took in `trials.chaos_3619.sweep._run_graph` — the SEEDED
+mode (`graph_leg.discover_subjects`) for every shape but `discovered_cohort`, and the SUBJECTLESS
+COHORT mode (`graph_leg.discover_cohort_for`, CHAOS-3645/#1623) for it — instead of always
+recomputing through the seeded mode regardless of shape.
+
+`decompose(consolidated-post-wave.records.json, "leg_b_job_held_constant")` now **succeeds**. The
+13 CHAOS-3645 cases contribute no `RefusalCause` at all on this tip — they are `scored`, not
+refused — and only `T07_going_sideways_open_question` remains a refusal, carrying the new
+`no_cohort_family_support` category (its family has no subjectless entry by design, so it refuses
+under both mechanisms).
+
+`DIVERGENCE_LEDGER` gained one additive entry, cited `CHAOS-3645` / `#1623`, `from_category
+no_mention_extracted -> to_category cohort_resolved_post_3645`, naming the same 13 case ids this
+note's per-ticket attribution table already lists above. It exists so
+`trial-results.records.json` and `post-3648-remeasure.records.json` — both frozen before
+CHAOS-3645 landed, both recording these 13 cases as `arm_refused` with no mention extracted —
+keep decomposing without raising: their pinned refusal and the live mechanism's resolution are
+both true, and the ledger entry is the citation that keeps them apart rather than either editing
+the pin or silently crediting it with a mechanism it never ran. `trial-results.records.json`'s own
+decomposition is unchanged at 26 total refusals for Leg B; what changed is which category 14 of
+them carry (see `tests/context_fabric/test_chaos_3619_refusal_causes.py`,
+`TestTheCohortModeIsDecomposedSeparately`).
+
+No `.records.json` file was regenerated or edited. See
+`tests/context_fabric/test_chaos_3655_consolidated_artifact.py::TestTheRecordedFindingStaysTrueOrTheNoteGetsUpdated::test_the_refusal_decomposition_now_describes_this_tip`
+and `tests/context_fabric/test_chaos_3619_refusal_causes.py` for the executable form of both
+paragraphs above.
+
 ## Reproducing this
 
 ```


### PR DESCRIPTION
## Issue

CHAOS-3656, Wave 3.2 Phase 0 (parent CHAOS-3659). Base `5e0afcb43` on `feature/chaos-3498-context-fabric`.

## Outcome

`trials/chaos_3619/refusal_causes.decompose()` recomputed every case through the SEEDED discovery path (`discover_subjects`) regardless of shape, so it could describe the CHAOS-3619 frozen pin but not the current merged tip: CHAOS-3645's 13 `discovered_cohort` cases now score through subjectless cohort discovery, which extracts no mention by design, so the seeded recomputation always found empty seeds while the records said `scored` — and `DIVERGENCE_LEDGER` had no entry for that mechanism. `decompose()` now recomputes through whichever entry mode a case's own `comparison_shape` actually took in `trials.chaos_3619.sweep._run_graph` (seeded for everything but `discovered_cohort`, subjectless cohort discovery — `discover_cohort_for` — for it), so a valid `DISCOVERED_COHORT` score no longer requires an extracted mention.

## Scope

**In scope:** `trials/chaos_3619/refusal_causes.py` (decomposition + `DIVERGENCE_LEDGER`, additive entry only); `tests/context_fabric/test_chaos_3619_refusal_causes.py` and `test_chaos_3655_consolidated_artifact.py`; `trials/chaos_3619/results/consolidated-post-wave-note.md` (dated, additive addendum).

**Not in scope / not touched:** `trials/chaos_3619/graph_leg.py`, `sweep.py`, anything under `src/dev_health_ops/context_fabric/graph_arm/` — read-only reference. No `.records.json` artifact is edited (all immutable). No unrelated defect fixed.

## RED-first evidence

Reproduced on tip `5e0afcb43` before any source change:
```
$ .venv/bin/python -c "...decompose(Path('trials/chaos_3619/results/consolidated-post-wave.records.json'), 'leg_b_job_held_constant')"
RuntimeError: the refusal decomposition no longer reproduces the recorded sweep...
  T01_clearly_struggling_team: recomputed empty_seeds=True but the records say disposition='scored'
  ... (13 cases total, all discovered_cohort)
```
Posted as the scope-lock comment on CHAOS-3656 before any edit.

Two new tests were then written against the *unfixed* source (source reverted to `5e0afcb43`, tests added) and observed to fail for the intended reason:
- `test_chaos_3655_consolidated_artifact.py::...::test_the_refusal_decomposition_now_describes_this_tip` — collection succeeded, assertion failed with the exact `RuntimeError` above (13-case list).
- `tests/context_fabric/test_chaos_3619_refusal_causes.py` — import error (`cannot import name 'COHORT_RESOLVED_POST_3645'`), confirming the new categories/ledger entry did not yet exist.

Source fix reapplied; both failures now pass (56/56 in the refusal-causes + consolidated-artifact files).

## Regression / reverse-direction controls added

- `test_a_cohort_ledgered_case_diverging_the_other_way_still_raises` — flips a CHAOS-3645-ledgered case's row to `scored` in a copy of the frozen pin, monkeypatches live cohort discovery to keep refusing it, asserts `decompose()` still raises naming the case and ticket (mirrors the existing CHAOS-3648 reverse-direction test).
- `test_a_current_cohort_case_regressing_to_refusal_raises` — against the **current-tip** consolidated records (already `scored`, no flip needed), monkeypatches live cohort discovery to refuse, asserts `decompose()` raises.
- `_records_with_disposition_flipped`'s "pick an unledgered refused row" fixture now excludes case ids from **every** ledger entry (was CHAOS-3648-only), because after this fix the first unexcluded arm_refused row in file order was a CHAOS-3645 cohort case whose live recomputation already resolves it — flipping it to `scored` would have silently stopped exercising "unrelated drift still raises."

## Verification

```
.venv/bin/python -m pytest tests/context_fabric/test_chaos_3619_*.py tests/context_fabric/test_chaos_3645_cohort_discovery.py \
  tests/context_fabric/test_chaos_3646_evidence_admission.py tests/context_fabric/test_chaos_3648_remeasure_artifact.py \
  tests/context_fabric/test_chaos_3655_consolidated_artifact.py -q
# 266 passed, 3 skipped (live-store lane, unrelated), in 4.4s

.venv/bin/ruff check trials/chaos_3619/refusal_causes.py tests/context_fabric/test_chaos_3619_refusal_causes.py tests/context_fabric/test_chaos_3655_consolidated_artifact.py
# All checks passed!

.venv/bin/mypy trials/chaos_3619/  # 13 source files
.venv/bin/mypy tests/context_fabric/test_chaos_3619_refusal_causes.py tests/context_fabric/test_chaos_3655_consolidated_artifact.py
# Success: no issues found

# pre-commit and pre-push lefthook gates (ruff-format, ruff-check, mypy over 2288 files): all green,
# using PATH="$PWD/.venv/bin:$PATH" so lefthook resolves the worktree's mypy (2.1.0) rather than
# Homebrew's (1.19.1, missing stubs) — no --no-verify used.
```

## Limitations

- Historical FROZEN decomposition (`trial-results.records.json`) still succeeds with the same 26-refusal total for Leg B, but 14 of those refusals now carry different categories (13 → `cohort_resolved_post_3645`, 1 → `no_cohort_family_support`) instead of all 14 being `no_mention_extracted`. This is an intended, tested behavior change — the old categorization conflated "no mechanism existed yet" with "extraction found nothing," which CHAOS-3656 exists to stop doing.
- `decompose()` is not called anywhere against `post-3648-remeasure.records.json` or `cohort-families-trial-results.records.json` in the existing test suite, so those two files' decomposability under the new mechanism fork is exercised only indirectly (both are pre/post-3645 respectively and follow the same logic verified against `trial-results.records.json` and `consolidated-post-wave.records.json`), not by a dedicated test.
- Did not find or file any unrelated defect during this work.