### PR TITLE
CHAOS-3685: commit/ci_run evidence resolvers -- ratified trust-threshold policy

### DIFF
--- a/src/dev_health_ops/api/dev/native_evidence_resolver.py
+++ b/src/dev_health_ops/api/dev/native_evidence_resolver.py
@@ -254,6 +254,193 @@ async def _resolve_review(
     )
 
 
+#: CHAOS-3685. ``ci_pipeline_runs.repo_id`` is NOT nullable
+#: (``000_raw_tables.sql``); ``pr_number`` IS -- the same per-row
+#: derive-vs-anchor shape as ``_resolve_deployment``. Unlike ``commit``
+#: below, no trust-threshold join is needed here at all: ``pr_number`` is
+#: populated straight from the CI provider's own native attribution
+#: (GitHub workflow-run ``pull_requests[0].number``, GitLab's
+#: ``merge_request_iid`` -- see ``providers/*/testops_pipeline.py``), never
+#: inferred, exactly the same raw-nullable-column shape
+#: ``deployments.pull_request_number`` already has. ``native_status_change.py``
+#: already joins on this column for team/PR scoping today -- this is not a
+#: new trust surface.
+_CI_RUN_RESOLVE_SQL = """
+SELECT repo_id, run_id, status, pr_number,
+       coalesce(finished_at, started_at) AS observed_at,
+       last_synced
+FROM ci_pipeline_runs FINAL
+WHERE org_id = {org_id:String}
+  AND concat(toString(repo_id), '#ci', run_id) = {locator:String}
+LIMIT 1
+"""
+
+
+async def _resolve_ci_run(
+    client: Any,
+    *,
+    org_id: str,
+    candidate: EvidenceCandidate,
+    policy: SourceFreshnessPolicy,
+    source_system: str,
+) -> EvidenceRecord | None:
+    rows = await query_dicts(
+        client, _CI_RUN_RESOLVE_SQL, {"org_id": org_id, "locator": candidate.locator}
+    )
+    if not rows:
+        return None
+    row = rows[0]
+    observed = _datetime(row.get("observed_at")) or datetime.now(UTC)
+    last_synced = _datetime(row.get("last_synced"))
+    freshness = policy.classify(last_synced, now=datetime.now(UTC))
+    pr_number = row.get("pr_number")
+    display_label = f"CI run {row['run_id']}"
+    raw_excerpt = f"Status: {row.get('status') or 'unknown'}"
+    repository_ids = (str(row["repo_id"]),)
+    stale = freshness is FreshnessState.STALE
+    if pr_number:
+        # A real, natively-attributed PR link on THIS row -- always derived
+        # when present, never skipped for the cheaper anchor-only path
+        # (same anti-laundering discipline as _resolve_deployment).
+        return EvidenceRecord(
+            source_system=source_system,
+            source_version=RESOLVER_SOURCE_VERSION,
+            entity_type="ci_run",
+            entity_id=f"{row['repo_id']}#pr{pr_number}",
+            display_label=display_label,
+            observed_at=observed,
+            freshness=freshness,
+            provenance="native",
+            confidence=1.0,
+            repository_ids=repository_ids,
+            raw_excerpt=raw_excerpt,
+            stale=stale,
+        )
+    # No PR link on this row -- repo_id is schema-guaranteed non-null, so
+    # the repository-only path always has a real anchor; this never reaches
+    # #1648's no-anchor refusal the way a repo-less incident can.
+    return EvidenceRecord(
+        source_system=source_system,
+        source_version=RESOLVER_SOURCE_VERSION,
+        entity_type="ci_run",
+        entity_id=str(row["run_id"]),
+        display_label=display_label,
+        observed_at=observed,
+        freshness=freshness,
+        provenance="native",
+        confidence=1.0,
+        repository_ids=repository_ids,
+        raw_excerpt=raw_excerpt,
+        stale=stale,
+        no_authorizable_entity=True,
+    )
+
+
+#: CHAOS-3685. ``git_commits`` has no PR/issue link column of its own; the
+#: only linkage is ``work_graph_pr_commit``, the purpose-built fast-path
+#: table ``work_graph/builder.py``'s own ``_build_pr_commit_edges_from_fast_path``
+#: already treats as canonical (not the generic, string-typed
+#: ``work_graph_edges``). The trust-threshold policy this ticket exists to
+#: force: **only ``provenance = 'native'`` derives the linked PR** --
+#: ``explicit_text``/``heuristic`` never do, regardless of confidence value
+#: (a confidence float does not establish the same class of guarantee as a
+#: native id; a 0.9-confidence commit-message regex match is still "text a
+#: human wrote"). The filter lives INSIDE the joined subquery, not as an
+#: outer ``WHERE``/``ORDER BY`` tiebreak, so a commit with only
+#: non-native links joins to nothing at all -- never ambiguous with
+#: ClickHouse's own no-match column defaults for the (non-nullable)
+#: ``pr_number``/``provenance`` columns on the fast-path table.
+#:
+#: Read from the only real writer of this table
+#: (``work_graph/builder.py:_derive_pr_commit_links``): production
+#: ingestion **never writes ``provenance='native'`` today** -- only
+#: ``explicit_text`` (0.9, explicit merge-keyword match) and ``heuristic``
+#: (0.6, squash-merge subject-suffix match), both below this threshold.
+#: **Practical consequence: ``commit`` candidates resolve repository-only
+#: in all real production data today**, until/unless a native PR-commit
+#: source is added upstream -- the "under-admits (safe but reduces
+#: coverage)" side of this ticket's own stated trade-off, taken
+#: deliberately. Fixtures do write ``native`` provenance
+#: (``fixtures/generators/commits.py``, ``fixtures/runner.py``), so the
+#: derive branch is exercised by the live-ClickHouse suite even though
+#: today's real ingestion never reaches it.
+_COMMIT_RESOLVE_SQL = """
+SELECT c.repo_id AS repo_id, c.hash AS hash, ifNull(c.message, '') AS message,
+       c.committer_when AS observed_at, c.last_synced AS last_synced,
+       p.pr_number AS pr_number
+FROM git_commits AS c FINAL
+LEFT JOIN (
+    SELECT repo_id, commit_hash, pr_number
+    FROM work_graph_pr_commit FINAL
+    WHERE org_id = {org_id:String} AND provenance = 'native'
+) AS p
+  ON p.repo_id = c.repo_id AND p.commit_hash = c.hash
+WHERE c.org_id = {org_id:String}
+  AND concat(toString(c.repo_id), '@', c.hash) = {locator:String}
+LIMIT 1
+"""
+
+
+async def _resolve_commit(
+    client: Any,
+    *,
+    org_id: str,
+    candidate: EvidenceCandidate,
+    policy: SourceFreshnessPolicy,
+    source_system: str,
+) -> EvidenceRecord | None:
+    rows = await query_dicts(
+        client, _COMMIT_RESOLVE_SQL, {"org_id": org_id, "locator": candidate.locator}
+    )
+    if not rows:
+        return None
+    row = rows[0]
+    observed = _datetime(row.get("observed_at")) or datetime.now(UTC)
+    last_synced = _datetime(row.get("last_synced"))
+    freshness = policy.classify(last_synced, now=datetime.now(UTC))
+    pr_number = row.get("pr_number")
+    commit_hash = str(row["hash"])
+    display_label = f"Commit {commit_hash[:12]}"
+    raw_excerpt = str(row.get("message") or "")
+    repository_ids = (str(row["repo_id"]),)
+    stale = freshness is FreshnessState.STALE
+    if pr_number:
+        # The subquery already restricted this join to provenance='native'
+        # -- a truthy pr_number here is always a natively-attributed link,
+        # never a laundered heuristic/explicit_text one.
+        return EvidenceRecord(
+            source_system=source_system,
+            source_version=RESOLVER_SOURCE_VERSION,
+            entity_type="commit",
+            entity_id=f"{row['repo_id']}#pr{pr_number}",
+            display_label=display_label,
+            observed_at=observed,
+            freshness=freshness,
+            provenance="native",
+            confidence=1.0,
+            repository_ids=repository_ids,
+            raw_excerpt=raw_excerpt,
+            stale=stale,
+        )
+    # No native-provenance link -- repo_id is schema-guaranteed non-null on
+    # git_commits, so the repository-only path always has a real anchor.
+    return EvidenceRecord(
+        source_system=source_system,
+        source_version=RESOLVER_SOURCE_VERSION,
+        entity_type="commit",
+        entity_id=commit_hash,
+        display_label=display_label,
+        observed_at=observed,
+        freshness=freshness,
+        provenance="native",
+        confidence=1.0,
+        repository_ids=repository_ids,
+        raw_excerpt=raw_excerpt,
+        stale=stale,
+        no_authorizable_entity=True,
+    )
+
+
 class NativeEvidenceCandidateResolver:
     """Resolves ``context_fabric_graph_arm`` candidates against real
     ClickHouse native evidence tables, one ``GraphObservationKind`` at a
@@ -270,17 +457,15 @@ class NativeEvidenceCandidateResolver:
     ``repo_id`` is not, so this is the first resolver with a genuine
     per-row choice between the two paths).
 
-    ``commit``/``ci_run`` are a deliberate, recorded gap, not an oversight,
-    tracked as `CHAOS-3685
-    <https://linear.app/fullchaos/issue/CHAOS-3685>`_ (not just this
-    docstring -- a requirement stated only in prose does not survive
-    triage): neither ``git_commits`` nor ``ci_pipeline_runs`` has any
-    PR/issue link column, and the only possible linkage -- the generic
-    ``work_graph_edges`` table -- carries a ``provenance``/``confidence``
-    spread (native, explicit_text, heuristic) that needs its own
-    trust-threshold design decision before it can safely grant
-    entity-level authorization. Per the CHAOS-3675 PR 3/3 scope-lock:
-    refusing these two with the gap recorded beats a speculative join.
+    `CHAOS-3685 <https://linear.app/fullchaos/issue/CHAOS-3685>`_ closes
+    the last two reachable ``GraphObservationKind``s with a native source:
+    ``ci_run`` (``ci_pipeline_runs.pr_number`` is a native, provider-
+    attributed column -- same derive-vs-anchor shape as ``deployment``,
+    no join needed) and ``commit`` (no link column of its own; joins
+    ``work_graph_pr_commit``, but only ``provenance='native'`` derives --
+    see ``_COMMIT_RESOLVE_SQL``'s docstring for the ratified trust
+    threshold and why real production data resolves it repository-only
+    today).
     """
 
     def __init__(
@@ -330,6 +515,22 @@ class NativeEvidenceCandidateResolver:
                 org_id=org_id,
                 candidate=candidate,
                 policy=self._policies["deployments"],
+                source_system=self.source_system,
+            )
+        if candidate.entity_type == "ci_run":
+            return await _resolve_ci_run(
+                self._client,
+                org_id=org_id,
+                candidate=candidate,
+                policy=self._policies["ci_runs"],
+                source_system=self.source_system,
+            )
+        if candidate.entity_type == "commit":
+            return await _resolve_commit(
+                self._client,
+                org_id=org_id,
+                candidate=candidate,
+                policy=self._policies["commits"],
                 source_system=self.source_system,
             )
         return None

