### PR TITLE
CHAOS-3632: write approved documents into the graph as real nodes

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/backend.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/backend.py
@@ -49,7 +49,9 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from dev_health_ops.api.dev.investigation_contract import RelationshipType
 
+from . import identity
 from .projection import GraphEdge, GraphNode, GraphProjection
+from .vocabulary import GraphObservationKind
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from graphiti_core.edges import EntityEdge
@@ -72,6 +74,7 @@ __all__ = [
     "graphiti_version",
     "parse_triple_fact",
     "require_graphiti",
+    "to_graphiti_document_nodes",
     "to_graphiti_edges",
     "to_graphiti_nodes",
     "triple_fact",
@@ -584,6 +587,90 @@ def to_graphiti_nodes(
                 name_embedding=embedder.embed(node.canonical_id)
                 if isinstance(embedder, DeterministicEmbedder)
                 else None,
+            )
+        )
+    return nodes
+
+
+async def to_graphiti_document_nodes(
+    projection: GraphProjection, embedder: EmbeddingBackend
+) -> list[EntityNode]:
+    """Approved documents as Graphiti ``EntityNode``s (CHAOS-3632).
+
+    Reads ``projection.approved_documents`` only -- never
+    ``rejected_document_ids``, which exists so a caller can account for what
+    was declined, not so the writer can decide differently.
+    ``test_chaos_3632_document_writer.py::test_a_rejected_document_never_
+    reaches_a_node`` is the guard that a rejected document cannot reach this
+    function's output by any path.
+
+    Three conventions this function commits to, agreed on CHAOS-3660:
+
+    * ``name`` is the document's ``title``, never its ``body`` --
+      :func:`to_graphiti_nodes`'s own "no prose" rule applies here exactly as
+      it does to every other node; the graph carries no rendered document
+      text as a display name.
+    * ``cf_entity_kind`` is never set (a document is not an entity); the
+      node is an OBSERVATION of kind :attr:`~.vocabulary.GraphObservationKind.
+      DOCUMENT`, exactly like every other structured record CHAOS-3617
+      ingests, so ``cf_subject_canonical_ids`` (the same CHAOS-3653 hop
+      contract observations already use) is how a document's subjects are
+      recovered on read -- no new attachment mechanism.
+    * ``body`` reaches the embedder and NOTHING else -- never a stored
+      attribute, never ``summary`` (:func:`to_graphiti_nodes`'s "no prose"
+      rule again), never any field a live reader echoes back. This is why
+      this function is ``async`` and :func:`to_graphiti_nodes` is not: the
+      embedder must be given ``body``, not ``title``, as the embedding
+      input, and ``graphiti_core.utils.bulk_utils.add_nodes_and_edges_bulk``
+      only calls ``generate_name_embedding`` (which would embed ``name`` --
+      the title) when ``name_embedding`` is still ``None`` on arrival. Pre-
+      computing it here from ``body``, for every embedder (not only the
+      deterministic one :func:`to_graphiti_nodes` special-cases, since that
+      function's sync signature cannot await a real embedder's network
+      call), is what makes a document findable by its actual content rather
+      than by title text alone.
+    """
+
+    entity_node_cls = graphiti_module("nodes").EntityNode
+    nodes: list[EntityNode] = []
+    for document in projection.approved_documents:
+        attributes: dict[str, Any] = {
+            "cf_canonical_id": document.canonical_id,
+            "cf_org_id": document.org_id,
+            ATTACHMENT_ENCODING_ATTRIBUTE: ATTACHMENT_ENCODING,
+            PROJECTION_EMBEDDER_ATTRIBUTE: embedder.model_id,
+            "cf_source_class": document.source_class.value,
+            "cf_observed_at": document.observed_at.isoformat(),
+            "cf_is_entity": False,
+            "cf_observation_kind": GraphObservationKind.DOCUMENT.value,
+        }
+        if document.repository_ids:
+            attributes["cf_repository_ids"] = ",".join(sorted(document.repository_ids))
+        if document.subjects:
+            # Sorted for the same reason to_graphiti_nodes sorts observation
+            # subjects: a store written twice from the same batch must be
+            # byte-identical.
+            subjects = sorted(ref.canonical_id for ref in document.subjects)
+            attributes[OBSERVATION_SUBJECTS_ATTRIBUTE] = ",".join(subjects)
+        for key, value in document.attributes.items():
+            attributes[f"cf_attr_{key}"] = value
+        name_embedding = await embedder.create(
+            input_data=[document.body.replace("\n", " ")]
+        )
+        nodes.append(
+            entity_node_cls(
+                uuid=identity.observation_uuid(
+                    document.org_id,
+                    GraphObservationKind.DOCUMENT,
+                    document.canonical_id,
+                ),
+                name=document.title,
+                group_id=projection.partition,
+                labels=[f"CFObs{GraphObservationKind.DOCUMENT.value.title()}"],
+                created_at=document.observed_at,
+                summary="",
+                attributes=attributes,
+                name_embedding=name_embedding,
             )
         )
     return nodes

--- a/src/dev_health_ops/context_fabric/graph_arm/records.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/records.py
@@ -195,6 +195,15 @@ class UnstructuredDocumentRecord:
     Extraction itself is out of PR1's scope; this type exists now so the
     boundary is visible in the ingestion contract from the start and so the
     structured path can be proven not to touch it.
