### PR TITLE
CHAOS-3632 (read-side): trust gate on document-derived observations in the semantic hop

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/semantic_retrieval.py
@@ -32,6 +32,32 @@ on all eight cases, the leg was cosine-only under a heading that said hybrid,
 and nothing failed. :func:`wait_for_fulltext_index` is the positive control
 that closes that, and it raises rather than warning.
 
+**CHAOS-3632 follow-up, resolved: document nodes are lexically title-only,
+by design, not an instance of the failure above.** FalkorDB's
+``node_name_and_summary`` full-text index covers exactly two properties,
+``name`` and ``summary`` (verified against
+``graphiti_core.graph_queries``'s own index definition, not assumed). A
+document node's ``name`` is its title; ``backend.to_graphiti_document_nodes``
+sets ``summary=""`` unconditionally and states plainly that document body
+"reaches the embedder and NOTHING else -- never a stored attribute, never
+``summary``". So BM25 can only ever match a document by its title text; the
+document's actual content is findable exclusively through cosine similarity
+against ``name_embedding``, which that same function precomputes from body
+for exactly this reason. This is deliberately **not** fixed by widening
+``summary`` to include body: doing so would store raw document prose in a
+field this arm (and any future reader) can read back verbatim, which is
+precisely the persisted-untrusted-prose surface CHAOS-3632's whole approval
+gate exists to keep closed -- "indexed text can aid retrieval but cannot
+become executable instruction or trusted wire content" reads a stored,
+queryable ``summary`` field as a bigger risk than a lexical-coverage gap.
+The gap is real (a query using only body-specific terms gets no BM25
+support for that node) but it is a narrower, permanent, load-bearing design
+choice, not the same class of defect as an index that has not populated
+yet: the fulltext-readiness failure above is an accident of timing on
+fields that should be indexed and are not yet; this is a decision to
+never index a field at all, made once, for a stated trust reason, and does
+not need a readiness probe the way the timing failure does.
+
 **Per-candidate mechanism is derived from what actually surfaced it.**
 Hybrid retrieval fuses two result sets, and a node that only BM25 found was
 found lexically. Labelling it ``EMBEDDING_SIMILARITY`` because the *leg* is
@@ -85,8 +111,9 @@ from .backend import (
     graphiti_module,
 )
 from .discovery import CandidateMatch
+from .drivers import TRUSTED_ATTRIBUTION_LEVELS
 from .readback import _entities_by_canonical_id
-from .vocabulary import GraphEntityKind
+from .vocabulary import GraphEntityKind, GraphObservationKind
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from collections.abc import Sequence
@@ -124,6 +151,14 @@ DEFAULT_SEMANTIC_LIMIT = 25
 _CANONICAL_ID_ATTRIBUTE = "cf_canonical_id"
 _ENTITY_KIND_ATTRIBUTE = "cf_entity_kind"
 _SOURCE_CLASS_ATTRIBUTE = "cf_source_class"
+_OBSERVATION_KIND_ATTRIBUTE = "cf_observation_kind"
+#: The raw, ``cf_attr_``-prefixed key ``backend.to_graphiti_document_nodes``
+#: writes every ``UnstructuredDocumentRecord.attributes`` entry under.
+#: Retrieval reads raw Graphiti nodes directly (never through ``readback``'s
+#: stripped shape), so this is the literal attribute name on the node, not
+#: the bare ``"corpus_trust"`` key :func:`drivers._is_trusted` reads off its
+#: own, already-processed record type.
+_CORPUS_TRUST_ATTRIBUTE = "cf_attr_corpus_trust"
 
 
 @runtime_checkable
@@ -479,6 +514,46 @@ def _subject_canonical_ids(node: Any) -> tuple[str, ...]:
     return tuple(item for item in raw.split(",") if item)
 
 
+def _is_document_observation(node: Any) -> bool:
+    """Whether ``node`` is a :attr:`~.vocabulary.GraphObservationKind.DOCUMENT`
+    observation -- the scope this gate applies to, and nothing wider. Every
+    other observation kind already passes through its own upstream quality
+    gate before reaching this arm's projection; see the module-level
+    CHAOS-3632 note above :func:`_document_trust_clears_bar`.
+    """
+
+    return (
+        _attribute(node, _OBSERVATION_KIND_ATTRIBUTE)
+        == GraphObservationKind.DOCUMENT.value
+    )
+
+
+def _document_trust_clears_bar(node: Any) -> bool:
+    """CHAOS-3632: whether a document-derived observation may hop a subject.
+
+    Mirrors :func:`drivers._is_trusted` exactly -- same source of truth
+    (``TRUSTED_ATTRIBUTION_LEVELS``), same refusal on an absent trust level.
+    ``backend.to_graphiti_document_nodes`` only ever writes a node for a
+    document ``projection.approved_documents`` already approved, but that
+    approval is computed once, at projection-build time; nothing re-checks
+    it afterward. A document approved when the projection was built and
+    later withdrawn, redacted, or revoked stays in the store, findable,
+    until the next full reprojection sweep purges it -- this is the re-check
+    that bounds that staleness window on read, rather than trusting a
+    one-time write-side gate to still be accurate.
+
+    A document carrying no ``corpus_trust`` attribute at all -- today's
+    actual shape, since ``corpus_adapter.py`` sets no ``attributes`` on any
+    document record -- is not trusted, the same "absence is not a default"
+    reasoning ``drivers._is_trusted`` states for exactly the same failure
+    mode: a stripped or never-written trust attribute must not silently read
+    as trustworthy.
+    """
+
+    trust = _attribute(node, _CORPUS_TRUST_ATTRIBUTE)
+    return trust is not None and trust in TRUSTED_ATTRIBUTION_LEVELS
+
+
 @dataclass(frozen=True, slots=True)
 class _HopSource:
     """The authorized observation that earned one subject its hop candidate."""
@@ -672,6 +747,13 @@ async def retrieve_candidates(
         kind_value = _attribute(node, _ENTITY_KIND_ATTRIBUTE)
         if kind_value is None:
             observations.append(canonical_id)
+            if _is_document_observation(node) and not _document_trust_clears_bar(node):
+                # CHAOS-3632: retrieval genuinely found this node -- it stays
+                # in observation_hits above -- but an untrusted document
+                # earns no hop. Skipping only this node's own contribution;
+                # a different, trusted observation naming the same subject
+                # is untouched (evaluated on its own iteration below).
+                continue
             score = float(score_by_uuid[uuid])
             for subject_id in _subject_canonical_ids(node):
                 if subject_id not in authorized:

--- a/tests/context_fabric/test_chaos_3632_document_trust_gate.py
+++ b/tests/context_fabric/test_chaos_3632_document_trust_gate.py
@@ -1,0 +1,324 @@
+"""CHAOS-3632 (read-side): a document-derived observation must clear the
+same trust bar as any other attributed record before it may hop a subject
+into a candidate.
+
+**Why the write side alone is not enough.** ``backend.to_graphiti_document_
+nodes`` (CHAOS-3632, write side) only ever writes a node for a document
+already in ``projection.approved_documents`` -- a rejected document never
+reaches the graph at all. But approval is computed once, at projection-build
+time; nothing re-checks it on read. A document approved when a projection
+was built and later withdrawn, redacted, or revoked stays in the store,
+findable, until the next full reprojection sweep purges it. This module's
+retrieval hop is where a live, per-read trust check closes that window --
+mirroring :func:`drivers._is_trusted`'s exact semantics (no trust level, or
+one outside ``TRUSTED_ATTRIBUTION_LEVELS``, is not trusted; no silent
+default) rather than trusting a one-time write-side gate to still be
+accurate.
+
+**Why this is scoped to DOCUMENT-kind observations only.** Every other
+observation kind (review, measurement, evidence-backed record, ...) already
+passes through its own, different quality gate before it ever reaches this
+arm's projection -- canonical-service admission, evidence-reference
+signing, the CHAOS-3627/3633/3650 machinery. Applying a blanket trust
+re-check to every observation kind here would silently change hop behaviour
+for records this ticket has no mandate over. A document is different:
+CHAOS-3632 exists specifically because documents are raw, human-authored
+prose with no such upstream gate of their own, and this arm is deciding for
+the first time whether one may act as evidence.
+
+Every test plants the specific defect this gate exists to catch, same shape
+as ``test_chaos_3653_observation_hop.py``: a fake driver returning a node
+that WOULD produce a wrong hop unless the guard under test is what stops it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.context_fabric.graph_arm import semantic_retrieval
+from dev_health_ops.context_fabric.graph_arm.backend import (
+    OBSERVATION_SUBJECTS_ATTRIBUTE,
+)
+from dev_health_ops.context_fabric.graph_arm.drivers import TRUSTED_ATTRIBUTION_LEVELS
+from dev_health_ops.context_fabric.graph_arm.readback import EntityLookupRow
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    retrieve_candidates,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import (
+    GraphEntityKind,
+    GraphObservationKind,
+)
+
+from . import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+_PARTITION = "cf_trial_org_test"
+
+
+@dataclass
+class _FakeNode:
+    uuid: str
+    name: str
+    group_id: str = _PARTITION
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def _observation_node(
+    uuid: str,
+    canonical_id: str,
+    title: str,
+    *,
+    subject_canonical_ids: tuple[str, ...] = (),
+    observation_kind: GraphObservationKind | None = None,
+    corpus_trust: str | None = None,
+) -> _FakeNode:
+    """Mirrors ``test_chaos_3653_observation_hop``'s helper, extended with
+    the two attributes this gate reads: ``cf_observation_kind`` (does the
+    document-only scope even apply?) and ``cf_attr_corpus_trust`` (the raw,
+    ``cf_attr_``-prefixed key ``backend.to_graphiti_document_nodes`` writes
+    every ``document.attributes`` entry under -- retrieval reads raw
+    Graphiti nodes directly, never through ``readback``'s stripped shape).
+    """
+
+    attributes: dict[str, Any] = {"cf_canonical_id": canonical_id}
+    if subject_canonical_ids:
+        attributes[OBSERVATION_SUBJECTS_ATTRIBUTE] = ",".join(subject_canonical_ids)
+    if observation_kind is not None:
+        attributes["cf_observation_kind"] = observation_kind.value
+    if corpus_trust is not None:
+        attributes["cf_attr_corpus_trust"] = corpus_trust
+    return _FakeNode(uuid=uuid, name=title, attributes=attributes)
+
+
+@dataclass(frozen=True)
+class _SemanticEmbedder:
+    model_id: str = "test_semantic_double.v1"
+    semantic: bool = True
+
+    async def create(self, input_data: Any) -> list[float]:
+        return [0.0] * 8
+
+
+@dataclass(frozen=True)
+class _FakeStore:
+    driver: Any
+    partition: str
+    embedder: Any
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, *, bm25: list, cosine: list) -> dict:
+    live_gate.require_graphiti_extra()
+    from graphiti_core.search import search_utils
+
+    calls: dict[str, Any] = {}
+
+    async def fake_fulltext(driver, query, search_filter, group_ids, limit):
+        calls["bm25_group_ids"] = group_ids
+        return list(bm25)
+
+    async def fake_similarity(
+        driver, search_vector, search_filter, group_ids, limit, *args, **kwargs
+    ):
+        return list(cosine)
+
+    monkeypatch.setattr(search_utils, "node_fulltext_search", fake_fulltext)
+    monkeypatch.setattr(search_utils, "node_similarity_search", fake_similarity)
+    return calls
+
+
+def _install_entity_lookup(
+    monkeypatch: pytest.MonkeyPatch, rows: tuple[EntityLookupRow, ...]
+) -> dict:
+    calls: dict[str, Any] = {}
+
+    async def fake_lookup(driver, partition, canonical_ids):
+        calls["partition"] = partition
+        calls["canonical_ids"] = tuple(canonical_ids)
+        return tuple(row for row in rows if row.canonical_id in canonical_ids)
+
+    monkeypatch.setattr(semantic_retrieval, "_entities_by_canonical_id", fake_lookup)
+    return calls
+
+
+_VERTEX_LOOKUP = (
+    EntityLookupRow(
+        canonical_id="proj_vertex",
+        kind=GraphEntityKind.PROJECT,
+        display_label="Vertex Platform",
+        source_class=SourceClass.WORK_GRAPH,
+    ),
+)
+
+
+class TestApprovedDocumentTrustGate:
+    async def test_a_trusted_document_hops_its_subject(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Positive control: nothing in TRUSTED_ATTRIBUTION_LEVELS is a
+        frozen-corpus value today (every corpus document is unapproved, per
+        corpus_adapter._document_is_approved), so this is a synthetic,
+        held-out fixture rather than a corpus case -- proving the gate
+        passes a genuinely trusted document, not merely that it never fires.
+        """
+
+        document = _observation_node(
+            "u_doc",
+            "doc_vertex_design_review",
+            "Vertex design review notes",
+            subject_canonical_ids=("proj_vertex",),
+            observation_kind=GraphObservationKind.DOCUMENT,
+            corpus_trust=next(iter(TRUSTED_ATTRIBUTION_LEVELS)),
+        )
+        _install(monkeypatch, bm25=[document], cosine=[document])
+        _install_entity_lookup(monkeypatch, _VERTEX_LOOKUP)
+
+        result = await retrieve_candidates(
+            "vertex design review",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert [c.canonical_id for c in result.candidates] == ["proj_vertex"]
+        assert result.candidates[0].via_observation_id == "doc_vertex_design_review"
+
+    @pytest.mark.parametrize(
+        "corpus_trust",
+        [
+            "withdrawn",
+            "redacted",
+            "untrusted_content",
+            None,  # the attribute is absent entirely -- today's actual corpus shape
+        ],
+    )
+    async def test_a_document_whose_trust_does_not_clear_the_bar_hops_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, corpus_trust: str | None
+    ) -> None:
+        """The defect this gate exists to catch: without it, a withdrawn,
+        redacted, or simply never-trusted document that named a subject
+        would still resolve that subject into a candidate -- exactly the
+        stale-approval window the module docstring above describes.
+        """
+
+        document = _observation_node(
+            "u_doc",
+            "doc_vertex_leaked_draft",
+            "Vertex leaked draft",
+            subject_canonical_ids=("proj_vertex",),
+            observation_kind=GraphObservationKind.DOCUMENT,
+            corpus_trust=corpus_trust,
+        )
+        _install(monkeypatch, bm25=[document], cosine=[document])
+        lookup_calls = _install_entity_lookup(monkeypatch, _VERTEX_LOOKUP)
+
+        result = await retrieve_candidates(
+            "vertex leaked draft",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert result.candidates == ()
+        assert "canonical_ids" not in lookup_calls, (
+            "an untrusted document's named subject must never even reach "
+            "the hop lookup -- the gate applies before the round trip, not "
+            "as a post-hoc filter on its result"
+        )
+
+    async def test_the_untrusted_document_is_still_counted_as_an_observation_hit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retrieval genuinely found this node -- that stays a true,
+        recorded fact (``observation_hits`` is a trial diagnostic of what
+        retrieval touched) even though it earns no hop. Silently dropping it
+        from the diagnostic would make an untrusted hit indistinguishable
+        from retrieval finding nothing at all.
+        """
+
+        document = _observation_node(
+            "u_doc",
+            "doc_untrusted",
+            "Untrusted note",
+            subject_canonical_ids=("proj_vertex",),
+            observation_kind=GraphObservationKind.DOCUMENT,
+            corpus_trust="withdrawn",
+        )
+        _install(monkeypatch, bm25=[document], cosine=[])
+        _install_entity_lookup(monkeypatch, _VERTEX_LOOKUP)
+
+        result = await retrieve_candidates(
+            "untrusted",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert result.observation_hits == ("doc_untrusted",)
+        assert result.candidates == ()
+
+    async def test_an_untrusted_document_does_not_shadow_a_trusted_source_for_the_same_subject(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gate skips only THIS document's own contribution -- it must
+        not suppress a different, trusted observation naming the identical
+        subject. Proves the check is scoped per-node, not a wholesale "any
+        untrusted hit poisons the subject" rule.
+        """
+
+        untrusted = _observation_node(
+            "u_untrusted",
+            "doc_untrusted",
+            "Untrusted mention",
+            subject_canonical_ids=("proj_vertex",),
+            observation_kind=GraphObservationKind.DOCUMENT,
+            corpus_trust="withdrawn",
+        )
+        trusted = _observation_node(
+            "u_trusted",
+            "rv_trusted_review",
+            "Trusted review",
+            subject_canonical_ids=("proj_vertex",),
+        )
+        _install(monkeypatch, bm25=[untrusted, trusted], cosine=[trusted])
+        _install_entity_lookup(monkeypatch, _VERTEX_LOOKUP)
+
+        result = await retrieve_candidates(
+            "vertex",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert [c.canonical_id for c in result.candidates] == ["proj_vertex"]
+        assert result.candidates[0].via_observation_id == "rv_trusted_review"
+
+    async def test_the_trust_gate_does_not_apply_to_non_document_observation_kinds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Scope boundary regression guard: an observation that is NOT a
+        document (no ``cf_observation_kind`` attribute at all -- the shape
+        every non-document observation in this projection has today) must
+        hop exactly as it did before this gate existed, regardless of what
+        its own ``corpus_trust`` reads. This ticket's mandate is the
+        document approval gate, not a new blanket trust re-check over every
+        observation kind this arm reads.
+        """
+
+        observation = _observation_node(
+            "u_obs",
+            "rv_vertex_cycles",
+            "Vertex review",
+            subject_canonical_ids=("proj_vertex",),
+            corpus_trust="withdrawn",  # would fail the bar, if the gate applied here
+        )
+        _install(monkeypatch, bm25=[observation], cosine=[observation])
+        _install_entity_lookup(monkeypatch, _VERTEX_LOOKUP)
+
+        result = await retrieve_candidates(
+            "vertex review",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex"}),
+        )
+
+        assert [c.canonical_id for c in result.candidates] == ["proj_vertex"]


### PR DESCRIPTION
## Issue / phase
Wave 3.2 / CHAOS-3660 (Phase 2A shared-contract territory). Child work under **CHAOS-3632** (plain reference, not close-linked -- this PR does not complete that issue). Read-side follow-up to Lane A's write-side PR #1665 (`f3ac1d221`).

## Observable outcome
A document-derived observation node in the graph (`cf_observation_kind == "document"`) whose `corpus_trust` attribute is absent or outside `TRUSTED_ATTRIBUTION_LEVELS` (`{"canonical", "provider_asserted"}`) no longer contributes its named subjects to the semantic retrieval observation→entity hop -- it is still recorded as a genuine retrieval hit (`observation_hits`), but resolves no candidate. A trusted document's named subject still hops exactly as before. Non-document observation kinds are untouched.

Also resolves the open "does BM25 see document body" question left by #1665: documented and decided (not fixed) -- see below.

## Architecture boundary
Single file touched in `src/`: `context_fabric/graph_arm/semantic_retrieval.py` (Lane D exclusive). Reads (does not modify) `drivers.TRUSTED_ATTRIBUTION_LEVELS` and `vocabulary.GraphObservationKind`, both already public. No shared/frozen file touched; no contract-owner protocol needed for this PR.

## Why a read-side check when the write side already gates approval
`backend.to_graphiti_document_nodes` (#1665) only ever writes a node for a document already in `projection.approved_documents` -- a rejected document never reaches the graph. But that approval is computed once, at projection-build time, and nothing re-checks it afterward. A document approved when a projection was built and later withdrawn, redacted, or revoked stays in the store, findable, until the next full reprojection sweep purges it. This PR's gate is what bounds that staleness window on *read*, mirroring `drivers._is_trusted`'s exact semantics (including its "absence is not a default" refusal) rather than trusting the one-time write-side gate to still be accurate.

Scoped to document-kind observations only, deliberately: every other observation kind already passes its own upstream quality gate (canonical-service admission, evidence-reference signing, CHAOS-3627/3633/3650) before reaching this arm's projection. A blanket re-check across every observation kind was not this ticket's mandate and risks silently changing hop behavior for records this PR has no claim over -- verified by a dedicated regression test (`test_the_trust_gate_does_not_apply_to_non_document_observation_kinds`).

## BM25-sees-body: decided, documented, not changed
Verified directly against `graphiti_core.graph_queries` (not assumed): FalkorDB's `node_name_and_summary` full-text index covers exactly `name` and `summary`. A document node's `summary` is always `""` by the write side's own deliberate design (body reaches only the embedder, never a stored/read-back-able field). So BM25 can only ever match a document by title text; body is findable exclusively via cosine similarity against the write side's body-derived `name_embedding`.

**Decision: this is correct as-is, not a gap to close.** Widening `summary` to include body would store raw document prose in a queryable, read-back-able field -- precisely the persisted-untrusted-prose surface CHAOS-3632's whole approval gate exists to keep closed ("indexed text can aid retrieval but cannot become executable instruction or trusted wire content"). The lexical-coverage gap is real (a query using only body-specific terms gets no BM25 support for that node) but it's a deliberate, already-ratified (CHAOS-3660) trust trade-off, not an index-not-ready timing accident like `wait_for_fulltext_index` guards against. Recorded in the module docstring for the next reader who re-asks this question.

## Scope / non-scope
**In scope:** the semantic-retrieval read-side trust re-check; the BM25/body decision.
**Not in scope (CHAOS-3632's own acceptance criteria still open, owned elsewhere or not yet assigned):** production configuration, telemetry, provider policy/budget, retention/deletion/audit behavior, full documentation. This PR alone does **not** complete CHAOS-3632 -- branch is deliberately ID-free per the standing rule (an issue ID in a branch name is reserved for a PR that fully completes that exact issue).

## Base / head SHA
Base: `f3ac1d221` (origin/feature/chaos-3498-context-fabric tip at branch time, Lane A's write-side merge)
Head: `528b3fd0483bc02dbb9ce39038cf1a376cf60ade`

## Migrations
None.

## Security impact
Closes a staleness window in a trust boundary: an untrusted/withdrawn document can no longer have its named subjects surfaced as retrieval candidates just because it was written to the graph before revocation. Fail-closed by construction (`trust is not None and trust in TRUSTED_ATTRIBUTION_LEVELS`) -- an attribute read failure or absence refuses, never defaults to trusted.

## RED-first evidence
`tests/context_fabric/test_chaos_3632_document_trust_gate.py` written first: 5 of 8 tests failed against the pre-existing code (the 3 scope-boundary/positive-control tests passed by construction, since they describe behavior the gate must NOT change). Confirmed failure mode matched the described defect exactly (an untrusted document's subject resolved into a candidate). Then the gate was added; all 8 pass.

## Verification
- Focused: `pytest tests/context_fabric/test_chaos_3632_document_trust_gate.py` -- 8 passed.
- Related: `test_chaos_3653_observation_hop.py`, `test_chaos_3654_refusal_threshold.py`, `test_chaos_3666_conversational_reference.py`, `test_chaos_3647_semantic_leg.py` -- 60 passed combined, no regressions.
- Full affected suite: `pytest tests/context_fabric/` -- 1534 passed, 54 skipped (pre-existing, graphiti-extra/live-store gated).
- `ruff format --check` / `ruff check` -- clean.
- `mypy` (worktree venv, full project) -- `Success: no issues found in 2320 source files`.
- No live FalkorDB round trip needed or added: this PR introduces no new store read/write, only attribute-based filtering over nodes already fetched by the existing (monkeypatched-in-tests) `search_utils` calls -- same test harness precedent as the original CHAOS-3653 hop PR.

## Known limitations
- The positive control (`test_a_trusted_document_hops_its_subject`) is necessarily synthetic: `corpus_adapter._document_is_approved` marks every frozen-corpus document unapproved today, so no corpus document ever reaches the graph as a node to test against. This matches the no-corpus-tuning discipline rather than working around it.
- CHAOS-3632 stays open after this merges -- retention/deletion/audit/telemetry/production config and docs remain, per the acceptance criteria this PR does not attempt.

## Rollout / rollback
No schema/config change. Behavior change is confined to documents whose `corpus_trust` attribute is set and outside `TRUSTED_ATTRIBUTION_LEVELS`, or absent -- today, no frozen-corpus document is ever approved to reach a node at all, so this PR has no observable effect on any existing trial run; it only takes effect once real approved+trust-tagged documents start flowing through the write side. Safe to revert independently.