### PR TITLE
CHAOS-3652: add DISCOVERED_COHORT to the production intent contract

### DIFF
--- a/contracts/ask-dev/v2/examples/negative/dev_question_intent.v1.discovered_cohort_requires_organization_wide_cardinality.json
+++ b/contracts/ask-dev/v2/examples/negative/dev_question_intent.v1.discovered_cohort_requires_organization_wide_cardinality.json
@@ -1,0 +1,25 @@
+{
+  "cardinality": "singular",
+  "clarification_reason": null,
+  "client_hint_deprecation_warning": null,
+  "client_question_class_hint": null,
+  "comparison_mode": "none",
+  "confidence": 0.95,
+  "generated_at": "2026-07-28T12:00:00Z",
+  "intent_id": "discovered_cohort",
+  "interpretation_reasons": [
+    "Exact repository name matched."
+  ],
+  "interpreter_version": "intent_interpreter.v1",
+  "mention_ordinals": [
+    0
+  ],
+  "ranking_requested": false,
+  "requested_dimensions": [],
+  "requested_metric_ids": [],
+  "requires_clarification": false,
+  "schema_version": "dev_question_intent.v1",
+  "subject_kinds": [
+    "repository"
+  ]
+}

--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -47,6 +47,11 @@
           "case": "clarification_without_reason",
           "path": "examples/negative/dev_question_intent.v1.clarification_without_reason.json",
           "sha256": "647687109c9ac4b368c3907a7791061305e4d0e93aa26a307f42d8d10f0dba3f"
+        },
+        {
+          "case": "discovered_cohort_requires_organization_wide_cardinality",
+          "path": "examples/negative/dev_question_intent.v1.discovered_cohort_requires_organization_wide_cardinality.json",
+          "sha256": "d33f1320734a49f8cd8d18c9d3b77ee4962396ad6c0500dba229c40f9dfffec7"
         }
       ],
       "positive": {
@@ -56,7 +61,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_question_intent.v1.schema.json",
-        "sha256": "ab9aba605adc6d28366087aa1d543453e5fac7eae09b25adee806b63f62e492e"
+        "sha256": "dbaf9871984d64ebc6c9ea0e270fe069b5d0a2d0476df685b2b98cb19f7d88c1"
       },
       "schema_version": "dev_question_intent.v1"
     },
@@ -151,7 +156,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_investigation_plan.v1.schema.json",
-        "sha256": "ad300ef9d6716a5d5c090ade23ff4cb438e32e2acae4c63c63f8d3f006e90ba2"
+        "sha256": "e0b5f48243149aecbb49a3736e015fa53749865fc6fdfb9dbda1ddae3d1ddd76"
       },
       "schema_version": "dev_investigation_plan.v1"
     },

--- a/contracts/ask-dev/v2/schemas/dev_investigation_plan.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_investigation_plan.v1.schema.json
@@ -169,7 +169,7 @@
       "type": "string"
     },
     "QuestionIntentID": {
-      "description": "The twelve Wave 3.1 launch intents (Amendment TRD v2 \u00a74.1).",
+      "description": "The twelve Wave 3.1 launch intents (Amendment TRD v2 \u00a74.1), plus the\nCHAOS-3652 graph-assisted subjectless-cohort-discovery intent.",
       "enum": [
         "entity_status",
         "portfolio_status",
@@ -182,7 +182,8 @@
         "team_health",
         "team_workload_balance",
         "operational_deficiency_inventory",
-        "bounded_investigation"
+        "bounded_investigation",
+        "discovered_cohort"
       ],
       "title": "QuestionIntentID",
       "type": "string"

--- a/contracts/ask-dev/v2/schemas/dev_question_intent.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_question_intent.v1.schema.json
@@ -49,7 +49,7 @@
       "type": "string"
     },
     "QuestionIntentID": {
-      "description": "The twelve Wave 3.1 launch intents (Amendment TRD v2 \u00a74.1).",
+      "description": "The twelve Wave 3.1 launch intents (Amendment TRD v2 \u00a74.1), plus the\nCHAOS-3652 graph-assisted subjectless-cohort-discovery intent.",
       "enum": [
         "entity_status",
         "portfolio_status",
@@ -62,7 +62,8 @@
         "team_health",
         "team_workload_balance",
         "operational_deficiency_inventory",
-        "bounded_investigation"
+        "bounded_investigation",
+        "discovered_cohort"
       ],
       "title": "QuestionIntentID",
       "type": "string"

--- a/src/dev_health_ops/api/dev/contract_fixtures_v2.py
+++ b/src/dev_health_ops/api/dev/contract_fixtures_v2.py
@@ -1306,7 +1306,20 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
                     "dev_question_intent.v1",
                     lambda value: value.__setitem__("requires_clarification", True),
                 ),
