### PR TITLE
CHAOS-3502: graph-assisted routing seam scaffolding (increment 1)

### DIFF
--- a/src/dev_health_ops/api/dev/graph_investigation_query.py
+++ b/src/dev_health_ops/api/dev/graph_investigation_query.py
@@ -1,0 +1,189 @@
+"""CHAOS-3502/CHAOS-3660: the production consumer-side graph-investigation seam.
+
+**Status: PROPOSAL, posted on CHAOS-3660 for Lane A review** (Wave 3.2 §8
+shared-contract protocol -- "graph query request/result contract" is a named
+stable seam). Lane B (this orchestrator/routing lane) owns the *consumer*
+side and is the one with an immediate need to call something; Lane A
+(CHAOS-3500) owns the real production implementation. Per the ratified plan
+(CHAOS-3660, team-lead), Lane B may bind orchestrator routing to this
+``Protocol`` and its own fake now; Lane A implements against it or
+counter-proposes, and team-lead arbitrates disagreement. Nothing here is a
+final spec.
+
+Why this shape, briefly (full reasoning in the CHAOS-3660 proposal comment):
+
+* The **result** reuses :class:`~.investigation_contract.AskDevInvestigationPacket`
+  wholesale rather than inventing a fourth output shape. It is already
+  documented (``investigation_contract/__init__.py``) as "the shared, frozen
+  wire shape every arm must emit... the input the Ask Dev frame reasons
+  over" -- exactly what a production caller needs, and reusing it is what
+  "no duplicate hand-maintained schemas" (handoff §8) asks for. Consuming it
+  from a real caller is NOT "trial construction copied into production":
+  the packet contract was built for cross-arm interop from the start.
+* The **request** deliberately does NOT expose the frozen trial's
+  ``QuestionFamilyID``/``AnalyticalJob`` vocabulary at this seam. That
+  registry is documented as "the frozen question-family registry for the
+  corrected trial" (``question_families.py``) with ten fixed families tied
+  to the trial's own exact/natural phrasings -- coupling production routing
+  to it directly would silently import trial-scoped assumptions into a
+  production contract. Instead the request carries what production's own
+  interpreter already computed (``QuestionIntentID``, ``Cardinality``,
+  resolved/unresolved mentions) and leaves any internal family/job
+  classification the graph service needs as Lane A's own implementation
+  detail, on Lane A's side of the seam.
+* **Authorization is supplied, never derived, at this seam.** Mirrors
+  ``graph_arm.readback.derive_authorized_entity_ids``'s own documented gap
+  (raises ``AuthorizationDerivationNotImplementedError`` today) -- the
+  orchestrator already knows the authorized/committed scope from
+  ``subject_preflight``/``scope_service`` before it would ever call this
+  seam, so there is no reason for the graph side to re-derive it, and doing
+  so would create two independent authorization computations that could
+  disagree.
+* **Deadline is absolute, not a duration.** CHAOS-3631 flagged unbounded
+  graph transport with no timeout; an absolute ``datetime`` deadline removes
+  the ambiguity a relative "give me 3 seconds" has once it crosses a queue,
+  a retry, or a slow caller.
+* **Transport/availability failure is a distinct axis from investigation
+  outcome.** ``AskDevInvestigationPacket.outcome`` (``InvestigationOutcome``)
+  only has semantic states (supported / needs_clarification / no_match /
+  unsupported) -- nothing for "the store was unreachable" or "the deadline
+  passed before this finished". Conflating the two would make a transport
+  failure indistinguishable from a legitimate no-match, which the handoff's
+  "missing/stale/unavailable/... remain distinct" guardrail forbids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol
+
+from .contracts_v2.base import Cardinality, QuestionIntentID
+from .contracts_v2.subject import DevSubjectMention
+from .investigation_contract import AskDevInvestigationPacket
+
+__all__ = [
+    "GraphInvestigationRequest",
+    "GraphQueryOutcome",
+    "GraphQueryResult",
+    "GraphInvestigationQuery",
+]
+
+
+class GraphQueryOutcome(StrEnum):
+    """The transport/availability axis -- distinct from the packet's own
+    semantic ``InvestigationOutcome``. A caller must be able to tell "the
+    graph route is unavailable, fall back" apart from "the graph route ran
+    and found nothing", and this is the only field that distinction lives
+    on.
+    """
+
+    #: The call completed before the deadline; ``GraphQueryResult.packet``
+    #: is populated and its own ``outcome`` field carries the semantic
+    #: result (which may itself be a refusal shape -- NO_MATCH,
+    #: NEEDS_CLARIFICATION, UNSUPPORTED -- that is still a completed call).
+    COMPLETED = "completed"
+    #: Projection/read is disabled (organization or runtime flag off).
+    #: Distinct from UNAVAILABLE: this is an intentional, configured state,
+    #: not a failure.
+    DISABLED = "disabled"
+    #: The graph store or service could not be reached at all.
+    UNAVAILABLE = "unavailable"
+    #: The projection is reachable but known stale beyond the caller's
+    #: tolerance (watermark lag). Distinct from UNAVAILABLE -- data exists,
+    #: it is just not current enough to answer from.
+    STALE = "stale"
+    #: The absolute deadline passed before the call completed.
+    DEADLINE_EXCEEDED = "deadline_exceeded"
+    #: The caller's own cancellation token fired (e.g. the parent Ask Dev
+    #: run was cancelled) before the call completed.
+    CANCELLED = "cancelled"
+    #: Any other provider-side failure the query service could not recover
+    #: from. Named rather than silently mapped to UNAVAILABLE so a caller
+    #: can distinguish "never reachable" from "reached, then broke".
+    PROVIDER_FAILURE = "provider_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class GraphInvestigationRequest:
+    """What the orchestrator already knows before it would call the graph
+    seam -- nothing here is derived BY the graph side; everything is
+    supplied.
+    """
+
+    org_id: str
+    run_id: str
+    #: Production's own interpreted intent (now including
+    #: ``QuestionIntentID.DISCOVERED_COHORT``, CHAOS-3652) and its cardinality.
+    #: The graph service classifies its own internal job/family from these
+    #: plus ``question_text`` -- production does not hand it a pre-classified
+    #: trial family.
+    intent_id: QuestionIntentID
+    cardinality: Cardinality
+    #: Already-extracted mentions (resolved or not -- resolution status is
+    #: NOT communicated here; see ``authorized_entity_ids`` below for what
+    #: the graph route may actually touch). Empty for
+    #: ``Cardinality.ORGANIZATION_WIDE`` (structurally, per
+    #: ``DevQuestionIntent.validate_intent_invariants``).
+    mentions: tuple[DevSubjectMention, ...]
+    #: The bounded (<=8KiB per ``DevMessageRequestV2``), already-validated
+    #: question text. Needed for the graph service's own family/candidate
+    #: classification. Server-side/internal only -- never echoed back
+    #: verbatim into a packet field a consumer renders untrusted (mirrors
+    #: the existing "no raw question text in logs/traces/labels" guardrail;
+    #: this is a same-process/internal call, not a log).
+    question_text: str
+    #: Supplied, never derived (see module docstring). The graph route must
+    #: never return, rank, or count toward truncation any entity outside
+    #: this set -- mirrors ``graph_arm.discover_cohort``'s own "authorization
+    #: applied on the way IN" invariant.
+    authorized_entity_ids: frozenset[str]
+    #: Absolute wall-clock deadline (CHAOS-3631). The query service must
+    #: return ``GraphQueryOutcome.DEADLINE_EXCEEDED`` rather than block past
+    #: this, under any internal retry/backoff it performs.
+    deadline: datetime
+    #: Bounded per the handoff's "max nodes, paths, depth, rows, bytes,
+    #: time, output budgets" requirement. Left as a generic mapping here
+    #: deliberately -- the concrete budget shape (node/path/hop/byte caps)
+    #: is exactly the kind of closed vocabulary CHAOS-3500 should define and
+    #: own; this proposal does not presume it.
+    budget_hints: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQueryResult:
+    outcome: GraphQueryOutcome
+    #: Populated iff ``outcome is GraphQueryOutcome.COMPLETED``. Its own
+    #: ``.outcome: InvestigationOutcome`` field carries the semantic result.
+    packet: AskDevInvestigationPacket | None = None
+    #: A short, content-safe (no raw question/entity text) diagnostic for
+    #: non-COMPLETED outcomes -- logged and telemetered, never shown to a
+    #: user verbatim.
+    diagnostic: str | None = None
+
+    def __post_init__(self) -> None:
+        if (self.outcome is GraphQueryOutcome.COMPLETED) != (self.packet is not None):
+            raise ValueError(
+                "GraphQueryResult.packet must be set if and only if "
+                "outcome is COMPLETED"
+            )
+
+
+class GraphInvestigationQuery(Protocol):
+    """The one call orchestrator routing makes into the graph-assisted seam.
+
+    Implementations MUST NOT raise for an ordinary unavailable/stale/
+    timeout/cancelled condition -- those are ``GraphQueryOutcome`` values,
+    not exceptions, so a caller can never accidentally let an unhandled
+    exception from this seam take down an otherwise-valid Ask Dev run
+    (mirrors ``investigation_shadow``'s "total exception containment"
+    posture, but for a route that DOES affect the answer, not a shadow).
+    An implementation MAY raise for a genuine programming error (a
+    malformed request), which is a bug in the caller, not a runtime
+    condition to model.
+    """
+
+    async def investigate(
+        self, request: GraphInvestigationRequest
+    ) -> GraphQueryResult: ...

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from collections import Counter
@@ -103,6 +104,7 @@ from .contracts_v2.frame import DevAnswerFrame
 from .contracts_v2.narrative import DevNarrative
 from .contracts_v2.plan import DevInvestigationPlan
 from .contracts_v2.subject import DevEntityRefV2
+from .graph_investigation_query import GraphInvestigationQuery
 from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
 from .investigation_shadow import (
@@ -962,6 +964,31 @@ class EventCancellationSignal:
 
 EventSink = Callable[[OrchestratorEvent], Awaitable[None]]
 
+#: CHAOS-3502: the runtime kill-switch for graph-assisted routing.
+#: Independent of the organization feature-policy gate
+#: (``licensing.registry.ASK_DEV_GRAPH_ROUTING_FEATURE``,
+#: ``production_runtime.py`` evaluates it and decides whether to construct a
+#: real ``GraphInvestigationQuery`` at all) -- same two-flag shape
+#: ``graph_arm.flags`` already uses for projection/read, and for the same
+#: reason: an operator needs a same-process kill switch that does not
+#: require a database round trip or waiting for an org-policy cache to
+#: invalidate, on TOP OF the organization opt-in, not instead of it. Default
+#: OFF, so an unset var is byte-identical to this seam not existing.
+GRAPH_ROUTING_RUNTIME_FLAG = "ASK_DEV_GRAPH_ROUTING_ENABLED"
+
+
+def graph_routing_runtime_enabled() -> bool:
+    """Whether the graph-assisted routing seam may run in this process.
+
+    Both this AND the organization feature-policy gate must be true for the
+    graph route to ever be attempted -- this function is only ever the
+    SECOND check, never a substitute for the org gate. See
+    ``GRAPH_ROUTING_RUNTIME_FLAG``'s own comment for why the two are
+    independent rather than one implying the other.
+    """
+
+    return os.getenv(GRAPH_ROUTING_RUNTIME_FLAG) == "1"
+
 
 class DevOrchestrator:
     """Execute one Ask Dev message as a bounded state machine."""
@@ -986,6 +1013,7 @@ class DevOrchestrator:
         qua_shadow: QuestionUnderstandingShadow | None = None,
         investigation_shadow: InvestigationShadow | None = None,
         investigation_packet_producer: InvestigationPacketProducer | None = None,
+        graph_investigation_query: GraphInvestigationQuery | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -1028,6 +1056,20 @@ class DevOrchestrator:
         # later changes production_runtime.py and nothing here.
         self._investigation_shadow = investigation_shadow
         self._investigation_packet_producer = investigation_packet_producer
+        # CHAOS-3502: ``None`` is the flag-off path -- no graph-assisted
+        # routing branch is attempted, byte-identical to this seam not
+        # existing (see ``test_chaos_3502_graph_routing_seam.py``'s
+        # inertness test). Even when set, ``run()`` also requires
+        # ``graph_routing_runtime_enabled()`` at the call site: the
+        # organization gate that decides whether to construct this at all
+        # (production_runtime.py) and the runtime kill switch are
+        # independent, mirroring ``graph_arm.flags``'s own
+        # projection/read-independence reasoning. As of this landing the
+        # branch only observes -- it does not yet turn a completed graph
+        # investigation into an answer; see the module docstring on
+        # ``graph_investigation_query.py`` and CHAOS-3502/CHAOS-3664 for the
+        # canonical-admission bridge that finishes this seam.
+        self._graph_investigation_query = graph_investigation_query
         self._composer = PromptComposer(registry)
 
     async def run(

--- a/src/dev_health_ops/licensing/registry.py
+++ b/src/dev_health_ops/licensing/registry.py
@@ -20,12 +20,21 @@ ASK_DEV_CONTEXTUAL_ENTRYPOINTS_FEATURE: Final = "ask_dev_contextual_entrypoints"
 #: behaves exactly as it does today: no server-owned interpretation, no subject
 #: preflight, every tool advertised, and the CHAOS-3289 backstop terminating.
 ASK_DEV_WAVE_3_1_FEATURE: Final = "ask_dev_wave_3_1"
+#: Wave 3.2 design-partner rollout gate (CHAOS-3502). Off means the run
+#: behaves exactly as it does today: no graph-assisted routing branch is
+#: attempted, whether or not the orchestrator was constructed with a
+#: ``graph_investigation_query`` -- this is the SECOND, organization-level
+#: gate; ``orchestrator.graph_routing_runtime_enabled()`` is the independent,
+#: same-process runtime kill switch. Both must be true for a run to attempt
+#: the graph route.
+ASK_DEV_GRAPH_ROUTING_FEATURE: Final = "ask_dev_graph_routing"
 EXPLICIT_PURCHASE_FEATURES: frozenset[str] = frozenset(
     {
         "agent_context_runtime",
         ASK_DEV_FEATURE,
         ASK_DEV_CONTEXTUAL_ENTRYPOINTS_FEATURE,
         ASK_DEV_WAVE_3_1_FEATURE,
+        ASK_DEV_GRAPH_ROUTING_FEATURE,
     }
 )
 ORG_OVERRIDE_ONLY_FEATURES: frozenset[str] = frozenset()
@@ -200,6 +209,13 @@ STANDARD_FEATURES: list[STANDARD_FEATURE_ROW] = [
         FeatureCategory.ANALYTICS,
         LicenseTier.COMMUNITY,
         "Server-owned question intent and named-subject preflight",
+    ),
+    (
+        ASK_DEV_GRAPH_ROUTING_FEATURE,
+        "Ask Dev Graph-Assisted Routing",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.COMMUNITY,
+        "Graph-assisted investigation for ambiguous, bounded, relational, and cohort questions (design-partner beta)",
     ),
     (
         "scheduled_jobs",

--- a/tests/_chaos_3502_graph_investigation_fake.py
+++ b/tests/_chaos_3502_graph_investigation_fake.py
@@ -1,0 +1,80 @@
+"""A Lane-B-owned fake for ``graph_investigation_query.GraphInvestigationQuery``.
+
+Lives in the ``tests`` package (mirrors ``tests/_chaos_3295_plan_executor``,
+``tests/_chaos_3292_preflight``) so both mypy and pytest resolve it the same
+way. Per the CHAOS-3660 ratified plan: Lane B binds orchestrator routing to
+the ``GraphInvestigationQuery`` Protocol and this fake ONLY -- this is not a
+scaled-down copy of the trial/shadow graph arm's construction, and it must
+never be imported from production code (``src/``). Its only job is to let
+Lane B's own orchestrator-routing tests exercise every ``GraphQueryOutcome``
+deterministically, without a live graph backend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationQuery,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
+from dev_health_ops.api.dev.investigation_contract import AskDevInvestigationPacket
+from dev_health_ops.api.dev.investigation_contract.fixtures import positive_fixtures
+
+__all__ = ["FakeGraphInvestigationQuery", "default_investigation_packet"]
+
+
+def default_investigation_packet() -> AskDevInvestigationPacket:
+    """A valid, contract-checked packet -- the same fixture the investigation
+    contract's own test suite validates against, so a fake result is never
+    accidentally malformed in a way production code would reject.
+    """
+
+    payload = positive_fixtures()["ask_dev_investigation_packet.v1"]
+    return AskDevInvestigationPacket.model_validate(payload)
+
+
+@dataclass
+class FakeGraphInvestigationQuery(GraphInvestigationQuery):
+    """Deterministic, in-memory. Configure ``outcome``/``packet`` for the
+    "happy path" cases; use ``responder`` for a test that needs the result to
+    depend on the request (e.g. asserting the request's ``authorized_entity_ids``
+    reached the fake unchanged).
+    """
+
+    outcome: GraphQueryOutcome = GraphQueryOutcome.COMPLETED
+    packet: AskDevInvestigationPacket | None = field(
+        default_factory=default_investigation_packet
+    )
+    diagnostic: str | None = None
+    #: When set, overrides ``outcome``/``packet``/``diagnostic`` entirely --
+    #: the fake calls this with the request and returns whatever it returns.
+    responder: Callable[[GraphInvestigationRequest], GraphQueryResult] | None = None
+    #: Every request this fake received, in call order -- lets a test assert
+    #: on what the orchestrator actually sent (deadline, authorized set,
+    #: intent) without needing a real graph backend to introspect.
+    received_requests: list[GraphInvestigationRequest] = field(default_factory=list)
+
+    async def investigate(self, request: GraphInvestigationRequest) -> GraphQueryResult:
+        self.received_requests.append(request)
+        if self.responder is not None:
+            return self.responder(request)
+        packet = self.packet if self.outcome is GraphQueryOutcome.COMPLETED else None
+        return GraphQueryResult(
+            outcome=self.outcome, packet=packet, diagnostic=self.diagnostic
+        )
+
+
+def deadline_from_now(seconds: float, *, now: Callable[[], datetime]) -> datetime:
+    """Small helper so a test's deadline is computed from its own injected
+    clock rather than a bare ``datetime.now()`` call the repo's fixed-clock
+    convention (``tests/_chaos_3292_preflight.fixed_now``) exists to avoid.
+    """
+
+    from datetime import timedelta
+
+    return now() + timedelta(seconds=seconds)

