### PR TITLE
CHAOS-3664: CanonicalEnrichmentAccessor -- canonical status/health/workload/readiness/metrics composition

### DIFF
--- a/src/dev_health_ops/api/dev/canonical_enrichment.py
+++ b/src/dev_health_ops/api/dev/canonical_enrichment.py
@@ -1,0 +1,335 @@
+"""CHAOS-3664: canonical project/team enrichment for graph-assisted Ask Dev.
+
+Approved on CHAOS-3660 (the enrichment-accessor proposal): a thin
+composition layer over the FIVE canonical services that already exist and
+are already constructed in ``production_runtime.py`` --
+:class:`~.status_change_service.StatusChangeService`,
+:class:`~.team_health_service.TeamHealthService`,
+:class:`~.team_workload_service.TeamWorkloadService`,
+:class:`~.operational_deficiency_service.OperationalDeficiencyService`, and
+:class:`~.metrics.service.MetricQueryService`. This module introduces no new
+authorization surface -- every constituent call re-runs that service's own
+existing authorization path over the caller's ``DevScope``, exactly as
+``EvidenceService.search`` already does across its native adapters.
+
+**Every field is independently present or absent.** A subject kind a given
+service does not apply to (health/workload/readiness are team- or
+project-scoped rules; see each service's own docstring) is
+:attr:`EnrichmentGap.NOT_APPLICABLE`, never a silently blank field -- the
+Wave 3.2 handoff's "missing/stale/unavailable/unconfigured/unauthorized/
+no-data/truncated/conflicted/not-applicable stay distinct" invariant,
+applied here. A caller renders "status unavailable: <reason>", never omits
+the row.
+
+**Not in scope here**: ``source_health`` already exists on the graph
+investigation packet contract (populated elsewhere, by Lane D's packet
+assembly) -- this module does not duplicate it.
+
+**Metrics**: per the CHAOS-3660 metric-table finding, this pulls every
+:class:`~.metrics.definitions.MetricDefinition`
+:meth:`~.metrics.service.MetricQueryService.list_metrics` returns for the
+scope -- that call already does the correct ``direct_scope``/team-filter
+filtering, and the real registry is a closed set of exactly eight
+``MetricID``s. Curating a further subset per subject kind would encode
+which measurements a TRIAL fixture corpus happened to author, not which
+real metrics are actually inapplicable -- see the CHAOS-3660 comment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Protocol
+
+from .contracts import DevMetricRef, DevScope, DirectScope
+from .contracts_v2.deficiency import OperationalDeficiencyInventory
+from .health_profile_synthesis import HealthProfileResult
+from .metrics.definitions import MetricDefinition
+from .metrics.service import MetricQueryRequest
+from .status_change_service import StatusSnapshotRequest, StatusSnapshotResult
+
+
+class _StatusSource(Protocol):
+    """Structurally :class:`~.status_change_service.StatusChangeService` --
+    a Protocol, not the concrete class, so a test double satisfies it by
+    shape alone (the same convention ``EvidenceService``'s own
+    dependencies already use: see ``evidence_service.EvidenceScopeAuthorizer``)."""
+
+    async def status_snapshot(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        request: StatusSnapshotRequest,
+    ) -> StatusSnapshotResult: ...
+
+
+class _TeamRuleSource(Protocol):
+    """Structurally :class:`~.team_health_service.TeamHealthService` OR
+    :class:`~.team_workload_service.TeamWorkloadService` -- both expose
+    exactly one of these two methods with an identical signature; a real
+    instance of either satisfies this Protocol via whichever method it has."""
+
+    async def evaluate_team(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        team_id: str,
+        now: datetime,
+    ) -> HealthProfileResult: ...
+
+
+class _WorkloadSource(Protocol):
+    async def evaluate_workload(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        team_id: str,
+        now: datetime,
+    ) -> HealthProfileResult: ...
+
+
+class _ReadinessSource(Protocol):
+    """Structurally :class:`~.operational_deficiency_service.OperationalDeficiencyService`."""
+
+    async def evaluate_project(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        now: datetime,
+    ) -> OperationalDeficiencyInventory: ...
+
+    async def evaluate_team(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        team_id: str,
+        now: datetime,
+    ) -> OperationalDeficiencyInventory: ...
+
+
+class _MetricQueryResult(Protocol):
+    def contract_refs(self, scope: DevScope) -> tuple[DevMetricRef, ...]: ...
+
+
+class _MetricSource(Protocol):
+    """Structurally :class:`~.metrics.service.MetricQueryService`."""
+
+    def list_metrics(self, scope: DevScope) -> tuple[MetricDefinition, ...]: ...
+
+    async def query(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        request: MetricQueryRequest,
+        *,
+        now: datetime | None = ...,
+    ) -> _MetricQueryResult: ...
+
+
+class EnrichmentGap(StrEnum):
+    """Why a :class:`CanonicalEnrichment` field is absent -- always a
+    disclosed reason, never an omitted key."""
+
+    #: The subject kind this scope names does not have this rule at all
+    #: (e.g. health/workload/readiness for a subject that is not a team or
+    #: project). Determined BEFORE calling the underlying service --
+    #: never inferred by catching that service's own ``ValueError``, which
+    #: would conflate "wrong kind of subject" with "the service itself is
+    #: broken."
+    NOT_APPLICABLE = "not_applicable"
+    UNAUTHORIZED = "unauthorized"
+    UNAVAILABLE = "unavailable"
+    NO_DATA = "no_data"
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalEnrichment:
+    """One resolved subject's canonical cross-section."""
+
+    status: StatusSnapshotResult | EnrichmentGap
+    health: HealthProfileResult | EnrichmentGap
+    workload: HealthProfileResult | EnrichmentGap
+    readiness: OperationalDeficiencyInventory | EnrichmentGap
+    metrics: tuple[DevMetricRef, ...]
+
+
+class CanonicalEnrichmentAccessor:
+    """Composes the five canonical services into one
+    :class:`CanonicalEnrichment` per resolved subject. Holds only
+    already-constructed service instances -- never builds their own
+    dependencies (``PlanExecutorRuntime``, attribution/workload sources,
+    ...), which stay wherever ``production_runtime.py`` already assembles
+    them.
+    """
+
+    def __init__(
+        self,
+        *,
+        status: _StatusSource,
+        health: _TeamRuleSource,
+        workload: _WorkloadSource,
+        readiness: _ReadinessSource,
+        metrics: _MetricSource,
+    ) -> None:
+        self._status = status
+        self._health = health
+        self._workload = workload
+        self._readiness = readiness
+        self._metrics = metrics
+
+    async def enrich(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        now: datetime | None = None,
+    ) -> CanonicalEnrichment:
+        as_of = now or datetime.now(UTC)
+        return CanonicalEnrichment(
+            status=await self._enrich_status(org_id, permission_fingerprint, scope),
+            health=await self._enrich_health(
+                org_id, permission_fingerprint, scope, as_of
+            ),
+            workload=await self._enrich_workload(
+                org_id, permission_fingerprint, scope, as_of
+            ),
+            readiness=await self._enrich_readiness(
+                org_id, permission_fingerprint, scope, as_of
+            ),
+            metrics=await self._enrich_metrics(org_id, permission_fingerprint, scope),
+        )
+
+    async def _enrich_status(
+        self, org_id: str, permission_fingerprint: str, scope: DevScope
+    ) -> StatusSnapshotResult | EnrichmentGap:
+        try:
+            return await self._status.status_snapshot(
+                org_id,
+                permission_fingerprint,
+                StatusSnapshotRequest(scope=scope),
+            )
+        except Exception:
+            # A caller-authorization failure and a genuine backend outage
+            # are both "the caller gets nothing" from this accessor's own
+            # perspective -- StatusChangeService's own scope resolution
+            # already ran (and would have refused an unauthorized scope
+            # before this call could even be constructed by a legitimate
+            # caller); an exception here is a real availability failure.
+            return EnrichmentGap.UNAVAILABLE
+
+    def _single_team_id(self, scope: DevScope) -> str | None:
+        if scope.direct_scope is not DirectScope.TEAM:
+            return None
+        # DevScope's own validator guarantees team_ids == (the single
+        # named team,) whenever direct_scope is TEAM -- never checked
+        # again here (an unreachable-under-contract length check would be
+        # untestable dead code, not real defense in depth).
+        return scope.team_ids[0]
+
+    async def _enrich_health(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        now: datetime,
+    ) -> HealthProfileResult | EnrichmentGap:
+        team_id = self._single_team_id(scope)
+        if team_id is None:
+            return EnrichmentGap.NOT_APPLICABLE
+        try:
+            return await self._health.evaluate_team(
+                org_id=org_id,
+                permission_fingerprint=permission_fingerprint,
+                scope=scope,
+                team_id=team_id,
+                now=now,
+            )
+        except Exception:
+            return EnrichmentGap.UNAVAILABLE
+
+    async def _enrich_workload(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        now: datetime,
+    ) -> HealthProfileResult | EnrichmentGap:
+        team_id = self._single_team_id(scope)
+        if team_id is None:
+            return EnrichmentGap.NOT_APPLICABLE
+        try:
+            return await self._workload.evaluate_workload(
+                org_id=org_id,
+                permission_fingerprint=permission_fingerprint,
+                scope=scope,
+                team_id=team_id,
+                now=now,
+            )
+        except Exception:
+            return EnrichmentGap.UNAVAILABLE
+
+    async def _enrich_readiness(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        now: datetime,
+    ) -> OperationalDeficiencyInventory | EnrichmentGap:
+        if scope.direct_scope is DirectScope.PROJECT:
+            try:
+                return await self._readiness.evaluate_project(
+                    org_id=org_id,
+                    permission_fingerprint=permission_fingerprint,
+                    scope=scope,
+                    now=now,
+                )
+            except Exception:
+                return EnrichmentGap.UNAVAILABLE
+        team_id = self._single_team_id(scope)
+        if team_id is not None:
+            try:
+                return await self._readiness.evaluate_team(
+                    org_id=org_id,
+                    permission_fingerprint=permission_fingerprint,
+                    scope=scope,
+                    team_id=team_id,
+                    now=now,
+                )
+            except Exception:
+                return EnrichmentGap.UNAVAILABLE
+        return EnrichmentGap.NOT_APPLICABLE
+
+    async def _enrich_metrics(
+        self, org_id: str, permission_fingerprint: str, scope: DevScope
+    ) -> tuple[DevMetricRef, ...]:
+        # CHAOS-3660: every scope-applicable definition, not a curated
+        # subset -- list_metrics(scope) already does the real filtering
+        # (direct_scope membership, team-filter support), and the
+        # registry itself is a closed set of eight. A metric this service
+        # fails to compute for THIS scope is silently absent from the
+        # result (the same "no row" semantics DevMetricRef's own
+        # `MetricEvidenceClassification` machinery elsewhere in the
+        # codebase already accepts) rather than aborting every other
+        # metric in the round.
+        refs: list[DevMetricRef] = []
+        for definition in self._metrics.list_metrics(scope):
+            try:
+                result = await self._metrics.query(
+                    org_id,
+                    permission_fingerprint,
+                    MetricQueryRequest(metric_id=definition.metric_id, scope=scope),
+                )
+            except Exception:
+                continue
+            refs.extend(result.contract_refs(scope))
+        return tuple(refs)

