### PR TITLE
Add cohort-discovery-family classification signal for the graph seam

### DIFF
--- a/src/dev_health_ops/api/dev/graph_investigation_query.py
+++ b/src/dev_health_ops/api/dev/graph_investigation_query.py
@@ -64,11 +64,51 @@ from .contracts_v2.subject import DevSubjectMention
 from .investigation_contract import AskDevInvestigationPacket
 
 __all__ = [
+    "CohortDiscoveryFamily",
     "GraphInvestigationRequest",
     "GraphQueryOutcome",
     "GraphQueryResult",
     "GraphInvestigationQuery",
 ]
+
+
+class CohortDiscoveryFamily(StrEnum):
+    """The production-side classification signal for a ``DISCOVERED_COHORT``
+    question -- CHAOS-3689 design round (proposed/signed off on CHAOS-3660).
+
+    ``cohort_discovery.discover_cohort`` requires a ``QuestionFamilyID`` to
+    select its candidate-kind universe (``FAMILY_CANDIDATE_KINDS``) and
+    corroboration metric set (``FAMILY_PRESSURE_METRICS``, CHAOS-3667's
+    held-out gate) -- a single ``QuestionIntentID`` value cannot carry that.
+    This is production's OWN closed vocabulary for the signal, deliberately
+    not a reuse of the trial's ten-member ``QuestionFamilyID`` -- Lane A's
+    ``ProductionGraphInvestigationQuery`` maps each member here to a
+    ``QuestionFamilyID`` representative via its own closed, exhaustive
+    table (never a default branch).
+
+    Deliberately two members, not five. Of the five subjectless-capable
+    trial families, ``STRUGGLING_TEAMS`` and ``PRESSURE_SIGNALS`` are
+    structurally identical to ``discover_cohort`` -- same candidate kind
+    (``{TEAM}``), same seven-metric corroboration set, and for a
+    ``DISCOVERED_COHORT``/``ORGANIZATION_WIDE`` request both permit
+    ``(DISCOVERED_COHORT, PORTFOLIO_WIDE)`` -- so collapsing them here loses
+    no observable behavior; it recognizes a real equivalence class, not a
+    guess. ``PORTFOLIO_DEPENDENCY_RISK``/``DECLARED_VERSUS_ACTUAL`` have NO
+    lexical coverage in ``question_interpreter``'s ``cohort.discovery``
+    recognizer today -- adding anchors for them is a separate, future,
+    measured pass (explicitly out of this round's "no corpus tuning"
+    scope), not represented here. A question that would need one of those
+    two families classifies as ``None`` (unclassifiable) today, exactly
+    like any other question this recognizer doesn't yet cover.
+    """
+
+    #: STRUGGLING_TEAMS / PRESSURE_SIGNALS (equivalent for this call shape,
+    #: see class docstring). Team-kind candidates, pressure-metric
+    #: corroboration.
+    TEAM_PRESSURE = "team_pressure"
+    #: PROJECT_CAPACITY. Project-kind candidates, capacity-metric
+    #: corroboration.
+    PROJECT_CAPACITY = "project_capacity"
 
 
 class GraphQueryOutcome(StrEnum):
@@ -116,9 +156,10 @@ class GraphInvestigationRequest:
     run_id: str
     #: Production's own interpreted intent (now including
     #: ``QuestionIntentID.DISCOVERED_COHORT``, CHAOS-3652) and its cardinality.
-    #: The graph service classifies its own internal job/family from these
-    #: plus ``question_text`` -- production does not hand it a pre-classified
-    #: trial family.
+    #: For everything except cohort-family selection, the graph service
+    #: classifies its own internal job/shape from these two fields alone --
+    #: see ``cohort_discovery_family`` below for the one signal these two
+    #: cannot carry (CHAOS-3689).
     intent_id: QuestionIntentID
     cardinality: Cardinality
     #: Already-extracted mentions (resolved or not -- resolution status is
