### PR TITLE
CHAOS-3650: canonical evidence refusal drops one driver, not the packet

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
@@ -137,6 +137,7 @@ __all__ = [
     "PacketTooLargeError",
     "SubjectMatchFinding",
     "AuthorizationWithheldEvidenceError",
+    "CanonicalEvidenceRefusedError",
     "UnsupportedMatchMechanismError",
     "TrialContext",
     "UnsupportedComparisonShapeError",
@@ -218,6 +219,31 @@ class AuthorizationWithheldEvidenceError(PermissionError):
 
     A ``PermissionError`` rather than a ``ValueError`` so a caller can route
     it the way it routes every other authorization refusal in this arm.
+    """
+
+
+class CanonicalEvidenceRefusedError(RuntimeError):
+    """A driver rests on evidence the canonical service declined to admit.
+
+    CHAOS-3650. A third case landing on the same missing-handle check as
+    :class:`AuthorizationWithheldEvidenceError` and the raw ``ValueError``
+    beside it, and distinct from both for the same reason those two are
+    distinct from each other: the CAUSE determines whether this is an arm
+    bug, a caller-authorization boundary working correctly, or -- this one
+    -- a canonical service exercising its own authority over what the frame
+    may cite. None of the three is the others, and collapsing any two would
+    misreport an honest refusal as a defect or a defect as a refusal.
+
+    Caught in :func:`build_packet`, not left to propagate: unlike the other
+    two, this one must not abort the whole packet. A driver whose support
+    the canonical service refused is dropped and disclosed; every driver
+    that does not cite the refused record is unaffected. See
+    ``_driver_candidates`` for where the catch happens and
+    ``PacketLimitationKind.AUTHORIZATION_FILTERED``'s existing
+    ``admission_refused`` disclosure for where the drop becomes visible to
+    a reader -- the count already included these records before this fix;
+    what changes is that a driver citing one no longer takes the rest of
+    the packet down with it.
     """
 
 
@@ -549,11 +575,13 @@ def _driver_candidate(
     known_subject_ids: Container[str],
     filtered_ids: Container[str],
     path_relevance: Mapping[str, RelevanceState],
+    admission_refused_ids: Container[str] = (),
 ) -> DriverCandidate:
     """One structural finding, as the frozen contract's driver candidate.
 
     Evidence is translated from canonical observation ids to the handles
-    this run minted, and an id with no handle **raises**.
+    this run minted, and an id with no handle **raises** -- one of three
+    ways, and CHAOS-3650 is the reason there are three rather than two.
 
     The first version dropped such ids silently. That branch turned out to be
     unreachable in every world under test — the guard-injection harness
@@ -562,7 +590,14 @@ def _driver_candidate(
     reachable and correct: a finding citing evidence this packet does not
     carry is an internal inconsistency between discovery and emission, and
     the honest response is to fail rather than to quietly emit a driver with
-    less support than it was built from.
+    less support than it was built from -- for the ids that ARE that
+    inconsistency. ``admission_refused_ids`` is the third case (CHAOS-3650)
+    that is not: the canonical evidence service declined to admit a record
+    the arm's traversal genuinely reached, which is the service exercising
+    its own authority, not the arm disagreeing with itself. That case raises
+    :class:`CanonicalEvidenceRefusedError`, which :func:`build_packet`
+    catches per finding and turns into a drop-and-disclose rather than a
+    packet-wide abort -- see the exception's own docstring.
     """
 
     def handles(ids: Sequence[str], role: str) -> tuple[str, ...]:
@@ -570,8 +605,23 @@ def _driver_candidate(
         if missing:
             # CHAOS-3627 fix round 2, verifier N1. Two very different things
             # were reaching this one raise, and only one of them is an
-            # internal inconsistency.
-            #
+            # internal inconsistency. CHAOS-3650 adds a third check, ahead of
+            # both: a canonically refused id is neither an authorization
+            # withholding nor an unobserved one, and checking for it first
+            # keeps the other two branches meaning exactly what their
+            # messages say -- an id that is BOTH withheld and refused cannot
+            # occur (see ``build_packet``'s own comment on why those two sets
+            # are disjoint by construction), so order does not trade one
+            # misclassification for another.
+            refused = sorted(item for item in missing if item in admission_refused_ids)
+            if refused:
+                raise CanonicalEvidenceRefusedError(
+                    f"driver {finding.driver_id} rests on {role} evidence the "
+                    f"canonical service declined to admit: {refused}. The arm "
+                    "reached these records; the service did not mint a "
+                    "handle for them, which is the service's own authority "
+                    "over what this frame may cite, not an arm defect"
+                )
             # An id the AUTHORIZATION FILTER removed -- because the record it
             # names is about an entity outside this caller's grant -- is the
             # arm working correctly on a partial grant. Raising there turned a
@@ -1417,6 +1467,15 @@ def build_packet(
     #: the ARM withholding an entity it may not name, this one is the
     #: canonical service withholding a record the arm asked about.
     admission_refused: set[str] = set()
+    #: CHAOS-3650. The SAME refusals as ``admission_refused``, keyed by the
+    #: observation's own canonical id rather than its admission locator --
+    #: what ``_driver_candidate`` needs, since a finding's ``evidence_ids``
+    #: are canonical ids and the two are not always equal (the locator falls
+    #: back to the canonical id only when no source-issued evidence id is
+    #: attached; see ``_admission_locator``). Populated at both refusal
+    #: sites below, alongside ``admission_refused`` rather than derived from
+    #: it, so the two can never drift apart.
+    admission_refused_observation_ids: set[str] = set()
     #: handle -> the admitted ref, so the entry can carry it VERBATIM.
     admitted_by_handle: dict[str, DevEvidenceRefV2] = {}
     for observation, supports in indexable:
@@ -1431,6 +1490,7 @@ def build_packet(
             admitted = admitted_evidence.get(_admission_locator(observation))
             if admitted is None:
                 admission_refused.add(_admission_locator(observation))
+                admission_refused_observation_ids.add(observation.canonical_id)
                 continue
             handle = admitted.evidence_ref_id
             admitted_by_handle[handle] = admitted
@@ -1482,6 +1542,7 @@ def build_packet(
             cited = admitted_evidence.get(_admission_locator(observation))
             if cited is None:
                 admission_refused.add(_admission_locator(observation))
+                admission_refused_observation_ids.add(observation.canonical_id)
                 continue
             handle = cited.evidence_ref_id
             admitted_by_handle[handle] = cited
@@ -1970,16 +2031,38 @@ def build_packet(
         | {member.canonical_id for member in cohort_members}
         | known_entity_ids
     )
-    driver_candidates = tuple(
-        _driver_candidate(
-            finding,
-            handle_by_observation,
-            known_subject_ids,
-            withheld_observation_ids,
-            path_relevance,
-        )
-        for finding in drivers or ()
-    )
+    # CHAOS-3650. A per-finding catch, not a comprehension: a driver whose
+    # evidence the canonical service refused must be dropped on its own,
+    # never take an unrelated sibling driver down with it. Every OTHER
+    # raise out of ``_driver_candidate`` -- an authorization withholding, or
+    # a genuinely unindexed id -- is still a packet-wide abort, unchanged;
+    # only ``CanonicalEvidenceRefusedError`` is caught here.
+    #
+    # The dropped driver_id is not carried further: the record it rested on
+    # is already counted in ``admission_refused`` and already disclosed by
+    # the AUTHORIZATION_FILTERED limitation below ("... and are not cited
+    # by this packet" -- now literally true for a driver that cited one,
+    # where before this fix the packet would not have constructed at all).
+    # A per-driver disclosure field would be a frozen-contract addition
+    # (new ``PacketLimitationKind``/``DriverExclusionReason`` member) this
+    # lane does not have standing to make unilaterally; see the PR/issue for
+    # the proposal posted for a contract owner's decision.
+    driver_candidates_list: list[DriverCandidate] = []
+    for finding in drivers or ():
+        try:
+            driver_candidates_list.append(
+                _driver_candidate(
+                    finding,
+                    handle_by_observation,
+                    known_subject_ids,
+                    withheld_observation_ids,
+                    path_relevance,
+                    admission_refused_observation_ids,
+                )
+            )
+        except CanonicalEvidenceRefusedError:
+            continue
+    driver_candidates = tuple(driver_candidates_list)
     # Evidence entries now name the drivers that cite them. Without this the
     # index and the drivers agree only in one direction: a driver could point
     # at an entry that never claimed to support it, which is how unrelated

--- a/tests/context_fabric/test_chaos_3650_evidence_closure_degrade.py
+++ b/tests/context_fabric/test_chaos_3650_evidence_closure_degrade.py
@@ -1,0 +1,242 @@
+"""CHAOS-3650: canonical evidence refusal narrows the answer, it does not
+crash it.
+
+Before this fix, ``packet_builder.py::_driver_candidate`` could not tell two
+very different reasons a driver's cited evidence carries no handle apart:
+nothing observed it (an internal inconsistency -- discovery and emission
+disagree), or the canonical evidence service legitimately declined to admit
+a record the arm's traversal genuinely reached. Both reached the same
+``ValueError("... never indexed ... Discovery and emission disagree")``,
+which is a real defect ONLY in the first case and an honest refusal
+mislabelled as an arm bug in the second -- and either way, one driver's
+missing support aborted the WHOLE packet, including unrelated drivers that
+never cited the refused record.
+
+The reproduction below uses ``admitted_evidence={}`` -- an admission map
+that is present (so the admission code path runs) but empty (so every
+locator is refused) -- which is the simplest possible shape of "canonical
+admission declined everything the traversal reached" and needs no synthetic
+``EvidenceCandidate``/``EvidenceService`` plumbing to construct honestly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from dev_health_ops.api.dev.investigation_contract import (
+    ComparisonShape,
+    DriverExclusionReason,
+    DriverStanding,
+    QuestionFamilyID,
+)
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.context_fabric.graph_arm import build_projection
+from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
+from dev_health_ops.context_fabric.graph_arm.drivers import discover_drivers
+from dev_health_ops.context_fabric.graph_arm.packet_builder import (
+    JobContext,
+    TrialContext,
+    build_packet,
+)
+from dev_health_ops.context_fabric.graph_arm.readback import ProjectionGraphReader
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+
+_PROBE_NOW = world.TRIAL_NOW
+
+
+@pytest.fixture(scope="module")
+def helio():
+    return build_projection(adapter.corpus_batch(world.ORG_HELIO))
+
+
+def _readout(projection, subject: str):
+    grant = adapter.authorized_entity_ids_for(world.PRINCIPAL_ANALYST)
+    return asyncio.run(
+        ProjectionGraphReader(projection).neighbourhood(
+            org_id=world.ORG_HELIO,
+            seed_canonical_ids=[subject],
+            authorized_entity_ids=sorted(grant),
+            max_hops=2,
+        )
+    )
+
+
+def _packet(readout, signer, *, drivers, admitted_evidence=None):
+    return build_packet(
+        readout=readout,
+        job=JobContext(
+            job_id="job_drivers",
+            question_family=QuestionFamilyID("project_status_drivers"),
+            job_statement="Why is this subject not finished?",
+            comparison_shape=ComparisonShape.SINGULAR_SUBJECT,
+            window_start=world.AS_OF_JUL_15,
+            window_end=world.TRIAL_NOW,
+        ),
+        watermark=IndexWatermark(
+            indexed_through=world.TRIAL_NOW,
+            projected_at=world.TRIAL_NOW,
+            records_indexed=1,
+        ),
+        signer=signer,
+        trial=TrialContext(
+            run_id="4f9a2c1e-2222-4333-8444-555566667777",
+            corpus_version=adapter.CORPUS_VERSION,
+        ),
+        produced_at=_PROBE_NOW,
+        drivers=drivers,
+        admitted_evidence=admitted_evidence,
+    )
+
+
+def _honest_and_unrelated(helio):
+    """A finding whose evidence a full admission run WOULD refuse, and a
+    genuinely evidence-free sibling that must survive that refusal
+    untouched -- proving unrelated drivers are not collateral damage.
+
+    The sibling is synthesised from ``honest`` (a distinct driver_id,
+    CANDIDATE_ONLY standing, no evidence and no path) rather than searched
+    for in the corpus: what matters for this test is that it cites nothing
+    admission could refuse, and CANDIDATE_ONLY sidesteps the unrelated
+    principal/contributing-standing closure requirements
+    (``validate_principal_standing_is_earned``) that a hand-built finding
+    would otherwise have to satisfy for reasons this test is not about.
+    """
+
+    readout = _readout(helio, "proj_identity_rewrite")
+    findings = discover_drivers(
+        readout, "proj_identity_rewrite", as_of=world.TRIAL_NOW
+    )[0]
+    honest = next(
+        item for item in findings if item.driver_id == "drv_block_wu_authcore_release"
+    )
+    assert honest.evidence_ids, "the finding carries no evidence; vacuous"
+    unrelated = replace(
+        honest,
+        driver_id="drv_test_unrelated_evidence_free",
+        standing=DriverStanding.CANDIDATE_ONLY,
+        evidence_ids=(),
+        conflicting_evidence_ids=(),
+        path_ids=(),
+        exclusion_reason=None,
+    )
+    return readout, honest, unrelated
+
+
+class TestTheDefectIsReproduced:
+    def test_admission_off_the_finding_indexes_cleanly(self, helio, signer) -> None:
+        """The control: without admission, the finding's own evidence mints
+        a handle exactly as ``discover_drivers`` built it."""
+
+        readout, honest, _unrelated = _honest_and_unrelated(helio)
+        packet = _packet(readout, signer, drivers=(honest,))
+        cited = {
+            candidate.driver_id: candidate.supporting_evidence_ids
+            for candidate in packet.driver_analysis.candidates
+        }
+        assert cited[honest.driver_id]
+
+    def test_a_canonically_refused_citation_no_longer_aborts_construction(
+        self, helio, signer
+    ) -> None:
+        """The CHAOS-3650 repro: admission present but refuses everything.
+
+        Before the fix this raised ``ValueError`` naming the refusal
+        "discovery and emission disagree" -- an honest canonical refusal
+        misclassified as an arm bug. After the fix the packet constructs.
+        """
+
+        readout, honest, _unrelated = _honest_and_unrelated(helio)
+        packet = _packet(readout, signer, drivers=(honest,), admitted_evidence={})
+        assert packet is not None
+
+
+class TestTheDroppedDriverIsDisclosedNotFabricated:
+    def test_the_unsupported_driver_does_not_reach_the_packet(
+        self, helio, signer
+    ) -> None:
+        """Drop, not admit-and-pretend. The frozen contract's own rule --
+        no asserted driver may cite evidence absent from the packet -- must
+        hold even for the STANDING this finding actually carries."""
+
+        readout, honest, _unrelated = _honest_and_unrelated(helio)
+        packet = _packet(readout, signer, drivers=(honest,), admitted_evidence={})
+        assert honest.driver_id not in {
+            candidate.driver_id for candidate in packet.driver_analysis.candidates
+        }
+
+    def test_no_refused_record_is_ever_cited(self, helio, signer) -> None:
+        """The invariant the ticket names explicitly: refused evidence must
+        never be admitted through the back door."""
+
+        readout, honest, _unrelated = _honest_and_unrelated(helio)
+        packet = _packet(readout, signer, drivers=(honest,), admitted_evidence={})
+        assert packet.evidence_coverage.evidence_index == ()
+
+    def test_the_refusal_is_disclosed(self, helio, signer) -> None:
+        readout, honest, _unrelated = _honest_and_unrelated(helio)
+        packet = _packet(readout, signer, drivers=(honest,), admitted_evidence={})
+        details = " ".join(
+            limitation.detail for limitation in packet.evidence_coverage.limitations
+        )
+        assert "not admitted by the canonical evidence service" in details
+
+    def test_an_unrelated_driver_survives_a_sibling_refusal(
+        self, helio, signer
+    ) -> None:
+        """The other half of "does not abort unrelated evidence and
+        answers": a driver that cites no refused evidence must reach the
+        packet even when a sibling driver's evidence was refused."""
+
+        readout, honest, unrelated = _honest_and_unrelated(helio)
+        packet = _packet(
+            readout, signer, drivers=(honest, unrelated), admitted_evidence={}
+        )
+        candidate_ids = {
+            candidate.driver_id for candidate in packet.driver_analysis.candidates
+        }
+        assert unrelated.driver_id in candidate_ids
+        assert honest.driver_id not in candidate_ids
+
+    def test_a_conflicting_citation_of_refused_evidence_also_drops_cleanly(
+        self, helio, signer
+    ) -> None:
+        """The same rule applies to conflicting_evidence_ids, not only
+        supporting evidence -- a driver cannot cite refused evidence through
+        either channel."""
+
+        readout, honest, _unrelated = _honest_and_unrelated(helio)
+        as_conflict = replace(
+            honest,
+            standing=DriverStanding.EXCLUDED,
+            exclusion_reason=DriverExclusionReason.EVIDENCE_CONFLICT_UNRESOLVED,
+            evidence_ids=(),
+            conflicting_evidence_ids=honest.evidence_ids,
+        )
+        packet = _packet(readout, signer, drivers=(as_conflict,), admitted_evidence={})
+        assert as_conflict.driver_id not in {
+            candidate.driver_id for candidate in packet.driver_analysis.candidates
+        }
+
+
+class TestAuthorizationWithholdingIsUnchanged:
+    """The pre-existing behaviour this fix must not touch: a driver resting
+    on evidence outside the CALLER's grant is a different refusal
+    (authorization, not canonical authority) and still raises."""
+
+    def test_an_authorization_withheld_citation_still_raises(
+        self, helio, signer
+    ) -> None:
+        from dataclasses import replace as dc_replace
+
+        readout, honest, _unrelated = _honest_and_unrelated(helio)
+        # An id genuinely unobserved (never in the readout at all) must
+        # still be treated as the internal inconsistency it is -- this fix
+        # is scoped to canonical refusal, not to relaxing this guard.
+        tampered = dc_replace(
+            honest, evidence_ids=(*honest.evidence_ids, "obs_never_indexed_at_all")
+        )
+        with pytest.raises(ValueError, match="never indexed"):
+            _packet(readout, signer, drivers=(tampered,))


### PR DESCRIPTION
## Issue and phase
CHAOS-3650. Phase 2C, Lane D — Wave 3.2. Child of CHAOS-3668.

## Observable outcome
`packet_builder.py::_driver_candidate` could not tell two different reasons a driver's cited evidence carries no handle apart: nothing observed it (an internal inconsistency — discovery and emission disagree) or the canonical evidence service legitimately declined to admit a record the arm's traversal genuinely reached. Both raised the same `ValueError` ("discovery and emission disagree"), which aborted the **whole packet** — including unrelated drivers that never cited the refused record — and mislabeled an honest canonical refusal as an arm bug.

## Architecture boundary
Chose **drop-and-disclose** (the ticket's option 1) over a withheld-evidence candidate finding (option 2), because option 1 doesn't require a frozen-contract enum addition and option 2 would. New `CanonicalEvidenceRefusedError`, raised when a missing evidence id is one the canonical service refused (tracked via a new `admission_refused_observation_ids` set, populated alongside the existing `admission_refused` locator set). `build_packet`'s driver-candidate construction now catches this per finding and drops just that finding — every other raise (authorization withholding, genuine inconsistency) still aborts, unchanged. No new wire field: the refused record was already counted in the existing `admission_refused` set, which already feeds the `AUTHORIZATION_FILTERED` limitation's detail text — that text was already accurate for evidence-index entries and is now also true for a driver that cited one.

## What this does NOT do (flagged for a contract-owner decision)
I considered a dedicated `DriverExclusionReason`/`PacketLimitationKind` member for a richer per-driver disclosure (naming which driver was dropped, not just the record count) — both of the ticket's suggested designs point that direction. I did not add one: both enums are frozen-contract vocabulary, the exact class of change the Wave 3.2 handoff's integration rules (§8) require posting for a contract owner's decision before landing, and this codebase is visibly careful about not conflating **authority** (canonical admission) with **authorization** (caller's grant) — reusing `UNAUTHORIZED_EVIDENCE`/`AUTHORIZATION_FILTERED` for this would repeat exactly the anti-pattern `TestSeamAuthorityIsNotAuthorization` polices against elsewhere in this codebase. Landing the minimal, contract-safe shape here; the richer disclosure is a named, proposed follow-up.

**Lane C coordination note:** the shared task board lists "Lane C: CHAOS-3650 coordination — safe partial-answer on canonical refusal" but no comment/PR from that side as of this writing. This PR is the consuming side of the handshake (how the packet degrades when told a record was refused); the producing side (what `EvidenceService` returns for a refused record) is Lane C's territory, and this fix assumes nothing about it beyond the already-shipped contract (`admitted_evidence.get(locator) is None` means refused).

## Base/head
Base: `origin/feature/chaos-3498-context-fabric` @ `81ffef6ef` (current tip, includes merged CHAOS-3634/3643/3653/3633; rebased clean, no conflicts — `_driver_candidate`'s new `staffing_qualification` field from CHAOS-3634 and this PR's new `admission_refused_ids` parameter compose without touching the same lines). Head: `chaos-3650-evidence-closure-degrade`.

## Migrations / configuration / feature flags
None.

## Security / privacy / retention impact
None. No refused evidence is ever admitted through this change (pinned by `test_no_refused_record_is_ever_cited`); the only behavior change is that a driver citing refused evidence is dropped from the packet instead of the whole packet failing to construct.

## RED-first evidence
`git stash` of the source change with the test file present reproduced the exact pre-fix `ValueError` on 6 of 8 new tests; GREEN after.

## Verification
- New `tests/context_fabric/test_chaos_3650_evidence_closure_degrade.py` (8 tests)
- `.venv/bin/python -m pytest tests/context_fabric/ -q` → 1402 passed, 42 skipped
- `.venv/bin/python -m pytest tests/api/dev/ -q` → 2972 passed, 71 skipped, 4 xfailed
- `.venv/bin/python -m pytest tests/context_fabric/test_chaos_3646_evidence_admission.py tests/context_fabric/test_chaos_3617_drivers.py -q` → 85 passed (closest-neighbor admission/driver suites)
- ruff / mypy (module + full-project lefthook gate) → clean

## Known limitations and follow-up issues
- Richer per-driver disclosure (naming the dropped driver, not just the refused-record count) needs a frozen-contract enum addition and a contract owner's decision — proposed here, not landed.
- Lane C's producing-side EvidenceService refusal-reason richness (if any is planned beyond present/absent) is not assumed or depended on by this fix.

## Rollout / rollback impact
Purely additive at the failure-classification layer; changes what was previously an unconditional `ValueError` (mislabeled) into a successfully-constructed packet missing only the affected driver(s), for any subject whose driver previously hit a canonical-refusal-shaped abort. No flag needed for the same reason as CHAOS-3634: there is no "prior good state" behind a crash to preserve.