### PR TITLE
CHAOS-3678: transport/outcome mapping for the graph query service

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/query_service.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/query_service.py
@@ -1,0 +1,315 @@
+"""CHAOS-3678: the production bounded graph query service.
+
+Implements :class:`~dev_health_ops.api.dev.graph_investigation_query.
+GraphInvestigationQuery` — Lane B's consumer-side Protocol
+(CHAOS-3502/CHAOS-3660). This module owns job → execution-mechanism
+selection only. The analytical job and comparison shape are classified by
+production's interpreter and arrive on the wire in
+``GraphInvestigationRequest.intent_id``/``.cardinality`` — the accepted
+CHAOS-3660 determination is that this pair already carries both signals in
+production's own vocabulary, so nothing here inspects ``question_text`` to
+decide what kind of question was asked. What stays graph-side is
+:func:`mechanism_for`: given an already-classified job and shape, which
+internal traversal/synthesis mechanism actually answers it.
+
+**Increment 1 scope, stated plainly rather than left to be discovered.**
+The transport/outcome mapping — ``GraphQueryOutcome``'s
+``DISABLED``/``UNAVAILABLE``/``STALE``/``DEADLINE_EXCEEDED``/``CANCELLED``
+states — is real, live-tested, and composes the absolute request deadline
+with CHAOS-3631's per-operation :class:`~.flags.GraphDeadlines` and
+CHAOS-3679's persisted watermark. The ``COMPLETED`` path — candidate
+resolution, traversal, driver synthesis and packet assembly — is not
+implemented yet: it depends on CHAOS-3660's packet-constructor ruling (a
+production-shaped packet constructor, ``build_production_packet``, not yet
+landed in ``packet_builder.py``, since the existing ``build_packet``
+requires a trial-only ``QuestionFamilyID``). Every mechanism that would
+reach packet assembly returns ``PROVIDER_FAILURE`` with a diagnostic naming
+the pending dependency — an honest "not yet", never a silent wrong answer,
+never a crash a caller has to guard against separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    QuestionIntentID,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationQuery,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
+
+from .flags import graph_read_enabled
+from .store import GraphArmStore, StoreUnavailableError
+from .watermark import DEFAULT_STALENESS_TOLERANCE, IndexWatermark
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "GraphMechanism",
+    "ProductionGraphInvestigationQuery",
+    "mechanism_for",
+]
+
+
+class GraphMechanism(StrEnum):
+    """Which internal execution path a ``(intent_id, cardinality)`` pair
+    selects.
+
+    Job/shape classification stays production's (CHAOS-3660 determination);
+    this is the one thing that stays graph-side: given an already-classified
+    job and shape, which traversal/synthesis mechanism actually answers it.
+    Trial metadata only — never reaches the wire.
+    """
+
+    #: One resolved subject, seeded neighbourhood traversal.
+    SEEDED_SINGULAR_SUBJECT = "seeded_singular_subject"
+    #: Two or more named subjects, seeded from each.
+    SEEDED_EXPLICIT_COHORT = "seeded_explicit_cohort"
+    #: Zero named subjects, a closed job-specific candidate universe
+    #: (CHAOS-3645's second entry mode).
+    SUBJECTLESS_COHORT_DISCOVERY = "subjectless_cohort_discovery"
+    #: No graph mechanism answers this ``(intent_id, cardinality)`` pair.
+    #: Distinct from every other member: selecting it means the caller asked
+    #: for organization-wide scope on an intent that is not
+    #: ``DISCOVERED_COHORT`` — the unrestricted sweep this arm must never
+    #: construct (handoff §4: "unresolved named subjects never widen to
+    #: organization scope").
+    UNSUPPORTED = "unsupported"
+
+
+def mechanism_for(
+    intent_id: QuestionIntentID, cardinality: Cardinality
+) -> GraphMechanism:
+    """The fixed ``(intent_id, cardinality) -> mechanism`` table.
+
+    Fixed and total — never question-text inspection, per the CHAOS-3660
+    job/shape determination. ``DISCOVERED_COHORT`` requires
+    ``Cardinality.ORGANIZATION_WIDE`` by production's own contract invariant
+    (``DevQuestionIntent.validate_intent_invariants``), so a request that
+    reached this function with that intent and a different cardinality would
+    already be invalid upstream; this function does not re-derive that
+    invariant; it only reads ``intent_id`` first because that is the more
+    specific signal.
+    """
+
+    if intent_id is QuestionIntentID.DISCOVERED_COHORT:
+        return GraphMechanism.SUBJECTLESS_COHORT_DISCOVERY
+    if cardinality is Cardinality.SINGULAR:
+        return GraphMechanism.SEEDED_SINGULAR_SUBJECT
+    if cardinality is Cardinality.PLURAL_COHORT:
+        return GraphMechanism.SEEDED_EXPLICIT_COHORT
+    return GraphMechanism.UNSUPPORTED
+
+
+def _diagnostic(operation: str, detail: str) -> str:
+    """A content-safe diagnostic: a fixed template and an operation name.
+
+    Mirrors CHAOS-3631/CHAOS-3676's content-safety bar — never the raw
+    question text, never an entity label, never a caller-controlled string
+    verbatim. ``detail`` is always a value THIS module chose (an exception
+    type name, a fixed phrase), never something read off the request.
+    """
+
+    return f"graph query service: {operation}: {detail}"
+
+
+class _WatermarkStore(Protocol):
+    """The two methods ``investigate`` needs from a store.
+
+    A ``Protocol`` rather than ``GraphArmStore`` itself, mirroring
+    ``projector.ProjectingStore``: tests exercise the transport/outcome
+    mapping against fakes that implement exactly these two methods, and
+    structural typing keeps this module honest about how little of the
+    store it actually depends on.
+    """
+
+    async def read_watermark(self) -> IndexWatermark: ...
+
+    async def close(self) -> None: ...
+
+
+class ProductionGraphInvestigationQuery:
+    """The production implementation of ``GraphInvestigationQuery``.
+
+    Structural conformance to the Protocol (duck typing — the Protocol is
+    ``runtime_checkable``-free by design, so no inheritance is required or
+    attempted). See the module docstring for what increment 1 does and does
+    not do.
+    """
+
+    def __init__(
+        self,
+        *,
+        staleness_tolerance: timedelta = DEFAULT_STALENESS_TOLERANCE,
+        store_factory: Callable[[str], _WatermarkStore] = GraphArmStore.for_org,
+    ) -> None:
+        self._staleness_tolerance = staleness_tolerance
+        # Injected rather than hardcoded to `GraphArmStore.for_org` inline,
+        # so tests can exercise every `GraphQueryOutcome` -- DISABLED,
+        # UNAVAILABLE, STALE, DEADLINE_EXCEEDED, CANCELLED -- against a fake
+        # store without a live FalkorDB for every case; only the
+        # live-store positive control needs the real default.
+        self._store_factory = store_factory
+
+    async def investigate(self, request: GraphInvestigationRequest) -> GraphQueryResult:
+        """Bounded by ``request.deadline`` end to end, never past it.
+
+        Order of checks is deliberate, each one a distinct outcome the
+        Protocol requires stay distinct from every other:
+
+        1. the read flag — an intentional, configured state, checked before
+           anything that could look like a transport problem;
+        2. the absolute deadline, already passed — checked before any I/O,
+           so a caller that waited too long to even dispatch the call gets
+           ``DEADLINE_EXCEEDED`` rather than a store construction it never
+           had time for;
+        3. store construction and the watermark read, both bounded by
+           whatever remains of the absolute deadline (composed with
+           CHAOS-3631's own per-operation ``GraphDeadlines`` bound — the
+           tighter of the two wins, since ``asyncio.wait_for`` here is
+           layered on top of, not instead of, the store's own bounded
+           calls);
+        4. freshness, from the CHAOS-3679 persisted watermark — checked
+           before mechanism selection, so a stale/unavailable partition
+           never reaches a traversal attempt against data that cannot
+           answer the question;
+        5. mechanism selection and (pending CHAOS-3660) execution.
+
+        ``asyncio.CancelledError`` is caught and converted to
+        ``GraphQueryOutcome.CANCELLED`` rather than left to propagate — the
+        Protocol's own docstring requires this ("the caller's own
+        cancellation token fired... before the call completed" is a
+        ``GraphQueryOutcome`` value, not an exception a caller must guard
+        against). This is a deliberate cancellation boundary: the seam
+        absorbs its own cancellation into a result rather than the request
+        task's; nothing above this call needs its own cancellation to be
+        interrupted mid-await for this to be correct, because control only
+        reaches here already inside this coroutine's own task.
+        """
+
+        if not graph_read_enabled():
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.DISABLED,
+                diagnostic=_diagnostic("read_flag", "graph read is disabled"),
+            )
+
+        now = datetime.now(UTC)
+        remaining = (request.deadline - now).total_seconds()
+        if remaining <= 0:
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.DEADLINE_EXCEEDED,
+                diagnostic=_diagnostic(
+                    "deadline", "the absolute deadline had already passed"
+                ),
+            )
+
+        store: _WatermarkStore | None = None
+        try:
+            try:
+                store = self._store_factory(request.org_id)
+            except StoreUnavailableError as exc:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.UNAVAILABLE,
+                    diagnostic=_diagnostic("store_construction", type(exc).__name__),
+                )
+
+            try:
+                watermark = await asyncio.wait_for(
+                    store.read_watermark(), timeout=remaining
+                )
+            except TimeoutError:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.DEADLINE_EXCEEDED,
+                    diagnostic=_diagnostic(
+                        "read_watermark", "did not complete before the deadline"
+                    ),
+                )
+            except StoreUnavailableError as exc:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.UNAVAILABLE,
+                    diagnostic=_diagnostic("read_watermark", type(exc).__name__),
+                )
+
+            freshness = watermark.freshness_for(
+                now, tolerance=self._staleness_tolerance
+            )
+            if freshness is SourceRequirementState.UNAVAILABLE:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.UNAVAILABLE,
+                    diagnostic=_diagnostic(
+                        "freshness", "partition has never been projected"
+                    ),
+                )
+            if freshness is SourceRequirementState.AVAILABLE_STALE:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.STALE,
+                    diagnostic=_diagnostic("freshness", watermark.detail_for(now)),
+                )
+
+            mechanism = mechanism_for(request.intent_id, request.cardinality)
+            if mechanism is GraphMechanism.UNSUPPORTED:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                    diagnostic=_diagnostic(
+                        "mechanism_selection",
+                        f"no graph mechanism for intent={request.intent_id.value} "
+                        f"cardinality={request.cardinality.value}",
+                    ),
+                )
+            # Increment 1: every SUPPORTED mechanism still returns
+            # PROVIDER_FAILURE. Packet assembly needs CHAOS-3660's
+            # production packet constructor, not yet landed -- see the
+            # module docstring. Naming the mechanism and the pending
+            # dependency rather than a bare "not implemented" is what makes
+            # this diagnostic actionable rather than a dead end.
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                diagnostic=_diagnostic(
+                    "execution",
+                    f"mechanism {mechanism.value} selected; packet assembly "
+                    "awaits CHAOS-3660's production packet constructor",
+                ),
+            )
+        except asyncio.CancelledError:
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.CANCELLED,
+                diagnostic=_diagnostic(
+                    "cancellation", "the calling task was cancelled"
+                ),
+            )
+        finally:
+            if store is not None:
+                try:
+                    await asyncio.wait_for(store.close(), timeout=5.0)
+                except Exception:  # noqa: BLE001
+                    # Closing best-effort: a close failure must never mask
+                    # whichever outcome the try block already decided, and
+                    # must never itself propagate as an unhandled exception
+                    # from a seam the Protocol requires not to raise for an
+                    # ordinary runtime condition.
+                    logger.warning(
+                        "context-fabric query service: store.close() failed "
+                        "for org %r after investigate() completed",
+                        request.org_id,
+                    )
+
+
+if TYPE_CHECKING:
+    # Exists only so mypy verifies structural conformance to the Protocol.
+    # Inert at runtime -- code under `if TYPE_CHECKING:` never executes, so
+    # this never actually constructs an instance -- but mypy still type
+    # checks the assignment, and would flag it if `investigate`'s signature
+    # ever drifted from the Protocol's. Cheaper and earlier than a test
+    # discovering the mismatch at a call site.
+    _conforms_to_protocol: GraphInvestigationQuery = ProductionGraphInvestigationQuery()

--- a/tests/context_fabric/test_chaos_3678_query_service.py
+++ b/tests/context_fabric/test_chaos_3678_query_service.py
@@ -1,0 +1,435 @@
+"""CHAOS-3678: the production bounded graph query service.
+
+Two halves, matching the module's own documented scope:
+
+* :func:`mechanism_for` — the fixed ``(intent_id, cardinality) ->
+  mechanism`` table (CHAOS-3660's accepted job/shape determination).
+* ``ProductionGraphInvestigationQuery.investigate`` — the transport/outcome
+  mapping, tested against fake stores injected via ``store_factory`` (no
+  live backend needed for DISABLED/UNAVAILABLE/STALE/DEADLINE_EXCEEDED/
+  CANCELLED/PROVIDER_FAILURE) plus one live positive control.
+
+The ``COMPLETED`` path is not implemented in this increment (see the module
+docstring) and is not tested here — every currently-SUPPORTED mechanism is
+asserted to reach ``PROVIDER_FAILURE`` with a diagnostic naming the pending
+dependency, which is the honest, current behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import Cardinality, QuestionIntentID
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+)
+from dev_health_ops.context_fabric.graph_arm.query_service import (
+    GraphMechanism,
+    ProductionGraphInvestigationQuery,
+    mechanism_for,
+)
+from dev_health_ops.context_fabric.graph_arm.store import (
+    GraphArmStore,
+    StoreUnavailableError,
+)
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+from tests.context_fabric import live_gate
+
+#: A fixed reference instant for constructing WATERMARK values only -- always
+#: comfortably in the past relative to the real clock, so "N days before
+#: this" reliably reads as stale. Deadlines must never be computed from this:
+#: `investigate()` compares them against the REAL `datetime.now(UTC)`, so a
+#: deadline offset from a fixed historical instant is a deadline already in
+#: the past on any test run -- see `_soon()`.
+_NOW = datetime(2026, 8, 9, 12, tzinfo=UTC)
+
+
+def _soon() -> datetime:
+    """A deadline comfortably in the future relative to the real clock."""
+
+    return datetime.now(UTC) + timedelta(seconds=30)
+
+
+def _fresh_watermark() -> IndexWatermark:
+    """A watermark current as of the real clock -- not `_NOW`, which is a
+    fixed historical instant for staleness tests only."""
+
+    return IndexWatermark(indexed_through=datetime.now(UTC), records_indexed=1)
+
+
+def _request(
+    *,
+    intent_id: QuestionIntentID = QuestionIntentID.PROJECT_HEALTH,
+    cardinality: Cardinality = Cardinality.SINGULAR,
+    deadline: datetime | None = None,
+    org_id: str = "org_query_service_test",
+) -> GraphInvestigationRequest:
+    return GraphInvestigationRequest(
+        org_id=org_id,
+        run_id="run_test",
+        intent_id=intent_id,
+        cardinality=cardinality,
+        mentions=(),
+        question_text="What is the status of the Nightfall Migration project?",
+        authorized_entity_ids=frozenset({"proj_nightfall_migration"}),
+        deadline=deadline or _soon(),
+    )
+
+
+class TestMechanismFor:
+    def test_discovered_cohort_selects_subjectless_cohort_discovery(self) -> None:
+        assert (
+            mechanism_for(
+                QuestionIntentID.DISCOVERED_COHORT, Cardinality.ORGANIZATION_WIDE
+            )
+            is GraphMechanism.SUBJECTLESS_COHORT_DISCOVERY
+        )
+
+    @pytest.mark.parametrize(
+        "intent_id",
+        [
+            QuestionIntentID.ENTITY_STATUS,
+            QuestionIntentID.PROJECT_HEALTH,
+            QuestionIntentID.TEAM_HEALTH,
+            QuestionIntentID.REMAINING_WORK,
+        ],
+    )
+    def test_singular_cardinality_selects_seeded_singular_subject(
+        self, intent_id: QuestionIntentID
+    ) -> None:
+        assert (
+            mechanism_for(intent_id, Cardinality.SINGULAR)
+            is GraphMechanism.SEEDED_SINGULAR_SUBJECT
+        )
+
+    def test_plural_cohort_cardinality_selects_seeded_explicit_cohort(self) -> None:
+        assert (
+            mechanism_for(QuestionIntentID.METRIC_COMPARISON, Cardinality.PLURAL_COHORT)
+            is GraphMechanism.SEEDED_EXPLICIT_COHORT
+        )
+
+    def test_organization_wide_with_a_non_cohort_intent_is_unsupported(self) -> None:
+        """The organization-wide sweep this arm must never construct.
+
+        ``ORGANIZATION_WIDE`` cardinality paired with any intent other than
+        ``DISCOVERED_COHORT`` is the shape handoff §4 forbids
+        ("unresolved named subjects never widen to organization scope") --
+        this table returns UNSUPPORTED rather than a mechanism, so
+        ``investigate`` never attempts it.
+        """
+
+        assert (
+            mechanism_for(
+                QuestionIntentID.PORTFOLIO_STATUS, Cardinality.ORGANIZATION_WIDE
+            )
+            is GraphMechanism.UNSUPPORTED
+        )
+
+    def test_the_table_is_fixed_not_content_derived(self) -> None:
+        """Same (intent_id, cardinality) -> same mechanism, always.
+
+        Not a meaningful assertion about randomness -- there is none -- but
+        a structural pin that the function takes exactly two arguments and
+        nothing resembling question text, which is easy to check by calling
+        it and impossible to check by reading the return type alone.
+        """
+
+        import inspect
+
+        params = list(inspect.signature(mechanism_for).parameters)
+        assert params == ["intent_id", "cardinality"]
+
+
+@dataclass
+class _FakeStore:
+    """Stands in for ``GraphArmStore`` at exactly the two methods
+    ``investigate`` calls: ``read_watermark`` and ``close``.
+    """
+
+    watermark: IndexWatermark | None = None
+    watermark_error: Exception | None = None
+    hang_seconds: float | None = None
+    closed: bool = False
+    close_calls: int = field(default=0)
+
+    async def read_watermark(self) -> IndexWatermark:
+        if self.hang_seconds is not None:
+            await asyncio.sleep(self.hang_seconds)
+        if self.watermark_error is not None:
+            raise self.watermark_error
+        assert self.watermark is not None
+        return self.watermark
+
+    async def close(self) -> None:
+        self.closed = True
+        self.close_calls += 1
+
+
+def _factory(store: _FakeStore):
+    def _build(_org_id: str) -> _FakeStore:
+        return store
+
+    return _build
+
+
+def _query(store: _FakeStore) -> ProductionGraphInvestigationQuery:
+    return ProductionGraphInvestigationQuery(store_factory=_factory(store))
+
+
+class TestDisabled:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_disabled_when_the_read_flag_is_off(self) -> None:
+        service = _query(_FakeStore())
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.DISABLED
+        assert result.packet is None
+
+    async def test_disabled_never_constructs_a_store(self, monkeypatch) -> None:
+        """The read flag is checked before the store factory is ever called."""
+
+        calls: list[str] = []
+
+        def _factory_records(org_id: str) -> _FakeStore:
+            calls.append(org_id)
+            return _FakeStore()
+
+        service = ProductionGraphInvestigationQuery(store_factory=_factory_records)
+        await service.investigate(_request())
+        assert calls == []
+
+
+class TestUnavailable:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_store_construction_failure_is_unavailable(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+
+        def _raising_factory(_org_id: str):
+            raise StoreUnavailableError("no trial graph store is configured")
+
+        service = ProductionGraphInvestigationQuery(store_factory=_raising_factory)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+        assert result.packet is None
+
+    async def test_a_watermark_read_failure_is_unavailable(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark_error=StoreUnavailableError("transport failure"))
+        service = _query(store)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+        assert store.closed is True
+
+    async def test_a_never_projected_partition_is_unavailable(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=IndexWatermark(indexed_through=None))
+        service = _query(store)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+
+
+class TestStale:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_watermark_beyond_tolerance_is_stale(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(
+            watermark=IndexWatermark(
+                indexed_through=_NOW - timedelta(days=2), records_indexed=5
+            )
+        )
+        service = _query(store)
+        result = await service.investigate(_request(deadline=_soon()))
+        assert result.outcome is GraphQueryOutcome.STALE
+        assert result.packet is None
+
+    async def test_a_partial_watermark_is_stale_even_if_recent(
+        self, monkeypatch
+    ) -> None:
+        """Mirrors ``IndexWatermark.freshness_for``'s own rule directly."""
+
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(
+            watermark=IndexWatermark(
+                indexed_through=_NOW, records_indexed=5, partial=True
+            )
+        )
+        service = _query(store)
+        result = await service.investigate(_request())
+        assert result.outcome is GraphQueryOutcome.STALE
+
+
+class TestDeadlineExceeded:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_a_deadline_already_past_never_touches_the_store(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        calls: list[str] = []
+
+        def _factory_records(org_id: str) -> _FakeStore:
+            calls.append(org_id)
+            return _FakeStore()
+
+        service = ProductionGraphInvestigationQuery(store_factory=_factory_records)
+        past_deadline = _NOW - timedelta(seconds=1)
+        result = await service.investigate(_request(deadline=past_deadline))
+        assert result.outcome is GraphQueryOutcome.DEADLINE_EXCEEDED
+        assert calls == [], "a caller that waited too long must not pay for a store"
+
+    async def test_a_hung_watermark_read_exceeds_the_deadline(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(hang_seconds=999.0)
+        service = _query(store)
+        near_deadline = datetime.now(UTC) + timedelta(milliseconds=50)
+        result = await service.investigate(_request(deadline=near_deadline))
+        assert result.outcome is GraphQueryOutcome.DEADLINE_EXCEEDED
+        assert store.closed is True, "the store is still closed on a deadline timeout"
+
+
+class TestCancelled:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_cancellation_during_the_watermark_read_is_reported_not_raised(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(hang_seconds=999.0)
+        service = _query(store)
+
+        task = asyncio.ensure_future(service.investigate(_request(deadline=_soon())))
+        await asyncio.sleep(0)  # let investigate() reach the hung await
+        task.cancel()
+        result = await task
+        assert result.outcome is GraphQueryOutcome.CANCELLED
+        assert store.closed is True
+
+
+class TestUnsupportedMechanism:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_an_unsupported_mechanism_is_provider_failure_not_a_crash(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=_fresh_watermark())
+        service = _query(store)
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.PORTFOLIO_STATUS,
+                cardinality=Cardinality.ORGANIZATION_WIDE,
+            )
+        )
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.diagnostic is not None
+        assert "no graph mechanism" in result.diagnostic
+
+
+class TestSupportedMechanismIsNotYetImplemented:
+    pytestmark = pytest.mark.asyncio
+
+    """Increment 1's honest boundary: selected, not yet executed."""
+
+    async def test_a_supported_mechanism_reaches_provider_failure_with_a_named_reason(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=_fresh_watermark())
+        service = _query(store)
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.PROJECT_HEALTH,
+                cardinality=Cardinality.SINGULAR,
+            )
+        )
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.packet is None
+        assert result.diagnostic is not None
+        assert "seeded_singular_subject" in result.diagnostic
+        assert "CHAOS-3660" in result.diagnostic
+
+
+class TestDiagnosticsAreContentSafe:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_no_diagnostic_carries_the_question_text(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        planted = "TOTALLY-SECRET-QUESTION-TEXT-MARKER"
+        store = _FakeStore(watermark=IndexWatermark(indexed_through=None))
+        service = _query(store)
+        request = GraphInvestigationRequest(
+            org_id="org_content_safety",
+            run_id="run_content_safety",
+            intent_id=QuestionIntentID.PROJECT_HEALTH,
+            cardinality=Cardinality.SINGULAR,
+            mentions=(),
+            question_text=planted,
+            authorized_entity_ids=frozenset(),
+            deadline=_soon(),
+        )
+        result = await service.investigate(request)
+        assert result.diagnostic is not None
+        assert planted not in result.diagnostic
+
+
+class TestStoreIsAlwaysClosed:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_the_store_is_closed_after_a_provider_failure(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=_fresh_watermark())
+        service = _query(store)
+        await service.investigate(_request())
+        assert store.close_calls == 1
+
+    async def test_the_store_is_never_closed_when_never_constructed(self) -> None:
+        """DISABLED short-circuits before any store exists to close."""
+
+        calls: list[str] = []
+
+        def _factory_records(org_id: str) -> _FakeStore:
+            calls.append(org_id)
+            return _FakeStore(watermark=_fresh_watermark())
+
+        service = ProductionGraphInvestigationQuery(store_factory=_factory_records)
+        await service.investigate(_request())
+        assert calls == []
+
+
+class TestLivePositiveControl:
+    pytestmark = pytest.mark.asyncio
+
+    """Against the real live store: proves the wiring, not just the fakes."""
+
+    @pytest.mark.graphiti
+    async def test_disabled_against_a_real_store_factory(self, monkeypatch) -> None:
+        live_gate.require_live_store()
+        monkeypatch.delenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", raising=False)
+        service = ProductionGraphInvestigationQuery(store_factory=GraphArmStore.for_org)
+        result = await service.investigate(_request(org_id="org_live_query_service"))
+        assert result.outcome is GraphQueryOutcome.DISABLED
+
+    @pytest.mark.graphiti
+    async def test_never_projected_against_a_real_store(self, monkeypatch) -> None:
+        live_gate.require_live_store()
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        service = ProductionGraphInvestigationQuery(store_factory=GraphArmStore.for_org)
+        result = await service.investigate(
+            _request(org_id="org_live_query_service_fresh")
+        )
+        assert result.outcome is GraphQueryOutcome.UNAVAILABLE


### PR DESCRIPTION
## Issue / Phase

CHAOS-3678 (production bounded graph query service) increment 1, revived from stale draft PR #1654 (superseded/closed — see below) after CHAOS-3660's packet-constructor work (#1657, #1661) landed. Branch is ID-free: this is one increment of CHAOS-3678's broader scope (COMPLETED-path packet assembly is a separate, larger follow-up PR, scoped and queued next).

## Observable outcome

`ProductionGraphInvestigationQuery` — the production implementation of Lane B's `GraphInvestigationQuery` Protocol (`api/dev/graph_investigation_query.py`) — plus `mechanism_for(intent_id, cardinality)`, the fixed job→execution-mechanism table. The transport/availability axis (`GraphQueryOutcome`) is real and live-tested end to end: `DISABLED` (read flag), `UNAVAILABLE` (store construction/watermark read failure), `STALE`/current (CHAOS-3679 persisted watermark freshness), `DEADLINE_EXCEEDED` (absolute deadline, checked both before dispatch and composed with CHAOS-3631's per-operation `GraphDeadlines`), `CANCELLED` (`asyncio.CancelledError` converted to a result, never left to propagate — required by the Protocol's own docstring).

## Architecture boundary

Job/comparison-shape classification stays production's (accepted CHAOS-3660 determination: `(intent_id, cardinality)` already carries both signals in production's own vocabulary on the wire) — `mechanism_for` never inspects `question_text`. Store access is injected via a `_WatermarkStore` Protocol (`read_watermark`/`close` only, mirroring `projector.ProjectingStore`), so the full outcome matrix is exercised against fakes with one live positive control, not a live FalkorDB for every case.

## Scope / non-scope

**In scope**: the complete transport/outcome mapping above. Every `SUPPORTED` mechanism (`SEEDED_SINGULAR_SUBJECT`/`SEEDED_EXPLICIT_COHORT`/`SUBJECTLESS_COHORT_DISCOVERY`) still returns `PROVIDER_FAILURE` with a diagnostic naming the mechanism and the pending dependency — an honest "not yet", never a silent wrong answer or a crash.

**Out of scope, on purpose**: the `COMPLETED` path (candidate resolution, traversal, driver synthesis, packet assembly via `build_production_packet`). Scoping that surfaced real design work with no shortcut available — production has no subject-resolution module at all (`GraphInvestigationRequest.mentions` are unresolved; the trial's mention→canonical-id logic lives only in `trials/chaos_3619/graph_leg.py` test-harness code, which production must never import) — so it is a separate, properly-scoped follow-up PR (SEEDED_SINGULAR_SUBJECT slice first, exact-match resolution only, `drivers=None`), not bundled here. `SEEDED_EXPLICIT_COHORT`/`SUBJECTLESS_COHORT_DISCOVERY` will be filed as tracked Linear follow-ups once that PR lands.

### On the dropped commit

The original #1654 draft carried two commits. The first (`939f18f9`, "CHAOS-3502: graph-assisted routing seam scaffolding") is **not** included here: it is fully superseded by Lane B's merged CHAOS-3502 work (#1658) — `orchestrator.py` at this branch's base already has the complete, more advanced wiring (the DISCOVERED_COHORT gate already calls `self._graph_investigation_query.investigate(...)`), confirmed by diffing the scaffolding commit's `graph_investigation_query.py` against the currently-merged version (identical apart from formatting). Cherry-picking it would have reintroduced an add/add conflict against strictly-better code. Only the second commit (`5cc44188f`, this PR's content) is genuinely new. #1654 itself will be closed as superseded once this merges.

## Base / head SHA

- Base: `da873078fd1a09e80788c555cd43b583c4ab28a8` (`feature/chaos-3498-context-fabric` tip — "CHAOS-3678: extract packet_builder into shared core + build_production_packet (#1661)")
- Head: `17a3d4e459aec8a6330c4a260cdd75528819e000`

## Migrations

None.

## Security / privacy

None. `_diagnostic()` emits only a fixed template plus a value this module chose (an exception type name, a fixed phrase) — never raw question text, an entity label, or anything caller-controlled verbatim, mirroring CHAOS-3631/CHAOS-3676's content-safety bar.

## RED-first evidence

Original commit's test file (`tests/context_fabric/test_chaos_3678_query_service.py`) was written test-first against the stubbed transport/outcome behavior when this increment was originally authored (pre-compaction in the earlier session); cherry-picked unchanged and re-verified green against the current tip rather than rewritten, since the transport/outcome contract it tests is unchanged by everything that has merged since.

## Verification

- `mypy .` (full repo) — Success, 2389 source files, 0 errors
- `ruff check` / `ruff format --check` — clean
- `pytest tests/context_fabric/test_chaos_3678_query_service.py` — 23 passed, 2 skipped (live-store positive control, gated on env)
- Pre-push lefthook gates (ruff-format, ruff-check, mypy) — all green, no `--no-verify` used

## Known limitations

Nothing calls `ProductionGraphInvestigationQuery` in production yet (it is not constructed by `production_runtime.py`) — every `SUPPORTED` mechanism is an honest stub. The follow-up PR (SEEDED_SINGULAR_SUBJECT) is scoped and queued next; this PR intentionally does not block on it.

## Rollout / rollback

Additive only: new module (`query_service.py`), no existing file touched. Nothing on trunk imports it yet. Revert is a plain single-commit revert.