### PR TITLE
CHAOS-3675 prereq: repository-only authorization for entity-less evidence

### DIFF
--- a/src/dev_health_ops/api/dev/evidence_service.py
+++ b/src/dev_health_ops/api/dev/evidence_service.py
@@ -96,6 +96,22 @@ class EvidenceRecord:
     #: (never trusting a resolver to remember to set it): see ``admit``'s
     #: docstring for why that is always correct for the admission path.
     record_locator: str | None = None
+    #: CHAOS-3675 PR2. An EXPLICIT, typed resolver capability, independent
+    #: of whatever ``entity_id`` holds. ``True`` only when a resolver has
+    #: independently confirmed, from the canonical row itself, that this
+    #: record has no directly-authorizable :class:`~.scope_service.EntityKind`
+    #: entity at all (a deployment with no linked PR, an incident with no
+    #: linked repository). ``entity_id`` stays whatever the record's own
+    #: descriptive identity is in that case (``DevEvidenceRef.entity_id``
+    #: requires a non-empty string; it is never repurposed as an
+    #: authorization signal) -- this flag, not the VALUE of ``entity_id``,
+    #: is what tells :meth:`EvidenceService.admit` to skip entity
+    #: authorization. A resolver that CAN derive an authorizable entity
+    #: must always derive it and leave this ``False``: gating on
+    #: ``entity_id``'s value instead would let a resolver bug (or a
+    #: resolver that took the cheap path instead of deriving) launder its
+    #: way past the entity check merely by returning something falsy.
+    no_authorizable_entity: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -802,8 +818,26 @@ class EvidenceService:
             # docstring. That single-element set is what turns the existing
             # containment check in ``_authorize_expansion`` from a tautology
             # into the admission path's entity authorization.
+            #
+            # CHAOS-3675 PR2, entity-less records (deployments with no
+            # linked PR, incidents with no linked repository): empty ONLY
+            # when the resolver has EXPLICITLY set
+            # ``no_authorizable_entity`` -- never inferred from
+            # ``entity_id``'s value, which stays a normal, non-empty
+            # descriptive identity either way (``DevEvidenceRef.entity_id``
+            # requires at least one character). Gating on the flag alone,
+            # not on ``entity_id`` being falsy, is what stops a resolver
+            # bug from silently earning repository-only authorization by
+            # merely returning something empty. An empty
+            # ``valid_entity_ids`` skips the entity containment check
+            # entirely (``_authorize_expansion``'s own truthy gate),
+            # leaving authorization to the unmodified, independent
+            # ``repository_ids`` check below it.
             record = replace(record, record_locator=candidate.locator)
