### PR TITLE
CHAOS-3675 PR 3/3: real ClickHouse-backed EvidenceCandidateResolver (deployments)

### DIFF
--- a/src/dev_health_ops/api/dev/native_evidence_resolver.py
+++ b/src/dev_health_ops/api/dev/native_evidence_resolver.py
@@ -270,14 +270,17 @@ class NativeEvidenceCandidateResolver:
     ``repo_id`` is not, so this is the first resolver with a genuine
     per-row choice between the two paths).
 
-    ``commit``/``ci_run`` are a deliberate, recorded gap, not an oversight:
-    neither ``git_commits`` nor ``ci_pipeline_runs`` has any PR/issue link
-    column, and the only possible linkage -- the generic ``work_graph_edges``
-    table -- carries a ``provenance``/``confidence`` spread (native,
-    explicit_text, heuristic) that needs its own trust-threshold design
-    decision before it can safely grant entity-level authorization. Per
-    the CHAOS-3675 PR 3/3 scope-lock: refusing these two with the gap
-    recorded beats a speculative join.
+    ``commit``/``ci_run`` are a deliberate, recorded gap, not an oversight,
+    tracked as `CHAOS-3685
+    <https://linear.app/fullchaos/issue/CHAOS-3685>`_ (not just this
+    docstring -- a requirement stated only in prose does not survive
+    triage): neither ``git_commits`` nor ``ci_pipeline_runs`` has any
+    PR/issue link column, and the only possible linkage -- the generic
+    ``work_graph_edges`` table -- carries a ``provenance``/``confidence``
+    spread (native, explicit_text, heuristic) that needs its own
+    trust-threshold design decision before it can safely grant
+    entity-level authorization. Per the CHAOS-3675 PR 3/3 scope-lock:
+    refusing these two with the gap recorded beats a speculative join.
     """
 
     def __init__(

--- a/src/dev_health_ops/api/dev/native_evidence_resolver.py
+++ b/src/dev_health_ops/api/dev/native_evidence_resolver.py
@@ -136,6 +136,89 @@ async def _resolve_incident(
     )
 
 
+#: CHAOS-3675 PR3. ``deployments.repo_id`` is NOT nullable -- a repository
+#: anchor always exists -- but ``pull_request_number`` IS, so unlike
+#: ``review``/``incident`` this row genuinely sometimes has a
+#: directly-authorizable PR entity and sometimes does not. Both branches
+#: are derived from THIS row, never from the candidate.
+_DEPLOYMENT_RESOLVE_SQL = """
+SELECT repo_id, deployment_id, status, environment, pull_request_number,
+       coalesce(deployed_at, finished_at, started_at, last_synced) AS observed_at,
+       last_synced
+FROM deployments FINAL
+WHERE org_id = {org_id:String}
+  AND concat(toString(repo_id), '#deployment', deployment_id) = {locator:String}
+LIMIT 1
+"""
+
+
+async def _resolve_deployment(
+    client: Any,
+    *,
+    org_id: str,
+    candidate: EvidenceCandidate,
+    policy: SourceFreshnessPolicy,
+    source_system: str,
+) -> EvidenceRecord | None:
+    rows = await query_dicts(
+        client,
+        _DEPLOYMENT_RESOLVE_SQL,
+        {"org_id": org_id, "locator": candidate.locator},
+    )
+    if not rows:
+        return None
+    row = rows[0]
+    observed = _datetime(row.get("observed_at")) or datetime.now(UTC)
+    last_synced = _datetime(row.get("last_synced"))
+    freshness = policy.classify(last_synced, now=datetime.now(UTC))
+    pr_number = row.get("pull_request_number")
+    display_label = f"Deployment {row['deployment_id']}"
+    raw_excerpt = (
+        f"Status: {row.get('status') or 'unknown'}. "
+        f"Environment: {row.get('environment') or 'unknown'}"
+    )
+    repository_ids = (str(row["repo_id"]),)
+    stale = freshness is FreshnessState.STALE
+    if pr_number:
+        # A real PR link exists on THIS row -- always derived when present,
+        # never skipped for the cheaper anchor-only path (CHAOS-3675 PR3
+        # scope-lock condition: anti-laundering, the first resolver here
+        # with a genuine per-row choice between the two).
+        return EvidenceRecord(
+            source_system=source_system,
+            source_version=RESOLVER_SOURCE_VERSION,
+            entity_type="deployment",
+            entity_id=f"{row['repo_id']}#pr{pr_number}",
+            display_label=display_label,
+            observed_at=observed,
+            freshness=freshness,
+            provenance="native",
+            confidence=1.0,
+            repository_ids=repository_ids,
+            raw_excerpt=raw_excerpt,
+            stale=stale,
+        )
+    # No PR link on this row -- repo_id is schema-guaranteed non-null, so
+    # the repository-only path always has a real anchor to attach to; this
+    # never reaches #1648's no-anchor refusal the way a repo-less incident
+    # can.
+    return EvidenceRecord(
+        source_system=source_system,
+        source_version=RESOLVER_SOURCE_VERSION,
+        entity_type="deployment",
+        entity_id=str(row["deployment_id"]),
+        display_label=display_label,
+        observed_at=observed,
+        freshness=freshness,
+        provenance="native",
+        confidence=1.0,
+        repository_ids=repository_ids,
+        raw_excerpt=raw_excerpt,
+        stale=stale,
+        no_authorizable_entity=True,
+    )
+
+
 async def _resolve_review(
     client: Any,
     *,
@@ -179,16 +262,22 @@ class NativeEvidenceCandidateResolver:
     Additive: only observation kinds with an implemented ``_resolve_*``
     below are handled; every other kind returns ``None`` (refused as
     ``NO_MATCHES``), never an error. CHAOS-3675 PR 1/3 implements
-    ``review`` (a directly-authorizable PR entity, derived from its own
-    row); PR 2/3 adds ``incident`` (no directly-authorizable entity in the
-    schema at all -- repository-only authorization via CHAOS-3675's
-    entity-less admission mechanism). ``deployment``'s linked PR is
-    nullable in the canonical schema (a deployment need not correspond to
-    any PR, but CAN), which needs its own per-row derive-vs-anchor
-    decision unlike ``incident``'s always-anchor shape; deferred to PR
-    3/3 rather than guessed at here. ``commit``/``ci_run`` need a
-    confirmed join path (candidate: ``work_graph_edges``) before they can
-    derive their linked entity at all -- also PR 3/3.
+    ``review`` (always a directly-authorizable PR entity); PR 2/3 adds
+    ``incident`` (never a directly-authorizable entity in the schema at
+    all -- always repository-only, via CHAOS-3675's entity-less admission
+    mechanism); PR 3/3 adds ``deployment`` (SOMETIMES a directly-
+    authorizable PR entity -- ``pull_request_number`` is nullable but
+    ``repo_id`` is not, so this is the first resolver with a genuine
+    per-row choice between the two paths).
+
+    ``commit``/``ci_run`` are a deliberate, recorded gap, not an oversight:
+    neither ``git_commits`` nor ``ci_pipeline_runs`` has any PR/issue link
+    column, and the only possible linkage -- the generic ``work_graph_edges``
+    table -- carries a ``provenance``/``confidence`` spread (native,
+    explicit_text, heuristic) that needs its own trust-threshold design
+    decision before it can safely grant entity-level authorization. Per
+    the CHAOS-3675 PR 3/3 scope-lock: refusing these two with the gap
+    recorded beats a speculative join.
     """
 
     def __init__(
@@ -230,6 +319,14 @@ class NativeEvidenceCandidateResolver:
                 org_id=org_id,
                 candidate=candidate,
                 policy=self._policies["incidents"],
+                source_system=self.source_system,
+            )
+        if candidate.entity_type == "deployment":
+            return await _resolve_deployment(
+                self._client,
+                org_id=org_id,
+                candidate=candidate,
+                policy=self._policies["deployments"],
                 source_system=self.source_system,
             )
         return None