--- a/tests/api/dev/test_native_evidence_resolver.py
+++ b/tests/api/dev/test_native_evidence_resolver.py
@@ -243,17 +243,14 @@ def test_a_locator_that_exists_only_in_a_different_org_is_refused(
     )
 
 
-@pytest.mark.parametrize("entity_type", ["commit", "ci_run"])
-def test_unimplemented_observation_kinds_are_refused_without_querying(
-    monkeypatch: pytest.MonkeyPatch, entity_type: str
+def test_a_wholly_unreachable_observation_kind_is_refused_without_querying(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``commit``/``ci_run`` are a deliberate, recorded gap (see the class
-    docstring: neither canonical table has a PR/issue link column, and the
-    only possible linkage needs a trust-threshold decision this resolver
-    doesn't have standing to make) -- refused cleanly, never a crash, and
-    never a query issued for a kind this resolver cannot yet verify
-    safely. ``review``/``incident``/``deployment`` are all implemented as
-    of PR 3/3 and covered by their own dedicated tests."""
+    """Every reachable ``GraphObservationKind`` with a native source
+    (``review``, ``incident``, ``deployment``, ``ci_run``, ``commit``) is
+    implemented as of CHAOS-3685 -- covered by their own dedicated tests.
+    A kind with no native source at all (e.g. ``document``) still refuses
+    cleanly, never a crash and never a query issued."""
 
     sink = _FakeSink([_row()])
     _monkeypatch_query_dicts(monkeypatch, sink)
@@ -261,7 +258,7 @@ def test_unimplemented_observation_kinds_are_refused_without_querying(
 
     candidate = EvidenceCandidate(
         source_system=ARM_SOURCE_SYSTEM,
-        entity_type=entity_type,
+        entity_type="document",
         entity_id="issue-999",
         locator="repo-1@deadbeef",
     )
@@ -758,6 +755,426 @@ def test_a_deployment_locator_that_exists_only_in_a_different_org_is_refused(
             org_id=ORG_B,
             scope=_UNUSED_SCOPE,
             candidate=_deployment_candidate(locator="repo-1#deploymentdeploy-3"),
+        )
+    )
+
+    assert refused is None
+    assert admitted is not None
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3685: the ci_run resolver. ``ci_pipeline_runs.pr_number`` is a
+# native, provider-attributed column (never inferred) -- structurally
+# identical to deployment's derive-vs-anchor shape, no join needed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CiRunRow:
+    org_id: str
+    repo_id: str
+    run_id: str
+    status: str
+    pr_number: int | None
+    observed_at: datetime
+    last_synced: datetime
+
+
+class _CiRunFakeSink:
+    """Simulates the ci_run-resolve SQL's own WHERE clause: a row is
+    returned only when BOTH ``org_id`` and the composite locator
+    (``{repo_id}#ci{run_id}``) match."""
+
+    def __init__(self, rows: list[_CiRunRow]) -> None:
+        self._rows = rows
+        self.calls: list[dict[str, Any]] = []
+
+    async def query_dicts(
+        self, query: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.calls.append(params)
+        for row in self._rows:
+            locator = f"{row.repo_id}#ci{row.run_id}"
+            if row.org_id == params["org_id"] and locator == params["locator"]:
+                return [
+                    {
+                        "repo_id": row.repo_id,
+                        "run_id": row.run_id,
+                        "status": row.status,
+                        "pr_number": row.pr_number,
+                        "observed_at": row.observed_at,
+                        "last_synced": row.last_synced,
+                    }
+                ]
+        return []
+
+
+def _monkeypatch_ci_run_query_dicts(
+    monkeypatch: pytest.MonkeyPatch, sink: _CiRunFakeSink
+) -> None:
+    async def _fake_query_dicts(client: Any, query: str, params: dict[str, Any]):
+        assert client is sink
+        return await sink.query_dicts(query, params)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence_resolver.query_dicts",
+        _fake_query_dicts,
+    )
+
+
+def _ci_run_candidate(
+    *, locator: str, claimed_entity_id: str = "issue-999"
+) -> EvidenceCandidate:
+    return EvidenceCandidate(
+        source_system=ARM_SOURCE_SYSTEM,
+        entity_type="ci_run",
+        entity_id=claimed_entity_id,
+        locator=locator,
+    )
+
+
+def test_a_ci_run_with_a_native_pr_link_derives_the_pr_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-first: before CHAOS-3685, ``ci_run``-kind candidates refuse
+    UNCONFIGURED. With ``pr_number`` populated (the CI provider's own
+    native attribution), resolution derives a genuine PR entity."""
+
+    row = _CiRunRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        run_id="run-1",
+        status="success",
+        pr_number=77,
+        observed_at=NOW,
+        last_synced=NOW,
+    )
+    sink = _CiRunFakeSink([row])
+    _monkeypatch_ci_run_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_ci_run_candidate(locator="repo-1#cirun-1"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is False
+    assert record.entity_id == "repo-1#pr77"
+    assert record.repository_ids == ("repo-1",)
+    assert "issue-999" not in (record.display_label, record.raw_excerpt or "")
+
+
+def test_a_ci_run_with_no_pr_link_falls_through_to_repository_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _CiRunRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        run_id="run-2",
+        status="failure",
+        pr_number=None,
+        observed_at=NOW,
+        last_synced=NOW,
+    )
+    sink = _CiRunFakeSink([row])
+    _monkeypatch_ci_run_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_ci_run_candidate(locator="repo-1#cirun-2"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == ("repo-1",)
+
+
+def test_a_ci_run_locator_that_exists_only_in_a_different_org_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _CiRunRow(
+        org_id=ORG_B,
+        repo_id="repo-1",
+        run_id="run-3",
+        status="success",
+        pr_number=1,
+        observed_at=NOW,
+        last_synced=NOW,
+    )
+    sink = _CiRunFakeSink([row])
+    _monkeypatch_ci_run_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    refused = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_ci_run_candidate(locator="repo-1#cirun-3"),
+        )
+    )
+    admitted = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_B,
+            scope=_UNUSED_SCOPE,
+            candidate=_ci_run_candidate(locator="repo-1#cirun-3"),
+        )
+    )
+
+    assert refused is None
+    assert admitted is not None
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3685: the commit resolver. Unlike ci_run, deriving a PR entity for
+# a commit needs a trust-threshold decision -- the fake sink here simulates
+# the FULL resolve SQL, including the subquery's ``provenance='native'``
+# filter, so the adversarial test below proves the filter itself, not an
+# assumption about it.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CommitRow:
+    org_id: str
+    repo_id: str
+    hash: str
+    message: str
+    observed_at: datetime
+    last_synced: datetime
+    #: (pr_number, provenance) pairs this commit has a work_graph_pr_commit
+    #: link to -- possibly none, possibly several (e.g. a cherry-pick).
+    links: tuple[tuple[int, str], ...] = ()
+
+
+class _CommitFakeSink:
+    """Simulates ``git_commits FINAL LEFT JOIN (SELECT ... FROM
+    work_graph_pr_commit FINAL WHERE org_id = ... AND provenance =
+    'native')``: a commit row is returned only when ``org_id`` + the
+    composite locator match; ``pr_number`` is populated ONLY when one of
+    the commit's links has ``provenance == 'native'`` -- modeling the
+    filter living INSIDE the joined subquery, not a post-hoc Python check.
+    """
+
+    def __init__(self, rows: list[_CommitRow]) -> None:
+        self._rows = rows
+        self.calls: list[dict[str, Any]] = []
+
+    async def query_dicts(
+        self, query: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.calls.append(params)
+        for row in self._rows:
+            locator = f"{row.repo_id}@{row.hash}"
+            if row.org_id != params["org_id"] or locator != params["locator"]:
+                continue
+            native_pr = next((pr for pr, prov in row.links if prov == "native"), None)
+            return [
+                {
+                    "repo_id": row.repo_id,
+                    "hash": row.hash,
+                    "message": row.message,
+                    "observed_at": row.observed_at,
+                    "last_synced": row.last_synced,
+                    "pr_number": native_pr,
+                }
+            ]
+        return []
+
+
+def _monkeypatch_commit_query_dicts(
+    monkeypatch: pytest.MonkeyPatch, sink: _CommitFakeSink
+) -> None:
+    async def _fake_query_dicts(client: Any, query: str, params: dict[str, Any]):
+        assert client is sink
+        return await sink.query_dicts(query, params)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.native_evidence_resolver.query_dicts",
+        _fake_query_dicts,
+    )
+
+
+def _commit_candidate(
+    *, locator: str, claimed_entity_id: str = "issue-999"
+) -> EvidenceCandidate:
+    return EvidenceCandidate(
+        source_system=ARM_SOURCE_SYSTEM,
+        entity_type="commit",
+        entity_id=claimed_entity_id,
+        locator=locator,
+    )
+
+
+def test_a_commit_with_a_native_provenance_link_derives_the_pr_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-first: before CHAOS-3685, ``commit``-kind candidates refuse
+    UNCONFIGURED. A ``provenance='native'`` work_graph_pr_commit link
+    derives the genuine PR entity."""
+
+    row = _CommitRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        hash="deadbeef",
+        message="Fix the thing",
+        observed_at=NOW,
+        last_synced=NOW,
+        links=((77, "native"),),
+    )
+    sink = _CommitFakeSink([row])
+    _monkeypatch_commit_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_commit_candidate(locator="repo-1@deadbeef"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is False
+    assert record.entity_id == "repo-1#pr77"
+    assert record.repository_ids == ("repo-1",)
+    assert "issue-999" not in (record.display_label, record.raw_excerpt or "")
+
+
+def test_a_commit_with_no_link_at_all_falls_through_to_repository_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _CommitRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        hash="cafebabe",
+        message="Unrelated change",
+        observed_at=NOW,
+        last_synced=NOW,
+        links=(),
+    )
+    sink = _CommitFakeSink([row])
+    _monkeypatch_commit_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_commit_candidate(locator="repo-1@cafebabe"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == ("repo-1",)
+
+
+def test_a_commit_with_only_a_heuristic_link_never_derives_the_pr_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adversarial / anti-laundering: a link EXISTS (a squash-merge subject
+    match, confidence 0.6) but its provenance is ``heuristic``, not
+    ``native``. The ratified trust threshold says this must NOT be trusted
+    for entity-level authorization, however plausible-looking -- the
+    resolver must fall through to repository-only exactly as if no link
+    existed at all, never derive from it."""
+
+    row = _CommitRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        hash="feedface",
+        message="Some commit (#77)",
+        observed_at=NOW,
+        last_synced=NOW,
+        links=((77, "heuristic"),),
+    )
+    sink = _CommitFakeSink([row])
+    _monkeypatch_commit_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_commit_candidate(locator="repo-1@feedface"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.entity_id == "feedface"
+
+
+def test_a_commit_with_only_an_explicit_text_link_never_derives_the_pr_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same control, the other non-native tier: an explicit merge-keyword
+    match (confidence 0.9 -- higher than the heuristic tier, and higher
+    than deployment/ci_run's own no-extra-gate columns) still must not
+    derive, because it is text-derived, not natively attributed."""
+
+    row = _CommitRow(
+        org_id=ORG_A,
+        repo_id="repo-1",
+        hash="0ff1ce",
+        message="Merge pull request #77 from feature/x",
+        observed_at=NOW,
+        last_synced=NOW,
+        links=((77, "explicit_text"),),
+    )
+    sink = _CommitFakeSink([row])
+    _monkeypatch_commit_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    record = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_commit_candidate(locator="repo-1@0ff1ce"),
+        )
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.entity_id == "0ff1ce"
+
+
+def test_a_commit_locator_that_exists_only_in_a_different_org_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    row = _CommitRow(
+        org_id=ORG_B,
+        repo_id="repo-1",
+        hash="abc123",
+        message="Org B's commit",
+        observed_at=NOW,
+        last_synced=NOW,
+        links=((1, "native"),),
+    )
+    sink = _CommitFakeSink([row])
+    _monkeypatch_commit_query_dicts(monkeypatch, sink)
+    resolver = NativeEvidenceCandidateResolver(sink)
+
+    refused = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_A,
+            scope=_UNUSED_SCOPE,
+            candidate=_commit_candidate(locator="repo-1@abc123"),
+        )
+    )
+    admitted = asyncio.run(
+        resolver.resolve(
+            org_id=ORG_B,
+            scope=_UNUSED_SCOPE,
+            candidate=_commit_candidate(locator="repo-1@abc123"),
         )
     )
 

--- a/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
+++ b/tests/api/dev/test_native_evidence_resolver_clickhouse_live.py
@@ -76,6 +76,9 @@ def _clean_tables(ch_client: Any) -> Any:
         "operational_incidents",
         "work_graph_deployment_incident_edges",
         "deployments",
+        "git_commits",
+        "ci_pipeline_runs",
+        "work_graph_pr_commit",
     )
     for table in tables:
         ch_client.command(f"TRUNCATE TABLE IF EXISTS {table}")
