### PR TITLE
graph-arm: retire the CHAOS-3627 _mint_handle workaround (CHAOS-3633 landed)

### DIFF
--- a/docs/contribute/architecture/graph-investigation-arm.md
+++ b/docs/contribute/architecture/graph-investigation-arm.md
@@ -847,13 +847,18 @@ the **record** is about, carried from the source, never by whichever
 observation the traversal happened to reach that cites it.
 
 Where a source issues none, the platform's own `EvidenceReferenceSigner`
-mints one — over the **record's** canonical id, not over the entity it is
-about. The platform payload uses one field for both, so two same-kind records
-about one entity otherwise mint the same handle and the contract's
-duplicate-handle refusal kills the whole packet on a legitimate handle-less
-world. The platform fix is CHAOS-3633; this is the arm-side containment, and
-its cost is that a minted handle is verified by re-deriving it through the
-same function rather than by `signer.verify` on the emitted ref.
+mints one — over the true entity **and** the record's own canonical id, in
+`entity_id` and `record_locator` respectively. Before CHAOS-3633 the platform
+payload had one field for both, so two same-kind records about one entity
+minted the same handle and the contract's duplicate-handle refusal killed the
+whole packet on a legitimate handle-less world; the arm's interim containment
+substituted `entity_id` with the record's canonical id to disambiguate, at
+the cost of the minted handle no longer verifying independently (see the
+residual below, now closed). CHAOS-3633 added `record_locator` to the signed
+payload for exactly this collision, so the substitution is retired:
+`entity_id` stays the true entity, `record_locator` carries the record's own
+identity, and a minted handle verifies through `signer.verify` on the emitted
+ref like any other platform-issued identity.
 
 **The two indexes behave differently, and only one of them refuses.** The
 projection builds an entity index keyed by `(kind, canonical_id)` and an
@@ -872,15 +877,17 @@ note claimed both indexes refuse, which was an overclaim a reviewer caught.
 Whether the entity index should refuse too is recorded on CHAOS-3627 and is
 not changed here.
 
-**Residual: a minted handle no longer verifies independently.** The arm signs
-a minted handle over the record's canonical id while the emitted `entity_id`
-is the entity, so `signer.verify` on the emitted ref cannot reproduce it and
-verification means re-deriving through the arm's own `_mint_handle`. That is
-verification by the same code that did the minting: a bug in the mint now
-verifies itself. It is the price of not shipping a denial-of-packet on
-legitimate handle-less sources, and it is temporary — CHAOS-3633's platform
-fix to the signer payload should restore true independent verifiability, and
-that ticket carries this requirement.
+**Residual, closed: a minted handle used to not verify independently.**
+Between CHAOS-3627's fix round and CHAOS-3633 landing, the arm signed a
+minted handle over the record's canonical id while the emitted `entity_id`
+was the entity, so `signer.verify` on the emitted ref could not reproduce it
+and verification meant re-deriving through the arm's own `_mint_handle` —
+verification by the same code that did the minting, a bug in the mint would
+have verified itself. CHAOS-3633's platform fix (a `record_locator` field in
+the signed payload, distinct from `entity_id`) removed the need for the
+substitution; the arm now signs both fields for what they actually are, and
+`test_chaos_3617_packet_contract.py`'s `TestEvidenceIdentity` asserts a
+minted handle through `signer.verify` again.
 
 **Residual: a carried handle's identity is asserted, never verified.**
 Ingestion checks a carried handle's *grammar* and the *completeness* of the