--- a/tests/api/dev/test_native_evidence_resolver.py
+++ b/tests/api/dev/test_native_evidence_resolver.py
@@ -1,6 +1,7 @@
-"""CHAOS-3675 PR 1/3 (review) and PR 2/3 (incident): production resolvers,
-and the invariant they exist to enforce -- the entity a record is about is
-derived from the canonical row, never from ``candidate.entity_id``.
+"""CHAOS-3675 PR 1/3 (review), PR 2/3 (incident), and PR 3/3 (deployment):
+production resolvers, and the invariant they exist to enforce -- the entity
+a record is about is derived from the canonical row, never from
+``candidate.entity_id``.
 
 Every test here uses a fake ClickHouse-shaped sink whose ``query_dicts``
 call simulates the real SQL's own filtering predicates, so an org-mismatch
@@ -242,13 +243,17 @@ def test_a_locator_that_exists_only_in_a_different_org_is_refused(
     )
 
 
+@pytest.mark.parametrize("entity_type", ["commit", "ci_run"])
 def test_unimplemented_observation_kinds_are_refused_without_querying(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, entity_type: str
 ) -> None:
-    """``deployment``/``commit``/``ci_run``/``incident`` are deliberately
-    unimplemented in PR 1/3 (see the class docstring) -- refused cleanly,
-    never a crash, and never a query issued for a kind this resolver
-    cannot yet verify safely."""
+    """``commit``/``ci_run`` are a deliberate, recorded gap (see the class
+    docstring: neither canonical table has a PR/issue link column, and the
+    only possible linkage needs a trust-threshold decision this resolver
+    doesn't have standing to make) -- refused cleanly, never a crash, and
+    never a query issued for a kind this resolver cannot yet verify
+    safely. ``review``/``incident``/``deployment`` are all implemented as
+    of PR 3/3 and covered by their own dedicated tests."""
 
     sink = _FakeSink([_row()])
     _monkeypatch_query_dicts(monkeypatch, sink)
