### PR TITLE
CHAOS-3653: observation->entity hop for semantic subject resolution

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/readback.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/readback.py
@@ -81,6 +81,7 @@ __all__ = [
     "DiscoveredEntity",
     "DiscoveredObservation",
     "DiscoveredPath",
+    "EntityLookupRow",
     "GraphReader",
     "InvestigationReadout",
     "LiveGraphReader",
@@ -975,6 +976,26 @@ WHERE n.group_id = $partition
 RETURN DISTINCT n.cf_attachment_encoding AS attachment_encoding
 """
 
+#: CHAOS-3653: the observation->entity hop's one query.
+#:
+#: Bounded by construction, not by convention: an explicit ``$partition``
+#: and an explicit ``$canonical_ids IN`` list, never a wildcard and never a
+#: neighbourhood walk. The caller (:func:`~.semantic_retrieval.retrieve_candidates`)
+#: builds ``canonical_ids`` from nothing but the ``cf_subject_canonical_ids``
+#: already written on observation nodes that leg's OWN query already
+#: retrieved -- so this cannot become a general "look up anything" primitive
+#: no matter what a future caller passes, and it never widens beyond what an
+#: already-authorized observation named.
+_ENTITY_LOOKUP_BY_ID_QUERY = """
+MATCH (n:Entity)
+WHERE n.group_id = $partition AND n.cf_is_entity = true
+  AND n.cf_canonical_id IN $canonical_ids
+RETURN n.cf_canonical_id AS canonical_id,
+       n.cf_entity_kind AS entity_kind,
+       n.name AS display_label,
+       n.cf_source_class AS source_class
+"""
+
 
 #: Every Cypher statement the arm can issue, in one place.
 #:
@@ -993,6 +1014,7 @@ READ_ONLY_QUERIES: tuple[str, ...] = (
     _EDGE_QUERY,
     _PROJECTION_EMBEDDER_QUERY,
     _ATTACHMENT_ENCODING_QUERY,
+    _ENTITY_LOOKUP_BY_ID_QUERY,
     NODE_COUNT_QUERY,
 )
 
@@ -1206,6 +1228,70 @@ async def _rows(driver: Any, query: str, **params: object) -> list[dict[str, Any
         return []
     records, _, _ = result
     return list(records)
+
+
+@dataclass(frozen=True, slots=True)
+class EntityLookupRow:
+    """One entity, fetched by :func:`_entities_by_canonical_id`.
+
+    Deliberately narrower than :class:`DiscoveredEntity`: this is a
+    provenance lookup for a hop (CHAOS-3653), not a traversal result, and it
+    carries only what a caller needs to name and classify the entity it
+    landed on.
+    """
+
+    canonical_id: str
+    kind: GraphEntityKind
+    display_label: str
+    source_class: SourceClass
+
+
+async def _entities_by_canonical_id(
+    driver: Any, partition: str, canonical_ids: Sequence[str]
+) -> tuple[EntityLookupRow, ...]:
+    """Entity nodes for an explicit, caller-supplied id set. Nothing wider.
+
+    CHAOS-3653: subject resolution needs a bounded observation->entity hop
+    -- semantic/BM25 retrieval finds the right evidence and the resolver
+    still needs the canonical entity that evidence is about, which is not
+    something either search primitive returns. This is that lookup, and
+    the whole of it: an explicit id list, this partition only, and a
+    single-hop ``IN`` match with no relationship traversal at all.
+
+    A node without a legible ``cf_entity_kind`` or ``cf_source_class`` is
+    dropped rather than guessed at, matching
+    :func:`~.semantic_retrieval.retrieve_candidates`'s own rule for a node
+    this arm cannot classify.
+
+    An empty ``canonical_ids`` returns ``()`` without a query round trip --
+    the caller has nothing to hop to, and an unconditioned ``IN []`` is not
+    a query worth sending.
+    """
+
+    if not canonical_ids:
+        return ()
+    rows = await _rows(
+        driver,
+        _ENTITY_LOOKUP_BY_ID_QUERY,
+        partition=partition,
+        canonical_ids=list(canonical_ids),
+    )
+    results: list[EntityLookupRow] = []
+    for row in rows:
+        kind_value = row.get("entity_kind")
+        source_class_value = row.get("source_class")
+        display_label = row.get("display_label")
+        if kind_value is None or source_class_value is None or display_label is None:
+            continue
+        results.append(
+            EntityLookupRow(
+                canonical_id=row["canonical_id"],
+                kind=GraphEntityKind(kind_value),
+                display_label=display_label,
+                source_class=SourceClass(source_class_value),
+            )
+        )
+    return tuple(results)
 
 
 def _as_datetime(value: object) -> datetime:

--- a/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
@@ -77,7 +77,13 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from dev_health_ops.api.dev.contracts_v2.base import SourceClass
 from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
 
-from .backend import EmbeddingBackend, MatchMechanism, graphiti_module
+from .backend import (
+    OBSERVATION_SUBJECTS_ATTRIBUTE,
+    EmbeddingBackend,
+    MatchMechanism,
+    graphiti_module,
+)
+from .readback import _entities_by_canonical_id
 from .vocabulary import GraphEntityKind
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -208,6 +214,13 @@ class SemanticCandidate:
     rrf_score: float
     #: Zero-based rank within this query's authorized result.
     rank: int
+    #: CHAOS-3653: set when this candidate was not itself surfaced by BM25
+    #: or cosine, but reached via an authorized observation's own
+    #: ``cf_subject_canonical_ids`` -- retrieval found the right evidence,
+    #: not the entity's own name. ``None`` for a direct hit. Provenance a
+    #: caller needs: "inferred from an attached observation" and "matched
+    #: the entity's own label" are different claims about the same rank.
+    via_observation_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -444,6 +457,34 @@ def _attribute(node: Any, key: str) -> Any:
     return attributes.get(key)
 
 
+def _subject_canonical_ids(node: Any) -> tuple[str, ...]:
+    """What an observation node declares itself to be about.
+
+    Mirrors :func:`readback._rows`'s own parse of the same attribute
+    exactly (comma-joined, empty items dropped) so the two readers of this
+    property cannot silently disagree about what it means. A node that
+    never carries the attribute at all -- a partition written before
+    CHAOS-3619 (H3) added it -- returns ``()``: absence of the capability,
+    not absence of subjects, and the hop below simply has nothing to do for
+    it, which is the safe default.
+    """
+
+    raw = _attribute(node, OBSERVATION_SUBJECTS_ATTRIBUTE)
+    if not isinstance(raw, str) or not raw:
+        return ()
+    return tuple(item for item in raw.split(",") if item)
+
+
+@dataclass(frozen=True, slots=True)
+class _HopSource:
+    """The authorized observation that earned one subject its hop candidate."""
+
+    observation_id: str
+    matched_text: str
+    score: float
+    methods: frozenset[RetrievalMethod]
+
+
 @dataclass(frozen=True, slots=True)
 class FulltextReadiness:
     """Evidence that the BM25 half of a hybrid leg is actually live."""
@@ -609,6 +650,11 @@ async def retrieve_candidates(
     withheld: dict[str, None] = {}
     authorized = frozenset(authorized_entity_ids)
     candidates: list[SemanticCandidate] = []
+    # CHAOS-3653: the best authorized observation found for each subject a
+    # retrieved observation named. "Best" is the observation with the
+    # higher fused score, so a subject named by several observations hops
+    # via the one retrieval trusted most, not an arbitrary one.
+    hop_sources: dict[str, _HopSource] = {}
 
     for uuid in fused_uuids:
         node = by_uuid[uuid]
@@ -622,6 +668,22 @@ async def retrieve_candidates(
         kind_value = _attribute(node, _ENTITY_KIND_ATTRIBUTE)
         if kind_value is None:
             observations.append(canonical_id)
+            score = float(score_by_uuid[uuid])
+            for subject_id in _subject_canonical_ids(node):
+                if subject_id not in authorized:
+                    # Same disclosure as a direct hit: an unauthorized
+                    # subject named by an observation is withheld, not
+                    # silently absent -- the count is real either way.
+                    withheld.setdefault(subject_id, None)
+                    continue
+                existing = hop_sources.get(subject_id)
+                if existing is None or score > existing.score:
+                    hop_sources[subject_id] = _HopSource(
+                        observation_id=canonical_id,
+                        matched_text=node.name,
+                        score=score,
+                        methods=frozenset(methods[uuid]),
+                    )
             continue
         kind = GraphEntityKind(kind_value)
         if kind is GraphEntityKind.ORGANIZATION:
@@ -660,6 +722,53 @@ async def retrieve_candidates(
                 rank=len(candidates),
             )
         )
+
+    # CHAOS-3653: observation -> entity hop. Only for subjects an authorized
+    # observation named AND that did not already reach ``candidates``
+    # directly -- a direct hit already carries the stronger claim ("this
+    # entity's own name/text matched"), and duplicating it under a weaker
+    # inferred claim would be reporting the same subject twice.
+    already_present = {item.canonical_id for item in candidates}
+    hop_needed = tuple(
+        subject_id for subject_id in hop_sources if subject_id not in already_present
+    )
+    if hop_needed:
+        hop_entities = await _entities_by_canonical_id(driver, partition, hop_needed)
+        # Highest-scoring source observation first, so the hop tail is
+        # ranked exactly as the direct candidates are: strongest evidence
+        # first, ties broken by canonical id for a total, content-derived
+        # order.
+        hop_entities = tuple(
+            sorted(
+                hop_entities,
+                key=lambda item: (
+                    -hop_sources[item.canonical_id].score,
+                    item.canonical_id,
+                ),
+            )
+        )
+        for entity in hop_entities:
+            if entity.kind is GraphEntityKind.ORGANIZATION:
+                continue
+            source = hop_sources[entity.canonical_id]
+            candidates.append(
+                SemanticCandidate(
+                    canonical_id=entity.canonical_id,
+                    kind=entity.kind,
+                    display_label=entity.display_label,
+                    signal=SubjectMatchSignal.FUZZY_LABEL,
+                    mechanism=_mechanism_for(source.methods),
+                    # The observation's own stored text, not the entity's:
+                    # what actually matched was the evidence, and the
+                    # provenance field is what says so.
+                    matched_text=source.matched_text,
+                    source_class=entity.source_class,
+                    methods=source.methods,
+                    rrf_score=source.score,
+                    rank=len(candidates),
+                    via_observation_id=source.observation_id,
+                )
+            )
 
     return SemanticRetrieval(
         query=query,

--- a/tests/context_fabric/test_chaos_3653_observation_hop.py
+++ b/tests/context_fabric/test_chaos_3653_observation_hop.py
@@ -1,0 +1,348 @@
+"""CHAOS-3653: the observation -> entity hop.
+
+Retrieval can find the right EVIDENCE — an observation whose stored text
+matches the question — without the entity it is about ever matching the
+query itself. Before this, the resolver had no route from "the right
+observation" to "the right entity": the observation was counted in
+``observation_hits`` and thrown away, and the caller was left with whatever
+unrelated entities happened to rank nearby.
+
+Every test here plants the specific defect its guard exists to catch, same
+shape as ``test_chaos_3647_semantic_leg.py``: a fake driver returning an
+observation node that WOULD produce a wrong or absent hop unless the guard
+under test is what stops it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.context_fabric.graph_arm import semantic_retrieval
+from dev_health_ops.context_fabric.graph_arm.backend import (
+    OBSERVATION_SUBJECTS_ATTRIBUTE,
+)
+from dev_health_ops.context_fabric.graph_arm.readback import EntityLookupRow
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    RetrievalMethod,
+    retrieve_candidates,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+from . import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+_PARTITION = "cf_trial_org_test"
+
+
+@dataclass
+class _FakeNode:
+    uuid: str
+    name: str
+    group_id: str = _PARTITION
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def _entity_node(
+    uuid: str,
+    canonical_id: str,
+    label: str,
+    *,
+    kind: str = GraphEntityKind.PROJECT.value,
+    source_class: str = SourceClass.WORK_GRAPH.value,
+) -> _FakeNode:
+    return _FakeNode(
+        uuid=uuid,
+        name=label,
+        attributes={
+            "cf_canonical_id": canonical_id,
+            "cf_entity_kind": kind,
+            "cf_source_class": source_class,
+        },
+    )
+
+
+def _observation_node(
+    uuid: str,
+    canonical_id: str,
+    title: str,
+    *,
+    subject_canonical_ids: tuple[str, ...] = (),
+) -> _FakeNode:
+    attributes: dict[str, Any] = {"cf_canonical_id": canonical_id}
+    if subject_canonical_ids:
+        attributes[OBSERVATION_SUBJECTS_ATTRIBUTE] = ",".join(subject_canonical_ids)
+    return _FakeNode(uuid=uuid, name=title, attributes=attributes)
+
+
+@dataclass(frozen=True)
+class _SemanticEmbedder:
+    model_id: str = "test_semantic_double.v1"
+    semantic: bool = True
+
+    async def create(self, input_data: Any) -> list[float]:
+        return [0.0] * 8
+
+
+@dataclass(frozen=True)
+class _FakeStore:
+    driver: Any
+    partition: str
+    embedder: Any
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, *, bm25: list, cosine: list) -> dict:
+    live_gate.require_graphiti_extra()
+    from graphiti_core.search import search_utils
+
+    calls: dict[str, Any] = {}
+
+    async def fake_fulltext(driver, query, search_filter, group_ids, limit):
+        calls["bm25_group_ids"] = group_ids
+        return list(bm25)
+
+    async def fake_similarity(
+        driver, search_vector, search_filter, group_ids, limit, *args, **kwargs
+    ):
+        return list(cosine)
+
+    monkeypatch.setattr(search_utils, "node_fulltext_search", fake_fulltext)
+    monkeypatch.setattr(search_utils, "node_similarity_search", fake_similarity)
+    return calls
+
+
+def _install_entity_lookup(
+    monkeypatch: pytest.MonkeyPatch, rows: tuple[EntityLookupRow, ...]
+) -> dict:
+    """Replace the hop's one lookup query. Recorded, never executed for real."""
+
+    calls: dict[str, Any] = {}
+
+    async def fake_lookup(driver, partition, canonical_ids):
+        calls["partition"] = partition
+        calls["canonical_ids"] = tuple(canonical_ids)
+        return tuple(row for row in rows if row.canonical_id in canonical_ids)
+
+    monkeypatch.setattr(semantic_retrieval, "_entities_by_canonical_id", fake_lookup)
+    return calls
+
+
+class TestTheHopResolvesTheCorrectSubject:
+    async def test_a_retrieved_observation_hops_to_its_subject(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The measured case: "kept cycling in review" finds the review
+        observation and must resolve the project it is about."""
+
+        observation = _observation_node(
+            "u_obs",
+            "rv_vertex_cycles",
+            "Vertex review",
+            subject_canonical_ids=("proj_vertex",),
+        )
+        _install(monkeypatch, bm25=[observation], cosine=[observation])
+        lookup_calls = _install_entity_lookup(
+            monkeypatch,
+            (
+                EntityLookupRow(
+                    canonical_id="proj_vertex",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Vertex Platform",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+
+        result = await retrieve_candidates(
+            "kept cycling in review",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert [c.canonical_id for c in result.candidates] == ["proj_vertex"]
+        candidate = result.candidates[0]
+        assert candidate.via_observation_id == "rv_vertex_cycles"
+        assert candidate.display_label == "Vertex Platform"
+        assert candidate.matched_text == "Vertex review", (
+            "the matched text must be the observation's own stored text, "
+            "not the entity's name -- that is what actually matched"
+        )
+        assert lookup_calls["canonical_ids"] == ("proj_vertex",)
+        assert result.observation_hits == ("rv_vertex_cycles",)
+
+    async def test_an_observation_with_no_subject_attribute_hops_nowhere(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A partition written before the attachment attribute existed."""
+
+        observation = _observation_node("u_obs", "rv_old", "Old review")
+        _install(monkeypatch, bm25=[observation], cosine=[])
+        lookup_calls = _install_entity_lookup(monkeypatch, ())
+
+        result = await retrieve_candidates(
+            "anything",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert result.candidates == ()
+        assert "canonical_ids" not in lookup_calls, (
+            "an observation with nothing to hop to must not trigger a "
+            "lookup round trip at all"
+        )
+
+
+class TestTheHopIsAuthorized:
+    async def test_an_unauthorized_subject_is_withheld_not_returned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        observation = _observation_node(
+            "u_obs",
+            "rv_restricted_review",
+            "Restricted review",
+            subject_canonical_ids=("proj_restricted",),
+        )
+        _install(monkeypatch, bm25=[observation], cosine=[])
+        lookup_calls = _install_entity_lookup(
+            monkeypatch,
+            (
+                EntityLookupRow(
+                    canonical_id="proj_restricted",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Restricted Compliance",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+
+        result = await retrieve_candidates(
+            "restricted",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset(),
+        )
+
+        assert result.candidates == ()
+        assert result.authorization_filtered_count == 1
+        assert result.withheld_canonical_ids == ("proj_restricted",)
+        assert "canonical_ids" not in lookup_calls, (
+            "an unauthorized subject must never reach the lookup query -- "
+            "authorization is applied before the hop is even attempted, "
+            "not after"
+        )
+
+    async def test_the_organization_is_never_a_hop_candidate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        observation = _observation_node(
+            "u_obs",
+            "rv_org_note",
+            "Org-wide note",
+            subject_canonical_ids=("org_helio",),
+        )
+        _install(monkeypatch, bm25=[observation], cosine=[])
+        _install_entity_lookup(
+            monkeypatch,
+            (
+                EntityLookupRow(
+                    canonical_id="org_helio",
+                    kind=GraphEntityKind.ORGANIZATION,
+                    display_label="Helio",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+
+        result = await retrieve_candidates(
+            "helio",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"org_helio"}),
+        )
+        assert result.candidates == ()
+
+
+class TestTheHopDoesNotDuplicateADirectHit:
+    async def test_a_subject_found_directly_is_not_also_added_via_hop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        direct = _entity_node("u_direct", "proj_vertex", "Vertex Platform")
+        observation = _observation_node(
+            "u_obs",
+            "rv_vertex_cycles",
+            "Vertex review",
+            subject_canonical_ids=("proj_vertex",),
+        )
+        _install(monkeypatch, bm25=[direct, observation], cosine=[direct, observation])
+        lookup_calls = _install_entity_lookup(
+            monkeypatch,
+            (
+                EntityLookupRow(
+                    canonical_id="proj_vertex",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Vertex Platform",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+
+        result = await retrieve_candidates(
+            "vertex",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert [c.canonical_id for c in result.candidates] == ["proj_vertex"]
+        assert result.candidates[0].via_observation_id is None, (
+            "a subject that matched directly carries the stronger claim; "
+            "the weaker observation-derived one must not overwrite or "
+            "duplicate it"
+        )
+        assert "canonical_ids" not in lookup_calls, (
+            "the direct hit already satisfies this subject, so the hop "
+            "lookup must not even be attempted for it"
+        )
+
+
+class TestTheHopPicksTheStrongestSource:
+    async def test_two_observations_naming_the_same_subject_use_the_higher_score(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both observations are BM25 hits; only one is also a cosine hit,
+        so it fuses to a strictly higher RRF score and must win the hop."""
+
+        weak = _observation_node(
+            "u_weak", "rv_weak", "Weak mention", subject_canonical_ids=("proj_vertex",)
+        )
+        strong = _observation_node(
+            "u_strong",
+            "rv_strong",
+            "Strong mention",
+            subject_canonical_ids=("proj_vertex",),
+        )
+        _install(monkeypatch, bm25=[weak, strong], cosine=[strong])
+        _install_entity_lookup(
+            monkeypatch,
+            (
+                EntityLookupRow(
+                    canonical_id="proj_vertex",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Vertex Platform",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+
+        result = await retrieve_candidates(
+            "vertex",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert len(result.candidates) == 1
+        assert result.candidates[0].via_observation_id == "rv_strong"
+        assert result.candidates[0].methods == frozenset(
+            {RetrievalMethod.BM25, RetrievalMethod.COSINE}
+        )


### PR DESCRIPTION
## Issue and phase
CHAOS-3653 (Phase 2A, Lane D — Wave 3.2). Child of CHAOS-3666.

## Observable outcome
Semantic/BM25 retrieval can find the right EVIDENCE — an observation whose stored text matches the question — without the entity it is about ever matching the query text itself. Measured: "What happened with the project that kept cycling in review?" ranked the correct review-cycle observation first, and the resolver discarded it into `observation_hits` with no route to the entity it was about.

Adds a bounded observation→entity hop: a retrieved, authorized observation's own `cf_subject_canonical_ids` attribute (already written by projection for exactly this, CHAOS-3619 H3) names the entities it is about, and those become candidates too, via a new `SemanticCandidate.via_observation_id` field distinguishing "inferred from an attached observation" from a direct name/label match.

## Architecture boundary
The hop is bounded by construction: only the subject ids an already-retrieved, already-authorized observation names — no relationship traversal, no wildcard, no expansion beyond that one declared attribute. Authorization runs on the subject ids *before* any lookup (unauthorized subjects go to `withheld`/`authorization_filtered_count`, same as a direct hit, and never reach the lookup). A subject already found directly is never duplicated via the hop. The organization is never a hop candidate.

## Scope / non-scope
- `graph_arm/semantic_retrieval.py` (mine, exclusive): the hop logic, `via_observation_id` field.
- `graph_arm/readback.py` (not on my exclusive list or any other lane's named exclusion; flagged explicitly since it's shared read infrastructure): one new bounded, read-only Cypher query (`_ENTITY_LOOKUP_BY_ID_QUERY`), registered in `READ_ONLY_QUERIES` so `test_chaos_3617_containment.py`'s query-surface exhaustiveness guard stays meaningful. No change to any existing query, `InvestigationReadout`, traversal shape, or `QUERY_VERSION`.

Notable: the fetch helper (`_entities_by_canonical_id`) is **private**, not public. First pass exposed it as public and took `partition` directly — `test_chaos_3617_no_caller_supplied_partition.py` correctly failed 3 tests on that (no public callable may accept a caller-supplied partition). Fixed by making it private, called only internally by `retrieve_candidates` with the partition its own `store.partition` already derived.

## Base/head
Base: `origin/feature/chaos-3498-context-fabric` @ `e035cf0e8` (current tip after CHAOS-3654 merged; rebased before branching so this PR is one clean commit against the real tip, not a duplicate of the merged 3654 diff). Head: `chaos-3653-observation-hop`.

## Migrations / configuration / feature flags
None.

## Security / privacy / retention impact
None new. Authorization is applied to hop subject ids before the lookup query runs, matching the existing direct-hit rule exactly; disclosure (`authorization_filtered_count`/`withheld_canonical_ids`) is real either way.

## RED-first evidence
New `tests/context_fabric/test_chaos_3653_observation_hop.py`. Confirmed RED against pre-fix code via `git stash` of the source changes with the test file present (`ImportError: cannot import name 'EntityLookupRow'`), GREEN after. Also caught (RED, then fixed) a real regression against `test_chaos_3617_no_caller_supplied_partition.py` during development — see above.

## Verification
- `.venv/bin/python -m pytest tests/context_fabric/test_chaos_3653_observation_hop.py tests/context_fabric/test_chaos_3647_semantic_leg.py tests/context_fabric/test_chaos_3617_containment.py tests/context_fabric/test_chaos_3617_no_caller_supplied_partition.py -q` → 55 passed
- `.venv/bin/python -m pytest tests/context_fabric/ -q` → 1378 passed, 43 skipped
- `.venv/bin/python -m pytest tests/api/dev/ -q` → 2964 passed, 71 skipped, 4 xfailed
- ruff / mypy (module + full-project lefthook gate) → clean

## Known limitations and follow-up issues
- Not yet wired into a production or trial caller (same status as CHAOS-3654 — this leg is not currently invoked outside its own tests and `trials/chaos_3647/legs.py`, unchanged here).
- Multiple observations naming the same subject pick the higher-fused-score one; ties beyond that aren't specially resolved (falls to whichever is encountered first in fused order), which is an acceptable, disclosed limitation rather than a silent one.

## Rollout / rollback impact
Purely additive. `SemanticCandidate` gains a defaulted field; `SemanticRetrieval`'s existing shape is unchanged. Nothing currently calls `retrieve_candidates` in a production path.