-            )
+            ),
+            (
+                # CHAOS-3652: DISCOVERED_COHORT requires organization-wide
+                # cardinality (zero named mentions) -- the base fixture is
+                # singular/one-mention, so setting only intent_id already
+                # violates the invariant without needing to touch cardinality
+                # too, which keeps the mutation minimal and attributable to
+                # one clause.
+                "discovered_cohort_requires_organization_wide_cardinality",
+                changed(
+                    "dev_question_intent.v1",
+                    lambda value: value.__setitem__("intent_id", "discovered_cohort"),
+                ),
+            ),
         ],
         "dev_subject_mention.v1": [
             (

--- a/src/dev_health_ops/api/dev/contracts_v2/base.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/base.py
@@ -103,7 +103,9 @@ class EntityKind(StrEnum):
 
 
 class QuestionIntentID(StrEnum):
-    """The twelve Wave 3.1 launch intents (Amendment TRD v2 §4.1)."""
+    """The twelve Wave 3.1 launch intents (Amendment TRD v2 §4.1), plus the
+    CHAOS-3652 graph-assisted subjectless-cohort-discovery intent.
+    """
 
     ENTITY_STATUS = "entity_status"
     PORTFOLIO_STATUS = "portfolio_status"
@@ -117,6 +119,24 @@ class QuestionIntentID(StrEnum):
     TEAM_WORKLOAD_BALANCE = "team_workload_balance"
     OPERATIONAL_DEFICIENCY_INVENTORY = "operational_deficiency_inventory"
     BOUNDED_INVESTIGATION = "bounded_investigation"
+    #: CHAOS-3652: a question that names zero subjects but lexically
+    #: describes a bounded team/project cohort-discovery job ("which teams
+    #: are currently struggling?"), as distinct from a genuinely
+    #: unbounded/ambiguous zero-mention question (which stays
+    #: ``BOUNDED_INVESTIGATION``). Requires ``Cardinality.ORGANIZATION_WIDE``
+    #: (``DevQuestionIntent.validate_intent_invariants``), but that is a
+    #: **closed-universe** discovery job, never organization-wide sweep
+    #: authorization: the graph-assisted route this intent triggers resolves
+    #: it against a bounded, question-family-specific candidate universe
+    #: derived server-side from the authorized scope (CHAOS-3645's
+    #: ``graph_arm.cohort_discovery.discover_cohort`` proved this shape:
+    #: family -> closed candidate-kind set -> authorized universe -> narrow
+    #: via graph relationships/measurements -- never an unrestricted
+    #: enumeration). ``ORGANIZATION_WIDE`` here only encodes "zero named
+    #: mentions were extracted"; it must never be read, by any consumer, as
+    #: authorization to sweep every entity in the organization. See
+    #: CHAOS-3652/CHAOS-3660 for the full guardrail discussion.
+    DISCOVERED_COHORT = "discovered_cohort"
 
 
 class Cardinality(StrEnum):

--- a/src/dev_health_ops/api/dev/contracts_v2/intent.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/intent.py
@@ -125,6 +125,25 @@ class DevQuestionIntent(ContractModelV2):
             raise ValueError("plural cohort intent requires two or more mentions")
         if self.cardinality is Cardinality.ORGANIZATION_WIDE and self.mention_ordinals:
             raise ValueError("organization-wide intent cannot carry subject mentions")
+        # CHAOS-3652: DISCOVERED_COHORT is the graph-assisted, zero-mention
+        # cohort-discovery intent. It must carry ORGANIZATION_WIDE
+        # cardinality -- not because it authorizes an organization-wide
+        # sweep (it does not; see QuestionIntentID.DISCOVERED_COHORT's own
+        # docstring for the closed-universe semantics), but because zero
+        # named mentions is the one structural fact that makes "no unresolved
+        # named subject can ever widen into this route" true by construction
+        # rather than by convention. A SINGULAR or PLURAL_COHORT
+        # DISCOVERED_COHORT intent would mean a named-but-unresolved subject
+        # reached the cohort-discovery route -- exactly the widening the
+        # Wave 3.2 guardrails forbid.
+        if (
+            self.intent_id is QuestionIntentID.DISCOVERED_COHORT
+            and self.cardinality is not Cardinality.ORGANIZATION_WIDE
+        ):
+            raise ValueError(
+                "discovered-cohort intent requires organization-wide "
+                "cardinality (zero named mentions)"
+            )
         # The client-supplied question_class is a non-authoritative hint per
         # the Wave 3.1 request amendment: whenever it is present, the server
         # must record a content-free deprecation diagnostic rather than use

--- a/src/dev_health_ops/api/dev/contracts_v2/plan.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/plan.py
@@ -72,6 +72,12 @@ PLAN_REGISTRY: frozenset[str] = frozenset(
         # loop produced this" is the fix; borrowing a real plan's identity to
         # pass the membership check would misstate what actually ran.
         "legacy.tool_choice.v1",
+        # CHAOS-3652: another compatibility marker, same shape as
+        # "investigation.bounded.v1" above -- QuestionIntentID.DISCOVERED_COHORT
+        # is not plan-governed (it routes to the graph-assisted investigation
+        # seam, not ``self._plan_registry``/``DevInvestigationPlan``), but its
+        # frames still need a truthful, registry-member ``versions.plan_id``.
+        "investigation.discovered_cohort.v1",
     }
 )
 

--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -75,6 +75,12 @@ PLAN_ID_BY_INTENT: Mapping[QuestionIntentID, str] = {
     QuestionIntentID.TEAM_WORKLOAD_BALANCE: "balance.team_workload.v1",
     QuestionIntentID.OPERATIONAL_DEFICIENCY_INVENTORY: "deficiency.operational.v1",
     QuestionIntentID.BOUNDED_INVESTIGATION: "investigation.bounded.v1",
+    # CHAOS-3652: a compatibility marker, same shape as BOUNDED_INVESTIGATION's
+    # entry above -- no DevInvestigationPlan document exists or should exist
+    # for this id. DISCOVERED_COHORT routes to the graph-assisted
+    # investigation seam (orchestrator.py), never through
+    # ``self._plan_registry``/``PlanExecutor``.
+    QuestionIntentID.DISCOVERED_COHORT: "investigation.discovered_cohort.v1",
 }
 
 # Import-time totality, in both directions: an intent added without a plan, or

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -839,6 +839,36 @@ _DEFICIENCY_ANCHORS = _any_of(
     "missing controls",
     "process gaps",
 )
+#: CHAOS-3652. Deliberately disjoint from ``_HEALTH_ANCHORS``/``_WORKLOAD_
+#: ANCHORS``' phrases -- a zero-mention question already recognized by an
+#: earlier recognizer (``balance.team_workload``, ``health.team``,
+#: ``health.project``) must keep resolving to that intent; this recognizer
+#: is deliberately placed last in ``_RECOGNIZERS`` so it only catches what
+#: nothing else does, and never re-routes an existing recognized shape.
+_COHORT_DISCOVERY_SUBJECT_ANCHORS = _any_of(
+    "team",
+    "teams",
+    "project",
+    "projects",
+    "squad",
+    "squads",
+    "repo",
+    "repos",
+    "repository",
+    "repositories",
+    "service",
+    "services",
+)
+_COHORT_DISCOVERY_JUDGMENT_ANCHORS = _any_of(
+    "struggling",
+    "struggle",
+    "falling behind",
+    "underperforming",
+    "capacity-constrained",
+    "capacity constrained",
+    "unusually lightly loaded",
+    "lightly loaded",
+)
 _RANKING_ANCHORS = _any_of(
     "top ",
     "most ",
@@ -962,6 +992,27 @@ _RECOGNIZERS: tuple[_Recognizer, ...] = (
         "status.singular",
         QuestionIntentID.ENTITY_STATUS,
         lambda s: _STATUS_ANCHORS(s.normalized) and s.mention_count >= 1,
+    ),
+    # CHAOS-3652. Placed last, deliberately: every earlier recognizer keeps
+    # first-match-wins precedence over this one, so this only catches a
+    # zero-mention, cohort-discovery-shaped question that would otherwise
+    # fall all the way through to BOUNDED_INVESTIGATION -- never anything an
+    # existing launch-intent recognizer already claims. Gated on
+    # ``mention_count == 0`` (checked before ``MAX_MENTIONS`` capping and
+    # after untyped-name merging -- see ``_Signals``): a question naming
+    # something, resolved or not, must never route here (Wave 3.2's
+    # no-organization-widening-for-an-unresolved-name guardrail; also
+    # enforced structurally by ``DevQuestionIntent.validate_intent_
+    # invariants``, which rejects this intent at any cardinality other than
+    # ``ORGANIZATION_WIDE``).
+    _Recognizer(
+        "cohort.discovery",
+        QuestionIntentID.DISCOVERED_COHORT,
+        lambda s: (
+            s.mention_count == 0
+            and _COHORT_DISCOVERY_SUBJECT_ANCHORS(s.normalized)
+            and _COHORT_DISCOVERY_JUDGMENT_ANCHORS(s.normalized)
+        ),
     ),
 )
 

--- a/tests/api/dev/test_chaos_3295_investigation_plans_registry.py
+++ b/tests/api/dev/test_chaos_3295_investigation_plans_registry.py
@@ -60,9 +60,12 @@ def test_totality_every_core_intent_has_a_registered_plan():
             QuestionIntentID.OPERATIONAL_DEFICIENCY_INVENTORY,
             QuestionIntentID.PORTFOLIO_STATUS,
             QuestionIntentID.BOUNDED_INVESTIGATION,
+            QuestionIntentID.DISCOVERED_COHORT,
         }:
             # Explicitly out of CHAOS-3295 scope (3303/3304/3305, or never
