### PR TITLE
CHAOS-3634/3643: qualify capacity/staffing drivers instead of aborting the packet

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/drivers.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/drivers.py
@@ -63,6 +63,7 @@ from dev_health_ops.api.dev.investigation_contract import (
     DriverStanding,
     RelationshipDirection,
     RelationshipType,
+    StaffingDenominatorState,
 )
 
 from .readback import (
@@ -236,6 +237,16 @@ class DriverFinding:
     confidence_qualifier: ConfidenceQualifier = ConfidenceQualifier.QUALIFIED
     conflicting_evidence_ids: tuple[str, ...] = ()
     conflict_detail: str | None = None
+    #: CHAOS-3634/3643: set only when ``category`` is
+    #: ``CAPACITY_OR_STAFFING``, and always set THEN — see
+    #: :func:`_qualify_staffing`. ``None`` on every other category, which
+    #: ``packet_builder`` relies on to decide whether to build a
+    #: ``StaffingQualification`` at all: the frozen contract refuses one on
+    #: a non-staffing driver just as firmly as it refuses a staffing driver
+    #: without one.
+    staffing_denominator_state: StaffingDenominatorState | None = None
+    staffing_denominator_source_classes: tuple[SourceClass, ...] = ()
+    staffing_qualification_note: str | None = None
 
     @property
     def is_asserted(self) -> bool:
@@ -999,6 +1010,58 @@ def _promote(findings: Sequence[DriverFinding]) -> list[DriverFinding]:
     ]
 
 
+#: CHAOS-3634/3643: what this arm can currently say about a capacity/
+#: staffing denominator. Every ``CAPACITY_OR_STAFFING`` finding today is
+#: built from ``interruption_load_percentile`` (the only entry
+#: :data:`MEASUREMENT_CATEGORY` maps to that category) -- an operational
+#: workload signal, not a planned-allocation, headcount, or contributor-
+#: availability feed. The note is arm-wide rather than per-finding
+#: deliberately: it is honest about what this arm can source today, and a
+#: future metric that genuinely IS an allocation feed changes
+#: ``MEASUREMENT_CATEGORY`` and this sentence together, rather than leaving
+#: a per-finding note that quietly stops being true.
+_NO_ALLOCATION_EVIDENCE_NOTE = (
+    "based on operational workload measurement (interruption/incident load "
+    "percentile); no planned-allocation, headcount, or contributor-"
+    "availability feed is available to this arm, so the denominator behind "
+    "any capacity/staffing claim here is absent"
+)
+
+
+def _qualify_staffing(finding: DriverFinding) -> DriverFinding:
+    """Attach a staffing-denominator disclosure to a capacity/staffing finding.
+
+    The frozen contract's ``validate_staffing_claims_are_qualified`` refuses
+    to construct a ``DriverCandidate`` in ``DriverCategory.CAPACITY_OR_STAFFING``
+    with no ``staffing_qualification`` at all -- "a staffing claim that says
+    nothing about its denominator is an unsupported claim" -- which is what
+    made ``team_atlas`` abort packet construction outright (CHAOS-3634).
+    ``DENOMINATOR_ABSENT`` is correct for every finding this arm produces
+    today; see :data:`_NO_ALLOCATION_EVIDENCE_NOTE`.
+
+    This does not touch ``confidence_qualifier``: ``_measurement_candidates``
+    never sets it above the ``QUALIFIED`` default for a capacity finding, so
+    there is nothing here to downgrade, and the frozen contract independently
+    refuses ``MEASURED_CERTAIN`` paired with a weak denominator
+    (CHAOS-3643) -- this function's job is only to make the denominator
+    disclosure exist, not to police the certainty claim a second time.
+
+    A no-op for every other category. The wire contract's mutual-exclusion
+    rule -- a NON-staffing driver may not carry a qualification either -- is
+    upheld by never setting these fields on one in the first place, not by
+    clearing them here for a category that never reaches this function with
+    them set.
+    """
+
+    if finding.category is not DriverCategory.CAPACITY_OR_STAFFING:
+        return finding
+    return replace(
+        finding,
+        staffing_denominator_state=StaffingDenominatorState.DENOMINATOR_ABSENT,
+        staffing_qualification_note=_NO_ALLOCATION_EVIDENCE_NOTE,
+    )
+
+
 def _mark_symptoms_of_drivers(
     findings: Sequence[DriverFinding],
 ) -> list[DriverFinding]:
@@ -1074,11 +1137,14 @@ def discover_drivers(
         observation_attachment_available=readout.observation_attachment_available,
     )
 
-    findings = (
-        _blocking_candidates(context, readout)
-        + _open_child_candidates(context, readout)
-        + _symptom_candidates(context, readout)
-        + _measurement_candidates(context, readout)
+    findings = tuple(
+        _qualify_staffing(item)
+        for item in (
+            _blocking_candidates(context, readout)
+            + _open_child_candidates(context, readout)
+            + _symptom_candidates(context, readout)
+            + _measurement_candidates(context, readout)
+        )
     )
     # Deduplicate by driver_id, keeping the first: the same blocker can be
     # reached by several paths, and reporting it twice would make one cause

--- a/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
@@ -85,6 +85,7 @@ from dev_health_ops.api.dev.investigation_contract import (
     RelevanceState,
     SourceContractVersion,
     SourceHealthObservation,
+    StaffingQualification,
     SubjectCandidate,
     SubjectCommitmentState,
     SubjectDiscovery,
@@ -95,6 +96,7 @@ from dev_health_ops.api.dev.investigation_contract import (
 )
 from dev_health_ops.api.dev.investigation_contract.vocabulary import (
     ASSERTED_DRIVER_STANDINGS,
+    UNQUALIFIED_DENOMINATOR_STATES,
     EdgeValidityBasis,
 )
 
@@ -633,6 +635,37 @@ def _driver_candidate(
             ]
         ),
         exclusion_reason=finding.exclusion_reason,
+        staffing_qualification=_staffing_qualification(finding),
+    )
+
+
+def _staffing_qualification(finding: DriverFinding) -> StaffingQualification | None:
+    """CHAOS-3634/3643: the frozen contract's disclosure for a capacity claim.
+
+    ``None`` for every non-staffing finding, which is what
+    ``DriverCandidate.validate_staffing_claims_are_qualified`` requires:
+    that validator refuses a qualification on a driver categorised anything
+    but ``CAPACITY_OR_STAFFING`` just as firmly as it refuses a staffing
+    driver with none at all. ``drivers._qualify_staffing`` is the one place
+    that sets ``finding.staffing_denominator_state``, and it only ever does
+    so alongside a non-empty note -- so a staffing finding reaching here
+    with no note is an internal inconsistency between discovery and
+    emission, not a value to paper over with a placeholder string.
+    """
+
+    if finding.staffing_denominator_state is None:
+        return None
+    if not finding.staffing_qualification_note:
+        raise ValueError(
+            f"driver {finding.driver_id} sets a staffing denominator state "
+            f"({finding.staffing_denominator_state}) with no qualification "
+            "note; a staffing disclosure that says nothing about its "
+            "denominator explains nothing"
+        )
+    return StaffingQualification(
+        denominator_state=finding.staffing_denominator_state,
+        denominator_source_classes=finding.staffing_denominator_source_classes,
+        qualification_note=finding.staffing_qualification_note,
     )
 
 
@@ -1802,6 +1835,30 @@ def build_packet(
                     f"{filtered_total} candidate results were outside the "
                     f"caller's authorized scope and were removed before "
                     f"ranking{admission_clause}"
+                ),
+            )
+        )
+    # CHAOS-3634/3643. The frozen contract's
+    # ``validate_staffing_absence_is_disclosed`` requires this limitation
+    # whenever ANY driver's denominator is weak (partial or absent) --
+    # checked against the raw findings, not ``driver_candidates`` (built
+    # below), because every finding this arm can currently produce in
+    # ``CAPACITY_OR_STAFFING`` carries exactly that denominator state (see
+    # ``drivers._qualify_staffing``), and the packet-level disclosure is
+    # required independently of whether any one such finding reaches
+    # asserted standing.
+    if drivers and any(
+        finding.staffing_denominator_state in UNQUALIFIED_DENOMINATOR_STATES
+        for finding in drivers
+    ):
+        limitations.append(
+            PacketLimitation(
+                kind=PacketLimitationKind.ABSENT_STAFFING_DENOMINATOR,
+                detail=(
+                    "one or more capacity/staffing findings rest on a "
+                    "partial or absent allocation denominator; see each "
+                    "driver's own staffing_qualification for what evidence "
+                    "was and was not available"
                 ),
             )
         )

