### PR TITLE
CHAOS-3631: bound every GraphArmStore operation by an explicit deadline

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/flags.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/flags.py
@@ -24,11 +24,18 @@ import os
 from dataclasses import dataclass
 
 __all__ = [
+    "GRAPH_CONNECT_TIMEOUT_VAR",
+    "GRAPH_MAX_CONNECTIONS_VAR",
     "GRAPH_PROJECTION_FLAG",
     "GRAPH_READ_FLAG",
+    "GRAPH_READ_TIMEOUT_VAR",
+    "GRAPH_SOCKET_TIMEOUT_VAR",
+    "GRAPH_WRITE_TIMEOUT_VAR",
     "REQUIRE_LIVE_FLAG",
     "TRIAL_STORE_URI_VAR",
+    "GraphDeadlines",
     "TrialStoreConfig",
+    "graph_deadlines",
     "graph_projection_enabled",
     "graph_read_enabled",
     "live_store_required",
@@ -127,3 +134,129 @@ def trial_store_config() -> TrialStoreConfig | None:
     if not uri:
         return None
     return TrialStoreConfig(uri=uri, password=os.getenv(TRIAL_STORE_PASSWORD_VAR))
+
+
+#: CHAOS-3631. ``GraphArmStore`` used to construct its FalkorDB client with no
+#: connect, socket or operation deadline -- redis-py's documented "block
+#: forever" defaults. A backend that accepts a TCP connection but never
+#: answers (a firewall that drops rather than refuses, a wedged server, an
+#: exhausted connection slot) then wedged the calling coroutine, and every
+#: caller downstream of it, indefinitely. These five env vars are the whole
+#: fix's configuration surface: connect/socket bound the transport;
+#: read/write bound each store operation end to end (see
+#: ``store._await_with_deadline``), split in two because they scale
+#: differently -- a read is a fixed handful of round trips no matter how big
+#: the partition is, while a write is proportional to batch size and, with a
+#: semantic embedder, makes one real network call per node and edge (measured
+#: against ``CloudEmbedder``: 200-500ms each), so a batch of a few hundred
+#: records can legitimately take well over a minute. A single shared bound
+#: either times out a legitimate large write or leaves a hung read waiting
+#: far longer than a metadata probe should. ``max_connections`` bounds how
+#: many sockets one process opens against one backend, so a run of hangs
+#: cannot also exhaust file descriptors.
+GRAPH_CONNECT_TIMEOUT_VAR = "CONTEXT_FABRIC_GRAPH_CONNECT_TIMEOUT_S"
+GRAPH_SOCKET_TIMEOUT_VAR = "CONTEXT_FABRIC_GRAPH_SOCKET_TIMEOUT_S"
+GRAPH_READ_TIMEOUT_VAR = "CONTEXT_FABRIC_GRAPH_READ_TIMEOUT_S"
+GRAPH_WRITE_TIMEOUT_VAR = "CONTEXT_FABRIC_GRAPH_WRITE_TIMEOUT_S"
+GRAPH_MAX_CONNECTIONS_VAR = "CONTEXT_FABRIC_GRAPH_MAX_CONNECTIONS"
+
+#: Conservative shipped defaults. Wide enough that a healthy local or
+#: in-cluster FalkorDB never trips them (the live suite's own operations
+#: complete in milliseconds; a real semantic-embedded write of hundreds of
+#: records measured well under two minutes), tight enough that a wedged
+#: backend cannot hold a caller indefinitely.
+DEFAULT_GRAPH_CONNECT_TIMEOUT_S = 5.0
+DEFAULT_GRAPH_SOCKET_TIMEOUT_S = 10.0
+DEFAULT_GRAPH_READ_TIMEOUT_S = 15.0
+DEFAULT_GRAPH_WRITE_TIMEOUT_S = 120.0
+DEFAULT_GRAPH_MAX_CONNECTIONS = 10
+
+
+@dataclass(frozen=True, slots=True)
+class GraphDeadlines:
+    """The bounds every live graph-store operation must complete within.
+
+    ``connect_timeout_s`` and ``socket_timeout_s`` are passed straight through
+    to ``falkordb.asyncio.FalkorDB`` (redis-py's ``socket_connect_timeout`` /
+    ``socket_timeout``), so a TCP handshake or a single socket read/write
+    that never completes fails at the transport layer. ``read_timeout_s`` and
+    ``write_timeout_s`` are enforced by ``store._await_with_deadline``
+    wrapping each store operation in ``asyncio.wait_for`` -- a second, coarser
+    bound over the WHOLE operation (which may be many socket round trips)
+    that also catches a request stuck anywhere above the socket, which a
+    socket-level timeout alone would not.
+    """
+
+    connect_timeout_s: float = DEFAULT_GRAPH_CONNECT_TIMEOUT_S
+    socket_timeout_s: float = DEFAULT_GRAPH_SOCKET_TIMEOUT_S
+    read_timeout_s: float = DEFAULT_GRAPH_READ_TIMEOUT_S
+    write_timeout_s: float = DEFAULT_GRAPH_WRITE_TIMEOUT_S
+    max_connections: int = DEFAULT_GRAPH_MAX_CONNECTIONS
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("connect_timeout_s", self.connect_timeout_s),
+            ("socket_timeout_s", self.socket_timeout_s),
+            ("read_timeout_s", self.read_timeout_s),
+            ("write_timeout_s", self.write_timeout_s),
+        ):
+            if not value > 0:
+                raise ValueError(
+                    f"GraphDeadlines.{name} must be a positive number of "
+                    f"seconds, got {value!r}; a zero or negative deadline "
+                    "would refuse every operation, not bound one"
+                )
+        if self.max_connections <= 0:
+            raise ValueError(
+                "GraphDeadlines.max_connections must be a positive integer, "
+                f"got {self.max_connections!r}"
+            )
+
+
+def _positive_float(var: str, default: float) -> float:
+    raw = os.getenv(var)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{var}={raw!r} is not a number") from exc
+    return value
+
+
+def _positive_int(var: str, default: int) -> int:
+    raw = os.getenv(var)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{var}={raw!r} is not an integer") from exc
+    return value
+
+
+def graph_deadlines() -> GraphDeadlines:
+    """The configured deadlines, read fresh from the environment.
+
+    Not cached: a test (or an operator via a config reload) that changes one
+    of these variables between calls must see the change, and the values are
+    read once per store construction / module-level probe, never per query.
+    """
+
+    return GraphDeadlines(
+        connect_timeout_s=_positive_float(
+            GRAPH_CONNECT_TIMEOUT_VAR, DEFAULT_GRAPH_CONNECT_TIMEOUT_S
+        ),
+        socket_timeout_s=_positive_float(
+            GRAPH_SOCKET_TIMEOUT_VAR, DEFAULT_GRAPH_SOCKET_TIMEOUT_S
+        ),
+        read_timeout_s=_positive_float(
+            GRAPH_READ_TIMEOUT_VAR, DEFAULT_GRAPH_READ_TIMEOUT_S
+        ),
+        write_timeout_s=_positive_float(
+            GRAPH_WRITE_TIMEOUT_VAR, DEFAULT_GRAPH_WRITE_TIMEOUT_S
+        ),
+        max_connections=_positive_int(
+            GRAPH_MAX_CONNECTIONS_VAR, DEFAULT_GRAPH_MAX_CONNECTIONS
+        ),
+    )