-            # plan-governed at all for BOUNDED_INVESTIGATION).
+            # plan-governed at all for BOUNDED_INVESTIGATION and, per
+            # CHAOS-3652, DISCOVERED_COHORT -- it routes to the graph-assisted
+            # investigation seam, not a ``DevInvestigationPlan``).
             continue
         assert intent_id in CORE_PLANS_BY_INTENT, f"{intent_id} has no core plan"
 

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -278,6 +278,77 @@ def test_message_request_v2_has_no_authoritative_question_class_field() -> None:
 
 
 # ---------------------------------------------------------------------------
+# CHAOS-3652: DISCOVERED_COHORT requires organization-wide cardinality
+# (mutate-per-clause: each direction of the implication is tested
+# independently, plus a positive control proving the new clause doesn't
+# over-reject an unrelated intent/cardinality combination).
+# ---------------------------------------------------------------------------
+
+
+def _discovered_cohort_payload() -> dict[str, Any]:
+    payload = deepcopy(positive_fixtures()["dev_question_intent.v1"])
+    payload["intent_id"] = "discovered_cohort"
+    payload["cardinality"] = "organization_wide"
+    payload["subject_kinds"] = []
+    payload["mention_ordinals"] = []
+    payload["interpretation_reasons"] = ["cohort.discovery"]
+    return payload
+
+
+def test_discovered_cohort_accepts_organization_wide_cardinality() -> None:
+    """Positive control: the new clause must not over-reject the one
+    combination it exists to allow."""
+
+    intent = v2.DevQuestionIntent.model_validate(_discovered_cohort_payload())
+    assert intent.intent_id is v2.QuestionIntentID.DISCOVERED_COHORT
+    assert intent.cardinality is v2.Cardinality.ORGANIZATION_WIDE
+
+
+def test_discovered_cohort_rejects_singular_cardinality() -> None:
+    """CHAOS-3652 load-bearing guardrail, clause direction 1 of 2: a named
+    (even if unresolved) subject must never carry the ``DISCOVERED_COHORT``
+    intent -- that would be organization/cohort widening for a named
+    subject, which Wave 3.2 forbids structurally, not just by convention."""
+
+    payload = _discovered_cohort_payload()
+    payload["cardinality"] = "singular"
+    payload["subject_kinds"] = ["team"]
+    payload["mention_ordinals"] = [0]
+    with pytest.raises(ValidationError, match="discovered-cohort intent requires"):
+        v2.DevQuestionIntent.model_validate(payload)
+
+
+def test_discovered_cohort_rejects_plural_cohort_cardinality() -> None:
+    """CHAOS-3652 load-bearing guardrail, clause direction 2 of 2: an
+    explicit (named) cohort must never carry the ``DISCOVERED_COHORT``
+    intent -- that intent means "the graph discovered this cohort", not
+    "the user named these subjects"."""
+
+    payload = _discovered_cohort_payload()
+    payload["cardinality"] = "plural_cohort"
+    payload["subject_kinds"] = ["team"]
+    payload["mention_ordinals"] = [0, 1]
+    with pytest.raises(ValidationError, match="discovered-cohort intent requires"):
+        v2.DevQuestionIntent.model_validate(payload)
+
+
+def test_organization_wide_cardinality_is_unaffected_for_other_intents() -> None:
+    """Scope check: the new clause is gated on
+    ``intent_id is DISCOVERED_COHORT`` -- confirm it does not fire for an
+    unrelated intent that also happens to carry organization-wide
+    cardinality (e.g. today's ``BOUNDED_INVESTIGATION`` catch-all)."""
+
+    payload = deepcopy(positive_fixtures()["dev_question_intent.v1"])
+    payload["intent_id"] = "bounded_investigation"
+    payload["cardinality"] = "organization_wide"
+    payload["subject_kinds"] = []
+    payload["mention_ordinals"] = []
+    payload["interpretation_reasons"] = ["recognizer.none"]
+    intent = v2.DevQuestionIntent.model_validate(payload)
+    assert intent.intent_id is v2.QuestionIntentID.BOUNDED_INVESTIGATION
+
+
+# ---------------------------------------------------------------------------
 # TEAM as a first-class subject kind (v2 contract layer only)
 # ---------------------------------------------------------------------------
 