--- a/tests/context_fabric/test_chaos_3620_authorization.py
+++ b/tests/context_fabric/test_chaos_3620_authorization.py
@@ -58,17 +58,18 @@ def _analyst_grant() -> frozenset[str]:
 
 
 #: Seeds whose driver-bearing packet cannot be constructed at all.
-#: ``team_atlas`` produces a capacity driver with no staffing qualification,
-#: which the frozen contract refuses.
 #:
-#: **CHAOS-3634 is DESCOPED — the abort is the design, not a pending fix.**
-#: The ticket owns the disposition of record. This exemption is therefore
-#: permanent rather than temporary, which makes pinning it *more* important,
-#: not less: a permanent exemption is exactly the kind that quietly widens.
-#: ``test_the_only_unconstructible_seed_is_the_one_we_named`` keeps it
-#: honest, and a second unconstructible seed appearing is a finding rather
-#: than a quiet gap in the sweep.
-UNCONSTRUCTIBLE_WITH_DRIVERS = {"team_atlas"}
+#: **CHAOS-3634/3643, fixed.** ``team_atlas`` used to produce a capacity
+#: driver with no ``staffing_qualification``, which the frozen contract
+#: refused outright. ``drivers._qualify_staffing`` now attaches a
+#: ``DENOMINATOR_ABSENT`` disclosure to every capacity/staffing finding this
+#: arm produces, so the set is empty. Kept as a named, empty set rather than
+#: deleted: the exhaustiveness check below (``test_the_only_unconstructible_
+#: seed_is_the_one_we_named``) is a live regression guard, not a historical
+#: note — if some future defect makes another seed unconstructible again,
+#: that test goes red and this is where the exemption gets named, not a
+#: silent widening of the sweep's skip.
+UNCONSTRUCTIBLE_WITH_DRIVERS: frozenset[str] = frozenset()
 
 
 def _subject_seeds() -> tuple[str, ...]:

--- a/tests/context_fabric/test_chaos_3620_semantic_safety.py
+++ b/tests/context_fabric/test_chaos_3620_semantic_safety.py
@@ -30,9 +30,12 @@ import pytest
 
 from dev_health_ops.api.dev import investigation_shadow as shadow
 from dev_health_ops.api.dev.investigation_contract import (
+    ConfidenceQualifier,
     DriverCategory,
     DriverRole,
     DriverStanding,
+    PacketLimitationKind,
+    StaffingDenominatorState,
 )
 from dev_health_ops.api.dev.investigation_contract.vocabulary import (
     ASSERTED_DRIVER_STANDINGS,
@@ -67,12 +70,14 @@ BANNED_BACKEND_TOKENS = (
 )
 
 
-#: Same denial-of-packet exemption the authorization sweep carries, and for
-#: the same reason: ``team_atlas`` cannot produce a driver-bearing packet at
-#: all (CHAOS-3634). Driver DISCOVERY still runs for it — only packet
-#: emission is refused — so the finding sweep below loses nothing, which is
-#: why it uses ``discover_drivers`` output rather than packets.
-PACKET_UNCONSTRUCTIBLE_WITH_DRIVERS = {"team_atlas"}
+#: Same (now empty) denial-of-packet exemption the authorization sweep
+#: carries. CHAOS-3634/3643 closed the defect: ``team_atlas`` builds a
+#: driver-bearing packet like any other seed now that capacity/staffing
+#: findings carry a ``staffing_qualification``. Kept named and empty, not
+#: deleted, for the same reason as ``test_chaos_3620_authorization.py``'s
+#: ``UNCONSTRUCTIBLE_WITH_DRIVERS`` — a live regression guard, not a
+#: historical note.
+PACKET_UNCONSTRUCTIBLE_WITH_DRIVERS: frozenset[str] = frozenset()
 
 
 def _every_authorized_subject() -> tuple[str, ...]:
@@ -160,30 +165,83 @@ class TestNoCanonicalTruthIsCreated:
             f"a capacity/staffing finding reached asserted standing: {offenders}"
         )
 
-    def test_an_unqualified_capacity_finding_cannot_be_EMITTED_at_all(self) -> None:
-        """The second, independent refusal — and a denial-of-packet.
+    def test_an_unqualified_capacity_finding_now_constructs_a_safe_packet(
+        self,
+    ) -> None:
+        """CHAOS-3634/3643, fixed: qualified, never a denial-of-packet.
 
