### PR TITLE
CHAOS-3679: persist and read back the projection watermark

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -30,6 +30,7 @@ orphan, and :func:`org_deletion_visit` — the callable registered in
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -72,6 +73,20 @@ __all__ = [
 
 #: The name this store registers under in ``EXTERNAL_DERIVED_STORES``.
 TRIAL_DERIVED_STORE_NAME = "context_fabric_graph_trial"
+
+#: CHAOS-3679. Prefix for the watermark's Redis key, on the FalkorDB client's
+#: OWN connection -- deliberately not a Cypher graph node. A graph node would
+#: be counted by ``readback.NODE_COUNT_QUERY``'s unconditional
+#: ``MATCH (n) RETURN count(n)``, silently breaking the
+#: ``count_nodes() == len(projection.nodes)`` / ``purge_org() returns
+#: len(projection.nodes)`` invariants the CHAOS-3617 live suite already
+#: asserts. A plain key needs no change to the closed query vocabulary and no
+#: change to node counting anywhere.
+_WATERMARK_KEY_PREFIX = "context_fabric:graph:watermark:"
+
+
+def _watermark_key(partition: str) -> str:
+    return f"{_WATERMARK_KEY_PREFIX}{partition}"
 
 
 class StoreUnavailableError(RuntimeError):
@@ -374,8 +389,83 @@ class GraphArmStore:
             self._partition,
             watermark.detail_for(indexed_through or datetime.now(UTC)),
         )
+        await self.persist_watermark(watermark)
         return WriteResult(
             nodes_written=len(nodes), edges_written=len(edges), watermark=watermark
+        )
+
+    async def persist_watermark(self, watermark: IndexWatermark) -> None:
+        """Durably record ``watermark`` for this store's partition.
+
+        CHAOS-3679. Called by :meth:`write_projection` after every successful
+        write, and exposed publicly so a caller with its own watermark (a
+        multi-batch run recording a partial one, for instance) can persist it
+        directly without going through a write. Stored as a plain Redis key
+        on the FalkorDB client's own connection -- see
+        :data:`_WATERMARK_KEY_PREFIX` for why this is deliberately not a
+        Cypher graph node.
+        """
+
+        payload = json.dumps(
+            {
+                "indexed_through": (
+                    watermark.indexed_through.isoformat()
+                    if watermark.indexed_through is not None
+                    else None
+                ),
+                "projected_at": (
+                    watermark.projected_at.isoformat()
+                    if watermark.projected_at is not None
+                    else None
+                ),
+                "records_indexed": watermark.records_indexed,
+                "partial": watermark.partial,
+            }
+        )
+        await self._bounded_read(
+            self._driver.client.connection.set(
+                _watermark_key(self._partition), payload
+            ),
+            operation="persist_watermark",
+        )
+
+    async def read_watermark(self) -> IndexWatermark:
+        """The durably persisted watermark for this store's partition.
+
+        CHAOS-3679. Returns ``IndexWatermark(indexed_through=None)`` --
+        never-projected -- when nothing has been persisted, which is
+        distinct from a transport failure: a hung or unreachable connection
+        raises :class:`GraphOperationTimeoutError`/
+        :class:`StoreUnavailableError` rather than silently reporting
+        never-projected. "Checked and absent" and "could not check" must
+        stay distinct here exactly as they do for
+        :func:`org_deletion_visit`'s :class:`DeletionCompletenessUnknownError`
+        -- a caller that cannot tell them apart would report an unreachable
+        store as confidently fresh-with-nothing-in-it.
+        """
+
+        raw = await self._bounded_read(
+            self._driver.client.connection.get(_watermark_key(self._partition)),
+            operation="read_watermark",
+        )
+        if raw is None:
+            return IndexWatermark(indexed_through=None)
+        data = json.loads(raw)
+        indexed_through_raw = data.get("indexed_through")
+        projected_at_raw = data.get("projected_at")
+        return IndexWatermark(
+            indexed_through=(
+                datetime.fromisoformat(indexed_through_raw)
+                if indexed_through_raw is not None
+                else None
+            ),
+            projected_at=(
+                datetime.fromisoformat(projected_at_raw)
+                if projected_at_raw is not None
+                else None
+            ),
+            records_indexed=int(data.get("records_indexed") or 0),
+            partial=bool(data.get("partial", False)),
         )
 
     async def partition_exists(self) -> bool:
