### PR TITLE
CHAOS-3650 admission-side: EvidenceAdmission.refused, a distinct canonical-refusal classification

### DIFF
--- a/src/dev_health_ops/api/dev/evidence_service.py
+++ b/src/dev_health_ops/api/dev/evidence_service.py
@@ -175,6 +175,26 @@ class EvidenceCandidate:
     repository_ids: tuple[str, ...] = ()
 
 
+#: CHAOS-3650 admission-side. The states that mean the canonical service
+#: LOOKED at this specific candidate and considered-and-declined it -- a
+#: source-backed "no" a consumer should disclose narrowly (this candidate
+#: is not supportable) and never retry as though it might succeed later:
+#: UNAUTHORIZED (the caller may not see it) and NO_MATCHES (the exact
+#: record the candidate named does not exist in canon). Deliberately
+#: excludes UNCONFIGURED (no resolver wired for this source_system at all
+#: -- an operational coverage gap, not a canonical judgment about the
+#: record) and UNAVAILABLE (a transient resolver failure -- retry-worthy,
+#: not a considered refusal). See :attr:`EvidenceAdmission.refused`,
+#: the single source of truth for this classification -- a consumer
+#: (e.g. a future frame assembler mapping refused evidence into a
+#: degraded answer per CHAOS-3650) must use that property rather than
+#: re-deriving membership itself, so this set cannot drift out from under
+#: a caller that hand-rolled the check.
+_CANONICALLY_REFUSED_STATES = frozenset(
+    {EvidenceAvailability.UNAUTHORIZED, EvidenceAvailability.NO_MATCHES}
+)
+
+
 @dataclass(frozen=True, slots=True)
 class EvidenceAdmission:
     """One candidate's outcome. ``evidence`` is ``None`` unless admitted."""
@@ -187,6 +207,23 @@ class EvidenceAdmission:
     @property
     def admitted(self) -> bool:
         return self.evidence is not None
+
+    @property
+    def refused(self) -> bool:
+        """CHAOS-3650. ``True`` exactly when the canonical service
+        considered this candidate and declined to admit it -- see
+        :data:`_CANONICALLY_REFUSED_STATES` for the exact membership and
+        why. ``False`` for every other non-admitted state, and always
+        ``False`` when :attr:`admitted` is ``True`` (the states are
+        mutually exclusive per candidate -- see :meth:`EvidenceService.admit`).
+
+        This is the property a consumer degrading an answer around a
+        refused candidate (never aborting the whole answer, never
+        conflating a genuine refusal with an unconfigured source or a
+        transient outage) should read, rather than hand-checking
+        ``state`` against a set it reconstructs itself.
+        """
+        return self.state in _CANONICALLY_REFUSED_STATES
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/api/dev/test_evidence_service.py
+++ b/tests/api/dev/test_evidence_service.py
@@ -1186,3 +1186,168 @@ async def test_the_no_anchor_guard_is_observed_failing_when_removed() -> None:
     # record for what it is.
     assert only.evidence is not None
     assert only.state is EvidenceAvailability.AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3650 admission-side: ``EvidenceAdmission.refused`` is the single
