### PR TITLE
CHAOS-3675 PR 2/3: real ClickHouse-backed EvidenceCandidateResolver (incidents)

### DIFF
--- a/src/dev_health_ops/api/dev/native_evidence_resolver.py
+++ b/src/dev_health_ops/api/dev/native_evidence_resolver.py
@@ -67,6 +67,75 @@ def _review_pr_entity_id(row: Mapping[str, Any]) -> str:
     return f"{row['repo_id']}#pr{row['number']}"
 
 
+#: CHAOS-3675 PR2. ``operational_incidents`` has no PR/work_item/project
+#: link column at all -- the only repository linkage is this LEFT JOIN,
+#: which can miss entirely (no edge row), not just carry a null
+#: ``repo_id``. ``org_id`` types differ across the two tables
+#: (``operational_incidents.org_id`` is ``String``,
+#: ``work_graph_deployment_incident_edges.org_id`` is ``UUID``) --
+#: ``toUUIDOrZero`` matches the cast ``native_evidence.py``'s own
+#: ``incidents`` ``_SourceSpec`` already uses for this exact join.
+_INCIDENT_RESOLVE_SQL = """
+SELECT i.id AS id, i.title AS title, i.normalized_status AS normalized_status,
+       coalesce(i.source_event_at, i.observed_at) AS observed_at,
+       i.last_synced AS last_synced, e.repo_id AS repo_id
+FROM operational_incidents AS i FINAL
+LEFT JOIN work_graph_deployment_incident_edges AS e FINAL
+  ON e.org_id = toUUIDOrZero(i.org_id) AND e.incident_id = i.id
+WHERE i.org_id = {org_id:String} AND i.id = {locator:String}
+LIMIT 1
+"""
+
+
+async def _resolve_incident(
+    client: Any,
+    *,
+    org_id: str,
+    candidate: EvidenceCandidate,
+    policy: SourceFreshnessPolicy,
+    source_system: str,
+) -> EvidenceRecord | None:
+    rows = await query_dicts(
+        client, _INCIDENT_RESOLVE_SQL, {"org_id": org_id, "locator": candidate.locator}
+    )
+    if not rows:
+        return None
+    row = rows[0]
+    repo_id = row.get("repo_id")
+    if not repo_id:
+        # No linked repository at all (missing edge row, or a null
+        # repo_id on the edge that exists) -- EntityKind has no INCIDENT
+        # member, and a repository is never entity-check-able (that's
+        # what no_authorizable_entity is for), so with no repository
+        # either there is NO authorization anchor whatsoever. Refused
+        # here, not emitted and left to admit()'s own anchor guard alone.
+        return None
+    observed = _datetime(row.get("observed_at")) or datetime.now(UTC)
+    last_synced = _datetime(row.get("last_synced"))
+    freshness = policy.classify(last_synced, now=datetime.now(UTC))
+    return EvidenceRecord(
+        source_system=source_system,
+        source_version=RESOLVER_SOURCE_VERSION,
+        entity_type="incident",
+        # Descriptive only -- see the module docstring. Incidents have no
+        # directly-authorizable entity in the current canonical schema at
+        # all (only ever a repository), so no_authorizable_entity is
+        # ALWAYS True whenever this resolver succeeds; there is no
+        # "sometimes derive an entity" branch to launder past, unlike the
+        # review/deployment resolvers.
+        entity_id=str(row["id"]),
+        display_label=f"Incident: {row.get('title') or row['id']}",
+        observed_at=observed,
+        freshness=freshness,
+        provenance="native",
+        confidence=1.0,
+        repository_ids=(str(repo_id),),
+        raw_excerpt=f"Status: {row.get('normalized_status') or 'unknown'}",
+        stale=freshness is FreshnessState.STALE,
+        no_authorizable_entity=True,
+    )
+
+
 async def _resolve_review(
     client: Any,
     *,
@@ -110,14 +179,16 @@ class NativeEvidenceCandidateResolver:
     Additive: only observation kinds with an implemented ``_resolve_*``
     below are handled; every other kind returns ``None`` (refused as
     ``NO_MATCHES``), never an error. CHAOS-3675 PR 1/3 implements
-    ``review`` only -- ``deployment``'s linked PR is nullable in the
-    canonical schema (a deployment need not correspond to any PR), which
-    needs its own authorization-shape decision (empty ``valid_entity_ids``,
-    repository-only authorization) before it can resolve safely; deferred
-    rather than guessed at here. ``commit``/``ci_run`` need a confirmed
-    join path (candidate: ``work_graph_edges``) before they can derive
-    their linked entity at all. ``incident`` follows the same shape
-    ``native_evidence.py``'s own ``incidents`` spec already joins through.
+    ``review`` (a directly-authorizable PR entity, derived from its own
+    row); PR 2/3 adds ``incident`` (no directly-authorizable entity in the
+    schema at all -- repository-only authorization via CHAOS-3675's
+    entity-less admission mechanism). ``deployment``'s linked PR is
+    nullable in the canonical schema (a deployment need not correspond to
+    any PR, but CAN), which needs its own per-row derive-vs-anchor
+    decision unlike ``incident``'s always-anchor shape; deferred to PR
+    3/3 rather than guessed at here. ``commit``/``ci_run`` need a
+    confirmed join path (candidate: ``work_graph_edges``) before they can
+    derive their linked entity at all -- also PR 3/3.
     """
 
     def __init__(
@@ -151,6 +222,14 @@ class NativeEvidenceCandidateResolver:
                 org_id=org_id,
                 candidate=candidate,
                 policy=self._policies["reviews"],
+                source_system=self.source_system,
+            )
+        if candidate.entity_type == "incident":
+            return await _resolve_incident(
+                self._client,
+                org_id=org_id,
+                candidate=candidate,
+                policy=self._policies["incidents"],
                 source_system=self.source_system,
             )
         return None

--- a/tests/api/dev/test_native_evidence_resolver.py
+++ b/tests/api/dev/test_native_evidence_resolver.py
@@ -1,10 +1,9 @@
-"""CHAOS-3675 PR 1/3: the production review resolver, and the invariant it
-exists to enforce -- the entity a record is about is derived from the
-canonical row, never from ``candidate.entity_id``.
+"""CHAOS-3675 PR 1/3 (review) and PR 2/3 (incident): production resolvers,
+and the invariant they exist to enforce -- the entity a record is about is
+derived from the canonical row, never from ``candidate.entity_id``.
 
 Every test here uses a fake ClickHouse-shaped sink whose ``query_dicts``
-call simulates the real SQL's own ``WHERE org_id = ... AND locator = ...``
-predicate (filtering by BOTH before returning a row), so an org-mismatch
+call simulates the real SQL's own filtering predicates, so an org-mismatch
 test exercises the same filtering discipline the live SQL performs, not
 merely that Python happens to pass the right parameter through. The
 tenant-isolation behaviour of the ACTUAL SQL text is separately proven live
@@ -294,3 +293,285 @@ def test_freshness_policy_governs_staleness(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert record is not None
     assert record.stale is True
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3675 PR 2/3: the incidents resolver. Incidents have NO
+# directly-authorizable entity in the current canonical schema at all --
+# only ever a repository, via a LEFT JOIN that can miss entirely (not just
+# carry a null repo_id) -- so every resolved incident is
+# no_authorizable_entity=True, and a repository-less incident is refused by
+# the resolver itself rather than emitted and left to admit()'s anchor
+# guard alone.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _IncidentRow:
+    org_id: str
+    id: str
+    title: str
+    normalized_status: str
+    observed_at: datetime
+    last_synced: datetime
+
+
+@dataclass(frozen=True)
+class _EdgeRow:
+    org_id: str
+    incident_id: str
+    repo_id: str | None
+
+
+class _IncidentFakeSink:
+    """Simulates ``operational_incidents FINAL LEFT JOIN
+    work_graph_deployment_incident_edges FINAL ON (org_id, incident_id)``:
+    an incident row is returned only when ``org_id``+``id`` match (the
+    ``WHERE`` clause); ``repo_id`` is populated only when a matching edge
+    row exists for the SAME org (the ``LEFT JOIN``'s own predicate) --
+    absent edge, not just a null column, models the real "join misses
+    entirely" case.
+    """
+
+    def __init__(
+        self, incidents: list[_IncidentRow], edges: list[_EdgeRow] | None = None
+    ) -> None:
+        self._incidents = incidents
+        self._edges = edges or []
+        self.calls: list[dict[str, Any]] = []
+
+    async def query_dicts(
+        self, query: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.calls.append(params)
+        for incident in self._incidents:
+            if incident.org_id != params["org_id"] or incident.id != params["locator"]:
+                continue
+            edge = next(
+                (
+                    e
+                    for e in self._edges
+                    if e.org_id == incident.org_id and e.incident_id == incident.id
+                ),
+                None,
+            )
+            return [
+                {
+                    "id": incident.id,
+                    "title": incident.title,
+                    "normalized_status": incident.normalized_status,
+                    "observed_at": incident.observed_at,
+                    "last_synced": incident.last_synced,
+                    "repo_id": edge.repo_id if edge else None,
+                }
+            ]
+        return []
+
+
+def _monkeypatch_incident_query_dicts(
+    monkeypatch: pytest.MonkeyPatch, sink: _IncidentFakeSink
+) -> None:
+    async def _fake_query_dicts(client: Any, query: str, params: dict[str, Any]):
+        assert client is sink
+        return await sink.query_dicts(query, params)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence_resolver.query_dicts",
+        _fake_query_dicts,
+    )
+
+
+def _incident_candidate(
+    *, locator: str = "inc-1", claimed_entity_id: str = "issue-999"
+) -> EvidenceCandidate:
+    return EvidenceCandidate(
+        source_system=ARM_SOURCE_SYSTEM,
+        entity_type="incident",
+        # A claim this resolver must never consult -- incidents never
+        # produce an entity-based authorization at all.
+        entity_id=claimed_entity_id,
+        locator=locator,
+    )
+
+
+def test_incident_with_a_linked_repository_is_admitted_repository_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-first: before PR 2/3, ``incident``-kind candidates dispatch to
+    nothing and refuse as ``UNCONFIGURED``. With a real linked repository,
+    resolution now succeeds -- always via the entity-less/repository-only
+    mechanism (CHAOS-3675 PR1's prereq), never a directly-authorized
+    entity, because incidents have none in the current schema."""
+
+    sink = _IncidentFakeSink(
+        incidents=[
+            _IncidentRow(
+                org_id=ORG_A,
+                id="inc-1",
+                title="Checkout latency spike",
+                normalized_status="resolved",
+                observed_at=NOW,
+                last_synced=NOW,
+            )
+        ],
+        edges=[_EdgeRow(org_id=ORG_A, incident_id="inc-1", repo_id="repo-1")],
+    )
+    _monkeypatch_incident_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A, scope=_UNUSED_SCOPE, candidate=_incident_candidate()
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == ("repo-1",)
+    assert record.entity_id == "inc-1"
+    # The candidate's claim never leaks anywhere on the resolved record.
+    assert "issue-999" not in (record.display_label, record.raw_excerpt or "")
+
+
+def test_an_incident_with_no_linked_repository_at_all_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No edge row at all (not merely a null ``repo_id`` on an existing
+    edge) -- the resolver refuses outright rather than emitting a record
+    with no authorization anchor at all."""
+
+    sink = _IncidentFakeSink(
+        incidents=[
+            _IncidentRow(
+                org_id=ORG_A,
+                id="inc-2",
+                title="Unlinked incident",
+                normalized_status="open",
+                observed_at=NOW,
+                last_synced=NOW,
+            )
+        ],
+        edges=[],
+    )
+    _monkeypatch_incident_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_incident_candidate(locator="inc-2"),
+        )
+    )
+
+    assert record is None
+
+
+def test_an_incident_with_a_null_repo_id_on_its_edge_also_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The edge row EXISTS but its own ``repo_id`` is null -- distinct from
+    the no-edge-at-all case above, and refused for the same reason: no
+    repository to anchor authorization to."""
+
+    sink = _IncidentFakeSink(
+        incidents=[
+            _IncidentRow(
+                org_id=ORG_A,
+                id="inc-3",
+                title="Edge with no repo",
+                normalized_status="open",
+                observed_at=NOW,
+                last_synced=NOW,
+            )
+        ],
+        edges=[_EdgeRow(org_id=ORG_A, incident_id="inc-3", repo_id=None)],
+    )
+    _monkeypatch_incident_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_incident_candidate(locator="inc-3"),
+        )
+    )
+
+    assert record is None
+
+
+def test_an_incident_locator_that_exists_only_in_a_different_org_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same cross-tenant control as the review resolver: a real incident
+    id, in a different org, must not resolve."""
+
+    sink = _IncidentFakeSink(
+        incidents=[
+            _IncidentRow(
+                org_id=ORG_B,
+                id="inc-4",
+                title="Org B's incident",
+                normalized_status="open",
+                observed_at=NOW,
+                last_synced=NOW,
+            )
+        ],
+        edges=[_EdgeRow(org_id=ORG_B, incident_id="inc-4", repo_id="repo-1")],
+    )
+    _monkeypatch_incident_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    refused = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_incident_candidate(locator="inc-4"),
+        )
+    )
+    admitted = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_B,
+            scope=_UNUSED_SCOPE,
+            candidate=_incident_candidate(locator="inc-4"),
+        )
+    )
+
+    assert refused is None
+    assert admitted is not None
+
+
+def test_an_edge_belonging_to_a_different_org_does_not_leak_its_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The incident itself is genuinely in ORG_A, but the only matching
+    edge row (by incident_id alone) belongs to ORG_B -- the join's own
+    ``org_id`` predicate must keep them apart, so ORG_A's incident resolves
+    with NO repository (refused), never ORG_B's repo_id smuggled across."""
+
+    sink = _IncidentFakeSink(
+        incidents=[
+            _IncidentRow(
+                org_id=ORG_A,
+                id="inc-5",
+                title="Org A's incident",
+                normalized_status="open",
+                observed_at=NOW,
+                last_synced=NOW,
+            )
+        ],
+        edges=[_EdgeRow(org_id=ORG_B, incident_id="inc-5", repo_id="org-b-repo")],
+    )
+    _monkeypatch_incident_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_incident_candidate(locator="inc-5"),
+        )
+    )
+
+    assert record is None

