### PR TITLE
CHAOS-3681: extract _assemble_grounded_answer from _server_grounded_answer

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -4775,36 +4775,41 @@ class DevOrchestrator:
         ``narrative_fallback.build_deterministic_fallback_narrative``'s own
         signature-level guarantee one layer down.
 
+        CHAOS-3502 (terminal-path integration-seam decision, CHAOS-3660):
+        this is now the TOOL-RESULTS-SPECIFIC half of what was previously
+        one function. It extracts canonical material from ``tool_results``
+        and computes the degraded flag, then hands both to
+        :meth:`_assemble_grounded_answer` -- the backend-neutral half,
+        shared with the graph-frame path so there is exactly one place a
+        ``DevAnswer`` gets assembled from server-verified material, not two
+        independent constructions that could quietly drift apart.
+
         Returns ``None`` -- meaning "terminate exactly as the pre-cutover
-        code did" -- in three cases, each of which is a case where shipping
-        would be worse than failing:
+        code did" -- in two cases here (a third, "nothing to ground on",
+        lives in :meth:`_assemble_grounded_answer` now and applies to both
+        frame sources identically):
 
         * the cutover is not active for this run (``ask_dev_wave_3_1`` off);
         * the tool results disagree about a canonical object
           (``_canonical_answer_data`` returns ``None``), which is an
-          integrity failure, not a grounding one;
-        * there is no canonical metric and no canonical evidence. An
-          "answer" built from nothing but this module's own copy would be a
-          substantive-looking shell, which is the precise failure the
-          CHAOS-3290 floor exists to prevent.
+          integrity failure, not a grounding one.
 