--- a/tests/api/dev/test_chaos_3502_graph_investigation_query.py
+++ b/tests/api/dev/test_chaos_3502_graph_investigation_query.py
@@ -1,0 +1,107 @@
+"""CHAOS-3502/CHAOS-3660: smoke coverage for the proposed consumer-side
+graph-investigation seam (``graph_investigation_query.py``) and its fake.
+
+Not full orchestrator-routing coverage yet (that lands with the actual
+routing branch) -- this proves the Protocol + fake are usable and that the
+transport/outcome contract behaves as documented before anything binds to
+it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import Cardinality, QuestionIntentID
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationQuery,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
+from dev_health_ops.api.dev.investigation_contract import AskDevInvestigationPacket
+from tests._chaos_3502_graph_investigation_fake import (
+    FakeGraphInvestigationQuery,
+    default_investigation_packet,
+)
+
+
+def _request(
+    *, authorized_entity_ids: frozenset[str] = frozenset()
+) -> GraphInvestigationRequest:
+    return GraphInvestigationRequest(
+        org_id="org_1",
+        run_id="run_1",
+        intent_id=QuestionIntentID.DISCOVERED_COHORT,
+        cardinality=Cardinality.ORGANIZATION_WIDE,
+        mentions=(),
+        question_text="Which teams are currently struggling?",
+        authorized_entity_ids=authorized_entity_ids,
+        deadline=datetime(2026, 8, 10, 0, 0, tzinfo=UTC),
+    )
+
+
+def test_fake_satisfies_the_protocol_structurally() -> None:
+    """``GraphInvestigationQuery`` is a plain (non-runtime-checkable) Protocol
+    -- matching this codebase's convention (``question_interpreter.
+    IntentClassifier``) -- so conformance is a static/mypy property, not an
+    ``isinstance`` check. Assigning to the Protocol-typed variable below is
+    the actual check: this file fails ``mypy`` if the fake's ``investigate``
+    signature ever drifts from the Protocol's.
+    """
+
+    fake: GraphInvestigationQuery = FakeGraphInvestigationQuery()
+    assert fake is not None
+
+
+@pytest.mark.asyncio
+async def test_completed_outcome_carries_a_valid_packet() -> None:
+    fake = FakeGraphInvestigationQuery()
+    result = await fake.investigate(_request())
+    assert result.outcome is GraphQueryOutcome.COMPLETED
+    assert isinstance(result.packet, AskDevInvestigationPacket)
+
+
+@pytest.mark.asyncio
+async def test_non_completed_outcome_never_carries_a_packet() -> None:
+    fake = FakeGraphInvestigationQuery(outcome=GraphQueryOutcome.UNAVAILABLE)
+    result = await fake.investigate(_request())
+    assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+    assert result.packet is None
+
+
+def test_result_rejects_completed_without_a_packet() -> None:
+    with pytest.raises(ValueError, match="if and only if"):
+        GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=None)
+
+
+def test_result_rejects_a_packet_on_a_non_completed_outcome() -> None:
+    with pytest.raises(ValueError, match="if and only if"):
+        GraphQueryResult(
+            outcome=GraphQueryOutcome.STALE, packet=default_investigation_packet()
+        )
+
+
+@pytest.mark.asyncio
+async def test_fake_records_the_request_it_received() -> None:
+    fake = FakeGraphInvestigationQuery()
+    authorized = frozenset({"proj_a", "proj_b"})
+    request = _request(authorized_entity_ids=authorized)
+    await fake.investigate(request)
+    assert fake.received_requests == [request]
+    assert fake.received_requests[0].authorized_entity_ids == authorized
+
+
+@pytest.mark.asyncio
+async def test_fake_responder_overrides_defaults() -> None:
+    fake = FakeGraphInvestigationQuery(
+        responder=lambda req: GraphQueryResult(
+            outcome=GraphQueryOutcome.DEADLINE_EXCEEDED,
+            diagnostic=f"deadline was {req.deadline.isoformat()}",
+        )
+    )
+    result = await fake.investigate(_request())
+    assert result.outcome is GraphQueryOutcome.DEADLINE_EXCEEDED
+    assert result.packet is None
+    assert result.diagnostic is not None and "2026-08-10" in result.diagnostic

--- a/tests/api/dev/test_chaos_3502_graph_routing_seam.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_seam.py
@@ -1,0 +1,122 @@
+"""CHAOS-3502: the graph-assisted routing seam's flag scaffolding.
+
+Landed ahead of the actual routing branch (which is blocked on a
+cross-lane design question about the packet -> canonical-frame bridge, see
+CHAOS-3660) -- mirrors CHAOS-3567's own "flag-off scaffolding first,
+consuming logic later" pattern. Covers only what exists today:
+
+* the runtime kill switch (``orchestrator.graph_routing_runtime_enabled``),
+  independent of the organization feature-policy gate;
+* the organization feature-policy gate itself
+  (``licensing.registry.ASK_DEV_GRAPH_ROUTING_FEATURE``), denied by default
+  on every tier;
+* ``DevOrchestrator`` accepting ``graph_investigation_query`` without any
+  behavior change -- ``run()`` does not read the attribute yet, so there is
+  nothing for it to change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import (
+    DevContractVersions,
+    DevScopeResolution,
+    DevToolResult,
+    ToolID,
+)
+from dev_health_ops.api.dev.orchestrator import (
+    GRAPH_ROUTING_RUNTIME_FLAG,
+    DevOrchestrator,
+    graph_routing_runtime_enabled,
+)
+from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
+from dev_health_ops.licensing.registry import (
+    ASK_DEV_GRAPH_ROUTING_FEATURE,
+    EXPLICIT_PURCHASE_FEATURES,
+    get_features_for_tier,
+)
+from dev_health_ops.licensing.types import LicenseTier
+from tests._chaos_3502_graph_investigation_fake import FakeGraphInvestigationQuery
+
+
+def _minimal_registry() -> AskDevToolRegistry:
+    async def execute(_context, request):
+        payload = dict(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    return AskDevToolRegistry({tool_id: execute for tool_id in ToolID})
+
+
+def _minimal_orchestrator_kwargs() -> dict:
+    async def resolve(**_values) -> DevScopeResolution:
+        return DevScopeResolution.model_validate(
+            positive_fixtures()["dev_scope_resolution.v1"]
+        )
+
+    return {
+        "provider": object(),  # AgentLLMProvider is structural; never called here
+        "provider_source": "platform",
+        "provider_family": "test",
+        "registry": _minimal_registry(),
+        "scope_resolver": resolve,
+        "versions": DevContractVersions.model_validate(
+            positive_fixtures()["dev_answer.v1"]["versions"]
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("1", True),
+    ],
+)
+def test_graph_routing_runtime_flag_defaults_off(
+    monkeypatch: pytest.MonkeyPatch, raw_value: str | None, expected: bool
+) -> None:
+    if raw_value is None:
+        monkeypatch.delenv(GRAPH_ROUTING_RUNTIME_FLAG, raising=False)
+    else:
+        monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, raw_value)
+    assert graph_routing_runtime_enabled() is expected
+
+
+def test_graph_routing_is_an_explicit_purchase_feature_denied_by_default() -> None:
+    assert ASK_DEV_GRAPH_ROUTING_FEATURE in EXPLICIT_PURCHASE_FEATURES
+    for tier in LicenseTier:
+        features = get_features_for_tier(tier)
+        assert features[ASK_DEV_GRAPH_ROUTING_FEATURE] is False
+
+
+def test_orchestrator_accepts_a_graph_investigation_query_collaborator() -> None:
+    """Construction-only smoke test: the parameter exists, defaults to
+    ``None`` (the flag-off path, mirroring every other optional collaborator
+    on this constructor), and accepting a real value does not raise. No
+    behavior assertion here -- ``run()`` does not read
+    ``self._graph_investigation_query`` yet, so there is nothing to observe
+    changing; that lands with the routing branch itself.
+    """
+
+    kwargs = _minimal_orchestrator_kwargs()
+    default = DevOrchestrator(**kwargs)
+    assert default._graph_investigation_query is None
+
+    with_query = DevOrchestrator(
+        **kwargs, graph_investigation_query=FakeGraphInvestigationQuery()
+    )
+    assert isinstance(
+        with_query._graph_investigation_query, FakeGraphInvestigationQuery
+    )

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -1239,13 +1239,14 @@ class TestGetFeaturesForTier:
         enterprise = get_features_for_tier(LicenseTier.ENTERPRISE)
         assert set(community.keys()) == set(team.keys()) == set(enterprise.keys())
 
