### PR TITLE
CHAOS-3633: distinguish same-kind evidence records with a signed record locator

### DIFF
--- a/contracts/ask-dev-investigation/v1/manifest.json
+++ b/contracts/ask-dev-investigation/v1/manifest.json
@@ -92,7 +92,7 @@
       ],
       "schema": {
         "path": "schemas/ask_dev_investigation_packet.v1.schema.json",
-        "sha256": "1778efab1665b2d474f36e744d53ca4368ac7d4ee33eff25db843da017693a30"
+        "sha256": "4be6588398a055b0ba9ef2fd891df2c7cfe230f1c4d25ffbe2ba2db8536d6567"
       },
       "schema_version": "ask_dev_investigation_packet.v1"
     },
@@ -316,7 +316,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/ask_dev_evidence_coverage.v1.schema.json",
-        "sha256": "8f2f196f8d25e22c30adffd753e4ae096472597f2c5df22c04cd4f15c2956d6b"
+        "sha256": "3d693ddce205c0ea445dc9c70d6a8ebf4579124f4ee6e223610735de1f97a9ff"
       },
       "schema_version": "ask_dev_evidence_coverage.v1"
     },

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_evidence_coverage.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_evidence_coverage.v1.schema.json
@@ -209,6 +209,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_packet.v1.schema.json
+++ b/contracts/ask-dev-investigation/v1/schemas/ask_dev_investigation_packet.v1.schema.json
@@ -635,6 +635,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -78,7 +78,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
+        "sha256": "8712d49d50e56e71030e3dbe27e70c9387a749ee0367c712e48b6940eb5df17f"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -156,7 +156,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
+        "sha256": "8c92ecc438cef1331ef130862bc75bf565c4111e74d8a03b67eb229e620d41ae"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -213,7 +213,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_ref.v1.schema.json",
-        "sha256": "ec835b4334f2f627a14fbb361244b403fd8faed8825b051122e16780918cdf2b"
+        "sha256": "4f523fa4b63df80da741a75e0483384467b74e082bcd0648f9bd12d863422620"
       },
       "schema_version": "dev_evidence_ref.v1"
     },
@@ -232,7 +232,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_expansion.v1.schema.json",
-        "sha256": "615e2e20b938e0e1181dcd5681495352f30d515f7a45f3fb0dd6879d6cdc0628"
+        "sha256": "d3ab1a7dfe7c667ab05f58b210f9cf7274d7dc7b34d1c1861baf708e86023d38"
       },
       "schema_version": "dev_evidence_expansion.v1"
     },
@@ -345,7 +345,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "7e596208a1c2711a4d6b7d2e6ba202b971a1ae8eae0af215e06aa01511f3e07e"
+        "sha256": "52e8aa52e86b16596ae671e5672e59fe6a61541c0dc12bef5135794d8265c937"
       },
       "schema_version": "dev_tool_result.v1"
     },
@@ -383,7 +383,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "694eeacf026c3c6abe6363625d1188fa59c3b1d194713acd8754babeeaa0dfad"
+        "sha256": "1581f9d501b4bbfa5bd2e273ebae6d10e5e9073972eb2ea43a43394720a00122"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
@@ -514,6 +514,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
@@ -636,6 +636,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_evidence_expansion.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_evidence_expansion.v1.schema.json
@@ -156,6 +156,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_evidence_ref.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_evidence_ref.v1.schema.json
@@ -168,6 +168,21 @@
       "title": "Provenance",
       "type": "string"
     },
+    "record_locator": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Record Locator"
+    },
     "repository_ids": {
       "items": {
         "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
@@ -725,6 +725,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -658,6 +658,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -378,7 +378,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer_frame.v1.schema.json",
-        "sha256": "80a3b34dd46091d0067b7557c9333a337d1cc3c5506bddeef3c5c749bcf52e51"
+        "sha256": "9c140c634b0150fa5fab46427552af46e2fcfa2ca42a43daee6901e9f0d7d021"
       },
       "schema_version": "dev_answer_frame.v1"
     },
@@ -466,7 +466,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v2.schema.json",
-        "sha256": "2b4d7ad84527b080a0844b87554e8452a6d3eca80b41ad56cbf89a8503116ab2"
+        "sha256": "c843bdd88103af02a497cacc0bf73de068a80a36b766c8726b0c615ff4ce5d67"
       },
       "schema_version": "dev_answer.v2"
     },