+# classification a consumer degrading an answer around a canonically
+# refused candidate should read -- distinct from an unconfigured source and
+# a transient outage, never re-derived by hand-checking ``state`` against a
+# set the caller reconstructs itself.
+# ---------------------------------------------------------------------------
+
+
+def _admission(state: EvidenceAvailability) -> EvidenceAdmission:
+    candidate = EvidenceCandidate(
+        source_system="reviews",
+        entity_type="review",
+        entity_id="issue-1",
+        locator="repo-a#pr1#review1",
+    )
+    return EvidenceAdmission(candidate=candidate, state=state)
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_refused"),
+    [
+        (EvidenceAvailability.UNAUTHORIZED, True),
+        (EvidenceAvailability.NO_MATCHES, True),
+        (EvidenceAvailability.UNCONFIGURED, False),
+        (EvidenceAvailability.UNAVAILABLE, False),
+        (EvidenceAvailability.AVAILABLE, False),
+        (EvidenceAvailability.REDACTED, False),
+        (EvidenceAvailability.STALE, False),
+    ],
+)
+def test_refused_is_true_only_for_a_considered_canonical_no(
+    state: EvidenceAvailability, expected_refused: bool
+) -> None:
+    """UNAUTHORIZED and NO_MATCHES are both the canonical service having
+    LOOKED at this exact candidate and declined it -- a source-backed "no".
+    UNCONFIGURED (no resolver wired for this source_system at all -- an
+    operational coverage gap, not a canonical judgment about the record)
+    and UNAVAILABLE (a transient resolver failure -- retry-worthy, never a
+    considered refusal) must NOT be conflated with that, exactly the
+    distinction CHAOS-3650's admission-side half exists to make explicit
+    for a future consumer degrading an answer around a refusal."""
+
+    assert _admission(state).refused is expected_refused
+
+
+def test_refused_and_admitted_are_always_mutually_exclusive() -> None:
+    for state in EvidenceAvailability:
+        admission = _admission(state)
+        assert not (admission.refused and admission.admitted), (
+            f"{state} must never be both refused and admitted"
+        )
+
+
+class _MixedOutcomeResolver:
+    """One resolver, three candidates, three genuinely different
+    admission outcomes -- proves ``admit()`` never collapses distinct
+    per-record reasons into a shared one, and that a single canonically
+    refused candidate never aborts its unrelated siblings (the same
+    property CHAOS-3650's packet-level fix proves at the packet layer,
+    proven here at the admission layer that feeds it)."""
+
+    source_system = "mixed"
+
+    async def resolve(self, *, org_id, scope, candidate):
+        if candidate.locator == "no-such-record":
+            # NO_MATCHES: the canonical service looked and this exact
+            # locator does not correspond to a real record.
+            return None
+        if candidate.locator == "wrong-entity":
+            # UNAUTHORIZED: a real record, genuinely about an entity the
+            # caller's grant does not contain.
+            return EvidenceRecord(
+                source_system="mixed",
+                source_version="test.v1",
+                entity_type="review",
+                entity_id="issue-999-not-granted",
+                display_label="A record about an entity outside the grant",
+                observed_at=NOW,
+                freshness=FreshnessState.FRESH,
+                provenance="native",
+                confidence=1.0,
+                repository_ids=("repo-a",),
+            )
+        return EvidenceRecord(
+            source_system="mixed",
+            source_version="test.v1",
+            entity_type="review",
+            entity_id="issue-1",
+            display_label="A genuinely admissible record",
+            observed_at=NOW,
+            freshness=FreshnessState.FRESH,
+            provenance="native",
+            confidence=1.0,
+            repository_ids=("repo-a",),
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_canonical_refusal_never_erases_unrelated_admitted_evidence_in_the_same_round() -> (
+    None
+):
+    """CHAOS-3650 acceptance criterion, proven at the admission layer: "A
+    single refused record cannot erase unrelated valid drivers or the
+    whole answer." Three candidates submitted together -- one admits, one
+    is NO_MATCHES, one is UNAUTHORIZED -- and every sibling resolves
+    exactly as it would alone; the batch never aborts and never conflates
+    the two distinct refusal reasons with each other or with the
+    admitted one."""
+
+    service = EvidenceService(
+        entitlement=Entitlement(),
+        authorizer=Authorizer(),
+        signer=EvidenceReferenceSigner(SECRET),
+        native_adapters=[],
+        candidate_resolvers=[_MixedOutcomeResolver()],
+    )
+    candidates = [
+        EvidenceCandidate(
+            source_system="mixed",
+            entity_type="review",
+            entity_id="issue-1",
+            locator="genuinely-admissible",
+        ),
+        EvidenceCandidate(
+            source_system="mixed",
+            entity_type="review",
+            entity_id="issue-1",
+            locator="no-such-record",
+        ),
+        EvidenceCandidate(
+            source_system="mixed",
+            entity_type="review",
+            entity_id="issue-1",
+            locator="wrong-entity",
+        ),
+    ]
+    result = await service.admit(
+        org_id="org-a",
+        permission_fingerprint="allowed",
+        scope_request=_request(EntityKind.ISSUE, "issue-1"),
+        candidates=candidates,
+    )
+    admitted, no_matches, unauthorized = result.admissions
+
+    assert admitted.state is EvidenceAvailability.AVAILABLE
+    assert admitted.admitted is True
+    assert admitted.refused is False
+
+    assert no_matches.state is EvidenceAvailability.NO_MATCHES
+    assert no_matches.admitted is False
+    assert no_matches.refused is True
+
+    assert unauthorized.state is EvidenceAvailability.UNAUTHORIZED
+    assert unauthorized.admitted is False
+    assert unauthorized.refused is True
+
+    # The two refusals are for genuinely different reasons -- a consumer
+    # reading only ``.refused`` cannot tell them apart, which is correct
+    # (both are "disclose narrowly, do not retry"), but the underlying
+    # ``state`` must still be preserved distinctly for anything that DOES
+    # want the finer-grained reason (e.g. telemetry).
+    assert no_matches.state != unauthorized.state


### PR DESCRIPTION
## Issue / phase
CHAOS-3650 (Lane C's admission-side half), re-activated this cycle. **Not claiming full completion** -- the packet-level degrade-not-abort leg (`graph_arm/packet_builder.py`) is Lane D's and already merged (#1644, `bf328514b`). No follow-up PR is planned from this lane; CHAOS-3650 itself may still need a final close decision from the orchestrator once both halves are accounted for. ID intentionally omitted from branch/title per the tightened rule.

## Observable outcome
Per the C/D boundary (CHAOS-3660 comment #29: Lane C never emits anything frame-shaped; a future consumer -- most likely Lane B's assembler -- reads `EvidenceAdmissionResult`), the admission layer now exposes a single, well-defined classification for "the canonical service considered this candidate and declined it": `EvidenceAdmission.refused: bool`.

## Design
Purely additive property on the existing `EvidenceAdmission` dataclass -- no new dataclass field, no wire-shape change, no new authorization behavior:
```python
_CANONICALLY_REFUSED_STATES = frozenset(
    {EvidenceAvailability.UNAUTHORIZED, EvidenceAvailability.NO_MATCHES}
)

@property
def refused(self) -> bool:
    return self.state in _CANONICALLY_REFUSED_STATES
```
- `UNAUTHORIZED` (caller may not see it) and `NO_MATCHES` (the exact record does not exist in canon) are both "the canonical service looked at this exact candidate and declined it" -- a source-backed no, matching CHAOS-3650's own text without distinguishing why.
- `UNCONFIGURED` (no resolver wired for this `source_system` at all) is excluded -- an operational coverage gap on our side, not a canonical judgment about the record.
- `UNAVAILABLE` (resolver raised) is excluded -- transient, retry-worthy, never a considered refusal.

Posted on CHAOS-3660 for visibility/correction on the exact membership before pushing (narrowing it later, e.g. to `UNAUTHORIZED` only, is a one-line change, not structural) -- proceeding under the standing GO rather than gating on a round-trip.

## Scope / non-scope
- **In scope**: `src/dev_health_ops/api/dev/evidence_service.py` (mine exclusively), its test file.
- **Not in scope**: `packet_builder.py` (Lane D's, untouched). No new `EvidenceAvailability` member (would be a shared-vocabulary change needing its own §8 round). No consumer wiring -- no assembler exists yet to consume this; this PR is the admission-side half only.

## Base / head
Base: `feature/chaos-3498-context-fabric` @ `073f040be` (current origin tip at branch time).
Head: `1a231d59d`.

## Migrations
None.

## Security impact
None -- read-only classification of already-computed state; no authorization logic changed.

## RED-first evidence
Mutation-verified, not assumed: stubbed `.refused` to always return `False`, ran the new tests, observed both the parametrized state-membership test AND the mixed-batch acceptance-criterion test fail for the right reason, restored.

**CHAOS-3650's own acceptance criterion, proven at the admission layer with a real `service.admit()` call**: "A single refused record cannot erase unrelated valid drivers or the whole answer." Three candidates submitted in one round -- one admits, one `NO_MATCHES`, one `UNAUTHORIZED` -- every sibling resolves exactly as it would alone; `admit()`'s existing per-candidate loop already never aborts (true before this PR; the new property just names the classification a consumer can use instead of hand-rolling `state in {...}` and risking exactly the conflation this ticket warns against).

## Verification
```
.venv/bin/ruff check / format --check           # clean
.venv/bin/mypy <2 changed files>                # clean
.venv/bin/python -m pytest tests/api/dev/test_evidence_service.py -q
  # 34 passed
.venv/bin/python -m pytest tests/api/dev/ tests/context_fabric/ -q
  # 4628 passed, 142 skipped, 4 xfailed, 0 failed
```
Pre-commit hook (full-tree mypy, 2320 source files): clean.

## Known limitations
No consumer reads `.refused` yet -- Lane B's future assembler is the intended reader, per the C/D boundary ruling. This PR only ensures the classification exists and is correct; wiring is out of scope here.

## Rollout / rollback
Additive property on an already-owned type; no runtime behavior change for any existing caller. Revert is a pure file-level revert with no migration or config implications.