### PR TITLE
Refuse entity-less admission with no repository anchor either

### DIFF
--- a/src/dev_health_ops/api/dev/evidence_service.py
+++ b/src/dev_health_ops/api/dev/evidence_service.py
@@ -111,6 +111,15 @@ class EvidenceRecord:
     #: ``entity_id``'s value instead would let a resolver bug (or a
     #: resolver that took the cheap path instead of deriving) launder its
     #: way past the entity check merely by returning something falsy.
+    #:
+    #: **Requires ``repository_ids`` to be non-empty.** ``admit`` refuses
+    #: (never silently admits) a record with this flag set AND empty
+    #: ``repository_ids``: ``_authorize_expansion``'s entity check and its
+    #: repository check are BOTH truthy-gated, so an entity-less,
+    #: repository-less record would skip both and be admitted
+    #: unconditionally to any caller with a generally-valid resolution --
+    #: an authorization bypass, not a convenience. Every resolver that sets
+    #: this flag must resolve a repository to attach.
     no_authorizable_entity: bool = False
 
 
@@ -834,6 +843,24 @@ class EvidenceService:
             # leaving authorization to the unmodified, independent
             # ``repository_ids`` check below it.
             record = replace(record, record_locator=candidate.locator)
+            if record.no_authorizable_entity and not record.repository_ids:
+                # An empty ``valid_entity_ids`` skips the entity check;
+                # ``_authorize_expansion``'s repository check is ALSO
+                # truthy-gated (``if evidence.repository_ids:``). A record
+                # with neither has no authorization anchor at all -- both
+                # checks would skip and it would be admitted
+                # unconditionally to any caller with a generally-valid
+                # resolution, regardless of scope. Refused here rather
+                # than trusted to every current and future resolver's own
+                # discipline never to produce that combination.
+                admissions.append(
+                    EvidenceAdmission(
+                        candidate=candidate,
+                        state=EvidenceAvailability.UNAUTHORIZED,
+                        warning="no_authorization_anchor",
+                    )
+                )
+                continue
             valid_entity_ids = (
                 () if record.no_authorizable_entity else (record.entity_id,)
             )

--- a/tests/api/dev/test_evidence_service.py
+++ b/tests/api/dev/test_evidence_service.py
@@ -10,6 +10,8 @@ import pytest
 from dev_health_ops.api.dev.contracts import FreshnessState
 from dev_health_ops.api.dev.evidence_service import (
     MAX_EXPANSION_BYTES,
+    EvidenceAdmission,
+    EvidenceAdmissionResult,
     EvidenceAvailability,
     EvidenceCandidate,
     EvidenceRecord,
@@ -1086,5 +1088,101 @@ async def test_the_repository_only_check_is_observed_failing_when_short_circuite
     # record wrongly admitted -- proving
     # ``test_entity_less_record_without_repository_access_is_refused``
     # exercises a real check against the unmodified service.
+    assert only.evidence is not None
+    assert only.state is EvidenceAvailability.AVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_a_record_with_no_authorization_anchor_at_all_is_refused() -> None:
+    """A record marked ``no_authorizable_entity`` with EMPTY
+    ``repository_ids`` has no authorization anchor whatsoever:
+    ``_authorize_expansion``'s entity check and its repository check are
+    BOTH truthy-gated, so neither would run -- an unconditional admission
+    to any caller with a generally-valid resolution, not merely a
+    convenience. ``admit`` must refuse this combination outright rather
+    than trust every current and future resolver never to produce it."""
+
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[_EntityLessResolver(marked=True, repository_ids=())],
+    )
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),
+        candidates=[_entity_less_candidate()],
+    )
+    (only,) = result.admissions
+    assert only.evidence is None
+    assert only.state is EvidenceAvailability.UNAUTHORIZED
+    assert only.warning == "no_authorization_anchor"
+
+
+@pytest.mark.asyncio
+async def test_the_no_anchor_guard_is_observed_failing_when_removed() -> None:
+    """Mutation-kill for the guard above: a service whose ``admit`` skips
+    straight to minting without the anchor check -- simulating the defect
+    the guard exists to catch -- wrongly admits the anchor-less record the
+    previous test correctly refuses."""
+
+    class _AnchorGuardSkippingService(EvidenceService):
+        async def admit(
+            self, *, org_id, permission_fingerprint, scope_request, candidates
+        ):
+            # Re-implements just enough of ``admit`` to demonstrate the
+            # ungated path, deliberately WITHOUT the no-anchor refusal --
+            # the same shape the real ``admit`` had before this guard was
+            # added.
+            admissions = []
+            for candidate in candidates:
+                resolver = self._resolvers.get(candidate.source_system)
+                assert resolver is not None
+                resolution = await self._authorizer.resolve(
+                    org_id, permission_fingerprint, scope_request
+                )
+                record = await resolver.resolve(
+                    org_id=org_id, scope=resolution, candidate=candidate
+                )
+                assert record is not None
+                valid_entity_ids = (
+                    () if record.no_authorizable_entity else (record.entity_id,)
+                )
+                ref = self._to_ref(org_id, record, valid_entity_ids=valid_entity_ids)
+                state, warning = await self._authorize_expansion(
+                    org_id, permission_fingerprint, scope_request, resolution, ref
+                )
+                admissions.append(
+                    EvidenceAdmission(
+                        candidate=candidate,
+                        state=state,
+                        evidence=ref
+                        if state is EvidenceAvailability.AVAILABLE
+                        else None,
+                        warning=warning,
+                    )
+                )
+            return EvidenceAdmissionResult(tuple(admissions))
+
+    service = _AnchorGuardSkippingService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[_EntityLessResolver(marked=True, repository_ids=())],
+    )
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(),
+        candidates=[_entity_less_candidate()],
+    )
+    (only,) = result.admissions
+    # This is the FAILURE the shim demonstrates: an anchor-less record,
+    # admitted unconditionally, because BOTH of _authorize_expansion's
+    # checks are truthy-gated and this shim never sees an empty-anchor
+    # record for what it is.
     assert only.evidence is not None
     assert only.state is EvidenceAvailability.AVAILABLE