@@ -485,7 +485,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v2.schema.json",
-        "sha256": "85e327677fd919beba5a7ae684c572befddd6474fbd2c0e3ea99576402bcd570"
+        "sha256": "19a3476fef002f7cd50ccc3a2c6ee9ad6dae9895e14cb3cf6fc81499bbe0d8cc"
       },
       "schema_version": "dev_stream_event.v2"
     }

--- a/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
@@ -1303,6 +1303,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
@@ -1020,6 +1020,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
@@ -1463,6 +1463,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -593,6 +593,19 @@ class DevEvidenceRef(ContractModel):
     ) = None
     repository_ids: list[OpaqueID] = Field(default_factory=list, max_length=20)
     valid_entity_ids: list[OpaqueID] = Field(default_factory=list, max_length=20)
+    #: CHAOS-3633. The SOURCE's own identity for this specific record,
+    #: distinct from ``entity_id`` (the entity the record is *about*).
+    #: ``None`` for every ref minted by ``search``/``expand`` today, which
+    #: describe one record per entity and never had a collision to prevent.
+    #: The canonical evidence-admission path (``EvidenceService.admit``)
+    #: always sets this to the submitted candidate's own locator, so two
+    #: distinct same-kind records about one entity -- two reviews on one
+    #: PR, two incidents about one project -- mint distinct handles instead
+    #: of colliding on one. Additive and optional so every currently
+    #: persisted ``dev_answer.v1`` evidence ref keeps verifying unchanged:
+    #: ``EvidenceReferenceSigner._payload`` binds this field into the
+    #: signed HMAC only when it is not ``None``.
+    record_locator: OpaqueID | None = None
     flags: DevEvidenceFlags
 
 

--- a/src/dev_health_ops/api/dev/evidence_service.py
+++ b/src/dev_health_ops/api/dev/evidence_service.py
@@ -16,7 +16,7 @@ import html
 import json
 import re
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from html.parser import HTMLParser
@@ -89,6 +89,13 @@ class EvidenceRecord:
     deleted: bool = False
     uncertain: bool = False
     conflicting: bool = False
+    #: CHAOS-3633. The source's own identity for this record, distinct from
+    #: ``entity_id`` -- see ``DevEvidenceRef.record_locator``. ``search``/
+    #: ``expand`` never set this. ``EvidenceService.admit`` overwrites it
+    #: unconditionally with the submitted candidate's own ``locator``
+    #: (never trusting a resolver to remember to set it): see ``admit``'s
+    #: docstring for why that is always correct for the admission path.
+    record_locator: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -392,6 +399,11 @@ class IdentityPayload(Protocol):
     def entity_id(self) -> str: ...
     @property
     def repository_ids(self) -> Sequence[str]: ...
+    #: CHAOS-3633. ``None`` for every identity that predates this field --
+    #: see ``DevEvidenceRef.record_locator`` for the collision this closes
+    #: and the backward-compatibility argument for the ``None`` default.
+    @property
+    def record_locator(self) -> str | None: ...
 
 
 class SignedIdentity(IdentityPayload, Protocol):
@@ -417,7 +429,7 @@ class EvidenceReferenceSigner:
     @staticmethod
     def _payload(org_id: str, evidence: IdentityPayload) -> bytes:
         repository_ids = sorted(evidence.repository_ids)
