### PR TITLE
CHAOS-3687: build the graph-assisted routing branch (CHAOS-3660 sign-off)

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -17,7 +17,7 @@ import time
 from collections import Counter
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, Protocol
 
 import annotated_types
@@ -42,6 +42,7 @@ from dev_health_ops.llm.agent.errors import (
 )
 from dev_health_ops.llm.budget import budget_idempotency_scope
 from dev_health_ops.metrics.prometheus import (
+    ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL,
     ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL,
     ASK_DEV_PLAN_REGISTRY_GAP_TOTAL,
     ASK_DEV_QUA_COMMIT_TOTAL,
@@ -105,7 +106,11 @@ from .contracts_v2.narrative import DevNarrative
 from .contracts_v2.plan import DevInvestigationPlan
 from .contracts_v2.subject import DevEntityRefV2
 from .evidence_service import EvidenceService
-from .graph_investigation_query import GraphInvestigationQuery
+from .graph_investigation_query import (
+    GraphInvestigationQuery,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+)
 from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
 from .investigation_shadow import (
@@ -128,6 +133,7 @@ from .no_match_terminal import (
 from .orchestrator_states import TERMINAL_STATES, RunState
 from .org_policy import ASK_DEV_RUN_COST_HARD_MAX_MICROUSD
 from .preflight_outcomes import (
+    GRAPH_ROUTED_QUESTION_INTENTS,
     LEGACY_ONLY_QUESTION_INTENTS,
     TERMINAL_STATE_BY_OUTCOME,
     project_preflight_error,
@@ -2707,6 +2713,11 @@ class DevOrchestrator:
                 if (
                     plan is None
                     and intent.intent_id not in LEGACY_ONLY_QUESTION_INTENTS
+                    # CHAOS-3502: also silent for DISCOVERED_COHORT -- it is
+                    # equally accounted for, just routed to the graph-assisted
+                    # seam below rather than the legacy loop. See
+                    # GRAPH_ROUTED_QUESTION_INTENTS's own docstring.
+                    and intent.intent_id not in GRAPH_ROUTED_QUESTION_INTENTS
                 ):
                     logger.warning(
                         "ask_dev.orchestrator.plan_registry_gap",
@@ -2797,6 +2808,92 @@ class DevOrchestrator:
                             ref.display_label
                             for ref in portfolio_subject_set.committed_entity_refs
                         )
+
+            # CHAOS-3502 (routing-branch design, signed off on CHAOS-3660):
+            # the graph-assisted seam. A sibling of the plan-governed block
+            # above, not nested inside it -- DISCOVERED_COHORT never has a
+            # plan (plan_eligible is always False for it by construction,
+            # since PLAN_ID_BY_INTENT gives it a compat-only token,
+            # CHAOS-3652), so gating this on self._plan_executor being
+            # wired would tie graph routing to an unrelated collaborator.
+            # Both organization opt-in (self._evidence_service/
+            # self._graph_investigation_query only get constructed when the
+            # org feature is on, production_runtime.py's job) and the
+            # runtime kill switch are required -- independent gates, same
+            # shape as every other flag pair in this file.
+            if (
+                preflight_result is not None
+                and preflight_result.interpretation.intent.intent_id
+                is QuestionIntentID.DISCOVERED_COHORT
+                and self._graph_investigation_query is not None
+                and self._evidence_service is not None
+                and graph_routing_runtime_enabled()
+            ):
+                graph_deadline = datetime.now(UTC) + timedelta(
+                    seconds=max(0.0, remaining())
+                )
+                graph_request = GraphInvestigationRequest(
+                    org_id=org_id,
+                    run_id=run_id,
+                    intent_id=preflight_result.interpretation.intent.intent_id,
+                    cardinality=preflight_result.interpretation.intent.cardinality,
+                    mentions=preflight_result.interpretation.mentions,
+                    question_text=request.question,
+                    # CHAOS-3502 known limitation, not silently assumed: no
+                    # code anywhere in this codebase yet derives "every
+                    # entity this principal may see in this org" --
+                    # graph_arm.readback.derive_authorized_entity_ids raises
+                    # AuthorizationDerivationNotImplementedError for the
+                    # identical reason. Empty is the SAFE default here (the
+                    # graph route refuses everything rather than
+                    # over-authorizing), not yet a USEFUL one -- real
+                    # derivation is separate, explicit follow-up work, not
+                    # guessed at in this seam.
+                    authorized_entity_ids=frozenset(),
+                    deadline=graph_deadline,
+                )
+                graph_result = await self._graph_investigation_query.investigate(
+                    graph_request
+                )
+                # Content-safe observability (beta gate 10): the label is
+                # the closed GraphQueryOutcome vocabulary, never question or
+                # entity text, so both the counter and the log are safe to
+                # ship as-is.
+                ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL.labels(
+                    outcome=graph_result.outcome.value
+                ).inc()
+                logger.info(
+                    "ask_dev.orchestrator.graph_routing_outcome",
+                    extra={"run_id": run_id, "outcome": graph_result.outcome.value},
+                )
+                if graph_result.outcome is GraphQueryOutcome.CANCELLED:
+                    # The RUN is cancelled, not just this one call -- unlike
+                    # every other outcome below, this does not fall through
+                    # to the legacy loop (see the CHAOS-3660 fallback table).
+                    return await finish(
+                        RunState.CANCELLED,
+                        error=error("cancelled", "The request was cancelled."),
+                    )
+                if graph_result.outcome is GraphQueryOutcome.COMPLETED:
+                    # CHAOS-3502: assembly (candidate extraction -> canonical
+                    # admission -> _graph_grounded_answer) is not yet wired
+                    # here -- it depends on Lane A's packet refactor and
+                    # Lane C's canonical enrichment type, both still pending
+                    # on CHAOS-3660 as of this landing. The graph result is
+                    # never silently discarded: the outcome counter/log
+                    # above already recorded a real COMPLETED call, distinct
+                    # from every failure/unavailable reason below.
+                    logger.info(
+                        "ask_dev.orchestrator.graph_routing_completed_assembly_deferred",
+                        extra={"run_id": run_id},
+                    )
+                # Every other outcome -- DISABLED, UNAVAILABLE, STALE,
+                # PROVIDER_FAILURE, DEADLINE_EXCEEDED, and
+                # COMPLETED-with-assembly-deferred immediately above -- falls
+                # through to the legacy loop below. Per the Wave 3.2 handoff
+                # §4: graph outage, lag, or unavailability must never break
+                # existing Ask Dev behavior, and this question's legacy
+                # answer is a real, already-working path, not a regression.
 
             for round_index in range(self._limits.model_rounds):
                 del round_index

--- a/src/dev_health_ops/api/dev/preflight_outcomes.py
+++ b/src/dev_health_ops/api/dev/preflight_outcomes.py
@@ -50,6 +50,7 @@ from .question_interpreter import INTERPRETER_VERSION
 
 __all__ = [
     "CLARIFICATION_COPY",
+    "GRAPH_ROUTED_QUESTION_INTENTS",
     "LEGACY_ONLY_QUESTION_INTENTS",
     "NOT_FOUND_CLOSE_MATCHES_KEY",
     "PLAN_ID_BY_INTENT",
@@ -120,6 +121,24 @@ if _unregistered:
 #: is a deliberate, reviewed edit here, never implicit.
 LEGACY_ONLY_QUESTION_INTENTS: frozenset[QuestionIntentID] = frozenset(
     {QuestionIntentID.BOUNDED_INVESTIGATION}
+)
+
+#: CHAOS-3502: intents that are correctly, permanently never plan-governed
+#: for the SAME structural reason as ``LEGACY_ONLY_QUESTION_INTENTS`` above
+#: (their ``PLAN_ID_BY_INTENT`` entry is a compat-only token, no
+#: ``DevInvestigationPlan`` exists or should exist for them) -- but that do
+#: NOT fall through to the legacy loop, because ``orchestrator.run()`` routes
+#: them to the graph-assisted seam instead (CHAOS-3660 routing-branch design,
+#: signed off). Kept as a THIRD, distinct set rather than folded into
+#: ``LEGACY_ONLY_QUESTION_INTENTS`` -- that set's own name and docstring both
+#: assert "falling through to the legacy loop is the intended behavior",
+#: which stops being true the moment a real destination exists. An intent in
+#: this set still logs no ``plan_registry_gap`` (checked in the same
+#: ``not in`` condition as the legacy set at the ``orchestrator.py`` call
+#: site), because it is equally accounted for -- just accounted for
+#: elsewhere.
+GRAPH_ROUTED_QUESTION_INTENTS: frozenset[QuestionIntentID] = frozenset(
+    {QuestionIntentID.DISCOVERED_COHORT}
 )
 
 #: Per-mention resolution outcome to the public v2 outcome. ``EXACT_MATCH`` is

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -87,7 +87,6 @@ from .contracts import (
     DevStatusFact,
     DevToolRequest,
     DevToolResult,
-    DirectScope,
     FreshnessState,
     ToolID,
 )
@@ -130,12 +129,10 @@ from .scope_catalog import ClickHouseAuthorizedEntityCatalog
 from .scope_service import (
     MODEL_SEARCHABLE_ENTITY_KINDS,
     EntityKind,
-    ScopeRef,
     ScopeRequestCache,
     ScopeResolutionService,
-    ScopeResolveRequest,
     ScopeSearchRequest,
-    TimeRangeRequest,
+    scope_request_from_scope,
 )
 from .status_change_service import (
     ChangeSummaryRequest,
@@ -1118,42 +1115,6 @@ def _provider(candidate: AgentProviderCandidate) -> AgentLLMProvider:
     )
 
 
-def _scope_request(scope: DevScope) -> ScopeResolveRequest:
-    refs: tuple[ScopeRef, ...]
-    if scope.direct_scope is DirectScope.ORGANIZATION:
-        refs = (ScopeRef(EntityKind.ORGANIZATION, scope.organization_id),)
-    elif scope.direct_scope is DirectScope.REPOSITORY:
-        refs = tuple(
-            ScopeRef(EntityKind.REPOSITORY, value) for value in scope.repositories
-        )
-    else:
-        refs = tuple(
-            ScopeRef(EntityKind(item.entity_type.value), item.entity_id)
-            for item in scope.entity_refs
-        )
-    return ScopeResolveRequest(
-        explicit_refs=refs,
-        # A team *direct* scope already carries its team as an explicit_ref
-        # (via the entity_refs branch above); team_ids there is required by
-        # DevScope.validate_direct_scope to name that same team, not a second
-        # independent dimension. Also passing it as a team_filter_ref would
-        # make `resolve()` treat the run as team-*filtered* (outcome=FILTERED)
-        # rather than an exact single-entity commit (CHAOS-3301).
-        team_filter_refs=(
-            ()
-            if scope.direct_scope is DirectScope.TEAM
-            else tuple(ScopeRef(EntityKind.TEAM, value) for value in scope.team_ids)
-        ),
-        time_range=TimeRangeRequest(
-            preset_days=None,
-            start_date=date.fromisoformat(scope.time_range.start.date().isoformat()),
-            end_date=date.fromisoformat(scope.time_range.end.date().isoformat()),
-            timezone=scope.time_range.timezone,
-        ),
-        allow_organization_fallback=False,
-    )
-
-
 async def _resolve_exact_contract(
     service: ScopeResolutionService,
     *,
@@ -1162,7 +1123,7 @@ async def _resolve_exact_contract(
     requested_scope: DevScope,
 ) -> DevScopeResolution:
     resolution = await service.resolve_contract(
-        org_id, permission_fingerprint, _scope_request(requested_scope)
+        org_id, permission_fingerprint, scope_request_from_scope(requested_scope)
     )
     if resolution.resolved_scope is None:
         return resolution.model_copy(update={"requested_scope": requested_scope})
@@ -1522,7 +1483,7 @@ class _ProductionPlanExecutorRuntime:
             org_id=org_id,
             permission_fingerprint=permission_fingerprint,
             request=WorkGraphNeighborsRequest(
-                scope_request=_scope_request(scope),
+                scope_request=scope_request_from_scope(scope),
                 root_refs=roots,
                 relationship_types=tuple(sorted(ALLOWED_RELATIONSHIP_TYPES)),
                 direction=GraphDirection.BOTH,
@@ -1534,7 +1495,7 @@ class _ProductionPlanExecutorRuntime:
         return await self.data_health_service.inspect(
             org_id=org_id,
             permission_fingerprint=permission_fingerprint,
-            scope_request=_scope_request(scope),
+            scope_request=scope_request_from_scope(scope),
             required_sources=NATIVE_EVIDENCE_SOURCES,
         )
 
@@ -2298,7 +2259,7 @@ async def _assemble_production_runtime(
             org_id=org_id,
             permission_fingerprint=context.permission_fingerprint,
             request=WorkGraphNeighborsRequest(
-                scope_request=_scope_request(request.scope),
+                scope_request=scope_request_from_scope(request.scope),
                 root_refs=roots,
                 relationship_types=tuple(sorted(ALLOWED_RELATIONSHIP_TYPES)),
                 direction=GraphDirection.BOTH,
@@ -2353,7 +2314,7 @@ async def _assemble_production_runtime(
         result = await evidence_service.search(
             org_id=org_id,
             permission_fingerprint=context.permission_fingerprint,
-            scope_request=_scope_request(request.scope),
+            scope_request=scope_request_from_scope(request.scope),
             query=request.query or "",
             limit=request.limit,
         )
@@ -2385,7 +2346,7 @@ async def _assemble_production_runtime(
         result = await evidence_service.expand(
             org_id=org_id,
             permission_fingerprint=context.permission_fingerprint,
-            scope_request=_scope_request(request.scope),
+            scope_request=scope_request_from_scope(request.scope),
             evidence=known,
         )
         facts = [
@@ -2411,7 +2372,7 @@ async def _assemble_production_runtime(
         result = await data_health_service.inspect(
             org_id=org_id,
             permission_fingerprint=context.permission_fingerprint,
-            scope_request=_scope_request(request.scope),
+            scope_request=scope_request_from_scope(request.scope),
             required_sources=NATIVE_EVIDENCE_SOURCES,
         )
         items = [
@@ -2657,7 +2618,7 @@ async def expand_production_evidence(
     return await service.expand(
         org_id=org_id,
         permission_fingerprint=permission_fingerprint,
-        scope_request=_scope_request(scope),
+        scope_request=scope_request_from_scope(scope),
         evidence=evidence,
     )
 

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -279,6 +279,55 @@ class ScopeResolveRequest:
                 raise ValueError("Surface context IDs must contain 1 to 128 characters")
 
 
+def scope_request_from_scope(scope: DevScope) -> ScopeResolveRequest:
+    """Derive a :class:`ScopeResolveRequest` from a client-supplied ``DevScope``.
+
+    CHAOS-3502: promoted from ``production_runtime._scope_request`` (a
+    behavior-preserving move, not a rewrite -- every existing call site there
+    now imports this instead of a private copy) so ``orchestrator.py`` can
+    build the same request shape ``EvidenceService.admit()`` needs without a
+    circular import: ``production_runtime.py`` already imports from
+    ``orchestrator.py`` (the DI/wiring layer depends on the orchestrator, not
+    the reverse), so the orchestrator can never import from
+    ``production_runtime``. ``scope_service.py`` -- where ``ScopeResolveRequest``
+    itself is already defined -- is the shared leaf both sides can import.
+    """
+
+    refs: tuple[ScopeRef, ...]
+    if scope.direct_scope is DirectScope.ORGANIZATION:
+        refs = (ScopeRef(EntityKind.ORGANIZATION, scope.organization_id),)
+    elif scope.direct_scope is DirectScope.REPOSITORY:
+        refs = tuple(
+            ScopeRef(EntityKind.REPOSITORY, value) for value in scope.repositories
+        )
+    else:
+        refs = tuple(
+            ScopeRef(EntityKind(item.entity_type.value), item.entity_id)
+            for item in scope.entity_refs
+        )
+    return ScopeResolveRequest(
+        explicit_refs=refs,
+        # A team *direct* scope already carries its team as an explicit_ref
+        # (via the entity_refs branch above); team_ids there is required by
+        # DevScope.validate_direct_scope to name that same team, not a second
+        # independent dimension. Also passing it as a team_filter_ref would
+        # make `resolve()` treat the run as team-*filtered* (outcome=FILTERED)
+        # rather than an exact single-entity commit (CHAOS-3301).
+        team_filter_refs=(
+            ()
+            if scope.direct_scope is DirectScope.TEAM
+            else tuple(ScopeRef(EntityKind.TEAM, value) for value in scope.team_ids)
+        ),
+        time_range=TimeRangeRequest(
+            preset_days=None,
+            start_date=date.fromisoformat(scope.time_range.start.date().isoformat()),
+            end_date=date.fromisoformat(scope.time_range.end.date().isoformat()),
+            timezone=scope.time_range.timezone,
+        ),
+        allow_organization_fallback=False,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ScopeSearchRequest:
     query: str

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -213,6 +213,16 @@ if _PROMETHEUS_AVAILABLE:
         ["intent"],
     )
 
+    ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_ask_dev_graph_routing_outcome_total",
+        "DISCOVERED_COHORT Ask Dev requests routed through the graph-assisted "
+        "seam, by GraphQueryOutcome (CHAOS-3502, beta gate 10 observability "
+        "hook). Every value other than 'completed' falls back to the legacy "
+        "model-tool-choice loop -- content-safe: the label is the closed "
+        "GraphQueryOutcome vocabulary, never question or entity text.",
+        ["outcome"],
+    )
+
     ASK_DEV_NARRATIVE_FALLBACK_TOTAL = _prometheus_client_module.Counter(
         "devhealth_ask_dev_narrative_fallback_total",
         "Ask Dev narrative provider calls that fell back to the deterministic "
@@ -337,6 +347,7 @@ else:
     ASK_DEV_UNHANDLED_RUN_FAULT_TOTAL = _noop_counter()
     ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL = _noop_counter()
     ASK_DEV_PLAN_REGISTRY_GAP_TOTAL = _noop_counter()
+    ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL = _noop_counter()
     ASK_DEV_NARRATIVE_FALLBACK_TOTAL = _noop_counter()
     ASK_DEV_QUA_SHADOW_TOTAL = _noop_counter()
     ASK_DEV_QUA_COMMIT_TOTAL = _noop_counter()

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -602,6 +602,8 @@ async def run_preflight_orchestrator(
     qua_shadow: Any = None,
     investigation_shadow: Any = None,
     investigation_packet_producer: Any = None,
+    graph_investigation_query: Any = None,
+    evidence_service: Any = None,
 ) -> RunOutput:
     """One full orchestrator run with the preflight wired the way production wires it.
 
@@ -623,6 +625,14 @@ async def run_preflight_orchestrator(
     ``PersistenceRunRecorder`` against a seeded database and assert on the
     actual rows a live run leaves behind, not a fake recorder's captured
     call list.
+
+    ``graph_investigation_query``/``evidence_service`` default to ``None``
+    (flag-off, same as production when the org feature is off) --
+    CHAOS-3502's routing-branch suite passes a real
+    ``FakeGraphInvestigationQuery`` plus a minimal ``EvidenceService`` here
+    so a genuine ``DISCOVERED_COHORT`` ``preflight_result`` (only the real
+    interpreter/preflight pipeline produces one) drives the actual routing
+    branch in ``DevOrchestrator.run()``, not a construction-only smoke test.
     """
 
     catalog = SeededCatalog(entities, fail_search=fail_search)
@@ -670,6 +680,8 @@ async def run_preflight_orchestrator(
         qua_shadow=qua_shadow,
         investigation_shadow=investigation_shadow,
         investigation_packet_producer=investigation_packet_producer,
+        graph_investigation_query=graph_investigation_query,
+        evidence_service=evidence_service,
     )
     result = await orchestrator.run(
         request=request,

--- a/tests/api/dev/test_chaos_3497_scope_observability.py
+++ b/tests/api/dev/test_chaos_3497_scope_observability.py
@@ -788,10 +788,10 @@ async def test_the_widening_marker_alone_would_be_the_wrong_predicate() -> None:
     a fact about a module nobody calls that way.
     """
 
-    from dev_health_ops.api.dev.production_runtime import _scope_request
     from dev_health_ops.api.dev.scope_service import (
         ScopeResolutionService,
         ScopeResolveRequest,
+        scope_request_from_scope,
     )
     from tests.api.dev.test_scope_service import FakeCatalog
 
@@ -809,7 +809,7 @@ async def test_the_widening_marker_alone_would_be_the_wrong_predicate() -> None:
     )
     assert "organization" in subject_free.fallbacks
 
-    assert _scope_request(_scope()).allow_organization_fallback is False, (
+    assert scope_request_from_scope(_scope()).allow_organization_fallback is False, (
         "HALF TWO MOVED: production now ASKS for the organization fallback, so "
         "the second producer is reachable from Ask Dev and an ordinary "
         "org-wide answer can carry fallbacks==['organization'] with no subject "

--- a/tests/api/dev/test_chaos_3502_graph_routing_branch.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_branch.py
@@ -1,0 +1,226 @@
+"""CHAOS-3502: the graph-assisted routing branch itself (CHAOS-3660 sign-off).
+
+Covers the two binding additions from team-lead's design sign-off on
+CHAOS-3660, both exercised through the real orchestrator seam
+(``run_preflight_orchestrator`` -- a genuine ``DISCOVERED_COHORT``
+``preflight_result`` only comes from the real interpreter/preflight
+pipeline, never a hand-built one):
+
+(a) every ``GraphQueryOutcome`` the seam can return emits a content-safe,
+    outcome-tagged log record plus increments
+    ``ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL`` with that outcome as the label
+    (beta gate 10 observability hook) -- and every outcome other than
+    ``CANCELLED`` falls through to the legacy model-tool-choice loop and
+    still produces a real answer, per the CHAOS-3660 fallback table;
+    ``CANCELLED`` terminates the run directly instead.
+(b) an explicit flag-off run is byte-identical (via
+    ``RunOutput.outcome_tuple()``) to a run where the graph collaborators
+    were never constructed at all, and the fake is never called -- proving
+    the new branch is genuinely inert, not merely "usually skipped", when
+    the runtime kill switch is off.
+
+Sibling of ``test_chaos_3502_graph_routing_seam.py`` (that file covers the
+flag scaffolding and construction-only collaborator wiring landed ahead of
+this branch); this file covers the branch's own dispatch behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from dev_health_ops.api.dev.evidence_service import (
+    EvidenceReferenceSigner,
+    EvidenceService,
+)
+from dev_health_ops.api.dev.graph_investigation_query import GraphQueryOutcome
+from dev_health_ops.api.dev.orchestrator import GRAPH_ROUTING_RUNTIME_FLAG
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.metrics.prometheus import ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL
+from tests._chaos_3292_preflight import ORG_ID, run_preflight_orchestrator
+from tests._chaos_3502_graph_investigation_fake import FakeGraphInvestigationQuery
+
+#: A real, zero-mention, cohort-discovery-shaped question --
+#: ``question_interpreter``'s ``cohort.discovery`` recognizer (subject
+#: anchor "teams" + judgment anchor "struggling", CHAOS-3652) resolves this
+#: to ``QuestionIntentID.DISCOVERED_COHORT`` /
+#: ``Cardinality.ORGANIZATION_WIDE`` through the real preflight pipeline --
+#: never asserted by construction here, only by driving the real seam.
+_DISCOVERED_COHORT_QUESTION = "Which teams are struggling right now?"
+
+_EVIDENCE_SIGNING_SECRET = "chaos-3502-branch-test-secret-at-least-32-bytes"
+
+#: Every non-terminal outcome: falls through to the legacy loop and still
+#: answers. CANCELLED is covered separately below (it terminates instead).
+_FALLTHROUGH_OUTCOMES = (
+    GraphQueryOutcome.COMPLETED,
+    GraphQueryOutcome.DISABLED,
+    GraphQueryOutcome.UNAVAILABLE,
+    GraphQueryOutcome.STALE,
+    GraphQueryOutcome.DEADLINE_EXCEEDED,
+    GraphQueryOutcome.PROVIDER_FAILURE,
+)
+
+
+class _Entitlement:
+    async def require(self, _org_id: str) -> None:
+        return None
+
+
+class _Authorizer:
+    async def resolve(self, _org_id: str, _permission_fingerprint: str, _request):
+        raise NotImplementedError(
+            "assembly is deferred (CHAOS-3502) -- this branch never reaches "
+            "evidence admission yet, so this must never be called"
+        )
+
+
+def _evidence_service() -> EvidenceService:
+    return EvidenceService(
+        entitlement=_Entitlement(),
+        authorizer=_Authorizer(),
+        signer=EvidenceReferenceSigner(_EVIDENCE_SIGNING_SECRET),
+        native_adapters=(),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", _FALLTHROUGH_OUTCOMES)
+async def test_every_fallthrough_outcome_is_observed_and_still_answers(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    outcome: GraphQueryOutcome,
+) -> None:
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    fake = FakeGraphInvestigationQuery(outcome=outcome)
+    before = ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL.labels(
+        outcome=outcome.value
+    )._value.get()
+
+    with caplog.at_level(logging.INFO, logger="dev_health_ops.api.dev.orchestrator"):
+        output = await run_preflight_orchestrator(
+            question=_DISCOVERED_COHORT_QUESTION,
+            entities=[],
+            org_id=ORG_ID,
+            script_id=f"chaos3502-{outcome.value}",
+            graph_investigation_query=fake,
+            evidence_service=_evidence_service(),
+        )
+
+    assert len(fake.received_requests) == 1, (
+        "the graph seam must be called exactly once for a genuine "
+        "DISCOVERED_COHORT run with both collaborators wired and the "
+        "runtime flag on"
+    )
+    assert fake.received_requests[0].intent_id.value == "discovered_cohort"
+
+    # Every fallthrough outcome must still complete as a real, non-error
+    # answer via the legacy loop -- per the CHAOS-3660 fallback table, a
+    # graph outage/lag/refusal-to-assemble must never regress an existing
+    # working answer.
+    assert output.result.state is not RunState.CANCELLED
+    assert output.result.state is not RunState.FAILED
+    assert output.result.answer is not None
+
+    assert any(
+        record.levelno == logging.INFO
+        and record.message == "ask_dev.orchestrator.graph_routing_outcome"
+        and getattr(record, "outcome", None) == outcome.value
+        for record in caplog.records
+    ), f"outcome {outcome.value!r} must emit the content-safe outcome-tagged log record"
+
+    after = ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL.labels(
+        outcome=outcome.value
+    )._value.get()
+    assert after == before + 1, (
+        f"outcome {outcome.value!r} must increment "
+        "ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL with that outcome as the label"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_outcome_terminates_the_run_directly(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """CANCELLED is the one outcome that does NOT fall through -- the RUN is
+    cancelled, not just this one call (module docstring / CHAOS-3660
+    fallback table). Distinct from the parametrized fallthrough cases
+    above: the legacy loop must never even start, so ``calls`` stays empty.
+    """
+
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    fake = FakeGraphInvestigationQuery(outcome=GraphQueryOutcome.CANCELLED)
+    before = ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL.labels(
+        outcome=GraphQueryOutcome.CANCELLED.value
+    )._value.get()
+
+    with caplog.at_level(logging.INFO, logger="dev_health_ops.api.dev.orchestrator"):
+        output = await run_preflight_orchestrator(
+            question=_DISCOVERED_COHORT_QUESTION,
+            entities=[],
+            org_id=ORG_ID,
+            script_id="chaos3502-cancelled",
+            graph_investigation_query=fake,
+            evidence_service=_evidence_service(),
+        )
+
+    assert output.result.state is RunState.CANCELLED
+    assert output.result.error is not None
+    assert output.result.error.code == "cancelled"
+    assert output.result.answer is None
+    assert output.calls == [], (
+        "a CANCELLED graph outcome must terminate the run before the "
+        "legacy model-tool-choice loop ever executes a tool"
+    )
+
+    assert any(
+        record.levelno == logging.INFO
+        and record.message == "ask_dev.orchestrator.graph_routing_outcome"
+        and getattr(record, "outcome", None) == "cancelled"
+        for record in caplog.records
+    ), "CANCELLED must still emit the content-safe outcome-tagged log record"
+
+    after = ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL.labels(
+        outcome=GraphQueryOutcome.CANCELLED.value
+    )._value.get()
+    assert after == before + 1
+
+
+@pytest.mark.asyncio
+async def test_flag_off_is_byte_identical_to_collaborators_never_wired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3660 binding addition (b): with the runtime flag off, a run
+    wired with real (non-``None``) ``graph_investigation_query``/
+    ``evidence_service`` collaborators must be byte-identical
+    (``RunOutput.outcome_tuple()``) to a run where those collaborators were
+    never constructed at all -- and the fake must never be called. Proves
+    the branch is genuinely inert when the kill switch is off, not merely
+    "usually skipped".
+    """
+
+    monkeypatch.delenv(GRAPH_ROUTING_RUNTIME_FLAG, raising=False)
+
+    fake = FakeGraphInvestigationQuery(outcome=GraphQueryOutcome.COMPLETED)
+    with_collaborators = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3502-flag-off",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+    )
+    assert fake.received_requests == [], (
+        "flag off must mean the graph seam is never called, even though "
+        "both collaborators are wired"
+    )
+
+    without_collaborators = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3502-flag-off",
+    )
+
+    assert with_collaborators.outcome_tuple() == without_collaborators.outcome_tuple()

--- a/tests/api/dev/test_project_scope_data_health.py
+++ b/tests/api/dev/test_project_scope_data_health.py
@@ -17,7 +17,7 @@ derives, from the same shared ``PROJECT_REPOSITORIES_SQL``, or fails closed.
 CHAOS-3375 found two residual gaps in that fix, both covered below:
 
 1. A committed TEAM direct scope reaches the *exact same* widening bug
-   (``production_runtime._scope_request``'s ``DirectScope.TEAM`` branch
+   (``scope_service.scope_request_from_scope``'s ``DirectScope.TEAM`` branch
    commits a TEAM entity with ``repository_id=None``, just like PROJECT) --
    #1453 only special-cased ``EntityKind.PROJECT``, so a team subject fell
    straight through to the org-wide ``empty(repository_ids) OR ...`` arm,


### PR DESCRIPTION
## Summary

Builds the DISCOVERED_COHORT routing branch inside `DevOrchestrator.run()`, implementing the design signed off on CHAOS-3660 (all four parts) plus its two binding additions:

- **(a)** every `GraphQueryOutcome` fallback path emits a content-safe, outcome-tagged log record and increments a new `ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL` counter (reason codes only — beta gate 10 observability hook).
- **(b)** an explicit flag-off run is byte-identical (`RunOutput.outcome_tuple()`) to a run where the graph collaborators were never constructed at all, and the fake seam is never called.

Behavior: `CANCELLED` terminates the run directly (`RunState.CANCELLED`, no legacy-loop tool calls); every other outcome — `COMPLETED` (assembly still deferred, see below), `DISABLED`, `UNAVAILABLE`, `STALE`, `DEADLINE_EXCEEDED`, `PROVIDER_FAILURE` — falls through to the existing legacy model-tool-choice loop unchanged, per the CHAOS-3660 fallback table.

Also lands two supporting pieces approved as part of the same sign-off:

- `preflight_outcomes.GRAPH_ROUTED_QUESTION_INTENTS`: a third exemption set (distinct from `LEGACY_ONLY_QUESTION_INTENTS`) so the plan-registry-gap check doesn't misfire for `DISCOVERED_COHORT`, which has a real destination (the graph seam), not a designed fallthrough.
- `scope_service.scope_request_from_scope`: a behavior-preserving promotion of `production_runtime._scope_request` to a shared leaf module, needed so `orchestrator.py` can build a `ScopeResolveRequest` without a circular import (ahead of the still-deferred `evidence_service.admit()` wiring).

## Non-scope (explicitly deferred, blocked on other lanes)

- Assembly for the `COMPLETED` outcome (candidate extraction → canonical admission → `_graph_grounded_answer`) — waits on Lane A's packet refactor and Lane C's canonical enrichment type.
- Real `authorized_entity_ids` derivation — no code in this codebase derives this yet today (mirrors `graph_arm.readback.derive_authorized_entity_ids`'s own `AuthorizationDerivationNotImplementedError`); passed as an empty `frozenset`, documented as a known, safe-by-default (fails closed) limitation.

## Linear

Closes CHAOS-3687 (child of CHAOS-3502). Design ratified on CHAOS-3660.

## Test plan

- [x] New `tests/api/dev/test_chaos_3502_graph_routing_branch.py`: every `GraphQueryOutcome` value dispatched through the real orchestrator seam (`run_preflight_orchestrator`, genuine `DISCOVERED_COHORT` preflight result), asserting fallback-vs-termination behavior, counter increment, and log emission per outcome.
- [x] Dedicated `CANCELLED`-terminates-the-run test (asserts `output.calls == []` — the legacy loop never starts).
- [x] Explicit flag-off byte-identical test.
- [x] Full `tests/api/dev` + `tests/context_fabric` + `tests/test_env_isolation_contract.py` sweep: 4456 passed, 118 skipped, 4 xfailed, 0 failed.
- [x] `ruff check` clean, `mypy` clean (full project, via pre-commit/pre-push hooks).