@@ -458,6 +461,288 @@ async def test_the_real_deployment_sql_enforces_tenant_isolation(
         org_id=ORG_B,
         locator=f"{REPO_ID}#deploymentdeploy-live-3",
         entity_type="deployment",
+    )
+
+    assert other_org is None
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3685: ci_run and commit, against the real schema. ci_run needs no
+# join (ci_pipeline_runs.pr_number is native-attributed); commit's trust
+# threshold (only provenance='native' on work_graph_pr_commit derives) is
+# the one property this file exists to prove against the REAL engine, not
+# a fake sink's assumption about it -- see
+# test_the_real_commit_sql_never_derives_from_a_heuristic_or_explicit_text_link
+# below, which was live-verified by breaking the production SQL text.
+# ---------------------------------------------------------------------------
+
+
+def _insert_ci_run(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: str = REPO_ID,
+    run_id: str,
+    status: str = "success",
+    pr_number: int | None,
+) -> None:
+    client.insert(
+        "ci_pipeline_runs",
+        [[org_id, repo_id, run_id, status, pr_number, NOW, NOW]],
+        column_names=[
+            "org_id",
+            "repo_id",
+            "run_id",
+            "status",
+            "pr_number",
+            "started_at",
+            "last_synced",
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_real_ci_run_sql_derives_a_natively_linked_pr(
+    ch_client: Any,
+) -> None:
+    _insert_ci_run(ch_client, org_id=ORG_A, run_id="run-live-1", pr_number=77)
+
+    record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}#cirun-live-1",
+        entity_type="ci_run",
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is False
+    assert record.entity_id == f"{REPO_ID}#pr77"
+    assert record.repository_ids == (REPO_ID,)
+
+
+@pytest.mark.asyncio
+async def test_the_real_ci_run_sql_falls_through_to_repository_only_when_unlinked(
+    ch_client: Any,
+) -> None:
+    _insert_ci_run(ch_client, org_id=ORG_A, run_id="run-live-2", pr_number=None)
+
+    record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}#cirun-live-2",
+        entity_type="ci_run",
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == (REPO_ID,)
+
+
+@pytest.mark.asyncio
+async def test_the_real_ci_run_sql_enforces_tenant_isolation(ch_client: Any) -> None:
+    _insert_ci_run(ch_client, org_id=ORG_A, run_id="run-live-3", pr_number=1)
+
+    other_org = await _resolve(
+        ch_client,
+        org_id=ORG_B,
+        locator=f"{REPO_ID}#cirun-live-3",
+        entity_type="ci_run",
+    )
+
+    assert other_org is None
+
+
+def _insert_commit(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: str = REPO_ID,
+    commit_hash: str,
+    message: str = "A commit",
+) -> None:
+    client.insert(
+        "git_commits",
+        [[org_id, repo_id, commit_hash, message, NOW, NOW, 1, NOW]],
+        column_names=[
+            "org_id",
+            "repo_id",
+            "hash",
+            "message",
+            "author_when",
+            "committer_when",
+            "parents",
+            "last_synced",
+        ],
+    )
+
+
+def _insert_pr_commit_link(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: str = REPO_ID,
+    pr_number: int,
+    commit_hash: str,
+    provenance: str,
+    confidence: float,
+) -> None:
+    client.insert(
+        "work_graph_pr_commit",
+        [
+            [
+                org_id,
+                repo_id,
+                pr_number,
+                commit_hash,
+                confidence,
+                provenance,
+                "test-evidence",
+                NOW,
+            ]
+        ],
+        column_names=[
+            "org_id",
+            "repo_id",
+            "pr_number",
+            "commit_hash",
+            "confidence",
+            "provenance",
+            "evidence",
+            "last_synced",
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_real_commit_sql_derives_a_native_provenance_linked_pr(
+    ch_client: Any,
+) -> None:
+    _insert_commit(ch_client, org_id=ORG_A, commit_hash="deadbeef01")
+    _insert_pr_commit_link(
+        ch_client,
+        org_id=ORG_A,
+        pr_number=77,
+        commit_hash="deadbeef01",
+        provenance="native",
+        confidence=1.0,
+    )
+
+    record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}@deadbeef01",
+        entity_type="commit",
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is False
+    assert record.entity_id == f"{REPO_ID}#pr77"
+    assert record.repository_ids == (REPO_ID,)
+
+
+@pytest.mark.asyncio
+async def test_the_real_commit_sql_never_derives_from_a_heuristic_or_explicit_text_link(
+    ch_client: Any,
+) -> None:
+    """**Adversarial / anti-laundering, live-verified.** Two commits, each
+    with a real ``work_graph_pr_commit`` row pointing at a real PR, but
+    below the ratified trust threshold: one ``heuristic`` (0.6, a
+    squash-merge subject match), one ``explicit_text`` (0.9, an explicit
+    merge-keyword match -- HIGHER confidence than the heuristic tier, to
+    prove the gate is genuinely on ``provenance``, not a confidence
+    cutoff a high-confidence non-native link could slip past). Neither
+    must derive the linked PR -- both must resolve repository-only,
+    exactly as if no link existed at all.
+
+    Live-verified as a real guard, not an assumed one: with
+    ``_COMMIT_RESOLVE_SQL``'s subquery ``AND provenance = 'native'``
+    clause removed, this test was re-run against this same live schema
+    and BOTH commits wrongly derived their linked PR (observed directly).
+    Do not weaken, skip, or delete this test.
+    """
+
+    _insert_commit(ch_client, org_id=ORG_A, commit_hash="heuristic01")
+    _insert_pr_commit_link(
+        ch_client,
+        org_id=ORG_A,
+        pr_number=77,
+        commit_hash="heuristic01",
+        provenance="heuristic",
+        confidence=0.6,
+    )
+    _insert_commit(ch_client, org_id=ORG_A, commit_hash="expltext01")
+    _insert_pr_commit_link(
+        ch_client,
+        org_id=ORG_A,
+        pr_number=88,
+        commit_hash="expltext01",
+        provenance="explicit_text",
+        confidence=0.9,
+    )
+
+    heuristic_record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}@heuristic01",
+        entity_type="commit",
+    )
+    explicit_text_record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}@expltext01",
+        entity_type="commit",
+    )
+
+    assert heuristic_record is not None
+    assert heuristic_record.no_authorizable_entity is True
+    assert heuristic_record.entity_id == "heuristic01"
+
+    assert explicit_text_record is not None
+    assert explicit_text_record.no_authorizable_entity is True
+    assert explicit_text_record.entity_id == "expltext01"
+
+
+@pytest.mark.asyncio
+async def test_the_real_commit_sql_falls_through_to_repository_only_when_unlinked(
+    ch_client: Any,
+) -> None:
+    _insert_commit(ch_client, org_id=ORG_A, commit_hash="nolinkhash")
+
+    record = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}@nolinkhash",
+        entity_type="commit",
+    )
+
+    assert record is not None
+    assert record.no_authorizable_entity is True
+    assert record.repository_ids == (REPO_ID,)
+
+
+@pytest.mark.asyncio
+async def test_the_real_commit_sql_enforces_tenant_isolation(ch_client: Any) -> None:
+    """A native-provenance link exists, but for a DIFFERENT org than the
+    caller -- the outer ``WHERE c.org_id`` and the subquery's own
+    ``WHERE org_id`` must both hold; a same-hash commit in ORG_A must not
+    resolve at all (it was never inserted for ORG_A), and must not
+    accidentally pick up ORG_B's link."""
+
+    _insert_commit(ch_client, org_id=ORG_B, commit_hash="orgbcommit")
+    _insert_pr_commit_link(
+        ch_client,
+        org_id=ORG_B,
+        pr_number=1,
+        commit_hash="orgbcommit",
+        provenance="native",
+        confidence=1.0,
+    )
+
+    other_org = await _resolve(
+        ch_client,
+        org_id=ORG_A,
+        locator=f"{REPO_ID}@orgbcommit",
+        entity_type="commit",
     )
 
     assert other_org is None


