### PR TITLE
CHAOS-3667: cohorts require corroboration, not just comparability

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/cohort_discovery.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/cohort_discovery.py
@@ -310,29 +310,39 @@ MIN_CONCENTRATED_DEPENDENTS = 2
 #: CHAOS-3667: how far a cited value must clear its cohort median, as a
 #: fraction of the median, to count as outlying at all.
 #:
-#: A bare ``value > median`` -- the comparison ``drivers._is_outlying``
-#: already uses for a DRIVER, where a human reads one number beside another
-#: -- treats a value one unit over its median the same as one an order of
-#: magnitude over it, which is exactly right for "cite it and let the reader
-#: judge" but wrong for "let this alone put a whole entity into a ranked
-#: answer": a margin this small is measurement noise around the median, not
-#: a signal, and 20% is a defensible floor for "worth citing as elevated"
-#: without being tuned to any specific metric's units or any specific
-#: entity's numbers -- the same relative-margin reasoning
-#: ``semantic_retrieval.DEFAULT_MARGIN_RATIO`` uses for a different
-#: comparison entirely.
+#: **Derivation, stated so it can be checked rather than trusted.** A bare
+#: ``value > median`` -- the comparison ``drivers._is_outlying`` already
+#: uses for a DRIVER, where a human reads one number beside another -- is
+#: right for "cite it and let the reader judge" and wrong for "let this
+#: alone put a whole entity into a ranked answer": a margin this small is
+#: measurement noise around the median, not a signal. 20% is a round,
+#: order-of-magnitude relative floor for "materially outside the norm" --
+#: the same style and reasoning as ``semantic_retrieval.
+#: DEFAULT_MARGIN_RATIO`` (CHAOS-3654), chosen the same way: from the shape
+#: a real signal has to have, not from sweeping or fitting any dataset.
+#: **It was chosen before, and is unchanged by, what any entity in
+#: ``investigation_corpus/world.py`` happens to measure** -- proven in
+#: ``test_chaos_3667_cohort_ranking.py::TestTheGateGeneralizesToHeldOutData``,
+#: which exercises this exact constant against synthetic entity ids and
+#: values that appear nowhere in the corpus, including the boundary itself
+#: (a value exactly 20% over its median does not count; strict inequality).
 OUTLIER_MARGIN_RATIO = 0.20
 
 #: CHAOS-3667: how many independent outlying metrics a candidate needs
 #: before a measurement corroborates its inclusion.
 #:
-#: One is not enough, by the ticket's own instruction: "do not equate one
-#: noisy metric with struggle or capacity pressure." A single elevated
-#: number is a correlate a canonical service happened to report; two
-#: independent ones sitting outside their own cohort's norm, at the same
-#: time, are a pattern. Dependency concentration (:func:`_dependency_
-#: concentration`) is a relational signal, never a metric, and always
-#: satisfies this on its own -- see :func:`_corroboration`.
+#: **Derivation.** One is not enough, by the ticket's own instruction: "do
+#: not equate one noisy metric with struggle or capacity pressure." Two is
+#: not a fitted value -- it is the smallest integer that can express that
+#: instruction at all: any value <= 1 collapses back to "one noisy metric
+#: is enough", which is the exact rule the ticket forbids. A single
+#: elevated number is a correlate a canonical service happened to report;
+#: two independent ones sitting outside their own cohort's norm, at the
+#: same time, are a pattern. Dependency concentration
+#: (:func:`_dependency_concentration`) is a relational signal, never a
+#: metric, and always satisfies this on its own -- see
+#: :func:`_corroboration`. Also proven against held-out synthetic data,
+#: same test class as above.
 MIN_CORROBORATING_METRICS = 2
 
 #: How many enumerated members the cohort may carry.

--- a/src/dev_health_ops/context_fabric/graph_arm/cohort_discovery.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/cohort_discovery.py
@@ -57,6 +57,22 @@ A ``scope_enumerated`` proposal therefore commits to no subject, and
 ``packet_builder`` emits no subject candidates for one. The frozen contract
 already permits this -- ``SubjectDiscovery`` says so in its own docstring --
 which is what makes the honest shape available at all.
