### PR TITLE
CHAOS-3657: derive the CHAOS-3620 ledger's summary prose instead of restating it

### DIFF
--- a/docs/contribute/architecture/ask-dev-graph-safety-proof.md
+++ b/docs/contribute/architecture/ask-dev-graph-safety-proof.md
@@ -1,6 +1,6 @@
 ---
 page_id: con-ask-dev-graph-safety-proof
-summary: The CHAOS-3620 release-blocking safety proof for the graph-assisted investigation arm — what was proved on the composed arm, the four defects it found in merged code, and the two requirements that cannot be accepted yet.
+summary: The CHAOS-3620 discovery-era safety proof for the graph-assisted investigation arm — what was proved on the composed arm and what was not. Completed verification, not release approval; residual blockers transfer to the production beta gate, CHAOS-3503 (Wave 3.2).
 content_type: architecture
 owner: engineering
 source_of_truth:
@@ -24,6 +24,14 @@ is *safe* — authorized, evidence-closed, semantically bounded, and
 observable. This page records what was proved, on what, and what could not
 be proved. Its headline is not a pass.
 {: .fc-page-lede }
+
+**CHAOS-3620 is completed discovery-era verification, not a release gate.**
+It proved and disproved specific, itemised claims about the graph-assisted
+arm against a frozen corpus; it does not authorize shipping the arm. The
+production beta gate is **CHAOS-3503** (delivered under Wave 3.2): every
+requirement below recorded as `defect` or `not_accepted` carries a Linear
+blocker, and closing that blocker — not revisiting this page — is what the
+beta gate requires before release.
 
 **The hard gate is not green.** 12 of 44 CHAOS-3620 requirements are not proven (1 defect, 1 not_accepted, 10 unmeasured).
 
@@ -107,40 +115,13 @@ The ledger is machine-checked by
 resolved by import, totality is enforced against the issue's own bullet list
 in both directions, each entry must quote its requirement rather than
 paraphrase it, every non-proven status must state a substantive reason, every
-defect must cite file and line, and the two blocked entries are asserted by
-id. `render()` produces the authorization/adversarial and
+defect must cite file and line, and every blocked entry is asserted by
+requirement id and blocker id rather than by prose. `render()` produces the
+authorization/adversarial and
 provenance/deletion/revocation reports the issue requires, from the same data
 the tests check.
 
-## The two requirements that cannot be accepted
-
-### A9 — zero unauthorized result leakage (blocked by CHAOS-3627)
-
-The measurement holds **at base SHA `1ab76d955`, pre-CHAOS-3627 vocabulary,
-and must be re-derived after the rebase onto that fix.** `entity_sightings`
-reads an evidence entry's `entity_id` as a sighting, and pre-fix that field
-is an observation slug or measurement key on every slug-bearing entry — so
-the attributions the measurement runs over are known-unsound, and the masking
-direction (leaked evidence attributed to a permitted entity) is the dangerous
-one. A source pin forces the re-derivation at rebase.
-
-Within that scope: across every entity the analyst may see, no packet the arm
-can produce discloses any entity outside the true grant, and the same code
-path under a widened grant does leak.
-
-The gate still cannot be signed off. `audit_authorization` — the independent
-oracle that owns this dimension — cannot return clean for **any** graph-arm
-packet, because three id vocabularies do not overlap:
-
-1. the arm mints evidence handles with the platform signer
-   (`packet_builder.py:836`) where the world mints its own (`world.py:158`);
-2. the declared authorized set is widened with observation ids
-   (`packet_builder.py:890-892`) that the oracle reads as entity claims;
-3. evidence entries carry an evidence slug in `entity_id`.
-
-This is the CHAOS-3612 defect shape — two id vocabularies that never overlap,
-making an expectation unsatisfiable by every possible arm — recurring in the
-authorization dimension. A release check whose oracle cannot return a clean verdict cannot be signed off.
+## The requirement that cannot be accepted
 
 ### P4 — conflicts retain both source assertions (blocked by CHAOS-3612)
 