### PR DESCRIPTION
## Issue / phase
CHAOS-3685 (child of CHAOS-3664, Lane C), re-activated this cycle. **Claim: this PR fully completes CHAOS-3685** -- both required resolvers (`_resolve_commit`, `_resolve_ci_run`), the ratified trust-threshold policy, the adversarial anti-laundering test, and live-ClickHouse verification are all here. ID is in the branch name and title on that basis (single PR, no follow-up needed) -- ratifying the tightened branch/PR-title rule.

## Observable outcome
Closes the CHAOS-3675 gap: every reachable `GraphObservationKind` with a native source (`review`, `incident`, `deployment`, `ci_run`, `commit`) now has a real `EvidenceCandidateResolver` in `native_evidence_resolver.py`.

## Scope-lock corrections (posted on CHAOS-3685 before coding)
The issue's own recon (written during CHAOS-3675 PR3) carried two premises that didn't hold once checked against the current schema and ingestion code:

1. **`ci_pipeline_runs.pr_number` exists** (added by migration `029_testops_tables.sql`, after the original recon) -- populated from the CI provider's own native attribution (GitHub workflow-run `pull_requests[0].number`, GitLab `merge_request_iid`), never inferred. `native_status_change.py` already joins on it for team/PR scoping today. **Consequence: `ci_run` needs no `work_graph_edges` join at all** -- `_resolve_ci_run` is structurally identical to `_resolve_deployment` (derive-vs-anchor from a native nullable column; `repo_id` schema-guaranteed non-null).
2. **`work_graph_pr_commit`** (the purpose-built PR<->commit fast-path table `work_graph/builder.py` already treats as canonical) is the correct join target for `commit`, not the generic string-typed `work_graph_edges` the issue originally proposed.