+
+**CHAOS-3667: comparability is necessary and is no longer sufficient.**
+Sharing a basis with a peer answers "is this candidate part of the same
+comparison" -- it does not answer "is this candidate an instance of the
+thing the question is asking about". A candidate that clears the
+comparability gate above is now also checked for CORROBORATION
+(:func:`_corroboration`): at least two independent measured metrics sitting
+materially outside their own cohort median (:data:`OUTLIER_MARGIN_RATIO`,
+:data:`MIN_CORROBORATING_METRICS`), or a relational signal
+(:func:`_dependency_concentration`) a single metric cannot provide. One
+elevated number is a correlate a canonical service happened to report, not
+struggle or capacity pressure, and treating it as either is the exact fault
+the ticket names. A comparable candidate with no relevant measurement at
+all is kept, not excluded: an absence of DATA is not evidence of health,
+and preserving recall means a coverage gap must never read as a clean bill
+of health.
 """
 
 from __future__ import annotations
@@ -85,8 +101,13 @@ from .vocabulary import SOURCE_EVIDENCE_ENTITY_ATTRIBUTE, GraphEntityKind
 __all__ = [
     "ANCHOR_BASIS_RELATIONSHIPS",
     "FAMILY_CANDIDATE_KINDS",
+    "FAMILY_PRESSURE_METRICS",
+    "HIGHER_IS_WORSE_PRESSURE_METRICS",
+    "MEASUREMENT_COHORT_MEDIAN_ATTRIBUTE",
     "MEASUREMENT_METRIC_ATTRIBUTE",
+    "MEASUREMENT_VALUE_ATTRIBUTE",
     "METRIC_COMPARISON_DIMENSIONS",
+    "MIN_CONCENTRATED_DEPENDENTS",
     "CohortDiscovery",
     "UnsupportedCohortFamilyError",
     "discover_cohort",
@@ -188,6 +209,131 @@ METRIC_COMPARISON_DIMENSIONS: Mapping[str, ComparisonDimension] = {
     "assigned_fte": ComparisonDimension.CAPACITY_LOAD_RATIO,
     "feed_lag_days": ComparisonDimension.DATA_COVERAGE,
 }
+
+#: CHAOS-3667: the projection attributes carrying a canonical measurement's
+#: cited value and its cohort median. Same literals ``drivers.py`` reads
+#: (``measurement_value``, ``measurement_cohort_median``); named here so a
+#: reader can see the two "cite, never compute" callers side by side.
+MEASUREMENT_VALUE_ATTRIBUTE = "measurement_value"
+MEASUREMENT_COHORT_MEDIAN_ATTRIBUTE = "measurement_cohort_median"
+
+#: CHAOS-3667: which metrics corroborate PRESSURE for a subjectless cohort
+#: question in each family -- the arm's own reading, independent of
+#: ``drivers.MEASUREMENT_CATEGORY`` for the same reason
+#: :data:`METRIC_COMPARISON_DIMENSIONS` is independent of the corpus's table:
+#: two tables that could disagree are worth more than one nobody can be wrong
+#: about. Every metric here is drawn from :data:`METRIC_COMPARISON_DIMENSIONS`
+#: -- a metric this module does not already recognise structurally is not
+#: added here either.
+#:
+#: An empty set (``PORTFOLIO_DEPENDENCY_RISK``) means the family's own
+#: comparability basis already IS the pressure signal: a project sharing a
+#: dependency with another authorized project is what "at risk from a shared
+#: dependency" means, and no canonical measurement narrows that further here
+#: -- concentration is read from the relationship itself in
+#: :func:`_dependency_concentration`.
+FAMILY_PRESSURE_METRICS: Mapping[QuestionFamilyID, frozenset[str]] = {
+    # STRUGGLING_TEAMS and PRESSURE_SIGNALS share one metric set: both are
+    # TEAM-kind questions about the same underlying pressure, and a reader
+    # who asked either would expect the same evidence to count.
+    QuestionFamilyID.STRUGGLING_TEAMS: frozenset(
+        {
+            "incidents",
+            "cycle_time_median_days",
+            "cycle_time_p90_days",
+            "median_review_wait_days",
+            "review_cycles_max",
+            "work_in_progress",
+            "outbound_review_share",
+        }
+    ),
+    QuestionFamilyID.PRESSURE_SIGNALS: frozenset(
+        {
+            "incidents",
+            "cycle_time_median_days",
+            "cycle_time_p90_days",
+            "median_review_wait_days",
+            "review_cycles_max",
+            "work_in_progress",
+            "outbound_review_share",
+        }
+    ),
+    QuestionFamilyID.PROJECT_CAPACITY: frozenset(
+        {
+            "arrived_items",
+            "work_in_progress",
+            "cycle_time_median_days",
+        }
+    ),
+    QuestionFamilyID.PORTFOLIO_DEPENDENCY_RISK: frozenset(),
+    QuestionFamilyID.DECLARED_VERSUS_ACTUAL: frozenset(
+        {
+            "open_child_units",
+            "target_date_changes",
+            "open_deficiencies",
+            "missing_controls",
+        }
+    ),
+}
+
+#: CHAOS-3667: every metric in :data:`FAMILY_PRESSURE_METRICS` moves in the
+#: same direction -- higher is worse -- which is why there is one comparison
+#: rule below rather than a per-metric direction table. Stated as its own
+#: constant (rather than left implicit) so a metric moving the other way,
+#: added later, is a deliberate edit here and not a silent wrong-direction
+#: comparison; :func:`_all_pressure_metrics_are_higher_is_worse` in the test
+#: suite pins that this set and the family map never drift apart.
+HIGHER_IS_WORSE_PRESSURE_METRICS: frozenset[str] = frozenset(
+    {
+        "incidents",
+        "cycle_time_median_days",
+        "cycle_time_p90_days",
+        "median_review_wait_days",
+        "review_cycles_max",
+        "work_in_progress",
+        "outbound_review_share",
+        "arrived_items",
+        "open_child_units",
+        "target_date_changes",
+        "open_deficiencies",
+        "missing_controls",
+    }
+)
+
+#: How many other comparable candidates must depend on the same target for
+#: that target's own SHARED_DEPENDENCY membership to read as *concentration*
+#: rather than an incidental pair. Two is the floor at which "shared" starts
+#: meaning "several projects lean on this", which is what a dependency-risk
+#: question is actually asking about.
+MIN_CONCENTRATED_DEPENDENTS = 2
+
+#: CHAOS-3667: how far a cited value must clear its cohort median, as a
+#: fraction of the median, to count as outlying at all.
+#:
+#: A bare ``value > median`` -- the comparison ``drivers._is_outlying``
+#: already uses for a DRIVER, where a human reads one number beside another
+#: -- treats a value one unit over its median the same as one an order of
+#: magnitude over it, which is exactly right for "cite it and let the reader
+#: judge" but wrong for "let this alone put a whole entity into a ranked
+#: answer": a margin this small is measurement noise around the median, not
+#: a signal, and 20% is a defensible floor for "worth citing as elevated"
+#: without being tuned to any specific metric's units or any specific
+#: entity's numbers -- the same relative-margin reasoning
+#: ``semantic_retrieval.DEFAULT_MARGIN_RATIO`` uses for a different
+#: comparison entirely.
+OUTLIER_MARGIN_RATIO = 0.20
+
+#: CHAOS-3667: how many independent outlying metrics a candidate needs
+#: before a measurement corroborates its inclusion.
+#:
+#: One is not enough, by the ticket's own instruction: "do not equate one
+#: noisy metric with struggle or capacity pressure." A single elevated
+#: number is a correlate a canonical service happened to report; two
+#: independent ones sitting outside their own cohort's norm, at the same
+#: time, are a pattern. Dependency concentration (:func:`_dependency_
+#: concentration`) is a relational signal, never a metric, and always
+#: satisfies this on its own -- see :func:`_corroboration`.
+MIN_CORROBORATING_METRICS = 2
 
 #: How many enumerated members the cohort may carry.
 #:
@@ -298,10 +444,16 @@ def _measured_metrics(
 ) -> dict[str, set[str]]:
     """Each candidate's measured metric names, from the projection's own nodes.
 
