### PR TITLE
CHAOS-3632: remove a single document's node, promptly, on approval revocation

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -20,11 +20,25 @@ it and could not use it if they did — :meth:`GraphArmStore.for_org` derives
 it, and every read re-derives and asserts it via
 :func:`identity.assert_partition_matches_org`.
 
-**Deletion is a drop, not a sweep.** :meth:`GraphArmStore.purge_org` deletes
-the whole keyspace. There is no per-node deletion path that could leave an
-orphan, and :func:`org_deletion_visit` — the callable registered in
+**Org deletion is a drop, not a sweep.** :meth:`GraphArmStore.purge_org`
+deletes the whole keyspace in one operation with no per-node traversal that
+could miss one, and :func:`org_deletion_visit` — the callable registered in
 ``EXTERNAL_DERIVED_STORES`` — is a thin wrapper over it that honours
 ``dry_run``.
+
+**One narrow exception to "no write Cypher in this arm" (CHAOS-3632).**
+:meth:`GraphArmStore.remove_document` deletes a single document's node by its
+server-derived uuid, promptly, without waiting for a full reprojection sweep
+— required because a revoked/withdrawn document's approval is checked once,
+at projection-build time; nothing re-checks it afterward, and the node would
+otherwise sit in the graph, findable by BM25/vector search, until the next
+sweep purges it. This is the arm's only per-node write: :data:`WRITE_QUERIES`
+declares it, exactly one entry, uuid-parameterized and single-node scoped —
+``tests/context_fabric/test_chaos_3617_containment.py`` widens its
+declared-surface guard to check membership in
+``READ_ONLY_QUERIES | WRITE_QUERIES`` instead of asserting no writes exist at
+all, and separately asserts this is the only write, it takes no
+caller-supplied Cypher, and it cannot match more than one node.
 """
 
 from __future__ import annotations
@@ -34,6 +48,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import Enum
 from typing import Any
 
 from .backend import (
@@ -54,14 +69,16 @@ from .flags import (
     graph_projection_enabled,
     trial_store_config,
 )
-from .identity import assert_partition_matches_org, partition_for_org
+from .identity import assert_partition_matches_org, observation_uuid, partition_for_org
 from .projection import GraphProjection
 from .readback import NODE_COUNT_QUERY
+from .vocabulary import GraphObservationKind
 from .watermark import IndexWatermark
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "DocumentRemovalReason",
     "EmbeddingBudgetExceededError",
     "GraphArmStore",
     "GraphOperationTimeoutError",
@@ -69,11 +86,57 @@ __all__ = [
     "partition_exists_for",
     "StoreUnavailableError",
     "TRIAL_DERIVED_STORE_NAME",
+    "WRITE_QUERIES",
     "org_deletion_visit",
 ]
 
 #: The name this store registers under in ``EXTERNAL_DERIVED_STORES``.
 TRIAL_DERIVED_STORE_NAME = "context_fabric_graph_trial"
+
+#: CHAOS-3632. The arm's ONE per-node write. Deletes a single document node
+#: by its server-derived uuid -- never a caller-supplied value, see
+#: :meth:`GraphArmStore.remove_document`. ``{uuid: $uuid}`` in the node
+#: pattern (not a bare ``MATCH (n)``) is what makes this provably single-node
+#: scoped: a query that matched every node and deleted them all would still
+#: satisfy "one string, one parameter" but would not satisfy "one node," so
+#: the scoping is asserted structurally by
+#: ``test_chaos_3617_containment.py``, not merely declared here. Read via
+#: ``execute_query(..., uuid=...)`` parameter binding, never string
+#: interpolation -- interpolating a canonical id into Cypher text is exactly
+#: the injection surface a "no write Cypher" guard exists to keep out, and
+#: widening that guard for this one query must not reopen it.
+_DELETE_DOCUMENT_NODE_QUERY = (
+    "MATCH (n {uuid: $uuid}) WITH n, count(n) AS matched "
+    "DETACH DELETE n RETURN matched AS total"
+)
+
+#: Every write-capable Cypher statement the arm can issue, in one place --
+#: the write-side counterpart to ``readback.READ_ONLY_QUERIES``. Exactly one
+#: entry: see the module docstring's "one narrow exception" note.
+WRITE_QUERIES: tuple[str, ...] = (_DELETE_DOCUMENT_NODE_QUERY,)
+
+
+class DocumentRemovalReason(str, Enum):
+    """Why a document's node was removed from the graph (CHAOS-3632).
+
+    Content-safe by construction: a member's *name* is a reason code, never
+    a title, body or canonical id, because these values are meant to flow
+    into telemetry labels and structured logs where indexed prose must never
+    appear (see the acceptance text's own "instruction-shaped content never
+    becomes trusted wire content" clause -- a log line is trusted wire
+    content too).
+    """
+
+    #: The document's approval was withdrawn/revoked/redacted after it was
+    #: already written -- the load-bearing case this primitive exists for.
+    APPROVAL_REVOKED = "approval_revoked"
+    #: Organization policy no longer permits this document class/source to
+    #: be indexed at all.
+    POLICY_FORBIDDEN = "policy_forbidden"
+    #: The document was found attributed to, or attached to, an
+    #: unauthorized/foreign tenant.
+    CROSS_TENANT = "cross_tenant"
+
 
 #: CHAOS-3679. Prefix for the watermark's Redis key, on the FalkorDB client's
 #: OWN connection -- deliberately not a Cypher graph node. A graph node would
@@ -560,6 +623,74 @@ class GraphArmStore:
             operation="purge_watermark",
         )
         return total
+
+    async def remove_document(
+        self, canonical_id: str, *, reason: DocumentRemovalReason
+    ) -> bool:
+        """Remove one document's node from this partition. Returns whether
+        anything was actually removed.
+
+        CHAOS-3632's "removing approval propagates to the index" clause.
+        ``to_graphiti_document_nodes`` (CHAOS-3632, write side) only ever
+        writes a node for a document already in ``projection.approved_
+        documents`` -- but that approval is checked once, at projection-build
+        time, and nothing re-checks it afterward. A document approved when a
+        projection was built and later withdrawn, redacted or revoked stays
+        in the store, findable by BM25/vector search, until the next full
+        reprojection sweep purges it (:meth:`purge_org` is organization-wide
+        and is not a routine response to one document's status changing).
+        This closes that gap on the write side, promptly, per-document.
+
+        Deliberately NOT ``graphiti_core``'s own ``EntityNode.delete()``:
+        that method matches only nodes labelled ``Entity``, ``Episodic`` or
+        ``Community`` for the FalkorDB/Neptune driver branch (verified
+        directly against the installed ``graphiti_core`` source, not
+        assumed). A document node's label is ``CFObsDocument`` --
+        :func:`~.backend.to_graphiti_document_nodes`'s own convention -- so
+        ``EntityNode.delete()`` would silently match nothing and report
+        success while removing zero nodes. :data:`_DELETE_DOCUMENT_NODE_QUERY`
+        matches on ``uuid`` alone, label-agnostic, which is what makes it
+        correct for a label graphiti's own delete does not know about.
+
+        Idempotent: removing an already-removed or never-written canonical id
+        is a safe no-op that returns ``False``, not an error -- a caller
+        reacting to a revocation event has no reliable way to know whether an
+        earlier delivery of the same event already ran.
+
+        ``uuid`` is derived here, server-side, from this store's own
+        ``org_id`` and the caller-supplied ``canonical_id`` -- never accepted
+        as a raw uuid -- so a caller can name what to remove only by the same
+        identity the write side used to create it, never an arbitrary graph
+        address.
+
+        This is a mutation proportional to a single node lookup, not to
+        partition size, but unlike :meth:`purge_org`'s fixed-cost keyspace
+        drop it is an unindexed property match (the arm builds no index on
+        this custom label), so it is bounded under the write deadline rather
+        than the read one -- the more conservative of the two.
+        """
+
+        uuid = observation_uuid(
+            self._org_id, GraphObservationKind.DOCUMENT, canonical_id
+        )
+        result = await self._bounded_write(
+            self._driver.execute_query(_DELETE_DOCUMENT_NODE_QUERY, uuid=uuid),
+            operation="remove_document",
+        )
+        records, _, _ = result
+        removed = bool(records) and int(records[0]["total"]) > 0
+        # canonical_id is an opaque internal identifier, logged the same way
+        # org_id is logged elsewhere in this module -- never the document's
+        # title or body, which is the content-safety line the acceptance
+        # text actually draws.
+        logger.info(
+            "context-fabric graph document %s %s in partition %s (reason=%s)",
+            canonical_id,
+            "removed" if removed else "not found; no-op",
+            self._partition,
+            reason.value,
+        )
+        return removed
 
 
 async def partition_exists_for(

--- a/tests/context_fabric/test_chaos_3617_containment.py
+++ b/tests/context_fabric/test_chaos_3617_containment.py
@@ -243,15 +243,23 @@ class TestNoProductionCoupling:
         assert not offenders, offenders
 
     def test_the_declared_query_surface_is_exhaustive(self) -> None:
-        """Every Cypher string in the arm is one of the declared three.
+        """Every Cypher string in the arm is one of the declared read-only
+        queries or the one declared write query.
 
         Scanned from the AST's string *constants*, not with a text grep:
         grepping the file matches the prose in its own docstrings, which is
         how a containment check quietly becomes vacuous (or, as here,
         permanently red for the wrong reason).
+
+        CHAOS-3632 widened this from "every Cypher string is read-only" to
+        "every Cypher string is declared and auditable" -- a single-node,
+        uuid-scoped delete (:data:`store_module.WRITE_QUERIES`) is a
+        legitimate need this arm did not have before (see
+        ``TestWriteSurfaceIsNarrow`` below for what keeps that one
+        exception from becoming a general write surface).
         """
 
-        declared = set(READ_ONLY_QUERIES)
+        declared = set(READ_ONLY_QUERIES) | set(store_module.WRITE_QUERIES)
         stray: dict[str, list[str]] = {}
         for path in sorted(_ARM_ROOT.rglob("*.py")):
             for value in _string_constants(path):
@@ -299,6 +307,84 @@ class TestNoProductionCoupling:
             assert query.lstrip().upper().startswith("MATCH")
             offending = _CYPHER_WRITE.findall(query.upper())
             assert not offending, (query, offending)
+
+
+class TestWriteSurfaceIsNarrow:
+    """CHAOS-3632's one exception, kept from becoming a general write hole.
+
+    ``test_the_declared_query_surface_is_exhaustive`` above already proves
+    every write query in the arm is declared in
+    ``store_module.WRITE_QUERIES`` -- any second write string, anywhere in
+    the package, shows up there as "stray" the moment it exists. What these
+    tests add is that the ONE declared write is itself as narrow as a
+    single-node delete can be: exactly one entry, never built by
+    interpolating a caller-supplied value into Cypher text, and unable to
+    match more than the one node its uuid names.
+    """
+
+    def test_exactly_one_write_query_is_declared(self) -> None:
+        assert len(store_module.WRITE_QUERIES) == 1, (
+            "a second write query would need its own review under this "
+            "same scrutiny -- growing this list silently is exactly what "
+            "the exhaustive declaration is supposed to prevent"
+        )
+
+    def test_the_write_query_is_a_plain_constant_not_built_at_runtime(self) -> None:
+        """Parameterized via ``execute_query(..., uuid=...)``, never
+        interpolated.
+
+        Proven structurally, not by inspection: the query is one of the
+        AST's string *constants* (``ast.Constant``), which an f-string or a
+        ``.format()``/``%`` build would never be -- those parse as
+        ``ast.JoinedStr`` or a ``BinOp``/``Call`` the constant scanner in
+        this module does not walk. A query assembled by interpolating a
+        caller-supplied canonical id into Cypher text would not appear here
+        as "declared" at all -- it would be invisible to both this test and
+        the exhaustiveness scan above, which is exactly the injection
+        surface a widened "no write Cypher" guard must not reopen.
+        """
+
+        store_path = Path(store_module.__file__)
+        constants = set(_string_constants(store_path))
+        for query in store_module.WRITE_QUERIES:
+            assert query in constants, (
+                f"{query!r} is not a plain string constant declared in "
+                f"{store_path} -- if it were assembled via f-string, "
+                "format() or % at call time, it would not appear here"
+            )
+            assert "$uuid" in query, (
+                "the write query must reference its match subject through "
+                "a bound Cypher parameter ($uuid), never a literal value"
+            )
+
+    def test_the_write_query_cannot_match_more_than_one_node(self) -> None:
+        """No unscoped ``MATCH (n)``-shaped clause reaches a write query.
+
+        A node pattern with no property filter (``MATCH (n)``, no ``{...}``)
+        would match every node in the partition; ``DETACH DELETE`` on that
+        match would be a full-partition wipe wearing a single-node delete's
+        name. Every write query's node pattern must filter on ``{uuid:
+        $uuid}`` directly in the ``MATCH`` clause -- not merely reference
+        ``uuid`` somewhere later in the query text, which a ``WHERE`` clause
+        added after an unscoped ``MATCH`` would also do while still matching
+        every node up to that point.
+        """
+
+        unscoped_match = re.compile(r"MATCH\s*\(\s*[A-Za-z_]\w*\s*\)")
+        scoped_match = re.compile(
+            r"MATCH\s*\(\s*[A-Za-z_]\w*\s*\{\s*uuid\s*:\s*\$uuid\s*\}\s*\)"
+        )
+        for query in store_module.WRITE_QUERIES:
+            assert not unscoped_match.search(query), (
+                query,
+                "an unscoped MATCH (n) node pattern could match every node "
+                "in the partition",
+            )
+            assert scoped_match.search(query), (
+                query,
+                "the write query's MATCH clause must filter its node "
+                "pattern on {uuid: $uuid} directly",
+            )
 
 
 class TestTelemetryContainment:

--- a/tests/context_fabric/test_chaos_3632_document_removal.py
+++ b/tests/context_fabric/test_chaos_3632_document_removal.py
@@ -1,0 +1,357 @@
+"""CHAOS-3632: removing a document's approval propagates to the index.
+
+Slice 1 of CHAOS-3632's remaining acceptance criteria. #1665 (write side)
+only ever writes a node for an already-approved document; #1666 (read side)
+hides an untrusted document's named subjects from the observation-hop, but
+neither one removes the node itself once it has been written. A document
+approved when a projection was built and later withdrawn, redacted or
+revoked stays in the store -- findable by BM25 and vector search, its title
+still surfacing as a genuine ``observation_hits`` retrieval hit -- until the
+next full reprojection sweep purges the whole partition.
+
+``GraphArmStore.remove_document`` (``store.py``) closes that: a targeted,
+uuid-scoped delete of one document's node, promptly, without touching
+anything else in the partition. These are the live tests -- the ones that
+can fail because Cypher or FalkorDB disagrees with what the code claims,
+which no in-memory test can measure.
+
+Also proves, against a real FalkorDB, the specific gotcha that ruled out
+reusing ``graphiti_core``'s own ``EntityNode.delete()``: that method matches
+only ``Entity``/``Episodic``/``Community`` labels for the FalkorDB driver
+branch, and a document node is labelled ``CFObsDocument`` -- so it would
+silently match nothing. ``remove_document``'s own uuid-only match pattern is
+what makes it correct for a label graphiti's delete does not know about.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from dev_health_ops.context_fabric.graph_arm import build_projection, fixtures
+from dev_health_ops.context_fabric.graph_arm.backend import graphiti_module
+from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    wait_for_fulltext_index,
+)
+from dev_health_ops.context_fabric.graph_arm.store import (
+    DocumentRemovalReason,
+    GraphArmStore,
+)
+from tests.context_fabric import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+#: The one approved document in ``fixtures.alpha_batch()`` -- see
+#: ``test_chaos_3632_document_writer.py`` for the same fixture used at the
+#: unit level. Its twin, ``doc_unapproved_thread``, is never approved and so
+#: never reaches a node at all -- exercised below as the "never written"
+#: no-op case, distinct from "written, then removed."
+_APPROVED_DOCUMENT_ID = "doc_nfm_readme"
+_NEVER_APPROVED_DOCUMENT_ID = "doc_unapproved_thread"
+_APPROVED_DOCUMENT_TITLE_PROBE = "Nightfall Migration design note"
+
+
+def _unique_org(prefix: str) -> str:
+    return f"{prefix}{uuid.uuid4().hex[:12]}"
+
+
+def _reorg(batch, org_id: str):
+    def rebind(record):
+        return dataclasses.replace(record, org_id=org_id)
+
+    return dataclasses.replace(
+        batch,
+        org_id=org_id,
+        entities=tuple(rebind(item) for item in batch.entities),
+        relationships=tuple(rebind(item) for item in batch.relationships),
+        observations=tuple(rebind(item) for item in batch.observations),
+        documents=tuple(rebind(item) for item in batch.documents),
+    )
+
+
+@pytest_asyncio.fixture
+async def alpha_store(monkeypatch) -> AsyncIterator[GraphArmStore]:
+    config = live_gate.require_live_store()
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+    live_gate.require_flag_state()
+
+    org_id = _unique_org("orgdocremoval")
+    projection = build_projection(_reorg(fixtures.alpha_batch(), org_id))
+    store = GraphArmStore.for_org(org_id, config=config)
+    try:
+        await store.build_indices()
+        await store.write_projection(projection)
+        yield store
+    finally:
+        try:
+            await store.purge_org()
+        finally:
+            await store.close()
+
+
+class TestRemovingTheApprovedDocument:
+    async def test_removal_deletes_exactly_one_node(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        before = await alpha_store.count_nodes()
+
+        removed = await alpha_store.remove_document(
+            _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+
+        assert removed is True
+        after = await alpha_store.count_nodes()
+        assert after == before - 1, (
+            "removing one document must change the node count by exactly "
+            "one -- more would mean the delete was not single-node scoped, "
+            "fewer would mean nothing was actually removed"
+        )
+
+    async def test_removal_is_idempotent(self, alpha_store: GraphArmStore) -> None:
+        first = await alpha_store.remove_document(
+            _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+        after_first = await alpha_store.count_nodes()
+
+        second = await alpha_store.remove_document(
+            _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+        after_second = await alpha_store.count_nodes()
+
+        assert first is True
+        assert second is False, (
+            "a second removal of an already-removed document must be a "
+            "safe no-op, not an error -- a caller reacting to a revocation "
+            "event has no reliable way to know an earlier delivery of the "
+            "same event already ran"
+        )
+        assert after_second == after_first, "the second call must delete nothing"
+
+    async def test_removal_logs_the_canonical_id_and_reason_code(
+        self, alpha_store: GraphArmStore, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.INFO):
+            await alpha_store.remove_document(
+                _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.POLICY_FORBIDDEN
+            )
+        messages = [record.message for record in caplog.records]
+        assert any(
+            _APPROVED_DOCUMENT_ID in message and "policy_forbidden" in message
+            for message in messages
+        ), messages
+
+
+class TestRemovingAnAbsentDocument:
+    async def test_a_never_approved_document_is_a_safe_no_op(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        """``doc_unapproved_thread`` never reached a node in the first
+        place (#1665's write-side approval gate) -- removing it must be
+        indistinguishable from removing anything else that was never
+        written, not a special "wasn't there to begin with" error.
+        """
+
+        before = await alpha_store.count_nodes()
+
+        removed = await alpha_store.remove_document(
+            _NEVER_APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+
+        assert removed is False
+        assert await alpha_store.count_nodes() == before
+
+    async def test_an_unrelated_canonical_id_is_a_safe_no_op(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        before = await alpha_store.count_nodes()
+
+        removed = await alpha_store.remove_document(
+            "doc_never_existed_at_all", reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+
+        assert removed is False
+        assert await alpha_store.count_nodes() == before
+
+
+class TestCrossTenantIsolation:
+    async def test_removal_in_one_partition_does_not_touch_another(
+        self, monkeypatch
+    ) -> None:
+        """Positive AND negative control in one test: org B's identically
+        named document survives org A's removal untouched, and org A's own
+        removal still took effect -- so this cannot pass by the delete
+        being a global no-op.
+        """
+
+        config = live_gate.require_live_store()
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+        live_gate.require_flag_state()
+
+        org_a = _unique_org("orgdocremovala")
+        org_b = _unique_org("orgdocremovalb")
+        store_a = GraphArmStore.for_org(org_a, config=config)
+        store_b = GraphArmStore.for_org(org_b, config=config)
+        try:
+            await store_a.build_indices()
+            await store_b.build_indices()
+            await store_a.write_projection(
+                build_projection(_reorg(fixtures.alpha_batch(), org_a))
+            )
+            await store_b.write_projection(
+                build_projection(_reorg(fixtures.alpha_batch(), org_b))
+            )
+            before_b = await store_b.count_nodes()
+
+            removed_in_a = await store_a.remove_document(
+                _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+            )
+
+            assert removed_in_a is True
+            assert await store_b.count_nodes() == before_b, (
+                "org A's removal must not affect org B's identically "
+                "canonical-id'd document -- each store handle is bound to "
+                "its own FalkorDB keyspace (database=partition), and the "
+                "uuid itself is org-scoped by identity.observation_uuid's "
+                "own hash construction"
+            )
+            # Negative control on B, using the SAME removal call: proves
+            # the still-present document really is removable in principle,
+            # so B's survival above is isolation, not a broken delete.
+            removed_in_b = await store_b.remove_document(
+                _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+            )
+            assert removed_in_b is True
+        finally:
+            try:
+                await store_a.purge_org()
+            finally:
+                await store_b.purge_org()
+                await store_a.close()
+                await store_b.close()
+
+
+class TestPurgeOrgComposesWithATargetedRemoval:
+    async def test_purge_after_removal_deletes_exactly_what_remains(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        """The registered-deletion-visit machinery (org_deletion_visit ->
+        purge_org) must still see and delete the correct count after a
+        targeted removal already ran -- proving the two deletion paths
+        compose rather than one leaving the other's bookkeeping stale.
+        """
+
+        await alpha_store.remove_document(
+            _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+        remaining = await alpha_store.count_nodes()
+
+        deleted = await alpha_store.purge_org()
+
+        assert deleted == remaining
+        assert await alpha_store.count_nodes() == 0
+
+
+class TestReadSidePromptness:
+    async def test_a_removed_document_is_no_longer_bm25_searchable(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        """Index -> delete -> search returns nothing. The positive control
+        (index) is not optional: without it, a search that never worked in
+        the first place would pass this test by measuring nothing.
+        """
+
+        await wait_for_fulltext_index(
+            alpha_store,
+            probe_query=_APPROVED_DOCUMENT_TITLE_PROBE,
+            expected_canonical_id=_APPROVED_DOCUMENT_ID,
+        )
+
+        await alpha_store.remove_document(
+            _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+
+        search_utils = graphiti_module("search.search_utils")
+        search_filters = graphiti_module("search.search_filters")
+        nodes = await search_utils.node_fulltext_search(
+            alpha_store.driver,
+            _APPROVED_DOCUMENT_TITLE_PROBE,
+            search_filters.SearchFilters(),
+            [alpha_store.partition],
+            25,
+        )
+        found_ids = {
+            node.attributes.get("cf_canonical_id")
+            for node in nodes
+            if getattr(node, "attributes", None)
+        }
+        assert _APPROVED_DOCUMENT_ID not in found_ids, (
+            "the removed document's title is still BM25-searchable after "
+            "remove_document -- 'removed or excluded PROMPTLY' does not "
+            "hold"
+        )
+
+    async def test_a_removed_document_is_no_longer_vector_searchable(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        """Same proof over cosine similarity. Uses the store's own embedder
+        (``DeterministicEmbedder`` in this live fixture) to reproduce the
+        exact vector the write side computed from the document's body --
+        deterministic and reproducible, so no live LLM call is needed to
+        prove this half of "BM25/vector retrieval must not return the
+        node."
+        """
+
+        document = next(
+            doc
+            for doc in fixtures.alpha_batch().documents
+            if doc.canonical_id == _APPROVED_DOCUMENT_ID
+        )
+        query_vector = await alpha_store.embedder.create(
+            input_data=[document.body.replace("\n", " ")]
+        )
+
+        search_utils = graphiti_module("search.search_utils")
+        search_filters = graphiti_module("search.search_filters")
+        before_nodes = await search_utils.node_similarity_search(
+            alpha_store.driver,
+            query_vector,
+            search_filters.SearchFilters(),
+            [alpha_store.partition],
+            25,
+        )
+        before_ids = {
+            node.attributes.get("cf_canonical_id")
+            for node in before_nodes
+            if getattr(node, "attributes", None)
+        }
+        assert _APPROVED_DOCUMENT_ID in before_ids, (
+            "the positive control failed: the document's own body-derived "
+            "vector does not find it before removal, so absence after "
+            "removal would prove nothing"
+        )
+
+        await alpha_store.remove_document(
+            _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+
+        after_nodes = await search_utils.node_similarity_search(
+            alpha_store.driver,
+            query_vector,
+            search_filters.SearchFilters(),
+            [alpha_store.partition],
+            25,
+        )
+        after_ids = {
+            node.attributes.get("cf_canonical_id")
+            for node in after_nodes
+            if getattr(node, "attributes", None)
+        }
+        assert _APPROVED_DOCUMENT_ID not in after_ids, (
+            "the removed document is still vector-searchable by its own "
+            "body-derived embedding after remove_document"
+        )


### PR DESCRIPTION
## Issue / phase
CHAOS-3632, slice 1 of the remaining acceptance criteria (write side #1665 and read side #1666 are merged; production config, telemetry, retention/deletion, audit and docs are still open). This PR is the retention/deletion slice: "removing approval propagates to the index." Plain reference, not close-linked -- CHAOS-3632 spans multiple PRs and stays open after this merges. Branch is deliberately ID-free per the standing rule.

## Observable outcome
Before this PR: a document's approval was checked once, at projection-build time (`build_projection`), and nothing re-checked it afterward. A document approved when a projection was built and later withdrawn, redacted or revoked stayed in the graph -- findable by BM25 and vector search, its title still surfacing as a genuine `observation_hits` retrieval hit (#1666 only gates whether its *named subjects* resolve as hop candidates, not whether the node itself is returned) -- until the next full reprojection sweep purged the whole partition.

After this PR: `GraphArmStore.remove_document(canonical_id, reason=...)` deletes exactly that document's node, immediately, without touching anything else in the partition. Verified live: index the document, confirm it's BM25/vector-searchable (positive control), remove it, confirm both searches return nothing.

## Architecture boundary
This is the arm's first per-node write, which collided with an existing invariant: `test_chaos_3617_containment.py` asserted the entire `context_fabric` package contains zero write/maintenance Cypher anywhere (true until now -- org-level `purge_org` uses the FalkorDB client's native keyspace `.delete()`, never a Cypher string; there is no non-Cypher way to delete a single node by uuid, confirmed directly against the FalkorDB client's own API surface).

Resolved by proposal, not by unilateral edit: I flagged the collision to the orchestrator before touching the guard, proposed widening its shape rather than dropping it, and D (owner of the read side this composes with) got a parallel objection window before I pushed -- closed with no objection.

The widened invariant: **every Cypher string in the arm is declared and auditable, and every write is provably single-node, server-derived-id scoped** -- not "no writes exist." `store.WRITE_QUERIES` declares exactly one entry, the write-side counterpart to `readback.READ_ONLY_QUERIES`:

```cypher
MATCH (n {uuid: $uuid}) WITH n, count(n) AS matched
DETACH DELETE n RETURN matched AS total
```

`test_the_declared_query_surface_is_exhaustive` now checks membership in `READ_ONLY_QUERIES | WRITE_QUERIES` (so a second, undeclared write string anywhere in the package still fails it -- proven below, not assumed). A new `TestWriteSurfaceIsNarrow` class asserts:
- exactly one write query is declared;
- it is a plain AST string **constant**, not built via f-string/`.format()`/`%` at runtime -- structural, not by inspection: an interpolated query would parse as `ast.JoinedStr`/`Call`, not `ast.Constant`, and would be invisible to the whole scan, not merely "undeclared." Interpolating a caller-supplied canonical id into Cypher text is exactly the injection surface a widened "no write Cypher" guard must not reopen;
- it cannot match more than one node -- no unscoped `MATCH (n)` pattern; the node pattern must filter on `{uuid: $uuid}` directly in the `MATCH` clause.

**Why not `graphiti_core`'s own `EntityNode.delete()`:** verified directly against the installed source (not assumed) -- that method matches only nodes labelled `Entity`, `Episodic` or `Community` on the FalkorDB driver branch. A document node is labelled `CFObsDocument` (`to_graphiti_document_nodes`'s own convention, #1665), so `EntityNode.delete()` would silently match nothing and report success while removing zero nodes. The new query matches on `uuid` alone, label-agnostic -- which is what makes it correct for a label graphiti's own delete does not know about, and the live suite proves the delete actually removes the node (a label-mismatched no-op could not pass those tests).

**Why not a soft-delete/tombstone** (set a removal attribute, filter on read, ride through graphiti_core's existing bulk-write path with no new Cypher string at all): considered and rejected. Post-#1666 a revoked document's node still surfaces as a genuine retrieval hit -- "removed or excluded PROMPTLY" needs the node itself gone from what BM25/vector search can return, not another read-side filter layered on top of #1666's.

## Scope / non-scope
**In scope:** the `remove_document` primitive; the containment-guard widening it required; live proof of single-node scoping, idempotency, cross-tenant isolation, composition with `purge_org`, and read-side (BM25 + vector) promptness.

**Not in scope:** wiring `remove_document` to an actual revocation-event source (corpus adapter, admission service, or similar) -- no such caller exists yet in this codebase; this PR is the primitive only. Also not in scope: telemetry counters and the audit query (CHAOS-3632's remaining slices 2/3).

## Base / head SHA
Base: `bf1ef8c67` (`origin/feature/chaos-3498-context-fabric`)
Head: `20f472b3b`

## Migrations
None.

## Security / privacy
`remove_document` takes a `canonical_id`; the uuid it deletes by is derived server-side from this store's own `org_id` (`identity.observation_uuid`), never accepted as a raw graph address -- a caller can name what to remove only through the same identity the write side used to create it. Content-safe logging: `DocumentRemovalReason` members are reason codes only (never a title, body or canonical id baked into the enum itself); the log line does carry the canonical id, the same class of opaque identifier `org_id` is already logged as elsewhere in this module -- never title or body.

## RED-first evidence
Two separate observations, both reverted before commit (`git diff --stat` confirmed clean each time):

1. **The containment guard's widened shape.** Planted an unscoped `MATCH (n) ... DETACH DELETE n` variant of the write query -- `test_the_write_query_is_a_plain_constant_not_built_at_runtime` and `test_the_write_query_cannot_match_more_than_one_node` failed with the exact expected messages. Separately planted a second, undeclared write string in an unrelated module (`admission.py`) -- `test_the_declared_query_surface_is_exhaustive` flagged it as stray.
2. **`remove_document` itself.** Stubbed it to skip the query entirely and always report "not found" -- 5 of the 9 new live tests failed with their intended messages (single-node count delta, idempotency, the cross-tenant positive control, BM25 promptness, vector promptness). The 4 that stayed green are exactly the ones that assert no-op behavior on an absent/never-approved document or check log content alone -- correctly insensitive to whether a real delete happened, not a blind spot in the new tests.

## Verification
Live, against a real running FalkorDB (`dev-health-ops-graph-trial-store`, `docker compose --profile graph-trial`):
- New `tests/context_fabric/test_chaos_3632_document_removal.py`, 9 tests: exact single-node delete count; idempotent removal; safe no-op on a never-approved document (never reached a node in the first place, per #1665's own write-side gate) and on an unrelated canonical id; cross-tenant isolation with a positive control proving the still-present document in the *other* partition really is removable (so its survival is isolation, not a broken delete); composition with `purge_org`/`org_deletion_visit`'s registered-deletion-visit machinery after a targeted removal; BM25 promptness (`wait_for_fulltext_index` as the positive control, so a search that never worked cannot pass this test by measuring nothing); vector-search promptness, using the store's own embedder to reproduce the exact write-time vector so no live LLM call is needed.
- Full `tests/context_fabric/` suite: 1590 passed, 2 failed -- the same `test_chaos_3647_live_semantic.py` failures already isolated as pre-existing and unrelated (live OpenAI-embedding-API drift) via stash comparison in #1665.
- `ruff format --check` / `ruff check` -- clean. `mypy` (worktree venv) -- `Success: no issues found in 2321 source files`.

## Known limitations
- `remove_document` is an unindexed property match (the arm builds no index on the `CFObsDocument` label), so its cost scales with partition size, unlike `purge_org`'s fixed-cost keyspace drop -- acceptable at trial scale, noted in the docstring, not something this PR optimizes.
- No production caller invokes this yet (see Scope). The primitive is proven correct and safe to wire up; the event source that should call it is a separate, unscoped piece of work.

## Rollout / rollback
No schema/config change, no new flag. `remove_document` is additive -- nothing calls it yet, so this PR has no observable effect on any existing trial run. Safe to revert independently; the containment-guard widening reverts cleanly alongside it since nothing else depends on `WRITE_QUERIES` existing.