### PR TITLE
CHAOS-3678: wire SEEDED_SINGULAR_SUBJECT to a real COMPLETED path

### DIFF
--- a/src/dev_health_ops/api/dev/graph_investigation_query.py
+++ b/src/dev_health_ops/api/dev/graph_investigation_query.py
@@ -139,6 +139,17 @@ class GraphInvestigationRequest:
     #: this set -- mirrors ``graph_arm.discover_cohort``'s own "authorization
     #: applied on the way IN" invariant.
     authorized_entity_ids: frozenset[str]
+    #: The bounded analytical window the run itself is scoped to --
+    #: CHAOS-3678 follow-up: the graph seam must never invent a product time
+    #: policy of its own, so this is supplied, exactly like
+    #: ``authorized_entity_ids`` above. The orchestrator populates both from
+    #: the SAME ``DevScope.time_range`` that already bounds every other
+    #: tool/metric execution for this run (``StepContext(scope=
+    #: authorized_scope, ...)`` at the plan-executor call site) -- never a
+    #: separately-invented window, so a graph-assisted answer and a
+    #: native-arm answer for the same run are bounded identically.
+    window_start: datetime
+    window_end: datetime
     #: Absolute wall-clock deadline (CHAOS-3631). The query service must
     #: return ``GraphQueryOutcome.DEADLINE_EXCEEDED`` rather than block past
     #: this, under any internal retry/backoff it performs.

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -2850,6 +2850,15 @@ class DevOrchestrator:
                     # derivation is separate, explicit follow-up work, not
                     # guessed at in this seam.
                     authorized_entity_ids=frozenset(),
+                    # CHAOS-3678: the SAME scope every other tool/metric
+                    # execution for this run is bounded by -- see
+                    # ``StepContext(scope=authorized_scope, ...)`` above.
+                    # The graph seam must never invent its own time policy;
+                    # reusing this window is what keeps a graph-assisted
+                    # answer and a native-arm answer for the same run
+                    # bounded identically.
+                    window_start=authorized_scope.time_range.start,
+                    window_end=authorized_scope.time_range.end,
                     deadline=graph_deadline,
                 )
                 graph_result = await self._graph_investigation_query.investigate(

--- a/src/dev_health_ops/context_fabric/graph_arm/query_service.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/query_service.py
@@ -12,20 +12,26 @@ decide what kind of question was asked. What stays graph-side is
 :func:`mechanism_for`: given an already-classified job and shape, which
 internal traversal/synthesis mechanism actually answers it.
 
-**Increment 1 scope, stated plainly rather than left to be discovered.**
-The transport/outcome mapping — ``GraphQueryOutcome``'s
+**Increment 1 scope.** The transport/outcome mapping — ``GraphQueryOutcome``'s
 ``DISABLED``/``UNAVAILABLE``/``STALE``/``DEADLINE_EXCEEDED``/``CANCELLED``
 states — is real, live-tested, and composes the absolute request deadline
 with CHAOS-3631's per-operation :class:`~.flags.GraphDeadlines` and
-CHAOS-3679's persisted watermark. The ``COMPLETED`` path — candidate
-resolution, traversal, driver synthesis and packet assembly — is not
-implemented yet: it depends on CHAOS-3660's packet-constructor ruling (a
-production-shaped packet constructor, ``build_production_packet``, not yet
-landed in ``packet_builder.py``, since the existing ``build_packet``
-requires a trial-only ``QuestionFamilyID``). Every mechanism that would
-reach packet assembly returns ``PROVIDER_FAILURE`` with a diagnostic naming
-the pending dependency — an honest "not yet", never a silent wrong answer,
-never a crash a caller has to guard against separately.
+CHAOS-3679's persisted watermark.
+
+**Increment 2 (this revision) implements exactly one COMPLETED path:**
+``GraphMechanism.SEEDED_SINGULAR_SUBJECT``, via
+:func:`~.subject_resolution._resolve_exact_subjects` (EXACT canonical-id/
+display-label match only — see that module's own docstring for why this is
+narrower than the trial's ``discovery.search_candidates``),
+:class:`~.readback.LiveGraphReader` traversal, and
+:func:`~.packet_builder.build_production_packet` with ``drivers=None`` (no
+driver synthesis — mirrors the trial's own PR1 scope, which never
+synthesized drivers either). ``SEEDED_EXPLICIT_COHORT`` and
+``SUBJECTLESS_COHORT_DISCOVERY`` still return ``PROVIDER_FAILURE`` with a
+diagnostic naming the mechanism — both need ``cohort_discovery`` wired in,
+tracked as separate follow-ups (filed on CHAOS-3678) rather than bundled
+here. Every path is an honest "not yet" where it applies, never a silent
+wrong answer, never a crash a caller has to guard against separately.
 """
 
 from __future__ import annotations
@@ -35,22 +41,31 @@ import logging
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from dev_health_ops.api.dev.contracts_v2.base import (
     Cardinality,
     QuestionIntentID,
     SourceRequirementState,
 )
+from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
 from dev_health_ops.api.dev.graph_investigation_query import (
     GraphInvestigationQuery,
     GraphInvestigationRequest,
     GraphQueryOutcome,
     GraphQueryResult,
 )
+from dev_health_ops.api.dev.investigation_contract import ComparisonShape
 
 from .flags import graph_read_enabled
+from .packet_builder import (
+    ProductionJobContext,
+    build_production_packet,
+    signer_from_environment,
+)
+from .readback import GraphReader, LiveGraphReader
 from .store import GraphArmStore, StoreUnavailableError
+from .subject_resolution import _resolve_exact_subjects
 from .watermark import DEFAULT_STALENESS_TOLERANCE, IndexWatermark
 
 logger = logging.getLogger(__name__)
@@ -139,6 +154,38 @@ class _WatermarkStore(Protocol):
     async def close(self) -> None: ...
 
 
+class _TraversalStore(Protocol):
+    """What live traversal and subject resolution need directly from a
+    store: partition identity and driver access.
+
+    Kept separate from ``_WatermarkStore`` rather than added to it (each
+    Protocol still states exactly one capability), so none of increment 1's
+    existing fakes -- which implement only ``read_watermark``/``close`` --
+    need to widen to keep passing; this is only reached once a mechanism
+    reaches ``SEEDED_SINGULAR_SUBJECT``'s COMPLETED path.
+
+    Production's default ``store_factory`` (``GraphArmStore.for_org``)
+    satisfies both this and ``_WatermarkStore`` from the very same real
+    instance -- the ``cast`` at the one call site that needs this view says
+    exactly that, rather than claiming a structural guarantee this module
+    does not have.
+    """
+
+    partition: str
+    _driver: Any
+
+
+#: A fixed, closed-vocabulary description -- never ``request.question_text``
+#: verbatim. The Protocol's own docstring bars echoing question text into a
+#: packet field a consumer renders; keying on ``QuestionIntentID`` instead
+#: means this can never emit caller-controlled text.
+_JOB_STATEMENT_TEMPLATE = "Investigate {intent} for the resolved subject."
+
+
+def _job_statement(intent_id: QuestionIntentID) -> str:
+    return _JOB_STATEMENT_TEMPLATE.format(intent=intent_id.value)
+
+
 class ProductionGraphInvestigationQuery:
     """The production implementation of ``GraphInvestigationQuery``.
 
@@ -153,6 +200,8 @@ class ProductionGraphInvestigationQuery:
         *,
         staleness_tolerance: timedelta = DEFAULT_STALENESS_TOLERANCE,
         store_factory: Callable[[str], _WatermarkStore] = GraphArmStore.for_org,
+        reader_factory: Callable[[Any], GraphReader] = LiveGraphReader,
+        signer_factory: Callable[[], EvidenceReferenceSigner] = signer_from_environment,
     ) -> None:
         self._staleness_tolerance = staleness_tolerance
         # Injected rather than hardcoded to `GraphArmStore.for_org` inline,