-        On that last point, ``investigation_result`` is deliberately NOT
-        part of the predicate, and the parameter is kept only to document
-        that (codex adversarial review, round 1 HIGH -- an earlier revision
-        did count plan findings as sufficient material). The plan's
-        health/deficiency findings are real server-computed content, but
-        ``finish()`` embeds them into the FRAME, and no client surface reads
-        a frame today: ``streaming.py`` sends ``result.answer`` live, and
-        ``router``'s replay prefers the stored v1 answer. So a run demoted
-        on the strength of findings alone would terminate COMPLETED while
-        the client received an answer with no claim, no metric and no
-        evidence -- the exact empty shell this function's third guard
-        exists to refuse, and a worse outcome than the honest
-        ``insufficient_evidence`` it replaced. When canonical material IS
-        present the findings ride along on the frame for free, which is the
-        only case where they add anything a caller can reach. Revisit once
-        CHAOS-3298 puts v2 on the wire and a findings-only frame is
-        genuinely readable.
+        ``investigation_result`` is deliberately NOT part of the predicate,
+        and the parameter is kept only to document that (codex adversarial
+        review, round 1 HIGH -- an earlier revision did count plan findings
+        as sufficient material). The plan's health/deficiency findings are
+        real server-computed content, but ``finish()`` embeds them into the
+        FRAME, and no client surface reads a frame today: ``streaming.py``
+        sends ``result.answer`` live, and ``router``'s replay prefers the
+        stored v1 answer. So a run demoted on the strength of findings
+        alone would terminate COMPLETED while the client received an answer
+        with no claim, no metric and no evidence -- the exact empty shell
+        ``_assemble_grounded_answer``'s guard exists to refuse, and a worse
+        outcome than the honest ``insufficient_evidence`` it replaced. When
+        canonical material IS present the findings ride along on the frame
+        for free, which is the only case where they add anything a caller
+        can reach. Revisit once CHAOS-3298 puts v2 on the wire and a
+        findings-only frame is genuinely readable.
         """
 
         del investigation_result  # see the docstring: documented non-input
@@ -4814,11 +4819,65 @@ class DevOrchestrator:
         if canonical_data is None:
             return None
         canonical_metrics, canonical_evidence = canonical_data
-        if not (canonical_metrics or canonical_evidence):
-            return None
         degraded = any(
             result.status in {"unavailable", "error"} for result in tool_results
         )
+        return self._assemble_grounded_answer(
+            answer_id=answer_id,
+            conversation_id=conversation_id,
+            resolution=resolution,
+            coverage=coverage,
+            canonical_metrics=canonical_metrics,
+            canonical_evidence=canonical_evidence,
+            degraded=degraded,
+            model=model,
+            now=now,
+            direct_summary=SERVER_GROUNDED_SUMMARY,
+            warnings=[SERVER_GROUNDED_WARNING],
+        )
+
+    def _assemble_grounded_answer(
+        self,
+        *,
+        answer_id: str,
+        conversation_id: str,
+        resolution: DevScopeResolution,
+        coverage: DevCoverage,
+        canonical_metrics: list[DevMetricRef],
+        canonical_evidence: list[DevEvidenceRef],
+        degraded: bool,
+        model: DevModelMetadata,
+        now: datetime,
+        direct_summary: str,
+        warnings: list[str],
+    ) -> DevAnswer | None:
+        """The backend-neutral core of a server-grounded ``DevAnswer``: no
+        live model prose, ever -- this function takes no ``DevAnswer``/
+        ``claims`` parameter at all, the same signature-level guarantee
+        :meth:`_server_grounded_answer`'s own docstring describes one layer
+        up.
+
+        CHAOS-3502 (terminal-path integration-seam decision, CHAOS-3660):
+        extracted so that BOTH the tool-results path
+        (:meth:`_server_grounded_answer`) and the graph-frame path (the
+        packet-sourced ``_graph_grounded_answer``, landing once the
+        admission-call leg and enrichment type are ready) assemble their
+        ``DevAnswer`` through this ONE core rather than two independent
+        constructions -- exactly the "one terminal path, two frame sources"
+        shape the ruling requires, one level below ``finish()`` itself
+        (which is already shared and needed no change).
+
+        Returns ``None`` when there is no canonical metric and no canonical
+        evidence: an "answer" built from nothing but a caller's own copy
+        would be a substantive-looking shell, which is the precise failure
+        the CHAOS-3290 floor exists to prevent. This guard is deliberately
+        backend-neutral -- it does not know or care whether its caller's
+        material came from a tool loop or a graph packet, only whether real
+        material exists.
+        """
+
+        if not (canonical_metrics or canonical_evidence):
+            return None
         return DevAnswer(
             schema_version="dev_answer.v1",
             answer_id=answer_id,
@@ -4831,13 +4890,13 @@ class DevOrchestrator:
             # COMPLETE additionally asserts every required source was fresh
             # and available (DevAnswer.validate_answer_invariants).
             status=AnswerStatus.DEGRADED if degraded else AnswerStatus.PARTIAL,
-            direct_summary=SERVER_GROUNDED_SUMMARY,
+            direct_summary=direct_summary,
             claims=[],
             metrics=canonical_metrics,
             evidence=canonical_evidence,
             conflicts=[],
             coverage=coverage,
-            warnings=[SERVER_GROUNDED_WARNING],
+            warnings=warnings,
             suggested_follow_up_questions=[],
             versions=self._versions,
             model=model,


### PR DESCRIPTION
## Issue and phase
CHAOS-3681 (child of CHAOS-3502, Wave 3.2 Phase 1, Lane B — grandparent CHAOS-3660). Terminal-path integration seam, signed off on CHAOS-3660 before implementation. Stacked on #1647 (CHAOS-3680, unmerged) — base branch `chaos-3680-evidence-candidate-extraction`.

## Observable outcome
None — pure, behavior-preserving refactor. `_server_grounded_answer` still returns exactly the same `DevAnswer | None` for exactly the same inputs it always has.

## Architecture boundary
Per the CHAOS-3660 "ONE terminal path, TWO frame sources" ruling: `finish()` (already the shared validate/sanitize/persist core) is untouched. `_server_grounded_answer`'s body did two jobs in one function — this PR splits out the backend-neutral half (the CHAOS-3290 empty-shell guard + `DevAnswer` construction) into a new `_assemble_grounded_answer`, so the still-to-come graph-frame path (`_graph_grounded_answer`) can share it instead of building a parallel `DevAnswer` construction that could drift from the tool-results one.

## Scope / non-scope
**In scope:** `orchestrator.py` only — the `_server_grounded_answer`/`_assemble_grounded_answer` split.
**Out of scope:** `_graph_grounded_answer` itself (needs the admission-call leg + Lane C's enrichment type, still pending), new copy (`GRAPH_GROUNDED_SUMMARY`/warning) and a distinct `grounding_validation_status` value for the graph path (separate §8 proposal, per team-lead's ruling — bundled together, not part of this PR).

## Base/head SHA and branch provenance
- Base: `feature/chaos-3498-context-fabric` (retargeted after #1647/CHAOS-3680 merged as `bd6c83d23`).
- Head: `9ff31ab05976e6da0c6defca0dbd3d489ee7134e`, branch `chaos-3681-assemble-grounded-answer`.

## Migrations/configuration/feature flags
None.

## Security/privacy/retention impact
None — no behavior change, verified below.

## RED-first evidence
N/A — refactor, not a bug fix. What's verified instead: a 103-test baseline (`test_chaos_3297_s5_guard_cutover.py` + `test_chaos_3292_mutations.py` + `test_orchestrator.py`) captured **before** the change, and the identical 103 pass **after**, byte-for-byte, with zero test files edited. If the refactor had changed observable behavior, at least one of these adversarial-invariant tests would have caught it.

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_chaos_3297_s5_guard_cutover.py tests/api/dev/test_chaos_3292_mutations.py tests/api/dev/test_orchestrator.py -v
  → 103 passed (before AND after — same 103, no test edits)
.venv/bin/python -m pytest tests/api/dev tests/context_fabric -m "not benchmark and not clickhouse" -q -n 4 --dist loadscope
  → 4427 passed, 65 skipped, 4 xfailed, 0 failed
.venv/bin/ruff check / mypy → clean
```
Pre-commit and pre-push lefthook gates passed locally.

## Known limitations and follow-up issues
- `_graph_grounded_answer` and the orchestrator routing branch that calls it are the next PR, once the admission-call leg exists and Lane C's enrichment contract lands on CHAOS-3660.
- New user-visible copy + distinct `grounding_validation_status` value: separate §8 proposal, not yet posted.

## Rollout/rollback impact
None — pure internal refactor, zero behavior change, verified against the full adversarial-invariant baseline. Revert is a plain `git revert`.

## Governance markers

TEST-EVIDENCE: no test file changed in this PR's own diff (pure refactor, existing tests already cover the extracted behavior) — verified instead via a before/after byte-identical baseline: `.venv/bin/python -m pytest tests/api/dev/test_chaos_3297_s5_guard_cutover.py tests/api/dev/test_chaos_3292_mutations.py tests/api/dev/test_orchestrator.py -v` → 103 passed, identical before and after the split. Full sweep on this head (via the stacked #1658 rebase, which includes this commit): `.venv/bin/python -m pytest tests/api/dev tests/context_fabric tests/test_env_isolation_contract.py -q` → 4562 passed, 0 failed. `ruff check` and `mypy` both clean.

RISK-NOTES: blast radius is `orchestrator.py`'s `_server_grounded_answer` only, and only its internal structure — the function signature and every observable return value are unchanged (behavior-preserving extraction, not new logic), so no caller elsewhere in the codebase is affected. Rollback is a plain `git revert` (no data, migration, or flag involved). Follow-up: the new `_assemble_grounded_answer` seam is currently used by only the existing tool-results path; the graph-frame path that will become its second caller lands in a later PR (#1658 and beyond), once Lane A's packet refactor and Lane C's enrichment type are ready.