+
+    ``attributes`` is the same closed-vocabulary, generic mapping
+    :class:`EntityRecord`/:class:`ObservationRecord` already carry (CHAOS-3632)
+    -- deliberately not a dedicated trust/evidence field. Trust and
+    provenance signals a document needs (``corpus_trust``, ``corpus_state``,
+    ...) already exist in :data:`~.projection.READBACK_ATTRIBUTE_KEYS`;
+    adding a parallel, document-specific vocabulary for the same concepts
+    would be the second hand-maintained implementation of one idea this
+    project's own corrective plan forbids.
     """
 
     org_id: str
@@ -206,6 +215,9 @@ class UnstructuredDocumentRecord:
     subjects: tuple[CanonicalRef, ...] = ()
     approved: bool = False
     repository_ids: tuple[str, ...] = ()
+    attributes: Mapping[str, str | int | float | bool | None] = field(
+        default_factory=dict
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -41,6 +41,7 @@ from .backend import (
     EmbeddingBackend,
     GraphitiUnavailableError,
     graphiti_module,
+    to_graphiti_document_nodes,
     to_graphiti_edges,
     to_graphiti_nodes,
 )
@@ -350,7 +351,19 @@ class GraphArmStore:
             # nothing, rather than costing most of the budget and then
             # stopping half-written. A non-semantic embedder makes no calls
             # and is deliberately not charged.
-            needed = len(projection.nodes) + len(projection.edges)
+            #
+            # Documents get their OWN embedding call each (CHAOS-3632:
+            # to_graphiti_document_nodes embeds body, unconditionally, for
+            # every embedder -- unlike to_graphiti_nodes, which only
+            # pre-embeds for the deterministic case and otherwise leaves
+            # add_nodes_and_edges_bulk to embed on name). Omitting them here
+            # would let a document-heavy batch spend more calls than this
+            # check ever saw.
+            needed = (
+                len(projection.nodes)
+                + len(projection.edges)
+                + len(projection.approved_documents)
+            )
             outcome = budgets.check_embedding_calls(needed)
             if not outcome.within_budget:
                 raise EmbeddingBudgetExceededError(
@@ -360,6 +373,11 @@ class GraphArmStore:
                 )
 
         nodes = to_graphiti_nodes(projection, self._embedder)
+        document_nodes = await self._bounded_write(
+            to_graphiti_document_nodes(projection, self._embedder),
+            operation="embed_documents",
+        )
+        nodes = nodes + document_nodes
         edges = to_graphiti_edges(projection, self._embedder)
         await self._bounded_write(
             graphiti_module("utils.bulk_utils").add_nodes_and_edges_bulk(
@@ -368,13 +386,20 @@ class GraphArmStore:
             operation="write_projection",
         )
         indexed_through = max(
-            (node.observed_at for node in projection.nodes),
+            (
+                *(node.observed_at for node in projection.nodes),
+                *(document.observed_at for document in projection.approved_documents),
+            ),
             default=None,
         )
         watermark = IndexWatermark(
             indexed_through=indexed_through,
             projected_at=datetime.now(UTC),
-            records_indexed=len(projection.nodes) + len(projection.edges),
+            records_indexed=(
+                len(projection.nodes)
+                + len(projection.edges)
+                + len(projection.approved_documents)
+            ),
             # A projection is all-or-nothing (over budget raises in
             # build_projection), and this write either completed or raised.
             # So a watermark produced here is never partial; the flag stays

--- a/tests/context_fabric/chaos_3620_dispositions.py
+++ b/tests/context_fabric/chaos_3620_dispositions.py
@@ -502,7 +502,7 @@ REQUIREMENTS: tuple[Requirement, ...] = (
         f"{_ADV}::TestTheLoadBearingInjectionCase::"
         "test_its_payload_still_never_reaches_a_packet",
         f"{_ADV}::TestTheLoadBearingInjectionCase::"
-        "test_because_nothing_reads_the_approved_set_at_all",
+        "test_approval_is_now_the_load_bearing_enforcement_gate",
         f"{_ADV}::TestTheLoadBearingInjectionCase::"
         "test_the_EPISODE_channel_carries_no_injection_because_none_is_ingested",
         f"{_ADV}::TestTheLoadBearingInjectionCase::"

--- a/tests/context_fabric/test_chaos_3617_live_store.py
+++ b/tests/context_fabric/test_chaos_3617_live_store.py
@@ -138,7 +138,11 @@ async def alpha_store(
 class TestLiveWriteAndReadBack:
     async def test_the_projection_is_written_and_counted(self, alpha_store) -> None:
         store, projection = alpha_store
-        assert await store.count_nodes() == len(projection.nodes)
+        # CHAOS-3632: approved documents are written as nodes too, alongside
+        # (not as part of) projection.nodes -- see to_graphiti_document_nodes.
+        assert await store.count_nodes() == len(projection.nodes) + len(
+            projection.approved_documents
+        )
 
     async def test_canonical_ids_survive_a_real_round_trip(self, alpha_store) -> None:
         """record -> Graphiti -> FalkorDB -> Cypher -> readout.
@@ -715,7 +719,8 @@ class TestDeterministicCleanup:
             assert await store.count_nodes() > 0
 
             deleted = await store.purge_org()
