### PR TITLE
CHAOS-3676: bounded retry and failure classification around graph projection

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/projector.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/projector.py
@@ -1,0 +1,289 @@
+"""CHAOS-3676: bounded retry, failure classification around a projection write.
+
+``GraphArmStore.write_projection`` had no retry and no failure
+classification: a transient failure (an unreachable/timed-out backend, per
+CHAOS-3631's :class:`~.store.GraphOperationTimeoutError`) and a permanent one
+(a malformed batch, an over-budget embedding run, a wrong-organization
+projection, the projection flag being off) both just propagated on the first
+attempt. :func:`project_with_retry` is the driver that sits between a future
+worker task and the store.
+
+**Idempotency is not re-proven here.** It is established one layer down, at
+the Graphiti/FalkorDB write itself: every node and edge is written via Cypher
+``MERGE`` keyed on a uuid :mod:`.identity` derives deterministically from the
+canonical id, so writing the same projection twice re-sets identical
+properties rather than duplicating anything. That is what makes retrying a
+write that may have partially succeeded safe in the first place — a retry
+after a mid-write timeout is a repeat of the same upsert, not a duplicate.
+
+**What this module does not do**, named explicitly because CHAOS-3500's
+required scope is broader than this one issue: it does not enqueue or
+dequeue a ``worker_job_outbox`` row, does not register a Celery task, and
+does not decide where a "project this organization's canonical delta" job
+comes from. Those are separate, already-flagged follow-up work. What this
+module produces — a structured :class:`ProjectionOutcome` distinguishing
+success, exhausted-transient-retry and permanent failure — is exactly the
+shape a future worker task needs to decide ``self.retry(...)`` versus
+writing a ``worker_job_outbox`` row to ``dead``, without that task having to
+inspect exception types itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+from .budgets import DEFAULT_BUDGETS, TrialBudgets
+from .projection import GraphProjection, ProjectionError, build_projection
+from .records import IngestionBatch
+from .store import (
+    EmbeddingBudgetExceededError,
+    ProjectionDisabledError,
+    StoreUnavailableError,
+    WriteResult,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_MAX_ATTEMPTS",
+    "DEFAULT_RETRY_BACKOFF_S",
+    "ProjectingStore",
+    "ProjectionFailureClass",
+    "ProjectionOutcome",
+    "project_with_retry",
+]
+
+#: How many total attempts a transient failure gets before the driver reports
+#: exhaustion. Small and fixed by default: a caller that wants more has to
+#: say so, and CHAOS-3631 requires that retries "do not amplify load against
+#: an already-struggling backend" -- a large default would violate that on
+#: its own.
+DEFAULT_MAX_ATTEMPTS = 3
+
+#: Base backoff between retries, in seconds. Doubles per attempt (capped),
+#: so total wall-clock across an exhausted run stays small and predictable.
+DEFAULT_RETRY_BACKOFF_S = 1.0
+
+#: The ceiling a single backoff sleep may reach, however many attempts are
+#: configured. Without a cap, a caller passing a large ``max_attempts`` would
+#: also get exponentially large individual sleeps -- bounding attempts alone
+#: does not bound the wait between them.
+_MAX_SINGLE_BACKOFF_S = 8.0
+
+#: Exceptions that mean "this specific attempt could not be judged" rather
+#: than "this projection is invalid" -- retryable up to the bound.
+#: ``GraphOperationTimeoutError`` (CHAOS-3631) is a subclass and is covered
+#: by this catch.
+_TRANSIENT_EXCEPTIONS: tuple[type[Exception], ...] = (StoreUnavailableError,)
+
+#: Exceptions that mean "retrying the identical call cannot help" -- refused
+#: immediately, on the first and only attempt.
+_PERMANENT_EXCEPTIONS: tuple[type[Exception], ...] = (
+    EmbeddingBudgetExceededError,
+    ProjectionDisabledError,
+    PermissionError,
+)
+
+
+class ProjectingStore(Protocol):
+    """The one method :func:`project_with_retry` needs from a store.
+
+    A ``Protocol`` rather than importing ``GraphArmStore`` as the parameter
+    type: tests exercise the retry/classification logic against fakes that
+    implement exactly this method, and structural typing keeps the driver
+    honest about how little of the store it actually depends on.
+    """
+
+    async def write_projection(
+        self, projection: GraphProjection, *, budgets: TrialBudgets = DEFAULT_BUDGETS
+    ) -> WriteResult: ...
+
+
+class ProjectionFailureClass(StrEnum):
+    """Why a :class:`ProjectionOutcome` failed, for a caller to act on.
+
+    The two members map directly onto what a future ``worker_job_outbox``
+    consumer needs to decide: ``TRANSIENT_EXHAUSTED`` means "retry again
+    later, via the outbox's own backoff" (this driver already tried and
+    could not get through); ``PERMANENT`` means "stop retrying, mark the
+    outbox row dead" -- retrying an identical call cannot change the
+    outcome.
+    """
+
+    TRANSIENT_EXHAUSTED = "transient_exhausted"
+    PERMANENT = "permanent"
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionOutcome:
+    """The result of one :func:`project_with_retry` call.
+
+    Exactly one of "success" and "failure" shape is valid, enforced in
+    ``__post_init__`` rather than left to convention: a caller must be able
+    to trust that ``write_result is not None`` if and only if
+    ``success is True``, without also checking ``failure_class``.
+    """
+
+    success: bool
+    attempts: int
+    write_result: WriteResult | None = None
+    failure_class: ProjectionFailureClass | None = None
+    failure_detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.attempts < 1:
+            raise ValueError(
+                f"a projection outcome reporting {self.attempts} attempts is "
+                "incoherent; project_with_retry always makes at least one"
+            )
+        if self.success:
+            if self.write_result is None:
+                raise ValueError(
+                    "a successful outcome must carry a write_result -- a "
+                    "success with nothing written is not distinguishable "
+                    "from a caller-side bug that forgot to check"
+                )
+            if self.failure_class is not None or self.failure_detail is not None:
+                raise ValueError(
+                    "a successful outcome must carry no failure detail; "
+                    "carrying both would leave a reader to guess which one "
+                    "is authoritative"
+                )
+        else:
+            if self.write_result is not None:
+                raise ValueError(
+                    "a failed outcome must carry no write_result -- nothing "
+                    "was durably written on the attempt this outcome reports"
+                )
+            if self.failure_class is None or self.failure_detail is None:
+                raise ValueError(
+                    "a failed outcome must carry a failure_class and a "
+                    "failure_detail; a failure with neither tells a caller "
+                    "nothing to act on"
+                )
+
+
+def _detail(operation: str, attempts: int, exc: Exception) -> str:
+    """A content-safe description of a failure. Never the exception's text.
+
+    Deliberately excludes ``str(exc)``. ``ProjectionError`` messages can
+    embed a source-supplied display label (two conflicting labels for one
+    canonical id, for instance), and this detail is meant to be logged and
+    carried on an outcome a worker task persists -- so it is built from a
+    fixed template, the operation name this module chose, the attempt count,
+    and the exception's TYPE name only. None of those can carry entity
+    content, whatever the exception's own message says.
+    """
+
+    return (
+        f"graph projection operation {operation!r} failed on attempt "
+        f"{attempts} with {type(exc).__name__}"
+    )
+
+
+async def project_with_retry(
+    store: ProjectingStore,
+    batch: IngestionBatch,
+    *,
+    budgets: TrialBudgets = DEFAULT_BUDGETS,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    backoff_s: float = DEFAULT_RETRY_BACKOFF_S,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> ProjectionOutcome:
+    """Project ``batch`` onto ``store``, retrying only transient write failures.
+
+    Two phases, and only the second retries:
+
+    1. :func:`~.projection.build_projection` runs exactly once. It is pure
+       and deterministic -- the same batch always yields the same
+       :class:`~.projection.GraphProjection` or the same
+       :class:`~.projection.ProjectionError` -- so retrying it could never
+       change the outcome. A ``ProjectionError`` here is reported as
+       ``PERMANENT`` with ``attempts=1``; the store is never called.
+    2. ``store.write_projection`` is attempted up to ``max_attempts`` times.
+       :data:`_TRANSIENT_EXCEPTIONS` (backend unreachable/timed out) are
+       retried with capped exponential backoff between attempts, never
+       after the last one. :data:`_PERMANENT_EXCEPTIONS` (over budget, the
+       projection flag off, a wrong-organization write) stop the loop on
+       the attempt that raised them -- retrying an identical call cannot
+       change a permanent refusal.
+
+    Any exception outside both classified sets propagates unchanged, on the
+    attempt it was raised. This driver retries exactly the failure shapes it
+    has a stated reason to believe are transient; guessing about an
+    unclassified exception (retrying it, or silently reclassifying it) would
+    risk masking a real defect behind an apparent retry success.
+    """
+
+    sleeper = sleep or _default_sleep()
+
+    try:
+        projection = build_projection(batch, budgets=budgets)
+    except ProjectionError as exc:
+        detail = _detail("build_projection", 1, exc)
+        logger.warning("%s", detail)
+        return ProjectionOutcome(
+            success=False,
+            attempts=1,
+            failure_class=ProjectionFailureClass.PERMANENT,
+            failure_detail=detail,
+        )
+
+    attempts = 0
+    last_detail: str | None = None
+    while attempts < max_attempts:
+        attempts += 1
+        try:
+            result = await store.write_projection(projection, budgets=budgets)
+        except _PERMANENT_EXCEPTIONS as exc:
+            detail = _detail("write_projection", attempts, exc)
+            logger.warning("%s", detail)
+            return ProjectionOutcome(
+                success=False,
+                attempts=attempts,
+                failure_class=ProjectionFailureClass.PERMANENT,
+                failure_detail=detail,
+            )
+        except _TRANSIENT_EXCEPTIONS as exc:
+            last_detail = _detail("write_projection", attempts, exc)
+            if attempts >= max_attempts:
+                break
+            backoff = min(backoff_s * (2 ** (attempts - 1)), _MAX_SINGLE_BACKOFF_S)
+            logger.warning(
+                "%s; retrying (attempt %d/%d) after %.1fs",
+                last_detail,
+                attempts + 1,
+                max_attempts,
+                backoff,
+            )
+            await sleeper(backoff)
+            continue
+        else:
+            return ProjectionOutcome(
+                success=True, attempts=attempts, write_result=result
+            )
+
+    assert last_detail is not None  # every path to here set it
+    return ProjectionOutcome(
+        success=False,
+        attempts=attempts,
+        failure_class=ProjectionFailureClass.TRANSIENT_EXHAUSTED,
+        failure_detail=last_detail,
+    )
+
+
+def _default_sleep() -> Callable[[float], Awaitable[None]]:
+    """Deferred import of ``asyncio.sleep`` as the default backoff sleeper.
+
+    Deferred rather than imported at module scope purely to keep the
+    parameter's default expression simple to read; there is no lazy-import
+    concern here the way there is for Graphiti.
+    """
+
+    import asyncio
+
+    return asyncio.sleep

--- a/tests/context_fabric/test_chaos_3676_projector.py
+++ b/tests/context_fabric/test_chaos_3676_projector.py
@@ -1,0 +1,342 @@
+"""CHAOS-3676: bounded retry, failure classification around write_projection.
+
+``GraphArmStore.write_projection`` had no retry and no failure
+classification: a transient failure (an unreachable/timed-out backend, per
+CHAOS-3631) and a permanent one (a malformed batch, an over-budget embedding
+run, a wrong-organization projection) both just propagated on the first
+attempt. ``project_with_retry`` is the driver that sits between a future
+worker task and the store: it retries the transient class up to a bounded
+attempt count with backoff, never retries the permanent class, and returns a
+structured :class:`ProjectionOutcome` so a caller can decide retry-via-outbox
+vs. dead-letter without inspecting exception types itself.
+
+Idempotency at the write layer is NOT re-proven here -- it is established at
+the Graphiti/FalkorDB layer (Cypher ``MERGE`` keyed on a deterministic uuid)
+and cited on the issue. This module tests the retry/classification driver
+added on top of an already-idempotent write.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from dev_health_ops.context_fabric.graph_arm import fixtures
+from dev_health_ops.context_fabric.graph_arm.projector import (
+    DEFAULT_MAX_ATTEMPTS,
+    ProjectionFailureClass,
+    ProjectionOutcome,
+    project_with_retry,
+)
+from dev_health_ops.context_fabric.graph_arm.store import (
+    EmbeddingBudgetExceededError,
+    GraphOperationTimeoutError,
+    ProjectionDisabledError,
+)
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+
+
+@dataclass
+class _FailNTimesThenSucceedStore:
+    """Raises a transient error the first ``fail_count`` calls, then succeeds."""
+
+    fail_count: int
+    calls: int = 0
+    sleeps: list[float] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        self.sleeps = []
+
+    async def write_projection(self, projection: Any, *, budgets: Any = None) -> Any:
+        self.calls += 1
+        if self.calls <= self.fail_count:
+            raise GraphOperationTimeoutError(
+                f"graph operation 'write_projection' did not complete within "
+                f"15.0s (org 'orgtest' partition 'cf_orgtest'); attempt {self.calls}"
+            )
+        return _fake_write_result()
+
+
+@dataclass
+class _AlwaysFailsTransientlyStore:
+    calls: int = 0
+
+    async def write_projection(self, projection: Any, *, budgets: Any = None) -> Any:
+        self.calls += 1
+        raise GraphOperationTimeoutError("graph operation 'write_projection' timed out")
+
+
+@dataclass
+class _AlwaysRaisesStore:
+    """Raises whatever exception instance it is constructed with."""
+
+    exc: Exception
+    calls: int = 0
+
+    async def write_projection(self, projection: Any, *, budgets: Any = None) -> Any:
+        self.calls += 1
+        raise self.exc
+
+
+def _fake_write_result() -> Any:
+    from dev_health_ops.context_fabric.graph_arm.store import WriteResult
+
+    return WriteResult(
+        nodes_written=3,
+        edges_written=1,
+        watermark=IndexWatermark(
+            indexed_through=datetime(2026, 8, 8, tzinfo=UTC),
+            projected_at=datetime(2026, 8, 8, tzinfo=UTC),
+            records_indexed=4,
+        ),
+    )
+
+
+def _batch():
+    return fixtures.alpha_batch()
+
+
+class TestSuccessAfterTransientFailures:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_retries_and_succeeds_within_the_bound(self) -> None:
+        store = _FailNTimesThenSucceedStore(fail_count=2)
+        outcome = await project_with_retry(
+            store, _batch(), max_attempts=3, backoff_s=0.0
+        )
+        assert outcome.success is True
+        assert outcome.attempts == 3
+        assert store.calls == 3
+        assert outcome.write_result is not None
+        assert outcome.failure_class is None
+        assert outcome.failure_detail is None
+
+    async def test_a_call_that_succeeds_first_try_is_not_retried(self) -> None:
+        store = _FailNTimesThenSucceedStore(fail_count=0)
+        outcome = await project_with_retry(store, _batch(), max_attempts=5)
+        assert outcome.success is True
+        assert outcome.attempts == 1
+        assert store.calls == 1
+
+
+class TestTransientExhaustion:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_stops_at_the_configured_bound_and_reports_transient_exhausted(
+        self,
+    ) -> None:
+        store = _AlwaysFailsTransientlyStore()
+        outcome = await project_with_retry(
+            store, _batch(), max_attempts=4, backoff_s=0.0
+        )
+        assert outcome.success is False
+        assert store.calls == 4, (
+            "a driver with no real bound would keep calling past the "
+            "configured max_attempts -- this asserts the count, not just "
+            "that failure was eventually reported"
+        )
+        assert outcome.attempts == 4
+        assert outcome.failure_class is ProjectionFailureClass.TRANSIENT_EXHAUSTED
+        assert outcome.write_result is None
+
+    async def test_the_default_bound_is_the_documented_constant(self) -> None:
+        store = _AlwaysFailsTransientlyStore()
+        outcome = await project_with_retry(store, _batch(), backoff_s=0.0)
+        assert store.calls == DEFAULT_MAX_ATTEMPTS
+        assert outcome.attempts == DEFAULT_MAX_ATTEMPTS
+
+    async def test_backoff_is_bounded_and_does_not_amplify_a_hung_backend(self) -> None:
+        """Total sleep across an exhausted retry run stays under a small ceiling.
+
+        Driven by a fake sleep that records durations rather than a real
+        ``asyncio.sleep`` -- a timing test against the wall clock would be a
+        flake, and a flaky test that is quietly retried is a bound nobody is
+        actually measuring.
+        """
+
+        store = _AlwaysFailsTransientlyStore()
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        outcome = await project_with_retry(
+            store, _batch(), max_attempts=5, backoff_s=0.5, sleep=fake_sleep
+        )
+        assert outcome.attempts == 5
+        # One sleep between each pair of attempts, never after the last.
+        assert len(sleeps) == 4
+        assert sum(sleeps) < 30.0, (
+            "backoff grew unbounded -- CHAOS-3631 requires retries that do "
+            "not amplify load against an already-struggling backend"
+        )
+
+
+class TestPermanentFailuresAreNeverRetried:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_malformed_batch_is_refused_before_any_write_attempt(self) -> None:
+        """``build_projection`` itself raises -- the store is never called.
+
+        Forced with a batch whose one observation names no subject entity --
+        ``build_projection`` refuses that deterministically (see
+        ``projection.py``'s "unattached evidence" check), which is a real
+        ``ProjectionError`` rather than a hand-authored one.
+        """
+
+        from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+        from dev_health_ops.context_fabric.graph_arm.records import (
+            IngestionBatch,
+            ObservationRecord,
+        )
+        from dev_health_ops.context_fabric.graph_arm.vocabulary import (
+            GraphObservationKind,
+        )
+
+        orphan_batch = IngestionBatch(
+            org_id="org_alpha",
+            entities=(),
+            relationships=(),
+            observations=(
+                ObservationRecord(
+                    org_id="org_alpha",
+                    kind=GraphObservationKind.MEASUREMENT,
+                    canonical_id="obs_orphan",
+                    source_class=SourceClass.WORK_GRAPH,
+                    title="orphan",
+                    subjects=(),
+                    observed_at=datetime(2026, 8, 8, tzinfo=UTC),
+                ),
+            ),
+        )
+        store = _AlwaysFailsTransientlyStore()
+        outcome = await project_with_retry(store, orphan_batch, max_attempts=5)
+        assert outcome.success is False
+        assert outcome.failure_class is ProjectionFailureClass.PERMANENT
+        assert store.calls == 0, (
+            "the store must never be called for a batch build_projection refused"
+        )
+
+    async def test_an_over_budget_embedding_run_is_not_retried(self) -> None:
+        store = _AlwaysRaisesStore(
+            exc=EmbeddingBudgetExceededError("would spend more embedding calls")
+        )
+        outcome = await project_with_retry(store, _batch(), max_attempts=5)
+        assert outcome.success is False
+        assert outcome.failure_class is ProjectionFailureClass.PERMANENT
+        assert store.calls == 1
+
+    async def test_a_wrong_organization_projection_is_not_retried(self) -> None:
+        store = _AlwaysRaisesStore(
+            exc=PermissionError("projection belongs to a different organization")
+        )
+        outcome = await project_with_retry(store, _batch(), max_attempts=5)
+        assert outcome.success is False
+        assert outcome.failure_class is ProjectionFailureClass.PERMANENT
+        assert store.calls == 1
+
+    async def test_the_projection_flag_being_off_is_not_retried(self) -> None:
+        store = _AlwaysRaisesStore(
+            exc=ProjectionDisabledError("graph projection is disabled")
+        )
+        outcome = await project_with_retry(store, _batch(), max_attempts=5)
+        assert outcome.success is False
+        assert outcome.failure_class is ProjectionFailureClass.PERMANENT
+        assert store.calls == 1
+
+
+class TestOutcomeShape:
+    def test_a_success_outcome_cannot_also_carry_failure_detail(self) -> None:
+        with pytest.raises(ValueError, match="successful outcome"):
+            ProjectionOutcome(
+                success=True,
+                attempts=1,
+                write_result=_fake_write_result(),
+                failure_class=ProjectionFailureClass.PERMANENT,
+            )
+
+    def test_a_success_outcome_must_carry_a_write_result(self) -> None:
+        with pytest.raises(ValueError, match="successful outcome"):
+            ProjectionOutcome(success=True, attempts=1, write_result=None)
+
+    def test_a_failure_outcome_cannot_carry_a_write_result(self) -> None:
+        with pytest.raises(ValueError, match="failed outcome"):
+            ProjectionOutcome(
+                success=False,
+                attempts=1,
+                write_result=_fake_write_result(),
+                failure_class=ProjectionFailureClass.PERMANENT,
+                failure_detail="x",
+            )
+
+    def test_a_failure_outcome_must_carry_a_class_and_detail(self) -> None:
+        with pytest.raises(ValueError, match="failed outcome"):
+            ProjectionOutcome(success=False, attempts=1)
+
+
+class TestFailureDetailIsContentSafe:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_permanent_build_failure_never_leaks_entity_labels(self) -> None:
+        """Plant a distinctive label in the batch that triggers ProjectionError.
+
+        ``build_projection`` can raise ``ProjectionError`` with a message that
+        embeds a source-supplied display label (e.g. two conflicting labels
+        for the same canonical id). The outcome's ``failure_detail`` must
+        never carry that text -- only a fixed template naming the operation,
+        attempt count and exception TYPE, matching the content-safety bar
+        CHAOS-3631 set for timeout messages.
+        """
+
+        from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+        from dev_health_ops.context_fabric.graph_arm.records import (
+            EntityRecord,
+            IngestionBatch,
+        )
+        from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+        planted_label = "TOTALLY-SECRET-DISPLAY-LABEL-MARKER"
+        now = datetime(2026, 8, 8, tzinfo=UTC)
+        conflicting_batch = IngestionBatch(
+            org_id="org_alpha",
+            entities=(
+                EntityRecord(
+                    org_id="org_alpha",
+                    kind=GraphEntityKind.PROJECT,
+                    canonical_id="proj_dup",
+                    display_label="Original Label",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=now,
+                ),
+                EntityRecord(
+                    org_id="org_alpha",
+                    kind=GraphEntityKind.PROJECT,
+                    canonical_id="proj_dup",
+                    display_label=planted_label,
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=now,
+                ),
+            ),
+        )
+        store = _AlwaysFailsTransientlyStore()
+        outcome = await project_with_retry(store, conflicting_batch, max_attempts=3)
+        assert outcome.success is False
+        assert outcome.failure_class is ProjectionFailureClass.PERMANENT
+        assert outcome.failure_detail is not None
+        assert planted_label not in outcome.failure_detail
+        assert "Original Label" not in outcome.failure_detail
+        assert "ProjectionError" in outcome.failure_detail
+
+    async def test_a_transient_exhaustion_detail_names_the_exception_type_only(
+        self,
+    ) -> None:
+        store = _AlwaysFailsTransientlyStore()
+        outcome = await project_with_retry(
+            store, _batch(), max_attempts=2, backoff_s=0.0
+        )
+        assert outcome.failure_detail is not None
+        assert "GraphOperationTimeoutError" in outcome.failure_detail
+        assert "write_projection" in outcome.failure_detail