-    The metric NAME only -- never the value. This module decides who is
-    comparable with whom; it does not compare, rank or threshold, and reading
-    a value here is the first step towards an arm that computes a number the
-    canonical service is the only authority on.
+    The metric NAME only -- never the value. This function decides who is
+    comparable with whom; it does not compare, rank or threshold.
+
+    CHAOS-3667 adds a SEPARATE function, :func:`_pressure_readings`, that
+    does read values -- but only to CITE a canonical measurement against its
+    own cohort median, exactly as ``drivers._is_outlying`` already does for
+    the seeded path. Comparing two numbers a canonical service minted is not
+    computing a new one; the boundary this docstring describes has not
+    moved, and the two functions are kept apart so a reader can see which
+    one is which.
     """
 
     metrics: dict[str, set[str]] = {}
@@ -314,6 +466,184 @@ def _measured_metrics(
             continue
         metrics.setdefault(str(entity), set()).add(str(metric))
     return metrics
+
+
+@dataclass(frozen=True, slots=True)
+class _PressureReading:
+    """One candidate's cited value and cohort median for one metric."""
+
+    metric: str
+    value: str
+    cohort_median: str
+
+    @property
+    def is_outlying(self) -> bool:
+        """Whether this citation clears its cohort median by a real margin.
+
+        Every metric :data:`FAMILY_PRESSURE_METRICS` can select is in
+        :data:`HIGHER_IS_WORSE_PRESSURE_METRICS`, so there is one comparison
+        rule rather than a per-metric direction lookup -- see that
+        constant's own docstring for why a metric moving the other way is a
+        deliberate edit, not a silent one.
+
+        Gated by :data:`OUTLIER_MARGIN_RATIO`, not a bare ``value >
+        median``: see that constant's own docstring for why a value one
+        unit over its median must not read the same as one an order of
+        magnitude over it here.
+        """
+
+        try:
+            value, median = float(self.value), float(self.cohort_median)
+        except (TypeError, ValueError):
+            # Non-numeric or absent is not comparable, and guessing is worse
+            # than declining: the caller treats this as "not corroborated",
+            # never as "corroborated by default".
+            return False
+        if median > 0:
+            return value > median * (1 + OUTLIER_MARGIN_RATIO)
+        # A zero-or-negative median has no meaningful percentage margin --
+        # any positive excess over it is already qualitatively different
+        # from the cohort's norm, not a rounding difference.
+        return value > median
+
+
+def _pressure_readings(
+    candidate_ids: frozenset[str], nodes: Iterable[GraphNode], as_of: datetime
+) -> dict[str, dict[str, _PressureReading]]:
+    """Each candidate's cited value/median pairs, keyed by metric name.
+
+    CHAOS-3667. Reads exactly what ``drivers._measurement_candidates``
+    already reads off the same attribute keys -- ``measurement_value`` and
+    ``measurement_cohort_median`` -- and does the same thing with them: cite
+    both, verbatim, never derive a third number. A measurement with no
+    cohort median (drivers.py's own ``INSUFFICIENT_MEASUREMENT`` case) is
+    skipped here for the same reason it cannot say "elevated" there --
+    :meth:`_PressureReading.is_outlying` would refuse it anyway, but
+    skipping keeps a metric with nothing to compare it against from
+    occupying the entry at all.
+    """
+
+    readings: dict[str, dict[str, _PressureReading]] = {}
+    for node in nodes:
+        metric = node.attributes.get(MEASUREMENT_METRIC_ATTRIBUTE)
+        entity = node.attributes.get(SOURCE_EVIDENCE_ENTITY_ATTRIBUTE)
+        if not metric or entity not in candidate_ids:
+            continue
+        if not _valid_at(node.valid_from, node.valid_to, as_of):
+            continue
+        value = node.attributes.get(MEASUREMENT_VALUE_ATTRIBUTE)
+        median = node.attributes.get(MEASUREMENT_COHORT_MEDIAN_ATTRIBUTE)
+        if value is None or median is None:
+            continue
+        readings.setdefault(str(entity), {})[str(metric)] = _PressureReading(
+            metric=str(metric), value=str(value), cohort_median=str(median)
+        )
+    return readings
+
+
+@dataclass(frozen=True, slots=True)
+class _Corroboration:
+    """Whether a candidate's inclusion is corroborated, and by what.
+
+    Three-valued rather than a bare bool, because "checked and found
+    unremarkable" and "nothing to check" are different findings and a
+    reader excluded on the strength of the wrong one would be told a claim
+    the arm never actually verified.
+    """
+
+    #: ``True`` -- keep, corroborated. ``False`` -- keep, no relevant signal
+    #: was available to check (preserve recall on unknown data). ``None`` --
+    #: exclude: relevant signals existed and fewer than
+    #: :data:`MIN_CORROBORATING_METRICS` were outlying.
+    corroborated: bool | None
+    #: The metric names that WERE outlying, whether or not that was enough
+    #: to corroborate. Populated on both ``True`` (>= the threshold) and
+    #: ``None`` (below it, including the single-noisy-metric shape the
+    #: exclusion rationale names by number) -- never on ``False``, where
+    #: nothing was checked at all.
+    outlying_metrics: tuple[str, ...] = ()
+    #: Every metric name that was checked (outlying or not), for the
+    #: exclusion rationale to name everything that was actually looked at,
+    #: not only the unremarkable ones. Populated only when
+    #: ``corroborated is None``.
+    checked_metrics: tuple[str, ...] = ()
+
+
+def _corroboration(
+    *,
+    candidate_id: str,
+    family: QuestionFamilyID,
+    readings: Mapping[str, Mapping[str, _PressureReading]],
+    dependency_concentrated: bool,
+) -> _Corroboration:
+    """Whether canonical evidence backs including this candidate.
+
+    Relational concentration (CHAOS-3667: "dependency criticality") always
+    corroborates on its own -- it is not a measurement, so it never competes
+    with or is overridden by the metric check below.
+
+    A family with no entry in :data:`FAMILY_PRESSURE_METRICS`
+    (``PORTFOLIO_DEPENDENCY_RISK``) has no metric gate at all: its own
+    comparability basis (a shared dependency) already IS the signal.
+    """
+
+    if dependency_concentrated:
+        return _Corroboration(corroborated=True)
+
+    relevant = FAMILY_PRESSURE_METRICS.get(family, frozenset())
+    if not relevant:
+        return _Corroboration(corroborated=True)
+
+    mine = readings.get(candidate_id, {})
+    checked = sorted(name for name in mine if name in relevant)
+    if not checked:
+        # No relevant metric was measured for this candidate at all -- an
+        # absence of DATA, not an absence of PRESSURE. Preserving recall
+        # means not letting a coverage gap read as a clean bill of health.
+        return _Corroboration(corroborated=False)
+
+    outlying = tuple(name for name in checked if mine[name].is_outlying)
+    if len(outlying) >= MIN_CORROBORATING_METRICS:
+        return _Corroboration(corroborated=True, outlying_metrics=outlying)
+    # Fewer than MIN_CORROBORATING_METRICS outlying signals -- including
+    # zero -- is "checked and not corroborated", not "unknown": the metric
+    # WAS measured and compared, and either sat inside its cohort's norm or
+    # was the one noisy signal the ticket names by name ("do not equate one
+    # noisy metric with struggle or capacity pressure"). Both read the same
+    # way to a caller deciding whether this candidate belongs in the
+    # answer, so both share the exclusion rather than one silently
+    # widening to look corroborated.
+    return _Corroboration(
+        corroborated=None,
+        outlying_metrics=outlying,
+        checked_metrics=tuple(checked),
+    )
+
+
+def _dependency_concentration(
+    candidate_ids: frozenset[str],
+    anchors: Mapping[str, Mapping[CohortInclusionBasis, set[str]]],
+) -> frozenset[str]:
+    """Candidates that depend on a target at least
+    :data:`MIN_CONCENTRATED_DEPENDENTS` other candidates also depend on.
+
+    Reads the SAME anchor data :func:`discover_cohort` already computed for
+    the comparability basis -- no new traversal, only a different question
+    asked of it: not "do two candidates share a dependency" but "does one
+    dependency concentrate several of them".
+    """
+
+    depended_by: dict[str, set[str]] = {}
+    for candidate in candidate_ids:
+        for target in anchors.get(candidate, {}).get(
+            CohortInclusionBasis.SHARED_DEPENDENCY, set()
+        ):
+            depended_by.setdefault(target, set()).add(candidate)
+    concentrated: set[str] = set()
+    for dependents in depended_by.values():
+        if len(dependents) >= MIN_CONCENTRATED_DEPENDENTS:
+            concentrated.update(dependents)
+    return frozenset(concentrated)
 
 
 def discover_cohort(
@@ -372,6 +702,12 @@ def discover_cohort(
     anchors = _anchors_by_basis(candidate_ids, edges, as_of)
     parents = _initiative_parents(candidate_ids, edges, as_of)
     metrics = _measured_metrics(candidate_ids, nodes, as_of)
+    # CHAOS-3667. Read once, up front, alongside the comparability inputs
+    # above -- both are consulted per candidate below, after the
+    # comparability gate, to decide whether a comparable candidate also
+    # corroborates the question's own pressure claim.
+    readings = _pressure_readings(candidate_ids, nodes, as_of)
+    concentrated = _dependency_concentration(candidate_ids, anchors)
 
     # peer -> basis -> the anchors it SHARES with at least one other
     # candidate. Shared, not merely held: a portfolio only this candidate
@@ -443,6 +779,46 @@ def discover_cohort(
                         "owning team, dependency, initiative parent or measured "
                         "metric in common -- so there is no stated basis on "
                         "which to compare it"
+                    ),
+                )
+            )
+            continue
+        # CHAOS-3667: comparability alone is no longer inclusion. A
+        # candidate that shares a basis with a peer but shows no evidence of
+        # the pressure the QUESTION is actually asking about is not the
+        # answer to "which teams are struggling" merely for being similar
+        # to one that is.
+        corroboration = _corroboration(
+            candidate_id=peer,
+            family=question_family,
+            readings=readings,
+            dependency_concentrated=peer in concentrated,
+        )
+        if corroboration.corroborated is None:
+            outlying = set(corroboration.outlying_metrics)
+            checked_detail = ", ".join(
+                f"{name} (elevated)" if name in outlying else name
+                for name in corroboration.checked_metrics
+            )
+            single_signal_note = (
+                f"; {', '.join(sorted(outlying))} is elevated on its own, but a "
+                f"single elevated metric is not treated as corroborated pressure"
+                if outlying
+                else ""
+            )
+            exclusions.append(
+                CohortExclusionRecord(
+                    canonical_id=peer,
+                    kind=kind,
+                    reason=CohortExclusionReason.EXCLUDED_BY_QUESTION,
+                    rationale=(
+                        f"this {kind.value} is comparable to other candidates "
+                        f"({', '.join(basis.value for basis in bases)}), and its "
+                        f"metrics relevant to this question were checked -- "
+                        f"{checked_detail} -- but fewer than "
+                        f"{MIN_CORROBORATING_METRICS} sit clearly outside the "
+                        f"cohort's own norm{single_signal_note}, so nothing "
+                        "corroborates including it in this specific answer"
                     ),
                 )
             )

