### PR TITLE
CHAOS-3683: inert EvidenceService collaborator on DevOrchestrator

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -104,6 +104,7 @@ from .contracts_v2.frame import DevAnswerFrame
 from .contracts_v2.narrative import DevNarrative
 from .contracts_v2.plan import DevInvestigationPlan
 from .contracts_v2.subject import DevEntityRefV2
+from .evidence_service import EvidenceService
 from .graph_investigation_query import GraphInvestigationQuery
 from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
@@ -1014,6 +1015,7 @@ class DevOrchestrator:
         investigation_shadow: InvestigationShadow | None = None,
         investigation_packet_producer: InvestigationPacketProducer | None = None,
         graph_investigation_query: GraphInvestigationQuery | None = None,
+        evidence_service: EvidenceService | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -1070,6 +1072,16 @@ class DevOrchestrator:
         # ``graph_investigation_query.py`` and CHAOS-3502/CHAOS-3664 for the
         # canonical-admission bridge that finishes this seam.
         self._graph_investigation_query = graph_investigation_query
+        # CHAOS-3502 increment 2c: ``None`` is the flag-off path, same shape
+        # as ``graph_investigation_query`` immediately above -- ``run()``
+        # does not read this attribute yet. Landed ahead of the routing
+        # branch that will call ``evidence_service.admit()`` on packet-
+        # extracted candidates (``graph_evidence_admission.
+        # extract_evidence_candidates``, CHAOS-3680) so that branch's own
+        # design (CHAOS-3660, pending sign-off) can assume the collaborator
+        # already exists rather than bundling its construction with the
+        # first PR that actually calls it.
+        self._evidence_service = evidence_service
         self._composer = PromptComposer(registry)
 
     async def run(

--- a/tests/api/dev/test_chaos_3502_graph_routing_seam.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_seam.py
@@ -1,17 +1,20 @@
 """CHAOS-3502: the graph-assisted routing seam's flag scaffolding.
 
-Landed ahead of the actual routing branch (which is blocked on a
-cross-lane design question about the packet -> canonical-frame bridge, see
-CHAOS-3660) -- mirrors CHAOS-3567's own "flag-off scaffolding first,
-consuming logic later" pattern. Covers only what exists today:
+Landed ahead of the actual routing branch (which gets its own design note
+on CHAOS-3660 -- exact hook point in ``run()``, ``ScopeResolveRequest``
+derivation, per-``GraphQueryOutcome`` fallback semantics, interaction with
+the ``plan_executor`` branch -- for sign-off before implementation) --
+mirrors CHAOS-3567's own "flag-off scaffolding first, consuming logic
+later" pattern. Covers only what exists today:
 
 * the runtime kill switch (``orchestrator.graph_routing_runtime_enabled``),
   independent of the organization feature-policy gate;
 * the organization feature-policy gate itself
   (``licensing.registry.ASK_DEV_GRAPH_ROUTING_FEATURE``), denied by default
   on every tier;
-* ``DevOrchestrator`` accepting ``graph_investigation_query`` without any
-  behavior change -- ``run()`` does not read the attribute yet, so there is
+* ``DevOrchestrator`` accepting ``graph_investigation_query`` and
+  ``evidence_service`` (CHAOS-3502 increment 2c) without any behavior
+  change -- ``run()`` does not read either attribute yet, so there is
   nothing for it to change.
 """
 
@@ -26,6 +29,10 @@ from dev_health_ops.api.dev.contracts import (
     DevToolResult,
     ToolID,
 )
+from dev_health_ops.api.dev.evidence_service import (
+    EvidenceReferenceSigner,
+    EvidenceService,
+)
 from dev_health_ops.api.dev.orchestrator import (
     GRAPH_ROUTING_RUNTIME_FLAG,
     DevOrchestrator,
@@ -39,6 +46,27 @@ from dev_health_ops.licensing.registry import (
 )
 from dev_health_ops.licensing.types import LicenseTier
 from tests._chaos_3502_graph_investigation_fake import FakeGraphInvestigationQuery
+
+_EVIDENCE_SIGNING_SECRET = "chaos-3683-test-secret-at-least-thirty-two-bytes-long"
+
+
+class _Entitlement:
+    async def require(self, _org_id: str) -> None:
+        return None
+
+
+class _Authorizer:
+    async def resolve(self, _org_id: str, _permission_fingerprint: str, _request):
+        raise NotImplementedError("construction-only smoke test; never called")
+
+
+def _minimal_evidence_service() -> EvidenceService:
+    return EvidenceService(
+        entitlement=_Entitlement(),
+        authorizer=_Authorizer(),
+        signer=EvidenceReferenceSigner(_EVIDENCE_SIGNING_SECRET),
+        native_adapters=(),
+    )
 
 
 def _minimal_registry() -> AskDevToolRegistry:
@@ -120,3 +148,22 @@ def test_orchestrator_accepts_a_graph_investigation_query_collaborator() -> None
     assert isinstance(
         with_query._graph_investigation_query, FakeGraphInvestigationQuery
     )
+
+
+def test_orchestrator_accepts_an_evidence_service_collaborator() -> None:
+    """Construction-only smoke test, same shape as the
+    ``graph_investigation_query`` one above (CHAOS-3502 increment 2c):
+    the parameter exists, defaults to ``None`` (flag-off), and accepting a
+    real ``EvidenceService`` does not raise. ``run()`` does not read
+    ``self._evidence_service`` yet -- that lands with the routing branch
+    that calls ``evidence_service.admit()`` on packet-extracted candidates,
+    which gets its own design note on CHAOS-3660 before implementation.
+    """
+
+    kwargs = _minimal_orchestrator_kwargs()
+    default = DevOrchestrator(**kwargs)
+    assert default._evidence_service is None
+
+    service = _minimal_evidence_service()
+    with_service = DevOrchestrator(**kwargs, evidence_service=service)
+    assert with_service._evidence_service is service


### PR DESCRIPTION
## Issue and phase
CHAOS-3683 (child of CHAOS-3502, Wave 3.2 Phase 1, Lane B — grandparent CHAOS-3660). Increment 2c: inert `EvidenceService` collaborator. Stacked on #1650 (CHAOS-3681, unmerged) — base branch `chaos-3681-assemble-grounded-answer`.

## Observable outcome
None. Same shape as #1641's `graph_investigation_query` collaborator: `DevOrchestrator` accepts an optional `evidence_service: EvidenceService | None = None`, `run()` does not read it.

## Architecture boundary
Approved by team-lead as a standalone increment ahead of the routing branch's own design (which needs sign-off separately — hook point in `run()`, `ScopeResolveRequest` derivation, per-`GraphQueryOutcome` fallback semantics, interaction with the `plan_executor` branch). Landing the collaborator now means that design doesn't have to bundle "and also add this constructor param" into itself.

## Scope / non-scope
**In scope:** `orchestrator.py` constructor param + attribute, one construction-only smoke test.
**Out of scope:** calling `evidence_service.admit()` from anywhere — that's the routing branch.

## Base/head SHA and branch provenance
- Base: `chaos-3681-assemble-grounded-answer` @ `5d64fd3b0` (= PR #1650's head).
- Head: `607228f37` on `chaos-3683-evidence-service-collaborator`.

## Migrations/configuration/feature flags
None.

## Security/privacy/retention impact
None — unreachable collaborator, no live code path.

## RED-first evidence
N/A — additive inert plumbing, same shape as #1641's precedent.

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_chaos_3502_graph_routing_seam.py -v
  → 8 passed
.venv/bin/python -m pytest tests/api/dev tests/context_fabric -m "not benchmark and not clickhouse" -q -n 4 --dist loadscope
  → 4428 passed, 65 skipped, 4 xfailed, 0 failed
.venv/bin/ruff check / ruff format --check / mypy → clean
```
Pre-commit and pre-push lefthook gates passed locally.

## Known limitations and follow-up issues
The routing branch that actually calls `evidence_service.admit()` needs its own CHAOS-3660 design note (in progress) before implementation.

## Rollout/rollback impact
None. Revert is a plain `git revert`.
