### PR TITLE
CHAOS-3678 increment 1: transport/outcome mapping for the graph query service

### DIFF
--- a/src/dev_health_ops/api/dev/graph_investigation_query.py
+++ b/src/dev_health_ops/api/dev/graph_investigation_query.py
@@ -1,0 +1,189 @@
+"""CHAOS-3502/CHAOS-3660: the production consumer-side graph-investigation seam.
+
+**Status: PROPOSAL, posted on CHAOS-3660 for Lane A review** (Wave 3.2 §8
+shared-contract protocol -- "graph query request/result contract" is a named
+stable seam). Lane B (this orchestrator/routing lane) owns the *consumer*
+side and is the one with an immediate need to call something; Lane A
+(CHAOS-3500) owns the real production implementation. Per the ratified plan
+(CHAOS-3660, team-lead), Lane B may bind orchestrator routing to this
+``Protocol`` and its own fake now; Lane A implements against it or
+counter-proposes, and team-lead arbitrates disagreement. Nothing here is a
+final spec.
+
+Why this shape, briefly (full reasoning in the CHAOS-3660 proposal comment):
+
+* The **result** reuses :class:`~.investigation_contract.AskDevInvestigationPacket`
+  wholesale rather than inventing a fourth output shape. It is already
+  documented (``investigation_contract/__init__.py``) as "the shared, frozen
+  wire shape every arm must emit... the input the Ask Dev frame reasons
+  over" -- exactly what a production caller needs, and reusing it is what
+  "no duplicate hand-maintained schemas" (handoff §8) asks for. Consuming it
+  from a real caller is NOT "trial construction copied into production":
+  the packet contract was built for cross-arm interop from the start.
+* The **request** deliberately does NOT expose the frozen trial's
+  ``QuestionFamilyID``/``AnalyticalJob`` vocabulary at this seam. That
+  registry is documented as "the frozen question-family registry for the
+  corrected trial" (``question_families.py``) with ten fixed families tied
+  to the trial's own exact/natural phrasings -- coupling production routing
+  to it directly would silently import trial-scoped assumptions into a
+  production contract. Instead the request carries what production's own
+  interpreter already computed (``QuestionIntentID``, ``Cardinality``,
+  resolved/unresolved mentions) and leaves any internal family/job
+  classification the graph service needs as Lane A's own implementation
+  detail, on Lane A's side of the seam.
+* **Authorization is supplied, never derived, at this seam.** Mirrors
+  ``graph_arm.readback.derive_authorized_entity_ids``'s own documented gap
+  (raises ``AuthorizationDerivationNotImplementedError`` today) -- the
+  orchestrator already knows the authorized/committed scope from
+  ``subject_preflight``/``scope_service`` before it would ever call this
+  seam, so there is no reason for the graph side to re-derive it, and doing
+  so would create two independent authorization computations that could
+  disagree.
+* **Deadline is absolute, not a duration.** CHAOS-3631 flagged unbounded
+  graph transport with no timeout; an absolute ``datetime`` deadline removes
+  the ambiguity a relative "give me 3 seconds" has once it crosses a queue,
+  a retry, or a slow caller.
+* **Transport/availability failure is a distinct axis from investigation
+  outcome.** ``AskDevInvestigationPacket.outcome`` (``InvestigationOutcome``)
+  only has semantic states (supported / needs_clarification / no_match /
+  unsupported) -- nothing for "the store was unreachable" or "the deadline
+  passed before this finished". Conflating the two would make a transport
+  failure indistinguishable from a legitimate no-match, which the handoff's
+  "missing/stale/unavailable/... remain distinct" guardrail forbids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol
+
+from .contracts_v2.base import Cardinality, QuestionIntentID
+from .contracts_v2.subject import DevSubjectMention
+from .investigation_contract import AskDevInvestigationPacket
+
+__all__ = [
+    "GraphInvestigationRequest",
+    "GraphQueryOutcome",
+    "GraphQueryResult",
+    "GraphInvestigationQuery",
+]
+
+
+class GraphQueryOutcome(StrEnum):
+    """The transport/availability axis -- distinct from the packet's own
+    semantic ``InvestigationOutcome``. A caller must be able to tell "the
+    graph route is unavailable, fall back" apart from "the graph route ran
+    and found nothing", and this is the only field that distinction lives
+    on.
+    """
+
+    #: The call completed before the deadline; ``GraphQueryResult.packet``
+    #: is populated and its own ``outcome`` field carries the semantic
+    #: result (which may itself be a refusal shape -- NO_MATCH,
+    #: NEEDS_CLARIFICATION, UNSUPPORTED -- that is still a completed call).
+    COMPLETED = "completed"
+    #: Projection/read is disabled (organization or runtime flag off).
+    #: Distinct from UNAVAILABLE: this is an intentional, configured state,
+    #: not a failure.
+    DISABLED = "disabled"
+    #: The graph store or service could not be reached at all.
+    UNAVAILABLE = "unavailable"
+    #: The projection is reachable but known stale beyond the caller's
+    #: tolerance (watermark lag). Distinct from UNAVAILABLE -- data exists,
+    #: it is just not current enough to answer from.
+    STALE = "stale"
+    #: The absolute deadline passed before the call completed.
+    DEADLINE_EXCEEDED = "deadline_exceeded"
+    #: The caller's own cancellation token fired (e.g. the parent Ask Dev
+    #: run was cancelled) before the call completed.
+    CANCELLED = "cancelled"
+    #: Any other provider-side failure the query service could not recover
+    #: from. Named rather than silently mapped to UNAVAILABLE so a caller
+    #: can distinguish "never reachable" from "reached, then broke".
+    PROVIDER_FAILURE = "provider_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class GraphInvestigationRequest:
+    """What the orchestrator already knows before it would call the graph
+    seam -- nothing here is derived BY the graph side; everything is
+    supplied.
+    """
+
+    org_id: str
+    run_id: str
+    #: Production's own interpreted intent (now including
+    #: ``QuestionIntentID.DISCOVERED_COHORT``, CHAOS-3652) and its cardinality.
+    #: The graph service classifies its own internal job/family from these
+    #: plus ``question_text`` -- production does not hand it a pre-classified
+    #: trial family.
+    intent_id: QuestionIntentID
+    cardinality: Cardinality
+    #: Already-extracted mentions (resolved or not -- resolution status is
+    #: NOT communicated here; see ``authorized_entity_ids`` below for what
+    #: the graph route may actually touch). Empty for
+    #: ``Cardinality.ORGANIZATION_WIDE`` (structurally, per
+    #: ``DevQuestionIntent.validate_intent_invariants``).
+    mentions: tuple[DevSubjectMention, ...]
+    #: The bounded (<=8KiB per ``DevMessageRequestV2``), already-validated
+    #: question text. Needed for the graph service's own family/candidate
+    #: classification. Server-side/internal only -- never echoed back
+    #: verbatim into a packet field a consumer renders untrusted (mirrors
+    #: the existing "no raw question text in logs/traces/labels" guardrail;
+    #: this is a same-process/internal call, not a log).
+    question_text: str
+    #: Supplied, never derived (see module docstring). The graph route must
+    #: never return, rank, or count toward truncation any entity outside
+    #: this set -- mirrors ``graph_arm.discover_cohort``'s own "authorization
+    #: applied on the way IN" invariant.
+    authorized_entity_ids: frozenset[str]
+    #: Absolute wall-clock deadline (CHAOS-3631). The query service must
+    #: return ``GraphQueryOutcome.DEADLINE_EXCEEDED`` rather than block past
+    #: this, under any internal retry/backoff it performs.
+    deadline: datetime
+    #: Bounded per the handoff's "max nodes, paths, depth, rows, bytes,
+    #: time, output budgets" requirement. Left as a generic mapping here
+    #: deliberately -- the concrete budget shape (node/path/hop/byte caps)
+    #: is exactly the kind of closed vocabulary CHAOS-3500 should define and
+    #: own; this proposal does not presume it.
+    budget_hints: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphQueryResult:
+    outcome: GraphQueryOutcome
+    #: Populated iff ``outcome is GraphQueryOutcome.COMPLETED``. Its own
+    #: ``.outcome: InvestigationOutcome`` field carries the semantic result.
+    packet: AskDevInvestigationPacket | None = None
+    #: A short, content-safe (no raw question/entity text) diagnostic for
+    #: non-COMPLETED outcomes -- logged and telemetered, never shown to a
+    #: user verbatim.
+    diagnostic: str | None = None
+
+    def __post_init__(self) -> None:
+        if (self.outcome is GraphQueryOutcome.COMPLETED) != (self.packet is not None):
+            raise ValueError(
+                "GraphQueryResult.packet must be set if and only if "
+                "outcome is COMPLETED"
+            )
+
+
+class GraphInvestigationQuery(Protocol):
+    """The one call orchestrator routing makes into the graph-assisted seam.
+
+    Implementations MUST NOT raise for an ordinary unavailable/stale/
+    timeout/cancelled condition -- those are ``GraphQueryOutcome`` values,
+    not exceptions, so a caller can never accidentally let an unhandled
+    exception from this seam take down an otherwise-valid Ask Dev run
+    (mirrors ``investigation_shadow``'s "total exception containment"
+    posture, but for a route that DOES affect the answer, not a shadow).
+    An implementation MAY raise for a genuine programming error (a
+    malformed request), which is a bug in the caller, not a runtime
+    condition to model.
+    """
+
+    async def investigate(
+        self, request: GraphInvestigationRequest
+    ) -> GraphQueryResult: ...

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -11,6 +11,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from collections import Counter
@@ -103,6 +104,7 @@ from .contracts_v2.frame import DevAnswerFrame
 from .contracts_v2.narrative import DevNarrative
 from .contracts_v2.plan import DevInvestigationPlan
 from .contracts_v2.subject import DevEntityRefV2
+from .graph_investigation_query import GraphInvestigationQuery
 from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
 from .investigation_shadow import (
@@ -962,6 +964,31 @@ class EventCancellationSignal:
 
 EventSink = Callable[[OrchestratorEvent], Awaitable[None]]
 
+#: CHAOS-3502: the runtime kill-switch for graph-assisted routing.
+#: Independent of the organization feature-policy gate
+#: (``licensing.registry.ASK_DEV_GRAPH_ROUTING_FEATURE``,
+#: ``production_runtime.py`` evaluates it and decides whether to construct a
+#: real ``GraphInvestigationQuery`` at all) -- same two-flag shape
+#: ``graph_arm.flags`` already uses for projection/read, and for the same
+#: reason: an operator needs a same-process kill switch that does not
+#: require a database round trip or waiting for an org-policy cache to
+#: invalidate, on TOP OF the organization opt-in, not instead of it. Default
+#: OFF, so an unset var is byte-identical to this seam not existing.
+GRAPH_ROUTING_RUNTIME_FLAG = "ASK_DEV_GRAPH_ROUTING_ENABLED"
+
+
+def graph_routing_runtime_enabled() -> bool:
+    """Whether the graph-assisted routing seam may run in this process.
+
+    Both this AND the organization feature-policy gate must be true for the
+    graph route to ever be attempted -- this function is only ever the
+    SECOND check, never a substitute for the org gate. See
+    ``GRAPH_ROUTING_RUNTIME_FLAG``'s own comment for why the two are
+    independent rather than one implying the other.
+    """
+
+    return os.getenv(GRAPH_ROUTING_RUNTIME_FLAG) == "1"
+
 
 class DevOrchestrator:
     """Execute one Ask Dev message as a bounded state machine."""
@@ -986,6 +1013,7 @@ class DevOrchestrator:
         qua_shadow: QuestionUnderstandingShadow | None = None,
         investigation_shadow: InvestigationShadow | None = None,
         investigation_packet_producer: InvestigationPacketProducer | None = None,
+        graph_investigation_query: GraphInvestigationQuery | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -1028,6 +1056,20 @@ class DevOrchestrator:
         # later changes production_runtime.py and nothing here.
         self._investigation_shadow = investigation_shadow
         self._investigation_packet_producer = investigation_packet_producer
+        # CHAOS-3502: ``None`` is the flag-off path -- no graph-assisted
+        # routing branch is attempted, byte-identical to this seam not
+        # existing (see ``test_chaos_3502_graph_routing_seam.py``'s
+        # inertness test). Even when set, ``run()`` also requires
+        # ``graph_routing_runtime_enabled()`` at the call site: the
+        # organization gate that decides whether to construct this at all
+        # (production_runtime.py) and the runtime kill switch are
+        # independent, mirroring ``graph_arm.flags``'s own
+        # projection/read-independence reasoning. As of this landing the
+        # branch only observes -- it does not yet turn a completed graph
+        # investigation into an answer; see the module docstring on
+        # ``graph_investigation_query.py`` and CHAOS-3502/CHAOS-3664 for the
+        # canonical-admission bridge that finishes this seam.
+        self._graph_investigation_query = graph_investigation_query
         self._composer = PromptComposer(registry)
 
     async def run(

--- a/src/dev_health_ops/context_fabric/graph_arm/query_service.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/query_service.py
@@ -1,0 +1,315 @@
+"""CHAOS-3678: the production bounded graph query service.
+
+Implements :class:`~dev_health_ops.api.dev.graph_investigation_query.
+GraphInvestigationQuery` — Lane B's consumer-side Protocol
+(CHAOS-3502/CHAOS-3660). This module owns job → execution-mechanism
+selection only. The analytical job and comparison shape are classified by
+production's interpreter and arrive on the wire in
+``GraphInvestigationRequest.intent_id``/``.cardinality`` — the accepted
+CHAOS-3660 determination is that this pair already carries both signals in
+production's own vocabulary, so nothing here inspects ``question_text`` to
+decide what kind of question was asked. What stays graph-side is
+:func:`mechanism_for`: given an already-classified job and shape, which
+internal traversal/synthesis mechanism actually answers it.
+
+**Increment 1 scope, stated plainly rather than left to be discovered.**
+The transport/outcome mapping — ``GraphQueryOutcome``'s
+``DISABLED``/``UNAVAILABLE``/``STALE``/``DEADLINE_EXCEEDED``/``CANCELLED``
+states — is real, live-tested, and composes the absolute request deadline
+with CHAOS-3631's per-operation :class:`~.flags.GraphDeadlines` and
+CHAOS-3679's persisted watermark. The ``COMPLETED`` path — candidate
+resolution, traversal, driver synthesis and packet assembly — is not
+implemented yet: it depends on CHAOS-3660's packet-constructor ruling (a
+production-shaped packet constructor, ``build_production_packet``, not yet
+landed in ``packet_builder.py``, since the existing ``build_packet``
+requires a trial-only ``QuestionFamilyID``). Every mechanism that would
+reach packet assembly returns ``PROVIDER_FAILURE`` with a diagnostic naming
+the pending dependency — an honest "not yet", never a silent wrong answer,
+never a crash a caller has to guard against separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    QuestionIntentID,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationQuery,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
+
+from .flags import graph_read_enabled
+from .store import GraphArmStore, StoreUnavailableError
+from .watermark import DEFAULT_STALENESS_TOLERANCE, IndexWatermark
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "GraphMechanism",
+    "ProductionGraphInvestigationQuery",
+    "mechanism_for",
+]
+
+
+class GraphMechanism(StrEnum):
+    """Which internal execution path a ``(intent_id, cardinality)`` pair
+    selects.
+
+    Job/shape classification stays production's (CHAOS-3660 determination);
+    this is the one thing that stays graph-side: given an already-classified
+    job and shape, which traversal/synthesis mechanism actually answers it.
+    Trial metadata only — never reaches the wire.
+    """
+
+    #: One resolved subject, seeded neighbourhood traversal.
+    SEEDED_SINGULAR_SUBJECT = "seeded_singular_subject"
+    #: Two or more named subjects, seeded from each.
+    SEEDED_EXPLICIT_COHORT = "seeded_explicit_cohort"
+    #: Zero named subjects, a closed job-specific candidate universe
+    #: (CHAOS-3645's second entry mode).
+    SUBJECTLESS_COHORT_DISCOVERY = "subjectless_cohort_discovery"
+    #: No graph mechanism answers this ``(intent_id, cardinality)`` pair.
+    #: Distinct from every other member: selecting it means the caller asked
+    #: for organization-wide scope on an intent that is not
+    #: ``DISCOVERED_COHORT`` — the unrestricted sweep this arm must never
+    #: construct (handoff §4: "unresolved named subjects never widen to
+    #: organization scope").
+    UNSUPPORTED = "unsupported"
+
+
+def mechanism_for(
+    intent_id: QuestionIntentID, cardinality: Cardinality
+) -> GraphMechanism:
+    """The fixed ``(intent_id, cardinality) -> mechanism`` table.
+
+    Fixed and total — never question-text inspection, per the CHAOS-3660
+    job/shape determination. ``DISCOVERED_COHORT`` requires
+    ``Cardinality.ORGANIZATION_WIDE`` by production's own contract invariant
+    (``DevQuestionIntent.validate_intent_invariants``), so a request that
+    reached this function with that intent and a different cardinality would
+    already be invalid upstream; this function does not re-derive that
+    invariant; it only reads ``intent_id`` first because that is the more
+    specific signal.
+    """
+
+    if intent_id is QuestionIntentID.DISCOVERED_COHORT:
+        return GraphMechanism.SUBJECTLESS_COHORT_DISCOVERY
+    if cardinality is Cardinality.SINGULAR:
+        return GraphMechanism.SEEDED_SINGULAR_SUBJECT
+    if cardinality is Cardinality.PLURAL_COHORT:
+        return GraphMechanism.SEEDED_EXPLICIT_COHORT
+    return GraphMechanism.UNSUPPORTED
+
+
+def _diagnostic(operation: str, detail: str) -> str:
+    """A content-safe diagnostic: a fixed template and an operation name.
+
+    Mirrors CHAOS-3631/CHAOS-3676's content-safety bar — never the raw
+    question text, never an entity label, never a caller-controlled string
+    verbatim. ``detail`` is always a value THIS module chose (an exception
+    type name, a fixed phrase), never something read off the request.
+    """
+
+    return f"graph query service: {operation}: {detail}"
+
+
+class _WatermarkStore(Protocol):
+    """The two methods ``investigate`` needs from a store.
+
+    A ``Protocol`` rather than ``GraphArmStore`` itself, mirroring
+    ``projector.ProjectingStore``: tests exercise the transport/outcome
+    mapping against fakes that implement exactly these two methods, and
+    structural typing keeps this module honest about how little of the
+    store it actually depends on.
+    """
+
+    async def read_watermark(self) -> IndexWatermark: ...
+
+    async def close(self) -> None: ...
+
+
+class ProductionGraphInvestigationQuery:
+    """The production implementation of ``GraphInvestigationQuery``.
+
+    Structural conformance to the Protocol (duck typing — the Protocol is
+    ``runtime_checkable``-free by design, so no inheritance is required or
+    attempted). See the module docstring for what increment 1 does and does
+    not do.
+    """
+
+    def __init__(
+        self,
+        *,
+        staleness_tolerance: timedelta = DEFAULT_STALENESS_TOLERANCE,
+        store_factory: Callable[[str], _WatermarkStore] = GraphArmStore.for_org,
+    ) -> None:
+        self._staleness_tolerance = staleness_tolerance
+        # Injected rather than hardcoded to `GraphArmStore.for_org` inline,
+        # so tests can exercise every `GraphQueryOutcome` -- DISABLED,
+        # UNAVAILABLE, STALE, DEADLINE_EXCEEDED, CANCELLED -- against a fake
+        # store without a live FalkorDB for every case; only the
+        # live-store positive control needs the real default.
+        self._store_factory = store_factory
+
+    async def investigate(self, request: GraphInvestigationRequest) -> GraphQueryResult:
+        """Bounded by ``request.deadline`` end to end, never past it.
+
+        Order of checks is deliberate, each one a distinct outcome the
+        Protocol requires stay distinct from every other:
+
+        1. the read flag — an intentional, configured state, checked before
+           anything that could look like a transport problem;
+        2. the absolute deadline, already passed — checked before any I/O,
+           so a caller that waited too long to even dispatch the call gets
+           ``DEADLINE_EXCEEDED`` rather than a store construction it never
+           had time for;
+        3. store construction and the watermark read, both bounded by
+           whatever remains of the absolute deadline (composed with
+           CHAOS-3631's own per-operation ``GraphDeadlines`` bound — the
+           tighter of the two wins, since ``asyncio.wait_for`` here is
+           layered on top of, not instead of, the store's own bounded
+           calls);
+        4. freshness, from the CHAOS-3679 persisted watermark — checked
+           before mechanism selection, so a stale/unavailable partition
+           never reaches a traversal attempt against data that cannot
+           answer the question;
+        5. mechanism selection and (pending CHAOS-3660) execution.
+
+        ``asyncio.CancelledError`` is caught and converted to
+        ``GraphQueryOutcome.CANCELLED`` rather than left to propagate — the
+        Protocol's own docstring requires this ("the caller's own
+        cancellation token fired... before the call completed" is a
+        ``GraphQueryOutcome`` value, not an exception a caller must guard
+        against). This is a deliberate cancellation boundary: the seam
+        absorbs its own cancellation into a result rather than the request
+        task's; nothing above this call needs its own cancellation to be
+        interrupted mid-await for this to be correct, because control only
+        reaches here already inside this coroutine's own task.
+        """
+
+        if not graph_read_enabled():
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.DISABLED,
+                diagnostic=_diagnostic("read_flag", "graph read is disabled"),
+            )
+
+        now = datetime.now(UTC)
+        remaining = (request.deadline - now).total_seconds()
+        if remaining <= 0:
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.DEADLINE_EXCEEDED,
+                diagnostic=_diagnostic(
+                    "deadline", "the absolute deadline had already passed"
+                ),
+            )
+
+        store: _WatermarkStore | None = None
+        try:
+            try:
+                store = self._store_factory(request.org_id)
+            except StoreUnavailableError as exc:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.UNAVAILABLE,
+                    diagnostic=_diagnostic("store_construction", type(exc).__name__),
+                )
+
+            try:
+                watermark = await asyncio.wait_for(
+                    store.read_watermark(), timeout=remaining
+                )
+            except TimeoutError:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.DEADLINE_EXCEEDED,
+                    diagnostic=_diagnostic(
+                        "read_watermark", "did not complete before the deadline"
+                    ),
+                )
+            except StoreUnavailableError as exc:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.UNAVAILABLE,
+                    diagnostic=_diagnostic("read_watermark", type(exc).__name__),
+                )
+
+            freshness = watermark.freshness_for(
+                now, tolerance=self._staleness_tolerance
+            )
+            if freshness is SourceRequirementState.UNAVAILABLE:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.UNAVAILABLE,
+                    diagnostic=_diagnostic(
+                        "freshness", "partition has never been projected"
+                    ),
+                )
+            if freshness is SourceRequirementState.AVAILABLE_STALE:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.STALE,
+                    diagnostic=_diagnostic("freshness", watermark.detail_for(now)),
+                )
+
+            mechanism = mechanism_for(request.intent_id, request.cardinality)
+            if mechanism is GraphMechanism.UNSUPPORTED:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                    diagnostic=_diagnostic(
+                        "mechanism_selection",
+                        f"no graph mechanism for intent={request.intent_id.value} "
+                        f"cardinality={request.cardinality.value}",
+                    ),
+                )
+            # Increment 1: every SUPPORTED mechanism still returns
+            # PROVIDER_FAILURE. Packet assembly needs CHAOS-3660's
+            # production packet constructor, not yet landed -- see the
+            # module docstring. Naming the mechanism and the pending
+            # dependency rather than a bare "not implemented" is what makes
+            # this diagnostic actionable rather than a dead end.
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                diagnostic=_diagnostic(
+                    "execution",
+                    f"mechanism {mechanism.value} selected; packet assembly "
+                    "awaits CHAOS-3660's production packet constructor",
+                ),
+            )
+        except asyncio.CancelledError:
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.CANCELLED,
+                diagnostic=_diagnostic(
+                    "cancellation", "the calling task was cancelled"
+                ),
+            )
+        finally:
+            if store is not None:
+                try:
+                    await asyncio.wait_for(store.close(), timeout=5.0)
+                except Exception:  # noqa: BLE001
+                    # Closing best-effort: a close failure must never mask
+                    # whichever outcome the try block already decided, and
+                    # must never itself propagate as an unhandled exception
+                    # from a seam the Protocol requires not to raise for an
+                    # ordinary runtime condition.
+                    logger.warning(
+                        "context-fabric query service: store.close() failed "
+                        "for org %r after investigate() completed",
+                        request.org_id,
+                    )
+
+
+if TYPE_CHECKING:
+    # Exists only so mypy verifies structural conformance to the Protocol.
+    # Inert at runtime -- code under `if TYPE_CHECKING:` never executes, so
+    # this never actually constructs an instance -- but mypy still type
+    # checks the assignment, and would flag it if `investigate`'s signature
+    # ever drifted from the Protocol's. Cheaper and earlier than a test
+    # discovering the mismatch at a call site.
+    _conforms_to_protocol: GraphInvestigationQuery = ProductionGraphInvestigationQuery()