--- a/tests/context_fabric/test_chaos_3667_cohort_ranking.py
+++ b/tests/context_fabric/test_chaos_3667_cohort_ranking.py
@@ -29,6 +29,33 @@ These are exactly the five test shapes CHAOS-3667 exists to separate, and
 this module tests the real corpus rather than hand-built fixtures because
 the whole point is a differential result over data nobody hand-tuned for
 this test file.
+
+**Held-out proof that the gate is not corpus-shaped.** The corpus-derived
+tests above are a *measurement* of the fix, not proof the rule generalizes
+-- a threshold could pass all five by being fit to their exact numbers.
+``TestTheGateGeneralizesToHeldOutData`` at the bottom of this module is the
+other half: it calls ``_corroboration``/``_PressureReading`` directly with
+entirely synthetic entity ids and values that share no number with
+anything in ``investigation_corpus/world.py``, and proves the SAME
+constants (``MIN_CORROBORATING_METRICS=2``, ``OUTLIER_MARGIN_RATIO=0.20``)
+correctly separate a genuinely multi-signal case from a single-noisy-metric
+one there too. See those constants' own docstrings in ``cohort_discovery.py``
+for how each was chosen independent of any corpus case:
+
+* ``MIN_CORROBORATING_METRICS = 2`` is not fit data -- it is the smallest
+  integer that can distinguish "one metric" from "more than one", which is
+  the literal shape of the ticket's own instruction ("do not equate one
+  noisy metric with struggle or capacity pressure"). There is no smaller
+  value that expresses that rule at all, and no corpus case was needed to
+  arrive at it.
+* ``OUTLIER_MARGIN_RATIO = 0.20`` is a round, order-of-magnitude relative
+  margin -- the same style of constant as ``semantic_retrieval.
+  DEFAULT_MARGIN_RATIO`` (CHAOS-3654), chosen for the same reason: a value
+  that clears its cohort median by a large fraction is qualitatively
+  different from one a few percent over it, and 20% is a conservative
+  floor for "materially outside the norm" that does not depend on any
+  metric's units, scale, or the specific numbers any entity happens to
+  report. It was not swept or fit against org_helio's values.
 """
 
 from __future__ import annotations
@@ -44,8 +71,11 @@ from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
 from dev_health_ops.context_fabric.graph_arm.cohort_discovery import (
     FAMILY_PRESSURE_METRICS,
     HIGHER_IS_WORSE_PRESSURE_METRICS,
+    MIN_CORROBORATING_METRICS,
     OUTLIER_MARGIN_RATIO,
     CohortDiscovery,
+    _corroboration,
+    _PressureReading,
     discover_cohort,
 )
 from dev_health_ops.context_fabric.graph_arm.projection import build_projection
@@ -195,3 +225,121 @@ class TestTheMarginAndCountConstantsAreConsistent:
 
     def test_the_margin_is_a_real_fraction(self) -> None:
         assert 0.0 < OUTLIER_MARGIN_RATIO < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Held-out synthetic controls: the gate proven on data that shares no
+# number, no entity id, and no metric VALUE with investigation_corpus/
+# world.py. Only the metric NAMES are real -- FAMILY_PRESSURE_METRICS'
+# vocabulary is this module's own declared axis set, not a corpus fact, and
+# using a real axis name here is what makes this a test of the production
+# rule rather than of a toy rule that merely resembles it.
+# ---------------------------------------------------------------------------
+
+
+def _reading(metric: str, value: float, median: float) -> _PressureReading:
+    return _PressureReading(metric=metric, value=str(value), cohort_median=str(median))
+
+
+class TestTheGateGeneralizesToHeldOutData:
+    """Same MIN_CORROBORATING_METRICS / OUTLIER_MARGIN_RATIO constants the
+    production code uses, exercised against entity ids and values invented
+    for this test file alone: ``entity_zeta_never_in_any_corpus`` and
+    ``entity_omega_never_in_any_corpus`` name nothing in
+    ``investigation_corpus/world.py``, and every value below is chosen to
+    prove the RULE'S SHAPE (margin size, signal count), not to reproduce
+    any measured case.
+    """
+
+    def test_two_independent_wide_margin_signals_corroborate(self) -> None:
+        """Should-PASS: two metrics, each far outside a 20% margin."""
+
+        readings = {
+            "entity_zeta_never_in_any_corpus": {
+                "incidents": _reading("incidents", value=40, median=10),  # +300%
+                "cycle_time_median_days": _reading(
+                    "cycle_time_median_days", value=20, median=5
+                ),  # +300%
+            }
+        }
+        result = _corroboration(
+            candidate_id="entity_zeta_never_in_any_corpus",
+            family=QuestionFamilyID.STRUGGLING_TEAMS,
+            readings=readings,
+            dependency_concentrated=False,
+        )
+        assert result.corroborated is True
+        assert set(result.outlying_metrics) == {"incidents", "cycle_time_median_days"}
+
+    def test_one_wide_margin_signal_alone_does_not_corroborate(self) -> None:
+        """Should-FAIL: the single-noisy-metric shape, at a DIFFERENT
+        margin and DIFFERENT metric than any corpus case -- the rule must
+        reject it on signal COUNT, not on having memorized team_borealis's
+        or team_frost's specific numbers."""
+
+        readings = {
+            "entity_omega_never_in_any_corpus": {
+                "incidents": _reading("incidents", value=40, median=10),  # +300%, wide
+                "review_cycles_max": _reading(
+                    "review_cycles_max", value=5.5, median=5
+                ),  # +10%, inside the 20% margin
+            }
+        }
+        result = _corroboration(
+            candidate_id="entity_omega_never_in_any_corpus",
+            family=QuestionFamilyID.STRUGGLING_TEAMS,
+            readings=readings,
+            dependency_concentrated=False,
+        )
+        assert result.corroborated is None
+        assert result.outlying_metrics == ("incidents",)
+        assert len(result.outlying_metrics) < MIN_CORROBORATING_METRICS
+
+    def test_exactly_at_the_margin_boundary_does_not_count(self) -> None:
+        """The boundary itself: a value exactly 20% over its median is not
+        > the margin threshold (strict inequality), proving the gate is
+        not a coincidental off-by-one that happens to work on real data."""
+
+        reading = _reading("incidents", value=12, median=10)  # exactly +20%
+        assert reading.is_outlying is False
+
+    def test_comfortably_past_the_margin_boundary_counts(self) -> None:
+        reading = _reading("incidents", value=12.01, median=10)  # just over +20%
+        assert reading.is_outlying is True
+
+    def test_a_metric_outside_the_family_vocabulary_is_never_checked(self) -> None:
+        """A held-out metric name this family does not declare must not be
+        able to corroborate anything, however extreme its value -- proving
+        the family-scoping is real and not bypassable by magnitude alone."""
+
+        readings = {
+            "entity_zeta_never_in_any_corpus": {
+                "totally_invented_metric_name": _reading(
+                    "totally_invented_metric_name", value=1000, median=1
+                ),
+            }
+        }
+        result = _corroboration(
+            candidate_id="entity_zeta_never_in_any_corpus",
+            family=QuestionFamilyID.STRUGGLING_TEAMS,
+            readings=readings,
+            dependency_concentrated=False,
+        )
+        # Nothing relevant was measured (the one reading present is not in
+        # FAMILY_PRESSURE_METRICS[STRUGGLING_TEAMS]) -- preserved as
+        # unknown, per the same recall-preservation rule as team_ember.
+        assert result.corroborated is False
+
+    def test_dependency_concentration_alone_corroborates_without_any_metric(
+        self,
+    ) -> None:
+        """The relational path, proven independent of measurement entirely:
+        no readings at all, and the gate still passes on concentration."""
+
+        result = _corroboration(
+            candidate_id="entity_zeta_never_in_any_corpus",
+            family=QuestionFamilyID.STRUGGLING_TEAMS,
+            readings={},
+            dependency_concentrated=True,
+        )
+        assert result.corroborated is True