@@ -128,11 +169,13 @@ class GraphInvestigationRequest:
     #: ``DevQuestionIntent.validate_intent_invariants``).
     mentions: tuple[DevSubjectMention, ...]
     #: The bounded (<=8KiB per ``DevMessageRequestV2``), already-validated
-    #: question text. Needed for the graph service's own family/candidate
-    #: classification. Server-side/internal only -- never echoed back
+    #: question text. Server-side/internal only -- never echoed back
     #: verbatim into a packet field a consumer renders untrusted (mirrors
     #: the existing "no raw question text in logs/traces/labels" guardrail;
-    #: this is a same-process/internal call, not a log).
+    #: this is a same-process/internal call, not a log). Per the CHAOS-3660
+    #: determination, the query service does not inspect this to classify
+    #: (see ``mechanism_for``'s own docstring) -- it is carried for the
+    #: mechanism's own downstream matching needs, not for classification.
     question_text: str
     #: Supplied, never derived (see module docstring). The graph route must
     #: never return, rank, or count toward truncation any entity outside
@@ -150,6 +193,18 @@ class GraphInvestigationRequest:
     #: native-arm answer for the same run are bounded identically.
     window_start: datetime
     window_end: datetime
+    #: The one production-derived classification signal this seam carries
+    #: (CHAOS-3689/CHAOS-3660) -- present only because ``(intent_id,
+    #: cardinality)`` cannot select a ``discover_cohort`` candidate-kind/
+    #: metric-family pair by itself. Supplied by the orchestrator's own
+    #: interpreter-level classification
+    #: (``question_interpreter.classify_cohort_discovery_family``), never
+    #: derived here. There is no "unclassifiable" member on
+    #: ``CohortDiscoveryFamily`` -- the orchestrator never constructs a
+    #: request for a question it could not classify (see the routing
+    #: branch's own gate), so this field is never ambiguous by the time it
+    #: reaches this seam.
+    cohort_discovery_family: CohortDiscoveryFamily
     #: Absolute wall-clock deadline (CHAOS-3631). The query service must
     #: return ``GraphQueryOutcome.DEADLINE_EXCEEDED`` rather than block past
     #: this, under any internal retry/backoff it performs.

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -147,6 +147,7 @@ from .qua_promotion import (
     verify_still_authorized,
 )
 from .qua_shadow import QUAShadowRecord, QuestionUnderstandingShadow
