### PR TITLE
CHAOS-3678: extract packet_builder into shared core + build_production_packet

### DIFF
--- a/src/dev_health_ops/api/dev/investigation_contract/packet.py
+++ b/src/dev_health_ops/api/dev/investigation_contract/packet.py
@@ -330,7 +330,7 @@ class ContractChangelogEntry:
 CONTRACT_CHANGELOG: tuple[ContractChangelogEntry, ...] = (
     ContractChangelogEntry(
         ticket="CHAOS-3660",
-        pull_request="TBD",
+        pull_request="#1657",
         landed_on="2026-08-10",
         schema="ask_dev_analytical_job",
         from_version="v1",

--- a/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
@@ -38,9 +38,11 @@ from collections.abc import Container, Mapping, Sequence
 from dataclasses import dataclass, field
 from dataclasses import replace as dataclasses_replace
 from datetime import datetime, timedelta
+from typing import Protocol
 
 from dev_health_ops.api.dev.contracts import FreshnessState
 from dev_health_ops.api.dev.contracts_v2.base import (
+    QuestionIntentID,
     SourceClass,
     SourceRequirementState,
 )
@@ -79,6 +81,7 @@ from dev_health_ops.api.dev.investigation_contract import (
     MissingSource,
     PacketLimitation,
     PacketLimitationKind,
+    ProductionJobProvenance,
     QuestionFamilyID,
     RelatedContext,
     RelatedEntity,
@@ -135,6 +138,7 @@ __all__ = [
     "IncomparableCohortError",
     "JobContext",
     "PacketTooLargeError",
+    "ProductionJobContext",
     "SubjectMatchFinding",
     "AuthorizationWithheldEvidenceError",
     "CanonicalEvidenceRefusedError",
@@ -142,6 +146,7 @@ __all__ = [
     "TrialContext",
     "UnsupportedComparisonShapeError",
     "build_packet",
+    "build_production_packet",
     "derive_outcome",
     "signer_from_environment",
 ]
@@ -338,6 +343,61 @@ class TrialContext:
     #: the trial artifact by the caller; kept here so a packet and its
     #: artifact cannot disagree about which build produced them.
     dependency_versions: Mapping[str, str] = field(default_factory=dict)
+
+
+class _JobLike(Protocol):
+    """The job fields ``_assemble_core`` needs that neither depend on nor
+    describe trial-vs-production provenance. :class:`JobContext` and
+    :class:`ProductionJobContext` both satisfy this structurally; neither
+    references the other, so this is the only coupling between them.
+
+    Declared as properties, not plain attributes: both implementations are
+    frozen dataclasses, whose fields mypy treats as read-only, so a
+    plain-attribute Protocol (implicitly settable) would reject them.
+    """
+
+    @property
+    def job_id(self) -> str: ...
+    @property
+    def job_statement(self) -> str: ...
+    @property
+    def comparison_shape(self) -> ComparisonShape: ...
+    @property
+    def window_start(self) -> datetime: ...
+    @property
+    def window_end(self) -> datetime: ...
+    @property
+    def timezone(self) -> str: ...
+    @property
+    def job_uncertainty(self) -> JobUncertainty: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ProductionJobContext:
+    """The analytical job production asked this arm to investigate.
+
+    Production's own analog of :class:`JobContext` (CHAOS-3660/CHAOS-3678).
+    It carries an ``intent_id``, never a ``QuestionFamilyID``: per the
+    CHAOS-3678 GO ruling, production classifies its own job and comparison
+    shape before ever calling this arm, so :func:`build_production_packet`
+    performs no family/comparison-shape permission check -- unlike
+    :func:`build_packet`, which still enforces the trial's
+    ``QUESTION_FAMILY_REGISTRY`` rule for ``JobContext.question_family``.
+
+    ``run_id`` is production's analog of ``TrialContext.run_id``: the
+    identifier the calling ``GraphInvestigationRequest`` already carries.
+    There is no corpus/fixture concept here at all, unlike ``TrialContext``.
+    """
+
+    job_id: str
+    intent_id: QuestionIntentID
+    run_id: str
+    job_statement: str
+    comparison_shape: ComparisonShape
+    window_start: datetime
+    window_end: datetime
+    timezone: str = "UTC"
+    job_uncertainty: JobUncertainty = JobUncertainty.PRECISE
 
 
 def signer_from_environment() -> EvidenceReferenceSigner:
@@ -1092,13 +1152,17 @@ def _lineage_path(
     )
 
 
-def build_packet(
+def _assemble_core(
     *,
     readout: InvestigationReadout,
-    job: JobContext,
+    job: _JobLike,
+    run_id: str,
+    question_family: QuestionFamilyID | None,
+    production_job: ProductionJobProvenance | None,
+    corpus_version: str | None,
+    trial_metadata: TrialMetadata | None,
     watermark: IndexWatermark,
     signer: EvidenceReferenceSigner,
-    trial: TrialContext,
     produced_at: datetime,
     embedder: EmbeddingBackend | None = None,
     subject_matches: Sequence[SubjectMatchFinding] | None = None,
@@ -1110,6 +1174,16 @@ def build_packet(
     admitted_evidence: Mapping[str, DevEvidenceRefV2] | None = None,
 ) -> AskDevInvestigationPacket:
     """Turn one bounded traversal into the frozen investigation packet.
+
+    Shared by :func:`build_packet` (trial, byte-stable) and
+    :func:`build_production_packet` (CHAOS-3678). Exactly one of
+    ``question_family``/``production_job`` must be non-``None`` --
+    ``AnalyticalJob``'s own exactly-one-of validator is what actually
+    enforces this, deliberately not duplicated here. ``question_family``
+    also controls whether the trial's family/comparison-shape permission
+    check runs at all: ``None`` (the production path) skips it entirely,
+    because production classifies its own job/shape before calling this arm
+    (CHAOS-3678 GO ruling) and has no family for the check to consult.
 
     ``admitted_evidence`` (CHAOS-3646) is the canonical evidence service's
     answer to this run's admission round, keyed by the SOURCE's own record
@@ -1191,10 +1265,21 @@ def build_packet(
         else set()
     )
 
-    family = QUESTION_FAMILY_REGISTRY[job.question_family]
-    if job.comparison_shape not in family.permitted_comparison_shapes:
+    # Trial-only: production has no question family, and classifies its own
+    # job/comparison-shape before calling this arm (CHAOS-3678 GO ruling),
+    # so there is no family here for a permission check to consult, and no
+    # family-declared required source classes below either.
+    family = (
+        QUESTION_FAMILY_REGISTRY[question_family]
+        if question_family is not None
+        else None
+    )
+    if (
+        family is not None
+        and job.comparison_shape not in family.permitted_comparison_shapes
+    ):
         raise ValueError(
-            f"family {job.question_family} does not permit the "
+            f"family {question_family} does not permit the "
             f"{job.comparison_shape} comparison shape"
         )
 
@@ -1723,7 +1808,14 @@ def build_packet(
             ),
         )
         for source_class in sorted(
-            set(family.required_source_classes) - set(observed_classes),
+            (
+                set(family.required_source_classes) - set(observed_classes)
+                if family is not None
+                # Production declares no family-required source-class set at
+                # this arm's level; nothing is disclosed MISSING on that
+                # basis alone.
+                else set()
+            ),
             key=lambda item: item.value,
         )
     )
@@ -1980,9 +2072,14 @@ def build_packet(
         edge_validity_basis=EdgeValidityBasis.NOT_REQUIRED,
     )
     analytical_job = AnalyticalJob(
-        schema_version="ask_dev_analytical_job.v1",
+        schema_version=(
+            "ask_dev_analytical_job.v1"
+            if question_family is not None
+            else "ask_dev_analytical_job.v2"
+        ),
         job_id=job.job_id,
-        question_family=job.question_family,
+        question_family=question_family,
+        production_job=production_job,
         job_uncertainty=job.job_uncertainty,
         job_statement=job.job_statement,
         comparison_shape=job.comparison_shape,
@@ -2155,18 +2252,13 @@ def build_packet(
             )
             for source_class in (observed_classes or [SourceClass.WORK_GRAPH])
         ),
-        corpus_version=trial.corpus_version,
-        trial=TrialMetadata(
-            arm_id=ARM_ID,
-            producer_id=PRODUCER_ID,
-            fixture_version=trial.fixture_version,
-            run_id=trial.run_id,
-        ),
+        corpus_version=corpus_version,
+        trial=trial_metadata,
     )
 
     packet = AskDevInvestigationPacket(
         schema_version="ask_dev_investigation_packet.v1",
-        packet_id=_packet_id(trial.run_id, job.job_id),
+        packet_id=_packet_id(run_id, job.job_id),
         organization_id=readout.org_id,
         produced_at=produced_at,
         # Derived, never passed in: an arm that could be told its own outcome
@@ -2208,3 +2300,113 @@ def build_packet(
             "than emitting a packet nobody bounded"
         )
     return packet
+
+
+def build_packet(
+    *,
+    readout: InvestigationReadout,
+    job: JobContext,
+    watermark: IndexWatermark,
+    signer: EvidenceReferenceSigner,
+    trial: TrialContext,
+    produced_at: datetime,
+    embedder: EmbeddingBackend | None = None,
+    subject_matches: Sequence[SubjectMatchFinding] | None = None,
+    cohort: CohortProposal | None = None,
+    drivers: Sequence[DriverFinding] | None = None,
+    drivers_truncated: bool = False,
+    budgets: TrialBudgets = DEFAULT_BUDGETS,
+    staleness_tolerance: timedelta = DEFAULT_STALENESS_TOLERANCE,
+    admitted_evidence: Mapping[str, DevEvidenceRefV2] | None = None,
+) -> AskDevInvestigationPacket:
+    """The trial's constructor (CHAOS-3617). Byte-stable: this is a thin
+    wrapper over :func:`_assemble_core` that supplies exactly the values the
+    original single-function ``build_packet`` computed inline, so every
+    existing caller sees zero output difference from the CHAOS-3678
+    extraction. See :func:`_assemble_core` for the parameter semantics this
+    delegates.
+    """
+
+    return _assemble_core(
+        readout=readout,
+        job=job,
+        run_id=trial.run_id,
+        question_family=job.question_family,
+        production_job=None,
+        corpus_version=trial.corpus_version,
+        trial_metadata=TrialMetadata(
+            arm_id=ARM_ID,
+            producer_id=PRODUCER_ID,
+            fixture_version=trial.fixture_version,
+            run_id=trial.run_id,
+        ),
+        watermark=watermark,
+        signer=signer,
+        produced_at=produced_at,
+        embedder=embedder,
+        subject_matches=subject_matches,
+        cohort=cohort,
+        drivers=drivers,
+        drivers_truncated=drivers_truncated,
+        budgets=budgets,
+        staleness_tolerance=staleness_tolerance,
+        admitted_evidence=admitted_evidence,
+    )
+
+
+def build_production_packet(
+    *,
+    readout: InvestigationReadout,
+    job: ProductionJobContext,
+    watermark: IndexWatermark,
+    signer: EvidenceReferenceSigner,
+    produced_at: datetime,
+    embedder: EmbeddingBackend | None = None,
+    subject_matches: Sequence[SubjectMatchFinding] | None = None,
+    cohort: CohortProposal | None = None,
+    drivers: Sequence[DriverFinding] | None = None,
+    drivers_truncated: bool = False,
+    budgets: TrialBudgets = DEFAULT_BUDGETS,
+    staleness_tolerance: timedelta = DEFAULT_STALENESS_TOLERANCE,
+    admitted_evidence: Mapping[str, DevEvidenceRefV2] | None = None,
+) -> AskDevInvestigationPacket:
+    """Production's constructor (CHAOS-3660/CHAOS-3678).
+
+    No ``TrialContext``, no ``QuestionFamilyID``, no fixture/corpus concept:
+    ``job.intent_id`` is production's own vocabulary (typed as the real
+    ``QuestionIntentID`` enum, so an invalid intent cannot reach this
+    function -- there is no separate runtime check to keep in sync with the
+    enum). The emitted ``AnalyticalJob`` carries ``production_job`` instead
+    of ``question_family``, and the emitted packet's ``versions.trial`` and
+    ``versions.corpus_version`` are both ``None``: per
+    ``investigation_contract/__init__.py``, ``TrialMetadata`` is optional
+    "evaluation metadata, never product truth", and production has none.
+
+    See :func:`_assemble_core` for the parameter semantics this delegates,
+    including ``admitted_evidence``, ``embedder`` and ``cohort``.
+    """
+
+    return _assemble_core(
+        readout=readout,
+        job=job,
+        run_id=job.run_id,
+        question_family=None,
+        production_job=ProductionJobProvenance(
+            schema_version="ask_dev_production_job_provenance.v1",
+            intent_id=job.intent_id.value,
+            run_id=job.run_id,
+        ),
+        corpus_version=None,
+        trial_metadata=None,
+        watermark=watermark,
+        signer=signer,
+        produced_at=produced_at,
+        embedder=embedder,
+        subject_matches=subject_matches,
+        cohort=cohort,
+        drivers=drivers,
+        drivers_truncated=drivers_truncated,
+        budgets=budgets,
+        staleness_tolerance=staleness_tolerance,
+        admitted_evidence=admitted_evidence,
+    )

--- a/tests/context_fabric/test_chaos_3678_production_packet.py
+++ b/tests/context_fabric/test_chaos_3678_production_packet.py
@@ -1,0 +1,183 @@
+"""CHAOS-3678: ``build_production_packet``, the packet_builder extraction.
+
+``build_packet`` (CHAOS-3617) and its ``JobContext``/``TrialContext`` are the
+trial's byte-stable constructor and stay untouched -- the whole existing
+``tests/context_fabric/`` suite is the byte-stability proof for that path,
+since any output drift there fails those tests. This module covers only what
+is new: ``build_production_packet``, which emits the same frozen
+``ask_dev_investigation_packet.v1`` shape for CHAOS-3678's production caller,
+with no ``QuestionFamilyID`` and no trial/fixture/corpus concept at all.
+
+Two things this module holds the line on, because both are silent-drift
+risks a type checker cannot catch:
+
+* the family/comparison-shape permission check
+  (``QUESTION_FAMILY_REGISTRY[...].permitted_comparison_shapes``) must fire
+  for the trial path and must NOT fire for production -- proven side by side
+  with the same comparison shape, not asserted from reading the code;
+* the emitted packet must validate against the real, generated JSON Schema
+  on disk, not just construct without a Python exception.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+
+import jsonschema
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import QuestionIntentID
+from dev_health_ops.api.dev.investigation_contract import (
+    ComparisonShape,
+    QuestionFamilyID,
+)
+from dev_health_ops.api.dev.investigation_contract.export import ARTIFACT_ROOT
+from dev_health_ops.context_fabric.graph_arm import fixtures
+from dev_health_ops.context_fabric.graph_arm.packet_builder import (
+    JobContext,
+    ProductionJobContext,
+    TrialContext,
+    build_packet,
+    build_production_packet,
+)
+from dev_health_ops.context_fabric.graph_arm.readback import ProjectionGraphReader
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+
+_PRODUCED_AT = datetime(2026, 8, 10, 12, 0, tzinfo=UTC)
+_TRIAL_RUN_ID = "4f9a2c1e-1111-4222-8333-444455556666"
+_PRODUCTION_RUN_ID = "7c3e9a10-2222-4333-9444-555566667777"
+
+
+def _readout(projection):
+    return asyncio.run(
+        ProjectionGraphReader(projection).neighbourhood(
+            org_id=projection.org_id,
+            seed_canonical_ids=["proj_nightfall_migration"],
+            authorized_entity_ids=fixtures.alpha_authorized_ids(),
+            max_hops=3,
+        )
+    )
+
+
+def _watermark() -> IndexWatermark:
+    return IndexWatermark(
+        indexed_through=fixtures.WINDOW_END,
+        projected_at=fixtures.WINDOW_END,
+        records_indexed=42,
+    )
+
+
+@pytest.fixture
+def readout(alpha_projection):
+    return _readout(alpha_projection)
+
+
+def _production_packet(
+    readout, signer, *, comparison_shape=ComparisonShape.SINGULAR_SUBJECT
+):
+    return build_production_packet(
+        readout=readout,
+        job=ProductionJobContext(
+            job_id="prod_job_status",
+            intent_id=QuestionIntentID.ENTITY_STATUS,
+            run_id=_PRODUCTION_RUN_ID,
+            job_statement="Status of the Nightfall Migration project.",
+            comparison_shape=comparison_shape,
+            window_start=fixtures.WINDOW_START,
+            window_end=fixtures.WINDOW_END,
+        ),
+        watermark=_watermark(),
+        signer=signer,
+        produced_at=_PRODUCED_AT,
+    )
+
+
+def test_build_production_packet_declares_production_provenance(readout, signer):
+    packet = _production_packet(readout, signer)
+    job = packet.analytical_job
+    assert job.schema_version == "ask_dev_analytical_job.v2"
+    assert job.question_family is None
+    assert job.production_job is not None
+    assert job.production_job.intent_id == QuestionIntentID.ENTITY_STATUS.value
+    assert job.production_job.run_id == _PRODUCTION_RUN_ID
+
+
+def test_build_production_packet_omits_trial_metadata(readout, signer):
+    packet = _production_packet(readout, signer)
+    assert packet.versions.trial is None
+    assert packet.versions.corpus_version is None
+
+
+def test_build_production_packet_validates_against_the_generated_schema(
+    readout, signer
+):
+    """Real jsonschema.validate against the artifact on disk, not just a
+    successful Pydantic construction -- the two implementations can diverge
+    (CHAOS-3615), so this exercises the actual generated schema.
+    """
+
+    packet = _production_packet(readout, signer)
+    schema = json.loads(
+        (
+            ARTIFACT_ROOT / "schemas" / "ask_dev_investigation_packet.v1.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+    jsonschema.validate(packet.model_dump(mode="json"), schema)
+
+
+def test_the_trial_family_check_still_fires_for_a_shape_it_forbids(readout, signer):
+    """RED anchor for the next test. STRUGGLING_TEAMS permits only
+    DISCOVERED_COHORT/PORTFOLIO_WIDE, so a SINGULAR_SUBJECT job under that
+    family must still be refused on the trial path -- proving the check this
+    extraction gates out for production is still load-bearing for
+    ``build_packet``.
+    """
+
+    with pytest.raises(ValueError, match="does not permit"):
+        build_packet(
+            readout=readout,
+            job=JobContext(
+                job_id="job_status",
+                question_family=QuestionFamilyID("struggling_teams"),
+                job_statement="Status of the Nightfall Migration project.",
+                comparison_shape=ComparisonShape.SINGULAR_SUBJECT,
+                window_start=fixtures.WINDOW_START,
+                window_end=fixtures.WINDOW_END,
+            ),
+            watermark=_watermark(),
+            signer=signer,
+            trial=TrialContext(run_id=_TRIAL_RUN_ID),
+            produced_at=_PRODUCED_AT,
+        )
+
+
+def test_build_production_packet_skips_the_family_permission_check(readout, signer):
+    """The same comparison shape the test above proves is family-forbidden
+    for a trial job must NOT be refused for a production job, because
+    production has no question family and classifies its own job/shape
+    before ever calling this arm (CHAOS-3678 GO ruling) -- there is no
+    family here for a permission check to consult.
+    """
+
+    packet = _production_packet(
+        readout, signer, comparison_shape=ComparisonShape.SINGULAR_SUBJECT
+    )
+    assert packet.analytical_job.comparison_shape is ComparisonShape.SINGULAR_SUBJECT
+
+
+def test_build_production_packet_still_enforces_arm_capability_rules(readout, signer):
+    """The family check is gated out, but the arm's own cohort-capability
+    rule (independent of any question family) still applies to production:
+    a cohort-shaped job with no cohort proposal is still refused.
+    """
+
+    from dev_health_ops.context_fabric.graph_arm.packet_builder import (
+        UnsupportedComparisonShapeError,
+    )
+
+    with pytest.raises(UnsupportedComparisonShapeError):
+        _production_packet(
+            readout, signer, comparison_shape=ComparisonShape.PORTFOLIO_WIDE
+        )


### PR DESCRIPTION
## Issue / Phase

CHAOS-3678 (production graph-assisted query service), the critical-path piece for CHAOS-3502's COMPLETED leg, per team-lead's packet-constructor ruling (shared core + two byte-stable constructors). Unparked from EXTRACTION-STATE-NOTE.md (posted to CHAOS-3678) after a budget re-check. Branch is intentionally ID-free: this is one increment of CHAOS-3678's broader scope, and a branch carrying the issue ID would prematurely auto-close it on merge (precedent: #1631/#1656).

## Observable outcome

`packet_builder.build_packet`'s ~1115-line body is split into a shared `_assemble_core` plus two thin constructors:

- `build_packet` (trial) — same signature, same docstring, byte-stable: every existing caller's output is unchanged.
- `build_production_packet` (new) — takes a new `ProductionJobContext` (job_id, intent_id: QuestionIntentID, run_id, job_statement, comparison_shape, window_start/end, timezone, job_uncertainty) instead of `JobContext` + `TrialContext`. No `QuestionFamilyID`, no trial/fixture/corpus concept.

## Architecture boundary

Two provenance-dependent dependencies are gated inside `_assemble_core` rather than duplicated:

1. The `QUESTION_FAMILY_REGISTRY` family/comparison-shape permission check, **plus a family-required-source-classes read my original scoping note missed** (`family.required_source_classes`, used to compute `MissingSource` entries) — both only run when `question_family is not None`. Production classifies its own job/comparison-shape before ever calling this arm (CHAOS-3678 GO ruling) and has no family for either check to consult.
2. `versions.trial` and `versions.corpus_version` are both `None` for a production packet — already optional on `InvestigationVersions` per its own docstring ("evaluation metadata, never product truth").

The arm's own capability rules that are independent of any question family (e.g. the cohort-shape/cohort-proposal check) are unconditional in `_assemble_core` and apply to both paths — proven by `test_build_production_packet_still_enforces_arm_capability_rules`.

`_JobLike` is a small structural `Protocol` (declared via `@property`, since both `JobContext` and `ProductionJobContext` are frozen dataclasses mypy treats as read-only) covering only the fields common to both job shapes, so `_assemble_core` never imports one job type into the other.

## Scope / non-scope

In scope: `packet_builder.py`'s extraction, `ProductionJobContext`, `build_production_packet`, and fixing the `CONTRACT_CHANGELOG` entry's `pull_request` placeholder ("TBD" → "#1657") now that CHAOS-3660's contract-widening PR has landed.

Out of scope: wiring `build_production_packet` into `ProductionGraphInvestigationQuery`/`query_service.py` (CHAOS-3678 increment 1, still draft PR #1654) — that lands separately once this merges, and is the next step that actually uses this constructor.

## Base / head SHA

- Base: `ecfa35787f8d4f4e597dbce74218ede9ab1fe9b8` (`feature/chaos-3498-context-fabric` tip at branch-cut time — "CHAOS-3687: build the graph-assisted routing branch (CHAOS-3660 sign-off)")
- Head: `a41d7e377ba706eaacc8390e2a58d6e30dd3e801`

## Migrations

None. Construction-code refactor plus one changelog placeholder fix; no schema/contract shape change.

## Security / privacy

None. No new PII surface; `ProductionJobContext.intent_id` is typed as the real `QuestionIntentID` enum (not a plain string), so an invalid intent cannot reach this function — there is no separate runtime validation to keep in sync with the enum, per the docstring on `ProductionJobProvenance`.

## RED-first evidence

`tests/context_fabric/test_chaos_3678_production_packet.py` was written first (confirmed failing on `ImportError: cannot import name 'ProductionJobContext'` before implementation existed) and proves, side by side with the identical comparison shape:

- `test_the_trial_family_check_still_fires_for_a_shape_it_forbids` — `STRUGGLING_TEAMS` (permits only `DISCOVERED_COHORT`/`PORTFOLIO_WIDE`) + `SINGULAR_SUBJECT` still raises `ValueError` on `build_packet`.
- `test_build_production_packet_skips_the_family_permission_check` — the identical `SINGULAR_SUBJECT` shape does NOT raise for `build_production_packet`, because there is no family to consult.
- `test_build_production_packet_validates_against_the_generated_schema` — real `jsonschema.validate` against the on-disk generated schema, not just a successful Pydantic construction (the two implementations can diverge per CHAOS-3615).
- `test_build_production_packet_declares_production_provenance` / `test_build_production_packet_omits_trial_metadata` — the emitted packet's provenance and version fields.
- `test_build_production_packet_still_enforces_arm_capability_rules` — the cohort-capability check still fires for production.

## Verification

- `pytest tests/context_fabric/` (the full byte-stability proof for the unmodified trial path) — 1473 passed, 52 skipped, 0 failed
- `pytest tests/context_fabric/test_chaos_3678_production_packet.py` — 6 passed
- `pytest tests/api/dev/ -k "contract or 3615 or 3616 or 3660"` — 1000 passed, 3 xfailed, 0 failed
- `mypy .` (full repo) — Success, 2387 source files, 0 errors
- `ruff check` / `ruff format --check` — clean
- Pre-commit and pre-push lefthook gates (ruff-format, ruff-check, mypy, commit-msg) — all green, no `--no-verify` used

## Known limitations

Nothing on trunk calls `build_production_packet` yet — CHAOS-3678 increment 1 (`ProductionGraphInvestigationQuery`, draft PR #1654) is the next PR that wires it in. Re-grep `job\.`/`trial\.`/`family\b` fresh if `packet_builder.py` changes again before that lands.

## Rollout / rollback

Additive: `build_packet`'s signature, docstring and output are unchanged (proven by the full existing suite), and `build_production_packet` is a new, unused-by-trunk entry point. Revert is a plain single-commit revert; nothing downstream depends on this yet.