--- a/src/dev_health_ops/licensing/registry.py
+++ b/src/dev_health_ops/licensing/registry.py
@@ -20,12 +20,21 @@ ASK_DEV_CONTEXTUAL_ENTRYPOINTS_FEATURE: Final = "ask_dev_contextual_entrypoints"
 #: behaves exactly as it does today: no server-owned interpretation, no subject
 #: preflight, every tool advertised, and the CHAOS-3289 backstop terminating.
 ASK_DEV_WAVE_3_1_FEATURE: Final = "ask_dev_wave_3_1"
+#: Wave 3.2 design-partner rollout gate (CHAOS-3502). Off means the run
+#: behaves exactly as it does today: no graph-assisted routing branch is
+#: attempted, whether or not the orchestrator was constructed with a
+#: ``graph_investigation_query`` -- this is the SECOND, organization-level
+#: gate; ``orchestrator.graph_routing_runtime_enabled()`` is the independent,
+#: same-process runtime kill switch. Both must be true for a run to attempt
+#: the graph route.
+ASK_DEV_GRAPH_ROUTING_FEATURE: Final = "ask_dev_graph_routing"
 EXPLICIT_PURCHASE_FEATURES: frozenset[str] = frozenset(
     {
         "agent_context_runtime",
         ASK_DEV_FEATURE,
         ASK_DEV_CONTEXTUAL_ENTRYPOINTS_FEATURE,
         ASK_DEV_WAVE_3_1_FEATURE,
+        ASK_DEV_GRAPH_ROUTING_FEATURE,
     }
 )
 ORG_OVERRIDE_ONLY_FEATURES: frozenset[str] = frozenset()
