### PR TITLE
CHAOS-3675 PR 1/3: real ClickHouse-backed EvidenceCandidateResolver (reviews)

### DIFF
--- a/src/dev_health_ops/api/dev/native_evidence_resolver.py
+++ b/src/dev_health_ops/api/dev/native_evidence_resolver.py
@@ -1,0 +1,156 @@
+"""CHAOS-3664/CHAOS-3675: real ClickHouse-backed candidate resolution for
+graph-discovered evidence admission.
+
+The CHAOS-3616 world resolver (``trials/chaos_3646/canonical.py``) reads a
+frozen fixture corpus and is test-only. This module is its production
+replacement: an :class:`~.evidence_service.EvidenceCandidateResolver`
+registered under ``context_fabric_graph_arm`` that resolves a graph-arm
+candidate against real ``native_evidence.py``-adjacent ClickHouse tables.
+
+**Structural finding this module is built on (CHAOS-3675 recon).**
+``EvidenceCandidate.entity_type`` is always a
+:class:`~context_fabric.graph_arm.vocabulary.GraphObservationKind` value --
+what KIND OF RECORD the arm observed (a commit, a review, a CI run, ...),
+never an :class:`~.scope_service.EntityKind` (what the record is ABOUT: a
+pull request, a project, ...). The two vocabularies are disjoint by
+construction -- an observation is always ``OBSERVED_ON`` an entity, never
+itself one -- and no reachable observation kind (``commit``, ``review``,
+``ci_run``, ``deployment``, ``incident``; every other
+``GraphObservationKind`` has no native-evidence source at all yet) has a
+directly-authorizable identity of its own.
+
+That makes the one invariant every resolver here exists to enforce:
+**the entity a record is about is derived from the canonical row, never
+from ``candidate.entity_id``.** ``EvidenceCandidate`` carries the arm's
+*belief* about what a record is about; a resolver that echoed it back
+unverified would let the arm mint authority through a canonical-looking
+door, which is exactly what CHAOS-3646's admission seam exists to prevent
+("the graph never mints authority" landing at the resolver layer, not just
+at the signer). Every ``_resolve_*`` method below re-derives the linked
+entity from the row it reads, and the candidate's own claim is consulted
+for nothing but the locator used to look the row up.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from dev_health_ops.api.queries.client import query_dicts
+
+from .contracts import FreshnessState
+from .evidence_service import EvidenceCandidate, EvidenceRecord
+from .native_evidence import (
+    SourceFreshnessPolicy,
+    _datetime,
+    default_native_freshness_policies,
+)
+from .scope_service import ScopeResolution
+
+RESOLVER_SOURCE_VERSION = "native-evidence-admission.v1"
+
+#: One row, keyed by the review's OWN composite locator -- never by the PR
+#: it belongs to, which is exactly the distinction CHAOS-3633 exists to
+#: preserve. ``number``/``repo_id`` are read back so the linked PR can be
+#: derived from THIS row, not trusted from the candidate.
+_REVIEW_RESOLVE_SQL = """
+SELECT repo_id, number, review_id, reviewer, state, submitted_at, last_synced
+FROM git_pull_request_reviews FINAL
+WHERE org_id = {org_id:String}
+  AND concat(toString(repo_id), '#pr', toString(number), '#review', review_id) = {locator:String}
+LIMIT 1
+"""
+
+
+def _review_pr_entity_id(row: Mapping[str, Any]) -> str:
+    return f"{row['repo_id']}#pr{row['number']}"
+
+
+async def _resolve_review(
+    client: Any,
+    *,
+    org_id: str,
+    candidate: EvidenceCandidate,
+    policy: SourceFreshnessPolicy,
+    source_system: str,
+) -> EvidenceRecord | None:
+    rows = await query_dicts(
+        client, _REVIEW_RESOLVE_SQL, {"org_id": org_id, "locator": candidate.locator}
+    )
+    if not rows:
+        return None
+    row = rows[0]
+    observed = _datetime(row.get("submitted_at")) or datetime.now(UTC)
+    last_synced = _datetime(row.get("last_synced"))
+    freshness = policy.classify(last_synced, now=datetime.now(UTC))
+    return EvidenceRecord(
+        source_system=source_system,
+        source_version=RESOLVER_SOURCE_VERSION,
+        entity_type="review",
+        # Derived from the row's own repo_id/number, never from
+        # candidate.entity_id -- see the module docstring.
+        entity_id=_review_pr_entity_id(row),
+        display_label=f"Review by {row.get('reviewer') or 'unknown'}",
+        observed_at=observed,
+        freshness=freshness,
+        provenance="native",
+        confidence=1.0,
+        repository_ids=(str(row["repo_id"]),),
+        raw_excerpt=f"Review state: {row.get('state') or 'unknown'}",
+        stale=freshness is FreshnessState.STALE,
+    )
+
+
+class NativeEvidenceCandidateResolver:
+    """Resolves ``context_fabric_graph_arm`` candidates against real
+    ClickHouse native evidence tables, one ``GraphObservationKind`` at a
+    time.
+
+    Additive: only observation kinds with an implemented ``_resolve_*``
+    below are handled; every other kind returns ``None`` (refused as
+    ``NO_MATCHES``), never an error. CHAOS-3675 PR 1/3 implements
+    ``review`` only -- ``deployment``'s linked PR is nullable in the
+    canonical schema (a deployment need not correspond to any PR), which
+    needs its own authorization-shape decision (empty ``valid_entity_ids``,
+    repository-only authorization) before it can resolve safely; deferred
+    rather than guessed at here. ``commit``/``ci_run`` need a confirmed
+    join path (candidate: ``work_graph_edges``) before they can derive
+    their linked entity at all. ``incident`` follows the same shape
+    ``native_evidence.py``'s own ``incidents`` spec already joins through.
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        policies: Mapping[str, SourceFreshnessPolicy] | None = None,
+    ) -> None:
+        # CHAOS-3617 containment: the production tree may not import the
+        # arm at module scope (``derived_store_registry`` is the one
+        # existing lazy-import exception; this is the second). Deferred to
+        # construction time, not module import time.
+        from dev_health_ops.context_fabric.graph_arm.admission import (
+            ARM_SOURCE_SYSTEM,
+        )
+
+        self.source_system = ARM_SOURCE_SYSTEM
+        self._client = client
+        self._policies = dict(policies or default_native_freshness_policies())
+
+    async def resolve(
+        self,
+        *,
+        org_id: str,
+        scope: ScopeResolution,
+        candidate: EvidenceCandidate,
+    ) -> EvidenceRecord | None:
+        if candidate.entity_type == "review":
+            return await _resolve_review(
+                self._client,
+                org_id=org_id,
+                candidate=candidate,
+                policy=self._policies["reviews"],
+                source_system=self.source_system,
+            )
+        return None

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -114,6 +114,7 @@ from .investigation_plans.wave_3_1_plans import (
 from .metrics.clickhouse import ClickHouseMetricSource
 from .metrics.service import MetricQueryRequest, MetricQueryService
 from .native_evidence import native_evidence_adapters
+from .native_evidence_resolver import NativeEvidenceCandidateResolver
 from .native_status_change import ClickHouseStatusChangeSource
 from .native_team_workload import ClickHouseTeamWorkloadSource
 from .operational_deficiency_service import OperationalDeficiencyService
@@ -1604,6 +1605,15 @@ async def _assemble_production_runtime(
         signer=evidence_signer,
         native_adapters=native_evidence_adapters(clickhouse),
         acr_adapter=None,
+        # CHAOS-3675 PR 1/3: the first real (non-fixture) candidate
+        # resolver. Registering it does not, by itself, admit anything --
+        # nothing in production calls ``EvidenceService.admit`` yet (Lane
+        # B's routing work does); this only replaces the "no shipped
+        # construction passes a resolver" default the class docstring
+        # describes. Handles ``review``-kind candidates only today; every
+        # other ``GraphObservationKind`` still refuses as
+        # ``source_unconfigured`` until PR 2/3 and PR 3/3 land.
+        candidate_resolvers=(NativeEvidenceCandidateResolver(clickhouse),),
     )
     data_health_service = DataHealthService(
         entitlement=entitlement,

--- a/tests/api/dev/test_native_evidence_resolver.py
+++ b/tests/api/dev/test_native_evidence_resolver.py
@@ -1,0 +1,296 @@
+"""CHAOS-3675 PR 1/3: the production review resolver, and the invariant it
+exists to enforce -- the entity a record is about is derived from the
+canonical row, never from ``candidate.entity_id``.
+
+Every test here uses a fake ClickHouse-shaped sink whose ``query_dicts``
+call simulates the real SQL's own ``WHERE org_id = ... AND locator = ...``
+predicate (filtering by BOTH before returning a row), so an org-mismatch
+test exercises the same filtering discipline the live SQL performs, not
+merely that Python happens to pass the right parameter through. The
+tenant-isolation behaviour of the ACTUAL SQL text is separately proven live
+in ``test_native_evidence_resolver_clickhouse_live.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.dev.evidence_service import EvidenceCandidate
+from dev_health_ops.api.dev.native_evidence import SourceFreshnessPolicy
+from dev_health_ops.api.dev.native_evidence_resolver import (
+    NativeEvidenceCandidateResolver,
+    _review_pr_entity_id,
+)
+from dev_health_ops.api.dev.scope_service import ScopeResolution
+from dev_health_ops.context_fabric.graph_arm.admission import ARM_SOURCE_SYSTEM
+
+NOW = datetime(2026, 7, 28, 12, tzinfo=UTC)
+ORG_A = "org-a"
+ORG_B = "org-b"
+#: This resolver never reads ``scope`` (see the module docstring: the
+#: entity comes from the row, never from ambient scope either) -- ``None``
+#: cast to the parameter's real type keeps every call site honestly typed
+#: instead of scattering per-call ``# type: ignore``s.
+_UNUSED_SCOPE = cast(ScopeResolution, None)
+
+
+@dataclass(frozen=True)
+class _Row:
+    org_id: str
+    locator: str
+    repo_id: str
+    number: int
+    review_id: str
+    reviewer: str
+    state: str
+    submitted_at: datetime
+    last_synced: datetime
+
+
+def _row(
+    *,
+    org_id: str = ORG_A,
+    repo_id: str = "repo-1",
+    number: int = 42,
+    review_id: str = "rev-9",
+    reviewer: str = "octocat",
+    state: str = "approved",
+) -> _Row:
+    locator = f"{repo_id}#pr{number}#review{review_id}"
+    return _Row(
+        org_id=org_id,
+        locator=locator,
+        repo_id=repo_id,
+        number=number,
+        review_id=review_id,
+        reviewer=reviewer,
+        state=state,
+        submitted_at=NOW - timedelta(hours=1),
+        last_synced=NOW - timedelta(minutes=5),
+    )
+
+
+class _FakeSink:
+    """Simulates the review-resolve SQL's own WHERE clause: a row is
+    returned only when BOTH ``org_id`` and the composite locator match --
+    the same two predicates ``_REVIEW_RESOLVE_SQL`` binds."""
+
+    def __init__(self, rows: list[_Row]) -> None:
+        self._rows = rows
+        self.calls: list[dict[str, Any]] = []
+
+    async def query_dicts(
+        self, query: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.calls.append(params)
+        for row in self._rows:
+            if row.org_id == params["org_id"] and row.locator == params["locator"]:
+                return [
+                    {
+                        "repo_id": row.repo_id,
+                        "number": row.number,
+                        "review_id": row.review_id,
+                        "reviewer": row.reviewer,
+                        "state": row.state,
+                        "submitted_at": row.submitted_at,
+                        "last_synced": row.last_synced,
+                    }
+                ]
+        return []
+
+
+def _monkeypatch_query_dicts(monkeypatch: pytest.MonkeyPatch, sink: _FakeSink) -> None:
+    async def _fake_query_dicts(client: Any, query: str, params: dict[str, Any]):
+        assert client is sink
+        return await sink.query_dicts(query, params)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence_resolver.query_dicts",
+        _fake_query_dicts,
+    )
+
+
+def _candidate(
+    locator: str, *, claimed_entity_id: str = "issue-999"
+) -> EvidenceCandidate:
+    return EvidenceCandidate(
+        source_system=ARM_SOURCE_SYSTEM,
+        entity_type="review",
+        # Deliberately a claim the row will NOT corroborate -- every test
+        # below asserts the resolver never trusts this value.
+        entity_id=claimed_entity_id,
+        locator=locator,
+    )
+
+
+def _resolve(resolver: NativeEvidenceCandidateResolver, candidate: EvidenceCandidate):
+    return asyncio.run(
+        resolver.resolve(org_id=ORG_A, scope=_UNUSED_SCOPE, candidate=candidate)
+    )
+
+
+def test_source_system_is_the_arm() -> None:
+    # Instance attribute, not class-level: the arm import is lazy (CHAOS-3617
+    # containment -- production may not import context_fabric at module
+    # scope), set at construction time.
+    assert NativeEvidenceCandidateResolver(_FakeSink([])).source_system == (
+        ARM_SOURCE_SYSTEM
+    )
+
+
+def test_review_pr_entity_id_is_derived_from_repo_and_number() -> None:
+    assert _review_pr_entity_id({"repo_id": "repo-1", "number": 42}) == "repo-1#pr42"
+
+
+def test_resolve_derives_the_pr_entity_from_the_row_never_the_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The core invariant. The candidate CLAIMS ``entity_id="issue-999"``;
+    the row is genuinely about a completely different PR. The resolved
+    record must reflect the ROW's truth, and the claim must not leak
+    through anywhere.
+    """
+
+    row = _row(repo_id="repo-1", number=42)
+    sink = _FakeSink([row])
+    _monkeypatch_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = _resolve(resolver, _candidate(row.locator, claimed_entity_id="issue-999"))
+
+    assert record is not None
+    assert record.entity_id == "repo-1#pr42"
+    assert record.entity_id != "issue-999"
+    assert "issue-999" not in (record.display_label, record.raw_excerpt or "")
+
+
+def test_resolve_is_keyed_by_locator_not_by_the_candidates_claimed_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second row exists whose locator matches the candidate's CLAIMED
+    entity_id string by coincidence -- the resolver must still look up by
+    ``candidate.locator`` and never fall back to matching on entity_id."""
+
+    real_row = _row(repo_id="repo-1", number=42, review_id="rev-9")
+    decoy_row = _row(repo_id="repo-1", number=999, review_id="rev-decoy")
+    sink = _FakeSink([real_row, decoy_row])
+    _monkeypatch_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = _resolve(
+        resolver, _candidate(real_row.locator, claimed_entity_id=decoy_row.locator)
+    )
+
+    assert record is not None
+    assert record.entity_id == "repo-1#pr42"
+
+
+def test_an_unknown_locator_is_refused_as_no_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = _FakeSink([])
+    _monkeypatch_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    assert _resolve(resolver, _candidate("repo-1#pr1#review1")) is None
+
+
+def test_a_locator_that_exists_only_in_a_different_org_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contract-owner requirement: a candidate claiming a locator that is
+    REAL, but in a different org, must die at resolution -- not just an
+    outright-nonexistent locator. The fake sink filters on org_id exactly
+    as the real SQL's ``WHERE org_id = {org_id:String}`` does, so this
+    proves the resolver actually threads the CALLER's org_id into the
+    lookup rather than trusting/ignoring it.
+    """
+
+    other_org_row = _row(org_id=ORG_B, repo_id="repo-1", number=42)
+    sink = _FakeSink([other_org_row])
+    _monkeypatch_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    # Same locator that IS real -- just in ORG_B, not the ORG_A this
+    # resolver is asked to resolve for.
+    assert (
+        asyncio.run(
+            resolver.resolve(
+                org_id=ORG_A,
+                scope=_UNUSED_SCOPE,
+                candidate=_candidate(other_org_row.locator),
+            )
+        )
+        is None
+    )
+    # And the SAME locator resolves cleanly for the org it actually
+    # belongs to -- proves the refusal above is the org check, not a
+    # broken lookup.
+    assert (
+        asyncio.run(
+            resolver.resolve(
+                org_id=ORG_B,
+                scope=_UNUSED_SCOPE,
+                candidate=_candidate(other_org_row.locator),
+            )
+        )
+        is not None
+    )
+
+
+def test_unimplemented_observation_kinds_are_refused_without_querying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``deployment``/``commit``/``ci_run``/``incident`` are deliberately
+    unimplemented in PR 1/3 (see the class docstring) -- refused cleanly,
+    never a crash, and never a query issued for a kind this resolver
+    cannot yet verify safely."""
+
+    sink = _FakeSink([_row()])
+    _monkeypatch_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    candidate = EvidenceCandidate(
+        source_system=ARM_SOURCE_SYSTEM,
+        entity_type="deployment",
+        entity_id="issue-999",
+        locator="repo-1#deployment1",
+    )
+    assert _resolve(resolver, candidate) is None
+    assert sink.calls == []
+
+
+def test_resolved_record_carries_the_repository_for_the_separate_repo_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _row(repo_id="repo-77")
+    sink = _FakeSink([row])
+    _monkeypatch_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = _resolve(resolver, _candidate(row.locator))
+
+    assert record is not None
+    assert record.repository_ids == ("repo-77",)
+
+
+def test_freshness_policy_governs_staleness(monkeypatch: pytest.MonkeyPatch) -> None:
+    row = _row()
+    sink = _FakeSink([row])
+    _monkeypatch_query_dicts(monkeypatch, sink)
+    always_stale = SourceFreshnessPolicy(
+        source_system="reviews",
+        policy_version="test-always-stale.v1",
+        maximum_age=timedelta(0),
+    )
+    resolver = NativeEvidenceCandidateResolver(sink, policies={"reviews": always_stale})
+
+    record = _resolve(resolver, _candidate(row.locator))
+
+    assert record is not None
+    assert record.stale is True

--- a/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
+++ b/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
@@ -1,0 +1,163 @@
+"""CHAOS-3675 PR 1/3: the review resolver's real SQL, against a real
+migrated ClickHouse schema -- not assumed from the query text, not
+simulated by a fake sink (``test_native_evidence_resolver.py`` covers the
+resolver's own logic that way; this file proves the SQL itself).
+
+Two properties a fake sink cannot establish:
+1. ``_REVIEW_RESOLVE_SQL`` parses and executes against the real
+   ``git_pull_request_reviews`` schema (column names/types match).
+2. The ``WHERE org_id = ...`` predicate genuinely enforces tenant
+   isolation in the real engine -- two rows sharing an identical composite
+   locator string but different ``org_id``s, and a lookup for one org never
+   returns the other's row.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+_PROTECTED_DATABASES = frozenset({"", "default"})
+
+
+def _database_of(dsn: str | None) -> str:
+    from urllib.parse import urlparse
+
+    return urlparse(dsn or "").path.lstrip("/").strip().lower()
+
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+_SKIP_REASON = (
+    "Requires a migrated SCRATCH CLICKHOUSE_URI "
+    "(e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate); "
+    f"got database {_database_of(CLICKHOUSE_URI) or '<unset>'!r}, which this "
+    "suite refuses to run against"
+)
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI or _database_of(CLICKHOUSE_URI) in _PROTECTED_DATABASES,
+        reason=_SKIP_REASON,
+    ),
+]
+
+ORG_A = "11111111-1111-4111-8111-111111111111"
+ORG_B = "22222222-2222-4222-8222-222222222222"
+REPO_ID = "33333333-3333-4333-8333-333333333333"
+NOW = datetime(2026, 7, 28, 12, tzinfo=UTC)
+
+
+@pytest.fixture(scope="module")
+def ch_client() -> Any:
+    import clickhouse_connect
+
+    assert CLICKHOUSE_URI is not None
+    client = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean_reviews_table(ch_client: Any) -> Any:
+    ch_client.command("TRUNCATE TABLE IF EXISTS git_pull_request_reviews")
+    yield
+    ch_client.command("TRUNCATE TABLE IF EXISTS git_pull_request_reviews")
+
+
+def _insert_review(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: str = REPO_ID,
+    number: int = 42,
+    review_id: str = "rev-9",
+    reviewer: str = "octocat",
+    state: str = "approved",
+) -> None:
+    client.insert(
+        "git_pull_request_reviews",
+        [[org_id, repo_id, number, review_id, reviewer, state, NOW, NOW]],
+        column_names=[
+            "org_id",
+            "repo_id",
+            "number",
+            "review_id",
+            "reviewer",
+            "state",
+            "submitted_at",
+            "last_synced",
+        ],
+    )
+
+
+async def _resolve(client: Any, *, org_id: str, locator: str):
+    from dev_health_ops.api.dev.evidence_service import EvidenceCandidate
+    from dev_health_ops.api.dev.native_evidence_resolver import (
+        NativeEvidenceCandidateResolver,
+    )
+    from dev_health_ops.context_fabric.graph_arm.admission import ARM_SOURCE_SYSTEM
+
+    resolver = NativeEvidenceCandidateResolver(client)
+    candidate = EvidenceCandidate(
+        source_system=ARM_SOURCE_SYSTEM,
+        entity_type="review",
+        entity_id="a-claim-the-real-row-does-not-corroborate",
+        locator=locator,
+    )
+    return await resolver.resolve(org_id=org_id, scope=None, candidate=candidate)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_the_real_sql_resolves_a_seeded_review_and_derives_its_pr(
+    ch_client: Any,
+) -> None:
+    _insert_review(ch_client, org_id=ORG_A)
+    locator = f"{REPO_ID}#pr42#reviewrev-9"
+
+    record = await _resolve(ch_client, org_id=ORG_A, locator=locator)
+
+    assert record is not None
+    assert record.entity_id == f"{REPO_ID}#pr42"
+    assert record.repository_ids == (REPO_ID,)
+    assert record.display_label == "Review by octocat"
+
+
+@pytest.mark.asyncio
+async def test_the_real_sql_enforces_tenant_isolation_on_an_identical_locator(
+    ch_client: Any,
+) -> None:
+    """Two rows, byte-identical composite locator, different orgs. The real
+    ``WHERE org_id = {org_id:String}`` predicate -- not Python -- is what
+    must keep them apart."""
+
+    locator = f"{REPO_ID}#pr42#reviewrev-9"
+    _insert_review(ch_client, org_id=ORG_A, reviewer="org-a-reviewer")
+    _insert_review(ch_client, org_id=ORG_B, reviewer="org-b-reviewer")
+
+    a = await _resolve(ch_client, org_id=ORG_A, locator=locator)
+    b = await _resolve(ch_client, org_id=ORG_B, locator=locator)
+
+    assert a is not None and a.display_label == "Review by org-a-reviewer"
+    assert b is not None and b.display_label == "Review by org-b-reviewer"
+
+    # And a THIRD org, with no row of its own, gets neither.
+    absent = await _resolve(
+        ch_client, org_id="99999999-9999-4999-8999-999999999999", locator=locator
+    )
+    assert absent is None
+
+
+@pytest.mark.asyncio
+async def test_an_unseeded_locator_resolves_to_none_against_the_real_table(
+    ch_client: Any,
+) -> None:
+    record = await _resolve(
+        ch_client, org_id=ORG_A, locator=f"{REPO_ID}#pr404#reviewnope"
+    )
+    assert record is None


### PR DESCRIPTION
Branch deliberately does NOT carry the CHAOS-3675 issue number: CHAOS-3675 spans 3 PRs (see the issue), and the #1631 mass-closure root cause was branch-name-linkage auto-closing an issue (and cascading to children) on the first PR that merges. This is PR 1 of 3; CHAOS-3675 should only close after PR 3/3.

## Issue and phase
[CHAOS-3675](https://linear.app/fullchaos/issue/CHAOS-3675) (part of it — PR 1/3) — child of [CHAOS-3664](https://linear.app/fullchaos/issue/CHAOS-3664), Phase 1 Lane C, under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660).

## Observable outcome
`EvidenceService.admit()` can resolve a real graph-arm `review`-kind candidate against real ClickHouse data (`git_pull_request_reviews`), replacing the CHAOS-3616 fixture-world resolver for that one observation kind. Production previously wired zero `candidate_resolvers` at all — admission was a structural no-op in every deployed process regardless of the CHAOS-3633 signer fix.

## Architecture boundary
Canonical admission side only. No graph-arm files touched except a lazy (function-scope) import of `ARM_SOURCE_SYSTEM`, required by and verified against `test_no_production_module_imports_the_arm_at_module_scope` (CHAOS-3617 containment — the arm may not be imported at module scope anywhere in the production tree; `derived_store_registry` is the one prior exception, this is the second).

## Recon correction (posted on CHAOS-3675 before writing code)
The original PR1 scope-lock targeted `work_items`/`pull_requests` — unreachable. `EvidenceCandidate.entity_type` is always a `GraphObservationKind` value (commit, review, ci_run, deployment, incident, ...), disjoint from `EntityKind` (project, work_unit, issue, pull_request, ...) — an observation is never itself an authorizable entity, always `OBSERVED_ON` one. No reachable observation kind has a directly-authorizable identity of its own, so **every** resolver — not just the reviews/incidents pair originally flagged — must independently derive the linked entity from the canonical row, never trust `candidate.entity_id`. That's the "graph never mints authority" invariant landing at the resolver layer, stated in the module docstring.

## Scope / non-scope
This PR: `review` only. `git_pull_request_reviews` already embeds its linked PR (`repo_id`, `number`) in the same row as the review's own composite locator, so no extra join is needed.
Deferred to PR 2/3 and PR 3/3 (not guessed at here):
- `deployment` — `pull_request_number` is `Nullable` in the canonical schema; a deployment with no linked PR needs its own authorization-shape decision (empty `valid_entity_ids`, repository-only authorization) before it can resolve safely.
- `commit`/`ci_run` — need a confirmed join path (candidate: `work_graph_edges`) to derive their linked entity at all.
- `incident` — follows `native_evidence.py`'s own `incidents` join shape.
- Every `GraphObservationKind` with no `native_evidence.py` source at all yet (status_change, decision, document, the agent_* family, measurement, release, test_report) is out of scope entirely.

## Base/head SHA and branch provenance
Base: `feature/chaos-3498-context-fabric` @ `d32dcbf2853cdcd51f2d3d7c6dc1665f9188effb` (current tip; branch created and rebased onto it after CHAOS-3633/#1635 merged)
Head: `evidence-resolver-reviews-pr1` @ latest commit on the branch.

## Migrations/configuration/feature flags
None. No schema change. Wires `candidate_resolvers=(NativeEvidenceCandidateResolver(clickhouse),)` into `production_runtime.py`'s existing `EvidenceService` construction — inert today, since nothing in production calls `.admit()` yet (Lane B's routing work does); this only replaces the "no shipped construction passes a resolver" default the class docstring describes.

## Security/privacy/retention impact
Strictly additive authorization surface. The core property under test throughout: a candidate's claimed `entity_id` is never trusted — the resolved entity always comes from an independent read of the canonical row. Cross-tenant isolation is proven live against real seeded ClickHouse rows, not assumed.

## RED-first evidence
Every adversarial property was verified by planting the specific defect it exists to catch and observing the test fail for that reason, then restoring the real code:
- **Never trust the candidate**: patched the resolver to use `candidate.entity_id` instead of the row-derived value — both `test_resolve_derives_the_pr_entity_from_the_row_never_the_candidate` and `test_resolve_is_keyed_by_locator_not_by_the_candidates_claimed_entity` failed with the wrong (candidate-claimed) entity_id.
- **Cross-tenant isolation (contract-owner requirement, unit level)**: patched the fake sink to drop its org filter — `test_a_locator_that_exists_only_in_a_different_org_is_refused` failed, returning the other org's row.
- **Cross-tenant isolation, live**: patched the *actual production SQL* (`WHERE 1=1` instead of `WHERE org_id = ...`) and ran the live-ClickHouse suite against real seeded rows — `test_the_real_sql_enforces_tenant_isolation_on_an_identical_locator` failed, returning `org-b-reviewer`'s row for an `org-a` lookup.

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_native_evidence_resolver.py -v                     # 9 passed
.venv/bin/python -m pytest tests/api/dev/test_native_evidence_resolver_clickhouse_live.py -v      # 3 passed (live, scratch ClickHouse db, migrated schema)
.venv/bin/python -m pytest tests/context_fabric/test_chaos_3617_containment.py -q                 # passed (arm-isolation guard)
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q                                # 4359 passed, 117 skipped, 4 xfailed, 0 failed
.venv/bin/mypy src/dev_health_ops/api/dev/ src/dev_health_ops/context_fabric/                     # Success: no issues
pre-commit hook (mypy over full 2291-file tree, ruff)                                             # Success: no issues
```
Live tests ran against a per-worktree scratch ClickHouse database (`ci_local_validate_<hash>`), migrated via `ClickHouseMetricsSink.ensure_schema(force=True)`, dropped on completion — never touched `default`. `ci/local_validate.sh` itself was not run (per lane instructions: it's the CI merge bar, not a lane tool).

## Known limitations and follow-up issues
- 4 of 5 reachable observation kinds (`deployment`, `commit`, `ci_run`, `incident`) still refuse as `source_unconfigured` — PR 2/3, PR 3/3.
- No production caller of `.admit()` exists yet — Lane B's routing work is the intended one; this PR only removes the resolver-side blocker.

## Rollout/rollback impact
Pure additive; no flag change. `EVIDENCE_ADMISSION_FLAG` (arm-side, unrelated to this PR) still gates whether the arm ever submits a candidate in the first place — default off. Safe to revert independently.