### PR TITLE
CHAOS-3666: conversation-context resolution for pronouns and prior-turn references

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
@@ -70,6 +70,7 @@ nobody has measured.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -83,6 +84,7 @@ from .backend import (
     MatchMechanism,
     graphiti_module,
 )
+from .discovery import CandidateMatch
 from .readback import _entities_by_canonical_id
 from .vocabulary import GraphEntityKind
 
@@ -94,6 +96,7 @@ __all__ = [
     "DEFAULT_MARGIN_RATIO",
     "DEFAULT_SEMANTIC_LIMIT",
     "DEFAULT_TIE_RATIO",
+    "ConversationalReferenceResult",
     "CrossPartitionRetrievalError",
     "FulltextIndexNotReadyError",
     "FulltextReadiness",
@@ -105,6 +108,7 @@ __all__ = [
     "SemanticRetrieval",
     "NonSemanticEmbedderError",
     "assess_disposition",
+    "resolve_conversational_reference",
     "retrieve_candidates",
     "wait_for_fulltext_index",
 ]
@@ -812,3 +816,230 @@ def _canonical_ids(nodes: Any) -> list[str]:
         if isinstance(canonical_id, str) and canonical_id:
             ids.append(canonical_id)
     return ids
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3666: conversation-context resolution for pronouns and prior-turn
+# references
+# ---------------------------------------------------------------------------
+
+#: The words a query built entirely from a conversational reference is made
+#: of: pronouns, demonstratives, and generic entity-KIND nouns that name a
+#: category without naming anything specific ("project", "team"). Closed and
+#: ordinary English vocabulary -- not tuned to any corpus's phrasing, and
+#: deliberately conservative: "the auth work" or "the payments project"
+#: still contains identifying content once these are stripped, and must
+#: fall through to exact/alias/fuzzy resolution rather than this leg.
+_DEICTIC_TOKENS = frozenset(
+    {
+        "it",
+        "its",
+        "that",
+        "this",
+        "them",
+        "those",
+        "these",
+        "one",
+        "ones",
+        "other",
+        "another",
+        "same",
+        "thing",
+        "things",
+        "project",
+        "team",
+    }
+)
+
+#: Question scaffolding stripped before checking whether what remains is
+#: purely deictic. Also closed, also ordinary vocabulary.
+_QUESTION_SCAFFOLD = frozenset(
+    {
+        "what",
+        "whats",
+        "why",
+        "how",
+        "when",
+        "where",
+        "who",
+        "is",
+        "are",
+        "was",
+        "were",
+        "did",
+        "does",
+        "do",
+        "the",
+        "a",
+        "an",
+        "of",
+        "with",
+        "about",
+        "on",
+        "up",
+        "s",
+        "status",
+        "state",
+        "happening",
+        "happened",
+        "happen",
+        "still",
+        "yet",
+        "going",
+        "doing",
+    }
+)
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+
+def _is_pure_conversational_reference(query: str) -> bool:
+    """Whether ``query`` names nothing but refers to something already
+    established in conversation.
+
+    Deliberately narrow: every token that survives stripping
+    :data:`_QUESTION_SCAFFOLD` must be in :data:`_DEICTIC_TOKENS`, or this
+    refuses. "What's holding it up?" leaves ``holding`` behind and is
+    refused here — CHAOS-3654's disposition policy is what handles a bare
+    pronoun with no referent at all; this function's job is the narrower
+    one of recognising a query that is confidently ONLY a reference, so a
+    single unambiguous prior subject may be proposed for it.
+    """
+
+    tokens = _WORD.findall(query.casefold())
+    residual = [token for token in tokens if token not in _QUESTION_SCAFFOLD]
+    return bool(residual) and all(token in _DEICTIC_TOKENS for token in residual)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationalReferenceResult:
+    """Whether a bare conversational reference resolved, and why (not).
+
+    ``candidate`` is ``None`` on every refusal path. This leg proposes at
+    most one subject and never a list: the whole point of a PURE pronoun
+    query is that it carries no content of its own to rank candidates by,
+    so an ambiguous prior context is a refusal here, not a clarification
+    with options — a caller wanting clarification candidates has the
+    semantic leg's own :func:`assess_disposition` for that.
+    """
+
+    candidate: CandidateMatch | None
+    reason: str
+
+
+async def resolve_conversational_reference(
+    query: str,
+    *,
+    store: RetrievalStore,
+    prior_subject_ids: Sequence[str],
+    authorized_entity_ids: Sequence[str] | frozenset[str],
+) -> ConversationalReferenceResult:
+    """Resolve a bare pronoun/deictic query to the prior turn's subject.
+
+    **What this is not.** Not retrieval, not embedding similarity, not a
+    read of conversation TEXT: ``prior_subject_ids`` is an explicit,
+    already-resolved list of canonical ids a caller (the conversation-state
+    owner, upstream of this arm) supplies. This function's only jobs are
+    (1) deciding whether ``query`` is confidently a bare reference and
+    nothing else, and (2) checking that exactly one authorized, currently-
+    real subject is available to resolve it to. Both are deterministic;
+    neither reads a vector.
+
+    **Why the signal is still gated as semantic.** The emitted candidate
+    carries :attr:`SubjectMatchSignal.CONVERSATIONAL_REFERENCE`, which
+    ``packet_builder._INHERENTLY_SEMANTIC_SIGNALS`` refuses under a
+    non-semantic embedder regardless of the mechanism that produced it.
+    That policy is honoured here rather than routed around: a pronoun
+    resolved with no corroborating content is exactly the kind of claim
+    this arm's Phase 2A safety posture reserves for a run that can actually
+    support a semantic capability, deterministic mechanism or not.
+
+    **Authorization is rechecked against the current grant, never trusted
+    from the prior turn.** A subject that was authorized last turn and is
+    not authorized now (a revoked grant, a organisation-scope change) must
+    not be resolved silently forward.
+
+    **Existence is reread from the store, never trusted from the caller.**
+    ``prior_subject_ids`` names what conversation state remembers; whether
+    that entity still exists, under what kind and label, is asked of the
+    store fresh — a deleted or renamed entity must not be resolved as if
+    nothing changed.
+    """
+
+    if not _is_pure_conversational_reference(query):
+        return ConversationalReferenceResult(
+            candidate=None,
+            reason=(
+                "the query carries content beyond a bare pronoun/deictic "
+                "reference; this leg only resolves a query that is "
+                "confidently nothing else"
+            ),
+        )
+
+    authorized = frozenset(authorized_entity_ids)
+    # De-duplicated, order-preserving, then authorization-filtered -- same
+    # posture as every other candidate set in this module: withheld before
+    # ranking, never silently absorbed into "no prior subject".
+    candidates = [
+        subject_id
+        for subject_id in dict.fromkeys(prior_subject_ids)
+        if subject_id in authorized
+    ]
+    if not prior_subject_ids:
+        return ConversationalReferenceResult(
+            candidate=None,
+            reason="no prior-turn subject is available to refer to",
+        )
+    if not candidates:
+        return ConversationalReferenceResult(
+            candidate=None,
+            reason=(
+                "every prior-turn subject is outside this caller's "
+                "currently authorized scope"
+            ),
+        )
+    if len(candidates) > 1:
+        return ConversationalReferenceResult(
+            candidate=None,
+            reason=(
+                f"{len(candidates)} prior-turn subjects are authorized and "
+                "equally plausible; a bare reference cannot choose between "
+                "them"
+            ),
+        )
+
+    subject_id = candidates[0]
+    rows = await _entities_by_canonical_id(store.driver, store.partition, (subject_id,))
+    if not rows:
+        return ConversationalReferenceResult(
+            candidate=None,
+            reason=(
+                "the prior-turn subject no longer exists in this "
+                "partition (deleted, revoked, or never real)"
+            ),
+        )
+    row = rows[0]
+    if row.kind is GraphEntityKind.ORGANIZATION:
+        return ConversationalReferenceResult(
+            candidate=None,
+            reason=(
+                "the prior-turn subject is the organization; the "
+                "organization is never a conversational referent"
+            ),
+        )
+    return ConversationalReferenceResult(
+        candidate=CandidateMatch(
+            canonical_id=row.canonical_id,
+            kind=row.kind,
+            display_label=row.display_label,
+            signal=SubjectMatchSignal.CONVERSATIONAL_REFERENCE,
+            # A deterministic lookup by an explicit prior-turn id -- not a
+            # fuzzy or embedding match. The SIGNAL is what carries the
+            # semantic-capability gate (see the module docstring above);
+            # the mechanism stays honest about what actually happened.
+            mechanism=MatchMechanism.EXACT_LOOKUP,
+            matched_text=row.display_label,
+            source_class=row.source_class,
+        ),
+        reason="resolved to the prior turn's single authorized, current subject",
+    )

--- a/tests/context_fabric/test_chaos_3666_conversational_reference.py
+++ b/tests/context_fabric/test_chaos_3666_conversational_reference.py
@@ -1,0 +1,234 @@
+"""CHAOS-3666: conversation-context resolution for pronouns and prior-turn
+references.
+
+``resolve_conversational_reference`` is a deliberately narrow capability:
+given a query that is confidently NOTHING but a bare pronoun/deictic
+reference, and an explicit, caller-supplied list of prior-turn subject
+ids, resolve to that subject if -- and only if -- exactly one is
+authorized and currently real. It reads no vector and no conversation
+text; "which subject the prior turn resolved to" is an input this arm is
+handed, not something it infers.
+
+Every test here plants the specific shape its guard exists to catch: a
+query that WOULD be wrongly resolved, or wrongly refused, unless the
+function under test is what decides it correctly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+from dev_health_ops.context_fabric.graph_arm.backend import MatchMechanism
+from dev_health_ops.context_fabric.graph_arm.readback import EntityLookupRow
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    resolve_conversational_reference,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+pytestmark = pytest.mark.asyncio
+
+_PARTITION = "cf_trial_org_test"
+
+
+@dataclass(frozen=True)
+class _FakeStore:
+    driver: Any
+    partition: str
+    embedder: Any = None
+
+
+def _install_lookup(monkeypatch: pytest.MonkeyPatch, rows: tuple[EntityLookupRow, ...]):
+    calls: dict[str, Any] = {}
+
+    async def fake_lookup(driver, partition, canonical_ids):
+        calls["partition"] = partition
+        calls["canonical_ids"] = tuple(canonical_ids)
+        return tuple(row for row in rows if row.canonical_id in canonical_ids)
+
+    import dev_health_ops.context_fabric.graph_arm.semantic_retrieval as module
+
+    monkeypatch.setattr(module, "_entities_by_canonical_id", fake_lookup)
+    return calls
+
+
+_ROW = EntityLookupRow(
+    canonical_id="proj_vertex",
+    kind=GraphEntityKind.PROJECT,
+    display_label="Vertex Platform",
+    source_class=SourceClass.WORK_GRAPH,
+)
+
+
+class TestPureReferencesResolve:
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "what about it",
+            "how is that doing",
+            "what's the status of the other project",
+            "what happened with that one",
+            "is it still going",
+        ],
+    )
+    async def test_a_bare_reference_resolves_to_the_single_prior_subject(
+        self, monkeypatch: pytest.MonkeyPatch, query: str
+    ) -> None:
+        _install_lookup(monkeypatch, (_ROW,))
+        result = await resolve_conversational_reference(
+            query,
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=("proj_vertex",),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+        assert result.candidate is not None
+        assert result.candidate.canonical_id == "proj_vertex"
+        assert result.candidate.signal is SubjectMatchSignal.CONVERSATIONAL_REFERENCE
+        assert result.candidate.mechanism is MatchMechanism.EXACT_LOOKUP
+
+
+class TestContentBearingQueriesAreRefused:
+    """The control: a query with real content must never resolve here,
+    even with a perfectly good prior subject sitting available."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "what's holding it up",  # CHAOS-3654's own measured case
+            "why is the auth work still failing",
+            "how is Halcyon doing",
+            "what is the payments rewrite status",
+        ],
+    )
+    async def test_a_content_bearing_query_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, query: str
+    ) -> None:
+        calls = _install_lookup(monkeypatch, (_ROW,))
+        result = await resolve_conversational_reference(
+            query,
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=("proj_vertex",),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+        assert result.candidate is None
+        assert "canonical_ids" not in calls, (
+            "a content-bearing query must not even reach the entity lookup"
+        )
+
+
+class TestNoPriorSubjectRefusesSafely:
+    async def test_an_empty_prior_subject_list_refuses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_lookup(monkeypatch, ())
+        result = await resolve_conversational_reference(
+            "what about it",
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=(),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+        assert result.candidate is None
+        assert "no prior-turn subject" in result.reason
+
+
+class TestAuthorizationIsRecheckedNotTrusted:
+    async def test_an_unauthorized_prior_subject_does_not_resolve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A grant that changed between turns must not be papered over."""
+
+        calls = _install_lookup(monkeypatch, (_ROW,))
+        result = await resolve_conversational_reference(
+            "what about it",
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=("proj_vertex",),
+            authorized_entity_ids=frozenset(),
+        )
+        assert result.candidate is None
+        assert "canonical_ids" not in calls, (
+            "an unauthorized prior subject must never reach the lookup"
+        )
+
+
+class TestMultiplePriorSubjectsRefuseRatherThanGuess:
+    async def test_two_authorized_prior_subjects_refuse(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_lookup(
+            monkeypatch,
+            (
+                _ROW,
+                EntityLookupRow(
+                    canonical_id="proj_beacon",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Beacon",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+        result = await resolve_conversational_reference(
+            "what about it",
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=("proj_vertex", "proj_beacon"),
+            authorized_entity_ids=frozenset({"proj_vertex", "proj_beacon"}),
+        )
+        assert result.candidate is None
+        assert "equally plausible" in result.reason
+
+    async def test_a_duplicated_prior_subject_is_not_treated_as_two(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The same subject named twice (e.g. two turns in a row) must
+        still resolve -- de-duplication, not accidental ambiguity."""
+
+        _install_lookup(monkeypatch, (_ROW,))
+        result = await resolve_conversational_reference(
+            "what about it",
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=("proj_vertex", "proj_vertex"),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+        assert result.candidate is not None
+        assert result.candidate.canonical_id == "proj_vertex"
+
+
+class TestExistenceIsRereadNotTrusted:
+    async def test_a_deleted_prior_subject_refuses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_lookup(monkeypatch, ())
+        result = await resolve_conversational_reference(
+            "what about it",
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=("proj_vertex",),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+        assert result.candidate is None
+        assert "no longer exists" in result.reason
+
+    async def test_the_organization_is_never_a_referent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_lookup(
+            monkeypatch,
+            (
+                EntityLookupRow(
+                    canonical_id="org_helio",
+                    kind=GraphEntityKind.ORGANIZATION,
+                    display_label="Helio",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+        result = await resolve_conversational_reference(
+            "what about it",
+            store=_FakeStore(object(), _PARTITION),
+            prior_subject_ids=("org_helio",),
+            authorized_entity_ids=frozenset({"org_helio"}),
+        )
+        assert result.candidate is None
+        assert "organization" in result.reason


### PR DESCRIPTION
## Issue and phase
CHAOS-3666 (Phase 2A), partial. Child of CHAOS-3661 — Wave 3.2, Lane D. This PR covers the conversation-context resolution half of the ticket only; see below for the other half's status.

## Observable outcome
New `semantic_retrieval.resolve_conversational_reference(query, *, store, prior_subject_ids, authorized_entity_ids)`. Not retrieval, not embedding similarity, not a read of conversation text — `prior_subject_ids` is an explicit, already-resolved list the caller supplies. This function decides (1) whether the query is confidently a bare pronoun/deictic reference and nothing else, and (2) whether exactly one authorized, currently-real subject is available to resolve it to.

## Architecture boundary
- Detection is a closed-vocabulary token-residual check (question scaffolding stripped, everything left must be deictic/generic-kind) — deterministic, no vector involved. "What's holding it up?" (CHAOS-3654's own measured case) correctly does NOT match — the two legs are complementary, not overlapping.
- Authorization is rechecked against the CURRENT grant, never trusted from the prior turn.
- Existence is reread from the store fresh via the merged CHAOS-3653 `_entities_by_canonical_id` lookup.
- More than one authorized prior subject refuses rather than guessing — governing rule: propose or refuse, never force.
- Emits `SubjectMatchSignal.CONVERSATIONAL_REFERENCE` / `MatchMechanism.EXACT_LOOKUP` (honest about the deterministic mechanism); `packet_builder._INHERENTLY_SEMANTIC_SIGNALS` still gates this signal behind a semantic embedder regardless of mechanism, and this PR honors that existing policy rather than routing around it.

## Scope / non-scope
`semantic_retrieval.py` only (mine, exclusive). **Not yet wired to a caller** — same status as CHAOS-3654/3653 at their PRs. `AnalyticalJob.conversation_reference_ids` already exists on the wire contract and is hardcoded to `()` at packet emission (`packet_builder.py:1991`); wiring it through to a real conversation-state source is Lane B's interpreter/routing territory, out of this PR.

**CHAOS-3632 (approved-text indexing surface) is explicitly NOT in this PR.** Traced the real gap: `backend.py` never writes `GraphProjection.approved_documents` into the graph at all (zero producers), and fixing it needs a `records.py` extension (trust/evidence-state fields) plus a new `backend.py` writer — Lane A's exclusive file. Full technical proposal posted on CHAOS-3660 per the integration protocol, including the finding that consumption is *already* mostly built (the merged CHAOS-3653 hop will pick up document-derived nodes for free if the writer follows the existing `cf_subject_canonical_ids` convention). Not self-authoring that part here.

## Base/head
Base: `origin/feature/chaos-3498-context-fabric` @ `828e2d5b2` (current tip). Head: `chaos-3666-conversational-reference`.

## Migrations / configuration / feature flags
None.

## Security / privacy / retention impact
None new. Authorization and existence are both rechecked fresh against the current grant/store rather than trusted from a caller-supplied prior turn.

## RED-first evidence
`git stash` of the source change with the test file present reproduced `ImportError`; GREEN after.

## Verification
- New `tests/context_fabric/test_chaos_3666_conversational_reference.py` (15 tests)
- `.venv/bin/python -m pytest tests/context_fabric/ -q` → 1449 passed, 52 skipped
- `.venv/bin/python -m pytest tests/api/dev/ -q` → 2996 passed, 74 skipped, 4 xfailed
- ruff / mypy (module + full-project lefthook gate) → clean

## Known limitations and follow-up issues
- Not wired to a caller (needs Lane B's conversation-state tracking).
- CHAOS-3632's approved-text indexing surface remains open, proposal posted on CHAOS-3660, waiting on a contract-owner decision + Lane A's `backend.py` writer.

## Rollout / rollback impact
Purely additive; new function, no existing behavior touched. Zero runtime effect until a caller adopts it.