--- a/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
@@ -826,37 +826,39 @@ def _mint_handle(
 ) -> str:
     """A handle for a record whose source issued none.
 
-    Minted through the platform's own ``EvidenceReferenceSigner`` -- not a
-    parallel scheme -- but over a record identified by its **canonical id**
-    rather than by the entity it is about.
+    Minted through the platform's own ``EvidenceReferenceSigner``, over a
+    record whose ``entity_id`` is the entity it is genuinely about --
+    unmodified -- and whose ``record_locator`` is the observation's own
+    canonical id.
 
-    That substitution is the arm-side fix for CHAOS-3633 and it is deliberate.
-    ``EvidenceReferenceSigner._payload`` identifies a record by ``(org,
-    source_system, source_version, entity_type, entity_id, repositories)``,
-    and ``entity_id`` on the wire is the entity the evidence is *about*. Two
-    distinct records of one kind about one entity therefore mint the SAME
-    handle, and since the frozen contract refuses a repeated handle in the
-    index, the second one killed the entire packet -- measured on a
-    legitimate handle-less world (the arm's own fixtures hold exactly such a
-    pair: ``dec_auth_1`` superseded by ``dec_auth_2``). A denial of service on
-    valid input, manufactured by the arm's own mint.
+    **This is the CHAOS-3633 platform fix, not the arm-side workaround it
+    replaced.** Before CHAOS-3633, ``EvidenceReferenceSigner._payload``
+    identified a record by ``(org, source_system, source_version,
+    entity_type, entity_id, repositories)`` alone, with no field for the
+    record's own identity. Two distinct records of one kind about one
+    entity therefore minted the SAME handle, and since the frozen contract
+    refuses a repeated handle in the index, the second one killed the
+    entire packet -- measured on a legitimate handle-less world (the arm's
+    own fixtures hold exactly such a pair: ``dec_auth_1`` superseded by
+    ``dec_auth_2``). The arm's interim fix substituted ``entity_id`` with
+    the observation's canonical id to disambiguate, at the cost of a real
+    handle no longer round-tripping through ``signer.verify`` (the emitted
+    ``entity_id`` was the entity while the signed one was the record --
+    ``test_chaos_3617_packet_contract`` re-derived the handle through this
+    function instead of verifying it, which proved the substitution self-
+    consistent and proved nothing about the platform's real identity
+    contract).
 
-    The platform fix belongs in ``evidence_service`` and is tracked as
-    CHAOS-3633; this arm must not reach into it. So the arm signs over the
-    record's identity, which is what the payload needed all along.
-
-    **The consequence, stated rather than buried**: the emitted evidence ref
-    no longer round-trips through ``signer.verify``, because the emitted
-    ``entity_id`` is the entity while the signed one is the record. Verifying
-    a minted handle means re-deriving it through this function -- which is
-    what ``test_chaos_3617_packet_contract`` now does. The property that
-    matters is unchanged: the handle comes from the evidence service's own
-    signing function, over this organization's key, and no scheme this arm
-    invented.
+    CHAOS-3633 added ``record_locator`` to the signed payload for exactly
+    this collision, so the workaround is retired: ``entity_id`` stays the
+    true entity, ``record_locator`` carries the record's own identity, and
+    the two records disambiguate on a field named for that job rather than
+    on a borrowed one. The handle round-trips through ``signer.verify``
+    again, and does.
     """
 
     return signer.issue(
-        org_id, dataclasses_replace(record, entity_id=observation.canonical_id)
+        org_id, dataclasses_replace(record, record_locator=observation.canonical_id)
     )
 
 