-        payload = {
+        payload: dict[str, object] = {
             "org": org_id,
             "source": evidence.source_system,
             "source_version": evidence.source_version,
@@ -425,6 +437,21 @@ class EvidenceReferenceSigner:
             "entity_id": evidence.entity_id,
             "repositories": repository_ids,
         }
+        # CHAOS-3633. Present only when set, so a payload with no locator
+        # (every native ``search``/``expand`` ref today, and every
+        # already-persisted ``dev_answer.v1`` reference) is byte-for-byte
+        # what this function produced before the field existed -- zero
+        # migration, every currently-issued handle keeps verifying.
+        #
+        # The key is a distinct, fixed, named JSON field -- never
+        # concatenated with ``entity_type``/``entity_id`` -- so
+        # ``(entity_type="a", record_locator="bc")`` and
+        # ``(entity_type="ab", record_locator="c")`` cannot collide the way
+        # naive string concatenation would
+        # (``test_adjacent_field_concatenation_cannot_collide_payloads``
+        # locks this).
+        if evidence.record_locator is not None:
+            payload["record_locator"] = evidence.record_locator
         return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
 
     def issue(self, org_id: str, record: EvidenceRecord) -> str:
@@ -679,6 +706,21 @@ class EvidenceService:
         refused by the existing code path rather than by a second one written
         here, and the emitted ref also stops claiming validity for entities
         that have nothing to do with it.
+
+        CHAOS-3633. ``record_locator`` on the minted ref is always the
+        submitted candidate's own ``locator`` -- overwritten unconditionally
+        after resolution, never left to whatever (if anything) the resolver
+        put on the ``EvidenceRecord`` it returned. That is safe, not merely
+        convenient: :class:`EvidenceCandidateResolver` -- see its docstring
+        -- answers exactly one question, "does the source have the record at
+        THIS locator", so a non-``None`` result is definitionally the record
+        for ``candidate.locator``. A resolver author cannot forget to make
+        two same-kind records about one entity mint distinct handles,
+        because this line does it regardless of what the resolver returns.
+        ``_minted_this_round`` below is the defense-in-depth backstop for
+        anything that could still defeat that -- a payload-encoding
+        regression, a future second minting path -- rather than the primary
+        mechanism.
         """
 
         await self._entitlement.require(org_id)
@@ -689,6 +731,12 @@ class EvidenceService:
             )
 
         admissions: list[EvidenceAdmission] = []
+        #: CHAOS-3633 non-vacuity backstop. Maps a minted ``evidence_ref_id``
+        #: to the locator that minted it THIS round. If a second,
+        #: DIFFERENT locator ever mints the identical handle, that is a
+        #: silent collision no matter its cause, and it is refused here
+        #: rather than returned as though it were a distinct, valid record.
+        _minted_this_round: dict[str, str] = {}
         for candidate in candidates:
             resolver = self._resolvers.get(candidate.source_system)
             if resolver is None:
@@ -738,14 +786,23 @@ class EvidenceService:
                 )
                 continue
             # Minted over the record the SOURCE returned, never over the
-            # candidate. A candidate that pointed at one record and got
-            # another back still yields a truthful handle, because the handle
-            # describes what the source actually had.
+            # candidate -- CONTENT always comes from ``record``, never
+            # ``candidate``. A candidate that pointed at one record and got
+            # another back still yields a truthful handle, because the
+            # handle describes what the source actually had.
+            #
+            # ``record_locator`` is the one exception, and it is an
+            # ADDRESS, not content: ``candidate.locator`` -- see class
+            # docstring -- is undisputedly the discovery layer's identity
+            # for the record it asked about, and ``resolver.resolve``
+            # already confirmed a genuine record exists at exactly that
+            # locator (see ``admit``'s own docstring, CHAOS-3633).
             #
             # ``valid_entity_ids`` is the record's OWN entity -- see the
             # docstring. That single-element set is what turns the existing
             # containment check in ``_authorize_expansion`` from a tautology
             # into the admission path's entity authorization.
+            record = replace(record, record_locator=candidate.locator)
             ref = self._to_ref(org_id, record, valid_entity_ids=(record.entity_id,))
             state, warning = await self._authorize_expansion(
                 org_id,
@@ -759,6 +816,17 @@ class EvidenceService:
                     EvidenceAdmission(candidate=candidate, state=state, warning=warning)
                 )
                 continue
+            colliding_locator = _minted_this_round.get(ref.evidence_ref_id)
+            if colliding_locator is not None and colliding_locator != candidate.locator:
+                admissions.append(
+                    EvidenceAdmission(
+                        candidate=candidate,
+                        state=EvidenceAvailability.UNAVAILABLE,
+                        warning="ambiguous_record_identity",
+                    )
+                )
+                continue
+            _minted_this_round[ref.evidence_ref_id] = candidate.locator
             admissions.append(
                 EvidenceAdmission(
                     candidate=candidate,
@@ -830,6 +898,7 @@ class EvidenceService:
             citation_text=sanitize_untrusted_text(record.raw_excerpt),
             repository_ids=list(record.repository_ids),
             valid_entity_ids=list(valid_entity_ids),
+            record_locator=record.record_locator,
             flags=DevEvidenceFlags(
                 stale=record.stale or record.freshness is FreshnessState.STALE,
                 unavailable=record.unavailable,

--- a/src/dev_health_ops/api/dev/investigation_plans/executor.py
+++ b/src/dev_health_ops/api/dev/investigation_plans/executor.py
@@ -107,6 +107,13 @@ class _CandidateIdentity:
     entity_type: str
     entity_id: str
     repository_ids: Sequence[str]
+    #: CHAOS-3633. ``None`` for every fact this executor derives -- none of
+    #: EVIDENCE_IDENTITY_TABLE's categories carry a source-record locator
+    #: distinct from ``entity_id`` -- which is also the correct default for
+    #: a handle minted before this field existed
+    #: (``EvidenceReferenceSigner._payload`` binds it only when set). See
+    #: ``evidence_service.IdentityPayload`` for the full property.
+    record_locator: str | None = None
 
 
 #: Codex finding (HIGH, 2026-08-02, round 2): raising the persistence

--- a/tests/api/dev/test_chaos_3297_s3_version_skew.py
+++ b/tests/api/dev/test_chaos_3297_s3_version_skew.py
@@ -121,9 +121,12 @@ def test_tolerant_parse_makes_the_pre_s3_frame_replayable() -> None:
 
 def test_tolerant_parse_changes_nothing_else() -> None:
     """ "Byte-identical" proof (team-lead's requirement 1): every field the
-    pre-s3 payload carried survives untouched -- the only delta introduced
-    anywhere in the round trip is the one new key on the one patched
-    metric.
+    pre-s3 payload carried survives untouched. The only deltas introduced
+    anywhere in the round trip are the one new key on the one patched
+    metric, the ``coverage.degraded_required_sources`` key CHAOS-3334 added,
+    and the ``record_locator`` key CHAOS-3633 added to every evidence ref --
+    all three additive, all three at their unset default for a payload that
+    predates them.
     """
 
     original = _pre_s3_payload()
@@ -149,9 +152,27 @@ def test_tolerant_parse_changes_nothing_else() -> None:
     frame = DevAnswerFrame.model_validate(patched)
     reserialized = frame.model_dump(mode="json")
     for key, value in original.items():
-        if key in {"metrics", "coverage"}:
+        if key in {"metrics", "coverage", "evidence"}:
             continue
         assert reserialized[key] == value, key
+
+    # ``evidence`` gained ``record_locator`` additively in CHAOS-3633 -- the
+    # same shape as ``coverage``'s ``degraded_required_sources`` below: a new
+    # optional field with a ``None`` default, no ``schema_version`` bump.
+    # This pre-s3 fixture predates the field entirely, so every ref's only
+    # addition is the new key at its unset default -- a pre-existing ref
+    # cannot have known a graph-admission record locator, so anything else
+    # here would be fabricated identity.
+    original_evidence = original["evidence"]
+    reserialized_evidence = reserialized["evidence"]
+    assert len(reserialized_evidence) == len(original_evidence)
+    for original_ref, reserialized_ref in zip(
+        original_evidence, reserialized_evidence, strict=True
+    ):
+        for key, value in original_ref.items():
+            assert reserialized_ref[key] == value, f"evidence.{key}"
+        assert set(reserialized_ref) - set(original_ref) == {"record_locator"}
+        assert reserialized_ref["record_locator"] is None
 
     # ``coverage`` gained ``degraded_required_sources`` additively in
     # CHAOS-3334 -- the same shape as this branch's own

--- a/tests/api/dev/test_evidence_service.py
+++ b/tests/api/dev/test_evidence_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
@@ -9,6 +11,7 @@ from dev_health_ops.api.dev.contracts import FreshnessState
 from dev_health_ops.api.dev.evidence_service import (
     MAX_EXPANSION_BYTES,
     EvidenceAvailability,
+    EvidenceCandidate,
     EvidenceRecord,
     EvidenceReferenceSigner,
     EvidenceService,
@@ -556,3 +559,346 @@ async def test_no_matches_is_distinct_from_unconfigured_optional_source() -> Non
         "work_items": EvidenceAvailability.NO_MATCHES,
         "acr": EvidenceAvailability.UNCONFIGURED,
     }
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3633: two same-kind records about one entity must not collide onto
+# one handle.
+# ---------------------------------------------------------------------------
+
+
+class _TwoRecordResolver:
+    """Resolves two DISTINCT records of the same kind about one entity.
+
+    Keyed by ``candidate.locator`` -- the source's own record identity
+    (CHAOS-3646, ``EvidenceCandidate.locator`` docstring) -- never by
+    ``entity_id``, which both records share on purpose: that sharing is
+    exactly the CHAOS-3633 scenario (two reviews on one PR, two incidents
+    about one project, ...).
+    """
+
+    source_system = "reviews"
+
+    def __init__(self, records_by_locator: dict[str, EvidenceRecord]) -> None:
+        self._records = records_by_locator
+
+    async def resolve(
+        self, *, org_id: str, scope: object, candidate: EvidenceCandidate
+    ) -> EvidenceRecord | None:
+        return self._records.get(candidate.locator)
+
+
+def _same_entity_record(locator: str, *, label: str) -> EvidenceRecord:
+    return EvidenceRecord(
+        source_system="reviews",
+        source_version="native.v1",
+        entity_type="pull_request",
+        entity_id="issue-1",
+        display_label=label,
+        observed_at=NOW,
+        freshness=FreshnessState.FRESH,
+        provenance="native",
+        confidence=1.0,
+        repository_ids=(),
+        raw_excerpt=f"{label} content, locator {locator}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_same_kind_records_about_one_entity_mint_distinct_handles() -> None:
+    """CHAOS-3633 RED-first: the defect this test demonstrates is a
+    denial-of-service on legitimate, distinct evidence. Before the fix,
+    ``EvidenceReferenceSigner._payload`` binds only
+    ``(org, source_system, source_version, entity_type, entity_id,
+    repositories)`` -- none of which differ between these two records, since
+    they are two DIFFERENT records about the SAME entity. Both mint the
+    identical ``evidence_ref_id``, and a caller enforcing "no repeated index
+    handle" (the frozen graph packet contract) refuses the second, genuine
+    record as though it were a duplicate of the first.
+    """
+
+    records = {
+        "review-1": _same_entity_record("review-1", label="First review"),
+        "review-2": _same_entity_record("review-2", label="Second review"),
+    }
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[_TwoRecordResolver(records)],
+    )
+    candidates = [
+        EvidenceCandidate(
+            source_system="reviews",
+            entity_type="pull_request",
+            entity_id="issue-1",
+            locator=locator,
+        )
+        for locator in ("review-1", "review-2")
+    ]
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(EntityKind.ISSUE, "issue-1"),
+        candidates=candidates,
+    )
+    first, second = result.admissions
+    assert first.state is EvidenceAvailability.AVAILABLE
+    assert second.state is EvidenceAvailability.AVAILABLE
+    assert first.evidence is not None
+    assert second.evidence is not None
+    assert first.evidence.display_label == "First review"
+    assert second.evidence.display_label == "Second review"
+    # The defect: without a distinct record identity in the signed payload,
+    # these two DIFFERENT records mint the SAME handle.
+    assert first.evidence.evidence_ref_id != second.evidence.evidence_ref_id
+
+
+def test_adjacent_field_concatenation_cannot_collide_payloads() -> None:
+    """Contract-owner condition 1: the signed payload is a JSON object with
+    a distinct named key per field, never a concatenation of
+    ``entity_type``/``record_locator`` -- so ``(entity_type="a",
+    record_locator="bc")`` and ``(entity_type="ab", record_locator="c")``
+    -- which a naive ``entity_type + record_locator`` string join WOULD
+    equate, both reducing to ``"abc"`` -- must sign to different bytes."""
+
+    left = EvidenceRecord(
+        source_system="reviews",
+        source_version="native.v1",
+        entity_type="a",
+        entity_id="issue-1",
+        display_label="Left",
+        observed_at=NOW,
+        freshness=FreshnessState.FRESH,
+        provenance="native",
+        confidence=1.0,
+        record_locator="bc",
+    )
+    right = replace(left, entity_type="ab", record_locator="c")
+    signer = EvidenceReferenceSigner(SECRET)
+    assert signer.issue("org-a", left) != signer.issue("org-a", right)
+
+
+class _RecordLocatorStrippingSigner(EvidenceReferenceSigner):
+    """A DELIBERATELY weakened encoder: identical to the real signer except
+    it drops ``record_locator`` from the signed payload -- i.e. exactly
+    today's pre-CHAOS-3633 behaviour. Exists only so the strip/forge tests
+    below can be shown failing against it, proving those tests actually
+    discriminate rather than passing by construction."""
+
+    @staticmethod
+    def _payload(org_id: str, evidence) -> bytes:
+        repository_ids = sorted(evidence.repository_ids)
+        payload = {
+            "org": org_id,
+            "source": evidence.source_system,
+            "source_version": evidence.source_version,
+            "entity_type": evidence.entity_type,
+            "entity_id": evidence.entity_id,
+            "repositories": repository_ids,
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _locator_bearing_record(locator: str) -> EvidenceRecord:
+    return EvidenceRecord(
+        source_system="reviews",
+        source_version="native.v1",
+        entity_type="pull_request",
+        entity_id="issue-1",
+        display_label="A review",
+        observed_at=NOW,
+        freshness=FreshnessState.FRESH,
+        provenance="native",
+        confidence=1.0,
+        repository_ids=(),
+        record_locator=locator,
+    )
+
+
+@pytest.mark.parametrize(
+    "signer_cls,discriminates",
+    [
+        pytest.param(EvidenceReferenceSigner, True, id="real_signer"),
+        pytest.param(_RecordLocatorStrippingSigner, False, id="weakened_signer"),
+    ],
+)
+def test_stripping_the_signed_locator_is_caught_only_by_the_real_signer(
+    signer_cls: type[EvidenceReferenceSigner], discriminates: bool
+) -> None:
+    """Contract-owner condition 2, strip direction: a ref signed WITH a
+    locator, then presented for verification WITHOUT one, must fail.
+    Parametrized over the real signer and the deliberately weakened one
+    above so this property is observed FAILING against the weak encoder
+    (``discriminates=False``) before it is trusted to pass against the real
+    one -- a strip test that could never fail proves nothing."""
+
+    signer = signer_cls(SECRET)
+    signed = _locator_bearing_record("review-1")
+    handle = signer.issue("org-a", signed)
+    stripped = replace(signed, record_locator=None)
+    verified = signer.verify(
+        "org-a",
+        SimpleNamespace(
+            evidence_ref_id=handle,
+            source_system=stripped.source_system,
+            source_version=stripped.source_version,
+            entity_type=stripped.entity_type,
+            entity_id=stripped.entity_id,
+            repository_ids=stripped.repository_ids,
+            record_locator=stripped.record_locator,
+        ),
+    )
+    # A stripped locator must NEVER verify against the real signer
+    # (``discriminates=True``), and -- observed here, not assumed -- DOES
+    # verify against the deliberately weakened one, which is exactly what
+    # makes the weakened encoder weak and this parametrization meaningful.
+    assert verified is not discriminates
+
+
+@pytest.mark.parametrize(
+    "signer_cls,discriminates",
+    [
+        pytest.param(EvidenceReferenceSigner, True, id="real_signer"),
+        pytest.param(_RecordLocatorStrippingSigner, False, id="weakened_signer"),
+    ],
+)
+def test_forging_a_different_locator_is_caught_only_by_the_real_signer(
+    signer_cls: type[EvidenceReferenceSigner], discriminates: bool
+) -> None:
+    """Contract-owner condition 2, forge direction: a ref signed for one
+    locator, then presented with a DIFFERENT locator substituted in, must
+    fail against the real signer -- and, observed here rather than assumed,
+    does NOT fail against the deliberately weakened one, proving this test
+    discriminates instead of passing by construction."""
+
+    signer = signer_cls(SECRET)
+    signed = _locator_bearing_record("review-1")
+    handle = signer.issue("org-a", signed)
+    forged = replace(signed, record_locator="review-2")
+    verified = signer.verify(
+        "org-a",
+        SimpleNamespace(
+            evidence_ref_id=handle,
+            source_system=forged.source_system,
+            source_version=forged.source_version,
+            entity_type=forged.entity_type,
+            entity_id=forged.entity_id,
+            repository_ids=forged.repository_ids,
+            record_locator=forged.record_locator,
+        ),
+    )
+    assert verified is not discriminates
+
+
+@pytest.mark.asyncio
+async def test_non_vacuity_admission_forces_distinct_locators_even_if_the_resolver_forgets() -> (
+    None
+):
+    """Contract-owner condition 3: same-kind multi-record admission MUST set
+    the locator -- unset-by-default must not be able to silently
+    reintroduce CHAOS-3633. The resolver below is deliberately "lazy": it
+    never sets ``record_locator`` on the ``EvidenceRecord`` it returns (the
+    field defaults to ``None``, exactly as every pre-fix resolver would).
+    ``EvidenceService.admit`` must still force distinctness by binding the
+    submitted candidate's own locator -- see ``admit``'s docstring -- so
+    this passes not because the resolver did the right thing, but because
+    the service does not let it get this wrong.
+    """
+
+    class _LazyResolver:
+        source_system = "reviews"
+
+        async def resolve(self, *, org_id, scope, candidate):
+            # Deliberately ignores ``candidate.locator`` when building the
+            # record -- ``record_locator`` stays at its ``None`` default.
+            return EvidenceRecord(
+                source_system="reviews",
+                source_version="native.v1",
+                entity_type="pull_request",
+                entity_id="issue-1",
+                display_label=f"Review at {candidate.locator}",
+                observed_at=NOW,
+                freshness=FreshnessState.FRESH,
+                provenance="native",
+                confidence=1.0,
+                repository_ids=(),
+            )
+
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[_LazyResolver()],
+    )
+    candidates = [
+        EvidenceCandidate(
+            source_system="reviews",
+            entity_type="pull_request",
+            entity_id="issue-1",
+            locator=locator,
+        )
+        for locator in ("review-1", "review-2")
+    ]
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(EntityKind.ISSUE, "issue-1"),
+        candidates=candidates,
+    )
+    first, second = result.admissions
+    assert first.evidence is not None and second.evidence is not None
+    assert first.evidence.evidence_ref_id != second.evidence.evidence_ref_id
+    assert first.evidence.record_locator == "review-1"
+    assert second.evidence.record_locator == "review-2"
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_handle_collision_within_one_round_is_refused_not_silently_merged() -> (
+    None
+):
+    """Defense-in-depth backstop for condition 3: even if two DIFFERENT
+    locators somehow minted the identical handle -- a payload-encoding
+    regression, not something reachable through the real signer today --
+    the second admission must be refused rather than silently returned as
+    though it were a distinct, valid record. Exercised with the
+    deliberately weakened (locator-blind) signer, which is exactly the kind
+    of regression this guard exists to catch.
+    """
+
+    class _TwoLocatorResolver:
+        source_system = "reviews"
+
+        async def resolve(self, *, org_id, scope, candidate):
+            return _locator_bearing_record(candidate.locator)
+
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=_RecordLocatorStrippingSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[_TwoLocatorResolver()],
+    )
+    candidates = [
+        EvidenceCandidate(
+            source_system="reviews",
+            entity_type="pull_request",
+            entity_id="issue-1",
+            locator=locator,
+        )
+        for locator in ("review-1", "review-2")
+    ]
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(EntityKind.ISSUE, "issue-1"),
+        candidates=candidates,
+    )
+    first, second = result.admissions
+    assert first.state is EvidenceAvailability.AVAILABLE
+    assert first.evidence is not None
+    assert second.state is EvidenceAvailability.UNAVAILABLE
+    assert second.evidence is None
+    assert second.warning == "ambiguous_record_identity"

--- a/tests/context_fabric/test_chaos_3646_evidence_admission.py
+++ b/tests/context_fabric/test_chaos_3646_evidence_admission.py
@@ -731,6 +731,9 @@ def test_a_refused_candidate_leaves_no_verifiable_residue() -> None:
         entity_type="work_item",
         entity_id="proj_quarry",
         repository_ids=(),
+        # What a genuine admission attempt for this locator would have
+        # bound (CHAOS-3633) -- the forgery is the entity, not the locator.
+        record_locator="wg_identity_rewrite",
     )
     assert signer.verify(ORG, forged) is False
 

--- a/trials/chaos_3646/canonical.py
+++ b/trials/chaos_3646/canonical.py
@@ -171,6 +171,13 @@ def record_for(
         # Carries the slug to the mint. Not emitted on the ref:
         # ``_safe_link`` ignores a path that does not start with "/".
         internal_path=evidence.slug,
+        # CHAOS-3633 platform fix: the slug IS this record's own locator --
+        # the same value ``_candidate()``'s ``locator`` field carries in
+        # this trial's own tests -- so ``EvidenceService.admit`` binding
+        # ``record_locator=candidate.locator`` and this function agree, and
+        # ``CorpusEvidenceSigner.verify`` (which calls this function with no
+        # candidate in scope at all) recomputes the identical payload.
+        record_locator=evidence.slug,
     )
 
 


### PR DESCRIPTION
Reopened from a child-issue-named branch, replacing #1634 (closed): that branch, chaos-3664-admission, carried the PARENT issue's ID, which is the root cause of the #1631 mass-closure bug (branch-name linkage auto-closes the linked issue and cascades to its children on merge). Identical commit, no code changes.

## Issue and phase
[CHAOS-3633](https://linear.app/fullchaos/issue/CHAOS-3633) — child of [CHAOS-3664](https://linear.app/fullchaos/issue/CHAOS-3664) (Phase 1, Lane C: productionize canonical graph evidence admission), under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660).

## Observable outcome
`EvidenceReferenceSigner` now mints distinct, stable handles for two same-kind source records about the same entity (two reviews on one PR, two incidents about one project), instead of colliding on one `evidence_ref_id` that the frozen graph packet contract's "no repeated index handle" rule then refused as though it were a duplicate.

## Architecture boundary
Fix lives entirely on the canonical admission side (`api/dev/evidence_service.py`, `api/dev/contracts.py`, `api/dev/investigation_plans/executor.py`). Does **not** touch `context_fabric/graph_arm/packet_builder.py` (Lane D's file per the CHAOS-3650 boundary ruling) — the CHAOS-3627 arm-side workaround there (`_mint_handle`'s canonical-id substitution, which breaks `signer.verify` round-trip on the emitted ref) can now be removed as a follow-up, since the platform payload carries real record identity again. Flagged to Lane D/team-lead, not done here.

## Scope / non-scope
In scope: signer payload + contract field + admission binding + protocol widening + tests + regenerated schema artifacts.
Out of scope: `packet_builder.py` (Lane D), real production `EvidenceCandidateResolver` adapters (separate, larger follow-up — production currently wires zero candidate resolvers, so admission is a structural no-op regardless of this fix), CHAOS-3650 partial-answer coordination.

## Base/head SHA and branch provenance
Base: `feature/chaos-3498-context-fabric` @ `97ab4949038ad0d5f8a3b84e10403de1c3155d8d`
Head: `chaos-3633-record-locator` @ `580af391ae5eeb501d15f6c7f92acbdbd04fe941` (same commit as the closed #1634, branch renamed only)

## Migrations/configuration/feature flags
None. No `schema_version` bump, no migration. `record_locator` is additive/optional on `DevEvidenceRef`; `EvidenceReferenceSigner._payload` includes it in the signed dict only when set, so every currently-issued/persisted `dev_answer.v1` evidence ref keeps verifying unchanged. Regenerated the checked-in JSON Schema artifacts the field touches: `contracts/ask-dev/v1`, `contracts/ask-dev/v2`, `contracts/ask-dev-investigation/v1` (additive-only diffs, reviewed).

## Security/privacy/retention impact
None negative. Strengthens the signed-handle identity binding. No new PII, no new persistence surface.

## RED-first evidence
`test_two_same_kind_records_about_one_entity_mint_distinct_handles`: two distinct `EvidenceRecord`s about one entity, differing only by resolver locator, observed minting the **identical** `evidence_ref_id` before the fix; passes after.

Contract-owner approval (CHAOS-3660) required three additional properties, each with its own test:
1. **Unambiguous encoding** — `test_adjacent_field_concatenation_cannot_collide_payloads`.
2. **Strip/forge round-trip** — `test_stripping_the_signed_locator_is_caught_only_by_the_real_signer` / `test_forging_a_different_locator_is_caught_only_by_the_real_signer`, each parametrized over the real signer and a deliberately weakened one, proving the tests discriminate.
3. **Non-vacuity** — `test_non_vacuity_admission_forces_distinct_locators_even_if_the_resolver_forgets` + `test_a_genuine_handle_collision_within_one_round_is_refused_not_silently_merged` (round-scoped duplicate guard, defense in depth).

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_evidence_service.py -v         # 19 passed
.venv/bin/python -m pytest tests/api/dev/ -q                                 # 2972 passed, 71 skipped, 4 xfailed
.venv/bin/python -m pytest tests/context_fabric/ -q                          # 1359 passed, 43 skipped
.venv/bin/mypy src/dev_health_ops/api/dev/ src/dev_health_ops/context_fabric/  # Success: no issues (110 + 26 files)
.venv/bin/ruff check / ruff format --check <changed files>                  # clean
pre-commit hook (mypy over full 2288-file tree)                             # Success: no issues
```

Downstream fixes required by the additive field, all re-verified rather than papered over:
- `trials/chaos_3646/canonical.py` (test infrastructure, **not** a frozen `trials/chaos_3619/results/*` measurement artifact) updated so its independent `verify()` recomputes the locator a genuine admission would bind.
- `tests/api/dev/test_chaos_3297_s3_version_skew.py` — a genuine frozen historical fixture (captured verbatim from `origin/main@47bf3c6e8`'s real producer, **fixture file itself untouched**) gains a `record_locator: null` key on every evidence ref when re-serialized; extended the test's own established pattern to assert this is the *only* new delta, at its unset default.

## Known limitations and follow-up issues
- Production wires zero `EvidenceCandidateResolver`s today, so this fix has no live production traffic yet — it unblocks the real-adapter work, doesn't complete it. Tracked as follow-up under CHAOS-3664.
- `packet_builder._mint_handle`'s CHAOS-3627 workaround removal — Lane D follow-up, flagged not done.

## Rollout/rollback impact
Pure additive contract + logic change behind no new flag; safe to revert independently. No data migration either direction.