@@ -200,6 +209,13 @@ STANDARD_FEATURES: list[STANDARD_FEATURE_ROW] = [
         FeatureCategory.ANALYTICS,
         LicenseTier.COMMUNITY,
         "Server-owned question intent and named-subject preflight",
+    ),
+    (
+        ASK_DEV_GRAPH_ROUTING_FEATURE,
+        "Ask Dev Graph-Assisted Routing",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.COMMUNITY,
+        "Graph-assisted investigation for ambiguous, bounded, relational, and cohort questions (design-partner beta)",
     ),
     (
         "scheduled_jobs",

--- a/tests/_chaos_3502_graph_investigation_fake.py
+++ b/tests/_chaos_3502_graph_investigation_fake.py
@@ -1,0 +1,80 @@
+"""A Lane-B-owned fake for ``graph_investigation_query.GraphInvestigationQuery``.
+
+Lives in the ``tests`` package (mirrors ``tests/_chaos_3295_plan_executor``,
+``tests/_chaos_3292_preflight``) so both mypy and pytest resolve it the same
+way. Per the CHAOS-3660 ratified plan: Lane B binds orchestrator routing to
+the ``GraphInvestigationQuery`` Protocol and this fake ONLY -- this is not a
+scaled-down copy of the trial/shadow graph arm's construction, and it must
+never be imported from production code (``src/``). Its only job is to let
+Lane B's own orchestrator-routing tests exercise every ``GraphQueryOutcome``
+deterministically, without a live graph backend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationQuery,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
+from dev_health_ops.api.dev.investigation_contract import AskDevInvestigationPacket
+from dev_health_ops.api.dev.investigation_contract.fixtures import positive_fixtures
+
+__all__ = ["FakeGraphInvestigationQuery", "default_investigation_packet"]
+
+
+def default_investigation_packet() -> AskDevInvestigationPacket:
+    """A valid, contract-checked packet -- the same fixture the investigation
+    contract's own test suite validates against, so a fake result is never
+    accidentally malformed in a way production code would reject.
+    """
+
+    payload = positive_fixtures()["ask_dev_investigation_packet.v1"]
+    return AskDevInvestigationPacket.model_validate(payload)
+
+
+@dataclass
+class FakeGraphInvestigationQuery(GraphInvestigationQuery):
+    """Deterministic, in-memory. Configure ``outcome``/``packet`` for the
+    "happy path" cases; use ``responder`` for a test that needs the result to
+    depend on the request (e.g. asserting the request's ``authorized_entity_ids``
+    reached the fake unchanged).
+    """
+
+    outcome: GraphQueryOutcome = GraphQueryOutcome.COMPLETED
+    packet: AskDevInvestigationPacket | None = field(
+        default_factory=default_investigation_packet
+    )
+    diagnostic: str | None = None
+    #: When set, overrides ``outcome``/``packet``/``diagnostic`` entirely --
+    #: the fake calls this with the request and returns whatever it returns.
+    responder: Callable[[GraphInvestigationRequest], GraphQueryResult] | None = None
+    #: Every request this fake received, in call order -- lets a test assert
+    #: on what the orchestrator actually sent (deadline, authorized set,
+    #: intent) without needing a real graph backend to introspect.
+    received_requests: list[GraphInvestigationRequest] = field(default_factory=list)
+
+    async def investigate(self, request: GraphInvestigationRequest) -> GraphQueryResult:
+        self.received_requests.append(request)
+        if self.responder is not None:
+            return self.responder(request)
+        packet = self.packet if self.outcome is GraphQueryOutcome.COMPLETED else None
+        return GraphQueryResult(
+            outcome=self.outcome, packet=packet, diagnostic=self.diagnostic
+        )
+
+
+def deadline_from_now(seconds: float, *, now: Callable[[], datetime]) -> datetime:
+    """Small helper so a test's deadline is computed from its own injected
+    clock rather than a bare ``datetime.now()`` call the repo's fixed-clock
+    convention (``tests/_chaos_3292_preflight.fixed_now``) exists to avoid.
+    """
+
+    from datetime import timedelta
+
+    return now() + timedelta(seconds=seconds)

--- a/tests/api/dev/test_chaos_3502_graph_investigation_query.py
+++ b/tests/api/dev/test_chaos_3502_graph_investigation_query.py
@@ -1,0 +1,107 @@
+"""CHAOS-3502/CHAOS-3660: smoke coverage for the proposed consumer-side
+graph-investigation seam (``graph_investigation_query.py``) and its fake.
+
+Not full orchestrator-routing coverage yet (that lands with the actual
+routing branch) -- this proves the Protocol + fake are usable and that the
+transport/outcome contract behaves as documented before anything binds to
+it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import Cardinality, QuestionIntentID
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationQuery,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
+from dev_health_ops.api.dev.investigation_contract import AskDevInvestigationPacket
+from tests._chaos_3502_graph_investigation_fake import (
+    FakeGraphInvestigationQuery,
+    default_investigation_packet,
+)
+
+
+def _request(
+    *, authorized_entity_ids: frozenset[str] = frozenset()
+) -> GraphInvestigationRequest:
+    return GraphInvestigationRequest(
+        org_id="org_1",
+        run_id="run_1",
+        intent_id=QuestionIntentID.DISCOVERED_COHORT,
+        cardinality=Cardinality.ORGANIZATION_WIDE,
+        mentions=(),
+        question_text="Which teams are currently struggling?",
+        authorized_entity_ids=authorized_entity_ids,
+        deadline=datetime(2026, 8, 10, 0, 0, tzinfo=UTC),
+    )
+
+
+def test_fake_satisfies_the_protocol_structurally() -> None:
+    """``GraphInvestigationQuery`` is a plain (non-runtime-checkable) Protocol
+    -- matching this codebase's convention (``question_interpreter.
+    IntentClassifier``) -- so conformance is a static/mypy property, not an
+    ``isinstance`` check. Assigning to the Protocol-typed variable below is
+    the actual check: this file fails ``mypy`` if the fake's ``investigate``
+    signature ever drifts from the Protocol's.
+    """
+
+    fake: GraphInvestigationQuery = FakeGraphInvestigationQuery()
+    assert fake is not None
+
+
+@pytest.mark.asyncio
+async def test_completed_outcome_carries_a_valid_packet() -> None:
+    fake = FakeGraphInvestigationQuery()
+    result = await fake.investigate(_request())
+    assert result.outcome is GraphQueryOutcome.COMPLETED
+    assert isinstance(result.packet, AskDevInvestigationPacket)
+
+
+@pytest.mark.asyncio
+async def test_non_completed_outcome_never_carries_a_packet() -> None:
+    fake = FakeGraphInvestigationQuery(outcome=GraphQueryOutcome.UNAVAILABLE)
+    result = await fake.investigate(_request())
+    assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+    assert result.packet is None
+
+
+def test_result_rejects_completed_without_a_packet() -> None:
+    with pytest.raises(ValueError, match="if and only if"):
+        GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=None)
+
+
+def test_result_rejects_a_packet_on_a_non_completed_outcome() -> None:
+    with pytest.raises(ValueError, match="if and only if"):
+        GraphQueryResult(
+            outcome=GraphQueryOutcome.STALE, packet=default_investigation_packet()
+        )
+
+
+@pytest.mark.asyncio
+async def test_fake_records_the_request_it_received() -> None:
+    fake = FakeGraphInvestigationQuery()
+    authorized = frozenset({"proj_a", "proj_b"})
+    request = _request(authorized_entity_ids=authorized)
+    await fake.investigate(request)
+    assert fake.received_requests == [request]
+    assert fake.received_requests[0].authorized_entity_ids == authorized
+
+
+@pytest.mark.asyncio
+async def test_fake_responder_overrides_defaults() -> None:
+    fake = FakeGraphInvestigationQuery(
+        responder=lambda req: GraphQueryResult(
+            outcome=GraphQueryOutcome.DEADLINE_EXCEEDED,
+            diagnostic=f"deadline was {req.deadline.isoformat()}",
+        )
+    )
+    result = await fake.investigate(_request())
+    assert result.outcome is GraphQueryOutcome.DEADLINE_EXCEEDED
+    assert result.packet is None
+    assert result.diagnostic is not None and "2026-08-10" in result.diagnostic