--- a/tests/api/dev/test_question_interpreter.py
+++ b/tests/api/dev/test_question_interpreter.py
@@ -95,6 +95,60 @@ async def test_an_unrecognized_question_degrades_rather_than_refusing() -> None:
     assert interpreted.intent.confidence < FALLBACK_CONFIDENCE_FLOOR
 
 
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Which teams are currently struggling?",
+        "Which projects are capacity-constrained?",
+    ],
+)
+@pytest.mark.asyncio
+async def test_subjectless_cohort_question_routes_to_discovered_cohort(
+    question: str,
+) -> None:
+    """CHAOS-3652: a zero-mention, bounded cohort-discovery question is
+    recognized as ``QuestionIntentID.DISCOVERED_COHORT`` (approved on
+    CHAOS-3660), distinct from a genuinely unbounded question, so it can be
+    routed to graph-assisted cohort discovery instead of the legacy loop
+    (routing itself is CHAOS-3502's job; this only proves the intent is
+    reachable). Was RED before the ``contracts_v2`` enum + this recognizer
+    landed -- see git history for the failing form.
+    """
+
+    interpreted = await _interpreter().interpret(request_for(question))
+    assert interpreted.intent.intent_id is QuestionIntentID.DISCOVERED_COHORT
+    assert interpreted.intent.cardinality is Cardinality.ORGANIZATION_WIDE
+    assert interpreted.intent.interpretation_reasons[0] != "recognizer.none"
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Is the Payments team currently struggling?",
+        "Is Nightfall capacity-constrained right now?",
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_named_subject_never_routes_to_discovered_cohort(
+    question: str,
+) -> None:
+    """CHAOS-3652 guardrail (team-lead condition, load-bearing): a question
+    that names a subject -- even one lexically shaped exactly like a
+    cohort-discovery question -- must never route to ``DISCOVERED_COHORT``.
+    That would be exactly the "unresolved named subject widens to
+    organization/cohort scope" shape Wave 3.2 forbids. Enforced lexically
+    here (the recognizer requires ``mention_count == 0``); enforced
+    structurally at the contract level by
+    ``test_discovered_cohort_rejects_singular_cardinality`` /
+    ``test_discovered_cohort_rejects_plural_cohort_cardinality`` in
+    ``test_contracts_v2.py``.
+    """
+
+    interpreted = await _interpreter().interpret(request_for(question))
+    assert interpreted.intent.intent_id is not QuestionIntentID.DISCOVERED_COHORT
+    assert interpreted.mentions, "expected a named subject to be extracted"
+
+
 @pytest.mark.asyncio
 async def test_recognizer_order_is_a_stable_tiebreak() -> None:
     """A question satisfying two recognizers always resolves the same way."""