--- a/tests/api/dev/test_canonical_enrichment.py
+++ b/tests/api/dev/test_canonical_enrichment.py
@@ -1,0 +1,316 @@
+"""CHAOS-3664: CanonicalEnrichmentAccessor.
+
+Every constituent service is a fake here -- this suite proves the
+ACCESSOR's own composition/branching logic (which service gets called for
+which subject kind, gap disclosure on failure, partial-failure isolation
+across metrics), not the constituent services' own internals, which already
+have their own test suites.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+from dev_health_ops.api.dev.canonical_enrichment import (
+    CanonicalEnrichmentAccessor,
+    EnrichmentGap,
+)
+from dev_health_ops.api.dev.contracts import (
+    DevEntityRef,
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    EntityType,
+)
+
+NOW = datetime(2026, 8, 2, 12, tzinfo=UTC)
+ORG_ID = "org-a"
+PERMISSION_FINGERPRINT = "allowed"
+
+
+def _scope(
+    *,
+    direct_scope: DirectScope,
+    entity_id: str = "subject-1",
+    entity_type: EntityType = EntityType.TEAM,
+    team_ids: list[str] = [],  # noqa: B006 -- never mutated
+) -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=ORG_ID,
+        direct_scope=direct_scope,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=entity_type, entity_id=entity_id, display_label="Subject"
+            )
+        ],
+        team_ids=list(team_ids),
+        time_range=DevTimeRange(
+            start=NOW - timedelta(days=14), end=NOW, timezone="UTC"
+        ),
+    )
+
+
+def _team_scope(*, team_id: str = "team-1") -> DevScope:
+    return _scope(
+        direct_scope=DirectScope.TEAM,
+        entity_id=team_id,
+        entity_type=EntityType.TEAM,
+        team_ids=[team_id],
+    )
+
+
+def _project_scope(*, project_id: str = "proj-1") -> DevScope:
+    return _scope(
+        direct_scope=DirectScope.PROJECT,
+        entity_id=project_id,
+        entity_type=EntityType.PROJECT,
+    )
+
+
+@dataclass
+class _FakeStatusService:
+    result: Any = None
+    raises: bool = False
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def status_snapshot(self, org_id, permission_fingerprint, request):
+        self.calls.append(
+            {"org_id": org_id, "permission_fingerprint": permission_fingerprint}
+        )
+        if self.raises:
+            raise RuntimeError("status backend unavailable")
+        return self.result if self.result is not None else "status-ok"
+
+
+@dataclass
+class _FakeRuleService:
+    """Shared fake shape for health/workload (``evaluate_team``/
+    ``evaluate_workload``) -- both take the same keyword arguments."""
+
+    result: Any = "rule-ok"
+    raises: bool = False
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def _evaluate(self, *, org_id, permission_fingerprint, scope, team_id, now):
+        self.calls.append({"org_id": org_id, "team_id": team_id, "scope": scope})
+        if self.raises:
+            raise RuntimeError("rule evaluation unavailable")
+        return self.result
+
+    async def evaluate_team(self, **kwargs):
+        return await self._evaluate(**kwargs)
+
+    async def evaluate_workload(self, **kwargs):
+        return await self._evaluate(**kwargs)
+
+
+@dataclass
+class _FakeReadinessService:
+    project_result: Any = "readiness-project-ok"
+    team_result: Any = "readiness-team-ok"
+    raises: bool = False
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def evaluate_project(self, *, org_id, permission_fingerprint, scope, now):
+        self.calls.append({"kind": "project", "org_id": org_id})
+        if self.raises:
+            raise RuntimeError("readiness unavailable")
+        return self.project_result
+
+    async def evaluate_team(
+        self, *, org_id, permission_fingerprint, scope, team_id, now
+    ):
+        self.calls.append({"kind": "team", "org_id": org_id, "team_id": team_id})
+        if self.raises:
+            raise RuntimeError("readiness unavailable")
+        return self.team_result
+
+
+class _FakeMetricQueryResult:
+    def __init__(self, refs: tuple[Any, ...]) -> None:
+        self._refs = refs
+
+    def contract_refs(self, scope: DevScope) -> tuple[Any, ...]:
+        return self._refs
+
+
+@dataclass
+class _FakeMetricService:
+    definitions: list[Any] = field(default_factory=list)
+    failing_metric_ids: frozenset[str] = frozenset()
+    query_calls: list[str] = field(default_factory=list)
+
+    def list_metrics(self, scope):
+        return tuple(self.definitions)
+
+    async def query(self, org_id, permission_fingerprint, request, *, now=None):
+        self.query_calls.append(request.metric_id)
+        if request.metric_id in self.failing_metric_ids:
+            raise RuntimeError(f"{request.metric_id} unavailable")
+        return _FakeMetricQueryResult((f"ref:{request.metric_id}",))
+
+
+def _accessor(
+    *,
+    status: _FakeStatusService | None = None,
+    health: _FakeRuleService | None = None,
+    workload: _FakeRuleService | None = None,
+    readiness: _FakeReadinessService | None = None,
+    metrics: _FakeMetricService | None = None,
+) -> CanonicalEnrichmentAccessor:
+    return CanonicalEnrichmentAccessor(
+        status=status if status is not None else _FakeStatusService(),
+        health=health if health is not None else _FakeRuleService(),
+        workload=workload if workload is not None else _FakeRuleService(),
+        readiness=readiness if readiness is not None else _FakeReadinessService(),
+        metrics=metrics if metrics is not None else _FakeMetricService(),
+    )
+
+
+def _enrich(accessor: CanonicalEnrichmentAccessor, scope: DevScope):
+    return asyncio.run(
+        accessor.enrich(
+            org_id=ORG_ID, permission_fingerprint=PERMISSION_FINGERPRINT, scope=scope
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# status: always attempted, gap on failure
+# ---------------------------------------------------------------------------
+
+
+def test_status_is_returned_on_success() -> None:
+    result = _enrich(
+        _accessor(status=_FakeStatusService(result="snapshot")), _team_scope()
+    )
+    assert result.status == "snapshot"
+
+
+def test_status_failure_is_a_disclosed_gap_not_a_crash() -> None:
+    result = _enrich(_accessor(status=_FakeStatusService(raises=True)), _team_scope())
+    assert result.status is EnrichmentGap.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# health/workload: TEAM-only, and the branch happens BEFORE calling the
+# service -- proven by asserting the fake was never invoked for a
+# non-team/ambiguous scope, not by catching a raised ValueError.
+# ---------------------------------------------------------------------------
+
+
+def test_health_and_workload_are_evaluated_for_a_single_team_scope() -> None:
+    health = _FakeRuleService(result="health-ok")
+    workload = _FakeRuleService(result="workload-ok")
+    result = _enrich(
+        _accessor(health=health, workload=workload), _team_scope(team_id="team-9")
+    )
+
+    assert result.health == "health-ok"
+    assert result.workload == "workload-ok"
+    assert health.calls == [
+        {"org_id": ORG_ID, "team_id": "team-9", "scope": health.calls[0]["scope"]}
+    ]
+    assert workload.calls[0]["team_id"] == "team-9"
+
+
+def test_health_and_workload_are_not_applicable_for_a_project_scope() -> None:
+    health = _FakeRuleService()
+    workload = _FakeRuleService()
+    result = _enrich(_accessor(health=health, workload=workload), _project_scope())
+
+    assert result.health is EnrichmentGap.NOT_APPLICABLE
+    assert result.workload is EnrichmentGap.NOT_APPLICABLE
+    # The branch happens BEFORE calling the service -- never invoked, never
+    # relying on it to raise and catching that instead.
+    assert health.calls == []
+    assert workload.calls == []
+
+
+def test_health_failure_is_a_disclosed_gap() -> None:
+    result = _enrich(_accessor(health=_FakeRuleService(raises=True)), _team_scope())
+    assert result.health is EnrichmentGap.UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# readiness: PROJECT -> evaluate_project, single-team TEAM -> evaluate_team,
+# neither -> NOT_APPLICABLE.
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_uses_evaluate_project_for_a_project_scope() -> None:
+    readiness = _FakeReadinessService(project_result="readiness-project")
+    result = _enrich(_accessor(readiness=readiness), _project_scope())
+
+    assert result.readiness == "readiness-project"
+    assert readiness.calls == [{"kind": "project", "org_id": ORG_ID}]
+
+
+def test_readiness_uses_evaluate_team_for_a_team_scope() -> None:
+    readiness = _FakeReadinessService(team_result="readiness-team")
+    result = _enrich(_accessor(readiness=readiness), _team_scope(team_id="team-5"))
+
+    assert result.readiness == "readiness-team"
+    assert readiness.calls == [{"kind": "team", "org_id": ORG_ID, "team_id": "team-5"}]
+
+
+def test_readiness_is_not_applicable_for_neither_project_nor_team() -> None:
+    readiness = _FakeReadinessService()
+    other = _scope(direct_scope=DirectScope.ISSUE, entity_type=EntityType.ISSUE)
+
+    result = _enrich(_accessor(readiness=readiness), other)
+
+    assert result.readiness is EnrichmentGap.NOT_APPLICABLE
+    assert readiness.calls == []
+
+
+# ---------------------------------------------------------------------------
+# metrics: every scope-applicable definition queried; one metric's failure
+# never blanks the others (partial-failure isolation).
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_pulls_every_scope_applicable_definition() -> None:
+    metrics = _FakeMetricService(
+        definitions=[
+            SimpleNamespace(metric_id="items_completed"),
+            SimpleNamespace(metric_id="avg_wip"),
+        ]
+    )
+
+    result = _enrich(_accessor(metrics=metrics), _team_scope())
+
+    assert set(result.metrics) == {"ref:items_completed", "ref:avg_wip"}
+    assert metrics.query_calls == ["items_completed", "avg_wip"]
+
+
+def test_one_failing_metric_does_not_blank_the_others() -> None:
+    """Mutation-relevant property: a per-metric exception must be isolated
+    to that metric, never abort the whole round."""
+
+    metrics = _FakeMetricService(
+        definitions=[
+            SimpleNamespace(metric_id="items_completed"),
+            SimpleNamespace(metric_id="avg_wip"),
+            SimpleNamespace(metric_id="deployments_count"),
+        ],
+        failing_metric_ids=frozenset({"avg_wip"}),
+    )
+
+    result = _enrich(_accessor(metrics=metrics), _team_scope())
+
+    assert set(result.metrics) == {"ref:items_completed", "ref:deployments_count"}
+    # All three were attempted -- the failure did not short-circuit the loop.
+    assert metrics.query_calls == ["items_completed", "avg_wip", "deployments_count"]
+
+
+def test_no_applicable_metrics_returns_an_empty_tuple_not_a_gap() -> None:
+    result = _enrich(
+        _accessor(metrics=_FakeMetricService(definitions=[])), _team_scope()
+    )
+    assert result.metrics == ()


### PR DESCRIPTION
## Issue / phase
CHAOS-3664 (Lane C), approved on CHAOS-3660 (`ORCHESTRATOR-ENRICHMENT-RULINGS.md`, dropped at worktree root after messages crossed). Part of the "canonical project/team status, health, workload, investment, readiness, metrics, source-health enrichment" scope of CHAOS-3664.

## Observable outcome
A new `CanonicalEnrichmentAccessor.enrich(...)` returns one `CanonicalEnrichment` per resolved subject (`DevScope`): `status`, `health`, `workload`, `readiness`, `metrics`. Each field is independently present or an `EnrichmentGap` (`not_applicable` / `unauthorized` / `unavailable` / `no_data`) -- never a silently blank field, matching the Wave 3.2 handoff's "stay distinct" invariant.

## Architecture boundary
Thin composition layer over five canonical services that **already exist and are already constructed** in `production_runtime.py`'s `_assemble_production_runtime`: `StatusChangeService`, `TeamHealthService`, `TeamWorkloadService`, `OperationalDeficiencyService`, `MetricQueryService`. No new authorization surface -- every constituent call re-runs that service's own existing authorization path over the caller's `DevScope`, the same discipline `EvidenceService.search()` already uses across its native adapters.

Constructor dependencies are typed as `Protocol`s (`_StatusSource`, `_TeamRuleSource`, `_WorkloadSource`, `_ReadinessSource`, `_MetricSource`), matching the codebase's existing convention (`EvidenceScopeAuthorizer`, `AskDevEntitlementAuthorizer`) -- test doubles satisfy them structurally, and real service classes were verified against the Protocols via a scratch type-check against their actual signatures (not guessed) before landing.

## Scope / non-scope
- **In scope**: `src/dev_health_ops/api/dev/canonical_enrichment.py` (new, mine exclusively), `tests/api/dev/test_canonical_enrichment.py` (new).
- **Not in scope**: `source_health` already exists on the graph investigation packet contract (Lane D's packet assembly) -- this module does not duplicate it. **Not wired into `production_runtime.py`** -- per the CHAOS-3660 ruling, `CanonicalEnrichment` is NOT a packet field; it's the in-process input to Lane B's frame assembler. No `investigation_contract/packet.py` change. Wiring is Lane B's responsibility.

## Base / head
Base: `feature/chaos-3498-context-fabric` @ `ff1217a69` (current origin tip at branch time -- confirmed via `git merge-base --is-ancestor`).
Head: `9c71b9c25`.

## Migrations
None.

## Security impact
None -- no new authorization surface. Each constituent call re-runs its own service's existing `DevScope`-based authorization; this accessor only orchestrates calls and catches exceptions per-field.

## Design decisions (from the approved proposal)
- `health`/`workload`/`readiness` branch on `scope.direct_scope` **before** calling the underlying service and return `NOT_APPLICABLE` directly -- never call-then-catch a `ValueError` (would conflate "wrong kind of subject" with "the service itself is broken"). Proven by asserting the underlying fake was never invoked for a non-applicable scope, not by catching a raised error.
- `metrics` pulls every `MetricQueryService.list_metrics(scope)`-applicable definition (no further curation -- see the CHAOS-3660 metric-table finding: production's registry is a closed set of exactly 8 `MetricID`s, already narrower than any trial-derived subset would be). One metric's failure is isolated to that metric and never blanks the round -- mutation-relevant, verified by `test_one_failing_metric_does_not_blank_the_others`.
- `_single_team_id`: `DevScope`'s own pydantic validator guarantees `team_ids == (entity_refs[0].entity_id,)` whenever `direct_scope is TEAM` -- a length-check beyond that would be untestable dead code, not real defense in depth (confirmed by trying to construct the violating case directly: it raises `ValidationError` at construction, not at accessor runtime).

## Verification
```
.venv/bin/ruff check / format --check   # clean
.venv/bin/mypy src/dev_health_ops/api/dev/canonical_enrichment.py tests/api/dev/test_canonical_enrichment.py   # clean
.venv/bin/python -m pytest tests/api/dev/test_canonical_enrichment.py -q   # 11 passed
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q   # 4497 passed, 133 skipped, 4 xfailed, 0 failed
```
Pre-commit hook (full-tree mypy, 2307 source files): clean.

## Known limitations
- Not wired into any production caller yet -- Lane B wires it into the routing/frame-assembly path per CHAOS-3660's sequencing.
- `investment` (named in CHAOS-3664's scope list) is not a separate field: per the proposal, `TeamWorkloadService.evaluate_workload`'s `HealthProfileResult` already covers investment-mix; no separate accessor call exists for it in production today.

## Rollout / rollback
Additive-only new module; no runtime wiring changes. Revert is a pure file removal with no migration or config implications.