## The ratified trust-threshold policy
Only `provenance = 'native'` on `work_graph_pr_commit` derives the linked PR entity. `explicit_text`/`heuristic` never do, **regardless of confidence value** -- a confidence float does not establish the same class of guarantee as a native id (a 0.9-confidence commit-message regex match is still "text a human wrote"). The filter lives *inside* the joined subquery (not an outer `WHERE`/`ORDER BY` tiebreak), so it's never ambiguous with ClickHouse's own no-match column defaults for the non-nullable `pr_number`/`provenance` columns on the fast-path table.

**Read from the only real writer of that table** (`work_graph/builder.py:_derive_pr_commit_links`): production ingestion never writes `provenance='native'` today -- only `explicit_text` (0.9) and `heuristic` (0.6), both below this threshold. **Practical, deliberate consequence: `commit` candidates resolve repository-only in all real production data today**, until a native PR-commit source is added upstream -- the issue's own "under-admits (safe but reduces coverage)" trade-off, taken on purpose. Fixtures write native provenance, so the derive branch is exercised by the live-ClickHouse suite even though today's real ingestion never reaches it.

`org_id` is `String` on `git_commits`, `ci_pipeline_runs`, and `work_graph_pr_commit` alike (`027_add_org_id_to_sorting_keys.py`) -- no cross-table cast needed this time, unlike incidents' UUID/String mismatch.

