### PR TITLE
CHAOS-3665: organization entitlement + composite availability for graph-assisted Ask Dev

### DIFF
--- a/src/dev_health_ops/api/dev/graph_routing_policy.py
+++ b/src/dev_health_ops/api/dev/graph_routing_policy.py
@@ -1,0 +1,201 @@
+"""CHAOS-3665 (Phase 1, ops-side leg): organization entitlement and the
+web-facing composite availability view for graph-assisted Ask Dev.
+
+Posted as a scoping proposal on CHAOS-3660 before this module was written;
+see that comment thread for the full reasoning. Two independent pieces:
+
+1. **Entitlement** (:class:`CanonicalGraphRoutingEntitlementAuthorizer`).
+   ``ask_dev_graph_routing`` is already a registered explicit-purchase
+   feature (``licensing/registry.py``) evaluated through the existing
+   ``decide_feature``/``evaluate_org_feature_async`` machinery -- this
+   mirrors ``entitlement.CanonicalAskDevEntitlementAuthorizer`` exactly, for
+   the design-partner-beta graph route rather than base Ask Dev. This is the
+   ORGANIZATION-level gate; ``orchestrator.graph_routing_runtime_enabled()``
+   is the separate, same-process runtime kill switch documented at
+   ``registry.ASK_DEV_GRAPH_ROUTING_FEATURE`` -- both must be true for a run
+   to attempt the graph route. Neither substitutes for the other.
+
+2. **Composite availability** (:func:`describe_availability`). CHAOS-3665's
+   acceptance criteria name a web-facing vocabulary --
+   enabled/unavailable/stale/lagging/truncated/fallback -- but that is
+   explicitly NOT a new, independent source of truth: it is derived from
+   the organization entitlement decision above, Lane B's transport-level
+   ``GraphQueryOutcome`` (``graph_investigation_query.py``), and the
+   packet's own already-validated truncation/staleness disclosure
+   (``investigation_contract.packet``'s ``PacketLimitationKind``). Minting a
+   fourth, parallel enum here was explicitly ruled out.
+
+   ``fallback`` is declared in :class:`GraphAssistedAvailability` (CHAOS-3665
+   names it) but :func:`describe_availability` never returns it: nothing in
+   the codebase today names "graph route attempted, answer degraded to
+   native investigation" as a fact. Per this project's verification
+   discipline, a measurement that cannot happen must fail loudly rather than
+   silently default -- so that state stays unreachable from this function
+   until a real signal exists for it (flagged as a gap on CHAOS-3660, not
+   guessed at here).
+"""
+
+from __future__ import annotations
+
+import uuid
+from enum import StrEnum
+from typing import Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.licensing import (
+    FeatureDecisionReason,
+    evaluate_org_feature_async,
+)
+from dev_health_ops.licensing.registry import ASK_DEV_GRAPH_ROUTING_FEATURE
+
+from .graph_investigation_query import GraphQueryOutcome, GraphQueryResult
+from .investigation_contract import AskDevInvestigationPacket, PacketLimitationKind
+
+__all__ = [
+    "GraphRoutingEntitlementAuthorizer",
+    "GraphRoutingPolicyDeniedError",
+    "CanonicalGraphRoutingEntitlementAuthorizer",
+    "GraphAssistedAvailability",
+    "limitation_kinds_of",
+    "describe_availability",
+]
+
+
+# --------------------------------------------------------------------------
+# Entitlement
+# --------------------------------------------------------------------------
+
+
+class GraphRoutingEntitlementAuthorizer(Protocol):
+    async def require(self, org_id: str) -> None: ...
+
+
+class GraphRoutingPolicyDeniedError(RuntimeError):
+    """Fail-closed denial from the canonical feature-decision seam."""
+
+    def __init__(self, reason: FeatureDecisionReason) -> None:
+        self.reason = reason
+        super().__init__("ask_dev_graph_routing_not_available")
+
+
+class CanonicalGraphRoutingEntitlementAuthorizer:
+    """Evaluate ``ask_dev_graph_routing`` without encoding plan names here.
+
+    Mirrors ``entitlement.CanonicalAskDevEntitlementAuthorizer`` field for
+    field -- same fail-closed shape, same feature-decision seam -- gating the
+    design-partner-beta graph route instead of base Ask Dev.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def require(self, org_id: str) -> None:
+        try:
+            parsed_org_id = uuid.UUID(org_id)
+        except ValueError as exc:
+            raise GraphRoutingPolicyDeniedError(
+                FeatureDecisionReason.INVALID_FEATURE_STATE
+            ) from exc
+        try:
+            decision = await evaluate_org_feature_async(
+                self._session,
+                parsed_org_id,
+                ASK_DEV_GRAPH_ROUTING_FEATURE,
+            )
+        except Exception as exc:
+            raise GraphRoutingPolicyDeniedError(
+                FeatureDecisionReason.STORAGE_ERROR
+            ) from exc
+        if not decision.allowed:
+            raise GraphRoutingPolicyDeniedError(decision.reason)
+
+
+# --------------------------------------------------------------------------
+# Composite availability
+# --------------------------------------------------------------------------
+
+
+class GraphAssistedAvailability(StrEnum):
+    """Web-facing degradation-state vocabulary for CHAOS-3665.
+
+    Not an independent source of truth -- see the module docstring.
+    """
+
+    ENABLED = "enabled"
+    UNAVAILABLE = "unavailable"
+    STALE = "stale"
+    LAGGING = "lagging"
+    TRUNCATED = "truncated"
+    FALLBACK = "fallback"
+
+
+#: Every ``GraphQueryOutcome`` other than ``COMPLETED``/``STALE`` means "no
+#: graph-assisted answer this run" from the web's point of view. The
+#: distinct transport diagnostic (why, specifically) stays on
+#: ``GraphQueryResult.diagnostic`` for logs/telemetry; the web only needs to
+#: know there is nothing graph-derived to render.
+_TRANSPORT_UNAVAILABLE_OUTCOMES: frozenset[GraphQueryOutcome] = frozenset(
+    {
+        GraphQueryOutcome.DISABLED,
+        GraphQueryOutcome.UNAVAILABLE,
+        GraphQueryOutcome.DEADLINE_EXCEEDED,
+        GraphQueryOutcome.CANCELLED,
+        GraphQueryOutcome.PROVIDER_FAILURE,
+    }
+)
+
+
+def limitation_kinds_of(
+    packet: AskDevInvestigationPacket,
+) -> frozenset[PacketLimitationKind]:
+    """The set of ``PacketLimitationKind``s a completed packet discloses.
+
+    Reads ``evidence_coverage.limitations`` -- the packet's own
+    cross-field validator (``validate_partial_results_are_disclosed``)
+    already guarantees any section's truncation or per-source staleness is
+    reflected here, so this is the one place to look rather than
+    re-deriving truncation/staleness from each section's own flags.
+    """
+
+    return frozenset(entry.kind for entry in packet.evidence_coverage.limitations)
+
+
+def describe_availability(
+    *,
+    entitled: bool,
+    result: GraphQueryResult | None,
+) -> GraphAssistedAvailability:
+    """Compose the org entitlement decision and a graph-route attempt's
+    outcome into the CHAOS-3665 web vocabulary.
+
+    ``result`` is ``None`` when the graph route was never attempted this run
+    (e.g. the runtime kill switch was off, or routing chose not to call the
+    seam at all) -- treated the same as any other "no graph-assisted answer"
+    case: ``unavailable``, never a fabricated ``enabled``.
+
+    Precedence when a completed packet discloses more than one relevant
+    limitation: ``truncated`` outranks ``lagging`` -- a bounded/cut-off
+    result is a stronger degradation to surface than "some of what fed it
+    was a little behind."
+    """
+
+    if not entitled:
+        return GraphAssistedAvailability.UNAVAILABLE
+    if result is None or result.outcome in _TRANSPORT_UNAVAILABLE_OUTCOMES:
+        return GraphAssistedAvailability.UNAVAILABLE
+    if result.outcome is GraphQueryOutcome.STALE:
+        return GraphAssistedAvailability.STALE
+    if result.outcome is not GraphQueryOutcome.COMPLETED:
+        raise AssertionError(f"unhandled GraphQueryOutcome member: {result.outcome!r}")
+    if result.packet is None:
+        raise AssertionError(
+            "GraphQueryResult declares COMPLETED but carries no packet; "
+            "this violates GraphQueryResult's own invariant"
+        )
+    kinds = limitation_kinds_of(result.packet)
+    if PacketLimitationKind.TRUNCATED_TRAVERSAL in kinds:
+        return GraphAssistedAvailability.TRUNCATED
+    if PacketLimitationKind.STALE_SOURCE in kinds:
+        return GraphAssistedAvailability.LAGGING
+    return GraphAssistedAvailability.ENABLED

--- a/tests/api/dev/test_chaos_3665_graph_routing_policy.py
+++ b/tests/api/dev/test_chaos_3665_graph_routing_policy.py
@@ -1,0 +1,238 @@
+"""CHAOS-3665 (ops-side leg): organization entitlement + the web-facing
+composite availability view for graph-assisted Ask Dev.
+
+Mirrors ``tests/api/dev/test_entitlement.py``'s shape for the entitlement
+half (same fail-closed feature-decision seam, now gating
+``ask_dev_graph_routing`` instead of ``ask_dev``). The composite-availability
+half is exercised as pure branching logic over ``GraphQueryOutcome`` plus the
+packet's own disclosed ``PacketLimitationKind``s -- see the CHAOS-3660
+proposal comment for why this derives from Lane B's existing
+``GraphQueryOutcome`` and the packet's own truncation/staleness disclosure
+rather than minting a fourth, independent vocabulary.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
+from dev_health_ops.api.dev.graph_routing_policy import (
+    CanonicalGraphRoutingEntitlementAuthorizer,
+    GraphAssistedAvailability,
+    GraphRoutingPolicyDeniedError,
+    describe_availability,
+    limitation_kinds_of,
+)
+from dev_health_ops.api.dev.investigation_contract import (
+    AskDevInvestigationPacket,
+    PacketLimitation,
+    PacketLimitationKind,
+)
+from dev_health_ops.licensing import FeatureDecision, FeatureDecisionReason
+from dev_health_ops.licensing.registry import ASK_DEV_GRAPH_ROUTING_FEATURE
+
+ORG_ID = "00000000-0000-0000-0000-000000000001"
+
+
+# --------------------------------------------------------------------------
+# Entitlement
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("allowed", "reason"),
+    [
+        (False, FeatureDecisionReason.EXPLICIT_PURCHASE_REQUIRED),
+        (True, FeatureDecisionReason.ENABLED_BY_ORG_OVERRIDE),
+        (True, FeatureDecisionReason.ENABLED_BY_LICENSE_OVERRIDE),
+    ],
+)
+async def test_entitlement_uses_the_graph_routing_feature_not_base_ask_dev(
+    monkeypatch: pytest.MonkeyPatch,
+    allowed: bool,
+    reason: FeatureDecisionReason,
+) -> None:
+    """This is the guard that matters most: a copy-paste from entitlement.py
+    that forgot to change the feature key would silently gate the beta route
+    on plain ``ask_dev`` instead of the design-partner-beta feature -- every
+    org with base Ask Dev would get graph routing for free.
+    """
+
+    calls: list[tuple[object, uuid.UUID, str]] = []
+
+    async def evaluate(
+        session: object, org_id: uuid.UUID, feature_key: str
+    ) -> FeatureDecision:
+        calls.append((session, org_id, feature_key))
+        return FeatureDecision(feature_key, allowed, reason)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.graph_routing_policy.evaluate_org_feature_async",
+        evaluate,
+    )
+    session = object()
+    authorizer = CanonicalGraphRoutingEntitlementAuthorizer(session)  # type: ignore[arg-type]
+
+    if allowed:
+        await authorizer.require(ORG_ID)
+    else:
+        with pytest.raises(GraphRoutingPolicyDeniedError) as exc_info:
+            await authorizer.require(ORG_ID)
+        assert exc_info.value.reason is reason
+
+    assert calls == [(session, uuid.UUID(ORG_ID), ASK_DEV_GRAPH_ROUTING_FEATURE)]
+
+
+@pytest.mark.asyncio
+async def test_entitlement_storage_failure_and_invalid_org_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unavailable(*_args: object) -> FeatureDecision:
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.graph_routing_policy.evaluate_org_feature_async",
+        unavailable,
+    )
+    authorizer = CanonicalGraphRoutingEntitlementAuthorizer(object())  # type: ignore[arg-type]
+
+    with pytest.raises(GraphRoutingPolicyDeniedError) as storage:
+        await authorizer.require(ORG_ID)
+    assert storage.value.reason is FeatureDecisionReason.STORAGE_ERROR
+
+    with pytest.raises(GraphRoutingPolicyDeniedError) as invalid:
+        await authorizer.require("not-an-org-id")
+    assert invalid.value.reason is FeatureDecisionReason.INVALID_FEATURE_STATE
+
+
+# --------------------------------------------------------------------------
+# Composite availability
+# --------------------------------------------------------------------------
+
+
+def _completed_packet() -> AskDevInvestigationPacket:
+    from tests._chaos_3502_graph_investigation_fake import default_investigation_packet
+
+    return default_investigation_packet()
+
+
+def _with_limitation_kinds(
+    packet: AskDevInvestigationPacket, kinds: tuple[PacketLimitationKind, ...]
+) -> AskDevInvestigationPacket:
+    """Patch only ``evidence_coverage.limitations`` -- deliberately bypasses
+    the packet's own cross-field disclosure validators (``model_copy``
+    doesn't re-run them), because this helper exists solely to feed
+    ``describe_availability`` a packet whose *limitation kinds* are
+    controlled, not to construct a fully self-consistent packet. The
+    plumbing from a real, validated packet is covered separately by
+    ``test_limitation_kinds_of_reads_the_real_contract_shape`` below.
+    """
+
+    limitations = tuple(
+        PacketLimitation(kind=kind, detail=f"test fixture: {kind.value}")
+        for kind in kinds
+    )
+    coverage = packet.evidence_coverage.model_copy(update={"limitations": limitations})
+    return packet.model_copy(update={"evidence_coverage": coverage})
+
+
+def test_limitation_kinds_of_reads_the_real_contract_shape() -> None:
+    """Confirms the extraction helper reads the packet's real,
+    contract-validated ``evidence_coverage.limitations`` -- not a
+    hand-rolled shape a unit test alone might get away with.
+    """
+
+    packet = _completed_packet()
+    kinds = limitation_kinds_of(packet)
+    assert kinds == frozenset(
+        entry.kind for entry in packet.evidence_coverage.limitations
+    )
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        GraphQueryOutcome.DISABLED,
+        GraphQueryOutcome.UNAVAILABLE,
+        GraphQueryOutcome.DEADLINE_EXCEEDED,
+        GraphQueryOutcome.CANCELLED,
+        GraphQueryOutcome.PROVIDER_FAILURE,
+    ],
+)
+def test_not_entitled_and_every_transport_failure_outcome_report_unavailable(
+    outcome: GraphQueryOutcome,
+) -> None:
+    result = GraphQueryResult(outcome=outcome, packet=None, diagnostic="probe")
+    assert describe_availability(entitled=True, result=result) is (
+        GraphAssistedAvailability.UNAVAILABLE
+    )
+    # Entitlement is checked first: even a COMPLETED-shaped result must not
+    # leak through for an org without the feature.
+    completed = GraphQueryResult(
+        outcome=GraphQueryOutcome.COMPLETED, packet=_completed_packet()
+    )
+    assert describe_availability(entitled=False, result=completed) is (
+        GraphAssistedAvailability.UNAVAILABLE
+    )
+
+
+def test_no_attempt_yet_is_unavailable_not_a_fabricated_enabled() -> None:
+    assert describe_availability(entitled=True, result=None) is (
+        GraphAssistedAvailability.UNAVAILABLE
+    )
+
+
+def test_route_level_stale_reports_stale() -> None:
+    result = GraphQueryResult(
+        outcome=GraphQueryOutcome.STALE,
+        packet=None,
+        diagnostic="watermark beyond tolerance",
+    )
+    assert describe_availability(entitled=True, result=result) is (
+        GraphAssistedAvailability.STALE
+    )
+
+
+def test_completed_with_truncated_traversal_reports_truncated() -> None:
+    packet = _with_limitation_kinds(
+        _completed_packet(), (PacketLimitationKind.TRUNCATED_TRAVERSAL,)
+    )
+    result = GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
+    assert describe_availability(entitled=True, result=result) is (
+        GraphAssistedAvailability.TRUNCATED
+    )
+
+
+def test_completed_with_stale_source_reports_lagging() -> None:
+    packet = _with_limitation_kinds(
+        _completed_packet(), (PacketLimitationKind.STALE_SOURCE,)
+    )
+    result = GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
+    assert describe_availability(entitled=True, result=result) is (
+        GraphAssistedAvailability.LAGGING
+    )
+
+
+def test_truncated_takes_precedence_over_lagging_when_both_present() -> None:
+    packet = _with_limitation_kinds(
+        _completed_packet(),
+        (PacketLimitationKind.TRUNCATED_TRAVERSAL, PacketLimitationKind.STALE_SOURCE),
+    )
+    result = GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
+    assert describe_availability(entitled=True, result=result) is (
+        GraphAssistedAvailability.TRUNCATED
+    )
+
+
+def test_clean_completed_reports_enabled() -> None:
+    packet = _with_limitation_kinds(_completed_packet(), ())
+    result = GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
+    assert describe_availability(entitled=True, result=result) is (
+        GraphAssistedAvailability.ENABLED
+    )