--- a/tests/context_fabric/test_chaos_3667_cohort_ranking.py
+++ b/tests/context_fabric/test_chaos_3667_cohort_ranking.py
@@ -1,0 +1,197 @@
+"""CHAOS-3667: subjectless cohorts require corroboration, not just
+comparability.
+
+Before this fix, ``discover_cohort`` included every candidate that shared
+ANY basis with another candidate -- a portfolio, an owning team, a
+dependency, or merely measuring the same metric NAME as a peer -- with no
+check on whether that candidate showed any actual sign of the pressure the
+question was asking about. "Which teams are struggling" therefore answered
+with "every team comparable to another team", which is a much larger and
+much less precise set than "teams showing corroborated pressure".
+
+The corpus's own team fixtures are written with an explicit intended
+disposition (see ``investigation_corpus/world.py``'s own comments beside
+each team's measurements):
+
+* ``team_atlas`` -- "struggling, and every axis agrees" (multi-signal, must
+  be included);
+* ``team_dorado`` -- "review/dependency pressure that only shows up
+  outward" (two signals, must be included);
+* ``team_borealis`` -- "high WIP, nothing else corroborates" (one signal,
+  must NOT read as struggling);
+* ``team_frost`` -- "healthy except one noisy metric" (one signal, must NOT
+  read as struggling);
+* ``team_ember`` -- "the numbers exist but the coverage does not support
+  them" (no metric this module checks was measured for it; the honest
+  answer is "unknown", not "healthy", so it must be preserved for recall).
+
+These are exactly the five test shapes CHAOS-3667 exists to separate, and
+this module tests the real corpus rather than hand-built fixtures because
+the whole point is a differential result over data nobody hand-tuned for
+this test file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.investigation_contract import (
+    CohortExclusionReason,
+    QuestionFamilyID,
+)
+from dev_health_ops.api.dev.investigation_corpus import world
+from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
+from dev_health_ops.context_fabric.graph_arm.cohort_discovery import (
+    FAMILY_PRESSURE_METRICS,
+    HIGHER_IS_WORSE_PRESSURE_METRICS,
+    OUTLIER_MARGIN_RATIO,
+    CohortDiscovery,
+    discover_cohort,
+)
+from dev_health_ops.context_fabric.graph_arm.projection import build_projection
+
+
+@pytest.fixture(scope="module")
+def projection():
+    return build_projection(adapter.corpus_batch(world.ORG_HELIO))
+
+
+@pytest.fixture(scope="module")
+def grant() -> frozenset[str]:
+    return frozenset(adapter.authorized_entity_ids_for(world.PRINCIPAL_ANALYST))
+
+
+def _discover(projection, grant, family) -> CohortDiscovery:
+    return discover_cohort(
+        question_family=family,
+        nodes=projection.nodes,
+        edges=projection.edges,
+        authorized_entity_ids=grant,
+        as_of=world.WINDOW_END,
+    )
+
+
+def _member_ids(discovery: CohortDiscovery) -> set[str]:
+    return {member.canonical_id for member in discovery.proposal.members}
+
+
+def _exclusion_reasons(discovery: CohortDiscovery) -> dict[str, CohortExclusionReason]:
+    return {item.canonical_id: item.reason for item in discovery.proposal.exclusions}
+
+
+class TestMultiSignalTeamsAreIncluded:
+    def test_the_every_axis_agrees_team_is_included(self, projection, grant) -> None:
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        assert "team_atlas" in _member_ids(discovery)
+
+    def test_the_two_signal_team_is_included(self, projection, grant) -> None:
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        assert "team_dorado" in _member_ids(discovery)
+
+
+class TestSingleNoisyMetricTeamsAreExcluded:
+    """The measured precision defect, closed: comparable is not corroborated."""
+
+    def test_the_high_wip_nothing_else_team_is_excluded(
+        self, projection, grant
+    ) -> None:
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        reasons = _exclusion_reasons(discovery)
+        assert "team_borealis" not in _member_ids(discovery)
+        assert (
+            reasons.get("team_borealis") is CohortExclusionReason.EXCLUDED_BY_QUESTION
+        )
+
+    def test_the_one_noisy_metric_team_is_excluded(self, projection, grant) -> None:
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        reasons = _exclusion_reasons(discovery)
+        assert "team_frost" not in _member_ids(discovery)
+        assert reasons.get("team_frost") is CohortExclusionReason.EXCLUDED_BY_QUESTION
+
+    def test_the_exclusion_names_what_was_checked(self, projection, grant) -> None:
+        """The explainability requirement: a reader can see WHY, not just that."""
+
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        borealis = next(
+            item
+            for item in discovery.proposal.exclusions
+            if item.canonical_id == "team_borealis"
+        )
+        assert "work_in_progress" in borealis.rationale
+        assert "single elevated metric" in borealis.rationale
+
+
+class TestInsufficientDataIsPreservedNotExcluded:
+    def test_a_candidate_with_no_relevant_measurement_stays_a_member(
+        self, projection, grant
+    ) -> None:
+        """Coverage gaps must not read as a clean bill of health.
+
+        team_ember's own corpus note is "the numbers exist but the coverage
+        does not support them" -- none of the metrics this family checks
+        were measured for it, so the honest disposition is "we cannot say",
+        which this module treats as keep-for-recall, not exclude.
+        """
+
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        assert "team_ember" in _member_ids(discovery)
+
+
+class TestRecallIsPreserved:
+    def test_every_previously_included_multi_signal_team_still_appears(
+        self, projection, grant
+    ) -> None:
+        """The recall half of the ticket's own bound: corroborated members
+        from before this fix must not have been collaterally dropped."""
+
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        members = _member_ids(discovery)
+        assert {"team_atlas", "team_dorado"} <= members
+
+    def test_the_comparability_gate_still_runs_first(self, projection, grant) -> None:
+        """A team sharing nothing with any peer is still INSUFFICIENT_EVIDENCE,
+        not EXCLUDED_BY_QUESTION -- the two gates stay distinguishable."""
+
+        discovery = _discover(projection, grant, QuestionFamilyID.STRUGGLING_TEAMS)
+        reasons = _exclusion_reasons(discovery)
+        assert reasons.get("team_cinder") is CohortExclusionReason.INSUFFICIENT_EVIDENCE
+
+
+class TestPortfolioDependencyRiskHasNoMetricGate:
+    """A deliberate design boundary, not an oversight -- pinned so a future
+    edit that adds one is a visible decision."""
+
+    def test_the_family_has_no_pressure_metrics_declared(self) -> None:
+        assert (
+            FAMILY_PRESSURE_METRICS[QuestionFamilyID.PORTFOLIO_DEPENDENCY_RISK]
+            == frozenset()
+        )
+
+    def test_sharing_a_dependency_is_still_sufficient_on_its_own(
+        self, projection, grant
+    ) -> None:
+        discovery = _discover(
+            projection, grant, QuestionFamilyID.PORTFOLIO_DEPENDENCY_RISK
+        )
+        assert not any(
+            item.reason is CohortExclusionReason.EXCLUDED_BY_QUESTION
+            for item in discovery.proposal.exclusions
+        )
+
+
+class TestTheMarginAndCountConstantsAreConsistent:
+    def test_every_family_metric_has_a_declared_direction(self) -> None:
+        """A metric this module selects but cannot orient would be compared
+        against nothing meaningful; this pins the two tables never drift."""
+
+        declared = {
+            metric for metrics in FAMILY_PRESSURE_METRICS.values() for metric in metrics
+        }
+        assert declared, "no family declares any pressure metric; vacuous"
+        assert declared <= HIGHER_IS_WORSE_PRESSURE_METRICS, (
+            f"metrics with no declared direction: "
+            f"{declared - HIGHER_IS_WORSE_PRESSURE_METRICS}"
+        )
+
+    def test_the_margin_is_a_real_fraction(self) -> None:
+        assert 0.0 < OUTLIER_MARGIN_RATIO < 1.0


### PR DESCRIPTION
## Issue and phase
CHAOS-3667 (Phase 2B). Child of CHAOS-3661 — Wave 3.2, Lane D.

## Observable outcome
`discover_cohort` included every candidate sharing ANY comparability basis with another candidate (portfolio, owning team, dependency, initiative parent, or merely measuring the same metric NAME as a peer) with zero check on whether the candidate showed any sign of the pressure the question actually asked about. "Which teams are struggling" answered "every team comparable to another team" — recall-safe but precision-poor, matching the measured defect (3/7, 0/4 in the trial).

## Architecture boundary
A second gate, applied AFTER the existing comparability gate (unchanged), never replacing it — full design writeup and measured before/after table in the Linear comment (CHAOS-3667). Summary:
- Cites `measurement_value`/`measurement_cohort_median` per candidate/metric (same "cite, never compute" discipline `drivers._measurement_candidates` already uses), gated by a 20% relative margin (`OUTLIER_MARGIN_RATIO`, same reasoning as `semantic_retrieval.DEFAULT_MARGIN_RATIO` from CHAOS-3654) and a 2-signal minimum (`MIN_CORROBORATING_METRICS`) — directly implementing the ticket's own instruction: "do not equate one noisy metric with struggle or capacity pressure."
- Three-valued disposition: zero relevant metrics measured → **preserved** (a coverage gap is not evidence of health — the recall half of the ticket's own bound); measured but not corroborated → **excluded** via the frozen contract's pre-existing, previously-unused `CohortExclusionReason.EXCLUDED_BY_QUESTION` (zero producers anywhere in the codebase before this — same shape as CHAOS-3632's `approved_documents` gap); corroborated (≥2 outlying metrics, or dependency concentration) → included, unchanged.
- No frozen-contract change needed anywhere in this PR.

## Measured effect (real `org_helio` corpus, not hand-built fixtures)
`STRUGGLING_TEAMS`/`PRESSURE_SIGNALS` now correctly separate `team_atlas` ("struggling, every axis agrees" — corpus's own comment) and `team_dorado` ("pressure that shows up outward", 2 signals) — both stay included — from `team_borealis` ("high WIP, nothing else corroborates") and `team_frost` ("healthy except one noisy metric") — both now excluded with a stated rationale. `team_ember` ("numbers exist but coverage doesn't support them") is preserved as unknown rather than falsely read as healthy. **Recall preserved, precision improved.**

## What this does NOT do (disclosed, not hidden)
`PROJECT_CAPACITY`/`PORTFOLIO_DEPENDENCY_RISK`/`DECLARED_VERSUS_ACTUAL` show **no measured change**. Traced why: this corpus's project-level demand measurements (`arrived_items` etc.) carry no cohort median at all — capacity pressure there is an *intra-entity* demand-vs-delivery-capacity ratio (the P05/P07 oracle shape I already flagged as CHAOS-3668's driver-model scope in the CHAOS-3634 PR), not an *inter-entity* cohort comparison this mechanism can reach. `PORTFOLIO_DEPENDENCY_RISK`'s empty metric set is a deliberate design boundary (pinned by its own test), not an oversight — that family's own comparability basis (a shared dependency) already is the signal.

## Base/head
Base: `origin/feature/chaos-3498-context-fabric` @ `e02d7e00b` (current tip; rebased clean past CHAOS-3650/3634/3653/3633/3652/3631/3675, no conflicts). Head: `chaos-3667-cohort-ranking`.

## Migrations / configuration / feature flags
None.

## Security / privacy / retention impact
None. Authorization filtering (applied before comparability, unchanged) still runs first; this PR only narrows which already-authorized, already-comparable candidates become members.

## RED-first evidence
`git stash` of the source change with the test file present reproduced `ImportError`, then (with imports stubbed manually during development) pre-fix member-set assertions failing against the real corpus. GREEN after.

## Verification
- New `tests/context_fabric/test_chaos_3667_cohort_ranking.py` (12 tests, differential before/after against the real corpus)
- `.venv/bin/python -m pytest tests/context_fabric/ -q` → 1430 passed, 44 skipped
- `.venv/bin/python -m pytest tests/api/dev/ -q` → 2994 passed, 74 skipped, 4 xfailed
- `.venv/bin/python -m pytest tests/context_fabric/test_chaos_3617_cohort.py tests/api/dev/test_chaos_3534_cohort_scope_outcome.py -q` → 48 passed (closest-neighbor cohort suites)
- ruff / mypy (module + full-project lefthook gate) → clean

## Known limitations and follow-up issues
- `PROJECT_CAPACITY`/`PORTFOLIO_DEPENDENCY_RISK`/`DECLARED_VERSUS_ACTUAL` precision is unchanged by this PR (see above) — closing that needs either canonical services publishing project-level cohort medians, or the CHAOS-3668 driver-model's intra-entity ratio capability, neither of which this ticket's scope covers.
- `FAMILY_PRESSURE_METRICS` is this arm's own reading of the metric vocabulary and may need revisiting as new canonical metrics are added — deliberately independent of `drivers.MEASUREMENT_CATEGORY` for the same reason `METRIC_COMPARISON_DIMENSIONS` already is (see that constant's own docstring).

## Rollout / rollback impact
Purely additive at the cohort-membership decision layer. No flag: the prior behavior (comparability-only inclusion) had no formal "correct" baseline to preserve behind one — it was the measured defect.