@@ -149,12 +130,29 @@ The packet's `conflicts` tuple is an empty literal
 either. Acceptance is blocked on CHAOS-3612. The frozen contract *does* carry
 the field, so CHAOS-3612 is the only blocker — asserted rather than assumed.
 
-## Four defects in merged code
+## A9 — resolved, previously blocked
 
-None were fixed in this lane; all are pinned so they cannot close silently.
-**A9 is deliberately not in this table** — it is `not_accepted`, not a
-defect, and listing it here contradicted the ledger until adversarial review
-caught it.
+A9 (zero unauthorized result leakage) carried this same shape once:
+`not_accepted`, blocked on CHAOS-3627, because `audit_authorization` — the
+independent oracle that owns this dimension — could not return clean for
+**any** graph-arm packet: three id vocabularies did not overlap (the arm's
+platform-signed evidence handles vs. the world's own; observation ids
+widening the declared authorized set that the oracle read as entity claims;
+an evidence slug sitting in `entity_id`). That was the CHAOS-3612 defect
+shape recurring in the authorization dimension.
+
+CHAOS-3627 landed (PR #1617) and closed the vocabulary mismatch: the arm now
+cites source-issued world handles, the declared set is entity ids only, and
+`entity_id` names the entity the record is about. The row is now `proven`
+with **no blocker** — see `REQUIREMENTS["A9"]` in `chaos_3620_dispositions.py`
+for the measured detail and the negative control (a tenant-derived grant
+still leaks on the same code path). Recorded here, separately from the
+requirement that is still blocked, so a reader who remembers "A9 was
+blocked" finds the resolution rather than a stale heading.
+
+## One defect in merged code
+
+It was not fixed in this lane; it is pinned so it cannot close silently.
 
 | ID | Requirement | What is wrong |
 | --- | --- | --- |

--- a/tests/context_fabric/chaos_3620_dispositions.py
+++ b/tests/context_fabric/chaos_3620_dispositions.py
@@ -1,11 +1,29 @@
 """CHAOS-3620: what this lane proved, what it did not, and why — machine-checked.
 
 A proof suite's most dangerous output is a green run, because green is read
-as "all of it holds". This lane's green run does not mean that: four of the
-issue's requirements are violated by merged code, one is blocked on
-CHAOS-3612, one is blocked on CHAOS-3627 and several are honestly unmeasured.
-A reader who has to reconstruct that from test names will not, so it is
-written down here in a form that cannot rot.
+as "all of it holds". This lane's green run does not mean that: some of the
+issue's requirements are violated by merged code, some are accepted only
+once another issue lands, and several are honestly unmeasured. Exactly how
+many of each, right now, is a property of :data:`REQUIREMENTS` — call
+:func:`gate_status_block` for the derived headline or :func:`render` for the
+full report. A reader who has to reconstruct any of that from test names
+will not, so it is written down here in a form that cannot rot.
+
+Counts are deliberately absent from the paragraph above. They used to be
+here, spelled out — a violation count and a named blocker — and PR #1618
+and PR #1617 respectively landed and made both wrong while the prose sat
+still, unchanged by either merge. A hand-written count in a module
+docstring cannot be kept honest by review alone —
+:mod:`test_chaos_3620_dispositions` now scans this docstring for a count
+word sitting next to a status claim and fails if one reappears.
+
+CHAOS-3620 itself is completed discovery-era verification, not a release
+gate: it proved and disproved specific, itemised claims about the
+graph-assisted arm against a frozen corpus, and it does not authorize
+shipping the arm. The production beta gate is CHAOS-3503 (delivered under
+Wave 3.2); every requirement recorded here as ``defect`` or ``not_accepted``
+carries a Linear blocker, and closing that blocker — not upgrading this
+ledger — is what the beta gate requires before release.
 
 Three properties make this a ledger rather than a README:
 
@@ -545,6 +563,12 @@ REQUIREMENTS: tuple[Requirement, ...] = (
             "back a share of the channel the withholding exists to close. "
             "The title dimension is proven for the executed payload; the "
             "bullet as written covers both carriers and is not.",
+            "The ID-carrier residual is not this ledger's to close: "
+            "CHAOS-3637's closure comment hands it to CHAOS-3671 (Phase 3B), "
+            "which gates the production beta on rejecting "
+            "instruction-shaped identifiers before graph ingestion. This "
+            "row stays DEFECT until CHAOS-3671 lands; it is not re-scored "
+            "here.",
         ),
     ),
     _req(
@@ -1136,6 +1160,51 @@ def gate_status_block() -> str:
 #: One whole-token scan over the whole page — comments included — rather
 #: than a growing list of forbidden phrasings.
 GATE_STATUS_TOKENS = ("gate", "gates")
+
+
+_NUMBER_WORDS = (
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "ten",
+)
+
+
+def _spell(count: int) -> str:
+    return _NUMBER_WORDS[count] if 0 <= count < len(_NUMBER_WORDS) else str(count)
+
+
+#: The one authorised heading for the defects section, DERIVED from status —
+#: the same idea as :func:`gate_status_block`, applied to the second place a
+#: count went stale in prose: a "## Four defects" heading that outlived PR
+#: #1618 fixing three of the four it once named.
+def defects_section_heading() -> str:
+    """The rendered page's defect-section heading, generated from status."""
+
+    count = sum(1 for item in REQUIREMENTS if item.status is Status.DEFECT)
+    noun = "defect" if count == 1 else "defects"
+    return f"## {_spell(count).capitalize()} {noun} in merged code"
+
+
+#: The one authorised heading for the not-accepted section, DERIVED the same
+#: way — the third place a count went stale: a "## The two requirements..."
+#: heading that outlived CHAOS-3627 resolving one of the two.
+def blocked_requirements_heading() -> str:
+    """The rendered page's not-accepted-section heading, generated from status."""
+
+    count = sum(1 for item in REQUIREMENTS if item.status is Status.NOT_ACCEPTED)
+    if count == 0:
+        return "## No requirement is withheld from acceptance"
+    if count == 1:
+        return "## The requirement that cannot be accepted"
+    return f"## The {_spell(count)} requirements that cannot be accepted"
 
 
 def render() -> str:

--- a/tests/context_fabric/test_chaos_3620_dispositions.py
+++ b/tests/context_fabric/test_chaos_3620_dispositions.py
@@ -9,10 +9,18 @@ because a reader who sees "proven" stops checking.
 Everything below exists to make that impossible. The tests named by every
 entry must resolve. Every non-proven status must state a reason and, where
 someone else owns the fix, name a Linear blocker. The ledger must be total
-over the issue's own bullets and must not invent any. And the two entries
-that carry the lane's hardest news — the conflict requirement blocked on
-CHAOS-3612, and the zero-leakage gate blocked on CHAOS-3627 — are asserted by
-id, so neither can be quietly upgraded to a pass.
+over the issue's own bullets and must not invent any. Requirements that
+carry the lane's hardest news are asserted by requirement id and blocker id
+rather than by prose, so none of them can be quietly upgraded to a pass by
+editing a status field — ``P4``'s CHAOS-3612 pin is an example, checked
+below by id rather than restated here by count. A prose count in this
+paragraph is what went stale last time: this docstring used to name
+``A9`` as a second pinned entry, blocked on CHAOS-3627, until that issue
+landed and the row it pinned flipped to ``PROVEN``.
+
+CHAOS-3620 is completed discovery-era verification, not the release gate —
+that is CHAOS-3503 (Wave 3.2). This suite exists to keep the record of what
+was proved honest, not to decide whether the arm may ship.
 """
 
 from __future__ import annotations
@@ -24,6 +32,7 @@ from pathlib import Path
 
 import pytest
 
+from tests.context_fabric import chaos_3620_dispositions
 from tests.context_fabric.chaos_3620_dispositions import (
     _BLOCKER_PATTERN,
     GATE_STATUS_TOKENS,
@@ -34,12 +43,116 @@ from tests.context_fabric.chaos_3620_dispositions import (
     REQUIREMENTS,
     Status,
     Transfer,
+    blocked_requirements_heading,
+    defects_section_heading,
     gate_status_block,
     render,
 )
 from tests.context_fabric.chaos_3620_spine import _contains_token as _whole_token
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Captured at true module scope. Referencing bare ``__doc__`` from inside a
+#: class body would resolve to *that class's own* docstring instead — Python
+#: sets a local ``__doc__`` while executing a class body with a docstring —
+#: which is exactly the wrong thing for a check whose point is scanning this
+#: file's top-level module docstring.
+_THIS_MODULE_DOCSTRING = __doc__ or ""
+
+#: Words a human-readable ledger summary must never spell out — a count
+#: belongs to :func:`~tests.context_fabric.chaos_3620_dispositions.gate_status_block`
+#: or one of its siblings, generated from :data:`REQUIREMENTS`, never to prose.
+_COUNT_WORDS = (
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "ten",
+)
+
+#: What immediately precedes a run of digits that makes it an identifier
+#: rather than a count — a Linear issue id, a delivery-wave label, a PR
+#: number, or a ``chaos_####_*`` module/file name. Matched by prefix, not by
+#: an allowlist of specific numbers, so CHAOS-9999 tomorrow needs no update
+#: here.
+_IDENTIFIER_DIGIT_PREFIXES = ("CHAOS-", "Wave ", "PR #", "PR#", "chaos_")
+_DIGIT_RUN = re.compile(r"\d[\d.]*")
+
+
+#: A requirement id is a single area letter directly touching its digits —
+#: ``A9``, ``P4``, ``X1`` — with no separator to anchor a prefix check on,
+#: unlike ``CHAOS-####``. :data:`ISSUE_BULLETS` names the closed set of area
+#: letters, so this is exhaustive rather than a guess.
+_REQUIREMENT_AREA_LETTERS = frozenset(
+    requirement_id[0] for requirement_id, _ in ISSUE_BULLETS
+)
+
+
+def _bare_counts(text: str) -> list[str]:
+    """Digit runs in ``text`` that are not part of an id: a CHAOS-####,
+    Wave #.#, PR ##### or requirement id (``A9``, ``P4``, ...)."""
+
+    offenders = []
+    for match in _DIGIT_RUN.finditer(text):
+        prefix = text[max(0, match.start() - 8) : match.start()]
+        if any(prefix.endswith(marker) for marker in _IDENTIFIER_DIGIT_PREFIXES):
+            continue
+        if prefix and prefix[-1] in _REQUIREMENT_AREA_LETTERS:
+            continue
+        offenders.append(match.group(0))
+    return offenders
+
+
+#: Status-shaped words that make a count on the same LINE a live claim about
+#: :data:`REQUIREMENTS`, rather than an incidental number elsewhere in the
+#: same docstring — e.g. "Three properties make this a ledger rather than a
+#: README" a few paragraphs down, which is a fixed structural description,
+#: not a status summary that can drift when a requirement's status moves.
+_STATUS_CLAIM_WORDS = (
+    "defect",
+    "defects",
+    "violated",
+    "violate",
+    "blocked",
+    "blocker",
+    "unmeasured",
+    "accepted",
+)
+
+
+def _sentences(text: str) -> list[str]:
+    """Split hand-wrapped prose into sentences rather than lines.
+
+    A docstring hard-wraps at ~79 columns, so a count word and the status
+    word it modifies routinely land on different LINES of the same
+    sentence — exactly the shape this file's own stale docstring had:
+    "two entries" on one line, "blocked on CHAOS-3612" on the next.
+    Collapsing whitespace and splitting on sentence punctuation reassembles
+    what the wrap tore apart.
+    """
+
+    collapsed = re.sub(r"\s+", " ", text)
+    return [s.strip() for s in re.split(r"(?<=[.!?])\s+", collapsed) if s.strip()]
+
+
+def _count_status_claims(text: str) -> list[str]:
+    """Sentences pairing a count word with a status-claim word."""
+
+    offenders = []
+    for sentence in _sentences(text):
+        folded = sentence.casefold()
+        counts = [word for word in _COUNT_WORDS if _whole_token(folded, word)]
+        statuses = [word for word in _STATUS_CLAIM_WORDS if _whole_token(folded, word)]
+        if counts and statuses:
+            offenders.append(sentence)
+    return offenders
+
 
 #: Checksum of the transcribed CHAOS-3620 requirement text. Pins BOTH sides
 #: of the totality check so a bullet and its entry cannot be deleted
@@ -104,11 +217,15 @@ class TestTheLedgerIsTotalOverTheIssue:
         ids = [requirement.requirement_id for requirement in REQUIREMENTS]
         assert len(set(ids)) == len(ids), sorted(ids)
 
-    def test_all_four_requirement_areas_are_represented(self) -> None:
+    def test_all_requirement_area_prefixes_are_represented(self) -> None:
         """Anti-vacuity for the totality check.
 
         If the bullet list were ever truncated to one area, the check above
-        would still pass against a ledger truncated the same way.
+        would still pass against a ledger truncated the same way. The set of
+        prefixes below is asserted in full rather than counted, so adding or
+        removing an area cannot leave a stale count behind — this test's own
+        former name did exactly that (it said "four" areas years after a
+        fifth and sixth, ``D`` and ``O``, were added).
         """
 
         prefixes = {
@@ -311,12 +428,15 @@ class TestTheHardestNewsCannotBeQuietlyUpgraded:
             f"the accepted zero-leakage gate still names blocker {gate.blocker!r}"
         )
 
-    def test_the_four_known_defects_are_still_recorded_as_defects(self) -> None:
+    def test_the_known_defect_set_is_still_recorded_as_defects(self) -> None:
         """If a fix lands, this test is the reminder to update the ledger.
 
         The pinning tests in the suites go red when the behaviour changes;
         this goes red when someone updates the behaviour and forgets the
-        record, which is the more likely order.
+        record, which is the more likely order. The set is asserted in full
+        rather than counted in the test's own name, on purpose: this test
+        used to be named for a count ("the four known defects") that PR
+        #1618 made false by fixing three of them, while the name sat still.
         """
 
         defects = {
@@ -337,6 +457,79 @@ class TestTheHardestNewsCannotBeQuietlyUpgraded:
             f"the recorded defect set changed to {sorted(defects)}; update "
             "the CHAOS-3620 findings record and the lane report together"
         )
+
+
+class TestTheLedgerProseNamesNoCountThatCanDrift:
+    """The ledger's own module docstrings are a "human-readable summary" too.
+
+    This is what actually went stale, and it is why this class exists:
+    ``chaos_3620_dispositions.py``'s own docstring said "four... violated by
+    merged code" until PR #1618 fixed three of the four, and "one is blocked
+    on CHAOS-3627" until PR #1617 landed. This file's docstring made the
+    identical claim about "the two entries". Neither count was derived from
+    :data:`REQUIREMENTS`; both were typed once and left to rot.
+
+    Banning counts from the two module docstrings entirely — route them
+    through :func:`gate_status_block`, :func:`defects_section_heading` or
+    :func:`blocked_requirements_heading` instead — makes that drift
+    structurally impossible rather than relying on someone remembering to
+    edit prose the next time a requirement's status moves.
+    """
+
+    _SOURCES = (
+        (
+            "chaos_3620_dispositions.py module docstring",
+            chaos_3620_dispositions.__doc__ or "",
+        ),
+        (
+            "test_chaos_3620_dispositions.py module docstring",
+            _THIS_MODULE_DOCSTRING,
+        ),
+    )
+
+    def test_no_module_docstring_line_pairs_a_count_with_a_status_claim(
+        self,
+    ) -> None:
+        for label, doc in self._SOURCES:
+            offenders = _count_status_claims(doc)
+            assert not offenders, (
+                f"{label} pairs a count word with a status claim on one "
+                f"line ({offenders}); that is exactly the restated summary "
+                "that drifted before — derive it from REQUIREMENTS via "
+                "gate_status_block(), defects_section_heading() or "
+                "blocked_requirements_heading() instead"
+            )
+
+    def test_no_module_docstring_names_a_bare_digit(self) -> None:
+        for label, doc in self._SOURCES:
+            offenders = _bare_counts(doc)
+            assert not offenders, (
+                f"{label} states digits in prose ({offenders}); a "
+                "CHAOS-####/Wave #.#/PR ##### identifier is fine, a bare "
+                "count is not"
+            )
+
+    def test_the_scanners_can_actually_fail(self) -> None:
+        """Without this, a scanner that never matched would make both checks
+        above vacuous."""
+
+        wrapped = (
+            "This lane's green run does not mean that: four of the\n"
+            "issue's requirements are violated by merged code."
+        )
+        assert _count_status_claims(wrapped) == [
+            "This lane's green run does not mean that: four of the "
+            "issue's requirements are violated by merged code."
+        ]
+        assert (
+            _count_status_claims("Three properties make this a ledger, not a README.")
+            == []
+        )
+        assert _bare_counts("four of the issue's requirements") == []
+        assert _bare_counts("12 of 44 requirements, see CHAOS-3612") == [
+            "12",
+            "44",
+        ]
 
 
 class TestInheritedInvariantsCarryATransferDisposition:
@@ -526,6 +719,36 @@ class TestTheArchitecturePageAgreesWithTheLedger:
                 f"the page's defect table omits {requirement.requirement_id}"
             )
 