@@ -418,6 +508,12 @@ class GraphArmStore:
         *genuine* deletion failure that happened to contain the same words.
         An incomplete deletion has to be visible —
         ``_purge_external_stores`` records exactly that.
+
+        CHAOS-3679: also removes the persisted watermark key. It is not part
+        of the graph keyspace the drop below removes -- a raw Redis key, by
+        design (see :data:`_WATERMARK_KEY_PREFIX`) -- so it needs its own
+        explicit cleanup, or organization deletion would leave freshness
+        metadata behind for an organization that no longer has any data.
         """
 
         if not await self.partition_exists():
@@ -433,6 +529,10 @@ class GraphArmStore:
         await self._bounded_read(
             self._driver.client.select_graph(self._partition).delete(),
             operation="purge_org",
+        )
+        await self._bounded_read(
+            self._driver.client.connection.delete(_watermark_key(self._partition)),
+            operation="purge_watermark",
         )
         return total
 

--- a/tests/context_fabric/test_chaos_3617_semantic_claims.py
+++ b/tests/context_fabric/test_chaos_3617_semantic_claims.py
@@ -572,9 +572,23 @@ class TestEmbeddingBudget:
             async def close(self) -> None:
                 return None
 
+        class _FakeConnection:
+            """CHAOS-3679: ``persist_watermark`` reaches this after a real
+            write, via ``driver.client.connection``. Not a FalkorDB fake --
+            this test never talks to one -- just enough to let the
+            durable-watermark write this store now always performs on a
+            successful projection complete without erroring."""
+
+            async def set(self, _key: str, _value: str) -> None:
+                return None
+
+        class _FakeClient:
+            connection = _FakeConnection()
+
         class _RecordingDriver:
             provider = "fake"
             graph_operations_interface = None
+            client = _FakeClient()
 
             def session(self) -> _FakeSession:
                 return _FakeSession()

--- a/tests/context_fabric/test_chaos_3679_watermark_persistence.py
+++ b/tests/context_fabric/test_chaos_3679_watermark_persistence.py
@@ -1,0 +1,250 @@
+"""CHAOS-3679: the projection watermark survives past the writing process.
+
+``IndexWatermark`` used to exist only as ``GraphArmStore.write_projection``'s
+in-memory return value -- nothing durable recorded it. A process other than
+the one that performed the write (in particular, a future read-side query
+service, which will typically be a different process from whatever last
+projected the organization) had no way to learn a partition's
+``indexed_through``/staleness at all.
+
+``GraphArmStore.read_watermark`` closes that: it is a plain Redis key on the
+FalkorDB client's own connection, not a Cypher graph node -- confirmed
+deliberately, not assumed, by the negative-control tests below that pin
+``count_nodes()`` unchanged. A graph node would have been counted by
+``NODE_COUNT_QUERY``'s unconditional ``MATCH (n) RETURN count(n)`` and
+silently broken the ``count_nodes() == len(projection.nodes)`` invariant the
+CHAOS-3617 live suite already asserts.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from dev_health_ops.context_fabric.graph_arm import build_projection, fixtures
+from dev_health_ops.context_fabric.graph_arm.store import GraphArmStore
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+from tests.context_fabric import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+
+def _unique_org(prefix: str) -> str:
+    return f"{prefix}{uuid.uuid4().hex[:12]}"
+
+
+def _reorg(batch, org_id: str):
+    import dataclasses
+
+    def rebind(record):
+        return dataclasses.replace(record, org_id=org_id)
+
+    return dataclasses.replace(
+        batch,
+        org_id=org_id,
+        entities=tuple(rebind(item) for item in batch.entities),
+        relationships=tuple(rebind(item) for item in batch.relationships),
+        observations=tuple(rebind(item) for item in batch.observations),
+        documents=tuple(rebind(item) for item in batch.documents),
+    )
+
+
+@pytest_asyncio.fixture
+async def store(monkeypatch) -> AsyncIterator[GraphArmStore]:
+    config = live_gate.require_live_store()
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+    org_id = _unique_org("orgwatermark")
+    opened = GraphArmStore.for_org(org_id, config=config)
+    try:
+        yield opened
+    finally:
+        try:
+            await opened.purge_org()
+        finally:
+            await opened.close()
+
+
+class TestNeverProjected:
+    async def test_a_fresh_partition_reads_back_as_never_projected(
+        self, store: GraphArmStore
+    ) -> None:
+        watermark = await store.read_watermark()
+        assert watermark.indexed_through is None
+        assert watermark.never_projected is True
+
+
+class TestRoundTrip:
+    async def test_a_written_watermark_round_trips_exactly(
+        self, store: GraphArmStore
+    ) -> None:
+        projection = build_projection(_reorg(fixtures.alpha_batch(), store.org_id))
+        result = await store.write_projection(projection)
+
+        read_back = await store.read_watermark()
+        assert read_back.indexed_through == result.watermark.indexed_through
+        assert read_back.projected_at == result.watermark.projected_at
+        assert read_back.records_indexed == result.watermark.records_indexed
+        assert read_back.partial == result.watermark.partial
+        assert read_back.partial is False
+
+    async def test_read_watermark_survives_a_fresh_store_handle(
+        self, store: GraphArmStore
+    ) -> None:
+        """The point of the whole issue: a DIFFERENT store handle sees it.
+
+        ``write_projection``'s return value only ever reached the process
+        that called it. Opening a brand new ``GraphArmStore`` for the same
+        organization and reading from THAT one is what proves the watermark
+        is durable rather than merely returned.
+        """
+
+        projection = build_projection(_reorg(fixtures.alpha_batch(), store.org_id))
+        written = await store.write_projection(projection)
+
+        fresh_handle = GraphArmStore.for_org(
+            store.org_id, config=live_gate.require_live_store()
+        )
+        try:
+            read_back = await fresh_handle.read_watermark()
+        finally:
+            await fresh_handle.close()
+
+        assert read_back.indexed_through == written.watermark.indexed_through
+        assert read_back.records_indexed == written.watermark.records_indexed
+
+
+class TestPurgeRemovesTheWatermark:
+    async def test_purging_removes_the_watermark_key(
+        self, store: GraphArmStore
+    ) -> None:
+        projection = build_projection(_reorg(fixtures.alpha_batch(), store.org_id))
+        await store.write_projection(projection)
+        assert (await store.read_watermark()).never_projected is False
+
+        await store.purge_org()
+
+        assert (await store.read_watermark()).never_projected is True
+
+    async def test_a_dry_run_purge_leaves_the_watermark_untouched(
+        self, store: GraphArmStore
+    ) -> None:
+        projection = build_projection(_reorg(fixtures.alpha_batch(), store.org_id))
+        written = await store.write_projection(projection)
+
+        await store.purge_org(dry_run=True)
+
+        read_back = await store.read_watermark()
+        assert read_back.never_projected is False
+        assert read_back.indexed_through == written.watermark.indexed_through
+
+
+class TestNoGraphNodeWasAdded:
+    """The negative control that proves the storage mechanism choice."""
+
+    async def test_count_nodes_is_unchanged_by_persisting_a_watermark(
+        self, store: GraphArmStore
+    ) -> None:
+        projection = build_projection(_reorg(fixtures.alpha_batch(), store.org_id))
+        result = await store.write_projection(projection)
+
+        # write_projection already persists the watermark as part of the
+        # call under test -- read it back explicitly too, so a version that
+        # persisted nothing (and thus trivially left count_nodes alone)
+        # cannot pass this test by doing nothing.
+        assert (await store.read_watermark()).never_projected is False
+        assert (
+            await store.count_nodes() == len(projection.nodes) == (result.nodes_written)
+        ), (
+            "count_nodes() changed after persisting a watermark -- the "
+            "watermark must never be stored as a Cypher graph node, because "
+            "NODE_COUNT_QUERY counts every node unconditionally"
+        )
+
+    async def test_purge_removes_exactly_the_projected_node_count(
+        self, store: GraphArmStore
+    ) -> None:
+        projection = build_projection(_reorg(fixtures.alpha_batch(), store.org_id))
+        await store.write_projection(projection)
+
+        deleted = await store.purge_org()
+
+        assert deleted == len(projection.nodes), (
+            "purge_org's node count included something other than the "
+            "projected nodes -- a graph-stored watermark sentinel would do "
+            "exactly this"
+        )
+
+
+class TestTransportFailureIsDistinctFromNeverProjected:
+    async def test_a_hung_connection_raises_rather_than_reporting_absence(self) -> None:
+        """ "Could not check" must never collapse into "checked and absent".
+
+        Mirrors CHAOS-3631's ``GraphOperationTimeoutError`` pattern and
+        ``org_deletion_visit``'s ``DeletionCompletenessUnknownError`` rule:
+        a transport failure is a distinct outcome from a positively-confirmed
+        never-projected partition.
+        """
+
+        import asyncio
+
+        from dev_health_ops.context_fabric.graph_arm.flags import GraphDeadlines
+        from dev_health_ops.context_fabric.graph_arm.store import (
+            GraphOperationTimeoutError,
+        )
+
+        class _HangingConnection:
+            async def get(self, _key: str) -> None:
+                await asyncio.sleep(999.0)
+
+        class _HangingClient:
+            def __init__(self) -> None:
+                self.connection = _HangingConnection()
+
+        class _HangingDriver:
+            def __init__(self) -> None:
+                self.client = _HangingClient()
+
+        from dev_health_ops.context_fabric.graph_arm.backend import (
+            DeterministicEmbedder,
+        )
+
+        hanging_store = GraphArmStore(
+            org_id="orghangwatermark",
+            driver=_HangingDriver(),
+            embedder=DeterministicEmbedder(),  # not touched by read_watermark
+            deadlines=GraphDeadlines(
+                connect_timeout_s=0.05,
+                socket_timeout_s=0.05,
+                read_timeout_s=0.05,
+                write_timeout_s=0.05,
+            ),
+        )
+        with pytest.raises(GraphOperationTimeoutError):
+            await hanging_store.read_watermark()
+
+
+class TestPartialWatermarkRoundTrips:
+    async def test_partial_survives_the_round_trip(self, store: GraphArmStore) -> None:
+        """Not exercised through ``write_projection`` (which never marks a
+        watermark partial -- see its own docstring), so this writes one
+        directly through the persistence primitive to prove ``partial``
+        itself round-trips rather than being silently coerced to ``False``.
+        """
+
+        watermark = IndexWatermark(
+            indexed_through=datetime(2026, 8, 8, tzinfo=UTC),
+            projected_at=datetime(2026, 8, 8, 1, tzinfo=UTC),
+            records_indexed=17,
+            partial=True,
+        )
+        await store.persist_watermark(watermark)
+
+        read_back = await store.read_watermark()
+        assert read_back.partial is True
+        assert read_back.records_indexed == 17
+        assert read_back.indexed_through == watermark.indexed_through
+        assert read_back.projected_at == watermark.projected_at