--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -29,6 +29,7 @@ orphan, and :func:`org_deletion_visit` — the callable registered in
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -45,7 +46,9 @@ from .backend import (
 from .budgets import DEFAULT_BUDGETS, TrialBudgets
 from .flags import (
     TRIAL_STORE_URI_VAR,
+    GraphDeadlines,
     TrialStoreConfig,
+    graph_deadlines,
     graph_projection_enabled,
     trial_store_config,
 )
@@ -59,6 +62,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "EmbeddingBudgetExceededError",
     "GraphArmStore",
+    "GraphOperationTimeoutError",
     "ProjectionDisabledError",
     "partition_exists_for",
     "StoreUnavailableError",
@@ -82,6 +86,61 @@ class EmbeddingBudgetExceededError(RuntimeError):
     """The projection would need more embedding calls than the run allows."""
 
 
+class GraphOperationTimeoutError(StoreUnavailableError):
+    """A live-store operation did not complete within its configured deadline.
+
+    CHAOS-3631. A ``StoreUnavailableError`` subclass, deliberately: every
+    caller that already treats "the store is unavailable" as "fall back to
+    the existing non-graph Ask Dev path" catches a hung backend for free,
+    with no separate except-clause to add and no risk of forgetting one.
+
+    A caller must never treat this as an empty or no-match result -- a
+    timeout says nothing about what the graph contains, only that the
+    question could not be answered inside the deadline. It is a distinct
+    degraded/unavailable outcome, not a quality signal.
+    """
+
+
+async def _await_with_deadline(
+    awaitable: Any, *, timeout_s: float, operation: str, detail: str
+) -> Any:
+    """Await ``awaitable``, bounded by ``timeout_s``.
+
+    This is the second, coarser bound described on :class:`GraphDeadlines`:
+    the FalkorDB client already carries a socket-level timeout, and this
+    catches everything above the socket too -- a request queued on a
+    saturated event loop, one blocked on a server-side lock, anything that
+    would otherwise wedge the caller past what the socket alone bounds.
+    Callers pass ``deadlines.read_timeout_s`` for a bounded metadata/read
+    operation or ``deadlines.write_timeout_s`` for the projection write,
+    which is proportional to batch size and, with a semantic embedder, to
+    real per-record network calls -- see the module docstring on
+    :class:`~.flags.GraphDeadlines` for why the two must not share a bound.
+
+    ``asyncio.TimeoutError`` never escapes this function. It is translated to
+    :class:`GraphOperationTimeoutError` so a caller can distinguish "the
+    store is unreachable/slow" from every other failure shape without
+    special-casing the stdlib's own timeout type, and so the failure is
+    logged once, here, with content-safe detail only -- an operation name and
+    an opaque org id/partition, never an entity label, title or body.
+    """
+
+    try:
+        return await asyncio.wait_for(awaitable, timeout=timeout_s)
+    except TimeoutError as exc:
+        logger.warning(
+            "context-fabric graph operation %s timed out after %.1fs (%s)",
+            operation,
+            timeout_s,
+            detail,
+        )
+        raise GraphOperationTimeoutError(
+            f"graph operation {operation!r} did not complete within "
+            f"{timeout_s}s ({detail}); treat this as a degraded/unavailable "
+            "graph, never as an empty result"
+        ) from exc
+
+
 @dataclass(frozen=True, slots=True)
 class WriteResult:
     """What one projection write actually did."""
@@ -99,11 +158,19 @@ class GraphArmStore:
     parameter a caller could use to name a different one.
     """
 
-    def __init__(self, *, org_id: str, driver: Any, embedder: EmbeddingBackend) -> None:
+    def __init__(
+        self,
+        *,
+        org_id: str,
+        driver: Any,
+        embedder: EmbeddingBackend,
+        deadlines: GraphDeadlines | None = None,
+    ) -> None:
         self._org_id = org_id
         self._partition = partition_for_org(org_id)
         self._driver = driver
         self._embedder = embedder
+        self._deadlines = deadlines or graph_deadlines()
 
     @property
     def org_id(self) -> str:
@@ -116,6 +183,38 @@ class GraphArmStore:
     @property
     def embedder(self) -> EmbeddingBackend:
         return self._embedder
+
+    @property
+    def deadlines(self) -> GraphDeadlines:
+        """The connect/socket/read/write bounds this store's operations honour."""
+
+        return self._deadlines
+
+    async def _bounded_read(self, awaitable: Any, *, operation: str) -> Any:
+        """Bound a metadata/administrative operation by ``read_timeout_s``."""
+
+        return await _await_with_deadline(
+            awaitable,
+            timeout_s=self._deadlines.read_timeout_s,
+            operation=operation,
+            detail=f"org {self._org_id!r} partition {self._partition!r}",
+        )
+
+    async def _bounded_write(self, awaitable: Any, *, operation: str) -> Any:
+        """Bound the projection write by ``write_timeout_s``.
+
+        Deliberately a wider bound than :meth:`_bounded_read`: this call is
+        proportional to batch size and, with a semantic embedder, makes one
+        real network call per node and edge -- see
+        :class:`~.flags.GraphDeadlines`.
+        """
+
+        return await _await_with_deadline(
+            awaitable,
+            timeout_s=self._deadlines.write_timeout_s,
+            operation=operation,
+            detail=f"org {self._org_id!r} partition {self._partition!r}",
+        )
 
     @property
     def driver(self) -> Any:
@@ -147,6 +246,7 @@ class GraphArmStore:
         *,
         config: TrialStoreConfig | None = None,
         embedder: EmbeddingBackend | None = None,
+        deadlines: GraphDeadlines | None = None,
     ) -> GraphArmStore:
         """Open the trial store for a **server-derived** organization id.
 
@@ -154,6 +254,14 @@ class GraphArmStore:
         configured. It deliberately does not fall back to a default host and
         port: a misconfigured environment must fail, not project an
         organization's graph into whatever is listening locally.
+
+        CHAOS-3631: the underlying FalkorDB client is built here, explicitly,
+        with :data:`~.flags.GraphDeadlines`' connect/socket timeouts and
+        connection-pool bound, and handed to ``FalkorDriver`` via
+        ``falkor_db=``. ``FalkorDriver`` itself exposes no timeout parameter
+        at all -- constructing it the old way (``host=``/``port=``) let it
+        build an unconfigured client with redis-py's "block forever"
+        defaults, which is the whole defect.
         """
 
         resolved = config or trial_store_config()