### PR DESCRIPTION
## Issue and phase

[CHAOS-3676](https://linear.app/fullchaos/issue/CHAOS-3676/idempotent-graph-projection-driver-bounded-retry-failure) — Phase 1, Lane A (production graph platform), child of [CHAOS-3500](https://linear.app/fullchaos/issue/CHAOS-3500/phase-1-platform-production-graph-projection-lifecycle-and-bounded) under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660/phase-1-wire-the-production-shaped-graph-assisted-ask-dev-path).

## Observable outcome

`GraphArmStore.write_projection` had no retry and no failure classification: a transient failure (`GraphOperationTimeoutError`/`StoreUnavailableError`, [CHAOS-3631](https://linear.app/fullchaos/issue/CHAOS-3631/grapharmstore-constructs-falkordriver-with-no-socket-timeout-a-hung)) and a permanent one (`ProjectionError`, `EmbeddingBudgetExceededError`, a wrong-organization `PermissionError`, `ProjectionDisabledError`) both propagated identically on the first attempt.

`project_with_retry` (new `graph_arm/projector.py`) retries only the transient class, up to a bounded configurable attempt count with capped exponential backoff; the permanent class is never retried — refused on the attempt that raised it. It returns a structured `ProjectionOutcome` distinguishing success / transient-exhausted / permanent, shaped so a future worker task can decide `self.retry(...)` vs. dead-lettering a `worker_job_outbox` row without inspecting exception types itself.

## Architecture boundary

New module only, in Lane A's exclusive-ownership area (`context_fabric/graph_arm/`). No existing file's behavior changes — `store.py`, `flags.py`, `projection.py` are read, not modified. `projector.py` depends only on `GraphArmStore`'s existing public API via a `Protocol` (`ProjectingStore`), not on its internals.

## Scope / non-scope

**In scope:** bounded retry + backoff for transient write failures; immediate refusal (no retry) for permanent failures; a structured, content-safe outcome type.

**Explicitly out of scope**, per research recorded on the issue before coding: no `worker_job_outbox` row is written, no Celery task is registered, no canonical-ingestion event wiring is added. This repo already has a durable retry/dead-letter mechanism (`worker_job_outbox` — Postgres `pending/claimed/delivered/dead` status, `attempt_count`/`max_attempts`/`next_attempt_at` columns, a Go relay consumer with its own bounded backoff) and this issue does not reinvent it; it produces the outcome shape a future consumer of that mechanism needs. Where a "project this organization's canonical delta" job gets enqueued from is a separate question this PR does not answer.

**Idempotency is not re-proven here.** It is established one layer down: `graphiti_core.utils.bulk_utils.add_nodes_and_edges_bulk` writes every node/edge via Cypher `MERGE` keyed on the deterministic uuid `identity.py` derives from the canonical id (verified by reading the generated Cypher in `graphiti_core/models/{nodes,edges}/*_db_queries.py`, not assumed) — a retried write after a partial failure re-sets identical properties rather than duplicating. That property is what makes retrying safe in the first place, and is cited/documented on the module rather than re-tested.

## Base/head SHA and branch provenance

`chaos-3676-projection-retry`, stacked on the not-yet-merged `chaos-3631-driver-timeouts` ([#1636](https://github.com/full-chaos/dev-health-ops/pull/1636)) — this PR's diff includes that PR's commit until #1636 merges, at which point it will shrink to just the `CHAOS-3676` commit. Rebased onto `origin/feature/chaos-3498-context-fabric` @ `d32dcbf28` (current tip at push time, includes CHAOS-3653/CHAOS-3633 merges) with no conflicts. Branch named for the child issue this PR completes, per the standing branch-naming rule (a parent-named branch auto-closes the parent issue and cascades to its children on merge via Linear's GitHub linkage).

## Migrations / configuration / feature flags

None. No new table, no new env var, no new Celery task. `project_with_retry`'s `max_attempts`/`backoff_s` are plain function parameters with fixed, documented defaults (`DEFAULT_MAX_ATTEMPTS = 3`, `DEFAULT_RETRY_BACKOFF_S = 1.0`, capped per-sleep at 8s).

## Security / privacy / retention impact

None. `ProjectionOutcome.failure_detail` is built from a fixed template (operation name, attempt count, exception TYPE name) and deliberately never includes `str(exc)` — `ProjectionError` messages can embed a source-supplied entity display label, so including the raw exception text would leak content into what's meant to be a safe, loggable/persistable outcome. Tested directly: a planted distinctive display-label string is asserted absent from the outcome.

## RED-first evidence

New module `projector.py` and new test module `test_chaos_3676_projector.py` did not exist before this change — the tests could not have passed against any prior tree. Verified for real by checking the module has no other production callers yet and every test targets code introduced in this PR's own commit.

## Focused and broad verification

All commands run at this PR's tested commit, live store `falkor://127.0.0.1:6389` with `CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1`.

```
.venv/bin/pytest tests/context_fabric/test_chaos_3676_projector.py -q
  → 15 passed

.venv/bin/pytest tests/context_fabric/ -q
  → 1451 passed, 1 skipped, 2 failed

.venv/bin/ruff check / ruff format --check src/.../projector.py tests/.../test_chaos_3676_projector.py
  → All checks passed! / already formatted

.venv/bin/mypy src/.../projector.py tests/.../test_chaos_3676_projector.py
  → Success: no issues found
```

**Both failures in the full suite are pre-existing and confirmed unrelated** — both in `test_chaos_3647_live_semantic.py` (Lane D's CHAOS-3647 territory, not touched by this PR):
- `TestThePinnedBaselineIsReproduced::test_the_colloquial_cases_still_resolve_nothing_deterministically` — same pre-existing "pinned baseline has moved" failure flagged on PR #1636.
- `TestTheAuthorizationProbesAreEffective::test_each_probe_measures_what_it_claims[unrestricted_control]` — verified by re-running that exact test with this PR's two new files stashed out (only `chaos-3631-driver-timeouts` content present): fails identically, same assertion, same message ("the control withheld 1 entities on a query aimed at nothing restricted"). This module's tests use only fakes (`_FailNTimesThenSucceedStore` etc.) — nothing in `test_chaos_3676_projector.py` writes to the live FalkorDB store, so it cannot be the source of live-store test-isolation flakiness.

## Known limitations and follow-up issues

- No worker/outbox wiring (see Scope/non-scope) — tracked as follow-up, not yet filed as its own issue since the enqueue side depends on a design decision (where canonical-delta events for the graph originate) outside this lane's current scope.
- `max_attempts`/`backoff_s` have no environment-variable override yet (unlike CHAOS-3631's `GraphDeadlines`) — deliberately: this driver has no caller yet, so tuning knobs before there's a real consumer to tune them for would be speculative.

## Rollout / rollback impact

Pure addition, zero behavior change to any existing code path (no existing file is modified). Rollback is a plain revert.