### PR DESCRIPTION
## Issue / phase
Wave 3.2, CHAOS-3665 (Phase 1: graph-assisted Ask Dev feature policy + shared Web rendering) -- **ops-side leg only**, first of multiple PRs (CHAOS-3665 mentioned as plain reference, not close-linked; this PR does not complete it). The web-repo half (shared rendering, Playwright, /dev + window surfaces) is a separate, later PR gated on Lane B's routing stack.

## Observable outcome
- An org without `ask_dev_graph_routing` entitlement gets a typed, fail-closed denial (`GraphRoutingPolicyDeniedError` carrying a `FeatureDecisionReason`) from a call site that mirrors the existing `entitlement.CanonicalAskDevEntitlementAuthorizer` shape exactly, gating the correct feature key.
- Given an org's entitlement decision and (optionally) a completed/failed graph-route attempt, `describe_availability()` returns one of CHAOS-3665's acceptance-criteria web states (`enabled/unavailable/stale/lagging/truncated`) derived from real signals already in the codebase -- no independent new vocabulary was minted.

## Architecture boundary
New, standalone, additive module: `src/dev_health_ops/api/dev/graph_routing_policy.py`. Touches no shared/frozen file. Composes:
- `licensing.registry.ASK_DEV_GRAPH_ROUTING_FEATURE` + `licensing.evaluate_org_feature_async` (both pre-existing, unmodified).
- Lane B's `graph_investigation_query.GraphQueryOutcome`/`GraphQueryResult` (pre-existing proposal file, unmodified, read-only import).
- `investigation_contract`'s `AskDevInvestigationPacket`/`PacketLimitationKind` (pre-existing, unmodified, read-only import).