-    def test_returns_32_features_including_explicit_purchase_ones(self):
+    def test_returns_33_features_including_explicit_purchase_ones(self):
         features = get_features_for_tier(LicenseTier.COMMUNITY)
-        assert len(features) == 32
+        assert len(features) == 33
         # Explicit-purchase features stay denied for every tier until an
         # organization or license override grants them.
         assert features["ask_dev_contextual_entrypoints"] is False
         assert features["ask_dev_wave_3_1"] is False
+        assert features["ask_dev_graph_routing"] is False
 
     def test_sign_license_uses_canonical_registry(self):
         """sign_license() with no explicit features uses get_features_for_tier."""


### PR DESCRIPTION
## Issue and phase
CHAOS-3502 (Wave 3.2 Phase 1, Lane B — parent CHAOS-3660), increment 1 of the graph-assisted routing work. **Stacked on #1633** (CHAOS-3652, unmerged) — this PR's base is `chaos-3502-routing`, not `feature/chaos-3498-context-fabric`, because `graph_investigation_query.py`'s own tests use `QuestionIntentID.DISCOVERED_COHORT`. Please review/merge #1633 first; this PR's diff (below) is only what's new on top of it.

## Observable outcome
None, by design. This lands plumbing only, following this codebase's established "flag-off scaffolding first, consuming logic later" pattern (CHAOS-3567's `TEMPORAL_CONTEXT` source-class stub, CHAOS-3389's QUA shadow seam). No code path reads the new collaborator yet.