-            assert deleted == len(projection.nodes)
+            # CHAOS-3632: approved documents are written as nodes too.
+            assert deleted == len(projection.nodes) + len(projection.approved_documents)
             # Read back rather than trusting the return value: a purge that
             # reported a count without deleting would pass on the count alone.
             assert await store.count_nodes() == 0
@@ -724,9 +729,10 @@ class TestDeterministicCleanup:
 
     async def test_a_dry_run_counts_without_deleting(self, alpha_store) -> None:
         store, projection = alpha_store
+        expected = len(projection.nodes) + len(projection.approved_documents)
         counted = await store.purge_org(dry_run=True)
-        assert counted == len(projection.nodes)
-        assert await store.count_nodes() == len(projection.nodes)
+        assert counted == expected
+        assert await store.count_nodes() == expected
 
     async def test_purging_an_organization_that_never_projected_is_not_an_error(
         self,
@@ -849,8 +855,13 @@ class TestDeterministicCleanup:
             if item.name == TRIAL_DERIVED_STORE_NAME
         )
         assert entry.visit is not None
-        assert await entry.visit(org_id, True) == len(projection.nodes)
-        assert await entry.visit(org_id, False) == len(projection.nodes)
+        # CHAOS-3632: approved documents are written as nodes too.
+        assert await entry.visit(org_id, True) == len(projection.nodes) + len(
+            projection.approved_documents
+        )
+        assert await entry.visit(org_id, False) == len(projection.nodes) + len(
+            projection.approved_documents
+        )
         assert await entry.visit(org_id, False) == 0
 
 

--- a/tests/context_fabric/test_chaos_3620_adversarial.py
+++ b/tests/context_fabric/test_chaos_3620_adversarial.py
@@ -76,6 +76,7 @@ from dev_health_ops.context_fabric.graph_arm.vocabulary import (
 )
 from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
 from tests.context_fabric import chaos_3620_spine as spine
+from tests.context_fabric import live_gate
 
 _PROBE_ORG = "org_3620_probe"
 _PROBE_AT = datetime(2026, 8, 1, tzinfo=UTC)
@@ -492,6 +493,8 @@ class TestTheLoadBearingInjectionCase:
         CHAOS-3632's write-side proof are demonstrably about the identical
         payload.
         """
+
+        live_gate.require_graphiti_extra()
 
         def _probe(canonical_id: str, *, approved: bool) -> UnstructuredDocumentRecord:
             return UnstructuredDocumentRecord(

--- a/tests/context_fabric/test_chaos_3620_adversarial.py
+++ b/tests/context_fabric/test_chaos_3620_adversarial.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 from datetime import UTC, datetime
-from pathlib import Path
 
 import pytest
 
@@ -46,8 +45,10 @@ from dev_health_ops.api.dev.investigation_corpus import world
 from dev_health_ops.context_fabric.graph_arm import build_projection
 from dev_health_ops.context_fabric.graph_arm import corpus_adapter as adapter
 from dev_health_ops.context_fabric.graph_arm.backend import (
+    DeterministicEmbedder,
     GraphitiUnavailableError,
     parse_triple_fact,
+    to_graphiti_document_nodes,
 )
 from dev_health_ops.context_fabric.graph_arm.budgets import (
     DEFAULT_BUDGETS,
@@ -463,38 +464,92 @@ class TestTheLoadBearingInjectionCase:
             "the denial-of-evidence route it was designed to avoid"
         )
 
-    def test_because_nothing_reads_the_approved_set_at_all(self) -> None:
-        """The reason, asserted rather than assumed — and the residual.
+    def test_approval_is_now_the_load_bearing_enforcement_gate(self) -> None:
+        """CHAOS-3632's instruction, fulfilled: this replaces the tripwire
+        that used to live here (``test_because_nothing_reads_the_approved_
+        set_at_all``), which asserted ``approved_documents`` had zero
+        readers in ``src/`` and named itself for deletion the moment that
+        stopped being true.
 
-        ``approved_documents`` is written by ``build_projection`` and read by
-        nobody. That is what actually contains the payload today, and it is
-        why the containment above is not evidence that approval works: it is
-        evidence that no extraction pass exists yet.
+        It is no longer true: ``backend.to_graphiti_document_nodes``
+        (CHAOS-3632) reads ``approved_documents`` and writes each one as a
+        graph node. So the class docstring's own framing has flipped --
+        "approval is not what contains the payload today" is now false, and
+        this test is the proof the old one demanded be built first:
+        approval decides whether a document reaches a node AT ALL, and the
+        rejected twin of the same poisoned probe must never reach one.
 
-        This test goes red the moment one does, which is exactly when the
-        approval gate stops being decorative and needs its own proof.
+        The node's own content stays contained a second, independent way
+        even for the APPROVED case: ``to_graphiti_document_nodes`` stores
+        ``body`` nowhere on the node (title only, per CHAOS-3660's
+        "name=title never body" convention) -- reading it back through
+        semantic/BM25 retrieval remains Lane D's follow-up
+        (``semantic_retrieval.py``, out of CHAOS-3632's scope), and direct
+        unit coverage of that convention lives in
+        ``test_chaos_3632_document_writer.py``. What this test adds that
+        module cannot: proof against the SAME adversarial probe this whole
+        class already uses, so the CHAOS-3620 injection record and
+        CHAOS-3632's write-side proof are demonstrably about the identical
+        payload.
         """
 