--- a/tests/api/dev/test_chaos_3502_graph_routing_seam.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_seam.py
@@ -1,0 +1,122 @@
+"""CHAOS-3502: the graph-assisted routing seam's flag scaffolding.
+
+Landed ahead of the actual routing branch (which is blocked on a
+cross-lane design question about the packet -> canonical-frame bridge, see
+CHAOS-3660) -- mirrors CHAOS-3567's own "flag-off scaffolding first,
+consuming logic later" pattern. Covers only what exists today:
+
+* the runtime kill switch (``orchestrator.graph_routing_runtime_enabled``),
+  independent of the organization feature-policy gate;
+* the organization feature-policy gate itself
+  (``licensing.registry.ASK_DEV_GRAPH_ROUTING_FEATURE``), denied by default
+  on every tier;
+* ``DevOrchestrator`` accepting ``graph_investigation_query`` without any
+  behavior change -- ``run()`` does not read the attribute yet, so there is
+  nothing for it to change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
+from dev_health_ops.api.dev.contracts import (
+    DevContractVersions,
+    DevScopeResolution,
+    DevToolResult,
+    ToolID,
+)
+from dev_health_ops.api.dev.orchestrator import (
+    GRAPH_ROUTING_RUNTIME_FLAG,
+    DevOrchestrator,
+    graph_routing_runtime_enabled,
+)
+from dev_health_ops.api.dev.tool_registry import AskDevToolRegistry
+from dev_health_ops.licensing.registry import (
+    ASK_DEV_GRAPH_ROUTING_FEATURE,
+    EXPLICIT_PURCHASE_FEATURES,
+    get_features_for_tier,
+)
+from dev_health_ops.licensing.types import LicenseTier
+from tests._chaos_3502_graph_investigation_fake import FakeGraphInvestigationQuery
+
+
+def _minimal_registry() -> AskDevToolRegistry:
+    async def execute(_context, request):
+        payload = dict(positive_fixtures()["dev_tool_result.v1"])
+        payload.update(
+            {
+                "run_id": request.run_id,
+                "tool_call_id": request.tool_call_id,
+                "tool_id": request.tool_id.value,
+            }
+        )
+        return DevToolResult.model_validate(payload)
+
+    return AskDevToolRegistry({tool_id: execute for tool_id in ToolID})
+
+
+def _minimal_orchestrator_kwargs() -> dict:
+    async def resolve(**_values) -> DevScopeResolution:
+        return DevScopeResolution.model_validate(
+            positive_fixtures()["dev_scope_resolution.v1"]
+        )
+
+    return {
+        "provider": object(),  # AgentLLMProvider is structural; never called here
+        "provider_source": "platform",
+        "provider_family": "test",
+        "registry": _minimal_registry(),
+        "scope_resolver": resolve,
+        "versions": DevContractVersions.model_validate(
+            positive_fixtures()["dev_answer.v1"]["versions"]
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("1", True),
+    ],
+)
+def test_graph_routing_runtime_flag_defaults_off(
+    monkeypatch: pytest.MonkeyPatch, raw_value: str | None, expected: bool
+) -> None:
+    if raw_value is None:
+        monkeypatch.delenv(GRAPH_ROUTING_RUNTIME_FLAG, raising=False)
+    else:
+        monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, raw_value)
+    assert graph_routing_runtime_enabled() is expected
+
+
+def test_graph_routing_is_an_explicit_purchase_feature_denied_by_default() -> None:
+    assert ASK_DEV_GRAPH_ROUTING_FEATURE in EXPLICIT_PURCHASE_FEATURES
+    for tier in LicenseTier:
+        features = get_features_for_tier(tier)
+        assert features[ASK_DEV_GRAPH_ROUTING_FEATURE] is False
+
+
+def test_orchestrator_accepts_a_graph_investigation_query_collaborator() -> None:
+    """Construction-only smoke test: the parameter exists, defaults to
+    ``None`` (the flag-off path, mirroring every other optional collaborator
+    on this constructor), and accepting a real value does not raise. No
+    behavior assertion here -- ``run()`` does not read
+    ``self._graph_investigation_query`` yet, so there is nothing to observe
+    changing; that lands with the routing branch itself.
+    """
+
+    kwargs = _minimal_orchestrator_kwargs()
+    default = DevOrchestrator(**kwargs)
+    assert default._graph_investigation_query is None
+
+    with_query = DevOrchestrator(
+        **kwargs, graph_investigation_query=FakeGraphInvestigationQuery()
+    )
+    assert isinstance(
+        with_query._graph_investigation_query, FakeGraphInvestigationQuery
+    )

--- a/tests/context_fabric/test_chaos_3678_query_service.py
+++ b/tests/context_fabric/test_chaos_3678_query_service.py
@@ -1,0 +1,435 @@
+"""CHAOS-3678: the production bounded graph query service.
+
+Two halves, matching the module's own documented scope:
+
+* :func:`mechanism_for` — the fixed ``(intent_id, cardinality) ->
+  mechanism`` table (CHAOS-3660's accepted job/shape determination).
+* ``ProductionGraphInvestigationQuery.investigate`` — the transport/outcome
+  mapping, tested against fake stores injected via ``store_factory`` (no
+  live backend needed for DISABLED/UNAVAILABLE/STALE/DEADLINE_EXCEEDED/
+  CANCELLED/PROVIDER_FAILURE) plus one live positive control.
+
+The ``COMPLETED`` path is not implemented in this increment (see the module
+docstring) and is not tested here — every currently-SUPPORTED mechanism is
+asserted to reach ``PROVIDER_FAILURE`` with a diagnostic naming the pending
+dependency, which is the honest, current behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import Cardinality, QuestionIntentID
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+)
+from dev_health_ops.context_fabric.graph_arm.query_service import (
+    GraphMechanism,
+    ProductionGraphInvestigationQuery,
+    mechanism_for,
+)
+from dev_health_ops.context_fabric.graph_arm.store import (
+    GraphArmStore,
+    StoreUnavailableError,
+)
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+from tests.context_fabric import live_gate
+
+#: A fixed reference instant for constructing WATERMARK values only -- always
+#: comfortably in the past relative to the real clock, so "N days before
+#: this" reliably reads as stale. Deadlines must never be computed from this:
+#: `investigate()` compares them against the REAL `datetime.now(UTC)`, so a
+#: deadline offset from a fixed historical instant is a deadline already in
+#: the past on any test run -- see `_soon()`.
+_NOW = datetime(2026, 8, 9, 12, tzinfo=UTC)
+
+
+def _soon() -> datetime:
+    """A deadline comfortably in the future relative to the real clock."""
+
+    return datetime.now(UTC) + timedelta(seconds=30)
+
+
+def _fresh_watermark() -> IndexWatermark:
+    """A watermark current as of the real clock -- not `_NOW`, which is a
+    fixed historical instant for staleness tests only."""
+
+    return IndexWatermark(indexed_through=datetime.now(UTC), records_indexed=1)
+
+
+def _request(
+    *,
+    intent_id: QuestionIntentID = QuestionIntentID.PROJECT_HEALTH,
+    cardinality: Cardinality = Cardinality.SINGULAR,
+    deadline: datetime | None = None,
+    org_id: str = "org_query_service_test",
+) -> GraphInvestigationRequest:
+    return GraphInvestigationRequest(
+        org_id=org_id,
+        run_id="run_test",
+        intent_id=intent_id,
+        cardinality=cardinality,
+        mentions=(),
+        question_text="What is the status of the Nightfall Migration project?",
+        authorized_entity_ids=frozenset({"proj_nightfall_migration"}),
+        deadline=deadline or _soon(),
+    )
+
+
+class TestMechanismFor:
+    def test_discovered_cohort_selects_subjectless_cohort_discovery(self) -> None:
+        assert (
+            mechanism_for(
+                QuestionIntentID.DISCOVERED_COHORT, Cardinality.ORGANIZATION_WIDE
+            )
+            is GraphMechanism.SUBJECTLESS_COHORT_DISCOVERY
+        )
+
+    @pytest.mark.parametrize(
+        "intent_id",
+        [
+            QuestionIntentID.ENTITY_STATUS,
+            QuestionIntentID.PROJECT_HEALTH,
+            QuestionIntentID.TEAM_HEALTH,
+            QuestionIntentID.REMAINING_WORK,
+        ],
+    )
+    def test_singular_cardinality_selects_seeded_singular_subject(
+        self, intent_id: QuestionIntentID
+    ) -> None:
+        assert (
+            mechanism_for(intent_id, Cardinality.SINGULAR)
+            is GraphMechanism.SEEDED_SINGULAR_SUBJECT
+        )
+
+    def test_plural_cohort_cardinality_selects_seeded_explicit_cohort(self) -> None:
+        assert (
+            mechanism_for(QuestionIntentID.METRIC_COMPARISON, Cardinality.PLURAL_COHORT)
+            is GraphMechanism.SEEDED_EXPLICIT_COHORT
+        )
+
+    def test_organization_wide_with_a_non_cohort_intent_is_unsupported(self) -> None:
+        """The organization-wide sweep this arm must never construct.
+
+        ``ORGANIZATION_WIDE`` cardinality paired with any intent other than
+        ``DISCOVERED_COHORT`` is the shape handoff §4 forbids
+        ("unresolved named subjects never widen to organization scope") --
+        this table returns UNSUPPORTED rather than a mechanism, so
+        ``investigate`` never attempts it.
+        """
+
+        assert (
+            mechanism_for(
+                QuestionIntentID.PORTFOLIO_STATUS, Cardinality.ORGANIZATION_WIDE
+            )
+            is GraphMechanism.UNSUPPORTED
+        )
+
+    def test_the_table_is_fixed_not_content_derived(self) -> None:
+        """Same (intent_id, cardinality) -> same mechanism, always.
+
+        Not a meaningful assertion about randomness -- there is none -- but
+        a structural pin that the function takes exactly two arguments and
+        nothing resembling question text, which is easy to check by calling
+        it and impossible to check by reading the return type alone.
+        """
+
+        import inspect
+
+        params = list(inspect.signature(mechanism_for).parameters)
+        assert params == ["intent_id", "cardinality"]
+
+
+@dataclass
+class _FakeStore:
+    """Stands in for ``GraphArmStore`` at exactly the two methods
+    ``investigate`` calls: ``read_watermark`` and ``close``.
+    """
+
+    watermark: IndexWatermark | None = None
+    watermark_error: Exception | None = None
+    hang_seconds: float | None = None
+    closed: bool = False
+    close_calls: int = field(default=0)
+
+    async def read_watermark(self) -> IndexWatermark:
+        if self.hang_seconds is not None:
+            await asyncio.sleep(self.hang_seconds)
+        if self.watermark_error is not None:
+            raise self.watermark_error
+        assert self.watermark is not None
+        return self.watermark
+
+    async def close(self) -> None:
+        self.closed = True
+        self.close_calls += 1
+
+
+def _factory(store: _FakeStore):
+    def _build(_org_id: str) -> _FakeStore:
+        return store
+
+    return _build
+
+
+def _query(store: _FakeStore) -> ProductionGraphInvestigationQuery:
+    return ProductionGraphInvestigationQuery(store_factory=_factory(store))
+
+
+class TestDisabled:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_disabled_when_the_read_flag_is_off(self) -> None:
+        service = _query(_FakeStore())
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.DISABLED
+        assert result.packet is None
+
+    async def test_disabled_never_constructs_a_store(self, monkeypatch) -> None:
+        """The read flag is checked before the store factory is ever called."""
+
+        calls: list[str] = []
+
+        def _factory_records(org_id: str) -> _FakeStore:
+            calls.append(org_id)
+            return _FakeStore()
+
+        service = ProductionGraphInvestigationQuery(store_factory=_factory_records)
+        await service.investigate(_request())
+        assert calls == []
+
+
+class TestUnavailable:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_store_construction_failure_is_unavailable(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+
+        def _raising_factory(_org_id: str):
+            raise StoreUnavailableError("no trial graph store is configured")
+
+        service = ProductionGraphInvestigationQuery(store_factory=_raising_factory)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+        assert result.packet is None
+
+    async def test_a_watermark_read_failure_is_unavailable(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark_error=StoreUnavailableError("transport failure"))
+        service = _query(store)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+        assert store.closed is True
+
+    async def test_a_never_projected_partition_is_unavailable(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=IndexWatermark(indexed_through=None))
+        service = _query(store)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+
+
+class TestStale:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_watermark_beyond_tolerance_is_stale(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(
+            watermark=IndexWatermark(
+                indexed_through=_NOW - timedelta(days=2), records_indexed=5
+            )
+        )
+        service = _query(store)
+        result = await service.investigate(_request(deadline=_soon()))
+        assert result.outcome is GraphQueryOutcome.STALE
+        assert result.packet is None
+
+    async def test_a_partial_watermark_is_stale_even_if_recent(
+        self, monkeypatch
+    ) -> None:
+        """Mirrors ``IndexWatermark.freshness_for``'s own rule directly."""
+
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(
+            watermark=IndexWatermark(
+                indexed_through=_NOW, records_indexed=5, partial=True
+            )
+        )
+        service = _query(store)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.STALE
+
+
+class TestDeadlineExceeded:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_deadline_already_past_never_touches_the_store(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        calls: list[str] = []
+
+        def _factory_records(org_id: str) -> _FakeStore:
+            calls.append(org_id)
+            return _FakeStore()
+
+        service = ProductionGraphInvestigationQuery(store_factory=_factory_records)
+        past_deadline = _NOW - timedelta(seconds=1)
+        result = await service.investigate(_request(deadline=past_deadline))
+        assert result.outcome is GraphQueryOutcome.DEADLINE_EXCEEDED
+        assert calls == [], "a caller that waited too long must not pay for a store"
+
+    async def test_a_hung_watermark_read_exceeds_the_deadline(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(hang_seconds=999.0)
+        service = _query(store)
+        near_deadline = datetime.now(UTC) + timedelta(milliseconds=50)
+        result = await service.investigate(_request(deadline=near_deadline))
+        assert result.outcome is GraphQueryOutcome.DEADLINE_EXCEEDED
+        assert store.closed is True, "the store is still closed on a deadline timeout"
+
+
+class TestCancelled:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_cancellation_during_the_watermark_read_is_reported_not_raised(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(hang_seconds=999.0)
+        service = _query(store)
+
+        task = asyncio.ensure_future(service.investigate(_request(deadline=_soon())))
+        await asyncio.sleep(0)  # let investigate() reach the hung await
+        task.cancel()
+        result = await task
+        assert result.outcome is GraphQueryOutcome.CANCELLED
+        assert store.closed is True
+
+
+class TestUnsupportedMechanism:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_an_unsupported_mechanism_is_provider_failure_not_a_crash(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=_fresh_watermark())
+        service = _query(store)
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.PORTFOLIO_STATUS,
+                cardinality=Cardinality.ORGANIZATION_WIDE,
+            )
+        )
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.diagnostic is not None
+        assert "no graph mechanism" in result.diagnostic
+
+
+class TestSupportedMechanismIsNotYetImplemented:
+    pytestmark = pytest.mark.asyncio
+
+    """Increment 1's honest boundary: selected, not yet executed."""
+
+    async def test_a_supported_mechanism_reaches_provider_failure_with_a_named_reason(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=_fresh_watermark())
+        service = _query(store)
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.PROJECT_HEALTH,
+                cardinality=Cardinality.SINGULAR,
+            )
+        )
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.packet is None
+        assert result.diagnostic is not None
+        assert "seeded_singular_subject" in result.diagnostic
+        assert "CHAOS-3660" in result.diagnostic
+
+
+class TestDiagnosticsAreContentSafe:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_no_diagnostic_carries_the_question_text(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        planted = "TOTALLY-SECRET-QUESTION-TEXT-MARKER"
+        store = _FakeStore(watermark=IndexWatermark(indexed_through=None))
+        service = _query(store)
+        request = GraphInvestigationRequest(
+            org_id="org_content_safety",
+            run_id="run_content_safety",
+            intent_id=QuestionIntentID.PROJECT_HEALTH,
+            cardinality=Cardinality.SINGULAR,
+            mentions=(),
+            question_text=planted,
+            authorized_entity_ids=frozenset(),
+            deadline=_soon(),
+        )
+        result = await service.investigate(request)
+        assert result.diagnostic is not None
+        assert planted not in result.diagnostic
+
+
+class TestStoreIsAlwaysClosed:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_the_store_is_closed_after_a_provider_failure(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=_fresh_watermark())
+        service = _query(store)
+        await service.investigate(_request())
+        assert store.close_calls == 1
+
+    async def test_the_store_is_never_closed_when_never_constructed(self) -> None:
+        """DISABLED short-circuits before any store exists to close."""
+
+        calls: list[str] = []
+
+        def _factory_records(org_id: str) -> _FakeStore:
+            calls.append(org_id)
+            return _FakeStore(watermark=_fresh_watermark())
+
+        service = ProductionGraphInvestigationQuery(store_factory=_factory_records)
+        await service.investigate(_request())
+        assert calls == []
+
+
+class TestLivePositiveControl:
+    pytestmark = pytest.mark.asyncio
+
+    """Against the real live store: proves the wiring, not just the fakes."""
+
+    @pytest.mark.graphiti
+    async def test_disabled_against_a_real_store_factory(self, monkeypatch) -> None:
+        live_gate.require_live_store()
+        monkeypatch.delenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", raising=False)
+        service = ProductionGraphInvestigationQuery(store_factory=GraphArmStore.for_org)
+        result = await service.investigate(_request(org_id="org_live_query_service"))
+        assert result.outcome is GraphQueryOutcome.DISABLED
+
+    @pytest.mark.graphiti
+    async def test_never_projected_against_a_real_store(self, monkeypatch) -> None:
+        live_gate.require_live_store()
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        service = ProductionGraphInvestigationQuery(store_factory=GraphArmStore.for_org)
+        result = await service.investigate(
+            _request(org_id="org_live_query_service_fresh")
+        )
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -1239,13 +1239,14 @@ class TestGetFeaturesForTier:
         enterprise = get_features_for_tier(LicenseTier.ENTERPRISE)
         assert set(community.keys()) == set(team.keys()) == set(enterprise.keys())
 
-    def test_returns_32_features_including_explicit_purchase_ones(self):
+    def test_returns_33_features_including_explicit_purchase_ones(self):
         features = get_features_for_tier(LicenseTier.COMMUNITY)
-        assert len(features) == 32
+        assert len(features) == 33
         # Explicit-purchase features stay denied for every tier until an
         # organization or license override grants them.
         assert features["ask_dev_contextual_entrypoints"] is False
         assert features["ask_dev_wave_3_1"] is False
+        assert features["ask_dev_graph_routing"] is False
 
     def test_sign_license_uses_canonical_registry(self):
         """sign_license() with no explicit features uses get_features_for_tier."""


### PR DESCRIPTION
## Issue and phase

[CHAOS-3678](https://linear.app/fullchaos/issue/CHAOS-3678/implement-graphinvestigationquery-the-production-bounded-graph-query) — Phase 1, Lane A (production graph platform), child of [CHAOS-3500](https://linear.app/fullchaos/issue/CHAOS-3500/phase-1-platform-production-graph-projection-lifecycle-and-bounded) under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660/phase-1-wire-the-production-shaped-graph-assisted-ask-dev-path).

**⚠️ Stacked on Lane B's not-yet-merged [#1641](https://github.com/full-chaos/dev-health-ops/pull/1641)** (`chaos-3677-graph-investigation-seam`, `api/dev/graph_investigation_query.py` — the `GraphInvestigationQuery` Protocol this PR implements). This diff will include #1641's changes until it merges, then shrink to just this PR's 2 files. Do not merge before #1641.

## Observable outcome

`ProductionGraphInvestigationQuery` implements Lane B's `GraphInvestigationQuery` Protocol. This increment delivers the full transport/outcome mapping — `DISABLED`, `UNAVAILABLE`, `STALE`, `DEADLINE_EXCEEDED`, `CANCELLED` are all real, live-tested outcomes — plus the `(intent_id, cardinality) → mechanism` selection table. The `COMPLETED` path (actual investigation execution + packet assembly) is explicitly not implemented yet; every currently-supported mechanism returns `PROVIDER_FAILURE` with a diagnostic naming the pending dependency.

## Architecture boundary

New module (`context_fabric/graph_arm/query_service.py`), in Lane A's exclusive-ownership area. Imports Lane B's Protocol/request/result types read-only. Depends on `GraphArmStore` only through a new minimal `_WatermarkStore` Protocol (mirrors `projector.ProjectingStore`), not the concrete class.

## Scope / non-scope

**In scope:** the outcome-mapping boundary (flag check → absolute-deadline check → bounded store construction/watermark read → freshness check → mechanism selection), composing CHAOS-3631's `GraphDeadlines` with the request's own absolute deadline via `asyncio.wait_for`, and CHAOS-3679's persisted watermark for staleness.

**Explicitly out of scope, named rather than silently absent:** candidate resolution, graph traversal, driver synthesis, packet assembly. These depend on [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660/phase-1-wire-the-production-shaped-graph-assisted-ask-dev-path)'s approved packet-constructor ruling (`build_production_packet` in `packet_builder.py`, not yet landed) and are increment 2+.

**Job/shape classification stays production's**, per the accepted CHAOS-3660 determination: `mechanism_for(intent_id, cardinality)` is a fixed, total table — it never inspects `question_text`. Pinned by `test_the_table_is_fixed_not_content_derived`, which asserts the function's signature carries only those two parameters.

## Base/head SHA and branch provenance

`chaos-3678-query-service`, stacked on `chaos-3677-graph-investigation-seam` (#1641), which is itself based on `origin/feature/chaos-3498-context-fabric` @ `d9c019010` (current tip at push time — includes merged CHAOS-3631/#1636, CHAOS-3676/#1642, CHAOS-3679/#1646). One commit ahead of #1641's tip.

## Migrations / configuration / feature flags

None. Reuses `CONTEXT_FABRIC_GRAPH_READ_ENABLED` (existing flag). No new env var.

## Security / privacy / retention impact

None new. `_diagnostic()` builds every diagnostic from a fixed template + operation name + a value this module chose (exception type name, a fixed phrase) — never `str(exc)`, never `request.question_text`, never entity data. Tested directly with a planted marker string in `question_text`.

## RED-first evidence

New module + new test module — 25 tests, all would fail with `ModuleNotFoundError`/`AttributeError` against any prior tree (the module didn't exist).

## Focused and broad verification

Live store `falkor://127.0.0.1:6389`, `CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1`.

```
.venv/bin/pytest tests/context_fabric/test_chaos_3678_query_service.py -q
  → 25 passed

.venv/bin/pytest tests/context_fabric/ tests/api/dev/ -q
  → 4519 passed, 74 skipped, 4 xfailed, 2 failed

.venv/bin/ruff check / format --check, .venv/bin/mypy
  → All checks passed! / already formatted / Success: no issues found
```

**Both failures are pre-existing and unrelated** (`test_chaos_3647_live_semantic.py`, Lane D's CHAOS-3647 territory) — the same two failures independently confirmed unrelated on the prior three PRs in this lane's stack (#1636, #1642, #1646); this PR touches neither semantic retrieval nor authorization probes.

A real test bug was found and fixed during my own verification: several tests computed request deadlines as an offset from a fixed historical timestamp (used for watermark construction) rather than the real clock, which made every such deadline already-past by the time `investigate()` compared it against `datetime.now(UTC)`. Caught immediately by the tests themselves failing with the wrong `GraphQueryOutcome` (`DEADLINE_EXCEEDED` instead of the case under test) — fixed by adding a `_soon()`/`_fresh_watermark()` helper pair that anchor to the real clock, keeping `_NOW` (the fixed historical instant) for staleness-test watermarks only.

## Known limitations and follow-up issues

- `COMPLETED` path: tracked as CHAOS-3678 increment 2+, blocked on the packet-constructor refactor (approved on CHAOS-3660, implementation starting next).
- No environment-variable override for `staleness_tolerance` yet — deliberately: no real caller exists yet to need one tuned differently from `DEFAULT_STALENESS_TOLERANCE`.

## Rollout / rollback impact

Pure addition, zero behavior change to any existing code path. Not wired into any production routing yet (that's Lane B's CHAOS-3502, calling this once it exists on trunk). Rollback is a plain revert.