### PR TITLE
CHAOS-3654: semantic retrieval refusal/clarification threshold

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
@@ -84,15 +84,21 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from collections.abc import Sequence
 
 __all__ = [
+    "DEFAULT_CLARIFICATION_LIMIT",
+    "DEFAULT_MARGIN_RATIO",
     "DEFAULT_SEMANTIC_LIMIT",
+    "DEFAULT_TIE_RATIO",
     "CrossPartitionRetrievalError",
     "FulltextIndexNotReadyError",
     "FulltextReadiness",
     "RetrievalMethod",
     "RetrievalStore",
     "SemanticCandidate",
+    "SemanticDisposition",
+    "SemanticDispositionResult",
     "SemanticRetrieval",
     "NonSemanticEmbedderError",
+    "assess_disposition",
     "retrieve_candidates",
     "wait_for_fulltext_index",
 ]
@@ -235,6 +241,202 @@ class SemanticRetrieval:
     @property
     def resolved(self) -> bool:
         return bool(self.candidates)
+
+
+class SemanticDisposition(StrEnum):
+    """What this leg is willing to do with its own ranked result.
+
+    **Not** a contract-level ``SubjectCommitmentState``. Every candidate this
+    leg produces carries :attr:`SubjectMatchSignal.FUZZY_LABEL` — see
+    :class:`SemanticCandidate` — and ``WEAK_SUBJECT_MATCH_SIGNALS`` already
+    forbids a candidate from reaching ``COMMITTED`` on that signal alone
+    (``vocabulary.py:191-199``). This leg cannot commit a subject and was
+    never going to; what varies here is how confidently its own ranking is
+    worth handing to whatever resolves the subject: as a single lead, as a
+    bounded set that needs disambiguating, or not at all.
+
+    ``PROPOSE`` is therefore "worth proposing as the lead candidate", never
+    "resolved". A caller that reads ``PROPOSE`` as commitment has made the
+    same mistake ``WEAK_SUBJECT_MATCH_SIGNALS`` exists to catch.
+    """
+
+    PROPOSE = "propose"
+    CLARIFY = "clarify"
+    REFUSE = "refuse"
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticDispositionResult:
+    """The disposition this leg's own result earns, and what to show for it."""
+
+    disposition: SemanticDisposition
+    #: Bounded to ``clarification_limit`` on CLARIFY, one candidate on
+    #: PROPOSE, empty on REFUSE. Never longer than what a caller may present.
+    presented: tuple[SemanticCandidate, ...]
+    #: Trial/operator diagnostic. Never packet content -- see
+    #: :func:`_canonical_ids` for why a rationale channel here is not a wire
+    #: field.
+    reason: str
+
+
+#: Rank-1 must beat rank-2 by at least this fraction of rank-1's own score to
+#: read as a genuine leader rather than noise. Derived from Reciprocal Rank
+#: Fusion's own decay curve -- ``score = sum(1 / (k + rank))`` per method,
+#: which drops fastest between the first few ranks -- so a real front-runner
+#: separates from its nearest competitor by a wide margin on that curve and a
+#: coincidental one does not. The constant describes that curve's shape, not
+#: any corpus's query text, and is validated in
+#: ``test_chaos_3654_refusal_threshold.py`` against synthetic cases built to
+#: exercise the shape rather than reproduce a measured question.
+DEFAULT_MARGIN_RATIO = 0.20
+
+#: A candidate scoring at or above this fraction of the leader's own score is
+#: "tied" with it for disambiguation purposes -- close enough on the RRF
+#: curve that picking one over the other is not defensible without more
+#: information.
+DEFAULT_TIE_RATIO = 0.85
+
+#: How many tied candidates a CLARIFY disposition will present. Matches the
+#: contract's own clarification-candidate bound in spirit: past a small
+#: number, "clarify" has degraded into "here is the authorized world",
+#: exactly what REFUSE exists to prevent.
+DEFAULT_CLARIFICATION_LIMIT = 5
+
+
+def _tied_candidates(
+    candidates: Sequence[SemanticCandidate], *, tie_ratio: float
+) -> list[SemanticCandidate]:
+    """Every candidate within ``tie_ratio`` of the leader's own score.
+
+    Always includes the leader itself (ratio 1.0 of itself). A guard against
+    ``top_score <= 0`` falls back to exact equality, since a ratio against a
+    non-positive score is not a meaningful fraction.
+    """
+
+    top_score = candidates[0].rrf_score
+    if top_score <= 0:
+        return [item for item in candidates if item.rrf_score == top_score]
+    return [item for item in candidates if item.rrf_score >= tie_ratio * top_score]
+
+
+def assess_disposition(
+    retrieval: SemanticRetrieval,
+    *,
+    clarification_limit: int = DEFAULT_CLARIFICATION_LIMIT,
+    margin_ratio: float = DEFAULT_MARGIN_RATIO,
+    tie_ratio: float = DEFAULT_TIE_RATIO,
+) -> SemanticDispositionResult:
+    """Whether this leg's own ranking is safe to propose, clarify, or refuse.
+
+    **The measured failure this closes.** "How is Halcyon doing?" — no such
+    entity exists — returned 20 confidently ranked candidates, because
+    cosine similarity against a real embedding model is rarely exactly zero
+    for *any* query, and nothing in :func:`retrieve_candidates` ever refused
+    on that basis. "What's holding it up?" with no conversational referent
+    returned 11. Both runs had one thing in common: no lexical evidence
+    anywhere in the corpus for the query text, and a leading candidate whose
+    only support was a vector nearest-neighbour guess.
+
+    **The rule is about the fused result's own shape, not about any query's
+    content.** Three signals, checked in order:
+
+    1. *Lexical grounding.* If ``retrieval.bm25_order`` is empty — BM25 found
+       nothing for this query anywhere in the authorized partition — and the
+       leading candidate has no BM25 support of its own, there is no
+       evidence anyone ever wrote this term near a real node. That is
+       exactly the shape a nonexistent entity or an orphan pronoun produces,
+       and it refuses regardless of how confident the cosine ranking looks.
+    2. *Rank-1/rank-2 margin.* A genuine front-runner separates from its
+       nearest competitor on RRF's own score-decay curve; noise does not.
+       ``DEFAULT_MARGIN_RATIO`` reads that separation, not any absolute
+       score.
+    3. *Tie count.* When several candidates cluster near the leader, the
+       honest answer is "these look similar" (CLARIFY, bounded) rather than
+       an arbitrary pick — and past ``clarification_limit`` tied candidates,
+       clarification has degraded into an enumeration, which REFUSE exists
+       to prevent.
+
+    Authorization has already run inside :func:`retrieve_candidates`, so
+    every candidate reaching this function is one the caller may see; this
+    function only decides how much of that authorized ranking to trust.
+    """
+
+    if not retrieval.candidates:
+        return SemanticDispositionResult(
+            disposition=SemanticDisposition.REFUSE,
+            presented=(),
+            reason="no authorized candidate survived retrieval and fusion",
+        )
+
+    candidates = retrieval.candidates
+    top = candidates[0]
+    top_corroborated = RetrievalMethod.BM25 in top.methods
+    lexically_grounded = bool(retrieval.bm25_order)
+
+    if not lexically_grounded and not top_corroborated:
+        return SemanticDispositionResult(
+            disposition=SemanticDisposition.REFUSE,
+            presented=(),
+            reason=(
+                "no lexical evidence for this query anywhere in the "
+                "authorized partition, and the leading candidate has only "
+                "vector-similarity support: the shape a nonexistent entity "
+                "or an unresolved reference produces"
+            ),
+        )
+
+    tied = _tied_candidates(candidates, tie_ratio=tie_ratio)
+
+    if len(candidates) == 1:
+        if top_corroborated:
+            return SemanticDispositionResult(
+                disposition=SemanticDisposition.PROPOSE,
+                presented=(top,),
+                reason="one authorized candidate, with lexical support",
+            )
+        return SemanticDispositionResult(
+            disposition=SemanticDisposition.REFUSE,
+            presented=(),
+            reason=(
+                "one authorized candidate with only vector-similarity "
+                "support and no competing candidate to weigh it against"
+            ),
+        )
+
+    second_score = candidates[1].rrf_score
+    top_score = top.rrf_score
+    margin = (top_score - second_score) / top_score if top_score > 0 else 0.0
+
+    if top_corroborated and len(tied) == 1 and margin >= margin_ratio:
+        return SemanticDispositionResult(
+            disposition=SemanticDisposition.PROPOSE,
+            presented=(top,),
+            reason=(
+                f"leader has lexical support and clears the next candidate "
+                f"by {margin:.0%}, at or above the {margin_ratio:.0%} margin"
+            ),
+        )
+
+    if len(tied) <= clarification_limit:
+        return SemanticDispositionResult(
+            disposition=SemanticDisposition.CLARIFY,
+            presented=tuple(tied[:clarification_limit]),
+            reason=(
+                f"{len(tied)} candidate(s) within {tie_ratio:.0%} of the "
+                "leader's own score; no defensible single pick"
+            ),
+        )
+
+    return SemanticDispositionResult(
+        disposition=SemanticDisposition.REFUSE,
+        presented=(),
+        reason=(
+            f"{len(tied)} candidates cluster near the leader's own score, "
+            f"past the {clarification_limit}-candidate clarification bound: "
+            "a diffuse ranking with no defensible subject, not a genuine "
+            "field of finalists"
+        ),
+    )
 
 
 def _attribute(node: Any, key: str) -> Any:

--- a/tests/context_fabric/test_chaos_3654_refusal_threshold.py
+++ b/tests/context_fabric/test_chaos_3654_refusal_threshold.py
@@ -1,0 +1,225 @@
+"""CHAOS-3654: the semantic leg's own refusal/clarification threshold.
+
+Every case here is synthetic and constructed for its *shape* — the RRF
+margin, the tie count, whether BM25 found anything at all — never lifted
+from the CHAOS-3619/3647 frozen corpus's actual questions or entity names.
+That is deliberate and is the whole point of
+``semantic_retrieval.assess_disposition``: the two measured failures
+("How is Halcyon doing?" returning 20 candidates, "What's holding it up?"
+with no referent returning 11) are instances of one shape — a diffuse,
+lexically-ungrounded fusion result — and a rule proven only on those two
+specific queries would be exactly the corpus-tuned threshold the ticket
+forbids. These cases are held out from that corpus by construction: they
+exercise the shape with entirely different synthetic node names and RRF
+scores, so a rule that only worked on "Halcyon" would fail here too.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+from dev_health_ops.context_fabric.graph_arm.backend import MatchMechanism
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    RetrievalMethod,
+    SemanticCandidate,
+    SemanticDisposition,
+    SemanticRetrieval,
+    assess_disposition,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+
+def _candidate(
+    canonical_id: str,
+    rrf_score: float,
+    rank: int,
+    *,
+    methods: frozenset[RetrievalMethod],
+) -> SemanticCandidate:
+    mechanism = (
+        MatchMechanism.EMBEDDING_SIMILARITY
+        if RetrievalMethod.COSINE in methods
+        else MatchMechanism.LEXICAL_FUZZY
+    )
+    return SemanticCandidate(
+        canonical_id=canonical_id,
+        kind=GraphEntityKind.PROJECT,
+        display_label=canonical_id,
+        signal=SubjectMatchSignal.FUZZY_LABEL,
+        mechanism=mechanism,
+        matched_text=canonical_id,
+        source_class=SourceClass.WORK_GRAPH,
+        methods=methods,
+        rrf_score=rrf_score,
+        rank=rank,
+    )
+
+
+def _retrieval(
+    candidates: tuple[SemanticCandidate, ...],
+    *,
+    bm25_order: tuple[str, ...] = (),
+    cosine_order: tuple[str, ...] = (),
+    query: str = "query",
+) -> SemanticRetrieval:
+    return SemanticRetrieval(
+        query=query,
+        candidates=candidates,
+        authorization_filtered_count=0,
+        withheld_canonical_ids=(),
+        retrieved_before_authorization=tuple(c.canonical_id for c in candidates),
+        bm25_order=bm25_order,
+        cosine_order=cosine_order,
+        observation_hits=(),
+    )
+
+
+_COSINE = frozenset({RetrievalMethod.COSINE})
+_BM25 = frozenset({RetrievalMethod.BM25})
+_BOTH = frozenset({RetrievalMethod.BM25, RetrievalMethod.COSINE})
+
+
+class TestNoMatchRefusesSafely:
+    """The two measured shapes: no lexical grounding anywhere."""
+
+    def test_a_nonexistent_entity_shaped_result_refuses(self) -> None:
+        """Held-out analogue of "How is Halcyon doing?" — 20 candidates.
+
+        Different node count, different scores, different names from the
+        measured case: only the shape is shared — BM25 found nothing at all,
+        and a wide field of cosine-only candidates decays smoothly with no
+        leader. If this rule only worked on the literal Halcyon numbers, it
+        would not refuse here.
+        """
+
+        candidates = tuple(
+            _candidate(f"proj_synthetic_{i}", 0.031 - i * 0.0007, i, methods=_COSINE)
+            for i in range(20)
+        )
+        retrieval = _retrieval(
+            candidates,
+            bm25_order=(),
+            cosine_order=tuple(c.canonical_id for c in candidates),
+        )
+        result = assess_disposition(retrieval)
+        assert result.disposition is SemanticDisposition.REFUSE
+        assert result.presented == ()
+
+    def test_a_referentless_pronoun_shaped_result_refuses(self) -> None:
+        """Held-out analogue of "What's holding it up?" — 11 candidates."""
+
+        candidates = tuple(
+            _candidate(f"wu_synthetic_{i}", 0.028 - i * 0.001, i, methods=_COSINE)
+            for i in range(11)
+        )
+        retrieval = _retrieval(candidates, bm25_order=())
+        result = assess_disposition(retrieval)
+        assert result.disposition is SemanticDisposition.REFUSE
+
+    def test_no_candidates_at_all_refuses(self) -> None:
+        result = assess_disposition(_retrieval(()))
+        assert result.disposition is SemanticDisposition.REFUSE
+        assert result.presented == ()
+
+    def test_a_lone_cosine_only_candidate_with_no_competition_refuses(self) -> None:
+        """One result is not automatically safe. Nothing corroborates it."""
+
+        candidate = _candidate("proj_lonely", 0.02, 0, methods=_COSINE)
+        retrieval = _retrieval((candidate,), bm25_order=("wu_unrelated",))
+        result = assess_disposition(retrieval)
+        assert result.disposition is SemanticDisposition.REFUSE
+
+
+class TestAGenuineLeaderProposes:
+    """The controls: a rule that never proposes is not a rule."""
+
+    def test_a_lexically_grounded_lone_candidate_proposes(self) -> None:
+        candidate = _candidate("proj_solo", 0.05, 0, methods=_BOTH)
+        retrieval = _retrieval((candidate,), bm25_order=("proj_solo",))
+        result = assess_disposition(retrieval)
+        assert result.disposition is SemanticDisposition.PROPOSE
+        assert result.presented == (candidate,)
+
+    def test_a_clear_margin_over_a_corroborated_leader_proposes(self) -> None:
+        leader = _candidate("proj_leader", 0.05, 0, methods=_BOTH)
+        runner_up = _candidate("proj_other", 0.02, 1, methods=_COSINE)
+        retrieval = _retrieval(
+            (leader, runner_up), bm25_order=("proj_leader", "some_other_hit")
+        )
+        result = assess_disposition(retrieval)
+        assert result.disposition is SemanticDisposition.PROPOSE
+        assert result.presented == (leader,)
+
+    def test_an_uncorroborated_leader_with_a_clear_margin_still_clarifies_or_refuses(
+        self,
+    ) -> None:
+        """FUZZY_LABEL alone never earns PROPOSE, margin or not.
+
+        A cosine-only leader with a wide margin over the next candidate is
+        still a single unverified vector guess; the contract's own
+        ``WEAK_SUBJECT_MATCH_SIGNALS`` rule is exactly why this leg does not
+        propose on cosine alone without lexical corroboration.
+        """
+
+        leader = _candidate("proj_leader", 0.05, 0, methods=_COSINE)
+        runner_up = _candidate("proj_other", 0.01, 1, methods=_COSINE)
+        retrieval = _retrieval((leader, runner_up), bm25_order=("something_else",))
+        result = assess_disposition(retrieval)
+        assert result.disposition is not SemanticDisposition.PROPOSE
+
+
+class TestATightFieldClarifies:
+    def test_two_near_tied_corroborated_candidates_clarify(self) -> None:
+        first = _candidate("proj_a", 0.030, 0, methods=_BOTH)
+        second = _candidate("proj_b", 0.029, 1, methods=_BOTH)
+        retrieval = _retrieval((first, second), bm25_order=("proj_a", "proj_b"))
+        result = assess_disposition(retrieval)
+        assert result.disposition is SemanticDisposition.CLARIFY
+        assert set(c.canonical_id for c in result.presented) == {"proj_a", "proj_b"}
+
+    def test_clarification_is_bounded_even_with_many_tied_candidates(self) -> None:
+        """Past the bound, a tied field is a diffuse ranking, not finalists."""
+
+        candidates = tuple(
+            _candidate(f"proj_tied_{i}", 0.030 - i * 0.0001, i, methods=_BOTH)
+            for i in range(9)
+        )
+        retrieval = _retrieval(
+            candidates, bm25_order=tuple(c.canonical_id for c in candidates)
+        )
+        result = assess_disposition(retrieval, clarification_limit=5)
+        assert result.disposition is SemanticDisposition.REFUSE, (
+            "9 tied candidates past a limit of 5 must not silently become an "
+            "enumeration of the authorized world under a clarify heading"
+        )
+
+    def test_clarification_candidates_are_within_the_configured_limit(self) -> None:
+        candidates = tuple(
+            _candidate(f"proj_tied_{i}", 0.030 - i * 0.0001, i, methods=_BOTH)
+            for i in range(4)
+        )
+        retrieval = _retrieval(
+            candidates, bm25_order=tuple(c.canonical_id for c in candidates)
+        )
+        result = assess_disposition(retrieval, clarification_limit=5)
+        assert result.disposition is SemanticDisposition.CLARIFY
+        assert len(result.presented) <= 5
+
+
+class TestTheRuleReadsShapeNotCorpusContent:
+    """Anti-corpus-tuning control: swap every identity, keep the shape."""
+
+    @pytest.mark.parametrize(
+        "prefix",
+        ["totally_unrelated_prefix", "another_org_shape", "zzz_synthetic"],
+    )
+    def test_the_no_match_shape_refuses_under_any_naming(self, prefix: str) -> None:
+        candidates = tuple(
+            _candidate(f"{prefix}_{i}", 0.03 - i * 0.0006, i, methods=_COSINE)
+            for i in range(15)
+        )
+        retrieval = _retrieval(candidates, bm25_order=())
+        result = assess_disposition(retrieval)
+        assert result.disposition is SemanticDisposition.REFUSE


### PR DESCRIPTION
## Issue and phase
CHAOS-3654 (Phase 2A, Lane D — Wave 3.2). Child of CHAOS-3666.

## Observable outcome
`semantic_retrieval.retrieve_candidates` previously returned every authorized fused BM25+cosine candidate up to `limit=25` with no confidence gate — a nonexistent entity or a referent-less pronoun still produced a full ranked list (measured: "How is Halcyon doing?" → 20 candidates, "What's holding it up?" → 11 candidates). This adds `assess_disposition()`, which reads the SHAPE of the fused result — lexical grounding, RRF rank-1/rank-2 margin, tie-cluster size — to choose:
- `PROPOSE` — one defensible lead candidate
- `CLARIFY` — a bounded (≤5) disambiguation set
- `REFUSE` — no defensible candidate at all

## Architecture boundary
Semantic retrieval still only proposes or refuses; it never forces a subject. `PROPOSE` is explicitly **not** contract-level `SubjectCommitmentState.COMMITTED` — every candidate here carries `SubjectMatchSignal.FUZZY_LABEL`, which `WEAK_SUBJECT_MATCH_SIGNALS` already forbids from justifying commitment alone (`investigation_contract/vocabulary.py:191-199`). This function only decides how much of the leg's own ranking is worth handing to whatever resolves the subject next.

## Scope / non-scope
In scope: `graph_arm/semantic_retrieval.py` only (my exclusive file per Lane D ownership). No contract, vocabulary, or packet_builder change.

Out of scope (named follow-up, not silently dropped): this leg is not yet wired into the production discovery path, and `trials/chaos_3647/legs.py` (the only current caller, via the CHAOS-3647 trial runner) is unchanged — adopting the new disposition there needs a live FalkorDB + real-embedder remeasurement pass I don't have standing infra to run truthfully in this PR. Tracked for the trial owner / next Phase 2A pass.

## Base/head
Base: `origin/feature/chaos-3498-context-fabric` @ `97ab49490` (exact tip, no drift). Head: `chaos-3661-quality`.

## Migrations / configuration / feature flags
None.

## Security / privacy / retention impact
None. Authorization filtering is unchanged (still runs inside `retrieve_candidates` before any candidate reaches this function); this only decides how much of an already-authorized ranking to trust.

## RED-first evidence
New `tests/context_fabric/test_chaos_3654_refusal_threshold.py`. Confirmed RED against pre-fix code (`ImportError: cannot import name 'SemanticDisposition'`) via `git stash` of the source change with the test file present, then GREEN after restoring the fix.

## Verification
- `.venv/bin/python -m pytest tests/context_fabric/test_chaos_3654_refusal_threshold.py tests/context_fabric/test_chaos_3647_semantic_leg.py tests/context_fabric/test_chaos_3620_semantic_safety.py -q` → 65 passed
- `.venv/bin/python -m pytest tests/context_fabric/ -q` → 1372 passed, 43 skipped (live-store gated, unaffected)
- `.venv/bin/python -m pytest tests/api/dev/ -q` → 2964 passed, 71 skipped, 4 xfailed
- `.venv/bin/ruff check` / `ruff format --check` → clean
- `.venv/bin/mypy src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py` → no issues
- lefthook pre-commit/pre-push (ruff + mypy over full project) → passed

## Known limitations and follow-up issues
- Margin/tie constants (`DEFAULT_MARGIN_RATIO=0.20`, `DEFAULT_TIE_RATIO=0.85`, `DEFAULT_CLARIFICATION_LIMIT=5`) are derived from RRF's own score-decay shape and validated on synthetic held-out cases, not on a live-model remeasurement of the frozen corpus. A live CHAOS-3647 remeasurement with this policy wired into `trials/chaos_3647/legs.py` is the natural next step and is left to the trial owner / next pass rather than done here without live infra.
- CHAOS-3653 (observation→entity hop) is a separate, related fix in the same module — not included here.

## Rollout / rollback impact
Purely additive (`assess_disposition` is a new function; `retrieve_candidates`'s existing return shape is untouched). Nothing currently calls it in a production or trial path, so this PR has zero runtime behavior change until a caller adopts it.