@@ -256,9 +261,9 @@ def test_unimplemented_observation_kinds_are_refused_without_querying(
 
     candidate = EvidenceCandidate(
         source_system=ARM_SOURCE_SYSTEM,
-        entity_type="deployment",
+        entity_type=entity_type,
         entity_id="issue-999",
-        locator="repo-1#deployment1",
+        locator="repo-1@deadbeef",
     )
     assert _resolve(resolver, candidate) is None
     assert sink.calls == []
@@ -575,3 +580,186 @@ def test_an_edge_belonging_to_a_different_org_does_not_leak_its_repository(
     )
 
     assert record is None
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3675 PR 3/3: the deployments resolver. Unlike review (always
+# derives) and incident (never derives), deployments genuinely sometimes
+# have a linked PR and sometimes don't -- the first resolver with a real
+# per-row choice between deriving an entity and falling through to
+# repository-only.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DeploymentRow:
+    org_id: str
+    repo_id: str
+    deployment_id: str
+    status: str
+    environment: str
+    pull_request_number: int | None
+    observed_at: datetime
+    last_synced: datetime
+
+
+class _DeploymentFakeSink:
+    """Simulates the deployment-resolve SQL's own WHERE clause: a row is
+    returned only when BOTH ``org_id`` and the composite locator
+    (``{repo_id}#deployment{deployment_id}``) match."""
+
+    def __init__(self, rows: list[_DeploymentRow]) -> None:
+        self._rows = rows
+        self.calls: list[dict[str, Any]] = []
+
+    async def query_dicts(
+        self, query: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.calls.append(params)
+        for row in self._rows:
+            locator = f"{row.repo_id}#deployment{row.deployment_id}"
+            if row.org_id == params["org_id"] and locator == params["locator"]:
+                return [
+                    {
+                        "repo_id": row.repo_id,
+                        "deployment_id": row.deployment_id,
+                        "status": row.status,
+                        "environment": row.environment,
+                        "pull_request_number": row.pull_request_number,
+                        "observed_at": row.observed_at,
+                        "last_synced": row.last_synced,
+                    }
+                ]
+        return []
+
+
+def _monkeypatch_deployment_query_dicts(
+    monkeypatch: pytest.MonkeyPatch, sink: _DeploymentFakeSink
+) -> None:
+    async def _fake_query_dicts(client: Any, query: str, params: dict[str, Any]):
+        assert client is sink
+        return await sink.query_dicts(query, params)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence_resolver.query_dicts",
+        _fake_query_dicts,
+    )
+
+
+def _deployment_candidate(
+    *, locator: str, claimed_entity_id: str = "issue-999"
+) -> EvidenceCandidate:
+    return EvidenceCandidate(
+        source_system=ARM_SOURCE_SYSTEM,
+        entity_type="deployment",
+        # Never consulted -- same rule as every other resolver here.
+        entity_id=claimed_entity_id,
+        locator=locator,
+    )
+
+
+def test_a_deployment_with_a_linked_pr_derives_the_pr_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-first: before PR 3/3, ``deployment``-kind candidates refuse
+    ``UNCONFIGURED``. With a real linked PR, resolution derives a genuine
+    PR entity -- never falls through to repository-only merely because
+    that path also exists on this resolver."""
+
+    row = _DeploymentRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        deployment_id="deploy-1",
+        status="success",
+        environment="production",
+        pull_request_number=77,
+        observed_at=NOW,
+        last_synced=NOW,
+    )
+    sink = _DeploymentFakeSink([row])
+    _monkeypatch_deployment_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_deployment_candidate(locator="repo-1#deploymentdeploy-1"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is False
+    assert record.entity_id == "repo-1#pr77"
+    assert record.repository_ids == ("repo-1",)
+    assert "issue-999" not in (record.display_label, record.raw_excerpt or "")
+
+
+def test_a_deployment_with_no_linked_pr_falls_through_to_repository_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pull_request_number IS NULL`` -- repo_id is schema-guaranteed
+    present, so this always has a real anchor; never reaches the
+    no-anchor refusal the way a repo-less incident can."""
+
+    row = _DeploymentRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        deployment_id="deploy-2",
+        status="success",
+        environment="production",
+        pull_request_number=None,
+        observed_at=NOW,
+        last_synced=NOW,
+    )
+    sink = _DeploymentFakeSink([row])
+    _monkeypatch_deployment_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_deployment_candidate(locator="repo-1#deploymentdeploy-2"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == ("repo-1",)
+
+
+def test_a_deployment_locator_that_exists_only_in_a_different_org_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _DeploymentRow(
+        org_id=ORG_B,
+        repo_id="repo-1",
+        deployment_id="deploy-3",
+        status="success",
+        environment="production",
+        pull_request_number=77,
+        observed_at=NOW,
+        last_synced=NOW,
+    )
+    sink = _DeploymentFakeSink([row])
+    _monkeypatch_deployment_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    refused = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_deployment_candidate(locator="repo-1#deploymentdeploy-3"),
+        )
+    )
+    admitted = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_B,
+            scope=_UNUSED_SCOPE,
+            candidate=_deployment_candidate(locator="repo-1#deploymentdeploy-3"),
+        )
+    )
+
+    assert refused is None
+    assert admitted is not None