+from .question_interpreter import classify_cohort_discovery_family
 from .scope_service import MAX_CANDIDATES, ScopeResolutionService
 from .status_answer_render import (
     build_deterministic_status_claims,
@@ -2821,10 +2822,20 @@ class DevOrchestrator:
             # org feature is on, production_runtime.py's job) and the
             # runtime kill switch are required -- independent gates, same
             # shape as every other flag pair in this file.
+            #
+            # CHAOS-3689/CHAOS-3660: computed unconditionally (cheap, pure
+            # lexical matching, no side effects) rather than gated behind
+            # the other conditions -- it must be known before the `if`
+            # below since it is itself one of the gates: an honestly
+            # unclassifiable question (``None``) means the graph seam is
+            # never called at all, exactly like any other gate failure --
+            # never a guess passed across the wire.
+            cohort_discovery_family = classify_cohort_discovery_family(request.question)
             if (
                 preflight_result is not None
                 and preflight_result.interpretation.intent.intent_id
                 is QuestionIntentID.DISCOVERED_COHORT
+                and cohort_discovery_family is not None
                 and self._graph_investigation_query is not None
                 and self._evidence_service is not None
                 and graph_routing_runtime_enabled()
@@ -2859,6 +2870,9 @@ class DevOrchestrator:
                     # bounded identically.
                     window_start=authorized_scope.time_range.start,
                     window_end=authorized_scope.time_range.end,
+                    # CHAOS-3689: non-None by construction -- the gate above
+                    # never enters this block when classification failed.
+                    cohort_discovery_family=cohort_discovery_family,
                     deadline=graph_deadline,
                 )
                 graph_result = await self._graph_investigation_query.investigate(

--- a/src/dev_health_ops/api/dev/question_interpreter.py
+++ b/src/dev_health_ops/api/dev/question_interpreter.py
@@ -62,6 +62,7 @@ from .contracts_v2 import (
     EntityKind,
     QuestionIntentID,
 )
+from .graph_investigation_query import CohortDiscoveryFamily
 from .metrics.definitions import METRIC_REGISTRY
 
 __all__ = [
@@ -74,6 +75,7 @@ __all__ = [
     "IntentClassifier",
     "InterpretedQuestion",
     "QuestionInterpreter",
+    "classify_cohort_discovery_family",
     "count_mention_candidates",
     "extract_mentions",
 ]
@@ -869,6 +871,32 @@ _COHORT_DISCOVERY_JUDGMENT_ANCHORS = _any_of(
     "unusually lightly loaded",
     "lightly loaded",
 )
+#: CHAOS-3689: family-classification sub-groups for
+#: ``classify_cohort_discovery_family``, split out of the two anchor groups
+#: above by kind -- the SAME phrase lists, zero new lexical surface (per
+#: this round's "no corpus tuning" constraint). Subject anchors split into
+#: TEAM / PROJECT / unclassifiable-on-purpose: ``repo``/``repos``/
+#: ``repository``/``repositories``/``service``/``services`` are deliberately
+#: NOT folded into PROJECT -- ``GraphEntityKind`` has distinct
+#: ``REPOSITORY``/``SERVICE`` members, and ``cohort_discovery.
+#: FAMILY_CANDIDATE_KINDS`` never maps any family to either, so a question
+#: naming them cannot be satisfied by ``discover_cohort`` regardless of
+#: family choice — honestly unclassifiable, not a guess. Judgment anchors
+#: split into PRESSURE (mirrors the trial's ``STRUGGLING_TEAMS``/
+#: ``PRESSURE_SIGNALS`` phrasing) / CAPACITY (mirrors ``PROJECT_CAPACITY``'s
+#: own "capacity-constrained... unusually lightly loaded" phrasing
+#: near-verbatim).
+_COHORT_DISCOVERY_TEAM_SUBJECT_ANCHORS = _any_of("team", "teams", "squad", "squads")
+_COHORT_DISCOVERY_PROJECT_SUBJECT_ANCHORS = _any_of("project", "projects")
+_COHORT_DISCOVERY_PRESSURE_JUDGMENT_ANCHORS = _any_of(
+    "struggling", "struggle", "falling behind", "underperforming"
+)
+_COHORT_DISCOVERY_CAPACITY_JUDGMENT_ANCHORS = _any_of(
+    "capacity-constrained",
+    "capacity constrained",
+    "unusually lightly loaded",
+    "lightly loaded",
+)
 _RANKING_ANCHORS = _any_of(
     "top ",
     "most ",
@@ -1015,6 +1043,48 @@ _RECOGNIZERS: tuple[_Recognizer, ...] = (
         ),
     ),
 )
+
+
+def classify_cohort_discovery_family(
+    question_text: str,
+) -> CohortDiscoveryFamily | None:
+    """CHAOS-3689/CHAOS-3660: the one closed-vocabulary classification signal
+    a ``DISCOVERED_COHORT`` question carries beyond ``(intent_id,
+    cardinality)`` -- see ``CohortDiscoveryFamily``'s own docstring
+    (``graph_investigation_query.py``) for why this exists and why it has
+    only two members.
+
+    Intended to be called only after the ``cohort.discovery`` recognizer has
+    already matched (i.e. at least one subject anchor and one judgment
+    anchor are already known present) -- this just identifies WHICH ones,
+    reusing the exact same, already-measured phrase lists (split into
+    sub-groups above, not new lexical surface).
+
+    Requires an EXCLUSIVE match on both axes -- exactly one subject kind and
+    exactly one judgment kind -- before committing to a family. Returns
+    ``None`` (honestly unclassifiable) for everything else: a mixed subject
+    ("teams and projects"), a mixed judgment, a cross-mismatch
+    ``FAMILY_CANDIDATE_KINDS`` cannot satisfy (e.g. "teams" +
+    "capacity-constrained" -- ``TEAM_PRESSURE`` requires a pressure
+    judgment, ``PROJECT_CAPACITY`` requires a project subject), or a
+    repo/service subject (``GraphEntityKind.REPOSITORY``/``SERVICE`` are
+    distinct from ``PROJECT``; no family maps to either). The caller
+    (orchestrator's routing branch) never invokes the graph seam at all when
+    this returns ``None`` -- an honest miss here falls back to the existing
+    legacy loop exactly like any other unclassified question, never a
+    guess.
+    """
+
+    normalized = _normalize(question_text)
+    is_team = _COHORT_DISCOVERY_TEAM_SUBJECT_ANCHORS(normalized)
+    is_project = _COHORT_DISCOVERY_PROJECT_SUBJECT_ANCHORS(normalized)
+    is_pressure = _COHORT_DISCOVERY_PRESSURE_JUDGMENT_ANCHORS(normalized)
+    is_capacity = _COHORT_DISCOVERY_CAPACITY_JUDGMENT_ANCHORS(normalized)
+    if is_team and not is_project and is_pressure and not is_capacity:
+        return CohortDiscoveryFamily.TEAM_PRESSURE
+    if is_project and not is_team and is_capacity and not is_pressure:
+        return CohortDiscoveryFamily.PROJECT_CAPACITY
+    return None
 
 
 def _cardinality_for(mention_count: int) -> Cardinality:

--- a/tests/api/dev/test_chaos_3502_graph_investigation_query.py
+++ b/tests/api/dev/test_chaos_3502_graph_investigation_query.py
@@ -15,6 +15,7 @@ import pytest
 
 from dev_health_ops.api.dev.contracts_v2.base import Cardinality, QuestionIntentID
 from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
     GraphInvestigationQuery,
     GraphInvestigationRequest,
     GraphQueryOutcome,
@@ -40,6 +41,9 @@ def _request(
         authorized_entity_ids=authorized_entity_ids,
         window_start=datetime(2026, 5, 12, 0, 0, tzinfo=UTC),
         window_end=datetime(2026, 8, 10, 0, 0, tzinfo=UTC),
+        # CHAOS-3689: matches the question text above -- "teams... struggling"
+        # is exactly the TEAM_PRESSURE pairing.
+        cohort_discovery_family=CohortDiscoveryFamily.TEAM_PRESSURE,
         deadline=datetime(2026, 8, 10, 0, 0, tzinfo=UTC),
     )
 

--- a/tests/api/dev/test_chaos_3502_graph_routing_branch.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_branch.py
@@ -34,7 +34,10 @@ from dev_health_ops.api.dev.evidence_service import (
     EvidenceReferenceSigner,
     EvidenceService,
 )
-from dev_health_ops.api.dev.graph_investigation_query import GraphQueryOutcome
+from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphQueryOutcome,
+)
 from dev_health_ops.api.dev.orchestrator import GRAPH_ROUTING_RUNTIME_FLAG
 from dev_health_ops.api.dev.orchestrator_states import RunState
 from dev_health_ops.metrics.prometheus import ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL
@@ -46,8 +49,20 @@ from tests._chaos_3502_graph_investigation_fake import FakeGraphInvestigationQue
 #: anchor "teams" + judgment anchor "struggling", CHAOS-3652) resolves this
 #: to ``QuestionIntentID.DISCOVERED_COHORT`` /
 #: ``Cardinality.ORGANIZATION_WIDE`` through the real preflight pipeline --
-#: never asserted by construction here, only by driving the real seam.
+#: never asserted by construction here, only by driving the real seam. Also
+#: an exclusive (TEAM, PRESSURE) pairing (CHAOS-3689), so
+#: ``classify_cohort_discovery_family`` resolves it to ``TEAM_PRESSURE``.
 _DISCOVERED_COHORT_QUESTION = "Which teams are struggling right now?"
+
+#: CHAOS-3689: still recognized as ``DISCOVERED_COHORT`` by the ``cohort.
+#: discovery`` recognizer (its own subject anchors are an undifferentiated
+#: union -- "team"/"teams" OR "project"/"projects" both satisfy it) but a
+#: mixed subject for family classification -- both TEAM and PROJECT anchors
+#: present, so neither exclusive pairing is satisfied. Verified directly
+#: (not guessed): the real interpreter resolves this to
+#: ``QuestionIntentID.DISCOVERED_COHORT`` with zero mentions, while
+#: ``classify_cohort_discovery_family`` returns ``None``.
+_UNCLASSIFIABLE_COHORT_QUESTION = "Which teams and projects are struggling?"
 
 _EVIDENCE_SIGNING_SECRET = "chaos-3502-branch-test-secret-at-least-32-bytes"
 
@@ -221,6 +236,77 @@ async def test_flag_off_is_byte_identical_to_collaborators_never_wired(
         entities=[],
         org_id=ORG_ID,
         script_id="chaos3502-flag-off",
+    )
+
+    assert with_collaborators.outcome_tuple() == without_collaborators.outcome_tuple()
+
+
+@pytest.mark.asyncio
+async def test_the_request_carries_the_classified_cohort_discovery_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3689: the routing branch populates ``GraphInvestigationRequest.
+    cohort_discovery_family`` from ``question_interpreter.
+    classify_cohort_discovery_family`` -- supplied, not re-derived by the
+    seam (same "supplied, never invented" posture as ``authorized_entity_ids``/
+    ``window_start``/``window_end``).
+    """
+
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    fake = FakeGraphInvestigationQuery(outcome=GraphQueryOutcome.DISABLED)
+
+    await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3689-family",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+    )
+
+    assert len(fake.received_requests) == 1
+    assert (
+        fake.received_requests[0].cohort_discovery_family
+        is CohortDiscoveryFamily.TEAM_PRESSURE
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unclassifiable_cohort_question_never_calls_the_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3689: an honest ``None`` classification gates the routing
+    branch itself -- the graph seam is never invoked at all, exactly like
+    every other gate failure (flag off, missing collaborator). The run
+    still completes via the legacy loop, and is byte-identical
+    (``RunOutput.outcome_tuple()``) to a run with the graph collaborators
+    never wired at all, mirroring the flag-off inertness test above.
+    """
+
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    fake = FakeGraphInvestigationQuery(outcome=GraphQueryOutcome.COMPLETED)
+
+    with_collaborators = await run_preflight_orchestrator(
+        question=_UNCLASSIFIABLE_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3689-unclassifiable",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+    )
+    assert fake.received_requests == [], (
+        "an unclassifiable cohort-discovery family must mean the graph seam "
+        "is never called, even though both collaborators are wired and the "
+        "flag is on"
+    )
+    assert with_collaborators.result.state is not RunState.FAILED
+    assert with_collaborators.result.answer is not None
+
+    without_collaborators = await run_preflight_orchestrator(
+        question=_UNCLASSIFIABLE_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3689-unclassifiable",
     )
 
     assert with_collaborators.outcome_tuple() == without_collaborators.outcome_tuple()

--- a/tests/api/dev/test_question_interpreter.py
+++ b/tests/api/dev/test_question_interpreter.py
@@ -12,6 +12,7 @@ from dev_health_ops.api.dev.contracts_v2 import (
     EntityKind,
     QuestionIntentID,
 )
+from dev_health_ops.api.dev.graph_investigation_query import CohortDiscoveryFamily
 from dev_health_ops.api.dev.question_interpreter import (
     _KIND_NOUNS,
     _NON_NAMING_MODIFIERS,
@@ -22,6 +23,7 @@ from dev_health_ops.api.dev.question_interpreter import (
     MAX_MENTIONS,
     ClassifierProposal,
     QuestionInterpreter,
+    classify_cohort_discovery_family,
     extract_mentions,
     untyped_name_candidates,
 )
@@ -147,6 +149,66 @@ async def test_a_named_subject_never_routes_to_discovered_cohort(
     interpreted = await _interpreter().interpret(request_for(question))
     assert interpreted.intent.intent_id is not QuestionIntentID.DISCOVERED_COHORT
     assert interpreted.mentions, "expected a named subject to be extracted"
+
+
+@pytest.mark.parametrize(
+    ("question", "expected"),
+    [
+        ("Which teams are currently struggling?", CohortDiscoveryFamily.TEAM_PRESSURE),
+        ("Which squads are falling behind?", CohortDiscoveryFamily.TEAM_PRESSURE),
+        (
+            "Which projects appear capacity-constrained?",
+            CohortDiscoveryFamily.PROJECT_CAPACITY,
+        ),
+        (
+            "Which projects are unusually lightly loaded relative to demand?",
+            CohortDiscoveryFamily.PROJECT_CAPACITY,
+        ),
+    ],
+)
+def test_classify_cohort_discovery_family_matches_the_exclusive_pairing(
+    question: str, expected: CohortDiscoveryFamily
+) -> None:
+    """CHAOS-3689: an exclusive (subject-kind, judgment-kind) pairing --
+    exactly the shape ``cohort.discovery`` already recognizes as
+    ``DISCOVERED_COHORT`` -- classifies to the matching family.
+    """
+
+    assert classify_cohort_discovery_family(question) is expected
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
+        # No anchor of either group at all.
+        "What is the sky?",
+        # Mixed subject: both TEAM and PROJECT anchors present.
+        "Which teams and projects are struggling?",
+        # Mixed judgment: both PRESSURE and CAPACITY anchors present.
+        "Which teams are struggling and capacity-constrained?",
+        # Cross-mismatch: FAMILY_CANDIDATE_KINDS cannot satisfy team+capacity
+        # (TEAM_PRESSURE needs a pressure judgment) or project+pressure
+        # (PROJECT_CAPACITY needs a project subject, TEAM_PRESSURE needs a
+        # team subject).
+        "Which teams are capacity-constrained?",
+        "Which projects are struggling?",
+        # GraphEntityKind.REPOSITORY/SERVICE are distinct from PROJECT and
+        # no family maps to either -- unclassifiable, not folded into
+        # PROJECT_CAPACITY.
+        "Which repos are struggling?",
+        "Which services are capacity-constrained?",
+    ],
+)
+def test_classify_cohort_discovery_family_is_honestly_unclassifiable(
+    question: str,
+) -> None:
+    """CHAOS-3689: every combination this round doesn't cover returns
+    ``None`` rather than guessing -- the orchestrator's routing-branch gate
+    treats ``None`` as "never call the graph seam", falling back to the
+    legacy loop exactly like any other unclassified question.
+    """
+
+    assert classify_cohort_discovery_family(question) is None
 
 
 @pytest.mark.asyncio

--- a/tests/context_fabric/test_chaos_3678_query_service.py
+++ b/tests/context_fabric/test_chaos_3678_query_service.py
@@ -45,6 +45,7 @@ from dev_health_ops.api.dev.contracts_v2.base import (
 from dev_health_ops.api.dev.contracts_v2.subject import DevSubjectMention
 from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
 from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
     GraphInvestigationRequest,
     GraphQueryOutcome,
 )
@@ -107,6 +108,11 @@ def _request(
     run_id: str = "run_test",
     mentions: tuple[DevSubjectMention, ...] = (),
     authorized_entity_ids: frozenset[str] = frozenset({"proj_nightfall_migration"}),
+    # CHAOS-3689: irrelevant to every test in this file today (none of them
+    # exercise SUBJECTLESS_COHORT_DISCOVERY's still-unwired COMPLETED path,
+    # per the module docstring above) -- a fixed placeholder so the
+    # constructor call stays valid now that the field is required.
+    cohort_discovery_family: CohortDiscoveryFamily = CohortDiscoveryFamily.TEAM_PRESSURE,
 ) -> GraphInvestigationRequest:
     return GraphInvestigationRequest(
         org_id=org_id,
@@ -118,6 +124,7 @@ def _request(
         authorized_entity_ids=authorized_entity_ids,
         window_start=datetime(2026, 5, 12, tzinfo=UTC),
         window_end=datetime(2026, 8, 9, tzinfo=UTC),
+        cohort_discovery_family=cohort_discovery_family,
         deadline=deadline or _soon(),
     )
 
@@ -945,6 +952,7 @@ class TestDiagnosticsAreContentSafe:
             authorized_entity_ids=frozenset(),
             window_start=datetime(2026, 5, 12, tzinfo=UTC),
             window_end=datetime(2026, 8, 9, tzinfo=UTC),
+            cohort_discovery_family=CohortDiscoveryFamily.TEAM_PRESSURE,
             deadline=_soon(),
         )
         result = await service.investigate(request)


### PR DESCRIPTION
## Summary

Production's `GraphInvestigationRequest` (`intent_id=DISCOVERED_COHORT`, `cardinality=ORGANIZATION_WIDE`) can't select `cohort_discovery.discover_cohort`'s candidate-kind/pressure-metric family (`FAMILY_CANDIDATE_KINDS`, `FAMILY_PRESSURE_METRICS`) — that requires a `QuestionFamilyID` a single intent value can't carry. Design round on CHAOS-3660, signed off by team-lead and D. This PR lands the **production-side classification signal only** — see Non-scope below for what's still needed.

- `CohortDiscoveryFamily`: a new, deliberately small (two-member) closed enum in `graph_investigation_query.py` — `TEAM_PRESSURE` and `PROJECT_CAPACITY`. `STRUGGLING_TEAMS`/`PRESSURE_SIGNALS` collapse into the former (structurally identical to `discover_cohort` for this call shape — same candidate kind, same metric set, same permitted comparison shapes — a real equivalence class, not a guess). `PORTFOLIO_DEPENDENCY_RISK`/`DECLARED_VERSUS_ACTUAL` have no lexical coverage in the interpreter today and are explicitly deferred to a future, separately-measured pass — no corpus tuning here.
- `question_interpreter.classify_cohort_discovery_family`: splits the existing `cohort.discovery` recognizer's anchor groups by sub-flavor (same phrase lists, zero new lexical surface) and requires an exclusive match on both subject-kind and judgment-kind before committing to a family. Everything else — a mixed subject, a mixed judgment, a cross-mismatch, or a repo/service subject (`GraphEntityKind.REPOSITORY`/`SERVICE` are distinct from `PROJECT`, and no family maps to either) — returns `None`, honestly unclassifiable.
- `orchestrator.py`: the routing branch's gate grows one condition (`cohort_discovery_family is not None`). An unclassifiable question never reaches the graph seam at all — falls through to the legacy loop exactly like any other gate failure, never a guess passed across the wire.

`GraphInvestigationRequest.cohort_discovery_family` is required, not Optional — the one construction site only reaches it once classified.

## Non-scope

Lane A wires `cohort_discovery.discover_cohort`'s actual consumption of this signal (CHAOS-3689) as a follow-up once this merges — this PR alone does not complete CHAOS-3689, hence the ID-free branch/title per team-lead's instruction.

## Linear

Design proposal + sign-off on CHAOS-3660. Implements the production-interpreter half of CHAOS-3689.

## Test plan

- [x] New unit tests in `test_question_interpreter.py`: every exclusive pairing classifies correctly; every mixed/cross-mismatch/repo-service case returns `None`.
- [x] New orchestrator-seam tests in `test_chaos_3502_graph_routing_branch.py`: the request carries the classified family; an unclassifiable question never calls the seam and is byte-identical to a run with the graph collaborators never wired.
- [x] Fixed two existing construction sites (`test_chaos_3502_graph_investigation_query.py`, `test_chaos_3678_query_service.py`) for the new required field.
- [x] Full `tests/api/dev` + `tests/context_fabric` + `tests/test_env_isolation_contract.py` sweep: 4658 passed, 0 failed.
- [x] `ruff check` clean, `mypy` clean (2320 source files).