Design reasoning -- including two corrections made mid-draft (retracting a parallel-enum proposal after finding `GraphQueryOutcome`; then retracting a "no signal for lagging" claim after finding `PacketLimitationKind.STALE_SOURCE`) -- is posted in full on CHAOS-3660 ahead of this code, per the shared-contract protocol.

## Scope / non-scope
**In scope:** organization/design-partner entitlement check for graph-assisted routing; a composite availability view for the web to render.
**Not in scope (explicitly deferred):**
- Wiring this into `orchestrator.py`/`production_runtime.py` (Lane A/B territory; `production_runtime.py` has zero references to `ASK_DEV_GRAPH_ROUTING_FEATURE` or `GraphInvestigationQuery` today -- that construction/gating call site doesn't exist yet for this module to plug into).
- `GraphAssistedAvailability.FALLBACK` is declared (CHAOS-3665 names it) but never returned by `describe_availability()` -- no signal for "graph attempted, degraded to native" exists anywhere in the codebase yet. Flagged as an open gap on CHAOS-3660 rather than guessed at.
- Everything web-repo (`dev-health-web` untouched).
- Whether "ACR-entitled" (chris's ruling) means a literal `agent_context_runtime` prerequisite dependency vs. just matching ACR's rigorous entitlement-checking pattern -- flagged as an open question on CHAOS-3660; this PR proceeds on the latter (no new cross-feature coupling invented).

## Base / head SHA
Base: `ff1217a69acc5fcfeaf4654936580c0696887b23` (origin/feature/chaos-3498-context-fabric tip at branch time)
Head: `8761214c26a5e6dda702496f2e0e698e4e21be5d`

## Migrations
None.

## Security impact
Fail-closed by construction: any exception from the feature-decision seam (storage error, malformed org id) raises `GraphRoutingPolicyDeniedError`, never silently allows. No new data access, no new auth surface -- reuses the existing `evaluate_org_feature_async` seam verbatim.

## RED-first evidence
`tests/api/dev/test_chaos_3665_graph_routing_policy.py` written and run against the *absent* module first:
```
ModuleNotFoundError: No module named 'dev_health_ops.api.dev.graph_routing_policy'
```
Then `graph_routing_policy.py` written; all 16 new tests pass.

## Verification
- Focused: `pytest tests/api/dev/test_chaos_3665_graph_routing_policy.py` -- 16 passed.
- Affected: `pytest tests/api/dev/ tests/api/licensing/` -- 3049 passed, 81 skipped (pre-existing), 4 xfailed (pre-existing).
- `ruff check` / `ruff format --check` -- clean.
- `mypy` (worktree venv, full project per `pyproject.toml` config) -- `Success: no issues found in 2307 source files`.
- No live-store boundary crossed (pure composition over existing in-memory types); no FalkorDB dependency.

## Known limitations
- `lagging`/`truncated`/`enabled`/`stale`/`unavailable` are derived and tested against real contract types (`GraphQueryOutcome`, `PacketLimitationKind` via the packet's own `evidence_coverage.limitations`, sourced from `_chaos_3502_graph_investigation_fake.default_investigation_packet()`); `fallback` is unreachable until a real "degraded to native" signal exists.
- Nothing calls this module yet -- it is a policy primitive for Lane A/B to call into once `production_runtime.py`'s graph-routing construction lands (CHAOS-3678/CHAOS-3502).
- The `agent_context_runtime` open question above is unresolved; easy follow-up if the ruling is (2) rather than (1).

## Rollout / rollback
No behavior change to any existing path -- new module, zero call sites yet. Safe to merge and revert independently of any other Wave 3.2 work.