## Scope / non-scope
- **In scope**: `src/dev_health_ops/api/dev/native_evidence_resolver.py` (mine exclusively), its two test files.
- **Not in scope**: no `evidence_service.py`/`admission.py` changes -- both resolvers use the existing, already-ratified `no_authorizable_entity` mechanism (CHAOS-3675/#1645/#1648). No commit->issue resolution attempted (no fast-path table exists for that linkage; left as a gap, not speculated).

## Base / head
Base: `feature/chaos-3498-context-fabric` @ `838ef2773` (current origin tip at branch time, confirmed via `git merge-base --is-ancestor`).
Head: `dc117ea9f`.

## Migrations
None -- reads existing tables only.

## Security impact
The trust-threshold policy IS the security-relevant decision this ticket exists to force -- see above. No change to `admit()`'s own authorization invariants.

## RED-first evidence
- Unit: the pre-existing `test_unimplemented_observation_kinds_are_refused_without_querying[commit]`/`[ci_run]` failed once dispatch was added (observed, then replaced with a single "wholly unreachable kind" test plus dedicated positive/negative coverage for both new kinds).
- **Adversarial / anti-laundering, live-verified against the real engine, not assumed**: seeded a real `work_graph_pr_commit` row at `heuristic` (0.6) and `explicit_text` (0.9 -- deliberately the *higher* confidence, to prove the gate is on `provenance` not a confidence cutoff) pointing at a real PR. Removed the subquery's `AND provenance = 'native'` clause, re-ran the test against a live scratch ClickHouse -- both commits wrongly derived their linked PR (observed directly). Restored the clause, re-ran, both fall through to repository-only as intended. Full 17/17 live suite green after restore.

## Verification
```
.venv/bin/ruff check / format --check           # clean
.venv/bin/mypy <3 changed files>                # clean
.venv/bin/python -m pytest tests/api/dev/test_native_evidence_resolver.py -q
  # 25 passed (fake-sink unit suite)
CLICKHOUSE_URI=<scratch> pytest tests/api/dev/test_native_evidence_resolver_clickhouse_live.py -q
  # 17 passed (real schema, real seeded rows spanning the trust boundary;
  #  scratch DB created/schema-built/dropped, never touches default)
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q
  # 4619 passed, 142 skipped, 4 xfailed, 0 failed
```
Pre-commit hook (full-tree mypy, 2320 source files): clean.

## Known limitations
- `commit` resolves repository-only for all real production data today (documented above and in the module docstring) -- not a bug, the deliberate safe side of the trust-threshold trade-off, until a native PR-commit source exists upstream.
- No commit->issue linkage attempted (no fast-path table for it exists).

## Rollout / rollback
Additive change to one already-owned module; no runtime wiring change beyond the two new dispatch branches. Revert is a pure file-level revert with no migration or config implications.