### PR DESCRIPTION
## Issue and phase

[CHAOS-3679](https://linear.app/fullchaos/issue/CHAOS-3679/persist-and-read-back-the-projection-watermark-from-the-live-store) — Phase 1, Lane A (production graph platform), child of [CHAOS-3500](https://linear.app/fullchaos/issue/CHAOS-3500/phase-1-platform-production-graph-projection-lifecycle-and-bounded) under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660/phase-1-wire-the-production-shaped-graph-assisted-ask-dev-path).

## Observable outcome

`IndexWatermark` existed only as `GraphArmStore.write_projection`'s in-memory return value. A process other than the one that performed the write — in particular a future read-side query service ([CHAOS-3678](https://linear.app/fullchaos/issue/CHAOS-3678/implement-graphinvestigationquery-the-production-bounded-graph-query)), which will typically be a different process from whatever last projected the organization — had no way to learn a partition's `indexed_through`/staleness at all. Discovered while scoping CHAOS-3678: any correct `STALE`/`UNAVAILABLE` determination on the read side needs this.

`GraphArmStore.persist_watermark`/`read_watermark` close the gap: the watermark now survives past the writing process, readable by any store handle for the same organization.

## Architecture boundary

`store.py` only (new methods on `GraphArmStore`). No change to `IndexWatermark` itself.

## Scope / non-scope

**Storage mechanism, and why it's not a graph node.** Confirmed by reading `readback.NODE_COUNT_QUERY` (`"MATCH (n) RETURN count(n) AS total"`, unconditional, no label filter) *before* choosing a mechanism, not after: a Cypher-stored watermark sentinel would have silently broken `count_nodes() == len(projection.nodes)` and `purge_org() returns len(projection.nodes)`, both asserted today in `test_chaos_3617_live_store.py`. Verified live locally that this real risk materializes if you get it wrong (see Verification). Went with a plain Redis key on the FalkorDB client's own connection (`self._driver.client.connection`, exposed by `falkordb.asyncio.FalkorDB`) instead — zero graph nodes written, zero change to `readback.py`'s closed query vocabulary, zero coordination needed with whoever owns it.

**`purge_org` now also deletes the watermark key** on a real (non-dry-run) deletion — it lives outside the graph keyspace the drop otherwise removes, so without this, organization deletion would leave freshness metadata behind for an org with no other data.

**Transport failure stays distinct from never-projected.** `read_watermark()` raises `GraphOperationTimeoutError`/`StoreUnavailableError` (CHAOS-3631's bounded `_bounded_read`) on a transport failure rather than silently reporting never-projected — mirrors `org_deletion_visit`'s `DeletionCompletenessUnknownError` rule that "checked and absent" and "could not check" must never collapse into each other.

## Base/head SHA and branch provenance

`chaos-3679-watermark-persistence`, branched off `origin/feature/chaos-3498-context-fabric` @ `bf328514b` (current tip at push time — includes CHAOS-3631/#1636, now merged, so this PR depends on nothing unmerged). One commit ahead. Branch named for the child issue it completes, per the standing branch rule.

## Migrations / configuration / feature flags

None. No new env var, no new table/migration — a plain Redis key under the existing FalkorDB connection, gated by the same `CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED`/`_READ_ENABLED` flags as everything else in this module.

## Security / privacy / retention impact

Retention: `purge_org` now cleans up the watermark key as part of organization deletion (previously would have leaked). No new content — the persisted payload is `{indexed_through, projected_at, records_indexed, partial}`, all either timestamps or counts, no entity data.

## RED-first evidence

New test module `test_chaos_3679_watermark_persistence.py` — 9 tests, all failed with `AttributeError: 'GraphArmStore' object has no attribute 'read_watermark'`/`'persist_watermark'` before the implementation (one test not calling either method passed trivially, as expected).

## Focused and broad verification

Live store `falkor://127.0.0.1:6389`, `CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1`.

```
.venv/bin/pytest tests/context_fabric/test_chaos_3679_watermark_persistence.py tests/context_fabric/test_chaos_3617_live_store.py tests/context_fabric/test_chaos_3617_semantic_claims.py -q
  → 66 passed

.venv/bin/pytest tests/context_fabric/ -q
  → 1469 passed, 2 failed

.venv/bin/ruff check / format --check, .venv/bin/mypy
  → All checks passed! / already formatted / Success: no issues found
```

**Both failures in the full suite are pre-existing and unrelated** (both in `test_chaos_3647_live_semantic.py`, Lane D's CHAOS-3647 territory) — the same two independently confirmed unrelated on prior PRs in this stack; neither touches `store.py`'s watermark methods.

**A real regression WAS found and fixed during this PR's own verification, worth flagging directly:** `test_chaos_3617_semantic_claims.py::TestEmbeddingBudget::test_the_embedder_is_really_exercised_under_a_generous_budget` broke on first full-suite run — its fake `_RecordingDriver` had no `.client` attribute, and `write_projection` now always calls `persist_watermark` after a successful write, which needs `driver.client.connection`. Fixed by adding a minimal fake `.client.connection` (a `set()` no-op) to that test's driver — the same "sibling fake driver needs updating for a new store.py capability" pattern as CHAOS-3631's own CI fix. Confirmed by isolating the failure, understanding its exact cause via traceback, and re-running the specific test file (25/25 pass) plus the full suite before/after.

## Known limitations and follow-up issues

- No TTL/expiry on the watermark key — it lives as long as the organization's data does (cleaned up by `purge_org`), which matches `IndexWatermark`'s own semantics (a watermark is meaningful indefinitely until superseded by a newer write or removed by deletion).
- CHAOS-3678 (the query service) is the actual consumer of `read_watermark()`; this PR only adds the primitive.

## Rollout / rollback impact

Pure addition. `write_projection`'s behavior changes only in that it now also persists a watermark key after a successful write (one extra bounded Redis `SET`) — no change to its return value or existing callers' observable behavior. Rollback is a plain revert.