### PR DESCRIPTION
Branch is ID-free per the standing multi-PR pattern -- this is a hardening found while doing CHAOS-3675 PR2 (incidents) recon, on top of #1645 which already merged.

## Issue and phase
Prerequisite for [CHAOS-3675](https://linear.app/fullchaos/issue/CHAOS-3675) PR 2/3 (incidents) — child of [CHAOS-3664](https://linear.app/fullchaos/issue/CHAOS-3664), Phase 1 Lane C, under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660).

## Observable outcome
`EvidenceService.admit()` now refuses (rather than unconditionally admits) a record marked `no_authorizable_entity=True` with empty `repository_ids`.

## Why this landed as its own PR
Discovered doing PR2's actual join recon (`operational_incidents` / `work_graph_deployment_incident_edges`), after #1645 merged: `_authorize_expansion`'s entity check (`if evidence.valid_entity_ids`) and its repository check (`if evidence.repository_ids`) are BOTH truthy-gated. #1645's mechanism correctly closes the entity-check gap, but a record with no entity AND no repository skips both checks and falls through to the unconditional `AVAILABLE` return — a real authorization bypass, not a theoretical one. Incidents can genuinely have no linked repository at all (the edge join can miss entirely, not just return a null `repo_id`), so a naive incidents resolver built directly on #1645's mechanism would have produced exactly this combination. Caught before writing that resolver, not after.

## Architecture boundary
Canonical admission side only (`evidence_service.py`, mine exclusively). No contract/schema change — the fix is entirely in `admit()`'s control flow.

## Base/head SHA and branch provenance
Base: `feature/chaos-3498-context-fabric` @ `e02d7e00b...` (current tip, includes #1645)
Head: `anchor-less-evidence-refusal`, one commit.

## Security/privacy/retention impact
Closes an authorization bypass in the mechanism #1645 introduced, before any real resolver uses it. Net effect is strictly more restrictive — nothing previously correctly admitted becomes refused; only the unsafe combination (no entity, no repository) is now refused instead of silently passing.

## RED-first evidence
`test_a_record_with_no_authorization_anchor_at_all_is_refused` — mutation-verified: removed the guard and confirmed `test_the_no_anchor_guard_is_observed_failing_when_removed`'s shim (deliberately reproducing `admit()`'s pre-guard shape) wrongly admits the anchor-less record, before restoring the real code.

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_evidence_service.py -v      # 25 passed
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q        # 4414 passed, 118 skipped, 4 xfailed, 0 failed
.venv/bin/mypy src/dev_health_ops/api/dev/evidence_service.py tests/api/dev/test_evidence_service.py   # Success: no issues
pre-commit hook (mypy over full tree, ruff)                              # Success: no issues
```

## Known limitations and follow-up issues
No real resolver uses `no_authorizable_entity` yet — CHAOS-3675 PR 2/3 (incidents) builds on this next.

## Rollout/rollback impact
Pure hardening of an unused-in-production mechanism; safe to revert independently.