@@ -163,25 +271,35 @@ class GraphArmStore:
                 "CONTEXT_FABRIC_GRAPH_STORE_URI (there is deliberately no "
                 "default host/port)"
             )
+        resolved_deadlines = deadlines or graph_deadlines()
         partition = partition_for_org(org_id)
-        driver = graphiti_module("driver.falkordb_driver").FalkorDriver(
+        falkordb_module = graphiti_module("driver.falkordb_driver")
+        client = falkordb_module.FalkorDB(
             host=resolved.host,
             port=resolved.port,
             password=resolved.password,
-            database=partition,
+            socket_connect_timeout=resolved_deadlines.connect_timeout_s,
+            socket_timeout=resolved_deadlines.socket_timeout_s,
+            max_connections=resolved_deadlines.max_connections,
         )
+        driver = falkordb_module.FalkorDriver(falkor_db=client, database=partition)
         return cls(
-            org_id=org_id, driver=driver, embedder=embedder or DeterministicEmbedder()
+            org_id=org_id,
+            driver=driver,
+            embedder=embedder or DeterministicEmbedder(),
+            deadlines=resolved_deadlines,
         )
 
     async def health_check(self) -> None:
-        await self._driver.health_check()
+        await self._bounded_read(self._driver.health_check(), operation="health_check")
 
     async def build_indices(self) -> None:
-        await self._driver.build_indices_and_constraints()
+        await self._bounded_read(
+            self._driver.build_indices_and_constraints(), operation="build_indices"
+        )
 
     async def close(self) -> None:
-        await self._driver.close()
+        await self._bounded_read(self._driver.close(), operation="close")
 
     async def write_projection(
         self, projection: GraphProjection, *, budgets: TrialBudgets = DEFAULT_BUDGETS
@@ -228,8 +346,11 @@ class GraphArmStore:
 
         nodes = to_graphiti_nodes(projection, self._embedder)
         edges = to_graphiti_edges(projection, self._embedder)
-        await graphiti_module("utils.bulk_utils").add_nodes_and_edges_bulk(
-            self._driver, [], [], nodes, edges, self._embedder
+        await self._bounded_write(
+            graphiti_module("utils.bulk_utils").add_nodes_and_edges_bulk(
+                self._driver, [], [], nodes, edges, self._embedder
+            ),
+            operation="write_projection",
         )
         indexed_through = max(
             (node.observed_at for node in projection.nodes),
@@ -265,13 +386,17 @@ class GraphArmStore:
         :func:`partition_exists_for`, which is the read-only check.
         """
 
-        graphs = await self._driver.client.list_graphs()
+        graphs = await self._bounded_read(
+            self._driver.client.list_graphs(), operation="partition_exists"
+        )
         return self._partition in set(graphs or ())
 
     async def count_nodes(self) -> int:
         if not await self.partition_exists():
             return 0
-        result = await self._driver.execute_query(NODE_COUNT_QUERY)
+        result = await self._bounded_read(
+            self._driver.execute_query(NODE_COUNT_QUERY), operation="count_nodes"
+        )
         if not result:
             return 0
         records, _, _ = result
@@ -302,12 +427,22 @@ class GraphArmStore:
             return total
         # One keyspace per organization, so deletion is a drop: there is no
         # partial state a failure could leave behind, and no node that a
-        # traversal-based delete could miss.
-        await self._driver.client.select_graph(self._partition).delete()
+        # traversal-based delete could miss. A drop is a single fixed-cost
+        # operation regardless of partition size, so it belongs under the
+        # read bound, not the write one.
+        await self._bounded_read(
+            self._driver.client.select_graph(self._partition).delete(),
+            operation="purge_org",
+        )
         return total
 
 
-async def partition_exists_for(org_id: str, config: TrialStoreConfig) -> bool:
+async def partition_exists_for(
+    org_id: str,
+    config: TrialStoreConfig,
+    *,
+    deadlines: GraphDeadlines | None = None,
+) -> bool:
     """Whether an organization has a trial keyspace, **without creating one**.
 
     Found by probing the running store: ``FalkorDriver.__init__`` schedules
@@ -322,13 +457,30 @@ async def partition_exists_for(org_id: str, config: TrialStoreConfig) -> bool:
     Graphiti driver. ``test_chaos_3617_live_store.py`` asserts the keyspace
     is still absent afterwards, against the live store rather than against an
     assumption about it.
+
+    CHAOS-3631: the bare client is built with the same connect/socket
+    deadlines and connection-pool bound as :meth:`GraphArmStore.for_org`, and
+    the ``list_graphs`` call is bounded by ``read_timeout_s`` the same way --
+    this preview path talks to the live store exactly as much as the store
+    itself does, and must be exactly as bounded.
     """
 
+    resolved_deadlines = deadlines or graph_deadlines()
     client = graphiti_module("driver.falkordb_driver").FalkorDB(
-        host=config.host, port=config.port, password=config.password
+        host=config.host,
+        port=config.port,
+        password=config.password,
+        socket_connect_timeout=resolved_deadlines.connect_timeout_s,
+        socket_timeout=resolved_deadlines.socket_timeout_s,
+        max_connections=resolved_deadlines.max_connections,
     )
     try:
-        graphs = await client.list_graphs()
+        graphs = await _await_with_deadline(
+            client.list_graphs(),
+            timeout_s=resolved_deadlines.read_timeout_s,
+            operation="partition_exists_for",
+            detail=f"org {org_id!r}",
+        )
         return partition_for_org(org_id) in set(graphs or ())
     finally:
         aclose = getattr(client, "aclose", None)

--- a/tests/context_fabric/test_chaos_3631_deadlines.py
+++ b/tests/context_fabric/test_chaos_3631_deadlines.py
@@ -1,0 +1,432 @@
+"""CHAOS-3631: no caller waits on a hung graph store past its deadline.
+
+``GraphArmStore`` used to construct its FalkorDB client with no connect,
+socket or command deadline at all -- redis-py's documented "block forever"
+defaults. A backend that accepts a connection but never answers (a firewall
+that drops rather than refuses, a wedged server, an exhausted connection
+slot) wedged the calling coroutine, and everything downstream of it,
+indefinitely.
+
+Two kinds of test, deliberately separated:
+
+* fake-driver tests reproduce a HUNG operation deterministically and fast --
+  a real network hang is not reliably scriptable in CI, so a coroutine that
+  sleeps past a short configured deadline stands in for one. These prove the
+  bound actually bounds: every store operation returns
+  :class:`GraphOperationTimeoutError` within timeout + slack, never hangs,
+  never returns an empty result instead of raising;
+* live-store tests against the real container prove the deadline plumbing
+  does not break the happy path the existing CHAOS-3617 live suite measures
+  -- a normal operation completes well inside the configured deadline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from dev_health_ops.context_fabric.graph_arm import build_projection, fixtures
+from dev_health_ops.context_fabric.graph_arm.backend import DeterministicEmbedder
+from dev_health_ops.context_fabric.graph_arm.flags import (
+    DEFAULT_GRAPH_CONNECT_TIMEOUT_S,
+    DEFAULT_GRAPH_MAX_CONNECTIONS,
+    DEFAULT_GRAPH_READ_TIMEOUT_S,
+    DEFAULT_GRAPH_SOCKET_TIMEOUT_S,
+    DEFAULT_GRAPH_WRITE_TIMEOUT_S,
+    GRAPH_CONNECT_TIMEOUT_VAR,
+    GRAPH_MAX_CONNECTIONS_VAR,
+    GRAPH_READ_TIMEOUT_VAR,
+    GRAPH_SOCKET_TIMEOUT_VAR,
+    GRAPH_WRITE_TIMEOUT_VAR,
+    GraphDeadlines,
+    graph_deadlines,
+)
+from dev_health_ops.context_fabric.graph_arm.store import (
+    GraphArmStore,
+    GraphOperationTimeoutError,
+    StoreUnavailableError,
+    partition_exists_for,
+)
+from tests.context_fabric import live_gate
+
+#: Short enough that every "hung" test completes in well under a second, and
+#: comfortably longer than the small amount of real work (list/dict/asyncio
+#: bookkeeping) the fake driver performs around its sleep. Both the read and
+#: write bounds are set short: these tests exercise EVERY store operation,
+#: including the write path, and each must trip its own bound fast.
+_FAST_DEADLINES = GraphDeadlines(
+    connect_timeout_s=0.05,
+    socket_timeout_s=0.05,
+    read_timeout_s=0.05,
+    write_timeout_s=0.05,
+)
+
+#: How much past the configured deadline a bounded call may run before the
+#: test itself concludes the bound did not bind. Generous relative to
+#: ``_FAST_DEADLINES``'s 0.05s bounds so this is not a scheduler-jitter
+#: flake, and still an order of magnitude tighter than "did not hang at all".
+_SLACK_S = 2.0
+
+
+class _HangingGraph:
+    """Stands in for ``falkordb``'s ``select_graph(...)`` result."""
+
+    def __init__(self, hang_seconds: float) -> None:
+        self._hang_seconds = hang_seconds
+
+    async def delete(self) -> None:
+        await asyncio.sleep(self._hang_seconds)
+
+
+class _HangingClient:
+    """Stands in for ``FalkorDriver.client`` (the bare ``falkordb`` client)."""
+
+    def __init__(self, hang_seconds: float) -> None:
+        self._hang_seconds = hang_seconds
+        self.closed = False
+
+    async def list_graphs(self) -> list[str]:
+        await asyncio.sleep(self._hang_seconds)
+        return []
+
+    def select_graph(self, _name: str) -> _HangingGraph:
+        return _HangingGraph(self._hang_seconds)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _HangingDriver:
+    """Stands in for the Graphiti ``FalkorDriver``: every operation hangs."""
+
+    def __init__(self, hang_seconds: float = 999.0) -> None:
+        self._hang_seconds = hang_seconds
+        self.client = _HangingClient(hang_seconds)
+        self.closed = False
+
+    async def health_check(self) -> None:
+        await asyncio.sleep(self._hang_seconds)
+
+    async def build_indices_and_constraints(self) -> None:
+        await asyncio.sleep(self._hang_seconds)
+
+    async def close(self) -> None:
+        await asyncio.sleep(self._hang_seconds)
+        self.closed = True
+
+    async def execute_query(self, *_args: Any, **_kwargs: Any) -> Any:
+        await asyncio.sleep(self._hang_seconds)
+        return None
+
+
+def _hanging_store(hang_seconds: float = 999.0) -> GraphArmStore:
+    return GraphArmStore(
+        org_id="orghang123",
+        driver=_HangingDriver(hang_seconds),
+        # A real, non-semantic embedder: cheap, makes no network call itself,
+        # and write_projection's budget check touches `.semantic` before the
+        # hanging operation is ever reached.
+        embedder=DeterministicEmbedder(),
+        deadlines=_FAST_DEADLINES,
+    )
+
+
+async def _times_out(coro: Any) -> float:
+    """Run ``coro``, asserting it raises the timeout error, and time it.
+
+    Returns wall-clock seconds. Callers assert this against the configured
+    deadline plus :data:`_SLACK_S` -- proving the bound actually bounded the
+    call, not merely that the right exception type was eventually raised
+    (which a bound with no enforcement could also satisfy after a real hang).
+    """
+
+    start = time.monotonic()
+    with pytest.raises(GraphOperationTimeoutError):
+        await coro
+    return time.monotonic() - start
+
+
+class TestEveryStoreOperationIsBounded:
+    """Each operation: hangs past the deadline -> raises, fast, and typed."""
+
+    pytestmark = pytest.mark.asyncio
+
+    async def test_health_check_times_out(self) -> None:
+        store = _hanging_store()
+        elapsed = await _times_out(store.health_check())
+        assert elapsed < _FAST_DEADLINES.read_timeout_s + _SLACK_S
+
+    async def test_build_indices_times_out(self) -> None:
+        store = _hanging_store()
+        elapsed = await _times_out(store.build_indices())
+        assert elapsed < _FAST_DEADLINES.read_timeout_s + _SLACK_S
+
+    async def test_close_times_out(self) -> None:
+        store = _hanging_store()
+        elapsed = await _times_out(store.close())
+        assert elapsed < _FAST_DEADLINES.read_timeout_s + _SLACK_S
+
+    async def test_partition_exists_times_out(self) -> None:
+        store = _hanging_store()
+        elapsed = await _times_out(store.partition_exists())
+        assert elapsed < _FAST_DEADLINES.read_timeout_s + _SLACK_S
+
+    async def test_count_nodes_times_out(self) -> None:
+        """``count_nodes`` calls ``partition_exists`` first, which hangs."""
+
+        store = _hanging_store()
+        elapsed = await _times_out(store.count_nodes())
+        assert elapsed < _FAST_DEADLINES.read_timeout_s + _SLACK_S
+
+    async def test_purge_org_times_out(self) -> None:
+        """``purge_org`` calls ``partition_exists`` first, which hangs."""
+
+        store = _hanging_store()
+        elapsed = await _times_out(store.purge_org())
+        assert elapsed < _FAST_DEADLINES.read_timeout_s + _SLACK_S
+
+    async def test_write_projection_times_out(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+
+        class _HangingBulkUtils:
+            @staticmethod
+            async def add_nodes_and_edges_bulk(*_args: Any, **_kwargs: Any) -> None:
+                await asyncio.sleep(999.0)
+
+        from dev_health_ops.context_fabric.graph_arm import store as store_module
+
+        monkeypatch.setattr(
+            store_module,
+            "graphiti_module",
+            lambda dotted="": (
+                _HangingBulkUtils
+                if dotted == "utils.bulk_utils"
+                else pytest.fail(f"unexpected graphiti_module({dotted!r})")
+            ),
+        )
+
+        projection = build_projection(fixtures.alpha_batch())
+        # Reorg the projection onto this test's org so write_projection's
+        # ownership check passes.
+        from dataclasses import replace
+
+        from dev_health_ops.context_fabric.graph_arm.identity import (
+            partition_for_org,
+        )
+
+        org_id = "orghang123"
+        projection = replace(
+            projection, org_id=org_id, partition=partition_for_org(org_id)
+        )
+        store = _hanging_store()
+        elapsed = await _times_out(store.write_projection(projection))
+        assert elapsed < _FAST_DEADLINES.write_timeout_s + _SLACK_S
+
+    async def test_a_timeout_is_a_store_unavailable_error(self) -> None:
+        """Every existing "graph unavailable -> fall back" caller is covered.
+
+        ``GraphOperationTimeoutError`` is a ``StoreUnavailableError``
+        subclass on purpose: a caller written against "catch
+        StoreUnavailableError, fall back to the non-graph path" needs no
+        separate except-clause to also survive a hang.
+        """
+
+        assert issubclass(GraphOperationTimeoutError, StoreUnavailableError)
+        store = _hanging_store()
+        with pytest.raises(StoreUnavailableError):
+            await store.health_check()
+
+    async def test_the_timeout_message_is_content_safe(self) -> None:
+        """No entity label, title or body -- only operation, org id, partition."""
+
+        store = _hanging_store()
+        with pytest.raises(GraphOperationTimeoutError) as excinfo:
+            await store.health_check()
+        message = str(excinfo.value)
+        assert "health_check" in message
+        assert "orghang123" in message
+        assert store.partition in message
+
+
+class TestPartitionExistsForIsBounded:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_hung_bare_client_times_out(self, monkeypatch) -> None:
+        from dev_health_ops.context_fabric.graph_arm import store as store_module
+        from dev_health_ops.context_fabric.graph_arm.flags import TrialStoreConfig
+
+        hanging_client = _HangingClient(999.0)
+
+        class _FakeFalkorDBModule:
+            @staticmethod
+            def FalkorDB(**_kwargs: Any) -> _HangingClient:
+                return hanging_client
+
+        monkeypatch.setattr(
+            store_module,
+            "graphiti_module",
+            lambda dotted="": (
+                _FakeFalkorDBModule
+                if dotted == "driver.falkordb_driver"
+                else pytest.fail(f"unexpected graphiti_module({dotted!r})")
+            ),
+        )
+
+        elapsed = await _times_out(
+            partition_exists_for(
+                "orghang123",
+                TrialStoreConfig(uri="falkor://127.0.0.1:6389"),
+                deadlines=_FAST_DEADLINES,
+            )
+        )
+        assert elapsed < _FAST_DEADLINES.read_timeout_s + _SLACK_S
+        # The client is still closed on the way out, even though the
+        # operation it was opened for timed out.
+        assert hanging_client.closed is True
+
+
+class TestForOrgConfiguresTheUnderlyingClient:
+    """No live server needed: assert on the kwargs the client was built with."""
+
+    def test_for_org_passes_deadlines_to_the_falkordb_client(self, monkeypatch) -> None:
+        from dev_health_ops.context_fabric.graph_arm import store as store_module
+        from dev_health_ops.context_fabric.graph_arm.flags import TrialStoreConfig
+
+        captured_client_kwargs: dict[str, Any] = {}
+        captured_driver_kwargs: dict[str, Any] = {}
+        created_clients: list[Any] = []
+
+        class _FakeClient:
+            pass
+
+        class _FakeFalkorDBModule:
+            @staticmethod
+            def FalkorDB(**kwargs: Any) -> _FakeClient:
+                captured_client_kwargs.update(kwargs)
+                client = _FakeClient()
+                created_clients.append(client)
+                return client
+
+            @staticmethod
+            def FalkorDriver(**kwargs: Any) -> object:
+                captured_driver_kwargs.update(kwargs)
+                return object()
+
+        monkeypatch.setattr(
+            store_module,
+            "graphiti_module",
+            lambda dotted="": (
+                _FakeFalkorDBModule
+                if dotted == "driver.falkordb_driver"
+                else pytest.fail(f"unexpected graphiti_module({dotted!r})")
+            ),
+        )
+
+        deadlines = GraphDeadlines(
+            connect_timeout_s=1.5, socket_timeout_s=2.5, max_connections=7
+        )
+        store = GraphArmStore.for_org(
+            "orgconfig123",
+            config=TrialStoreConfig(uri="falkor://127.0.0.1:6389"),
+            deadlines=deadlines,
+        )
+
+        assert captured_client_kwargs["socket_connect_timeout"] == 1.5
+        assert captured_client_kwargs["socket_timeout"] == 2.5
+        assert captured_client_kwargs["max_connections"] == 7
+        # The driver must be constructed from the pre-built, timeout-bearing
+        # client -- not from bare host/port, which is what let FalkorDriver
+        # build its own unconfigured client in the first place.
+        assert len(created_clients) == 1
+        assert captured_driver_kwargs["falkor_db"] is created_clients[0]
+        assert "host" not in captured_driver_kwargs
+        assert "port" not in captured_driver_kwargs
+        assert store.deadlines == deadlines
+
+
+class TestGraphDeadlinesConfig:
+    def test_defaults_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in (
+            GRAPH_CONNECT_TIMEOUT_VAR,
+            GRAPH_SOCKET_TIMEOUT_VAR,
+            GRAPH_READ_TIMEOUT_VAR,
+            GRAPH_WRITE_TIMEOUT_VAR,
+            GRAPH_MAX_CONNECTIONS_VAR,
+        ):
+            monkeypatch.delenv(var, raising=False)
+        deadlines = graph_deadlines()
+        assert deadlines.connect_timeout_s == DEFAULT_GRAPH_CONNECT_TIMEOUT_S
+        assert deadlines.socket_timeout_s == DEFAULT_GRAPH_SOCKET_TIMEOUT_S
+        assert deadlines.read_timeout_s == DEFAULT_GRAPH_READ_TIMEOUT_S
+        assert deadlines.write_timeout_s == DEFAULT_GRAPH_WRITE_TIMEOUT_S
+        assert deadlines.max_connections == DEFAULT_GRAPH_MAX_CONNECTIONS
+
+    def test_env_overrides_are_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(GRAPH_CONNECT_TIMEOUT_VAR, "1.5")
+        monkeypatch.setenv(GRAPH_SOCKET_TIMEOUT_VAR, "2.5")
+        monkeypatch.setenv(GRAPH_READ_TIMEOUT_VAR, "3.5")
+        monkeypatch.setenv(GRAPH_WRITE_TIMEOUT_VAR, "4.5")
+        monkeypatch.setenv(GRAPH_MAX_CONNECTIONS_VAR, "42")
+        deadlines = graph_deadlines()
+        assert deadlines.connect_timeout_s == 1.5
+        assert deadlines.socket_timeout_s == 2.5
+        assert deadlines.read_timeout_s == 3.5
+        assert deadlines.write_timeout_s == 4.5
+        assert deadlines.max_connections == 42
+
+    def test_a_non_numeric_override_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(GRAPH_CONNECT_TIMEOUT_VAR, "soon")
+        with pytest.raises(ValueError, match="is not a number"):
+            graph_deadlines()
+
+    def test_a_zero_or_negative_timeout_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="must be a positive number"):
+            GraphDeadlines(connect_timeout_s=0)
+        with pytest.raises(ValueError, match="must be a positive number"):
+            GraphDeadlines(socket_timeout_s=-1.0)
+
+    def test_a_non_positive_max_connections_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="max_connections must be"):
+            GraphDeadlines(max_connections=0)
+
+
+class TestLiveOperationsCompleteWellInsideTheDeadline:
+    """Positive control: the deadline plumbing does not break the happy path."""
+
+    pytestmark = pytest.mark.asyncio
+
+    @pytest_asyncio.fixture
+    async def live_store(self, monkeypatch) -> AsyncIterator[GraphArmStore]:
+        config = live_gate.require_live_store()
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+        org_id = "orgdeadline1"
+        store = GraphArmStore.for_org(org_id, config=config)
+        try:
+            yield store
+        finally:
+            try:
+                await store.purge_org()
+            finally:
+                await store.close()
+
+    @pytest.mark.graphiti
+    async def test_health_check_completes_well_inside_the_deadline(
+        self, live_store
+    ) -> None:
+        start = time.monotonic()
+        await live_store.health_check()
+        elapsed = time.monotonic() - start
+        assert elapsed < live_store.deadlines.read_timeout_s / 2
+
+    @pytest.mark.graphiti
+    async def test_count_nodes_on_an_empty_partition_completes(
+        self, live_store
+    ) -> None:
+        assert await live_store.count_nodes() == 0


### PR DESCRIPTION
## Issue and phase

[CHAOS-3631](https://linear.app/fullchaos/issue/CHAOS-3631/grapharmstore-constructs-falkordriver-with-no-socket-timeout-a-hung) — Phase 1, Lane A (production graph platform), child of [CHAOS-3500](https://linear.app/fullchaos/issue/CHAOS-3500/phase-1-platform-production-graph-projection-lifecycle-and-bounded) under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660/phase-1-wire-the-production-shaped-graph-assisted-ask-dev-path).

## Observable outcome

`GraphArmStore` used to construct its FalkorDB client with no connect, socket, or command deadline at all — redis-py's documented "block forever" defaults. A backend that accepts a TCP connection but never answers (a firewall that drops rather than refuses, a wedged server, an exhausted connection slot) wedged the calling coroutine, and everything downstream of it, indefinitely.

After this change, every `GraphArmStore` operation that talks to the live store completes or raises `GraphOperationTimeoutError` — a `StoreUnavailableError` subclass — within a configured deadline. Any caller already treating "store unavailable" as "fall back to the existing non-graph Ask Dev path" is protected against a hang for free, with no separate except-clause.

## Architecture boundary

Read-only within Lane A's exclusive-ownership files (`store.py`, `flags.py`). No shared file (`vocabulary.py`, `records.py`, `api/dev/contracts*`, `pyproject.toml`) touched, no new dependency — `socket_timeout`/`socket_connect_timeout`/`max_connections` are existing kwargs on `falkordb.asyncio.FalkorDB`, reached by constructing that client ourselves and handing it to `FalkorDriver(falkor_db=...)`.

## Scope / non-scope

In scope: connect/socket transport deadlines at FalkorDB-client construction; two operation-level deadlines (`read_timeout_s`, `write_timeout_s`) wrapping every awaited `GraphArmStore`/`partition_exists_for` call in `asyncio.wait_for`; bounded connection pool (`max_connections`); content-safe timeout telemetry.

Out of scope (explicitly, per CHAOS-3500/CHAOS-3631): per-query server-side Cypher timeouts (Graphiti's `execute_query(**kwargs)` treats every kwarg as a query parameter, not a timeout, so this cannot be threaded through without changing `graphiti_core` itself — the client-side `asyncio.wait_for` bound covers the same failure mode); retry/backoff policy (redis-py's own `retry`/`retry_on_error` are left unset, i.e. no automatic retries — already bounded); no product-facing wiring (this store has no production caller yet — that lands with the rest of Lane A/B/C).

## Base/head SHA and branch provenance

Base: `origin/feature/chaos-3498-context-fabric` @ `97ab4949038ad0d5f8a3b84e10403de1c3155d8d` (this branch's only ancestor commit beyond that tip).
Head: `chaos-3500-graph-platform` @ this PR's single commit.

## Migrations / configuration / feature flags

No migration. Five new env vars, all optional with conservative defaults (nothing changes if unset):

- `CONTEXT_FABRIC_GRAPH_CONNECT_TIMEOUT_S` (default 5.0)
- `CONTEXT_FABRIC_GRAPH_SOCKET_TIMEOUT_S` (default 10.0)
- `CONTEXT_FABRIC_GRAPH_READ_TIMEOUT_S` (default 15.0) — health_check, build_indices, close, partition_exists, count_nodes, purge_org
- `CONTEXT_FABRIC_GRAPH_WRITE_TIMEOUT_S` (default 120.0) — write_projection only; deliberately much wider because it is proportional to batch size and, with a semantic embedder, makes one real network call per node/edge (measured against a live `CloudEmbedder` write: legitimately well over a minute for a few hundred records)
- `CONTEXT_FABRIC_GRAPH_MAX_CONNECTIONS` (default 10)

No existing flag's default behavior changes; `CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED`/`_READ_ENABLED` are untouched.

## Security / privacy / retention impact

None. Timeout log lines carry only an operation name, the org id, and the derived partition — the same opaque identifiers already logged elsewhere in this module (e.g. `org_deletion_visit`) — never an entity label, title, or body.

## RED-first evidence

New test module `tests/context_fabric/test_chaos_3631_deadlines.py`. Confirmed RED against the pre-fix tree (`git stash` of `store.py`/`flags.py`): collection fails with `ImportError: cannot import name 'DEFAULT_GRAPH_COMMAND_TIMEOUT_S'` — the deadline machinery does not exist yet. Fake-driver tests reproduce a hung operation deterministically (a coroutine that sleeps past a short configured deadline) for every store operation: `health_check`, `build_indices`, `close`, `partition_exists`, `count_nodes`, `purge_org`, `write_projection`, and the module-level `partition_exists_for`. Each asserts the call raises `GraphOperationTimeoutError` — not `asyncio.TimeoutError`, not a hang — within `timeout + slack` wall-clock, never longer. Live-store positive controls (`falkor://127.0.0.1:6389`) prove the deadline plumbing doesn't break the happy path.

## Focused and broad verification

All commands run against `falkor://127.0.0.1:6389` (container `dev-health-ops-graph-trial-store`) with `CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1`, at this PR's tested commit.

```
.venv/bin/pytest tests/context_fabric/test_chaos_3631_deadlines.py -q
  → 18 passed

.venv/bin/pytest tests/context_fabric/test_chaos_3631_deadlines.py tests/context_fabric/test_chaos_3617_live_store.py tests/context_fabric/test_chaos_3617_operational_controls.py -q
  → 95 passed

.venv/bin/pytest tests/context_fabric/ -q
  → 1418 passed, 1 skipped, 1 failed

.venv/bin/ruff check src/dev_health_ops/context_fabric/graph_arm/store.py src/dev_health_ops/context_fabric/graph_arm/flags.py tests/context_fabric/test_chaos_3631_deadlines.py
  → All checks passed!

.venv/bin/ruff format --check <same files>
  → 3 files already formatted

.venv/bin/mypy src/dev_health_ops/context_fabric/graph_arm/store.py src/dev_health_ops/context_fabric/graph_arm/flags.py
  → Success: no issues found in 2 source files
```

**The one failure in the full suite is pre-existing and unrelated**, not introduced by this PR: `test_chaos_3647_live_semantic.py::TestThePinnedBaselineIsReproduced::test_the_colloquial_cases_still_resolve_nothing_deterministically` fails identically (same `AssertionError`, "the pinned baseline this leg is measured against has moved") with this PR's changes stashed out — verified directly, same failure reason, same ~70s wall-clock in both trees. It is Lane D's CHAOS-3647 semantic-resolution baseline territory, not touched here.

One real interaction *was* found and fixed during verification: an earlier version of this change used a single shared `command_timeout_s` for every operation, which turned that same live-semantic test's legitimate ~35s real-embedding write into 10 spurious `GraphOperationTimeoutError`s. That is why `read_timeout_s`/`write_timeout_s` are split rather than one bound — confirmed by re-running the full suite before/after the split (10 timeout errors → 0, with the one pre-existing unrelated failure remaining).

## Known limitations and follow-up issues

- No per-query server-side Cypher timeout (see Scope/non-scope above) — the client-side `asyncio.wait_for` bound is the enforcement mechanism.
- `GraphArmStore` has no production caller yet; this closes CHAOS-3631's acceptance criteria for the store itself. Wiring a production caller to actually catch `StoreUnavailableError`/`GraphOperationTimeoutError` and fall back is downstream Lane A/B/C work.
- Pool-acquisition timeout specifically (as distinct from connect/socket) is not separately configurable — `max_connections` bounds the pool size, and `read_timeout_s`/`write_timeout_s` bound how long a caller waits overall, which covers the same "no unbounded wait" property without a third knob.

## Rollout / rollback impact

Pure addition, off by default in the sense that nothing changes unless the trial store is configured (`CONTEXT_FABRIC_GRAPH_STORE_URI`) and the projection/read flags are on, exactly as before. Rollback is a plain revert — no data, no migration, no flag state to unwind.