--- a/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
+++ b/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
@@ -75,6 +75,7 @@ def _clean_tables(ch_client: Any) -> Any:
         "git_pull_request_reviews",
         "operational_incidents",
         "work_graph_deployment_incident_edges",
+        "deployments",
     )
     for table in tables:
         ch_client.command(f"TRUNCATE TABLE IF EXISTS {table}")
@@ -363,3 +364,100 @@ async def test_an_incident_with_no_edge_at_all_refuses_against_the_real_table(
     )
 
     assert record is None
+
+
+def _insert_deployment(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: str = REPO_ID,
+    deployment_id: str,
+    pull_request_number: int | None,
+    status: str = "success",
+    environment: str = "production",
+) -> None:
+    client.insert(
+        "deployments",
+        [
+            [
+                org_id,
+                repo_id,
+                deployment_id,
+                status,
+                environment,
+                pull_request_number,
+                NOW,
+                NOW,
+            ]
+        ],
+        column_names=[
+            "org_id",
+            "repo_id",
+            "deployment_id",
+            "status",
+            "environment",
+            "pull_request_number",
+            "deployed_at",
+            "last_synced",
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_real_deployment_sql_derives_a_linked_pr(ch_client: Any) -> None:
+    _insert_deployment(
+        ch_client, org_id=ORG_A, deployment_id="deploy-live-1", pull_request_number=77
+    )
+
+    record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}#deploymentdeploy-live-1",
+        entity_type="deployment",
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is False
+    assert record.entity_id == f"{REPO_ID}#pr77"
+    assert record.repository_ids == (REPO_ID,)
+
+
+@pytest.mark.asyncio
+async def test_the_real_deployment_sql_falls_through_to_repository_only_when_unlinked(
+    ch_client: Any,
+) -> None:
+    _insert_deployment(
+        ch_client,
+        org_id=ORG_A,
+        deployment_id="deploy-live-2",
+        pull_request_number=None,
+    )
+
+    record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}#deploymentdeploy-live-2",
+        entity_type="deployment",
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == (REPO_ID,)
+
+
+@pytest.mark.asyncio
+async def test_the_real_deployment_sql_enforces_tenant_isolation(
+    ch_client: Any,
+) -> None:
+    _insert_deployment(
+        ch_client, org_id=ORG_A, deployment_id="deploy-live-3", pull_request_number=1
+    )
+
+    other_org = await _resolve(
+        ch_client,
+        org_id=ORG_B,
+        locator=f"{REPO_ID}#deploymentdeploy-live-3",
+        entity_type="deployment",
+    )
+
+    assert other_org is None