-        Beyond the standing cap, the frozen contract refuses a
-        capacity/staffing driver carrying no ``staffing_qualification``: "a
-        staffing claim that says nothing about its denominator is an
-        unsupported claim". On ``team_atlas`` that refusal aborts packet
-        construction entirely.
+        The frozen contract refuses a capacity/staffing driver carrying no
+        ``staffing_qualification`` at all: "a staffing claim that says
+        nothing about its denominator is an unsupported claim". Before this
+        fix, ``team_atlas`` hit exactly that refusal and packet construction
+        aborted outright — recorded as a permanent, ticketed disposition
+        while CHAOS-3634 was descoped from the CHAOS-3619 trial's fix train.
 
-        Recorded as its own disposition rather than absorbed as a skip. It is
-        a real safety refusal working, *and* a denial of service for that
-        subject. Both halves are true and a reader needs both.
+        Now that the ticket's fix has landed (post-ADR CHAOS-3621
+        acceptance), ``drivers._qualify_staffing`` attaches a
+        ``DENOMINATOR_ABSENT`` disclosure to every capacity/staffing
+        finding, so the packet constructs. This test pins the two halves
+        that make that safe rather than merely unblocked:
 
-        **CHAOS-3634 is DESCOPED from the fix train — the abort stays.** The
-        ticket is the owner of record for the disposition, not a pending fix,
-        so this test is not waiting for anything: it pins a permanent
-        property of the current design. If the abort ever stops happening
-        that is a deliberate change and this goes red to say so.
+        1. the disclosure is honest — ``DENOMINATOR_ABSENT``, because this
+           arm has no allocation/headcount feed, only an operational
+           workload measurement;
+        2. the certainty stays bounded — ``QUALIFIED``, never
+           ``MEASURED_CERTAIN`` — which is the other half of the same rule
+           and the one CHAOS-3643's P06 case is about: a missing denominator
+           must never be presented as confident.
+
+        If either half regresses -- the finding goes back to raising, or the
+        disclosure quietly claims more certainty than the evidence
+        supports -- this goes red.
         """
 
-        from pydantic import ValidationError
+        investigation = spine.investigate("team_atlas", with_drivers=True)
+        packet = investigation.packet
 
-        with pytest.raises(ValidationError, match="staffing_qualification"):
-            spine.investigate("team_atlas", with_drivers=True)
+        capacity_drivers = [
+            candidate
+            for candidate in packet.driver_analysis.candidates
+            if candidate.category is DriverCategory.CAPACITY_OR_STAFFING
+        ]
+        assert capacity_drivers, (
+            "team_atlas produced no capacity/staffing candidate at all, so "
+            "this test is no longer exercising the case it is named for"
+        )
+        for candidate in capacity_drivers:
+            assert candidate.staffing_qualification is not None, (
+                f"{candidate.driver_id} carries no staffing_qualification; "
+                "this packet should never have been constructible"
+            )
+            assert (
+                candidate.staffing_qualification.denominator_state
+                is StaffingDenominatorState.DENOMINATOR_ABSENT
+            ), (
+                f"{candidate.driver_id} claims a denominator state of "
+                f"{candidate.staffing_qualification.denominator_state}, but "
+                "this arm has no allocation/headcount feed to support "
+                "anything stronger"
+            )
+            assert (
+                candidate.confidence_qualifier
+                is not ConfidenceQualifier.MEASURED_CERTAIN
+            ), (
+                f"{candidate.driver_id} presents staffing certainty with no "
+                "supporting denominator -- the exact CHAOS-3643 defect"
+            )
+            assert candidate.standing not in ASSERTED_DRIVER_STANDINGS, (
+                f"{candidate.driver_id} was asserted despite an absent "
+                "staffing denominator"
+            )
+
+        assert any(
+            limitation.kind is PacketLimitationKind.ABSENT_STAFFING_DENOMINATOR
+            for limitation in packet.evidence_coverage.limitations
+        ), (
+            "the packet carries a weak-denominator staffing finding but "
+            "does not disclose ABSENT_STAFFING_DENOMINATOR at the packet "
+            "level -- the frozen contract requires both"
+        )
 
     def test_no_measurement_only_category_reaches_asserted_standing(self) -> None:
         """The general rule the staffing ban is one instance of."""

--- a/tests/context_fabric/test_chaos_3634_staffing_qualification.py
+++ b/tests/context_fabric/test_chaos_3634_staffing_qualification.py
@@ -1,0 +1,269 @@
+"""CHAOS-3634/3643: capacity/staffing findings carry a real denominator
+disclosure, and packet construction survives it.
+
+Before this fix, ``drivers.discover_drivers`` produced a
+``CAPACITY_OR_STAFFING`` finding (``drv_metric_atlas_load`` on
+``team_atlas``, from the corpus's interruption-load measurement) with no
+``staffing_qualification`` at all. The frozen contract's
+``DriverCandidate.validate_staffing_claims_are_qualified`` refuses to
+construct such a candidate — "a staffing claim that says nothing about its
+denominator is an unsupported claim" — so ``team_atlas`` could never
+produce a driver-bearing packet (CHAOS-3634's denial-of-packet), and the
+same rule is what CHAOS-3643's "unsupported certainty" case is the other
+half of: a weak denominator paired with ``MEASURED_CERTAIN`` is refused
+independently.
+
+Every test here plants the specific shape its guard exists to catch:
+construct a finding that WOULD abort or WOULD overstate certainty unless
+``drivers._qualify_staffing`` / ``packet_builder._staffing_qualification``
+are what stop it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from dev_health_ops.api.dev.investigation_contract import (
+    ConfidenceQualifier,
+    DriverCategory,
+    DriverRole,
+    DriverStanding,
+    PacketLimitationKind,
+    StaffingDenominatorState,
+)
+from dev_health_ops.api.dev.investigation_contract.vocabulary import (
+    ASSERTED_DRIVER_STANDINGS,
+    UNQUALIFIED_DENOMINATOR_STATES,
+)
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.context_fabric.graph_arm import build_projection
+from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
+from dev_health_ops.context_fabric.graph_arm.drivers import (
+    DriverFinding,
+    _qualify_staffing,
+    discover_drivers,
+)
+from dev_health_ops.context_fabric.graph_arm.packet_builder import (
+    _staffing_qualification,
+)
+from dev_health_ops.context_fabric.graph_arm.readback import ProjectionGraphReader
+from tests.context_fabric import chaos_3620_spine as spine
+
+
+@pytest.fixture(scope="module")
+def helio():
+    return build_projection(adapter.corpus_batch(world.ORG_HELIO))
+
+
+def _findings(projection, subject: str) -> dict[str, DriverFinding]:
+    grant = adapter.authorized_entity_ids_for(world.PRINCIPAL_ANALYST)
+    readout = asyncio.run(
+        ProjectionGraphReader(projection).neighbourhood(
+            org_id=world.ORG_HELIO,
+            seed_canonical_ids=[subject],
+            authorized_entity_ids=sorted(grant),
+            max_hops=2,
+        )
+    )
+    return {
+        item.driver_id: item
+        for item in discover_drivers(readout, subject, as_of=world.TRIAL_NOW)[0]
+    }
+
+
+def _finding(**overrides: object) -> DriverFinding:
+    base: dict[str, object] = {
+        "driver_id": "drv_test",
+        "subject_id": "proj_test",
+        "cause_id": "proj_test",
+        "category": DriverCategory.CAPACITY_OR_STAFFING,
+        "role": DriverRole.CONTEXTUAL_CORRELATE,
+        "standing": DriverStanding.CANDIDATE_ONLY,
+        "mechanism": "cited_measurement",
+        "summary_subject": "proj_test",
+        "summary_detail": "test",
+    }
+    base.update(overrides)
+    return DriverFinding(**base)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# drivers._qualify_staffing: the unit under test, in isolation
+# --------------------------------------------------------------------------
+
+
+class TestQualifyStaffingUnit:
+    def test_a_capacity_finding_gets_denominator_absent(self) -> None:
+        qualified = _qualify_staffing(_finding())
+        assert (
+            qualified.staffing_denominator_state
+            is StaffingDenominatorState.DENOMINATOR_ABSENT
+        )
+        assert qualified.staffing_qualification_note
+
+    def test_the_note_names_what_evidence_actually_backs_the_claim(self) -> None:
+        """A disclosure that says nothing is the CHAOS-3634 defect restated."""
+
+        qualified = _qualify_staffing(_finding())
+        note = qualified.staffing_qualification_note or ""
+        assert "allocation" in note or "headcount" in note
+        assert "interruption" in note or "workload" in note
+
+    def test_a_non_capacity_finding_is_untouched(self) -> None:
+        """The mutual-exclusion rule: a non-staffing driver must never
+        carry a staffing qualification, so this must be a true no-op."""
+
+        finding = _finding(category=DriverCategory.QUALITY_OR_DEFECT)
+        qualified = _qualify_staffing(finding)
+        assert qualified is finding
+        assert qualified.staffing_denominator_state is None
+        assert qualified.staffing_qualification_note is None
+
+    def test_confidence_is_never_upgraded_by_qualification(self) -> None:
+        """Qualifying the denominator must never itself grant certainty."""
+
+        finding = _finding(confidence_qualifier=ConfidenceQualifier.QUALIFIED)
+        qualified = _qualify_staffing(finding)
+        assert qualified.confidence_qualifier is ConfidenceQualifier.QUALIFIED
+
+
+# --------------------------------------------------------------------------
+# packet_builder._staffing_qualification: the wire-shape translation
+# --------------------------------------------------------------------------
+
+
+class TestStaffingQualificationTranslation:
+    def test_a_qualified_finding_becomes_a_contract_object(self) -> None:
+        finding = _qualify_staffing(_finding())
+        qualification = _staffing_qualification(finding)
+        assert qualification is not None
+        assert (
+            qualification.denominator_state
+            is StaffingDenominatorState.DENOMINATOR_ABSENT
+        )
+        assert qualification.qualification_note == finding.staffing_qualification_note
+
+    def test_a_non_staffing_finding_translates_to_none(self) -> None:
+        finding = _finding(category=DriverCategory.QUALITY_OR_DEFECT)
+        assert _staffing_qualification(finding) is None
+
+    def test_a_staffing_finding_with_no_note_raises_rather_than_guesses(self) -> None:
+        """An internal-inconsistency guard: ``_qualify_staffing`` never
+        produces this shape, but a future caller that sets the state
+        without a note must not silently ship an empty disclosure."""
+
+        broken = _finding(
+            staffing_denominator_state=StaffingDenominatorState.DENOMINATOR_ABSENT,
+            staffing_qualification_note=None,
+        )
+        with pytest.raises(ValueError, match="qualification note"):
+            _staffing_qualification(broken)
+
+
+# --------------------------------------------------------------------------
+# End to end: the real corpus case that used to abort packet construction
+# --------------------------------------------------------------------------
+
+
+class TestTheTeamAtlasCase:
+    def test_the_capacity_finding_is_produced_and_qualified(self, helio) -> None:
+        found = _findings(helio, "team_atlas")
+        load = found["drv_metric_atlas_load"]
+        assert load.category is DriverCategory.CAPACITY_OR_STAFFING
+        assert (
+            load.staffing_denominator_state
+            is StaffingDenominatorState.DENOMINATOR_ABSENT
+        )
+        assert load.staffing_qualification_note
+
+    def test_the_finding_is_never_asserted(self, helio) -> None:
+        """The standing cap (test_chaos_3620_semantic_safety.py's own
+        rule) must hold regardless of this fix."""
+
+        found = _findings(helio, "team_atlas")
+        load = found["drv_metric_atlas_load"]
+        assert load.standing not in ASSERTED_DRIVER_STANDINGS
+
+    def test_the_confidence_never_exceeds_qualified(self, helio) -> None:
+        """CHAOS-3643's own case: a weak denominator must never travel
+        with certain confidence."""
+
+        found = _findings(helio, "team_atlas")
+        load = found["drv_metric_atlas_load"]
+        assert load.confidence_qualifier is not ConfidenceQualifier.MEASURED_CERTAIN
+
+    def test_the_full_packet_now_constructs_without_raising(self) -> None:
+        """The denial-of-packet CHAOS-3634 exists to fix, observed closed."""
+
+        investigation = spine.investigate("team_atlas", with_drivers=True)
+        assert investigation.packet is not None
+
+    def test_the_packet_discloses_the_absent_denominator(self) -> None:
+        investigation = spine.investigate("team_atlas", with_drivers=True)
+        limitations = investigation.packet.evidence_coverage.limitations
+        assert any(
+            item.kind is PacketLimitationKind.ABSENT_STAFFING_DENOMINATOR
+            for item in limitations
+        )
+
+    def test_no_staffing_candidate_in_the_packet_is_asserted_or_certain(self) -> None:
+        investigation = spine.investigate("team_atlas", with_drivers=True)
+        capacity = [
+            candidate
+            for candidate in investigation.packet.driver_analysis.candidates
+            if candidate.category is DriverCategory.CAPACITY_OR_STAFFING
+        ]
+        assert capacity, "no capacity candidate reached the packet; test is vacuous"
+        for candidate in capacity:
+            assert candidate.standing not in ASSERTED_DRIVER_STANDINGS
+            assert (
+                candidate.confidence_qualifier
+                is not ConfidenceQualifier.MEASURED_CERTAIN
+            )
+            assert candidate.staffing_qualification is not None
+            assert (
+                candidate.staffing_qualification.denominator_state
+                in UNQUALIFIED_DENOMINATOR_STATES
+            )
+
+
+# --------------------------------------------------------------------------
+# The A05 boundary: what this fix does NOT claim
+# --------------------------------------------------------------------------
+
+
+class TestTheFixDoesNotClaimPersonLevelSafetyIsNew:
+    """CHAOS-3634's acceptance mentions the A05 person-level-bait case.
+
+    A05's own oracle (``oracles.py::A05_person_level_bait``) is about
+    whether the QUESTION INTERPRETER ever commits ``team_atlas`` as a
+    subject for a colloquial single-team question in the first place --
+    that policy is out of this arm's reach entirely (it lives upstream of
+    discovery, in Lane B's routing/interpretation territory) and is not
+    touched by this fix. What this fix owns, and what this test pins, is
+    the arm's OWN defence in depth: even when the arm IS asked to
+    investigate ``team_atlas`` directly, nothing it produces is asserted,
+    nothing is a per-person claim, and nothing crashes.
+    """
+
+    def test_the_capacity_finding_names_no_individual(self, helio) -> None:
+        found = _findings(helio, "team_atlas")
+        load = found["drv_metric_atlas_load"]
+        # An aggregate team-level workload measurement, never a contributor
+        # id or a person-shaped attribute.
+        assert "contributor" not in load.driver_id
+        assert load.subject_id == "team_atlas"
+        assert load.cause_id == "team_atlas"
+
+    def test_unrelated_evidence_for_team_atlas_survives_the_fix(self, helio) -> None:
+        """The other half of "does not abort unrelated evidence": a fix
+        that only qualified the capacity finding but broke something else
+        about team_atlas's packet would be a regression this test catches."""
+
+        investigation = spine.investigate("team_atlas", with_drivers=True)
+        assert investigation.packet.related_context.entities, (
+            "team_atlas produced an empty related context; unrelated "
+            "evidence did not survive packet construction"
+        )


### PR DESCRIPTION
## Issue and phase
CHAOS-3634 (beta blocker) + CHAOS-3643 (its child, P06). Phase 2C, Lane D — Wave 3.2. Children of CHAOS-3668.

## Observable outcome
`packet_builder.py::_driver_candidate` built every `DriverCandidate` without ever setting `staffing_qualification`. The frozen contract's `validate_staffing_claims_are_qualified` refuses to construct **any** driver (any standing, not just asserted) in `DriverCategory.CAPACITY_OR_STAFFING` with no qualification at all — so `team_atlas` (whose corpus plants an outlying `interruption_load_percentile` measurement, `drv_metric_atlas_load`) raised `ValidationError` and could never produce a driver-bearing packet at all. This closes both halves of the fix: the packet now constructs, and the disclosure it carries is honest and never overstates certainty.

## Prior scope ruling
CHAOS-3634 carried a 2026-08-09 comment: DESCOPED from the CHAOS-3619 trial's fix train pending the CHOSEN path post-ADR-CHAOS-3621 acceptance ("the ticket stays open, armed and ready, for that decision"). CHAOS-3621 is now accepted and this Wave 3.2 handoff explicitly assigns CHAOS-3634/3643 to Lane D's driver-synthesis foundations — treating that as the trigger. Flagging in case that reading needs correction.

## Architecture boundary
- `drivers.py` (mine, exclusive): new `_qualify_staffing(finding)`, applied to every finding `discover_drivers` produces. For `CAPACITY_OR_STAFFING` (today, only ever `interruption_load_percentile` — an operational workload signal, not an allocation/headcount feed), attaches `StaffingDenominatorState.DENOMINATOR_ABSENT` plus a note naming exactly what evidence is/isn't available. No-op for every other category (preserves the contract's mutual-exclusion rule).
- `packet_builder.py` (flagged, not on any lane's exclusion list — see prior PRs in this stack): new `_staffing_qualification(finding)` translates those fields into a `StaffingQualification` wire object; wired into `_driver_candidate`. Raises rather than guessing on an internal inconsistency (denominator state set with no note — never produced by `_qualify_staffing`, but defended against). Also adds the packet-level `ABSENT_STAFFING_DENOMINATOR` limitation `validate_staffing_absence_is_disclosed` requires independently — the *second* validator hit after fixing the first, both caught RED-first during development.
- CHAOS-3643 (P06/unsupported certainty): `confidence_qualifier` already defaulted to `QUALIFIED` (never `MEASURED_CERTAIN`) for every measurement-cited finding in current code, so no separate downgrade logic was needed — pinned with a dedicated test so it stays true.

## What this does NOT claim (read before assuming CHAOS-3668 is closed)
- **A05 (person-level bait):** its correct answer is that the question interpreter never commits `team_atlas` as a subject for that colloquial question at all — upstream Lane B/interpreter territory, untouched here. This fix owns the arm's own defence in depth instead (nothing asserted, nothing person-shaped, unrelated evidence survives) — see `TestTheFixDoesNotClaimPersonLevelSafetyIsNew` in the new test file.
- **P05/P07's full driver-model capability is NOT built here.** Those oracle cases expect a `PRINCIPAL_DRIVER`-standing capacity finding from a demand-vs-delivery-capacity comparison citing actual allocation evidence (`INVESTMENT_ALLOCATION` records) — a structural rule `drivers.py` does not have today (the only current capacity rule caps at `CONTEXTUAL_CORRELATE`/`CANDIDATE_ONLY`). That's CHAOS-3668's larger "driver model" workstream, explicitly out of this narrower ticket's scope. Named so "team_atlas builds a packet now" isn't mistaken for "P05/P06/P07 score green" — they don't yet.

## Base/head
Base: `origin/feature/chaos-3498-context-fabric` @ `d32dcbf28` (current tip, includes merged CHAOS-3653/CHAOS-3633; rebased cleanly, no conflicts with CHAOS-3633's evidence-handle changes). Head: `chaos-3634-staffing-qualification`.

## Migrations / configuration / feature flags
None.

## Security / privacy / retention impact
None. No new evidence, authorization, or person-level data path. The finding this fix qualifies already existed and was already capped at `CONTEXTUAL_CORRELATE`/`CANDIDATE_ONLY` (never asserted) before this change — that safety property is unchanged and is pinned by a dedicated test.

## RED-first evidence
- `git stash` of source changes with test changes present reproduced: `ImportError` (new test file), an unchanged `ValidationError` (rewritten test in `test_chaos_3620_semantic_safety.py`), and an `AssertionError` on the now-populated `UNCONSTRUCTIBLE_WITH_DRIVERS` set (`test_chaos_3620_authorization.py`). All three confirmed RED, then GREEN after restoring the fix.
- During development, the fix itself went through two RED→green cycles live: first the `DriverCandidate`-level `staffing_qualification` validator, then (once that passed) the packet-level `ABSENT_STAFFING_DENOMINATOR` limitation validator — both real defects the frozen contract caught, not hypothetical.

## Verification
- New `tests/context_fabric/test_chaos_3634_staffing_qualification.py` (15 tests: unit tests for `_qualify_staffing`/`_staffing_qualification` in isolation + end-to-end against the real `team_atlas` corpus case)
- Updated two pinned tests whose own docstrings said they should go red on a deliberate fix (`test_chaos_3620_semantic_safety.py`, `test_chaos_3620_authorization.py`)
- `.venv/bin/python -m pytest tests/context_fabric/ -q` → 1394 passed, 42 skipped
- `.venv/bin/python -m pytest tests/api/dev/ -q` → 2964 passed, 71 skipped, 4 xfailed
- ruff / mypy (module + full-project lefthook gate) → clean

## Known limitations and follow-up issues
- CHAOS-3668's full driver-model capability (demand-vs-delivery `PRINCIPAL_DRIVER` findings citing allocation evidence, P05/P07 oracle shapes) remains open, separately-tracked work — not attempted here.
- A05's question-interpretation-level correctness (never committing `team_atlas` as subject for that specific colloquial question) remains open, Lane B territory.

## Rollout / rollback impact
Additive at the finding-emission layer; changes what was previously an unconditional `ValidationError` into a successfully-constructed, honestly-qualified packet for any subject whose capacity/staffing finding previously aborted. No flag needed — the prior behavior was an unconditional crash for the affected subject(s), so there is no "prior good state" to preserve behind a flag.