### PR TITLE
CHAOS-3680: extract EvidenceCandidates from a graph investigation packet

### DIFF
--- a/src/dev_health_ops/api/dev/graph_evidence_admission.py
+++ b/src/dev_health_ops/api/dev/graph_evidence_admission.py
@@ -1,0 +1,77 @@
+"""CHAOS-3502 increment 2: the candidate-extraction leg of the packet->frame bridge.
+
+Ruled on CHAOS-3660 (orchestrator, integration-seam decision): "Lane B
+delivers: the assembler -- extract candidates from AskDevInvestigationPacket,
+call C's admission service, assemble contracts_v2 DevInvestigationResult/
+DevAnswerFrame from admitted results + enrichment." This module is the first
+half of that: extraction only. It does not call
+:meth:`~.evidence_service.EvidenceService.admit` itself (that is an
+orchestrator-owned, request-scoped call needing ``org_id``/
+``permission_fingerprint``/``scope_request``) -- it only turns a packet's
+proposed evidence into the exact input shape ``admit()`` needs.
+
+**Why this reuses the real ``EvidenceCandidate``/``EvidenceService`` types
+rather than a fake.** Unlike the graph query seam (Lane A's CHAOS-3500,
+genuinely not built yet) or the canonical-admission-result contract (Lane
+C's CHAOS-3664, still landing), ``evidence_service.EvidenceCandidate`` and
+``EvidenceService.admit()`` are *already* real, stable, production contracts
+(CHAOS-3646, merged). Building a parallel interface here would be exactly
+the "duplicate hand-maintained schema" the handoff's §8 forbids. What is
+still incomplete is *behind* ``EvidenceService`` (``candidate_resolvers`` for
+graph-sourced candidates specifically -- Lane C's CHAOS-3664/3675), which
+this module does not need to see: an unconfigured resolver already produces
+an honest ``EvidenceAvailability.UNCONFIGURED`` refusal per candidate, not a
+crash or a fabricated success.
+
+**Why every candidate needs ``record_locator`` (CHAOS-3633).** A packet's
+``InvestigationEvidenceEntry.evidence: DevEvidenceRefV2`` was minted by the
+graph arm's own (pre-authorization) handle service when the packet was
+built -- a *proposed* identity, not an admitted one
+(``investigation_contract``'s own docstring: "the graph proposes; canonical
+services verify"). ``EvidenceCandidate.locator`` is the field
+``EvidenceService.admit()`` re-resolves against, distinct from
+``entity_id`` -- the exact distinction CHAOS-3633 exists to preserve: two
+same-kind records about one entity are two records, not one just because
+they share an ``entity_id``. A packet entry with no ``record_locator`` (pre-
+CHAOS-3633 graph-arm code, or a source the arm cannot address a specific
+record within) produces a candidate with an EMPTY locator string --
+deliberately not coerced to ``entity_id`` or silently dropped, either of
+which would reintroduce the exact collision CHAOS-3633 closed. An empty
+locator is not a special case here: it is simply a locator no configured
+resolver's records will match, so ``admit()`` refuses it through its
+ordinary "no record at this address" path.
+"""
+
+from __future__ import annotations
+
+from .evidence_service import EvidenceCandidate
+from .investigation_contract import AskDevInvestigationPacket
+
+__all__ = ["extract_evidence_candidates"]
+
+
+def extract_evidence_candidates(
+    packet: AskDevInvestigationPacket,
+) -> tuple[EvidenceCandidate, ...]:
+    """One :class:`EvidenceCandidate` per packet evidence-index entry, in
+    the packet's own order.
+
+    Deliberately 1:1 and order-preserving -- the caller (the increment-2
+    assembler, not yet built) must be able to line up
+    ``EvidenceAdmissionResult.admissions`` against
+    ``packet.evidence_coverage.evidence_index`` positionally to know which
+    refused candidate corresponds to which packet claim, exactly as
+    :class:`~.evidence_service.EvidenceAdmissionResult`'s own docstring
+    requires ("one entry per candidate, always").
+    """
+
+    return tuple(
+        EvidenceCandidate(
+            source_system=entry.evidence.source_system,
+            entity_type=entry.evidence.entity_type,
+            entity_id=entry.evidence.entity_id,
+            locator=entry.evidence.record_locator or "",
+            repository_ids=tuple(entry.evidence.repository_ids),
+        )
+        for entry in packet.evidence_coverage.evidence_index
+    )