## Architecture boundary
- `graph_investigation_query.py` is the **proposed** consumer-side `GraphInvestigationQuery` Protocol — posted on CHAOS-3660 for Lane A (CHAOS-3500) review/counter-proposal, per the ratified cross-lane plan (team-lead). Not a commitment Lane A must implement as-is.
- `DevOrchestrator` gets an optional `graph_investigation_query` collaborator, `None` by default (the flag-off path — same shape as every other optional collaborator already on this constructor: `preflight`, `plan_executor`, `qua_shadow`, `investigation_shadow`, `investigation_packet_producer`).
- Two independent flags, mirroring the wave-3.1 rollout pattern exactly (team-lead approved, condition 3 of the CHAOS-3652 approval): `licensing.registry.ASK_DEV_GRAPH_ROUTING_FEATURE` (org opt-in) and `orchestrator.graph_routing_runtime_enabled()` (same-process kill switch, env `ASK_DEV_GRAPH_ROUTING_ENABLED`).
- The fake (`tests/_chaos_3502_graph_investigation_fake.py`) lives in `tests/`, is never imported from `src/`, and is explicitly documented as not a scaled-down copy of the trial/shadow graph arm's construction.

## Scope / non-scope
**In scope:** the Protocol + request/result types; the two flags; `DevOrchestrator` accepting (but not yet using) the collaborator.
**Explicitly out of scope, and why:** the actual `run()` routing branch that calls `investigate()` and turns a `GraphQueryOutcome.COMPLETED` result into a canonical `DevAnswerFrame`. This depends on an open question posted to team-lead: does packet→frame assembly belong in orchestrator.py (mine), or does it consume something Lane C's canonical-admission work (CHAOS-3664) already frame-shapes? Landing this once, correctly, beats guessing and reworking — see CHAOS-3502 comment thread and CHAOS-3660 for the question and full context.

