### PR TITLE
CHAOS-3688: wire SEEDED_EXPLICIT_COHORT to a real COMPLETED path

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/cohort.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/cohort.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Protocol
 
 from dev_health_ops.api.dev.investigation_contract import (
     CohortExclusionReason,
@@ -36,7 +37,6 @@ from dev_health_ops.api.dev.investigation_contract import (
     RelationshipType,
 )
 
-from .projection import GraphEdge
 from .vocabulary import GraphEntityKind
 
 __all__ = [
@@ -44,11 +44,38 @@ __all__ = [
     "COHORT_BEARING_RELATIONSHIPS",
     "PEER_RELATIONSHIPS",
     "CohortCandidate",
+    "CohortEdgeLike",
     "CohortEntryMode",
     "CohortExclusionRecord",
     "CohortProposal",
     "build_cohort",
 ]
+
+
+class CohortEdgeLike(Protocol):
+    """The three fields :func:`build_cohort` actually reads off an edge.
+
+    CHAOS-3617's :class:`~.projection.GraphEdge` (the trial's in-memory,
+    fixture-built edge) satisfies this structurally and keeps working
+    unchanged -- this widens the *parameter type*, not the trial's own
+    call site. CHAOS-3688 needs a second, live-store-backed edge shape with
+    none of ``GraphEdge``'s other fields (uuid, org_id, source/target uuid
+    and kind, ...) real to fabricate; this Protocol is what makes passing
+    that shape here honest rather than a synthetic ``GraphEdge`` with
+    placeholder values for fields nothing here reads.
+
+    Declared via ``@property`` (read-only), not plain attributes: frozen
+    dataclasses (both ``GraphEdge`` and CHAOS-3688's live edge shape) have
+    mypy-read-only fields, which a plain-attribute Protocol would reject --
+    same reasoning as ``packet_builder._JobLike``.
+    """
+
+    @property
+    def relationship(self) -> RelationshipType: ...
+    @property
+    def source_canonical_id(self) -> str: ...
+    @property
+    def target_canonical_id(self) -> str: ...
 
 
 class CohortEntryMode(StrEnum):
@@ -215,7 +242,7 @@ class CohortProposal:
 
 def build_cohort(
     subject_id: str,
-    edges: Sequence[GraphEdge],
+    edges: Sequence[CohortEdgeLike],
     entity_labels: Mapping[str, tuple[GraphEntityKind, str]],
     authorized_entity_ids: Sequence[str] | frozenset[str],
     *,

--- a/src/dev_health_ops/context_fabric/graph_arm/query_service.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/query_service.py
@@ -18,7 +18,7 @@ states — is real, live-tested, and composes the absolute request deadline
 with CHAOS-3631's per-operation :class:`~.flags.GraphDeadlines` and
 CHAOS-3679's persisted watermark.
 
-**Increment 2 (this revision) implements exactly one COMPLETED path:**
+**Increment 2 implemented one COMPLETED path:**
 ``GraphMechanism.SEEDED_SINGULAR_SUBJECT``, via
 :func:`~.subject_resolution._resolve_exact_subjects` (EXACT canonical-id/
 display-label match only — see that module's own docstring for why this is
@@ -26,12 +26,20 @@ narrower than the trial's ``discovery.search_candidates``),
 :class:`~.readback.LiveGraphReader` traversal, and
 :func:`~.packet_builder.build_production_packet` with ``drivers=None`` (no
 driver synthesis — mirrors the trial's own PR1 scope, which never
-synthesized drivers either). ``SEEDED_EXPLICIT_COHORT`` and
-``SUBJECTLESS_COHORT_DISCOVERY`` still return ``PROVIDER_FAILURE`` with a
-diagnostic naming the mechanism — both need ``cohort_discovery`` wired in,
-tracked as separate follow-ups (filed on CHAOS-3678) rather than bundled
-here. Every path is an honest "not yet" where it applies, never a silent
-wrong answer, never a crash a caller has to guard against separately.
+synthesized drivers either).
+
+**Increment 3 (this revision) adds ``SEEDED_EXPLICIT_COHORT``** (CHAOS-3688),
+following the trial's own construction
+(``trials/chaos_3619/graph_leg.py``'s ``assemble_packet``) exactly: every
+mention resolves the same EXACT-only way, the first resolved candidate
+becomes the anchor subject, and :func:`~.cohort.build_cohort` walks two hops
+out from it over live edges (:func:`~.subject_resolution._live_cohort_edges`)
+to discover peers — never a cohort built directly from "the other named
+mentions". ``SUBJECTLESS_COHORT_DISCOVERY`` still returns
+``PROVIDER_FAILURE`` with a diagnostic naming the mechanism — it needs
+``cohort_discovery.discover_cohort`` wired in, tracked as CHAOS-3689. Every
+path is an honest "not yet" where it applies, never a silent wrong answer,
+never a crash a caller has to guard against separately.
 """
 
 from __future__ import annotations
@@ -57,6 +65,7 @@ from dev_health_ops.api.dev.graph_investigation_query import (
 )
 from dev_health_ops.api.dev.investigation_contract import ComparisonShape
 
+from .cohort import build_cohort
 from .flags import graph_read_enabled
 from .packet_builder import (
     ProductionJobContext,
@@ -65,7 +74,12 @@ from .packet_builder import (
 )
 from .readback import GraphReader, LiveGraphReader
 from .store import GraphArmStore, StoreUnavailableError
-from .subject_resolution import _resolve_exact_subjects
+from .subject_resolution import (
+    _live_cohort_edges,
+    _live_entities,
+    _live_entity_labels,
+    _resolve_exact_subjects,
+)
 from .watermark import DEFAULT_STALENESS_TOLERANCE, IndexWatermark
 
 logger = logging.getLogger(__name__)
@@ -326,22 +340,26 @@ class ProductionGraphInvestigationQuery:
                         f"cardinality={request.cardinality.value}",
                     ),
                 )
-            if mechanism is not GraphMechanism.SEEDED_SINGULAR_SUBJECT:
-                # SEEDED_EXPLICIT_COHORT / SUBJECTLESS_COHORT_DISCOVERY:
-                # both still need cohort_discovery wired in -- tracked as
-                # separate follow-ups on CHAOS-3678, not bundled here.
-                # Naming the mechanism rather than a bare "not implemented"
-                # is what makes this diagnostic actionable.
-                return GraphQueryResult(
-                    outcome=GraphQueryOutcome.PROVIDER_FAILURE,
-                    diagnostic=_diagnostic(
-                        "execution",
-                        f"mechanism {mechanism.value} selected; packet "
-                        "assembly for this mechanism is a tracked follow-up",
-                    ),
+            if mechanism is GraphMechanism.SEEDED_SINGULAR_SUBJECT:
+                return await self._complete_seeded_singular_subject(
+                    request, store, watermark
                 )
-            return await self._complete_seeded_singular_subject(
-                request, store, watermark
+            if mechanism is GraphMechanism.SEEDED_EXPLICIT_COHORT:
+                return await self._complete_seeded_explicit_cohort(
+                    request, store, watermark
+                )
+            # SUBJECTLESS_COHORT_DISCOVERY (CHAOS-3689): still needs
+            # cohort_discovery.discover_cohort wired in -- a separate,
+            # tracked follow-up, not bundled here. Naming the mechanism
+            # rather than a bare "not implemented" is what makes this
+            # diagnostic actionable.
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                diagnostic=_diagnostic(
+                    "execution",
+                    f"mechanism {mechanism.value} selected; packet "
+                    "assembly for this mechanism is a tracked follow-up",
+                ),
             )
         except asyncio.CancelledError:
             return GraphQueryResult(
@@ -429,6 +447,102 @@ class ProductionGraphInvestigationQuery:
             return GraphQueryResult(
                 outcome=GraphQueryOutcome.PROVIDER_FAILURE,
                 diagnostic=_diagnostic("execution", type(exc).__name__),
+            )
+        return GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
+
+    async def _complete_seeded_explicit_cohort(
+        self,
+        request: GraphInvestigationRequest,
+        store: _WatermarkStore,
+        watermark: IndexWatermark,
+    ) -> GraphQueryResult:
+        """``SEEDED_EXPLICIT_COHORT``'s COMPLETED path (CHAOS-3688).
+
+        Resolves every mention (PLURAL_COHORT cardinality: two or more,
+        per ``DevQuestionIntent.validate_intent_invariants``) by the same
+        EXACT-only match as the singular path, then follows the trial's
+        own construction (``trials/chaos_3619/graph_leg.py``'s
+        ``assemble_packet``) exactly: the FIRST resolved candidate becomes
+        the anchor subject, and ``cohort.build_cohort`` walks two hops out
+        from it -- peers are DISCOVERED via shared team/portfolio/
+        initiative/dependency edges, not simply "the other named
+        mentions". A caller who named two subjects sharing no anchor gets
+        an honestly small or empty cohort from ``build_cohort`` itself,
+        never one fabricated from the mentions.
+
+        No mention resolving to an authorized anchor, or ``build_cohort``
+        producing fewer than two members or no comparison dimension
+        (``IncomparableCohortError``), both reach ``PROVIDER_FAILURE`` with
+        a diagnostic naming the mechanism -- an honest, explicit
+        degradation. Unlike ``SEEDED_SINGULAR_SUBJECT``, there is no
+        "empty but valid" packet shape here: ``ComparisonShape.
+        EXPLICIT_COHORT`` requires a real, comparable cohort by contract,
+        so a caller must be told plainly rather than handed a packet that
+        looks like a completed comparison but silently compares nothing.
+        """
+
+        traversal_store = cast(_TraversalStore, store)
+        queries = [mention.normalized_lookup_text for mention in request.mentions]
+        try:
+            candidates = await _resolve_exact_subjects(
+                traversal_store._driver,
+                traversal_store.partition,
+                queries,
+                request.authorized_entity_ids,
+            )
+            if not candidates:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                    diagnostic=_diagnostic(
+                        "execution",
+                        f"mechanism {GraphMechanism.SEEDED_EXPLICIT_COHORT.value}: "
+                        "no mention resolved to an authorized anchor subject",
+                    ),
+                )
+            subject_id = candidates[0].canonical_id
+            edges = await _live_cohort_edges(
+                traversal_store._driver, traversal_store.partition
+            )
+            entities = await _live_entities(
+                traversal_store._driver, traversal_store.partition
+            )
+            cohort = build_cohort(
+                subject_id,
+                edges,
+                _live_entity_labels(entities),
+                request.authorized_entity_ids,
+            )
+            reader = self._reader_factory(traversal_store)
+            readout = await reader.neighbourhood(
+                org_id=request.org_id,
+                seed_canonical_ids=[subject_id],
+                authorized_entity_ids=tuple(request.authorized_entity_ids),
+            )
+            packet = build_production_packet(
+                readout=readout,
+                job=ProductionJobContext(
+                    job_id=f"graph_query_{request.run_id}",
+                    intent_id=request.intent_id,
+                    run_id=request.run_id,
+                    job_statement=_job_statement(request.intent_id),
+                    comparison_shape=ComparisonShape.EXPLICIT_COHORT,
+                    window_start=request.window_start,
+                    window_end=request.window_end,
+                ),
+                cohort=cohort,
+                watermark=watermark,
+                signer=self._signer_factory(),
+                produced_at=datetime.now(UTC),
+                staleness_tolerance=self._staleness_tolerance,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                diagnostic=_diagnostic(
+                    "execution",
+                    f"mechanism {GraphMechanism.SEEDED_EXPLICIT_COHORT.value}: "
+                    f"{type(exc).__name__}",
+                ),
             )
         return GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
 

--- a/src/dev_health_ops/context_fabric/graph_arm/subject_resolution.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/subject_resolution.py
@@ -16,26 +16,36 @@ refusal/degradation outcome rather than ever guessing. Widening this to the
 trial's full signal set is separate, explicitly-scoped follow-up work, not a
 quietly-expanding default.
 
-Reuses :data:`~.readback._ENTITY_QUERY` and :func:`~.readback._rows`
-verbatim -- the same partition-scoped, unconditional entity fetch
-:class:`~.readback.LiveGraphReader` already runs for every traversal, so this
-module adds no new Cypher and no new live-store surface, only exact matching
-and authorization filtering over rows that query already proves correct.
+Reuses :data:`~.readback._ENTITY_QUERY`/:data:`~.readback._EDGE_QUERY` and
+:func:`~.readback._rows` verbatim -- the same partition-scoped, unconditional
+entity/edge fetch :class:`~.readback.LiveGraphReader` already runs for every
+traversal, so this module adds no new Cypher and no new live-store surface,
+only interpretation over rows those queries already prove correct.
+
+CHAOS-3688 adds two more live-data helpers for :func:`~.cohort.build_cohort`
+(the ``SEEDED_EXPLICIT_COHORT`` mechanism): an edge fetch shaped to
+``cohort.CohortEdgeLike`` and an ``entity_labels`` map, both derived from the
+SAME live queries this module already runs -- not a second live-store
+integration, an extension of the one this module is.
 """
 
 from __future__ import annotations
 
 import unicodedata
 from collections.abc import Sequence
+from dataclasses import dataclass
 from re import compile as _compile
 from typing import Any
 
 from dev_health_ops.api.dev.contracts_v2.base import SourceClass
-from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+from dev_health_ops.api.dev.investigation_contract import (
+    RelationshipType,
+    SubjectMatchSignal,
+)
 
-from .backend import MatchMechanism
+from .backend import MatchMechanism, parse_triple_fact
 from .discovery import CandidateMatch
-from .readback import _ENTITY_QUERY, _rows
+from .readback import _EDGE_QUERY, _ENTITY_QUERY, _rows
 from .vocabulary import GraphEntityKind
 
 #: Deliberately empty: this module's one function is package-private (see
@@ -71,6 +81,46 @@ def _normalize(text: str) -> str:
     return _WHITESPACE.sub(" ", _PUNCTUATION.sub(" ", folded)).strip()
 
 
+@dataclass(frozen=True, slots=True)
+class _LiveEntity:
+    """One partition entity, as fetched by :func:`_live_entities`.
+
+    Deliberately narrower than :class:`~.readback.DiscoveredEntity`: this
+    carries nothing about traversal (no ``alias_values``, no
+    ``attributes``) -- both this module's callers only ever read identity
+    and classification.
+    """
+
+    canonical_id: str
+    kind: GraphEntityKind
+    display_label: str
+    source_class: SourceClass
+
+
+async def _live_entities(driver: Any, partition: str) -> tuple[_LiveEntity, ...]:
+    """Every entity in the partition, unconditionally -- shared by
+    :func:`_resolve_exact_subjects` (search target) and
+    :func:`_live_entity_labels` (``build_cohort``'s label lookup). One
+    fetch, two interpretations, rather than two separate live-store reads
+    of the same query.
+    """
+
+    entities: list[_LiveEntity] = []
+    for record in await _rows(driver, _ENTITY_QUERY, partition=partition):
+        kind_value = record.get("entity_kind")
+        if kind_value is None:
+            continue
+        entities.append(
+            _LiveEntity(
+                canonical_id=record["canonical_id"],
+                kind=GraphEntityKind(kind_value),
+                display_label=record["display_label"],
+                source_class=SourceClass(record["source_class"]),
+            )
+        )
+    return tuple(entities)
+
+
 async def _resolve_exact_subjects(
     driver: Any,
     partition: str,
@@ -88,16 +138,18 @@ async def _resolve_exact_subjects(
     derives ``partition`` from the store it already holds, never from a
     caller-supplied value.
 
-    ``queries`` is normally the caller's mention texts. Every query is
+    ``queries`` is normally the caller's mention texts -- one per resolved
+    seed, so ``SEEDED_EXPLICIT_COHORT`` (CHAOS-3688) passes every mention's
+    text in one call rather than one call per mention. Every query is
     checked against every entity; a query matching nothing, or matching only
     an unauthorized entity, contributes no result -- there is no partial
     credit and no fallback signal weaker than the two this module supports.
 
     Order among results (when more than one query matches) is NOT specified
-    beyond entity iteration order: callers with exactly one query -- this
-    slice's only caller -- do not need one, and inventing an ordering
-    contract for a first slice that has no multi-query caller yet would be
-    a commitment nothing here can honor. ``discovery.CandidateMatch`` is
+    beyond entity iteration order -- ordering results to match caller intent
+    (e.g. "the Nth match corresponds to the Nth mention") is the caller's
+    job, since two different mentions can resolve to the same entity or one
+    mention's text can match nothing at all. ``discovery.CandidateMatch`` is
     reused directly (not a parallel type) so its already-tested
     ``rank_key`` is available the moment a caller needs to rank multiple
     queries' worth of results.
@@ -109,45 +161,90 @@ async def _resolve_exact_subjects(
 
     authorized = frozenset(authorized_entity_ids)
     matches: list[CandidateMatch] = []
-    for record in await _rows(driver, _ENTITY_QUERY, partition=partition):
-        kind_value = record.get("entity_kind")
-        if kind_value is None:
-            continue
-        kind = GraphEntityKind(kind_value)
-        if kind is GraphEntityKind.ORGANIZATION:
+    for entity in await _live_entities(driver, partition):
+        if entity.kind is GraphEntityKind.ORGANIZATION:
             continue
 
-        canonical_id = record["canonical_id"]
-        display_label = record["display_label"]
-        if _normalize(canonical_id) in normalized_queries:
+        if _normalize(entity.canonical_id) in normalized_queries:
             signal = SubjectMatchSignal.EXACT_CANONICAL_ID
-            matched_text = canonical_id
-        elif _normalize(display_label) in normalized_queries:
+            matched_text = entity.canonical_id
+        elif _normalize(entity.display_label) in normalized_queries:
             signal = SubjectMatchSignal.EXACT_DISPLAY_NAME
-            matched_text = display_label
+            matched_text = entity.display_label
         else:
             continue
 
-        if canonical_id not in authorized:
+        if entity.canonical_id not in authorized:
             # Withheld before it is ever returned -- mirrors
             # discovery.search_candidates's own "authorization applied
-            # before ranking" rule. Not counted here: this slice's one
-            # caller (query_service, SEEDED_SINGULAR_SUBJECT) has exactly
-            # one mention, so an authorization-filtered count belongs on
-            # its own SubjectDiscovery section, not invented in this
-            # function ahead of a caller that needs it.
+            # before ranking" rule. Not counted here: an
+            # authorization-filtered count belongs on the caller's own
+            # SubjectDiscovery section, not invented ahead of a caller
+            # that needs it.
             continue
 
         matches.append(
             CandidateMatch(
-                canonical_id=canonical_id,
-                kind=kind,
-                display_label=display_label,
+                canonical_id=entity.canonical_id,
+                kind=entity.kind,
+                display_label=entity.display_label,
                 signal=signal,
                 mechanism=_SIGNAL_MECHANISM[signal],
                 matched_text=matched_text,
-                source_class=SourceClass(record["source_class"]),
+                source_class=entity.source_class,
             )
         )
 
     return tuple(matches)
+
+
+def _live_entity_labels(
+    entities: Sequence[_LiveEntity],
+) -> dict[str, tuple[GraphEntityKind, str]]:
+    """The ``canonical_id -> (kind, label)`` map :func:`~.cohort.build_cohort`
+    takes. Excludes ``ORGANIZATION`` -- mirrors the trial's own
+    ``graph_leg._entity_labels``: the partition root is an entity node with
+    no emittable subject kind, and a cohort that could contain it would be
+    a cohort containing the tenant.
+    """
+
+    return {
+        entity.canonical_id: (entity.kind, entity.display_label)
+        for entity in entities
+        if entity.kind is not GraphEntityKind.ORGANIZATION
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class _CohortEdge:
+    """One partition edge, shaped to ``cohort.CohortEdgeLike`` -- the three
+    fields :func:`~.cohort.build_cohort` reads and nothing else. Never a
+    ``projection.GraphEdge`` with placeholder values for the fields this
+    has no live-store-cheap source for (uuid, source/target uuid and kind):
+    fabricating those would be more dishonest than a narrower type.
+    """
+
+    relationship: RelationshipType
+    source_canonical_id: str
+    target_canonical_id: str
+
+
+async def _live_cohort_edges(driver: Any, partition: str) -> tuple[_CohortEdge, ...]:
+    """Every edge in the partition, unconditionally -- the same
+    unconditional, partition-scoped fetch :class:`~.readback.LiveGraphReader`
+    already runs for every traversal (:data:`~.readback._EDGE_QUERY`), reused
+    verbatim. ``build_cohort`` walks two hops from an arbitrary subject, so
+    it needs the full adjacency, not a traversal-bounded subset.
+    """
+
+    edges: list[_CohortEdge] = []
+    for record in await _rows(driver, _EDGE_QUERY, partition=partition):
+        source_id, relationship, target_id = parse_triple_fact(record["fact"])
+        edges.append(
+            _CohortEdge(
+                relationship=relationship,
+                source_canonical_id=source_id,
+                target_canonical_id=target_id,
+            )
+        )
+    return tuple(edges)

--- a/tests/context_fabric/test_chaos_3678_query_service.py
+++ b/tests/context_fabric/test_chaos_3678_query_service.py
@@ -8,17 +8,24 @@ Three halves, matching the module's own documented scope:
   mapping, tested against fake stores injected via ``store_factory`` (no
   live backend needed for DISABLED/UNAVAILABLE/STALE/DEADLINE_EXCEEDED/
   CANCELLED/PROVIDER_FAILURE) plus one live positive control.
-* ``SEEDED_SINGULAR_SUBJECT``'s ``COMPLETED`` path (this revision) —
-  tested against a fake ``reader_factory``/fake driver, never a live
-  FalkorDB: ``subject_resolution.resolve_exact_subjects`` already has its
-  own direct unit coverage (``test_chaos_3678_subject_resolution.py``), so
-  what matters here is the wiring between resolution, traversal and
+* ``SEEDED_SINGULAR_SUBJECT``'s ``COMPLETED`` path — tested against a fake
+  ``reader_factory``/fake driver, never a live FalkorDB:
+  ``subject_resolution._resolve_exact_subjects`` already has its own direct
+  unit coverage (``test_chaos_3678_subject_resolution.py``), so what
+  matters here is the wiring between resolution, traversal and
   ``build_production_packet``, not re-proving the resolver's own rules.
+* ``SEEDED_EXPLICIT_COHORT``'s ``COMPLETED`` path (this revision) — same
+  fake-driver approach; ``cohort.build_cohort`` and
+  ``subject_resolution._live_cohort_edges``/``_live_entity_labels`` each
+  have their own coverage elsewhere, so this proves the wiring: every
+  mention resolves, the first becomes the anchor, ``build_cohort`` runs
+  against live-shaped edges, and an incomparable/unresolved result reaches
+  ``PROVIDER_FAILURE`` naming the mechanism rather than a partial-silent
+  success.
 
-``SEEDED_EXPLICIT_COHORT``/``SUBJECTLESS_COHORT_DISCOVERY`` remain
-untouched by this revision — both still reach ``PROVIDER_FAILURE`` with a
-diagnostic naming the mechanism, which is the honest, current behaviour
-until ``cohort_discovery`` is wired in as a tracked follow-up.
+``SUBJECTLESS_COHORT_DISCOVERY`` remains untouched — still reaches
+``PROVIDER_FAILURE`` with a diagnostic naming the mechanism, the honest,
+current behaviour until ``cohort_discovery`` is wired in as CHAOS-3689.
 """
 
 from __future__ import annotations
@@ -41,6 +48,10 @@ from dev_health_ops.api.dev.graph_investigation_query import (
     GraphInvestigationRequest,
     GraphQueryOutcome,
 )
+from dev_health_ops.api.dev.investigation_contract import (
+    RelationshipDirection,
+    RelationshipType,
+)
 from dev_health_ops.context_fabric.graph_arm.query_service import (
     GraphMechanism,
     ProductionGraphInvestigationQuery,
@@ -48,7 +59,9 @@ from dev_health_ops.context_fabric.graph_arm.query_service import (
 )
 from dev_health_ops.context_fabric.graph_arm.readback import (
     DiscoveredEntity,
+    DiscoveredPath,
     InvestigationReadout,
+    PathStep,
 )
 from dev_health_ops.context_fabric.graph_arm.store import (
     GraphArmStore,
@@ -372,33 +385,17 @@ class TestUnsupportedMechanism:
         assert "no graph mechanism" in result.diagnostic
 
 
-class TestCohortMechanismsAreNotYetImplemented:
+class TestSubjectlessCohortDiscoveryIsNotYetImplemented:
     pytestmark = pytest.mark.asyncio
 
     """The remaining honest boundary: selected, not yet executed.
 
-    SEEDED_SINGULAR_SUBJECT graduated to a real COMPLETED path this
-    revision (see ``TestSeededSingularSubjectCompletes`` below) --
-    SEEDED_EXPLICIT_COHORT and SUBJECTLESS_COHORT_DISCOVERY have not, since
-    both need ``cohort_discovery`` wired in as a separate follow-up.
+    SEEDED_SINGULAR_SUBJECT and SEEDED_EXPLICIT_COHORT both graduated to
+    real COMPLETED paths (see ``TestSeededSingularSubjectCompletes`` and
+    ``TestSeededExplicitCohortCompletes`` below) -- SUBJECTLESS_COHORT_
+    DISCOVERY has not, since it needs ``cohort_discovery`` wired in as a
+    separate follow-up (CHAOS-3689).
     """
-
-    async def test_seeded_explicit_cohort_reaches_provider_failure_with_a_named_reason(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
-        store = _FakeStore(watermark=_fresh_watermark())
-        service = _query(store)
-        result = await service.investigate(
-            _request(
-                intent_id=QuestionIntentID.METRIC_COMPARISON,
-                cardinality=Cardinality.PLURAL_COHORT,
-            )
-        )
-        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
-        assert result.packet is None
-        assert result.diagnostic is not None
-        assert "seeded_explicit_cohort" in result.diagnostic
 
     async def test_subjectless_cohort_discovery_reaches_provider_failure(
         self, monkeypatch
@@ -427,28 +424,63 @@ class _FakeDriver:
     ``test_chaos_3678_subject_resolution.py``'s fake -- this class exists
     separately because it belongs to a different fake store's lifecycle,
     not because the contract differs.
+
+    Query-aware (dispatches on ``"RELATES_TO" in query``) because
+    ``_complete_seeded_explicit_cohort`` issues BOTH an entity query
+    (``_resolve_exact_subjects``/``_live_entities``) and an edge query
+    (``_live_cohort_edges``) against the same driver -- a single flat
+    ``rows`` list would hand entity-shaped dicts back for the edge query
+    and vice versa.
     """
 
     rows: list[dict] = field(default_factory=list)
+    edge_rows: list[dict] = field(default_factory=list)
 
     async def execute_query(self, query: str, **params: object) -> tuple:
+        if "RELATES_TO" in query:
+            return (self.edge_rows, None, None)
         return (self.rows, None, None)
 
 
-def _entity_row(canonical_id: str, display_label: str) -> dict:
+def _entity_row(
+    canonical_id: str,
+    display_label: str,
+    *,
+    kind: str = GraphEntityKind.PROJECT.value,
+) -> dict:
     return {
         "canonical_id": canonical_id,
-        "entity_kind": GraphEntityKind.PROJECT.value,
+        "entity_kind": kind,
         "display_label": display_label,
         "source_class": SourceClass.WORK_GRAPH.value,
     }
 
 
-def _mention(text: str) -> DevSubjectMention:
+def _edge_row(source: str, relationship: RelationshipType, target: str) -> dict:
+    return {
+        "fact": f"{source} {relationship.value} {target}",
+        "source_class": SourceClass.WORK_GRAPH.value,
+        "observed_at": "2026-05-01T00:00:00+00:00",
+        "observation_ids": "",
+        "valid_from": None,
+        "valid_to": None,
+    }
+
+
+#: mention_id per ordinal -- fixed rather than randomly generated, so a
+#: multi-mention test's fixture is deterministic and readable.
+_MENTION_IDS = (
+    "1c2d3e4f-1111-4222-8333-444455556666",
+    "2c2d3e4f-1111-4222-8333-444455556666",
+    "3c2d3e4f-1111-4222-8333-444455556666",
+)
+
+
+def _mention(text: str, *, ordinal: int = 0) -> DevSubjectMention:
     return DevSubjectMention(
         schema_version="dev_subject_mention.v1",
-        mention_id="1c2d3e4f-1111-4222-8333-444455556666",
-        mention_ordinal=0,
+        mention_id=_MENTION_IDS[ordinal],
+        mention_ordinal=ordinal,
         original_text_span=text,
         requested_entity_kind=EntityKind.PROJECT,
         normalized_lookup_text=text,
@@ -626,6 +658,270 @@ class TestSeededSingularSubjectCompletes:
                 cardinality=Cardinality.SINGULAR,
                 run_id=_RUN_UUID,
                 mentions=(_mention("nothing matches"),),
+            )
+        )
+        assert store.close_calls == 1
+
+
+class TestSeededExplicitCohortCompletes:
+    pytestmark = pytest.mark.asyncio
+
+    """CHAOS-3688's real COMPLETED path.
+
+    Mirrors ``TestSeededSingularSubjectCompletes``'s fake-driver/fake-reader
+    approach: ``cohort.build_cohort`` and ``subject_resolution``'s live-data
+    helpers each have their own direct coverage elsewhere, so what these
+    tests prove is the wiring between "every mention resolves", "the first
+    becomes the anchor", "build_cohort runs against live-shaped edges", and
+    "an incomparable or unresolved result reaches PROVIDER_FAILURE naming
+    the mechanism, never a partial-silent success" (§4).
+    """
+
+    def _service(
+        self, *, driver: _FakeDriver, reader: _FakeReader
+    ) -> ProductionGraphInvestigationQuery:
+        store = _FakeStore(watermark=_fresh_watermark(), _driver=driver)
+        return ProductionGraphInvestigationQuery(
+            store_factory=_factory(store),
+            reader_factory=lambda _store: reader,
+            signer_factory=lambda: EvidenceReferenceSigner(_TEST_SIGNING_SECRET),
+        )
+
+    async def test_two_mentions_sharing_a_team_complete_with_a_real_cohort(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(
+            rows=[
+                _entity_row("proj_a", "Project A"),
+                _entity_row("proj_b", "Project B"),
+                _entity_row("team_x", "Team X", kind=GraphEntityKind.TEAM.value),
+            ],
+            edge_rows=[
+                _edge_row("proj_a", RelationshipType.OWNED_BY_TEAM, "team_x"),
+                _edge_row("proj_b", RelationshipType.OWNED_BY_TEAM, "team_x"),
+            ],
+        )
+        readout = InvestigationReadout(
+            org_id="org_query_service_test",
+            partition="cf_query_service_test",
+            seed_canonical_ids=("proj_a",),
+            authorized_entity_ids=("proj_a", "proj_b", "team_x"),
+            entities=(
+                DiscoveredEntity(
+                    canonical_id="proj_a",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Project A",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime.now(UTC),
+                ),
+            ),
+            # A real traversal from proj_a walks its own edge to team_x --
+            # packet_builder only COMMITS a subject touched by at least one
+            # path (its own rule, already covered by that module's tests);
+            # this is what a real neighbourhood() would have produced.
+            paths=(
+                DiscoveredPath(
+                    path_id="p0001",
+                    origin_canonical_id="proj_a",
+                    terminal_canonical_id="team_x",
+                    steps=(
+                        PathStep(
+                            from_canonical_id="proj_a",
+                            from_kind=GraphEntityKind.PROJECT,
+                            relationship=RelationshipType.OWNED_BY_TEAM,
+                            direction=RelationshipDirection.FORWARD,
+                            to_canonical_id="team_x",
+                            to_kind=GraphEntityKind.TEAM,
+                            source_class=SourceClass.WORK_GRAPH,
+                            observed_at=datetime.now(UTC),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        reader = _FakeReader(readout=readout)
+        service = self._service(driver=driver, reader=reader)
+
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.METRIC_COMPARISON,
+                cardinality=Cardinality.PLURAL_COHORT,
+                run_id=_RUN_UUID,
+                mentions=(
+                    _mention("Project A", ordinal=0),
+                    _mention("Project B", ordinal=1),
+                ),
+                authorized_entity_ids=frozenset({"proj_a", "proj_b", "team_x"}),
+            )
+        )
+
+        assert result.outcome is GraphQueryOutcome.COMPLETED
+        assert result.packet is not None
+        assert len(reader.calls) == 1
+        assert reader.calls[0]["org_id"] == "org_query_service_test"
+        assert reader.calls[0]["seed_canonical_ids"] == ["proj_a"]
+        # request.authorized_entity_ids is a frozenset -- iteration order is
+        # not guaranteed, unlike the singular-subject test's single-element
+        # case, so this compares as a set rather than pinning an order
+        # nothing here actually commits to.
+        assert set(reader.calls[0]["authorized_entity_ids"]) == {
+            "proj_a",
+            "proj_b",
+            "team_x",
+        }
+        job = result.packet.analytical_job
+        assert job.schema_version == "ask_dev_analytical_job.v2"
+        assert job.production_job is not None
+        assert result.packet.comparison_cohort.comparison_shape.value == (
+            "explicit_cohort"
+        )
+        # comparison_cohort.members lists everyone being compared -- the
+        # anchor subject alongside the peer build_cohort discovered, not
+        # peers only.
+        assert sorted(
+            member.canonical_id for member in result.packet.comparison_cohort.members
+        ) == ["proj_a", "proj_b"]
+
+    async def test_no_mention_resolving_reaches_provider_failure_naming_the_mechanism(
+        self, monkeypatch
+    ) -> None:
+        """§4: an unresolved anchor is an honest, explicit degradation --
+        never a partial-silent COMPLETED packet comparing nothing.
+        """
+
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(rows=[_entity_row("proj_a", "Project A")], edge_rows=[])
+        reader = _FakeReader(
+            readout=InvestigationReadout(
+                org_id="org_query_service_test",
+                partition="cf_query_service_test",
+                seed_canonical_ids=(),
+            )
+        )
+        service = self._service(driver=driver, reader=reader)
+
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.METRIC_COMPARISON,
+                cardinality=Cardinality.PLURAL_COHORT,
+                run_id=_RUN_UUID,
+                # Neither mention matches anything in the fixture.
+                mentions=(
+                    _mention("Nobody Home", ordinal=0),
+                    _mention("Nobody Else", ordinal=1),
+                ),
+            )
+        )
+
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.packet is None
+        assert result.diagnostic is not None
+        assert "seeded_explicit_cohort" in result.diagnostic
+        assert reader.calls == []
+
+    async def test_an_anchor_with_no_peers_reaches_provider_failure_not_a_lone_cohort(
+        self, monkeypatch
+    ) -> None:
+        """``build_cohort`` refuses fewer than two members
+        (``IncomparableCohortError``) -- caught and reported honestly,
+        never surfaced as a crash.
+        """
+
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(
+            rows=[
+                _entity_row("proj_a", "Project A"),
+                _entity_row("team_x", "Team X", kind=GraphEntityKind.TEAM.value),
+            ],
+            # proj_a HAS an anchor (team_x), but no OTHER entity shares
+            # it -- build_cohort finds team_x as an anchor and zero peers.
+            edge_rows=[
+                _edge_row("proj_a", RelationshipType.OWNED_BY_TEAM, "team_x"),
+            ],
+        )
+        readout = InvestigationReadout(
+            org_id="org_query_service_test",
+            partition="cf_query_service_test",
+            seed_canonical_ids=("proj_a",),
+            authorized_entity_ids=("proj_a", "team_x"),
+            entities=(
+                DiscoveredEntity(
+                    canonical_id="proj_a",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Project A",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime.now(UTC),
+                ),
+            ),
+            # proj_a is legitimately committed (its own edge to team_x),
+            # so this test isolates IncomparableCohortError specifically --
+            # not the "subject never committed" error the missing-path
+            # case would raise instead.
+            paths=(
+                DiscoveredPath(
+                    path_id="p0001",
+                    origin_canonical_id="proj_a",
+                    terminal_canonical_id="team_x",
+                    steps=(
+                        PathStep(
+                            from_canonical_id="proj_a",
+                            from_kind=GraphEntityKind.PROJECT,
+                            relationship=RelationshipType.OWNED_BY_TEAM,
+                            direction=RelationshipDirection.FORWARD,
+                            to_canonical_id="team_x",
+                            to_kind=GraphEntityKind.TEAM,
+                            source_class=SourceClass.WORK_GRAPH,
+                            observed_at=datetime.now(UTC),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        reader = _FakeReader(readout=readout)
+        service = self._service(driver=driver, reader=reader)
+
+        result = await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.METRIC_COMPARISON,
+                cardinality=Cardinality.PLURAL_COHORT,
+                run_id=_RUN_UUID,
+                mentions=(
+                    _mention("Project A", ordinal=0),
+                    _mention("Nobody Else", ordinal=1),
+                ),
+                authorized_entity_ids=frozenset({"proj_a", "team_x"}),
+            )
+        )
+
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.packet is None
+        assert result.diagnostic is not None
+        assert "seeded_explicit_cohort" in result.diagnostic
+        assert "IncomparableCohortError" in result.diagnostic
+
+    async def test_the_store_is_closed_after_completed(self, monkeypatch) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(rows=[], edge_rows=[])
+        reader = _FakeReader(
+            readout=InvestigationReadout(
+                org_id="org_query_service_test",
+                partition="cf_query_service_test",
+                seed_canonical_ids=(),
+            )
+        )
+        store = _FakeStore(watermark=_fresh_watermark(), _driver=driver)
+        service = ProductionGraphInvestigationQuery(
+            store_factory=_factory(store),
+            reader_factory=lambda _store: reader,
+            signer_factory=lambda: EvidenceReferenceSigner(_TEST_SIGNING_SECRET),
+        )
+        await service.investigate(
+            _request(
+                intent_id=QuestionIntentID.METRIC_COMPARISON,
+                cardinality=Cardinality.PLURAL_COHORT,
+                run_id=_RUN_UUID,
+                mentions=(_mention("nothing matches", ordinal=0),),
             )
         )
         assert store.close_calls == 1

--- a/tests/context_fabric/test_chaos_3678_subject_resolution.py
+++ b/tests/context_fabric/test_chaos_3678_subject_resolution.py
@@ -22,9 +22,16 @@ from typing import Any
 import pytest
 
 from dev_health_ops.api.dev.contracts_v2.base import SourceClass
-from dev_health_ops.api.dev.investigation_contract import SubjectMatchSignal
+from dev_health_ops.api.dev.investigation_contract import (
+    RelationshipType,
+    SubjectMatchSignal,
+)
 from dev_health_ops.context_fabric.graph_arm.backend import MatchMechanism
 from dev_health_ops.context_fabric.graph_arm.subject_resolution import (
+    _live_cohort_edges,
+    _live_entities,
+    _live_entity_labels,
+    _LiveEntity,
     _resolve_exact_subjects,
 )
 from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
@@ -175,3 +182,105 @@ async def test_empty_queries_short_circuits_without_a_round_trip() -> None:
         "an empty query list has nothing to look up; a query sent anyway "
         "is not a query worth sending"
     )
+
+
+# ---- CHAOS-3688: cohort-seeding live helpers -------------------------------
+
+
+async def test_live_entities_skips_rows_with_no_legible_kind() -> None:
+    """Mirrors readback's own rule for a node this arm cannot classify --
+    dropped rather than guessed at.
+    """
+
+    driver = _FakeDriver(
+        rows=[
+            _entity_record("proj_a", "Project A"),
+            {
+                "canonical_id": "proj_b",
+                "entity_kind": None,
+                "display_label": "Project B",
+                "source_class": SourceClass.WORK_GRAPH.value,
+            },
+        ]
+    )
+    entities = await _live_entities(driver, _PARTITION)
+    assert [entity.canonical_id for entity in entities] == ["proj_a"]
+
+
+async def test_live_entity_labels_excludes_organization() -> None:
+    """A pure function (no ``await`` needed) -- ``async def`` only to match
+    the module-level ``pytestmark = pytest.mark.asyncio``, which
+    pytest-asyncio warns about applying to a sync test.
+
+    The partition root must never become a cohort label -- a cohort that
+    could contain it would be a cohort containing the tenant.
+    """
+
+    entities = (
+        _LiveEntity(
+            canonical_id="proj_nightfall_migration",
+            kind=GraphEntityKind.PROJECT,
+            display_label="Nightfall Migration",
+            source_class=SourceClass.WORK_GRAPH,
+        ),
+        _LiveEntity(
+            canonical_id="org_acme",
+            kind=GraphEntityKind.ORGANIZATION,
+            display_label="Acme Corp",
+            source_class=SourceClass.WORK_GRAPH,
+        ),
+    )
+    labels = _live_entity_labels(entities)
+    assert labels == {
+        "proj_nightfall_migration": (GraphEntityKind.PROJECT, "Nightfall Migration")
+    }
+
+
+def _edge_record(source: str, relationship: RelationshipType, target: str) -> dict:
+    return {
+        "fact": f"{source} {relationship.value} {target}",
+        "source_class": SourceClass.WORK_GRAPH.value,
+        "observed_at": "2026-05-01T00:00:00+00:00",
+        "observation_ids": "",
+        "valid_from": None,
+        "valid_to": None,
+    }
+
+
+async def test_live_cohort_edges_parses_the_stored_triple() -> None:
+    driver = _FakeDriver(
+        rows=[
+            _edge_record(
+                "proj_nightfall_migration",
+                RelationshipType.OWNED_BY_TEAM,
+                "team_platform",
+            )
+        ]
+    )
+    edges = await _live_cohort_edges(driver, _PARTITION)
+    assert len(edges) == 1
+    assert edges[0].source_canonical_id == "proj_nightfall_migration"
+    assert edges[0].relationship is RelationshipType.OWNED_BY_TEAM
+    assert edges[0].target_canonical_id == "team_platform"
+
+
+async def test_live_cohort_edges_rejects_a_prose_fact() -> None:
+    """The same detection ``parse_triple_fact`` already gives every other
+    live reader: a stored fact containing prose is caught on read, not
+    quietly presented as evidence.
+    """
+
+    driver = _FakeDriver(
+        rows=[
+            {
+                "fact": "this is not a canonical triple",
+                "source_class": SourceClass.WORK_GRAPH.value,
+                "observed_at": "2026-05-01T00:00:00+00:00",
+                "observation_ids": "",
+                "valid_from": None,
+                "valid_to": None,
+            }
+        ]
+    )
+    with pytest.raises(ValueError, match="not a canonical triple rendering"):
+        await _live_cohort_edges(driver, _PARTITION)


### PR DESCRIPTION
## Issue / Phase

CHAOS-3688 (production graph-assisted query service, SEEDED_EXPLICIT_COHORT mechanism), filed by team-lead after CHAOS-3678's #1663 merged. Branch carries the issue ID: **this PR fully completes CHAOS-3688** — scoped and confirmed after reading `build_cohort`'s real signature and the trial's own construction path before committing to the ID-bearing name, per the standing branch-naming rule (a branch carrying an issue ID must fully close that exact issue).

## Observable outcome

`ProductionGraphInvestigationQuery.investigate()` now implements a second real `COMPLETED` path, `GraphMechanism.SEEDED_EXPLICIT_COHORT`. Every mention in the request resolves via the same EXACT-only `_resolve_exact_subjects` as the singular-subject path (#1663); the first resolved candidate becomes the anchor subject, and `cohort.build_cohort` walks two hops out from it over live edges to discover peers. `SUBJECTLESS_COHORT_DISCOVERY` (CHAOS-3689) is untouched — still an honest `PROVIDER_FAILURE` stub.

## Architecture boundary

**Followed the trial's own construction, not a new design.** Scoping this found `trials/chaos_3619/graph_leg.py`'s `assemble_packet` already does exactly this for every non-singular comparison shape: `subject_id = seeds[0]` (the first resolved seed becomes the anchor), then `build_cohort(subject_id, edges, entity_labels, authorized_entity_ids)` discovers peers via shared team/portfolio/initiative/dependency relationships. `SEEDED_EXPLICIT_COHORT` does **not** mean "directly compare the N named mentions" — it means "anchor on the first resolved mention and discover its real cohort", identical to what the trial has always done. A caller naming two subjects sharing no anchor gets an honestly small or empty cohort from `build_cohort` itself, never one fabricated from the mentions.

**`cohort.py`'s `build_cohort` edges parameter widened** from `Sequence[GraphEdge]` (`projection.py`'s in-memory, fixture-built edge — many required fields: uuid, org_id, source/target uuid and kind) to `Sequence[CohortEdgeLike]`, a new Protocol naming only the three fields the function actually reads (`relationship`, `source_canonical_id`, `target_canonical_id` — verified by grep before designing this, not assumed). `GraphEdge` already satisfies it structurally, so the trial's own call site needs zero changes — this widens the *parameter type*, not what the trial passes, mirroring the `_JobLike`/`_TraversalStore` Protocol pattern from the two prior CHAOS-3678 PRs. The alternative (a synthetic `GraphEdge` with placeholder values for fields nothing here has a live-store-cheap source for) would have been more dishonest than a narrower type.

**Two new live-data helpers in `subject_resolution.py`** (package-private, same reasoning as `_resolve_exact_subjects` — see that module's docstring): `_live_cohort_edges` reuses `readback._EDGE_QUERY`/`parse_triple_fact` verbatim (no new Cypher), and `_live_entity_labels` builds the `canonical_id -> (kind, label)` map `build_cohort` needs, excluding `ORGANIZATION` (mirrors the trial's own `graph_leg._entity_labels`). Both share a new `_live_entities` helper factored out of `_resolve_exact_subjects` (one entity fetch, two interpretations, rather than two live-store reads of the same query).

**Honest degradation, not partial-silent success (team-lead's §4 ruling).** No mention resolving to an authorized anchor, or `build_cohort` producing fewer than two members / no comparison dimension (`IncomparableCohortError`), both reach `PROVIDER_FAILURE` with a diagnostic naming the mechanism. Unlike `SEEDED_SINGULAR_SUBJECT`, there is no "empty but valid" packet shape for `EXPLICIT_COHORT` — the contract requires a real, comparable cohort, so a caller is told plainly rather than handed a packet that looks completed but silently compares nothing.

## Scope / non-scope

In scope: `cohort.py`'s `CohortEdgeLike` Protocol widening, `subject_resolution.py`'s two new live-data helpers + the `_live_entities` refactor, `query_service.py`'s `_complete_seeded_explicit_cohort`.

Out of scope: `SUBJECTLESS_COHORT_DISCOVERY` (CHAOS-3689, separately filed by team-lead) — needs `cohort_discovery.discover_cohort` wired in, a different construction path (`SCOPE_ENUMERATED`, not `SUBJECT_ANCHORED`) with no anchor subject at all.

## Base / head SHA

- Base: `412f38976` (`feature/chaos-3498-context-fabric` tip — "CHAOS-3678: wire SEEDED_SINGULAR_SUBJECT to a real COMPLETED path (#1663)")
- Head: `94db58583be2180a297906a75eb491561a06d831`

## Migrations

None.

## Security / privacy

None new. `build_cohort`'s own authorization-before-ranking rule applies unchanged (an anchor or peer outside `authorized_entity_ids` is withheld, never returned). No new caller-controlled text reaches any packet field.

## RED-first evidence

- `tests/context_fabric/test_chaos_3678_subject_resolution.py` (+4 tests): `_live_entities` drops a row with no legible kind (mirrors the existing readback rule), `_live_entity_labels` excludes `ORGANIZATION`, `_live_cohort_edges` parses a stored triple correctly and rejects a prose fact (same `parse_triple_fact` detection every other live reader gets).
- `tests/context_fabric/test_chaos_3678_query_service.py` — new `TestSeededExplicitCohortCompletes` class (4 tests): two mentions sharing a team complete with a real 2-member cohort; zero resolving mentions reaches `PROVIDER_FAILURE` naming the mechanism (§4); an anchor with an anchor-relationship but no peer reaches `PROVIDER_FAILURE` with `IncomparableCohortError` specifically (isolated from the "never committed" failure mode by giving the anchor a real traversal path first — verified empirically that the two failure modes are checked in a specific order in `packet_builder._assemble_core` and wrote the fixture to isolate the one under test); store closed after `COMPLETED`. The stale "not yet implemented" test for this mechanism was removed from `TestCohortMechanismsAreNotYetImplemented` (renamed `TestSubjectlessCohortDiscoveryIsNotYetImplemented`, now covering only CHAOS-3689's mechanism) rather than left green for the wrong reason.

## Verification

- `mypy .` (full repo) — Success, 2391 source files, 0 errors
- `ruff check` / `ruff format --check` — clean
- `pytest tests/context_fabric/` (full suite) — 1514 passed, 54 skipped, 0 failed
- `pytest tests/context_fabric/test_chaos_3678_query_service.py` run 5× consecutively to rule out frozenset-iteration-order flakiness in the new cohort tests (found and fixed one such flaky assertion before it could land) — 30 passed every run
- `pytest tests/context_fabric/test_chaos_3617_no_caller_supplied_partition.py` (the tenancy-isolation guard both `_live_cohort_edges`/`_live_entities` had to stay private for) — passing
- Pre-commit and pre-push lefthook gates — all green, no `--no-verify` used

## Known limitations

Nothing in production constructs a `ProductionGraphInvestigationQuery` yet — this is still increment work. `_live_cohort_edges`/`_live_entities` each re-fetch the partition's full catalog per call, same acceptable-for-a-first-slice tradeoff already noted in #1663.

## Rollout / rollback

Additive to the two existing PRs' surface: `cohort.py`'s Protocol widening is backward-compatible (verified: `GraphEdge` structurally satisfies `CohortEdgeLike`, all three existing `build_cohort` call sites' tests pass unchanged). Nothing on trunk calls the new COMPLETED path yet. Revert is a plain single-commit revert.