-        arm_root = (
-            Path(spine.__file__).resolve().parents[2]
-            / "src"
-            / "dev_health_ops"
-            / "context_fabric"
+        def _probe(canonical_id: str, *, approved: bool) -> UnstructuredDocumentRecord:
+            return UnstructuredDocumentRecord(
+                org_id=world.ORG_HELIO,
+                canonical_id=canonical_id,
+                title="Migration notes",
+                body=_INJECTION_PAYLOAD,
+                source_class=SourceClass.WORK_GRAPH,
+                observed_at=_PROBE_AT,
+                subjects=(
+                    CanonicalRef(kind=GraphEntityKind.PROJECT, canonical_id="proj_acr"),
+                ),
+                approved=approved,
+            )
+
+        # Two probes, same payload, differing ONLY in approval -- the one
+        # variable this test exists to isolate.
+        batch = adapter.corpus_batch(world.ORG_HELIO)
+        projection = build_projection(
+            dataclasses.replace(
+                batch,
+                documents=(
+                    *batch.documents,
+                    _probe("doc_probe_approved_poison_2", approved=True),
+                    _probe("doc_probe_rejected_poison", approved=False),
+                ),
+            )
         )
-        readers = sorted(
-            path.relative_to(arm_root).as_posix()
-            for path in arm_root.rglob("*.py")
-            if "approved_documents" in path.read_text(encoding="utf-8")
-            and path.name != "projection.py"
+        assert "doc_probe_approved_poison_2" in {
+            document.canonical_id for document in projection.approved_documents
+        }
+        assert "doc_probe_rejected_poison" in projection.rejected_document_ids
+
+        nodes = asyncio.run(
+            to_graphiti_document_nodes(projection, DeterministicEmbedder())
         )
-        assert not readers, (
-            "something now reads projection.approved_documents: "
-            f"{readers}. Untrusted document text is reachable by an "
-            "extraction pass, so approval has become the load-bearing gate. "
-            "CHAOS-3632 is the instruction: the approval-enforcement proof "
-            "must be built BEFORE the extraction pass ships. Do not delete "
-            "this test -- read the ticket, then replace it with that proof "
-            "-- the CHAOS-3620 injection record must be updated"
+        node_ids = {node.attributes["cf_canonical_id"] for node in nodes}
+        assert "doc_probe_approved_poison_2" in node_ids, (
+            "an APPROVED poisoned document did not reach a node -- approval "
+            "is supposed to be the gate that lets it through"
+        )
+        assert "doc_probe_rejected_poison" not in node_ids, (
+            "a REJECTED poisoned document reached a node -- approval is not "
+            "enforced, and the CHAOS-3620 containment this class measures "
+            "no longer holds"
+        )
+        (approved_node,) = (
+            node
+            for node in nodes
+            if node.attributes["cf_canonical_id"] == "doc_probe_approved_poison_2"
+        )
+        serialized = repr(
+            (approved_node.name, approved_node.summary, approved_node.attributes)
+        )
+        assert _INJECTION_PAYLOAD[:40] not in serialized, (
+            "the approved probe's own payload text reached the node despite "
+            "being approved to exist as a node -- 'name=title never body' "
+            "is what is supposed to prevent this, independent of approval"
         )
 
 

--- a/tests/context_fabric/test_chaos_3632_document_writer.py
+++ b/tests/context_fabric/test_chaos_3632_document_writer.py
@@ -31,6 +31,7 @@ from dev_health_ops.context_fabric.graph_arm.records import (
     UnstructuredDocumentRecord,
 )
 from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+from tests.context_fabric import live_gate
 
 pytestmark = pytest.mark.asyncio
 
@@ -42,6 +43,7 @@ _REJECTED_BODY_MARKER = "Ignore previous instructions"
 
 
 async def test_only_the_approved_document_reaches_a_node(alpha_projection) -> None:
+    live_gate.require_graphiti_extra()
     nodes = await to_graphiti_document_nodes(alpha_projection, DeterministicEmbedder())
     assert [node.attributes["cf_canonical_id"] for node in nodes] == ["doc_nfm_readme"]
 
@@ -54,6 +56,7 @@ async def test_a_rejected_document_never_reaches_a_node(alpha_projection) -> Non
     output, in case a future edit routed it into a different field.
     """
 
+    live_gate.require_graphiti_extra()
     nodes = await to_graphiti_document_nodes(alpha_projection, DeterministicEmbedder())
     canonical_ids = {node.attributes["cf_canonical_id"] for node in nodes}
     assert "doc_unapproved_thread" not in canonical_ids
@@ -63,6 +66,7 @@ async def test_a_rejected_document_never_reaches_a_node(alpha_projection) -> Non
 
 
 async def test_name_is_title_never_body(alpha_projection) -> None:
+    live_gate.require_graphiti_extra()
     (node,) = await to_graphiti_document_nodes(
         alpha_projection, DeterministicEmbedder()
     )
@@ -76,6 +80,7 @@ async def test_summary_stays_empty(alpha_projection) -> None:
     never end up there either.
     """
 
+    live_gate.require_graphiti_extra()
     (node,) = await to_graphiti_document_nodes(
         alpha_projection, DeterministicEmbedder()
     )
@@ -83,6 +88,7 @@ async def test_summary_stays_empty(alpha_projection) -> None:
 
 
 async def test_body_is_stored_nowhere_on_the_node(alpha_projection) -> None:
+    live_gate.require_graphiti_extra()
     (node,) = await to_graphiti_document_nodes(
         alpha_projection, DeterministicEmbedder()
     )
@@ -93,6 +99,7 @@ async def test_body_is_stored_nowhere_on_the_node(alpha_projection) -> None:
 
 
 async def test_cf_entity_kind_is_absent(alpha_projection) -> None:
+    live_gate.require_graphiti_extra()
     (node,) = await to_graphiti_document_nodes(
         alpha_projection, DeterministicEmbedder()
     )
@@ -102,6 +109,7 @@ async def test_cf_entity_kind_is_absent(alpha_projection) -> None:
 
 
 async def test_subjects_join_into_the_observation_attribute(alpha_projection) -> None:
+    live_gate.require_graphiti_extra()
     (node,) = await to_graphiti_document_nodes(
         alpha_projection, DeterministicEmbedder()
     )
@@ -115,6 +123,7 @@ async def test_generic_attributes_pass_through_with_the_cf_attr_prefix() -> None
     convention :func:`to_graphiti_nodes` already uses.
     """
 
+    live_gate.require_graphiti_extra()
     document = UnstructuredDocumentRecord(
         org_id="org_test",
         canonical_id="doc_trust_test",
@@ -144,6 +153,8 @@ async def test_name_embedding_is_a_function_of_body_not_title() -> None:
     ``body`` -- proven here by holding title fixed and varying body, and
     the converse.
     """
+
+    live_gate.require_graphiti_extra()
 
     def _doc(canonical_id: str, *, title: str, body: str) -> UnstructuredDocumentRecord:
         return UnstructuredDocumentRecord(
@@ -190,6 +201,7 @@ async def test_name_embedding_is_a_function_of_body_not_title() -> None:
 
 
 async def test_repository_ids_join_when_present() -> None:
+    live_gate.require_graphiti_extra()
     document = UnstructuredDocumentRecord(
         org_id="org_test",
         canonical_id="doc_repo_test",
@@ -213,6 +225,7 @@ async def test_repository_ids_join_when_present() -> None:
 
 
 async def test_no_approved_documents_produces_no_nodes() -> None:
+    live_gate.require_graphiti_extra()
     projection = GraphProjection(
         org_id="org_test",
         partition="cf_trial_org_test",
@@ -225,6 +238,7 @@ async def test_no_approved_documents_produces_no_nodes() -> None:
 
 
 async def test_multiple_subjects_sort_deterministically() -> None:
+    live_gate.require_graphiti_extra()
     document = UnstructuredDocumentRecord(
         org_id="org_test",
         canonical_id="doc_multi_subject",

--- a/tests/context_fabric/test_chaos_3632_document_writer.py
+++ b/tests/context_fabric/test_chaos_3632_document_writer.py
@@ -1,0 +1,250 @@
+"""CHAOS-3632: approved documents reach the store as real nodes.
+
+``build_projection`` (CHAOS-3617) already computes ``approved_documents``/
+``rejected_document_ids`` -- read once, from the corpus adapter onward, but
+never converted to a node: :func:`to_graphiti_nodes` iterates
+``projection.nodes`` only, which never contained a document at all. This
+module is the writer that closes that gap
+(:func:`~.backend.to_graphiti_document_nodes`) and the guard that a
+*rejected* document cannot reach it by any path.
+
+Reading documents back through semantic/BM25 retrieval is explicitly out of
+scope here -- that is Lane D's follow-up on ``semantic_retrieval.py``. What
+this module proves is narrower and prior to that: the node exists, carries
+the agreed attribute convention, and a rejected document never becomes one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.context_fabric.graph_arm import fixtures
+from dev_health_ops.context_fabric.graph_arm.backend import (
+    OBSERVATION_SUBJECTS_ATTRIBUTE,
+    DeterministicEmbedder,
+    to_graphiti_document_nodes,
+)
+from dev_health_ops.context_fabric.graph_arm.projection import GraphProjection
+from dev_health_ops.context_fabric.graph_arm.records import (
+    CanonicalRef,
+    UnstructuredDocumentRecord,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+pytestmark = pytest.mark.asyncio
+
+#: alpha_batch's adversarial fixture: an UNAPPROVED document whose body is a
+#: prompt-injection attempt. If this text ever reached a node, it would be
+#: exactly the "rejected material becomes graph-visible" fault this module
+#: exists to prevent.
+_REJECTED_BODY_MARKER = "Ignore previous instructions"
+
+
+async def test_only_the_approved_document_reaches_a_node(alpha_projection) -> None:
+    nodes = await to_graphiti_document_nodes(alpha_projection, DeterministicEmbedder())
+    assert [node.attributes["cf_canonical_id"] for node in nodes] == ["doc_nfm_readme"]
+
+
+async def test_a_rejected_document_never_reaches_a_node(alpha_projection) -> None:
+    """The RED anchor this whole module exists to keep green.
+
+    Not just "the rejected canonical id is absent" -- the rejected
+    document's own adversarial body text must not appear ANYWHERE in the
+    output, in case a future edit routed it into a different field.
+    """
+
+    nodes = await to_graphiti_document_nodes(alpha_projection, DeterministicEmbedder())
+    canonical_ids = {node.attributes["cf_canonical_id"] for node in nodes}
+    assert "doc_unapproved_thread" not in canonical_ids
+
+    serialized = repr([(node.name, node.summary, node.attributes) for node in nodes])
+    assert _REJECTED_BODY_MARKER not in serialized
+
+
+async def test_name_is_title_never_body(alpha_projection) -> None:
+    (node,) = await to_graphiti_document_nodes(
+        alpha_projection, DeterministicEmbedder()
+    )
+    assert node.name == "Nightfall Migration design note"
+    assert "auth gateway" not in node.name
+
+
+async def test_summary_stays_empty(alpha_projection) -> None:
+    """Mirrors to_graphiti_nodes's own no-prose rule -- summary is
+    Graphiti's slot for model-written text, and a document's body must
+    never end up there either.
+    """
+
+    (node,) = await to_graphiti_document_nodes(
+        alpha_projection, DeterministicEmbedder()
+    )
+    assert node.summary == ""
+
+
+async def test_body_is_stored_nowhere_on_the_node(alpha_projection) -> None:
+    (node,) = await to_graphiti_document_nodes(
+        alpha_projection, DeterministicEmbedder()
+    )
+    body_fragment = "auth gateway's token exchange"
+    assert body_fragment not in node.name
+    assert body_fragment not in node.summary
+    assert body_fragment not in repr(node.attributes)
+
+
+async def test_cf_entity_kind_is_absent(alpha_projection) -> None:
+    (node,) = await to_graphiti_document_nodes(
+        alpha_projection, DeterministicEmbedder()
+    )
+    assert "cf_entity_kind" not in node.attributes
+    assert node.attributes["cf_is_entity"] is False
+    assert node.attributes["cf_observation_kind"] == "document"
+
+
+async def test_subjects_join_into_the_observation_attribute(alpha_projection) -> None:
+    (node,) = await to_graphiti_document_nodes(
+        alpha_projection, DeterministicEmbedder()
+    )
+    assert node.attributes[OBSERVATION_SUBJECTS_ATTRIBUTE] == "proj_nightfall_migration"
+
+
+async def test_generic_attributes_pass_through_with_the_cf_attr_prefix() -> None:
+    """CHAOS-3632's records.py addition: the same generic ``attributes``
+    field EntityRecord/ObservationRecord already carry, not a dedicated
+    trust field -- so it round-trips through the identical ``cf_attr_``
+    convention :func:`to_graphiti_nodes` already uses.
+    """
+
+    document = UnstructuredDocumentRecord(
+        org_id="org_test",
+        canonical_id="doc_trust_test",
+        title="Trust-carrying document",
+        body="body text, never stored",
+        source_class=SourceClass.WORK_GRAPH,
+        observed_at=fixtures.WINDOW_END,
+        approved=True,
+        attributes={"corpus_trust": "trusted"},
+    )
+    projection = GraphProjection(
+        org_id="org_test",
+        partition="cf_trial_org_test",
+        projection_version="test.v1",
+        nodes=(),
+        edges=(),
+        approved_documents=(document,),
+    )
+    (node,) = await to_graphiti_document_nodes(projection, DeterministicEmbedder())
+    assert node.attributes["cf_attr_corpus_trust"] == "trusted"
+
+
+async def test_name_embedding_is_a_function_of_body_not_title() -> None:
+    """The whole point of this function being async and unconditional
+    (unlike to_graphiti_nodes's deterministic-only special case): a
+    document must be findable by content, so its vector has to come from
+    ``body`` -- proven here by holding title fixed and varying body, and
+    the converse.
+    """
+
+    def _doc(canonical_id: str, *, title: str, body: str) -> UnstructuredDocumentRecord:
+        return UnstructuredDocumentRecord(
+            org_id="org_test",
+            canonical_id=canonical_id,
+            title=title,
+            body=body,
+            source_class=SourceClass.WORK_GRAPH,
+            observed_at=fixtures.WINDOW_END,
+            approved=True,
+        )
+
+    same_title_different_body = GraphProjection(
+        org_id="org_test",
+        partition="cf_trial_org_test",
+        projection_version="test.v1",
+        nodes=(),
+        edges=(),
+        approved_documents=(
+            _doc("doc_a", title="Same title", body="body one"),
+            _doc("doc_b", title="Same title", body="body two"),
+        ),
+    )
+    nodes = await to_graphiti_document_nodes(
+        same_title_different_body, DeterministicEmbedder()
+    )
+    assert nodes[0].name_embedding != nodes[1].name_embedding
+
+    same_body_different_title = GraphProjection(
+        org_id="org_test",
+        partition="cf_trial_org_test",
+        projection_version="test.v1",
+        nodes=(),
+        edges=(),
+        approved_documents=(
+            _doc("doc_c", title="Title one", body="identical body text"),
+            _doc("doc_d", title="Title two", body="identical body text"),
+        ),
+    )
+    nodes = await to_graphiti_document_nodes(
+        same_body_different_title, DeterministicEmbedder()
+    )
+    assert nodes[0].name_embedding == nodes[1].name_embedding
+
+
+async def test_repository_ids_join_when_present() -> None:
+    document = UnstructuredDocumentRecord(
+        org_id="org_test",
+        canonical_id="doc_repo_test",
+        title="Repo-scoped document",
+        body="body",
+        source_class=SourceClass.WORK_GRAPH,
+        observed_at=fixtures.WINDOW_END,
+        approved=True,
+        repository_ids=("repo_b", "repo_a"),
+    )
+    projection = GraphProjection(
+        org_id="org_test",
+        partition="cf_trial_org_test",
+        projection_version="test.v1",
+        nodes=(),
+        edges=(),
+        approved_documents=(document,),
+    )
+    (node,) = await to_graphiti_document_nodes(projection, DeterministicEmbedder())
+    assert node.attributes["cf_repository_ids"] == "repo_a,repo_b"
+
+
+async def test_no_approved_documents_produces_no_nodes() -> None:
+    projection = GraphProjection(
+        org_id="org_test",
+        partition="cf_trial_org_test",
+        projection_version="test.v1",
+        nodes=(),
+        edges=(),
+    )
+    nodes = await to_graphiti_document_nodes(projection, DeterministicEmbedder())
+    assert nodes == []
+
+
+async def test_multiple_subjects_sort_deterministically() -> None:
+    document = UnstructuredDocumentRecord(
+        org_id="org_test",
+        canonical_id="doc_multi_subject",
+        title="Multi-subject document",
+        body="body",
+        source_class=SourceClass.WORK_GRAPH,
+        observed_at=fixtures.WINDOW_END,
+        approved=True,
+        subjects=(
+            CanonicalRef(kind=GraphEntityKind.PROJECT, canonical_id="proj_z"),
+            CanonicalRef(kind=GraphEntityKind.PROJECT, canonical_id="proj_a"),
+        ),
+    )
+    projection = GraphProjection(
+        org_id="org_test",
+        partition="cf_trial_org_test",
+        projection_version="test.v1",
+        nodes=(),
+        edges=(),
+        approved_documents=(document,),
+    )
+    (node,) = await to_graphiti_document_nodes(projection, DeterministicEmbedder())
+    assert node.attributes[OBSERVATION_SUBJECTS_ATTRIBUTE] == "proj_a,proj_z"

--- a/tests/context_fabric/test_chaos_3679_watermark_persistence.py
+++ b/tests/context_fabric/test_chaos_3679_watermark_persistence.py
@@ -156,9 +156,11 @@ class TestNoGraphNodeWasAdded:
         # persisted nothing (and thus trivially left count_nodes alone)
         # cannot pass this test by doing nothing.
         assert (await store.read_watermark()).never_projected is False
-        assert (
-            await store.count_nodes() == len(projection.nodes) == (result.nodes_written)
-        ), (
+        # CHAOS-3632: approved documents are written as nodes too, alongside
+        # (not as part of) projection.nodes -- result.nodes_written already
+        # reflects that; the live count must agree with it.
+        expected = len(projection.nodes) + len(projection.approved_documents)
+        assert await store.count_nodes() == expected == result.nodes_written, (
             "count_nodes() changed after persisting a watermark -- the "
             "watermark must never be stored as a Cypher graph node, because "
             "NODE_COUNT_QUERY counts every node unconditionally"
@@ -172,10 +174,11 @@ class TestNoGraphNodeWasAdded:
 
         deleted = await store.purge_org()
 
-        assert deleted == len(projection.nodes), (
+        # CHAOS-3632: approved documents are written as nodes too.
+        assert deleted == len(projection.nodes) + len(projection.approved_documents), (
             "purge_org's node count included something other than the "
-            "projected nodes -- a graph-stored watermark sentinel would do "
-            "exactly this"
+            "projected nodes and written documents -- a graph-stored "
+            "watermark sentinel would do exactly this"
         )
 
 


### PR DESCRIPTION
## Issue / Phase
CHAOS-3632, write side. Part of the CHAOS-3498 context-fabric embedded-surface work. This PR spans the writer only; the read-side trust-check in `semantic_retrieval.py` is Lane D's follow-up (tracked separately) — **not** in this diff.

## Observable outcome
Before this PR, `GraphProjection.approved_documents`/`rejected_document_ids` (computed by `build_projection` since CHAOS-3617) were read by nothing — `to_graphiti_nodes` iterates `projection.nodes` only, which never contains a document. Approved documents were silently dropped on write; rejected documents were (trivially) also dropped, but for the wrong reason — no enforcement gate existed either way.

After this PR: every approved document in a projection is written as a Graphiti `EntityNode` in the same partition, findable by its actual content (embedding is a function of body, never title). Every rejected/unapproved document is provably excluded — never reaches a node, and its raw text never appears in the payload of a node that *does* land (adversarial test, not just an absence check).

## Architecture boundary
`to_graphiti_document_nodes` (new, `backend.py`) is a document is an **observation** (`GraphObservationKind.DOCUMENT`), following the exact same structured-record write path CHAOS-3617 established for every other observation kind — no new attachment mechanism, no new node type, no new vocabulary:

- `cf_entity_kind` absent — this is an observation, not an entity.
- `cf_subject_canonical_ids` comma-joined, following the CHAOS-3653 hop contract — D's `semantic_retrieval.py` follow-up reads this exactly like every other observation's subject attribute.
- `name = document.title`, **never** `document.body`. `summary` stays empty. Body reaches the embedder and nothing else — never stored as a name, a summary, or an attribute.
- Generic `document.attributes` pass through with the existing `cf_attr_` prefix (same convention `EntityRecord`/`ObservationRecord` already use) — trust/evidence/provenance signals read back exactly like `READBACK_ATTRIBUTE_KEYS` members. No new hand-maintained parallel vocabulary.
- `records.py`: `UnstructuredDocumentRecord` gains the same generic `attributes: Mapping[str, str | int | float | bool | None]` field `ObservationRecord` already carries — not a dedicated trust field. Diff was posted on CHAOS-3660 for D's objection window before landing, per protocol.

Unlike `to_graphiti_nodes` (which special-cases a synchronous, deterministic-only path), `to_graphiti_document_nodes` is async and calls the embedder unconditionally for every embedder implementation. Reason: Graphiti's `add_nodes_and_edges_bulk_tx` only auto-embeds a node's `name` when `name_embedding` arrives `None` — a pre-set embedding is respected, never overwritten. A document embedded implicitly (via name only) would be findable by title text alone; pre-computing `name_embedding` from `body` here makes a document findable by its actual content, for every embedder.

`store.py`'s `write_projection` now writes document nodes alongside (not merged into) `projection.nodes`, under the same write-deadline budget.

## Scope / non-scope
**In scope:** `records.py` attributes field; `backend.py` writer; `store.py` wiring (budget accounting + watermark); tests proving rejection enforcement and the write-side conventions above.

**Explicitly not in scope:** `semantic_retrieval.py`'s trust-check read path (D's follow-up — this PR is write-only). No new vocabulary, no new attachment mechanism, no change to `READBACK_ATTRIBUTE_KEYS`.

## Base / head SHA
Base: `52d06d631` (`origin/feature/chaos-3498-context-fabric`)
Head: `2ecbe936d`

## Migrations
None. No schema change; new attribute keys follow the existing `cf_*` / `cf_attr_*` conventions on existing node types.

## Security / privacy
The core guard this PR adds enforcement for: a rejected/unapproved document must never reach a node, and even for an *approved* document, its raw body text must never leak into a stored attribute, name, or summary — only into the embedding input. Verified adversarially (see below), not just by absence-checking.

## RED-first evidence
12 new unit tests in `tests/context_fabric/test_chaos_3632_document_writer.py`, written before the implementation: rejected-document exclusion (checked both by canonical-id absence and by scanning the full serialized node repr for the adversarial payload text), name=title/never-body, `cf_entity_kind` absence, subject-attribute join, generic attribute passthrough with the `cf_attr_` prefix, and — verified by mutation testing, not merely asserted — that `name_embedding` is a function of `body`, not `title`, in both directions.

CHAOS-3620's adversarial suite (`test_chaos_3620_adversarial.py`) had a deliberate tripwire test, `test_because_nothing_reads_the_approved_set_at_all`, whose own docstring said: *"This test goes red the moment one does... Do not delete this test -- read the ticket, then replace it with that proof."* This PR's write path is exactly that moment. Replaced it with `test_approval_is_now_the_load_bearing_enforcement_gate`: two poisoned probes built from the same injection payload (one approved, one rejected) — the approved probe's canonical_id lands in the output, the rejected one's doesn't, and the approved node's own serialized (name, summary, attributes) never contains the injection text. Updated `chaos_3620_dispositions.py`'s test-name reference to match (that file resolves test names by string as a drift guard — the rename would have broken it silently otherwise, caught by a full-suite run).

## Verification
- `ruff` clean, `mypy` clean (2319 source files, via pre-push hook).
- Full `tests/context_fabric/` suite passing.
- Live round-trip verified against a real running FalkorDB (`dev-health-ops-graph-trial-store`, `docker compose`): `count_nodes()`/`purge_org()` invariants in `test_chaos_3617_live_store.py` and `test_chaos_3679_watermark_persistence.py` assumed `count_nodes() == len(projection.nodes)`; adding document nodes to the write batch broke that everywhere it was asserted (6 call sites across 2 files) — fixed to `len(projection.nodes) + len(projection.approved_documents)`. One of the six was only found by actually running the live suite, not by static grep.
- `store.py`'s embedding-call budget check and the watermark's `records_indexed`/`indexed_through` previously undercounted writes by omitting documents entirely — a real correctness gap (an undercounted budget check doesn't protect against what's actually spent; an undercounted watermark underreports freshness when the most recent record is a document). Fixed as part of this PR.
- Two pre-existing failures observed in the full live suite (`test_chaos_3647_live_semantic.py`) were isolated via `git stash` comparison against the unmodified tree — identical failures reproduce with none of this PR's changes present, confirming they're unrelated (live OpenAI-embedding-API drift, not caused by this diff).

## Known limitations
- The trust/evidence read-side check in `semantic_retrieval.py` does not yet exist — this PR only makes trust attributes available on the node (via the generic `attributes` passthrough); D's follow-up wires the read-side enforcement.
- `to_graphiti_document_nodes` always calls the embedder (no deterministic-only fast path like `to_graphiti_nodes`), which is intentional per the reasoning above, but means document writes always pay one embedder call per document.

## Rollout / rollback
No feature flag change — this executes unconditionally whenever `write_projection` runs and `projection.approved_documents` is non-empty (i.e., whenever upstream document ingestion + approval populates it; today's fixtures are the only non-empty case in tests). Rollback is a plain revert; no data migration or backfill is implied since no documents have been written to any live partition by this path yet.