-            ref = self._to_ref(org_id, record, valid_entity_ids=(record.entity_id,))
+            valid_entity_ids = (
+                () if record.no_authorizable_entity else (record.entity_id,)
+            )
+            ref = self._to_ref(org_id, record, valid_entity_ids=valid_entity_ids)
             state, warning = await self._authorize_expansion(
                 org_id,
                 permission_fingerprint,

--- a/tests/api/dev/test_evidence_service.py
+++ b/tests/api/dev/test_evidence_service.py
@@ -902,3 +902,189 @@ async def test_a_genuine_handle_collision_within_one_round_is_refused_not_silent
     assert second.state is EvidenceAvailability.UNAVAILABLE
     assert second.evidence is None
     assert second.warning == "ambiguous_record_identity"
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3675 PR2: entity-less admission (a deployment with no linked PR, an
+# incident with no linked repository) falls through to repository-only
+# authorization -- ONLY when explicitly marked, never merely because
+# entity_id happens to be empty.
+# ---------------------------------------------------------------------------
+
+
+class _EntityLessResolver:
+    """Returns a record with no directly-authorizable entity -- the shape a
+    real deployment/incident resolver produces when its linkage column is
+    genuinely absent."""
+
+    source_system = "deployments"
+
+    def __init__(self, *, marked: bool, repository_ids: tuple[str, ...]) -> None:
+        self._marked = marked
+        self._repository_ids = repository_ids
+
+    async def resolve(self, *, org_id, scope, candidate):
+        return EvidenceRecord(
+            source_system="deployments",
+            source_version="native.v1",
+            entity_type="deployment",
+            # A normal, non-empty DESCRIPTIVE identity -- DevEvidenceRef.
+            # entity_id requires at least one character and is never
+            # repurposed as an authorization signal. Whether this record
+            # authorizes via entity or via repository-only is governed
+            # SOLELY by ``no_authorizable_entity`` below, not by this
+            # value.
+            entity_id="repo-a#deployment1",
+            display_label="Deployment with no linked PR",
+            observed_at=NOW,
+            freshness=FreshnessState.FRESH,
+            provenance="native",
+            confidence=1.0,
+            repository_ids=self._repository_ids,
+            no_authorizable_entity=self._marked,
+        )
+
+
+def _entity_less_candidate(*, entity_id: str = "issue-999") -> EvidenceCandidate:
+    return EvidenceCandidate(
+        source_system="deployments",
+        entity_type="deployment",
+        # Deliberately a claim the resolver's own record does not carry --
+        # nothing about entity-less admission should ever consult it.
+        entity_id=entity_id,
+        locator="repo-a#deployment1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_entity_less_record_with_repository_access_is_admitted() -> None:
+    """RED-first: before this fix, admit() hardcoded
+    ``valid_entity_ids=(record.entity_id,)`` -- an entity-less record
+    produced ``("",)``, which the entity containment check always fails
+    (the empty string is never a real authorized entity), wrongly refusing
+    evidence the caller's repository access should admit.
+    """
+
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[
+            _EntityLessResolver(marked=True, repository_ids=("repo-a",))
+        ],
+    )
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),  # repo-a, granted
+        candidates=[_entity_less_candidate()],
+    )
+    (only,) = result.admissions
+    assert only.state is EvidenceAvailability.AVAILABLE
+    assert only.evidence is not None
+    assert only.evidence.valid_entity_ids == []
+
+
+@pytest.mark.asyncio
+async def test_without_the_explicit_marker_the_entity_check_runs_as_before() -> None:
+    """Condition (i): the empty-``valid_entity_ids`` path requires the
+    EXPLICIT ``no_authorizable_entity`` marker -- gating on the flag alone,
+    never inferred from ``entity_id``'s value. With the marker ``False``,
+    the SAME record's descriptive (but non-authorizable) ``entity_id``
+    goes through the ordinary entity containment check exactly as before
+    this fix, and is refused because the caller's grant does not contain
+    it -- proving the fallback is opt-in per record, not automatic
+    whenever a resolver returns something that isn't a "real" entity."""
+
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[
+            _EntityLessResolver(marked=False, repository_ids=("repo-a",))
+        ],
+    )
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),
+        candidates=[_entity_less_candidate()],
+    )
+    (only,) = result.admissions
+    assert only.evidence is None
+    assert only.state is EvidenceAvailability.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_entity_less_record_without_repository_access_is_refused() -> None:
+    """Condition (iii), positive case: the repository-only fallback is a
+    REAL check, not a rubber stamp -- an entity-less record naming a repo
+    the caller cannot see is refused. The mutation-kill proof that this
+    test actually discriminates is
+    ``test_the_repository_only_check_is_observed_failing_when_short_circuited``
+    below."""
+
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[
+            _EntityLessResolver(marked=True, repository_ids=("repo-unauthorized",))
+        ],
+    )
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),  # repo-a granted; the record names a DIFFERENT repo
+        candidates=[_entity_less_candidate()],
+    )
+    (only,) = result.admissions
+    assert only.evidence is None
+    assert only.state is EvidenceAvailability.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_the_repository_only_check_is_observed_failing_when_short_circuited() -> (
+    None
+):
+    """Condition (iii), the mutation-kill proof itself: a signer/service
+    combination that SKIPS the repository check entirely -- simulating the
+    defect class the check exists to catch -- wrongly admits the
+    unauthorized-repo record the previous test correctly refuses. Observed
+    failing here (against the shim), never assumed passing against the
+    real code."""
+
+    class _RepositoryCheckSkippingService(EvidenceService):
+        async def _authorize_expansion(
+            self, org_id, permission_fingerprint, scope_request, resolution, evidence
+        ):
+            # Short-circuits exactly the check CHAOS-3675 PR2 condition
+            # (iii) requires: no repository re-resolution, no containment
+            # comparison, always "available".
+            return EvidenceAvailability.AVAILABLE, None
+
+    service = _RepositoryCheckSkippingService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[
+            _EntityLessResolver(marked=True, repository_ids=("repo-unauthorized",))
+        ],
+    )
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),
+        candidates=[_entity_less_candidate()],
+    )
+    (only,) = result.admissions
+    # This is the FAILURE the shim demonstrates -- an unauthorized-repo
+    # record wrongly admitted -- proving
+    # ``test_entity_less_record_without_repository_access_is_refused``
+    # exercises a real check against the unmodified service.
+    assert only.evidence is not None
+    assert only.state is EvidenceAvailability.AVAILABLE