### PR DESCRIPTION
## Issue and phase
CHAOS-3652 (Wave 3.2 Phase 1, Lane B — parent CHAOS-3502 / CHAOS-3660). Contract change approved on CHAOS-3660 by team-lead, four conditions, all addressed below and in the CHAOS-3652 comment thread.

## Observable outcome
Production's `dev_question_intent.v1` contract can now express "zero named subjects, but the question describes a bounded team/project cohort-discovery job" (`QuestionIntentID.DISCOVERED_COHORT`), distinct from a genuinely unbounded/ambiguous zero-mention question (still `BOUNDED_INVESTIGATION`). `question_interpreter.py` recognizes this shape lexically (e.g. "which teams are currently struggling?", "which projects are capacity-constrained?").

## Architecture boundary
Intent recognition only. This does **not** wire the graph-assisted investigation route — that's CHAOS-3502. A recognized `DISCOVERED_COHORT` question today safely falls through to the legacy free-form loop with a loud `plan_registry_gap` signal (same graceful-degradation path every other newly-recognized-but-unwired intent already uses in this codebase — never a regression, never a crash). No graph/`context_fabric` code is imported or touched. No canonical authority moved into the graph. No trial artifact rewritten.

## Scope / non-scope
**In scope:** `contracts_v2` enum member + invariant + compat plan-id token (shared contract, approved on CHAOS-3660); `question_interpreter.py` recognizer (Lane B exclusive); checked-in JSON Schema/fixture regen; a pre-existing totality-guard test fix (`test_chaos_3295_investigation_plans_registry.py`) surfaced by the full-suite run.
**Out of scope:** orchestrator routing branch, graph query interface, feature flags, canonical evidence admission (CHAOS-3502/3500/3664, separate PRs), web schema.graphql (see condition 3 below — no web codegen exists in this repo for this contract; the *ops-side* JSON Schema artifact is what's regenerated here).

## Base/head SHA and branch provenance
- Base: `origin/feature/chaos-3498-context-fabric` @ `97ab4949038ad0d5f8a3b84e10403de1c3155d8d` (merge-base, confirmed via `git merge-base`, unchanged since worktree setup).
- Head: `1076398da11b83fc1ca73da72d87e659ac4717b5` on `chaos-3502-routing`.
- One commit, narrow diff (13 files, 284 insertions / 9 deletions).

## Migrations/configuration/feature flags
None. No new `RunState`, no DB migration, no feature flag (this is intent-recognition only; routing/flags are CHAOS-3502).

## Security/privacy/retention impact
None directly. Structurally reinforces an existing safety guardrail: `DevQuestionIntent.validate_intent_invariants` now rejects `DISCOVERED_COHORT` at any cardinality other than `ORGANIZATION_WIDE` (zero named mentions) — makes "an unresolved named subject can never widen into cohort-discovery scope" true by construction, not just convention. See condition 1/2 below.

## RED-first evidence
`tests/api/dev/test_question_interpreter.py::test_subjectless_cohort_question_routes_to_discovered_cohort` originally asserted `intent.intent_id is QuestionIntentID.DISCOVERED_COHORT`, confirmed failing before this change with `AttributeError: type object 'QuestionIntentID' has no attribute 'DISCOVERED_COHORT'`. A characterization test proving today's gap behavior (`BOUNDED_INVESTIGATION`/`recognizer.none`) was added first, then deleted per its own docstring once the RED test went green (git history shows both).

## Team-lead's four approval conditions — addressed
1. **Negative test, unresolved named subject never routes to `DISCOVERED_COHORT`** (load-bearing): lexical (`test_a_named_subject_never_routes_to_discovered_cohort`) + structural/mutate-per-clause (`test_discovered_cohort_rejects_singular_cardinality`, `..._rejects_plural_cohort_cardinality`, plus positive control and scope-check) + a checked-in golden negative fixture.
2. **Closed-universe semantics stated in the contract itself**: `QuestionIntentID.DISCOVERED_COHORT`'s docstring in `contracts_v2/base.py` and the invariant's own comment in `intent.py`.
3. **GraphQL/web codegen check**: no `schema.graphql`/Strawberry exposure anywhere for `QuestionIntentID` (verified by grep across `api/graphql/`). It does reach a checked-in JSON Schema artifact (`contracts/ask-dev/v2/schemas/dev_question_intent.v1.schema.json` + `dev_investigation_plan.v1.schema.json`), regenerated here via `export_contracts_v2.py` and verified by `test_checked_in_contract_artifacts_have_no_drift`. Per that module's docstring, `dev-health-web`'s contract-fetch script is the intended eventual consumer (v1 today; CHAOS-3298 tracks its v2 repoint) — **no web repo change is part of this PR**; per the approved plan, ops lands first and web regenerates in a follow-up team-lead coordinates.
4. **Invariant tests mutate per-clause**: both directions of the new implication tested independently, plus positive control and cross-intent scope check (see condition 1's test list).

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_contracts_v2.py tests/api/dev/test_question_interpreter.py tests/api/dev/test_contracts.py -q
  → 433 passed
.venv/bin/python -m pytest tests/api/dev/test_orchestrator.py tests/api/dev/test_orchestrator_persistence.py tests/api/dev/test_chaos_3393_portfolio_orchestrator.py -q
  → 84 passed
.venv/bin/python -m pytest tests/llm/test_chaos_3452_qua_shadow_budget.py tests/api/dev/test_chaos_3389_qua_shadow.py tests/api/dev/test_chaos_3297_s3_wave_3_1_plans.py tests/api/dev/test_chaos_3295_investigation_plans_registry.py tests/api/dev/test_subject_preflight.py tests/api/dev/test_chaos_3295_investigation_plans_executor.py -q
  → 101 passed (one pre-existing totality-guard test broke first pass; fixed in this PR, see below)
.venv/bin/python -m pytest tests/api/dev -m "not benchmark and not clickhouse" -q -n 4 --dist loadscope
  → 2969 passed, 21 skipped, 4 xfailed, 0 failed
.venv/bin/ruff check / ruff format --check / mypy on all touched files → clean
```
Pre-commit and pre-push lefthook gates (ruff-fix, ruff-format, mypy, commit-msg, pre-push ruff/mypy) all passed locally.

**Genuine regression found and fixed by the broad run:** `test_chaos_3295_investigation_plans_registry.py::test_totality_every_core_intent_has_a_registered_plan` exhaustively iterates every `QuestionIntentID` member; `DISCOVERED_COHORT` needed to join its "never plan-governed" exclusion set (same reasoning as `BOUNDED_INVESTIGATION` — it routes to the graph-assisted seam, never a `DevInvestigationPlan`). Included in this PR.

## Known limitations and follow-up issues
- Orchestrator routing to the graph-assisted investigation is not part of this PR — CHAOS-3502 (in progress, same worktree/branch will host a follow-up PR).
- Recognizer phrase coverage is intentionally narrow ("struggling", "capacity-constrained", etc.) — broader/ranked cohort-question coverage is Lane D's CHAOS-3667.
- Web (`dev-health-web`) contract regeneration is not part of this PR (see condition 3).

## Rollout/rollback impact
None — additive contract change, no runtime behavior change reachable today (the recognizer can now assign `DISCOVERED_COHORT`, but nothing routes on it differently from any other unwired intent yet). Revert is a plain `git revert` with no data/migration implications.