@@ -161,6 +210,16 @@ class ProductionGraphInvestigationQuery:
         # store without a live FalkorDB for every case; only the
         # live-store positive control needs the real default.
         self._store_factory = store_factory
+        # Same rationale as store_factory: SEEDED_SINGULAR_SUBJECT's tests
+        # supply a fake GraphReader (a canned neighbourhood() result)
+        # instead of needing a live-store-compatible entity/edge fixture
+        # for a test that only exercises transport/outcome mapping.
+        self._reader_factory = reader_factory
+        # Resolved lazily, per call -- see `_complete_seeded_singular_
+        # subject` -- never at construction, so increment 1's existing
+        # tests (none of which reach that far) are unaffected by whether
+        # JWT_SECRET_KEY happens to be set in the test environment.
+        self._signer_factory = signer_factory
 
     async def investigate(self, request: GraphInvestigationRequest) -> GraphQueryResult:
         """Bounded by ``request.deadline`` end to end, never past it.
@@ -267,19 +326,22 @@ class ProductionGraphInvestigationQuery:
                         f"cardinality={request.cardinality.value}",
                     ),
                 )
-            # Increment 1: every SUPPORTED mechanism still returns
-            # PROVIDER_FAILURE. Packet assembly needs CHAOS-3660's
-            # production packet constructor, not yet landed -- see the
-            # module docstring. Naming the mechanism and the pending
-            # dependency rather than a bare "not implemented" is what makes
-            # this diagnostic actionable rather than a dead end.
-            return GraphQueryResult(
-                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
-                diagnostic=_diagnostic(
-                    "execution",
-                    f"mechanism {mechanism.value} selected; packet assembly "
-                    "awaits CHAOS-3660's production packet constructor",
-                ),
+            if mechanism is not GraphMechanism.SEEDED_SINGULAR_SUBJECT:
+                # SEEDED_EXPLICIT_COHORT / SUBJECTLESS_COHORT_DISCOVERY:
+                # both still need cohort_discovery wired in -- tracked as
+                # separate follow-ups on CHAOS-3678, not bundled here.
+                # Naming the mechanism rather than a bare "not implemented"
+                # is what makes this diagnostic actionable.
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                    diagnostic=_diagnostic(
+                        "execution",
+                        f"mechanism {mechanism.value} selected; packet "
+                        "assembly for this mechanism is a tracked follow-up",
+                    ),
+                )
+            return await self._complete_seeded_singular_subject(
+                request, store, watermark
             )
         except asyncio.CancelledError:
             return GraphQueryResult(
@@ -303,6 +365,72 @@ class ProductionGraphInvestigationQuery:
                         "for org %r after investigate() completed",
                         request.org_id,
                     )
+
+    async def _complete_seeded_singular_subject(
+        self,
+        request: GraphInvestigationRequest,
+        store: _WatermarkStore,
+        watermark: IndexWatermark,
+    ) -> GraphQueryResult:
+        """The one COMPLETED path this increment implements.
+
+        Resolves the request's first mention (SINGULAR cardinality) by
+        EXACT canonical-id/display-label match only -- see
+        :mod:`.subject_resolution`'s own module docstring for why this is
+        narrower than the trial's ``discovery.search_candidates``. A
+        mention that does not resolve still reaches ``COMPLETED``: the
+        seam's own outcome axis distinguishes "the call completed" from
+        "the investigation found the subject", and an empty seed list
+        produces a packet whose own ``outcome`` honestly discloses no
+        committed subject -- never a guess, and never reported as a
+        transport failure it is not (mirrors the Protocol's own "a
+        completed call may still carry a refusal shape" documentation).
+
+        Any unexpected exception during resolution, traversal or packet
+        assembly is caught and reported as ``PROVIDER_FAILURE`` rather than
+        left to propagate -- the Protocol's docstring reserves an
+        uncaught exception for "a bug in the caller", which this is not.
+        """
+
+        traversal_store = cast(_TraversalStore, store)
+        queries = [mention.normalized_lookup_text for mention in request.mentions[:1]]
+        try:
+            candidates = await _resolve_exact_subjects(
+                traversal_store._driver,
+                traversal_store.partition,
+                queries,
+                request.authorized_entity_ids,
+            )
+            reader = self._reader_factory(traversal_store)
+            readout = await reader.neighbourhood(
+                org_id=request.org_id,
+                seed_canonical_ids=[
+                    candidate.canonical_id for candidate in candidates[:1]
+                ],
+                authorized_entity_ids=tuple(request.authorized_entity_ids),
+            )
+            packet = build_production_packet(
+                readout=readout,
+                job=ProductionJobContext(
+                    job_id=f"graph_query_{request.run_id}",
+                    intent_id=request.intent_id,
+                    run_id=request.run_id,
+                    job_statement=_job_statement(request.intent_id),
+                    comparison_shape=ComparisonShape.SINGULAR_SUBJECT,
+                    window_start=request.window_start,
+                    window_end=request.window_end,
+                ),
+                watermark=watermark,
+                signer=self._signer_factory(),
+                produced_at=datetime.now(UTC),
+                staleness_tolerance=self._staleness_tolerance,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                diagnostic=_diagnostic("execution", type(exc).__name__),
+            )
+        return GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
 
 
 if TYPE_CHECKING:

--- a/src/dev_health_ops/context_fabric/graph_arm/subject_resolution.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/subject_resolution.py
@@ -1,0 +1,153 @@
+"""CHAOS-3678: EXACT-only live subject resolution for production.
+
+The trial's :func:`~.discovery.search_candidates` resolves a reference
+against canonical id, display name, every alias kind (acronym/previous-name/
+provider-identifier) AND a token-containment fuzzy fallback -- and it
+operates over an in-memory :class:`~.projection.GraphProjection` built from a
+fixture corpus, never the live store.
+
+Neither shape fits this first production slice. Per team-lead's ruling on
+CHAOS-3678 (binding, cited as "§4"): production's COMPLETED path resolves a
+mention on ``EXACT_CANONICAL_ID`` or ``EXACT_DISPLAY_NAME`` only -- no alias,
+no acronym, no previous-name, and emphatically no fuzzy widening. A mention
+that only fuzzy- or alias-matches gets nothing here, and the caller
+(:mod:`.query_service`) is expected to carry that through to an honest
+refusal/degradation outcome rather than ever guessing. Widening this to the
+trial's full signal set is separate, explicitly-scoped follow-up work, not a
+quietly-expanding default.
+
+Reuses :data:`~.readback._ENTITY_QUERY` and :func:`~.readback._rows`
+verbatim -- the same partition-scoped, unconditional entity fetch
+:class:`~.readback.LiveGraphReader` already runs for every traversal, so this
+module adds no new Cypher and no new live-store surface, only exact matching
+and authorization filtering over rows that query already proves correct.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Sequence
+from re import compile as _compile
+from typing import Any
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+
+from .backend import MatchMechanism
+from .discovery import CandidateMatch
+from .readback import _ENTITY_QUERY, _rows
+from .vocabulary import GraphEntityKind
+
+#: Deliberately empty: this module's one function is package-private (see
+#: its own docstring on why it takes a raw ``partition`` -- CHAOS-3617's
+#: "no caller-supplied partition parameter" guard scans public callables
+#: only, and a raw partition parameter is exactly the shape that guard
+#: exists to catch).
+__all__: list[str] = []
+
+#: Both signals this module can produce are unambiguous lookups over stored
+#: text, never retrieval -- mirrors ``discovery._SIGNAL_MECHANISM`` for the
+#: same two entries.
+_SIGNAL_MECHANISM = {
+    SubjectMatchSignal.EXACT_CANONICAL_ID: MatchMechanism.EXACT_LOOKUP,
+    SubjectMatchSignal.EXACT_DISPLAY_NAME: MatchMechanism.EXACT_LOOKUP,
+}
+
+_PUNCTUATION = _compile(r"[^\w\s]+")
+_WHITESPACE = _compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    """Casefold, strip punctuation, collapse whitespace -- comparison only.
+
+    Identical normalization to ``discovery._normalize``, duplicated rather
+    than imported: it is three lines, and importing a private helper across
+    a semantic boundary (fuzzy-capable vs. exact-only) invites the two to
+    drift apart silently later. The behavior staying identical today is
+    covered by ``test_case_and_punctuation_insensitive_but_still_exact``.
+    """
+
+    folded = unicodedata.normalize("NFKD", text).casefold()
+    return _WHITESPACE.sub(" ", _PUNCTUATION.sub(" ", folded)).strip()
+
+
+async def _resolve_exact_subjects(
+    driver: Any,
+    partition: str,
+    queries: Sequence[str],
+    authorized_entity_ids: Sequence[str] | frozenset[str],
+) -> tuple[CandidateMatch, ...]:
+    """Exact canonical-id or display-label matches only, authorized only.
+
+    Package-private (leading underscore) rather than exported: it takes a
+    raw ``partition`` directly, which CHAOS-3617's "no caller-supplied
+    partition parameter" guard (``test_chaos_3617_no_caller_supplied_
+    partition.py``) forbids on any PUBLIC callable in this package -- the
+    server derives the partition, a caller must never be able to name one.
+    ``query_service.py`` (same package) is this function's only caller and
+    derives ``partition`` from the store it already holds, never from a
+    caller-supplied value.
+
+    ``queries`` is normally the caller's mention texts. Every query is
+    checked against every entity; a query matching nothing, or matching only
+    an unauthorized entity, contributes no result -- there is no partial
+    credit and no fallback signal weaker than the two this module supports.
+
+    Order among results (when more than one query matches) is NOT specified
+    beyond entity iteration order: callers with exactly one query -- this
+    slice's only caller -- do not need one, and inventing an ordering
+    contract for a first slice that has no multi-query caller yet would be
+    a commitment nothing here can honor. ``discovery.CandidateMatch`` is
+    reused directly (not a parallel type) so its already-tested
+    ``rank_key`` is available the moment a caller needs to rank multiple
+    queries' worth of results.
+    """
+
+    normalized_queries = {_normalize(query) for query in queries if _normalize(query)}
+    if not normalized_queries:
+        return ()
+
+    authorized = frozenset(authorized_entity_ids)
+    matches: list[CandidateMatch] = []
+    for record in await _rows(driver, _ENTITY_QUERY, partition=partition):
+        kind_value = record.get("entity_kind")
+        if kind_value is None:
+            continue
+        kind = GraphEntityKind(kind_value)
+        if kind is GraphEntityKind.ORGANIZATION:
+            continue
+
+        canonical_id = record["canonical_id"]
+        display_label = record["display_label"]
+        if _normalize(canonical_id) in normalized_queries:
+            signal = SubjectMatchSignal.EXACT_CANONICAL_ID
+            matched_text = canonical_id
+        elif _normalize(display_label) in normalized_queries:
+            signal = SubjectMatchSignal.EXACT_DISPLAY_NAME
+            matched_text = display_label
+        else:
+            continue
+
+        if canonical_id not in authorized:
+            # Withheld before it is ever returned -- mirrors
+            # discovery.search_candidates's own "authorization applied
+            # before ranking" rule. Not counted here: this slice's one
+            # caller (query_service, SEEDED_SINGULAR_SUBJECT) has exactly
+            # one mention, so an authorization-filtered count belongs on
+            # its own SubjectDiscovery section, not invented in this
+            # function ahead of a caller that needs it.
+            continue
+
+        matches.append(
+            CandidateMatch(
+                canonical_id=canonical_id,
+                kind=kind,
+                display_label=display_label,
+                signal=signal,
+                mechanism=_SIGNAL_MECHANISM[signal],
+                matched_text=matched_text,
+                source_class=SourceClass(record["source_class"]),
+            )
+        )
+
+    return tuple(matches)

--- a/tests/api/dev/test_chaos_3502_graph_investigation_query.py
+++ b/tests/api/dev/test_chaos_3502_graph_investigation_query.py
@@ -38,6 +38,8 @@ def _request(
         mentions=(),
         question_text="Which teams are currently struggling?",
         authorized_entity_ids=authorized_entity_ids,
+        window_start=datetime(2026, 5, 12, 0, 0, tzinfo=UTC),
+        window_end=datetime(2026, 8, 10, 0, 0, tzinfo=UTC),
         deadline=datetime(2026, 8, 10, 0, 0, tzinfo=UTC),
     )
 

--- a/tests/context_fabric/test_chaos_3678_query_service.py
+++ b/tests/context_fabric/test_chaos_3678_query_service.py
@@ -1,6 +1,6 @@
 """CHAOS-3678: the production bounded graph query service.
 
-Two halves, matching the module's own documented scope:
+Three halves, matching the module's own documented scope:
 
 * :func:`mechanism_for` — the fixed ``(intent_id, cardinality) ->
   mechanism`` table (CHAOS-3660's accepted job/shape determination).
@@ -8,11 +8,17 @@ Two halves, matching the module's own documented scope:
   mapping, tested against fake stores injected via ``store_factory`` (no
   live backend needed for DISABLED/UNAVAILABLE/STALE/DEADLINE_EXCEEDED/
   CANCELLED/PROVIDER_FAILURE) plus one live positive control.
+* ``SEEDED_SINGULAR_SUBJECT``'s ``COMPLETED`` path (this revision) —
+  tested against a fake ``reader_factory``/fake driver, never a live
+  FalkorDB: ``subject_resolution.resolve_exact_subjects`` already has its
+  own direct unit coverage (``test_chaos_3678_subject_resolution.py``), so
+  what matters here is the wiring between resolution, traversal and
+  ``build_production_packet``, not re-proving the resolver's own rules.
 
-The ``COMPLETED`` path is not implemented in this increment (see the module
-docstring) and is not tested here — every currently-SUPPORTED mechanism is
-asserted to reach ``PROVIDER_FAILURE`` with a diagnostic naming the pending
-dependency, which is the honest, current behaviour.
+``SEEDED_EXPLICIT_COHORT``/``SUBJECTLESS_COHORT_DISCOVERY`` remain
+untouched by this revision — both still reach ``PROVIDER_FAILURE`` with a
+diagnostic naming the mechanism, which is the honest, current behaviour
+until ``cohort_discovery`` is wired in as a tracked follow-up.
 """
 
 from __future__ import annotations
@@ -23,7 +29,14 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from dev_health_ops.api.dev.contracts_v2.base import Cardinality, QuestionIntentID
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    EntityKind,
+    QuestionIntentID,
+    SourceClass,
+)
+from dev_health_ops.api.dev.contracts_v2.subject import DevSubjectMention
+from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
 from dev_health_ops.api.dev.graph_investigation_query import (
     GraphInvestigationRequest,
     GraphQueryOutcome,
@@ -33,10 +46,15 @@ from dev_health_ops.context_fabric.graph_arm.query_service import (
     ProductionGraphInvestigationQuery,
     mechanism_for,
 )
+from dev_health_ops.context_fabric.graph_arm.readback import (
+    DiscoveredEntity,
+    InvestigationReadout,
+)
 from dev_health_ops.context_fabric.graph_arm.store import (
     GraphArmStore,
     StoreUnavailableError,
 )
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
 from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
 from tests.context_fabric import live_gate
 
@@ -62,21 +80,31 @@ def _fresh_watermark() -> IndexWatermark:
     return IndexWatermark(indexed_through=datetime.now(UTC), records_indexed=1)
 
 
+#: A real UUID -- ``ProductionJobProvenance.run_id`` is a ``ServerHandle``
+#: (exact 36-char UUID pattern), which only the COMPLETED-path tests reach.
+_RUN_UUID = "9c9a3f9e-1111-4222-8333-444455556666"
+
+
 def _request(
     *,
     intent_id: QuestionIntentID = QuestionIntentID.PROJECT_HEALTH,
     cardinality: Cardinality = Cardinality.SINGULAR,
     deadline: datetime | None = None,
     org_id: str = "org_query_service_test",
+    run_id: str = "run_test",
+    mentions: tuple[DevSubjectMention, ...] = (),
+    authorized_entity_ids: frozenset[str] = frozenset({"proj_nightfall_migration"}),
 ) -> GraphInvestigationRequest:
     return GraphInvestigationRequest(
         org_id=org_id,
-        run_id="run_test",
+        run_id=run_id,
         intent_id=intent_id,
         cardinality=cardinality,
-        mentions=(),
+        mentions=mentions,
         question_text="What is the status of the Nightfall Migration project?",
-        authorized_entity_ids=frozenset({"proj_nightfall_migration"}),
+        authorized_entity_ids=authorized_entity_ids,
+        window_start=datetime(2026, 5, 12, tzinfo=UTC),
+        window_end=datetime(2026, 8, 9, tzinfo=UTC),
         deadline=deadline or _soon(),
     )
 
@@ -156,6 +184,12 @@ class _FakeStore:
     hang_seconds: float | None = None
     closed: bool = False
     close_calls: int = field(default=0)
+    #: Only read by the COMPLETED path (``_TraversalStore``'s two members,
+    #: via ``cast``) -- every other test class never reaches that far, so
+    #: these defaults are never exercised outside
+    #: ``TestSeededSingularSubjectCompletes``.
+    partition: str = "cf_query_service_test"
+    _driver: object = None
 
     async def read_watermark(self) -> IndexWatermark:
         if self.hang_seconds is not None:
@@ -338,12 +372,18 @@ class TestUnsupportedMechanism:
         assert "no graph mechanism" in result.diagnostic
 
 
-class TestSupportedMechanismIsNotYetImplemented:
+class TestCohortMechanismsAreNotYetImplemented:
     pytestmark = pytest.mark.asyncio
 
-    """Increment 1's honest boundary: selected, not yet executed."""
+    """The remaining honest boundary: selected, not yet executed.
 
-    async def test_a_supported_mechanism_reaches_provider_failure_with_a_named_reason(
+    SEEDED_SINGULAR_SUBJECT graduated to a real COMPLETED path this
+    revision (see ``TestSeededSingularSubjectCompletes`` below) --
+    SEEDED_EXPLICIT_COHORT and SUBJECTLESS_COHORT_DISCOVERY have not, since
+    both need ``cohort_discovery`` wired in as a separate follow-up.
+    """
+
+    async def test_seeded_explicit_cohort_reaches_provider_failure_with_a_named_reason(
         self, monkeypatch
     ) -> None:
         monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
@@ -351,15 +391,244 @@ class TestSupportedMechanismIsNotYetImplemented:
         service = _query(store)
         result = await service.investigate(
             _request(
-                intent_id=QuestionIntentID.PROJECT_HEALTH,
-                cardinality=Cardinality.SINGULAR,
+                intent_id=QuestionIntentID.METRIC_COMPARISON,
+                cardinality=Cardinality.PLURAL_COHORT,
             )
         )
         assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
         assert result.packet is None
         assert result.diagnostic is not None
-        assert "seeded_singular_subject" in result.diagnostic
-        assert "CHAOS-3660" in result.diagnostic
+        assert "seeded_explicit_cohort" in result.diagnostic
+
+    async def test_subjectless_cohort_discovery_reaches_provider_failure(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        store = _FakeStore(watermark=_fresh_watermark())
+        service = _query(store)
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.DISCOVERED_COHORT,
+                cardinality=Cardinality.ORGANIZATION_WIDE,
+            )
+        )
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.packet is None
+        assert result.diagnostic is not None
+        assert "subjectless_cohort_discovery" in result.diagnostic
+
+
+_TEST_SIGNING_SECRET = "chaos-3678-query-service-test-signing-secret-not-real"
+
+
+@dataclass
+class _FakeDriver:
+    """Mirrors ``readback._rows``'s contract, same shape as
+    ``test_chaos_3678_subject_resolution.py``'s fake -- this class exists
+    separately because it belongs to a different fake store's lifecycle,
+    not because the contract differs.
+    """
+
+    rows: list[dict] = field(default_factory=list)
+
+    async def execute_query(self, query: str, **params: object) -> tuple:
+        return (self.rows, None, None)
+
+
+def _entity_row(canonical_id: str, display_label: str) -> dict:
+    return {
+        "canonical_id": canonical_id,
+        "entity_kind": GraphEntityKind.PROJECT.value,
+        "display_label": display_label,
+        "source_class": SourceClass.WORK_GRAPH.value,
+    }
+
+
+def _mention(text: str) -> DevSubjectMention:
+    return DevSubjectMention(
+        schema_version="dev_subject_mention.v1",
+        mention_id="1c2d3e4f-1111-4222-8333-444455556666",
+        mention_ordinal=0,
+        original_text_span=text,
+        requested_entity_kind=EntityKind.PROJECT,
+        normalized_lookup_text=text,
+    )
+
+
+@dataclass
+class _FakeReader:
+    """A canned ``GraphReader``, decoupled from any store -- this
+    increment's tests need to control exactly what a traversal returns
+    without a live-store-compatible entity/edge/observation fixture.
+    """
+
+    readout: InvestigationReadout
+    calls: list[dict] = field(default_factory=list)
+
+    async def neighbourhood(
+        self,
+        *,
+        org_id: str,
+        seed_canonical_ids,
+        authorized_entity_ids,
+        max_hops: int = 3,
+        budgets=None,
+    ) -> InvestigationReadout:
+        self.calls.append(
+            {
+                "org_id": org_id,
+                "seed_canonical_ids": list(seed_canonical_ids),
+                "authorized_entity_ids": list(authorized_entity_ids),
+            }
+        )
+        return self.readout
+
+
+class TestSeededSingularSubjectCompletes:
+    pytestmark = pytest.mark.asyncio
+
+    """This revision's one real COMPLETED path.
+
+    Both tests use the identical fake driver/reader/mentions setup except
+    for one thing -- the query text -- so the difference in outcome is
+    attributable to resolution finding (or not finding) the subject, not
+    to an incidental setup difference between the two tests.
+    """
+
+    def _service(
+        self, *, driver: _FakeDriver, reader: _FakeReader
+    ) -> ProductionGraphInvestigationQuery:
+        store = _FakeStore(watermark=_fresh_watermark(), _driver=driver)
+        return ProductionGraphInvestigationQuery(
+            store_factory=_factory(store),
+            reader_factory=lambda _store: reader,
+            signer_factory=lambda: EvidenceReferenceSigner(_TEST_SIGNING_SECRET),
+        )
+
+    async def test_a_resolving_mention_reaches_completed_with_a_committed_subject(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(
+            rows=[_entity_row("proj_nightfall_migration", "Nightfall Migration")]
+        )
+        readout = InvestigationReadout(
+            org_id="org_query_service_test",
+            partition="cf_query_service_test",
+            seed_canonical_ids=("proj_nightfall_migration",),
+            # A real traversal populates this from its own authorized-scope
+            # check; the packet contract cross-validates every subject
+            # candidate against it, so the fake readout must too.
+            authorized_entity_ids=("proj_nightfall_migration",),
+            entities=(
+                DiscoveredEntity(
+                    canonical_id="proj_nightfall_migration",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Nightfall Migration",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime.now(UTC),
+                ),
+            ),
+        )
+        reader = _FakeReader(readout=readout)
+        service = self._service(driver=driver, reader=reader)
+
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.PROJECT_HEALTH,
+                cardinality=Cardinality.SINGULAR,
+                run_id=_RUN_UUID,
+                mentions=(_mention("Nightfall Migration"),),
+                authorized_entity_ids=frozenset({"proj_nightfall_migration"}),
+            )
+        )
+
+        assert result.outcome is GraphQueryOutcome.COMPLETED
+        assert result.packet is not None
+        assert reader.calls == [
+            {
+                "org_id": "org_query_service_test",
+                "seed_canonical_ids": ["proj_nightfall_migration"],
+                "authorized_entity_ids": ["proj_nightfall_migration"],
+            }
+        ]
+        job = result.packet.analytical_job
+        assert job.schema_version == "ask_dev_analytical_job.v2"
+        assert job.production_job is not None
+        assert job.production_job.run_id == _RUN_UUID
+        # PROPOSED, not necessarily COMMITTED: commitment additionally
+        # requires the seed be touched by at least one traversal path
+        # (``packet_builder``'s own rule, already covered by that module's
+        # tests) -- what THIS test proves is that resolution's match
+        # reached subject_discovery as a real candidate at all, which is
+        # the wiring under test here.
+        assert [
+            candidate.canonical_id
+            for candidate in result.packet.subject_discovery.candidates
+        ] == ["proj_nightfall_migration"]
+
+    async def test_a_non_resolving_mention_still_reaches_completed_not_a_guess(
+        self, monkeypatch
+    ) -> None:
+        """§4: no fuzzy/unresolved-name widening. A mention that resolves to
+        nothing is still an honestly COMPLETED call -- the packet itself
+        discloses no committed subject, never a fabricated one and never a
+        transport failure this is not.
+        """
+
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(
+            rows=[_entity_row("proj_nightfall_migration", "Nightfall Migration")]
+        )
+        readout = InvestigationReadout(
+            org_id="org_query_service_test",
+            partition="cf_query_service_test",
+            seed_canonical_ids=(),
+        )
+        reader = _FakeReader(readout=readout)
+        service = self._service(driver=driver, reader=reader)
+
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.PROJECT_HEALTH,
+                cardinality=Cardinality.SINGULAR,
+                run_id=_RUN_UUID,
+                # Only a fuzzy/partial overlap with the fixture's entity --
+                # resolve_exact_subjects's own negative control.
+                mentions=(_mention("Nightfall"),),
+                authorized_entity_ids=frozenset({"proj_nightfall_migration"}),
+            )
+        )
+
+        assert result.outcome is GraphQueryOutcome.COMPLETED
+        assert result.packet is not None
+        assert reader.calls[0]["seed_canonical_ids"] == []
+        assert result.packet.subject_discovery.committed_subject_ids == ()
+
+    async def test_the_store_is_closed_after_completed(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(rows=[])
+        readout = InvestigationReadout(
+            org_id="org_query_service_test",
+            partition="cf_query_service_test",
+            seed_canonical_ids=(),
+        )
+        reader = _FakeReader(readout=readout)
+        store = _FakeStore(watermark=_fresh_watermark(), _driver=driver)
+        service = ProductionGraphInvestigationQuery(
+            store_factory=_factory(store),
+            reader_factory=lambda _store: reader,
+            signer_factory=lambda: EvidenceReferenceSigner(_TEST_SIGNING_SECRET),
+        )
+        await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.PROJECT_HEALTH,
+                cardinality=Cardinality.SINGULAR,
+                run_id=_RUN_UUID,
+                mentions=(_mention("nothing matches"),),
+            )
+        )
+        assert store.close_calls == 1
 
 
 class TestDiagnosticsAreContentSafe:
@@ -378,6 +647,8 @@ class TestDiagnosticsAreContentSafe:
             mentions=(),
             question_text=planted,
             authorized_entity_ids=frozenset(),
+            window_start=datetime(2026, 5, 12, tzinfo=UTC),
+            window_end=datetime(2026, 8, 9, tzinfo=UTC),
             deadline=_soon(),
         )
         result = await service.investigate(request)

--- a/tests/context_fabric/test_chaos_3678_subject_resolution.py
+++ b/tests/context_fabric/test_chaos_3678_subject_resolution.py
@@ -1,0 +1,177 @@
+"""CHAOS-3678: EXACT-only live subject resolution for production.
+
+Per team-lead's ruling (§4 binds hard): production's first COMPLETED-path
+slice resolves a mention to a subject on ``EXACT_CANONICAL_ID`` or
+``EXACT_DISPLAY_NAME`` only -- never alias, acronym, previous-name or fuzzy
+matching, which ``discovery.search_candidates`` supports for the trial but
+which this module deliberately does not reach. A mention that only fuzzy- or
+alias-matches must resolve to *nothing* here, not a guess.
+
+Tested against a fake driver exposing ``execute_query`` (the same contract
+``readback._rows`` calls), not a live FalkorDB -- this module reuses
+``readback._ENTITY_QUERY`` verbatim so the query itself is already covered
+by the live-store tests that exercise ``LiveGraphReader``; what is new here
+is the exact-only matching and authorization filtering on top of it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+from dev_health_ops.context_fabric.graph_arm.backend import MatchMechanism
+from dev_health_ops.context_fabric.graph_arm.subject_resolution import (
+    _resolve_exact_subjects,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+pytestmark = pytest.mark.asyncio
+
+_PARTITION = "cf_trial_org_test"
+
+
+def _entity_record(
+    canonical_id: str,
+    display_label: str,
+    *,
+    kind: str = GraphEntityKind.PROJECT.value,
+    source_class: str = SourceClass.WORK_GRAPH.value,
+) -> dict[str, Any]:
+    return {
+        "canonical_id": canonical_id,
+        "entity_kind": kind,
+        "display_label": display_label,
+        "source_class": source_class,
+    }
+
+
+@dataclass
+class _FakeDriver:
+    """Mirrors ``readback._rows``'s contract: ``execute_query`` returns a
+    ``(records, header, stats)`` triple; only ``records`` is read.
+    """
+
+    rows: list[dict[str, Any]] = field(default_factory=list)
+    call_count: int = 0
+
+    async def execute_query(self, query: str, **params: object) -> tuple:
+        self.call_count += 1
+        return (self.rows, None, None)
+
+
+async def test_exact_canonical_id_match_resolves() -> None:
+    driver = _FakeDriver(
+        rows=[_entity_record("proj_nightfall_migration", "Nightfall Migration")]
+    )
+    matches = await _resolve_exact_subjects(
+        driver,
+        _PARTITION,
+        queries=["proj_nightfall_migration"],
+        authorized_entity_ids=("proj_nightfall_migration",),
+    )
+    assert len(matches) == 1
+    assert matches[0].canonical_id == "proj_nightfall_migration"
+    assert matches[0].signal is SubjectMatchSignal.EXACT_CANONICAL_ID
+    assert matches[0].mechanism is MatchMechanism.EXACT_LOOKUP
+
+
+async def test_exact_display_name_match_resolves() -> None:
+    driver = _FakeDriver(
+        rows=[_entity_record("proj_nightfall_migration", "Nightfall Migration")]
+    )
+    matches = await _resolve_exact_subjects(
+        driver,
+        _PARTITION,
+        queries=["Nightfall Migration"],
+        authorized_entity_ids=("proj_nightfall_migration",),
+    )
+    assert len(matches) == 1
+    assert matches[0].canonical_id == "proj_nightfall_migration"
+    assert matches[0].signal is SubjectMatchSignal.EXACT_DISPLAY_NAME
+
+
+async def test_case_and_punctuation_insensitive_but_still_exact() -> None:
+    """Normalization tolerance, not fuzziness: casing/punctuation/whitespace
+    variance is not the widening §4 forbids -- a genuinely different string
+    (below) must still not match.
+    """
+
+    driver = _FakeDriver(
+        rows=[_entity_record("proj_nightfall_migration", "Nightfall Migration")]
+    )
+    matches = await _resolve_exact_subjects(
+        driver,
+        _PARTITION,
+        queries=["  NIGHTFALL-migration  "],
+        authorized_entity_ids=("proj_nightfall_migration",),
+    )
+    assert len(matches) == 1
+
+
+async def test_no_match_returns_empty_not_a_guess() -> None:
+    """The negative control for the module's whole reason to exist: a
+    fuzzy/partial textual overlap must resolve to nothing here, even though
+    ``discovery.search_candidates`` (the trial's fuller capability) would
+    treat "Nightfall" as a ``FUZZY_LABEL`` hit against "Nightfall Migration".
+    """
+
+    driver = _FakeDriver(
+        rows=[_entity_record("proj_nightfall_migration", "Nightfall Migration")]
+    )
+    matches = await _resolve_exact_subjects(
+        driver,
+        _PARTITION,
+        queries=["Nightfall"],
+        authorized_entity_ids=("proj_nightfall_migration",),
+    )
+    assert matches == ()
+
+
+async def test_unauthorized_match_is_withheld() -> None:
+    """Authorization applied before the match is ever returned -- mirrors
+    ``discovery.search_candidates``'s own "withheld before ranking" rule.
+    """
+
+    driver = _FakeDriver(
+        rows=[_entity_record("proj_nightfall_migration", "Nightfall Migration")]
+    )
+    matches = await _resolve_exact_subjects(
+        driver,
+        _PARTITION,
+        queries=["proj_nightfall_migration"],
+        authorized_entity_ids=(),
+    )
+    assert matches == ()
+
+
+async def test_organization_kind_is_never_a_subject_match() -> None:
+    driver = _FakeDriver(
+        rows=[
+            _entity_record(
+                "org_acme", "Acme Corp", kind=GraphEntityKind.ORGANIZATION.value
+            )
+        ]
+    )
+    matches = await _resolve_exact_subjects(
+        driver,
+        _PARTITION,
+        queries=["Acme Corp"],
+        authorized_entity_ids=("org_acme",),
+    )
+    assert matches == ()
+
+
+async def test_empty_queries_short_circuits_without_a_round_trip() -> None:
+    driver = _FakeDriver(rows=[_entity_record("proj_x", "Project X")])
+    matches = await _resolve_exact_subjects(
+        driver, _PARTITION, queries=(), authorized_entity_ids=("proj_x",)
+    )
+    assert matches == ()
+    assert driver.call_count == 0, (
+        "an empty query list has nothing to look up; a query sent anyway "
+        "is not a query worth sending"
+    )


### PR DESCRIPTION
## ✅ B's sign-off landed

This PR modifies `api/dev/graph_investigation_query.py` (Lane B's file — `GraphInvestigationRequest` gains `window_start`/`window_end`). Lane B signed off on the field shape, no objection, and independently confirmed the exact citation below (checked cold against the merged tip) before I'd finished writing this PR body -- it already matches what I'd implemented.

## Issue / Phase

CHAOS-3678 (production bounded graph query service), the SEEDED_SINGULAR_SUBJECT slice — scoped and approved by team-lead as its own PR, stacked after #1662 (transport/outcome mapping, merged). Branch is ID-free per the standing branch-naming rule.

## Observable outcome

`ProductionGraphInvestigationQuery.investigate()` now implements one real `COMPLETED` path. For `GraphMechanism.SEEDED_SINGULAR_SUBJECT`: the request's first mention is resolved via `subject_resolution._resolve_exact_subjects` (EXACT canonical-id/display-label match only — no alias, no acronym, no fuzzy widening), traversed via `LiveGraphReader` (injected through a new `reader_factory`), and assembled into a real packet via `build_production_packet(drivers=None)`. A mention that does not resolve still reaches `COMPLETED` — the packet itself discloses no committed subject, never a guess and never misreported as a transport failure. `SEEDED_EXPLICIT_COHORT`/`SUBJECTLESS_COHORT_DISCOVERY` are unchanged (still `PROVIDER_FAILURE`, pending `cohort_discovery` wiring as tracked follow-ups).

## Architecture boundary

**Subject resolution is package-private** (`_resolve_exact_subjects`, not exported): it takes a raw `partition` parameter, which CHAOS-3617's "no caller-supplied partition parameter" guard (`test_chaos_3617_no_caller_supplied_partition.py`) forbids on any *public* callable in `graph_arm` — this actually caught the first draft (I'd exported it; the guard's own test suite failed and named exactly why). `query_service.py` (same package) derives `partition` from the store it already holds, never from a caller.

**Store-handle decision** (asked for explicitly by team-lead): a second narrow `_TraversalStore` Protocol (`partition`, `_driver` only) beside `_WatermarkStore`, accessed via a documented `cast()` at the one call site that needs it — not a widening of `_WatermarkStore`. Every one of increment 1's existing fakes (which implement only `read_watermark`/`close`) keeps passing unchanged.

**The time-window gap**: `GraphInvestigationRequest` had no time window at all. Team-lead's ruling (rejecting a graph-side default outright — "the CALLER owns the window"): add `window_start`/`window_end` to the request, populated by the orchestrator from the *same* source that already bounds every other tool/metric execution for the run. Exact site, confirmed independently by both team-lead and Lane B: `orchestrator.py` line ~1998, `authorized_scope = resolution.resolved_scope` — the same `DevScope` every legacy tool-execution context constructs from (the same variable feeds `StepContext(scope=authorized_scope, ...)` at the plan-executor call site, and the same pattern recurs at the tool sites ~3068/3148/3751). Concretely: `window_start=authorized_scope.time_range.start`, `window_end=authorized_scope.time_range.end` (`DevTimeRange`, an `AwareDatetime` pair, `contracts.py`). For `DISCOVERED_COHORT` specifically, `preflight_result`'s `committed_resolution` is `None` by design, so `authorized_scope` (set at line ~1998, never reassigned before the graph-routing block for this intent) is the only resolved scope available at the call site — the same window `subject_preflight._organization_resolution()` already copies verbatim for the equivalent org-wide case. The graph seam invents no product time policy of its own.

**`job_statement`**: a fixed, closed-vocabulary template keyed on `QuestionIntentID` (`"Investigate {intent} for the resolved subject."`) — never `request.question_text` verbatim, per the Protocol's own "never echoed into a packet field a consumer renders" guardrail. Approved by team-lead.

## Scope / non-scope

In scope: `subject_resolution.py` (new), the `investigate()` COMPLETED-path wiring, the `GraphInvestigationRequest` window fields, the orchestrator call-site population, `job_statement`'s template.

Out of scope: `SEEDED_EXPLICIT_COHORT`/`SUBJECTLESS_COHORT_DISCOVERY` (need `cohort_discovery` wired in — to be filed as tracked Linear follow-ups on CHAOS-3678 once this merges, per team-lead's instruction). Driver synthesis (`drivers=None` — mirrors the trial's own PR1 scope, which never synthesized drivers either).

## Base / head SHA

- Base: `f6301898b2fdf0ed39d33010a8d8fb30ae277465` (`feature/chaos-3498-context-fabric` tip — "CHAOS-3678 increment 1: transport/outcome mapping for the graph query service (#1662)")
- Head: `b468be4258c1f744efa90070e26325396d005adb`

## Migrations

None.

## Security / privacy

None new. `_resolve_exact_subjects` applies authorization *before* returning a match (mirrors `discovery.search_candidates`'s "withheld before ranking" rule) — an unauthorized match contributes nothing. `job_statement`'s fixed template cannot emit caller-controlled text.

## RED-first evidence

- `tests/context_fabric/test_chaos_3678_subject_resolution.py` (7 tests, written first): exact canonical-id match, exact display-name match, normalization-tolerant-but-still-exact, **the negative control** — a fuzzy/partial match ("Nightfall" against "Nightfall Migration") returns nothing, proving this module genuinely does not reach `discovery.search_candidates`'s wider capability — unauthorized-match withholding, ORGANIZATION-kind exclusion, and an empty-query short-circuit proven by an actual call-count assertion (not just an empty-result assertion, which would pass either way).
- `tests/context_fabric/test_chaos_3678_query_service.py` (new `TestSeededSingularSubjectCompletes` class): a resolving mention reaches `COMPLETED` with the subject in `subject_discovery.candidates`, wired through a fake `reader_factory` (no live FalkorDB needed) and a real `EvidenceReferenceSigner`; a non-resolving mention (§4's negative control again, at the wiring layer) still reaches `COMPLETED`, never `PROVIDER_FAILURE`; the store is closed after `COMPLETED` same as every other outcome. The two cohort mechanisms' "not yet implemented" tests were re-targeted from the now-real `SEEDED_SINGULAR_SUBJECT` to `SEEDED_EXPLICIT_COHORT`/`SUBJECTLESS_COHORT_DISCOVERY` specifically.

## Verification

- `mypy .` (full repo) — Success, 2391 source files, 0 errors
- `ruff check` / `ruff format --check` — clean
- `pytest tests/context_fabric/` (full suite, proves nothing else regressed) — 1507 passed, 54 skipped, 0 failed
- `pytest tests/context_fabric/test_chaos_3617_no_caller_supplied_partition.py` — the tenancy-isolation guard this PR's first draft actually tripped — now passing
- `pytest tests/api/dev/test_orchestrator.py tests/api/dev/test_chaos_3502_graph_investigation_query.py -k "graph_routing or 3502 or 3665 or 3687"` — 43 passed, 0 failed
- Pre-commit and pre-push lefthook gates — all green, no `--no-verify` used

## Known limitations

Nothing in production constructs a `ProductionGraphInvestigationQuery` yet (`production_runtime.py` doesn't wire it in) — this is still increment work, not yet live. `_resolve_exact_subjects` re-fetches the partition's full entity catalog per call (reuses the same unconditional `_ENTITY_QUERY` `LiveGraphReader.neighbourhood` already runs) rather than caching — acceptable for a first slice, worth revisiting if this becomes a hot path.

## Rollout / rollback

Additive: nothing on trunk calls the new COMPLETED path yet. `GraphInvestigationRequest`'s two new required fields are the only breaking-shaped change, and every existing constructor call site (2 tests + `orchestrator.py`) is updated in this same PR — but that's exactly why B's sign-off matters before merge. Revert is a plain single-commit revert.