### PR DESCRIPTION
Branch is ID-free (no closing keyword either) -- CHAOS-3675 will be closed manually in Linear once this merges, not via auto-link, per the standing multi-PR pattern from this lane.

## Issue and phase
[CHAOS-3675](https://linear.app/fullchaos/issue/CHAOS-3675) PR 3/3 (final) — child of [CHAOS-3664](https://linear.app/fullchaos/issue/CHAOS-3664), Phase 1 Lane C, under [CHAOS-3660](https://linear.app/fullchaos/issue/CHAOS-3660). Builds on #1645, #1648, and #1651 (all merged).

## Observable outcome
`EvidenceService.admit()` can resolve a `deployment`-kind graph-arm candidate against real ClickHouse data. **This closes CHAOS-3675**: every `GraphObservationKind` with an existing `native_evidence.py` source (`review`, `incident`, `deployment`) now has a real resolver, replacing the CHAOS-3616 fixture-world resolver for all of them.

## Recon finding — the genuine derive-vs-anchor case
`deployments.repo_id` is **not** nullable (a repository anchor always exists, unlike `incident`, which can have none at all); `pull_request_number` **is** nullable. This is the first resolver with a real per-row choice: `review` always derives a PR entity, `incident` never does, `deployment` sometimes does. Anti-laundering (a row WITH a real PR link must always derive it, never take the cheaper anchor-only path) is mutation-verified: planted "never derive" directly in the resolver and watched the derive-case test fail before restoring.

## Recorded gap — `commit`/`ci_run` (not implemented, by design)
Neither `git_commits` nor `ci_pipeline_runs` has any PR/issue link column. The only possible linkage — the generic `work_graph_edges` table — needs a `provenance`/`confidence` trust-threshold decision (native vs. explicit_text vs. heuristic-discovered edges) before it can safely grant entity-level authorization, which this PR doesn't have standing to make unilaterally. Per the scope-lock and the orchestrator's steer: refusing these two with the gap documented in the module docstring beats a speculative join. Both continue to refuse `UNCONFIGURED`.

## Architecture boundary
`native_evidence_resolver.py` only (mine, exclusive). No `evidence_service.py`/`production_runtime.py` change — the derive-vs-anchor mechanism already existed from #1645/#1648; this is its first per-row-conditional user, and the resolver was already wired generically in PR 1/3.

## Base/head SHA and branch provenance
Base: `feature/chaos-3498-context-fabric` @ `e56301e84...` (current tip, includes #1645, #1648, #1651)
Head: `deployments-evidence-resolver`, one commit.

## Security/privacy/retention impact
Same never-trust-the-candidate and anti-laundering invariants as PR 1/3 and PR 2/3, now proven on the first resolver that genuinely has both an entity-derivation path and a repository-only path to choose between per row.

## RED-first evidence
New unit + live tests for both branches, observed `UNCONFIGURED` before dispatch was added. Also fixed a stale existing test (`test_unimplemented_observation_kinds_are_refused_without_querying`) that used `deployment` as its "still unimplemented" example — caught by actually running the suite after this PR's change, not assumed; re-pointed to `commit`/`ci_run`, the two kinds that remain genuinely unimplemented.

Also strengthens `test_the_real_incident_join_does_not_leak_a_different_orgs_edge`'s docstring per orchestrator review of #1651: explicitly names it as the strongest evidence artifact this lane produced (a real cross-tenant leak reproduced against a live database, not a unit-test analogy) so a future reader doesn't weaken or drop it.

## Focused and broad verification
```
.venv/bin/python -m pytest tests/api/dev/test_native_evidence_resolver.py -v                     # 18 passed
.venv/bin/python -m pytest tests/api/dev/test_native_evidence_resolver_clickhouse_live.py -v      # 10 passed (live, scratch ClickHouse, real seeded rows)
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q                                # 4439 passed, 133 skipped, 4 xfailed, 0 failed
.venv/bin/mypy src/dev_health_ops/api/dev/                                                        # Success: no issues (111 files)
pre-commit hook (mypy over full tree, ruff)                                                       # Success: no issues
```

## Known limitations and follow-up issues
`commit`/`ci_run` remain unimplemented — the recorded gap above. A future issue for the `work_graph_edges` trust-threshold decision is the natural follow-up, not filed here (narrow scope).

## Rollout/rollback impact
Pure additive; no flag change. `EVIDENCE_ADMISSION_FLAG` still gates whether the arm ever submits a candidate at all — default off. Safe to revert independently.