## Base/head SHA and branch provenance
- Base: `chaos-3502-routing` @ `1076398da11b83fc1ca73da72d87e659ac4717b5` (= PR #1633's head, CHAOS-3652, unmerged).
- Head: `004202ff6...` on `chaos-3502-routing-seam`.
- Ultimate base once #1633 merges: `feature/chaos-3498-context-fabric` @ `97ab4949038ad0d5f8a3b84e10403de1c3155d8d`.

## Migrations/configuration/feature flags
One new feature key (`ask_dev_graph_routing`) in the canonical feature registry, `EXPLICIT_PURCHASE_FEATURES`, and the `STANDARD_FEATURES` table — denied by default on every license tier (verified by test). One new env var (`ASK_DEV_GRAPH_ROUTING_ENABLED`, default off). No DB migration — new feature keys don't require an Alembic seed (existing `0007`/`0017` migrations seed specific historical flags, not a totality of the current registry — confirmed by running the full billing/licensing suite).

## Security/privacy/retention impact
None. No new code path is reachable — both flags gate nothing yet, since `run()` doesn't read the collaborator.

## RED-first evidence
N/A in the traditional sense — this is inert scaffolding, not a behavior fix. What's tested is that the scaffolding behaves exactly as documented (flags default off across every input including "unset"/"0"/"false"; the org feature is denied on every tier; the orchestrator stores but does not invoke the collaborator).

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_chaos_3502_graph_investigation_query.py tests/api/dev/test_chaos_3502_graph_routing_seam.py -q
  → 14 passed
.venv/bin/python -m pytest tests/test_billing.py tests/test_licensing.py -q
  → 140 passed
.venv/bin/python -m pytest tests/api/dev -m "not benchmark and not clickhouse" -q -n 4 --dist loadscope
  → 2984 passed, 21 skipped, 4 xfailed, 0 failed
.venv/bin/ruff check / ruff format --check / mypy on all touched files → clean
```
Pre-commit and pre-push lefthook gates (ruff-fix, ruff-format, mypy, commit-msg, pre-push ruff/mypy) passed locally.

## Known limitations and follow-up issues
- The actual routing branch is increment 2, blocked on the packet→frame ownership question above.
- `budget_hints` on `GraphInvestigationRequest` is intentionally unopinionated (`dict[str, int]`) pending Lane A's CHAOS-3500 budget vocabulary.
- Singular-subject graph-assisted routing (vs. the subjectless-cohort path this Protocol was primarily designed against) is not yet scoped in the request shape beyond carrying `mentions`/`cardinality` — will be refined once CHAOS-3500 clarifies the query surface.

## Rollout/rollback impact
None — every new code path is unreachable (flags default off, and even wired on, nothing in `run()` consumes the collaborator yet). Revert is a plain `git revert`.