@@ -1496,11 +1498,20 @@ def build_packet(
             admitted_by_handle[handle] = admitted
         else:
             issued = observation.attributes.get(SOURCE_EVIDENCE_HANDLE_ATTRIBUTE)
-            handle = (
-                issued
-                if issued is not None
-                else _mint_handle(signer, readout.org_id, observation, record)
-            )
+            if issued is not None:
+                handle = issued
+            else:
+                handle = _mint_handle(signer, readout.org_id, observation, record)
+                # The payload _mint_handle signed carried record_locator
+                # (see its own docstring). The STORED record -- what
+                # becomes the emitted wire ref below -- must carry the
+                # same field, or the emitted ref's record_locator would be
+                # absent while the handle was signed with one present, and
+                # signer.verify would recompute a different payload than
+                # what this function actually signed.
+                record = dataclasses_replace(
+                    record, record_locator=observation.canonical_id
+                )
         if handle in evidence_groups:
             # Only reachable for a genuinely repeated SOURCE-issued handle
             # now: the arm's own mint discriminates by record identity (see
@@ -1643,6 +1654,12 @@ def build_packet(
                     "citation_text": None,
                     "repository_ids": list(group.record.repository_ids),
                     "valid_entity_ids": list(entry_supports),
+                    # CHAOS-3633/_mint_handle: present on the wire exactly
+                    # when it was present in the signed payload, so
+                    # signer.verify recomputes the SAME bytes that were
+                    # actually signed. None for a source-carried handle
+                    # (that payload never had one either).
+                    "record_locator": group.record.record_locator,
                     "flags": {},
                 },
                 source_class=group.source_class,

--- a/tests/context_fabric/test_chaos_3617_packet_contract.py
+++ b/tests/context_fabric/test_chaos_3617_packet_contract.py
@@ -365,22 +365,24 @@ class TestEvidenceIdentity:
     def test_the_arm_mints_a_platform_handle_when_the_source_issues_none(
         self, alpha_projection, signer
     ) -> None:
-        r"""The fallback branch, observed rather than assumed.
+        """The fallback branch, verified rather than re-derived.
 
-        Re-deriving through the same ``EvidenceReferenceSigner`` the evidence
-        service uses is the only check that means anything for a handle the
-        arm mints: it proves the arm did not invent a parallel scheme.
+        CHAOS-3633 added ``record_locator`` to the platform's signed
+        payload, retiring the arm-side workaround that used to substitute
+        ``entity_id`` with the record's canonical id to avoid a same-kind
+        collision (see ``_mint_handle``'s own docstring for that history).
+        The minted handle now round-trips through ``signer.verify`` like
+        any other platform-issued identity: ``entity_id`` on the wire is
+        the true entity, ``record_locator`` is the record's own identity,
+        and ``verify`` recomputes the SAME payload that was signed because
+        both fields are emitted, not one substituted for the other.
 
-        Re-derived rather than ``signer.verify``\ ed, and the difference is
-        CHAOS-3627's fix round. The arm signs a minted handle over the
-        RECORD's canonical id while the emitted ``entity_id`` is the entity
-        the evidence is about, because the platform payload uses one field for
-        both and two same-kind records about one entity otherwise collide --
-        which killed whole packets on legitimate handle-less worlds
-        (CHAOS-3633). ``verify`` recomputes from the emitted fields and so
-        cannot see the substitution; this asserts the stronger thing, that the
-        handle is byte-identical to what the service's own signing function
-        produces for that record.
+        ``signer.verify`` rather than a re-derived ``signer.issue`` call --
+        the stronger check, and the one this test used before CHAOS-3627's
+        fix round made it impossible: proof that the emitted ref is
+        actually self-consistent with what the platform's own function
+        would sign for it, not merely that the arm's minting function is
+        deterministic.
         """
 
         readout = _unissued(alpha_projection, _UNISSUED)
@@ -390,22 +392,13 @@ class TestEvidenceIdentity:
             item for item in readout.observations if item.canonical_id == _UNISSUED
         )
 
-        expected = signer.issue(
-            packet.organization_id,
-            EvidenceRecord(
-                source_system=entry.evidence.source_system,
-                source_version=entry.evidence.source_version,
-                entity_type=entry.evidence.entity_type,
-                entity_id=observation.canonical_id,
-                display_label=entry.evidence.display_label,
-                observed_at=entry.evidence.observed_at,
-                freshness=FreshnessState(entry.evidence.freshness),
-                provenance=entry.evidence.provenance,
-                confidence=entry.evidence.confidence,
-                repository_ids=tuple(entry.evidence.repository_ids),
-            ),
+        assert entry.evidence.record_locator == observation.canonical_id
+        assert entry.evidence.entity_id != observation.canonical_id, (
+            "entity_id must stay the true entity now that record_locator "
+            "carries the record's own identity -- the substitution this "
+            "test used to require is exactly what CHAOS-3633 retired"
         )
-        assert entry.evidence.evidence_ref_id == expected
+        assert signer.verify(packet.organization_id, entry.evidence)
 
     def test_a_minted_handle_for_another_organization_does_not_verify(
         self, alpha_projection, signer
@@ -421,9 +414,6 @@ class TestEvidenceIdentity:
         readout = _unissued(alpha_projection, _UNISSUED)
         packet = _packet(readout, signer)
         entry = _entry_for(packet, _UNISSUED)
-        observation = next(
-            item for item in readout.observations if item.canonical_id == _UNISSUED
-        )
 
         def mint(org_id: str) -> str:
             return signer.issue(
@@ -432,13 +422,14 @@ class TestEvidenceIdentity:
                     source_system=entry.evidence.source_system,
                     source_version=entry.evidence.source_version,
                     entity_type=entry.evidence.entity_type,
-                    entity_id=observation.canonical_id,
+                    entity_id=entry.evidence.entity_id,
                     display_label=entry.evidence.display_label,
                     observed_at=entry.evidence.observed_at,
                     freshness=FreshnessState(entry.evidence.freshness),
                     provenance=entry.evidence.provenance,
                     confidence=entry.evidence.confidence,
                     repository_ids=tuple(entry.evidence.repository_ids),
+                    record_locator=entry.evidence.record_locator,
                 ),
             )
 


### PR DESCRIPTION
## Issue and phase
Follow-up cleanup queued by the orchestrator after Lane C's CHAOS-3633 merged (873adb31b). Referenced here as plain mentions only (per branch-naming/PR-linkage lesson learned on an earlier PR in this stack) — not close-linking CHAOS-3627 or CHAOS-3633, since this PR completes neither of those tickets on its own.

## Observable outcome
CHAOS-3633 added `record_locator` to `EvidenceReferenceSigner`'s signed payload specifically to disambiguate two same-kind records about one entity — the platform-side fix the arm's `_mint_handle` had been working around since CHAOS-3627 by substituting the minted record's `entity_id` with its own canonical id. That substitution avoided the handle collision but meant a minted handle could no longer round-trip through `signer.verify` (only through re-deriving it via the arm's own `_mint_handle` — verification by the same code that did the minting, a residual explicitly documented as temporary pending CHAOS-3633).

With the platform fix in place, the workaround is retired:
- `_mint_handle` now signs `entity_id=<the true entity>` (unmodified) and `record_locator=<the observation's own canonical id>`.
- `build_packet`'s evidence-indexing pass carries `record_locator` through from the mint into the *stored* `EvidenceRecord` — previously the record used for signing was augmented locally and discarded, so the stored/emitted record never carried it, which would have made the emitted ref's `record_locator` silently absent while the handle was signed with one present (`signer.verify` would then recompute a different payload than what was actually signed).
- The emitted wire evidence dict now includes `record_locator`, present exactly when it was present in the signed payload (`None` for a source-carried handle, matching the signer's own backward-compatibility rule).

## Architecture boundary
Arm-side only. No contract/vocabulary change — `record_locator` already existed on `EvidenceRecord`/`DevEvidenceRef` (added by CHAOS-3633); this PR only starts using it correctly.

## Scope / non-scope
`packet_builder.py` (approved for Lane D per `ORCHESTRATOR-PACKET-BUILDER-OWNERSHIP.md`, narrow additive change to evidence-closure emission), its test file, and the architecture doc describing this exact residual. No driver-emission logic touched.

## Base/head
Base: `origin/feature/chaos-3498-context-fabric` @ `f01767a50` (current tip). Head: `graph-arm-retire-mint-handle-workaround`.

## Migrations / configuration / feature flags
None.

## Security / privacy / retention impact
None. The signed payload is stronger (two distinguishing fields instead of one substituted field); no new evidence path, no authorization change.

## RED-first evidence
`git stash` of the source change reproduced both `TestEvidenceIdentity` test failures (byte-mismatch against the old entity_id-substitution scheme) before the fix; GREEN after.

## Verification
- `.venv/bin/python -m pytest tests/context_fabric/test_chaos_3617_packet_contract.py -q` → 28 passed
- `.venv/bin/python -m pytest tests/context_fabric/ -q` → 1419 passed, 52 skipped
- `.venv/bin/python -m pytest tests/api/dev/ -q` → 2994 passed, 74 skipped, 4 xfailed
- ruff / mypy (module + full-project lefthook gate) → clean

## Known limitations and follow-up issues
None new. `docs/contribute/architecture/graph-investigation-arm.md`'s "minted handle no longer verifies independently" residual is now marked closed.

## Rollout / rollback impact
Purely additive/corrective at the evidence-mint layer. Every previously-carried (source-issued) handle is untouched; only minted handles change shape, and they verify more strongly than before, not less.