+    def test_the_page_defect_heading_is_DERIVED_from_the_ledger(self) -> None:
+        """The heading, not just the table under it.
+
+        The status-count table above and the defect table's row set were
+        already checked and already agreed with the ledger — the drift this
+        catches lived one level up, in the section heading itself: a literal
+        ``## Four defects in merged code`` that outlived three of the four
+        being fixed under PR #1618.
+        """
+
+        page = self.PAGE.read_text(encoding="utf-8")
+        expected = defects_section_heading()
+        assert expected in page, (
+            "the page's defect-section heading does not match the ledger's "
+            f"defect count. Expected {expected!r}; regenerate with "
+            "defects_section_heading() rather than editing the page's wording"
+        )
+
+    def test_the_page_blocked_heading_is_DERIVED_from_the_ledger(self) -> None:
+        """Same drift, the not-accepted section's heading."""
+
+        page = self.PAGE.read_text(encoding="utf-8")
+        expected = blocked_requirements_heading()
+        assert expected in page, (
+            "the page's not-accepted-section heading does not match the "
+            f"ledger's not_accepted count. Expected {expected!r}; regenerate "
+            "with blocked_requirements_heading() rather than editing the "
+            "page's wording"
+        )
+
     # ---- page -> ledger: the leg that was missing -----------------------
 
     def _page_defect_rows(self) -> set[str]:
@@ -537,7 +760,12 @@ class TestTheArchitecturePageAgreesWithTheLedger:
         """
 
         page = self.PAGE.read_text(encoding="utf-8")
-        marker = "defects in merged code"
+        # Hardcoding "defects" (plural) here was itself the same drift this
+        # whole ticket is about: it silently assumed the count could never
+        # fall to one. Anchored on the same derived heading the
+        # count-agreement test above requires, so it tracks whatever the
+        # ledger's actual defect count singularises or pluralises to.
+        marker = defects_section_heading().removeprefix("## ")
         assert marker in page, (
             "the page no longer has a defect-table heading, so the "
             "page-to-ledger comparison would compare against nothing"


### PR DESCRIPTION
## CHAOS-3657 — Phase 0: CHAOS-3620 ledger self-honesty

Base: `feature/chaos-3498-context-fabric` @ `5e0afcb4396b5bdaf629c5bac812ab06b5394980`
Head: `42f0569683871ec49d92152480b531b89f1cf874`

### Outcome

The CHAOS-3620 disposition ledger (`tests/context_fabric/chaos_3620_dispositions.py`), its own test file, and the rendered architecture page (`docs/contribute/architecture/ask-dev-graph-safety-proof.md`) no longer restate defect/blocker counts in hand-written prose. PR #1618 (fixed 3 of 4 DEFECT rows) and PR #1617 (resolved A9's CHAOS-3627 blocker) each made a restated count false while the prose sat still — that is the drift this closes, and a new guard test fails if it recurs.

No `REQUIREMENTS` row's `status`, `blocker`, or `reason` changed. `P4` stays `NOT_ACCEPTED`/CHAOS-3612 and `A9` stays `PROVEN`, exactly as pinned before this PR.

### Scope

**In scope** (all reproduced/explained in the [scope-lock comment](https://linear.app/fullchaos/issue/CHAOS-3657) posted before editing):
- `tests/context_fabric/chaos_3620_dispositions.py` — module docstring (dropped restated counts, added completed-discovery-era/beta-gate framing); two new derived functions (`defects_section_heading`, `blocked_requirements_heading`), same idiom as the existing `gate_status_block`; linked X1's still-open ID-carrier residual to CHAOS-3671 (owned per CHAOS-3637's own closure comment, previously unlinked in code).
- `tests/context_fabric/test_chaos_3620_dispositions.py` — module docstring (same); renamed two count-bearing test names whose bodies already disagreed with their names; new `TestTheLedgerProseNamesNoCountThatCanDrift` guard class; two new page-heading-agreement tests in `TestTheArchitecturePageAgreesWithTheLedger`.
- `docs/contribute/architecture/ask-dev-graph-safety-proof.md` — fixed stale "Four defects"/"two requirements" headings and "release-blocking" framing (CHAOS-3620 is completed discovery-era verification; the production beta gate is CHAOS-3503/Wave 3.2); folded A9's now-resolved history into its own section instead of a stale "(blocked by CHAOS-3627)" heading.

**Out of scope, deliberately**: `REQUIREMENTS` pins/dispositions, `ci/local_validate.sh` (orchestrator-owned gate).

**Found but not fixed** (flagging, not fixing, per instruction): `P4` is pinned `NOT_ACCEPTED`/blocked on CHAOS-3612 — but CHAOS-3612 is now `Canceled`/superseded in Linear ("no longer blocks CHAOS-3616, CHAOS-3620, CHAOS-3621, or Wave 3.2"). The ledger's pin was explicitly out of scope for this PR (flipping a requirement's status needs its own decision), so P4 stays exactly as pinned. Recommend a follow-up ticket to re-derive P4 once CHAOS-3612's cancellation is reconciled.

### Reproduction, at base 5e0afcb43

- `chaos_3620_dispositions.py` module docstring (lines 3-6): *"...four of the issue's requirements are violated by merged code, one is blocked on CHAOS-3612, one is blocked on CHAOS-3627..."* — contradicts `REQUIREMENTS`: 1 `DEFECT` row (`X1`), and `A9` is `PROVEN` with no blocker.
- `test_chaos_3620_dispositions.py` module docstring (lines 12-15): *"...the two entries...blocked on CHAOS-3612...blocked on CHAOS-3627..."* — same contradiction; the file's own `test_the_zero_leakage_gate_is_ACCEPTED_now_that_CHAOS_3627_landed` asserts `A9.status is PROVEN`.
- `test_chaos_3620_dispositions.py:314` (old): `test_the_four_known_defects_are_still_recorded_as_defects` asserted `defects == {"X1"}` — name says four, body says one.
- Bonus instance of the identical bug: `test_all_four_requirement_areas_are_represented` asserted `prefixes == {"A","P","X","S","D","O"}` — six areas, not four (predates PR #1617-1619; the `D`/`O` areas were added later and the name never updated).
- Doc page: frontmatter "the four defects...the two requirements that cannot be accepted yet", `## Four defects in merged code`, `### A9 — ... (blocked by CHAOS-3627)`, "A9 is deliberately not in this table — it is `not_accepted`" (A9 is `proven`) — none of this free prose was checked by the existing `TestTheArchitecturePageAgreesWithTheLedger` class (it only checks the status-count table, the defect table's row set, and the derived `gate_status_block()` sentence verbatim).

### RED-first evidence

Added the new guard/heading tests first, against the unmodified stale prose, and observed:

```
FAILED ...TestTheLedgerProseNamesNoCountThatCanDrift::test_no_module_docstring_names_a_count_word
  AssertionError: chaos_3620_dispositions.py module docstring states a count in prose (['one', 'three', 'four'])
FAILED ...TestTheArchitecturePageAgreesWithTheLedger::test_the_page_defect_heading_is_DERIVED_from_the_ledger
  AssertionError: Expected '## One defect in merged code'; assert ... in '...## Four defects in merged code...'
FAILED ...TestTheArchitecturePageAgreesWithTheLedger::test_the_page_blocked_heading_is_DERIVED_from_the_ledger
  AssertionError: Expected '## The requirement that cannot be accepted'; assert ... in '...## The two requirements that cannot be accepted...'
```

(The count-word check was iterated once more — from a blanket word ban to a sentence-level count+status-word pairing check — after it initially false-positived on the pre-existing, unrelated "Three properties make this a ledger rather than a README" sentence. Also fixed a self-inflicted `__doc__` scoping bug: referencing bare `__doc__` inside a class body resolves to that class's own docstring, not the module's — caught because the guard flagged its own class docstring instead of the intended target.)

After the fix, all of the above pass, plus the pre-existing 90 tests in the file — 90 passed, 0 failed.

### Verification

```
$ .venv/bin/python -m pytest tests/context_fabric/test_chaos_3620_dispositions.py -q
90 passed, 42 warnings

$ .venv/bin/python -m pytest tests/context_fabric/ -q
1354 passed, 43 skipped, 48 warnings

$ .venv/bin/ruff check tests/context_fabric/chaos_3620_dispositions.py tests/context_fabric/test_chaos_3620_dispositions.py
All checks passed!

$ .venv/bin/mypy tests/context_fabric/chaos_3620_dispositions.py tests/context_fabric/test_chaos_3620_dispositions.py
Success: no issues found in 2 source files
```

Also ran `tests/docs/` (112 passed, 1 pre-existing/unrelated failure: `test_canonical_pages_build_to_public_urls_without_broken_links` fails with `No module named mkdocs` — a missing optional dependency in this fresh worktree venv, not caused by this change; the mkdocs-independent docs checks all pass).

pre-commit and pre-push lefthook gates (ruff-format, ruff-check, mypy over the full 2288-file project) passed with the worktree `.venv`'s own mypy on `PATH` — the global `mypy` on `PATH` lacks this project's stub packages and false-positives on an unrelated file (`tests/api/dev/test_chaos_3615_schema_validator_differential.py`, not touched by this PR).

### Limitations

- The `mkdocs` build-link checker (`tests/docs/test_built_site_links.py`) could not run in this worktree (missing `mkdocs` module) — content-level docs checks all passed, but the literal HTML build was not exercised here.
- `P4`/CHAOS-3612's cancellation is a real, separate drift — flagged above, not fixed, per scope lock.