### PR DESCRIPTION
Branch is deliberately ID-free (not "chaos-3675-...") -- CHAOS-3675 spans multiple PRs and only the final one should close-link it, per the standing pattern from #1631/#1643/#1635.

## Issue and phase
Prerequisite for [CHAOS-3675](https://linear.app/fullchaos/issue/CHAOS-3675) PR 2/3 (incidents) and PR 3/3 (deployments) — child of [CHAOS-3664](https://linear.app/fullchaos/issue/CHAOS-3664), Phase 1 Lane C, under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660), where this shape was proposed and approved in principle with three binding conditions before this PR was written.

## Observable outcome
`EvidenceService.admit()` can admit a record with no directly-authorizable entity (a deployment with no linked PR, an incident with no linked repository — both real, common rows: `deployments.pull_request_number` and `work_graph_deployment_incident_edges.repo_id` are both `Nullable` in the canonical schema) when the caller has repository access, instead of always wrongly refusing it. `_authorize_expansion`'s repository-only check already existed; `admit()`'s hardcoded `valid_entity_ids=(record.entity_id,)` — a literal 1-tuple that can never be satisfied when there's no real entity — was the bug.

## Architecture boundary
Canonical admission side only (`evidence_service.py`, mine exclusively). No contract/schema change: `DevEvidenceRef.valid_entity_ids` already accepts an empty list; the new `EvidenceRecord.no_authorizable_entity` marker is internal and never serialized onto the wire ref.

## Scope / non-scope
This PR: the authorization mechanism only, proven with a synthetic resolver. No real resolver uses the new flag yet — that's PR 2/3 (incidents) and PR 3/3 (deployments), which this unblocks.

## Base/head SHA and branch provenance
Base: `feature/chaos-3498-context-fabric` @ `0751438ce...` (current tip, includes CHAOS-3675 PR1/#1643 and CHAOS-3631/#1636)
Head: `entity-less-evidence-authorization`, one commit, rebased onto that tip.

## Migrations/configuration/feature flags
None.

## Security/privacy/retention impact
Authorization-invariant change — the reason this got the CHAOS-3660 §8 proposal treatment rather than landing directly. Net effect is narrowing what gets wrongly REFUSED, not widening what gets admitted beyond the caller's actual repository grant: an entity-less record still requires the caller to hold real repository access via the unmodified repository check.

## RED-first evidence + the three binding conditions
- **RED-first**: `test_entity_less_record_with_repository_access_is_admitted` — before the fix, an entity-less record with genuine repository access was wrongly `UNAUTHORIZED`; after, `AVAILABLE`.
- **(i) Explicit typed capability, not inferred from `entity_id`'s value**: `no_authorizable_entity: bool = False`, independent of `entity_id` (which stays a normal non-empty descriptive string — `DevEvidenceRef.entity_id` requires ≥1 character). Verified by `test_without_the_explicit_marker_the_entity_check_runs_as_before`: the identical record, marker `False`, goes through the ordinary (and here, failing) entity check.
- **(ii) Anti-laundering, mutation-verified**: planted "ignore the marker, always run the entity check" directly in `admit()` and observed the RED-first test fail for exactly that reason, before restoring the real code.
- **(iii) Repository-only fallback gets its own mutation-kill proof**: `test_the_repository_only_check_is_observed_failing_when_short_circuited` subclasses `EvidenceService` with a shim `_authorize_expansion` that skips the repository check entirely, and shows it wrongly admits a record naming a repo the caller cannot see — proving the sibling positive test (`test_entity_less_record_without_repository_access_is_refused`) exercises a real, unmodified check rather than something vacuously true.

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_evidence_service.py -v      # 23 passed
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q        # 4395 passed, 118 skipped, 4 xfailed, 0 failed
.venv/bin/mypy src/dev_health_ops/api/dev/                                # Success: no issues (110 files)
pre-commit hook (mypy over full 2291-file tree, ruff)                     # Success: no issues
```

## Known limitations and follow-up issues
No real resolver uses this yet — CHAOS-3675 PR 2/3 (incidents) is next, PR 3/3 (deployments) after.

## Rollout/rollback impact
Pure additive default (`no_authorizable_entity` defaults `False`, zero behavior change for every existing resolver); safe to revert independently.