--- a/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
+++ b/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
@@ -318,11 +318,27 @@ async def test_the_real_incident_sql_enforces_tenant_isolation(
 async def test_the_real_incident_join_does_not_leak_a_different_orgs_edge(
     ch_client: Any,
 ) -> None:
-    """The incident itself is genuinely ORG_A's; the only matching edge row
+    """**Reproduces an actual cross-tenant data leak against the real
+    ClickHouse engine -- not a unit-test analogy, a live-verified defect.**
+
+    The incident itself is genuinely ORG_A's; the only matching edge row
     (by ``incident_id`` alone) belongs to ORG_B. The join's own ``org_id``
-    predicate (not just the outer ``WHERE``) must keep them apart -- ORG_A's
-    incident resolves with no repository at all, refused, never ORG_B's
-    repository smuggled across via the join."""
+    predicate (not just the outer ``WHERE`` on the incident row) must keep
+    them apart -- ORG_A's incident must resolve with no repository at all
+    and be refused, never ORG_B's repository silently attached via the
+    join.
+
+    This is the one test in the whole CHAOS-3675 effort verified by
+    breaking the PRODUCTION SQL text itself
+    (``_INCIDENT_RESOLVE_SQL``'s join condition, dropping
+    ``toUUIDOrZero(i.org_id) AND``) and re-running THIS test against a
+    live scratch database with real seeded rows in both tables: with the
+    org predicate removed, ORG_B's ``repo_id`` genuinely appeared on
+    ORG_A's resolved record (observed directly, not inferred) -- a real
+    cross-tenant repository leak, not a hypothetical one. Do not weaken,
+    skip, or delete this test as "just a live-environment nicety": it is
+    the strongest evidence artifact this lane produced that the join's
+    tenant isolation is real rather than assumed from the query text."""
 
     _insert_incident(ch_client, org_id=ORG_A, incident_id="inc-live-3")
     _insert_incident_edge(

--- a/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
+++ b/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
@@ -1,15 +1,21 @@
-"""CHAOS-3675 PR 1/3: the review resolver's real SQL, against a real
-migrated ClickHouse schema -- not assumed from the query text, not
-simulated by a fake sink (``test_native_evidence_resolver.py`` covers the
+"""CHAOS-3675 PR 1/3 (review) and PR 2/3 (incident) resolver SQL, against a
+real migrated ClickHouse schema -- not assumed from the query text, not
+simulated by a fake sink (``test_native_evidence_resolver.py`` covers each
 resolver's own logic that way; this file proves the SQL itself).
 
-Two properties a fake sink cannot establish:
-1. ``_REVIEW_RESOLVE_SQL`` parses and executes against the real
-   ``git_pull_request_reviews`` schema (column names/types match).
+Three properties a fake sink cannot establish:
+1. The resolve SQL parses and executes against the real schema (column
+   names/types match) -- including the incident resolver's cross-table
+   ``org_id`` type mismatch (``operational_incidents.org_id`` is
+   ``String``, ``work_graph_deployment_incident_edges.org_id`` is
+   ``UUID``) and its ``toUUIDOrZero`` cast.
 2. The ``WHERE org_id = ...`` predicate genuinely enforces tenant
-   isolation in the real engine -- two rows sharing an identical composite
-   locator string but different ``org_id``s, and a lookup for one org never
-   returns the other's row.
+   isolation in the real engine -- two rows sharing an identical locator
+   but different ``org_id``s, and a lookup for one org never returns the
+   other's row.
+3. For incidents specifically: the join's OWN ``org_id`` predicate keeps
+   an edge belonging to a different org from leaking its repository onto
+   an otherwise-genuine same-org incident.
 """
 
 from __future__ import annotations
@@ -64,10 +70,17 @@ def ch_client() -> Any:
 
 
 @pytest.fixture(autouse=True)
-def _clean_reviews_table(ch_client: Any) -> Any:
-    ch_client.command("TRUNCATE TABLE IF EXISTS git_pull_request_reviews")
+def _clean_tables(ch_client: Any) -> Any:
+    tables = (
+        "git_pull_request_reviews",
+        "operational_incidents",
+        "work_graph_deployment_incident_edges",
+    )
+    for table in tables:
+        ch_client.command(f"TRUNCATE TABLE IF EXISTS {table}")
     yield
-    ch_client.command("TRUNCATE TABLE IF EXISTS git_pull_request_reviews")
+    for table in tables:
+        ch_client.command(f"TRUNCATE TABLE IF EXISTS {table}")
 
 
 def _insert_review(
@@ -96,7 +109,90 @@ def _insert_review(
     )
 
 
-async def _resolve(client: Any, *, org_id: str, locator: str):
+def _insert_incident(
+    client: Any,
+    *,
+    org_id: str,
+    incident_id: str,
+    title: str = "Checkout latency spike",
+) -> None:
+    client.insert(
+        "operational_incidents",
+        [
+            [
+                org_id,
+                "pagerduty",
+                "instance-1",
+                "incident",
+                incident_id,
+                NOW,
+                incident_id,
+                NOW,
+                NOW,
+                "resolved",
+                title,
+                0,
+            ]
+        ],
+        column_names=[
+            "org_id",
+            "provider",
+            "provider_instance_id",
+            "source_entity_type",
+            "external_id",
+            "source_version_at",
+            "id",
+            "observed_at",
+            "last_synced",
+            "normalized_status",
+            "title",
+            "is_deleted",
+        ],
+    )
+
+
+def _insert_incident_edge(
+    client: Any,
+    *,
+    org_id: str,
+    incident_id: str,
+    repo_id: str,
+    deployment_id: str = "deploy-1",
+) -> None:
+    client.insert(
+        "work_graph_deployment_incident_edges",
+        [
+            [
+                f"edge-{org_id}-{incident_id}",
+                org_id,
+                deployment_id,
+                incident_id,
+                "native",
+                repo_id,
+                1.0,
+                "edge",
+                "",
+                NOW,
+            ]
+        ],
+        column_names=[
+            "edge_id",
+            "org_id",
+            "deployment_id",
+            "incident_id",
+            "provider",
+            "repo_id",
+            "confidence",
+            "source",
+            "evidence",
+            "observed_at",
+        ],
+    )
+
+
+async def _resolve(
+    client: Any, *, org_id: str, locator: str, entity_type: str = "review"
+):
     from dev_health_ops.api.dev.evidence_service import EvidenceCandidate
     from dev_health_ops.api.dev.native_evidence_resolver import (
         NativeEvidenceCandidateResolver,
@@ -106,7 +202,7 @@ async def _resolve(client: Any, *, org_id: str, locator: str):
     resolver = NativeEvidenceCandidateResolver(client)
     candidate = EvidenceCandidate(
         source_system=ARM_SOURCE_SYSTEM,
-        entity_type="review",
+        entity_type=entity_type,
         entity_id="a-claim-the-real-row-does-not-corroborate",
         locator=locator,
     )
@@ -160,4 +256,94 @@ async def test_an_unseeded_locator_resolves_to_none_against_the_real_table(
     record = await _resolve(
         ch_client, org_id=ORG_A, locator=f"{REPO_ID}#pr404#reviewnope"
     )
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_the_real_incident_sql_joins_across_the_org_id_type_mismatch(
+    ch_client: Any,
+) -> None:
+    """``operational_incidents.org_id`` is ``String``;
+    ``work_graph_deployment_incident_edges.org_id`` is ``UUID`` -- the
+    resolver's ``toUUIDOrZero(i.org_id)`` cast must actually join correctly
+    against the real engine, not just parse."""
+
+    _insert_incident(ch_client, org_id=ORG_A, incident_id="inc-live-1")
+    _insert_incident_edge(
+        ch_client, org_id=ORG_A, incident_id="inc-live-1", repo_id=REPO_ID
+    )
+
+    record = await _resolve(
+        ch_client, org_id=ORG_A, locator="inc-live-1", entity_type="incident"
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == (REPO_ID,)
+    assert record.entity_id == "inc-live-1"
+
+
+@pytest.mark.asyncio
+async def test_the_real_incident_sql_enforces_tenant_isolation(
+    ch_client: Any,
+) -> None:
+    """Two incidents, byte-identical id, different orgs -- the real
+    ``WHERE i.org_id = {org_id:String}`` predicate must keep them apart."""
+
+    _insert_incident(
+        ch_client, org_id=ORG_A, incident_id="inc-live-2", title="Org A incident"
+    )
+    _insert_incident_edge(
+        ch_client, org_id=ORG_A, incident_id="inc-live-2", repo_id=REPO_ID
+    )
+    _insert_incident(
+        ch_client, org_id=ORG_B, incident_id="inc-live-2", title="Org B incident"
+    )
+    _insert_incident_edge(
+        ch_client, org_id=ORG_B, incident_id="inc-live-2", repo_id=REPO_ID
+    )
+
+    a = await _resolve(
+        ch_client, org_id=ORG_A, locator="inc-live-2", entity_type="incident"
+    )
+    b = await _resolve(
+        ch_client, org_id=ORG_B, locator="inc-live-2", entity_type="incident"
+    )
+
+    assert a is not None and a.display_label == "Incident: Org A incident"
+    assert b is not None and b.display_label == "Incident: Org B incident"
+
+
+@pytest.mark.asyncio
+async def test_the_real_incident_join_does_not_leak_a_different_orgs_edge(
+    ch_client: Any,
+) -> None:
+    """The incident itself is genuinely ORG_A's; the only matching edge row
+    (by ``incident_id`` alone) belongs to ORG_B. The join's own ``org_id``
+    predicate (not just the outer ``WHERE``) must keep them apart -- ORG_A's
+    incident resolves with no repository at all, refused, never ORG_B's
+    repository smuggled across via the join."""
+
+    _insert_incident(ch_client, org_id=ORG_A, incident_id="inc-live-3")
+    _insert_incident_edge(
+        ch_client, org_id=ORG_B, incident_id="inc-live-3", repo_id=REPO_ID
+    )
+
+    record = await _resolve(
+        ch_client, org_id=ORG_A, locator="inc-live-3", entity_type="incident"
+    )
+
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_an_incident_with_no_edge_at_all_refuses_against_the_real_table(
+    ch_client: Any,
+) -> None:
+    _insert_incident(ch_client, org_id=ORG_A, incident_id="inc-live-4")
+
+    record = await _resolve(
+        ch_client, org_id=ORG_A, locator="inc-live-4", entity_type="incident"
+    )
+
     assert record is None


### PR DESCRIPTION
Branch is ID-free per the standing multi-PR pattern (CHAOS-3675 stays open until PR 3/3).

## Issue and phase
[CHAOS-3675](https://linear.app/fullchaos/issue/CHAOS-3675) PR 2/3 — child of [CHAOS-3664](https://linear.app/fullchaos/issue/CHAOS-3664), Phase 1 Lane C, under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660). Builds on #1645 and #1648 (both merged), which land the entity-less/repository-only admission mechanism this resolver is the second real user of.

## Observable outcome
`EvidenceService.admit()` can resolve an `incident`-kind graph-arm candidate against real ClickHouse data (`operational_incidents` joined to `work_graph_deployment_incident_edges`), the second real resolver alongside PR 1/3's `review`.

## Recon finding, different shape from `review`
`operational_incidents` has no PR/work_item/project link column at all (also checked `operational_service_repository_mappings` — same conclusion: it only ever resolves to a repository too). `EntityKind` has no INCIDENT member, and a repository is never entity-check-able by design — that's exactly what #1645/#1648's mechanism exists for. So **every** resolved incident is `no_authorizable_entity=True`; unlike `review` (always a derivable PR) or `deployment` (PR 3/3, sometimes a derivable PR), there is no "sometimes derive an entity" branch to launder past here at all. An incident with no derivable repository — either no matching edge row, or an edge row whose own `repo_id` is null, two distinct cases, both tested — is refused by the resolver itself, not emitted and left to #1648's anchor guard as the only backstop.

## Architecture boundary
`native_evidence_resolver.py` only (mine, exclusive). No `production_runtime.py` change needed — `NativeEvidenceCandidateResolver` was already wired generically in PR 1/3; this widens what observation kinds it handles.

## Scope / non-scope
This PR: `incident` only. `deployment` (genuinely nullable PR link, needs its own derive-vs-anchor branching) and `commit`/`ci_run` (need a confirmed `work_graph_edges` join path) remain PR 3/3.

## Base/head SHA and branch provenance
Base: `feature/chaos-3498-context-fabric` @ `d9c019010...` (current tip, includes #1645 + #1648)
Head: `incidents-evidence-resolver`, one commit.

## Migrations/configuration/feature flags
None.

## Security/privacy/retention impact
Cross-table join introduces a new tenant-isolation surface: `operational_incidents.org_id` (`String`) vs `work_graph_deployment_incident_edges.org_id` (`UUID`), joined via `toUUIDOrZero`. Proven correct against the real engine, not assumed — see verification below.

## RED-first evidence
`test_the_real_incident_sql_joins_across_the_org_id_type_mismatch` — before this PR, `incident`-kind candidates have no dispatch and refuse `UNCONFIGURED`; after, a genuinely linked incident resolves.

Every adversarial property mutation-verified, not just asserted:
- **No-anchor refusal** (both missing-edge and null-`repo_id` cases): removed the refusal branch in the resolver, watched both unit tests fail with a record carrying `repository_ids=('None',)`, restored.
- **Cross-tenant edge leak** (incident's own `org_id` is correct, but the only matching edge belongs to a DIFFERENT org): dropped the fake sink's edge-org filter, watched the unit test fail; separately dropped the join's own `org_id` predicate directly in the **production SQL** and ran the live suite against real seeded rows in both tables — confirmed a genuine cross-tenant repository leak (`repository_ids=('org-b-repo',)` appearing on an org-a incident), then restored.

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_native_evidence_resolver.py -v                     # 14 passed
.venv/bin/python -m pytest tests/api/dev/test_native_evidence_resolver_clickhouse_live.py -v      # 7 passed (live, scratch ClickHouse, real seeded rows in both joined tables)
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q                                # 4435 passed, 130 skipped, 4 xfailed, 0 failed
.venv/bin/mypy src/dev_health_ops/api/dev/                                                        # Success: no issues (111 files)
pre-commit hook (mypy over full tree, ruff)                                                       # Success: no issues
```
Live tests ran against a per-worktree scratch ClickHouse database, migrated via `ClickHouseMetricsSink.ensure_schema(force=True)`, dropped on completion — never touched `default`.

## Known limitations and follow-up issues
`deployment`/`commit`/`ci_run` still refuse `UNCONFIGURED` — PR 3/3.

## Rollout/rollback impact
Pure additive; no flag change. `EVIDENCE_ADMISSION_FLAG` still gates whether the arm ever submits a candidate at all — default off. Safe to revert independently.