--- a/tests/api/dev/test_chaos_3502_graph_evidence_admission.py
+++ b/tests/api/dev/test_chaos_3502_graph_evidence_admission.py
@@ -1,0 +1,85 @@
+"""CHAOS-3502 increment 2: the candidate-extraction leg of the packet->frame
+bridge (``graph_evidence_admission.extract_evidence_candidates``).
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from dev_health_ops.api.dev.evidence_service import EvidenceCandidate
+from dev_health_ops.api.dev.graph_evidence_admission import (
+    extract_evidence_candidates,
+)
+from dev_health_ops.api.dev.investigation_contract import AskDevInvestigationPacket
+from dev_health_ops.api.dev.investigation_contract.fixtures import positive_fixtures
+
+
+def _packet() -> AskDevInvestigationPacket:
+    payload = deepcopy(positive_fixtures()["ask_dev_investigation_packet.v1"])
+    return AskDevInvestigationPacket.model_validate(payload)
+
+
+def test_one_candidate_per_evidence_index_entry_in_order() -> None:
+    packet = _packet()
+    candidates = extract_evidence_candidates(packet)
+    assert len(candidates) == len(packet.evidence_coverage.evidence_index)
+    for candidate, entry in zip(
+        candidates, packet.evidence_coverage.evidence_index, strict=True
+    ):
+        assert isinstance(candidate, EvidenceCandidate)
+        assert candidate.source_system == entry.evidence.source_system
+        assert candidate.entity_type == entry.evidence.entity_type
+        assert candidate.entity_id == entry.evidence.entity_id
+        assert candidate.repository_ids == tuple(entry.evidence.repository_ids)
+
+
+def test_a_missing_record_locator_becomes_an_empty_string_not_entity_id() -> None:
+    """CHAOS-3633 guardrail: an absent locator must never be coerced to
+    ``entity_id`` (that would silently re-collapse two same-kind records
+    about one entity back onto each other) and must never be dropped
+    (that would silently narrow the candidate set). It becomes an empty
+    string -- a locator no real resolver record will match, so admission
+    refuses it through its ordinary "no record at this address" path
+    rather than a fabricated success or a raised exception.
+    """
+
+    packet = _packet()
+    assert all(
+        entry.evidence.record_locator is None
+        for entry in packet.evidence_coverage.evidence_index
+    ), "fixture assumption changed -- this test needs a record_locator=None entry"
+
+    candidates = extract_evidence_candidates(packet)
+    assert candidates
+    for candidate, entry in zip(
+        candidates, packet.evidence_coverage.evidence_index, strict=True
+    ):
+        assert candidate.locator == ""
+        assert candidate.locator != entry.evidence.entity_id
+
+
+def test_a_present_record_locator_passes_through_unchanged() -> None:
+    payload = deepcopy(positive_fixtures()["ask_dev_investigation_packet.v1"])
+    payload["evidence_coverage"]["evidence_index"][0]["evidence"]["record_locator"] = (
+        "review_platform:pr_4821:review_2"
+    )
+    packet = AskDevInvestigationPacket.model_validate(payload)
+
+    candidates = extract_evidence_candidates(packet)
+    assert candidates[0].locator == "review_platform:pr_4821:review_2"
+
+
+def test_extraction_is_purely_derived_and_mints_nothing() -> None:
+    """The candidate carries no evidence_ref_id, display_label, citation_text,
+    observed_at, confidence, provenance, or freshness -- exactly the CHAOS-3646
+    guarantee (see EvidenceCandidate's own docstring): the graph proposes, it
+    never mints authority, and the dataclass has nowhere to put a handle even
+    if this function tried to smuggle one through.
+    """
+
+    packet = _packet()
+    candidates = extract_evidence_candidates(packet)
+    for candidate in candidates:
+        assert not hasattr(candidate, "evidence_ref_id")
+        assert not hasattr(candidate, "display_label")
+        assert not hasattr(candidate, "confidence")


### PR DESCRIPTION
## Issue and phase
CHAOS-3680 (child of CHAOS-3502, Wave 3.2 Phase 1, Lane B — grandparent CHAOS-3660). Increment 2a of the graph-assisted routing work: the candidate-extraction leg of the packet-to-frame bridge. **Stacked on #1641** (CHAOS-3677 seam scaffolding, unmerged) — base branch `chaos-3677-graph-investigation-seam`. Please land #1639 → #1641 first.

## Observable outcome
None yet, by design — this is the first of three legs the bridge needs (extraction → admission call → frame assembly), and only extraction lands here. `graph_evidence_admission.extract_evidence_candidates(packet) -> tuple[EvidenceCandidate, ...]` is a pure function, not called from any live code path.

## Architecture boundary
Per the CHAOS-3660 integration-seam ruling (bridge ownership): Lane B extracts candidates from `AskDevInvestigationPacket`, calls Lane C's admission service, assembles the canonical frame. This PR is extraction only. It deliberately does **not** call `EvidenceService.admit()` (that's orchestrator-owned and request-scoped) and does **not** assemble a `DevAnswer`/`DevAnswerFrame` (that's the terminal-path extraction, design posted on CHAOS-3660, awaiting sign-off before implementation).

Reuses the real, already-production `EvidenceCandidate`/`EvidenceService` types (CHAOS-3646) rather than inventing a parallel interface or a fake — those are stable, reviewed contracts, not something still being negotiated with Lane A/C. What's still incomplete (Lane C's CHAOS-3664/3675 candidate resolvers for graph-sourced evidence specifically) lives *behind* `EvidenceService`, invisible to this extraction step: an unconfigured resolver already produces an honest `UNCONFIGURED` refusal per candidate.

## Scope / non-scope
**In scope:** `graph_evidence_admission.py` (new file, mine), tests against real `investigation_contract` packet fixtures.
**Out of scope:** calling `admit()`, frame assembly, the terminal-path refactor (`_assemble_grounded_answer`/`_graph_grounded_answer`) — that PR comes after CHAOS-3660 sign-off.

## Base/head SHA and branch provenance
- Base: `chaos-3677-graph-investigation-seam` @ `eeb037e37` (= PR #1641's head).
- Head: `95a3ecb0c` on `chaos-3680-evidence-candidate-extraction`.
- Ultimate base once the stack lands: `feature/chaos-3498-context-fabric`.

## Migrations/configuration/feature flags
None.

## Security/privacy/retention impact
None directly — no live code path calls this yet. The function itself preserves CHAOS-3633's evidence-identity guardrail explicitly: a candidate's `locator` is never coerced from `entity_id` and never silently dropped when the packet's `record_locator` is absent (empty string instead, which any real resolver simply won't match — an honest refusal path, not a fabricated success).

## RED-first evidence
N/A — new pure function, no prior broken behavior to reproduce. Tests assert the documented contract directly (1:1 order-preserving extraction, CHAOS-3646's "candidate carries no evidence_ref_id/display_label/confidence" no-authority guarantee, and the CHAOS-3633 locator-absence handling with an explicit negative check that it's not coerced to `entity_id`).

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_chaos_3502_graph_evidence_admission.py -v
  → 4 passed
.venv/bin/python -m pytest tests/api/dev tests/context_fabric -m "not benchmark and not clickhouse" -q -n 4 --dist loadscope
  → 4399 passed, 63 skipped, 4 xfailed, 0 failed
.venv/bin/ruff check / ruff format --check / mypy → clean
```
Pre-commit and pre-push lefthook gates passed locally.

## Known limitations and follow-up issues
- Admission-call leg (calling `EvidenceService.admit()` from the orchestrator, with `org_id`/`permission_fingerprint`/`scope_request`) is a follow-up, not yet ticketed separately.
- Frame-assembly leg is blocked on the CHAOS-3660 terminal-path sign-off.

## Rollout/rollback impact
None — unreachable pure function. Revert is a plain `git revert`.
