### PR TITLE
Wire disposition-gating into the semantic subject-resolution trial, fix a stale authorization-probe invariant

### DIFF
--- a/tests/context_fabric/test_chaos_3647_live_semantic.py
+++ b/tests/context_fabric/test_chaos_3647_live_semantic.py
@@ -237,10 +237,22 @@ class TestTheSemanticLegRunsAgainstTheRealThing:
             ),
         )
         assert resolution.leg is LegId.SEMANTIC_HYBRID
-        assert resolution.subjects, (
-            "hybrid retrieval returned nothing for a query naming a real "
-            "project; the store, the index or the vectors are not what this "
-            "leg thinks they are"
+        # CHAOS-3666: ``subjects`` is now disposition-gated (see
+        # ``resolve_semantic``'s own docstring), so it may legitimately be
+        # empty on a genuine REFUSE even when the underlying mechanism is
+        # completely sound. The soundness claim this test makes -- the
+        # store, the index and the vectors are real and reachable -- is
+        # ``bm25_order``/``cosine_order`` (the RAW primitive output, never
+        # gated); asserting on those is the correct proof now, not on
+        # ``subjects``, which is a policy decision, not a mechanism check.
+        assert resolution.bm25_order or resolution.cosine_order, (
+            "neither retrieval primitive returned anything for a query "
+            "naming a real project; the store, the index or the vectors "
+            "are not what this leg thinks they are"
+        )
+        assert resolution.disposition, (
+            "the disposition policy must always reach a verdict; an empty "
+            "value here means assess_disposition was not reached at all"
         )
         assert resolution.cosine_order, "the cosine primitive returned nothing"
         assert resolution.bm25_order, (

--- a/tests/context_fabric/test_chaos_3666_semantic_leg_disposition.py
+++ b/tests/context_fabric/test_chaos_3666_semantic_leg_disposition.py
@@ -1,0 +1,165 @@
+"""CHAOS-3666: the CHAOS-3647 trial's semantic leg must report what a caller
+would actually receive, not the raw unbounded candidate list.
+
+**The gap this closes.** ``trials/chaos_3647/legs.py::resolve_semantic``
+called ``semantic_retrieval.retrieve_candidates`` and reported every
+authorized candidate it returned as the leg's "answer" -- never calling
+``semantic_retrieval.assess_disposition``. CHAOS-3654 built the
+refusal/clarification disposition policy specifically so a caller never
+receives a fabricated top-1 pick from a diffuse, ungrounded ranking; a trial
+harness that skips it measures the wrong thing. Concretely: regenerating
+``trials/chaos_3647/results/semantic-leg.records.json`` live (2026-08-10,
+current tip) still showed the H08 case ("How is Halcyon doing?", a
+nonexistent entity) "ranking 25 candidates anyway, led by repo_beacon" --
+the exact measured failure CHAOS-3654's own module docstring says is fixed,
+reproduced here at unit level because the fix was never wired into what the
+trial reports.
+
+Every test plants the specific shape (no lexical grounding / a genuine
+leader / several tied candidates) ``assess_disposition`` exists to
+distinguish, same harness convention as
+``test_chaos_3653_observation_hop.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+from trials.chaos_3647.legs import resolve_semantic
+
+from . import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+_PARTITION = "cf_trial_org_test"
+
+
+@dataclass
+class _FakeNode:
+    uuid: str
+    name: str
+    group_id: str = _PARTITION
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def _entity_node(
+    uuid: str,
+    canonical_id: str,
+    label: str,
+    *,
+    kind: str = GraphEntityKind.PROJECT.value,
+    source_class: str = SourceClass.WORK_GRAPH.value,
+) -> _FakeNode:
+    return _FakeNode(
+        uuid=uuid,
+        name=label,
+        attributes={
+            "cf_canonical_id": canonical_id,
+            "cf_entity_kind": kind,
+            "cf_source_class": source_class,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class _SemanticEmbedder:
+    model_id: str = "test_semantic_double.v1"
+    semantic: bool = True
+
+    async def create(self, input_data: Any) -> list[float]:
+        return [0.0] * 8
+
+
+@dataclass(frozen=True)
+class _FakeStore:
+    driver: Any
+    partition: str
+    embedder: Any
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, *, bm25: list, cosine: list) -> None:
+    live_gate.require_graphiti_extra()
+    from graphiti_core.search import search_utils
+
+    async def fake_fulltext(driver, query, search_filter, group_ids, limit):
+        return list(bm25)
+
+    async def fake_similarity(
+        driver, search_vector, search_filter, group_ids, limit, *args, **kwargs
+    ):
+        return list(cosine)
+
+    monkeypatch.setattr(search_utils, "node_fulltext_search", fake_fulltext)
+    monkeypatch.setattr(search_utils, "node_similarity_search", fake_similarity)
+
+
+class TestTheLegReportsDispositionGatedSubjectsNotRawCandidates:
+    async def test_no_lexical_grounding_refuses_empty_not_a_ranked_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The H08 shape exactly: BM25 finds nothing, cosine alone returns a
+        pile of vector-similarity guesses. Before this fix, every one of
+        them was reported as the leg's ranked answer.
+        """
+
+        weak_guesses = [
+            _entity_node(f"u{i}", f"proj_guess_{i}", f"Guess {i}") for i in range(20)
+        ]
+        _install(monkeypatch, bm25=[], cosine=weak_guesses)
+
+        resolution = await resolve_semantic(
+            question="How is Halcyon doing?",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset(f"proj_guess_{i}" for i in range(20)),
+        )
+
+        assert resolution.subjects == (), (
+            "no lexical evidence anywhere and only vector-similarity "
+            "guesses is exactly the REFUSE shape; the leg must report "
+            "nothing resolved, not 20 confident candidates"
+        )
+        assert resolution.disposition == "refuse"
+
+    async def test_a_genuine_leader_with_lexical_support_proposes_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        leader = _entity_node("u_leader", "proj_vertex", "Vertex Platform")
+        also_ran = _entity_node("u_other", "proj_other", "Other Project")
+        _install(monkeypatch, bm25=[leader], cosine=[leader, also_ran])
+
+        resolution = await resolve_semantic(
+            question="vertex platform",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex", "proj_other"}),
+        )
+
+        assert resolution.top_n(10) == ("proj_vertex",), (
+            "a leader with lexical support and a real margin over the "
+            "field must PROPOSE exactly one subject, not the whole "
+            "authorized candidate set"
+        )
+        assert resolution.disposition == "propose"
+
+    async def test_tied_candidates_clarify_bounded_not_the_whole_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node_a = _entity_node("u_a", "proj_a", "Project A")
+        node_b = _entity_node("u_b", "proj_b", "Project B")
+        # Each leads one primitive and trails the other, so their fused RRF
+        # scores come out equal (a genuine tie) rather than one leading both
+        # primitives and producing a clean, non-tied margin.
+        _install(monkeypatch, bm25=[node_a, node_b], cosine=[node_b, node_a])
+
+        resolution = await resolve_semantic(
+            question="one of the projects",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_a", "proj_b"}),
+        )
+
+        assert set(resolution.top_n(10)) == {"proj_a", "proj_b"}
+        assert resolution.disposition == "clarify"

--- a/tests/context_fabric/test_chaos_3666_unrestricted_control_probe.py
+++ b/tests/context_fabric/test_chaos_3666_unrestricted_control_probe.py
@@ -1,0 +1,170 @@
+"""CHAOS-3666: ``unrestricted_control``'s pass condition predates the
+CHAOS-3653 observation->entity hop and is now stale.
+
+**The gap this closes.** Regenerating the CHAOS-3647 trial artifact live
+(2026-08-10) flipped ``unrestricted_control`` from pass to fail for the
+first time since the probe was written -- not from a leak
+(``any_unauthorized_entity_ranked`` stayed ``false`` throughout, and the
+restricted entity never once reached ``ranked_canonical_ids``, only
+``withheld_canonical_ids``), but because CHAOS-3653's hop legitimately
+widens what gets retrieved: an authorized observation's own subjects now
+enter the candidate pool, and for this control's query that pool
+incidentally included the restricted ``proj_quarry``, which the filter then
+correctly excluded.
+
+The probe's original pass condition, ``authorization_filtered_count == 0``,
+assumed a query "aimed at nothing restricted" would never retrieve anything
+restricted at all. That assumption predates the hop. Every id in
+``withheld_canonical_ids`` is, by construction, genuinely outside
+``authorized_entity_ids`` (see ``semantic_retrieval.retrieve_candidates``'s
+own withholding logic) -- so a nonzero count here can only mean "something
+else, legitimately restricted, was correctly excluded", never "the control
+target was over-filtered". Conflating the two turns a correct, expected
+consequence of a widened retrieval net into a false failure.
+
+The real invariant the control exists to protect -- "the control target
+itself is not being swallowed by an over-eager filter" -- is preserved by
+checking ``target_ranked`` alone; a withholding of something else is a
+different, unrelated, correct exclusion this control was never measuring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+from trials.chaos_3647.probes import AuthorizationProbe, run_probe
+
+from . import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+_PARTITION = "cf_trial_org_test"
+
+
+@dataclass
+class _FakeNode:
+    uuid: str
+    name: str
+    group_id: str = _PARTITION
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def _entity_node(uuid: str, canonical_id: str, label: str) -> _FakeNode:
+    return _FakeNode(
+        uuid=uuid,
+        name=label,
+        attributes={
+            "cf_canonical_id": canonical_id,
+            "cf_entity_kind": GraphEntityKind.PROJECT.value,
+            "cf_source_class": SourceClass.WORK_GRAPH.value,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class _SemanticEmbedder:
+    model_id: str = "test_semantic_double.v1"
+    semantic: bool = True
+
+    async def create(self, input_data: Any) -> list[float]:
+        return [0.0] * 8
+
+
+@dataclass(frozen=True)
+class _FakeStore:
+    driver: Any
+    partition: str
+    embedder: Any
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, *, bm25: list, cosine: list) -> None:
+    live_gate.require_graphiti_extra()
+    from graphiti_core.search import search_utils
+
+    async def fake_fulltext(driver, query, search_filter, group_ids, limit):
+        return list(bm25)
+
+    async def fake_similarity(
+        driver, search_vector, search_filter, group_ids, limit, *args, **kwargs
+    ):
+        return list(cosine)
+
+    monkeypatch.setattr(search_utils, "node_fulltext_search", fake_fulltext)
+    monkeypatch.setattr(search_utils, "node_similarity_search", fake_similarity)
+
+
+_CONTROL = AuthorizationProbe(
+    probe_id="test_unrestricted_control",
+    query="Identity Platform Rewrite",
+    principal_id="principal_test",
+    target_entity_id="proj_target",
+    target_is_restricted=False,
+    rationale="test",
+)
+
+
+class TestUnrestrictedControlUnderTheHopsWiderNet:
+    async def test_target_ranked_cleanly_alongside_an_incidental_restricted_withholding_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exact live shape: the control target ranks, and the hop's
+        wider net also (incidentally) surfaces something restricted, which
+        gets correctly withheld. This must PASS -- the boundary held.
+        """
+
+        target = _entity_node("u_target", "proj_target", "Target Project")
+        incidental_restricted = _entity_node(
+            "u_other", "proj_other_restricted", "Some Other Restricted Project"
+        )
+        _install(monkeypatch, bm25=[target, incidental_restricted], cosine=[target])
+
+        outcome = await run_probe(
+            _CONTROL,
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_target"}),
+        )
+
+        assert outcome.target_ranked is True
+        assert outcome.authorization_filtered_count == 1
+        assert outcome.verdict == "pass", outcome.detail
+
+    async def test_target_not_ranked_at_all_still_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression guard: the one real failure mode this control exists
+        for -- the target itself unreachable -- must still fail.
+        """
+
+        _install(monkeypatch, bm25=[], cosine=[])
+
+        outcome = await run_probe(
+            _CONTROL,
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_target"}),
+        )
+
+        assert outcome.target_ranked is False
+        assert outcome.verdict == "fail"
+
+    async def test_clean_run_with_nothing_withheld_still_passes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Baseline, unchanged: the original ideal case must still pass."""
+
+        target = _entity_node("u_target", "proj_target", "Target Project")
+        _install(monkeypatch, bm25=[target], cosine=[target])
+
+        outcome = await run_probe(
+            _CONTROL,
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_target"}),
+        )
+
+        assert outcome.target_ranked is True
+        assert outcome.authorization_filtered_count == 0
+        assert outcome.verdict == "pass"

--- a/trials/chaos_3647/legs.py
+++ b/trials/chaos_3647/legs.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Any
 
 from dev_health_ops.context_fabric.graph_arm.discovery import search_candidates
 from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
+    assess_disposition,
     retrieve_candidates,
 )
 from trials.chaos_3619.graph_leg import mention_texts
@@ -122,6 +123,18 @@ class LegResolution:
     #: only. Recorded because an empty tuple here is the single most
     #: load-bearing fact in the whole comparison.
     mentions: tuple[str, ...] = ()
+    #: CHAOS-3666. The semantic leg's own ``SemanticDisposition`` (propose /
+    #: clarify / refuse), empty string on the deterministic legs, which
+    #: apply no disposition policy. ``subjects`` on the semantic leg is
+    #: already gated to what this disposition presents -- this field exists
+    #: so a reader of the trial artifact can see the POLICY DECISION that
+    #: produced ``subjects``, not just its result: a REFUSE (empty
+    #: ``subjects``) is a different finding from retrieval simply returning
+    #: nothing, and only this field distinguishes them.
+    disposition: str = ""
+    #: The disposition policy's own stated reason. Trial diagnostic, mirrors
+    #: ``SemanticDispositionResult.reason``.
+    disposition_reason: str = ""
 
     @property
     def resolved(self) -> bool:
@@ -244,6 +257,19 @@ async def resolve_semantic(
     empty mention tuple would guarantee an empty result and measure nothing.
     The cost of that choice is that the two legs no longer share an input,
     which is exactly what ``DETERMINISTIC_QUESTION`` exists to price.
+
+    **CHAOS-3666: reports what a caller would actually receive.**
+    ``retrieve_candidates`` alone returns every authorized candidate it
+    fused, unbounded and unfiltered by confidence -- exactly the raw ranking
+    ``semantic_retrieval.assess_disposition`` exists to gate before anything
+    downstream trusts it (see that function's own docstring: a nonexistent
+    entity or an unresolved reference produces a long, confident-looking
+    ranking with no lexical grounding underneath it). This leg calls it and
+    reports only ``disposition_result.presented`` as ``subjects`` -- empty on
+    REFUSE, one entry on PROPOSE, a bounded tied set on CLARIFY -- so
+    ``subjects`` here means the same thing it means on the deterministic
+    legs: what this leg would actually hand a consumer, not an internal
+    ranking a policy layer would filter before anyone saw it.
     """
 
     retrieval = await retrieve_candidates(
@@ -252,6 +278,7 @@ async def resolve_semantic(
         authorized_entity_ids=authorized_entity_ids,
         limit=limit,
     )
+    disposition_result = assess_disposition(retrieval)
     return LegResolution(
         leg=LegId.SEMANTIC_HYBRID,
         query=question,
@@ -265,11 +292,13 @@ async def resolve_semantic(
                 methods=tuple(sorted(method.value for method in candidate.methods)),
                 rrf_score=candidate.rrf_score,
             )
-            for candidate in retrieval.candidates
+            for candidate in disposition_result.presented
         ),
         authorization_filtered_count=retrieval.authorization_filtered_count,
         withheld_canonical_ids=retrieval.withheld_canonical_ids,
         bm25_order=retrieval.bm25_order,
         cosine_order=retrieval.cosine_order,
         observation_hits=retrieval.observation_hits,
+        disposition=disposition_result.disposition.value,
+        disposition_reason=disposition_result.reason,
     )

--- a/trials/chaos_3647/probes.py
+++ b/trials/chaos_3647/probes.py
@@ -229,24 +229,40 @@ async def run_probe(
 
     if not probe.target_is_restricted:
         effective = True
-        if target_ranked and retrieval.authorization_filtered_count == 0:
-            verdict, detail = (
-                "pass",
-                "an authorized target was ranked and nothing was withheld, "
-                "so the filter is not simply withholding everything",
-            )
-        elif not target_ranked:
+        if not target_ranked:
             verdict, detail = (
                 "fail",
                 f"the control target {probe.target_entity_id} was not ranked; "
                 "retrieval cannot reach an entity the principal may see, so "
                 "no withholding result from this suite is interpretable",
             )
-        else:
+        elif retrieval.authorization_filtered_count == 0:
             verdict, detail = (
-                "fail",
-                f"the control withheld {retrieval.authorization_filtered_count} "
-                "entities on a query aimed at nothing restricted",
+                "pass",
+                "an authorized target was ranked and nothing was withheld, "
+                "so the filter is not simply withholding everything",
+            )
+        else:
+            # CHAOS-3666: the CHAOS-3653 hop widens what gets retrieved (an
+            # authorized observation's own subjects now enter the candidate
+            # pool), so a query "aimed at nothing restricted" can still
+            # incidentally retrieve something that IS restricted. Every id
+            # in ``withheld_canonical_ids`` is, by construction, genuinely
+            # outside ``authorized_entity_ids`` (see
+            # ``retrieve_candidates``'s own withholding logic) -- so this can
+            # only mean a DIFFERENT, real restricted entity was correctly
+            # excluded, never that the control target was over-filtered.
+            # The control's actual invariant -- the target itself is not
+            # swallowed by an over-eager filter -- already held via
+            # ``target_ranked`` above.
+            verdict, detail = (
+                "pass",
+                f"the control target ranked cleanly; "
+                f"{retrieval.authorization_filtered_count} other, genuinely "
+                "restricted entities were incidentally retrieved by a wider "
+                "candidate net and correctly withheld -- the filter working "
+                "under a broader retrieval, not the control being "
+                "over-filtered",
             )
         return ProbeOutcome(
             probe_id=probe.probe_id,

--- a/trials/chaos_3647/results/regeneration-note.md
+++ b/trials/chaos_3647/results/regeneration-note.md
@@ -1,0 +1,108 @@
+# semantic-leg.records.json regeneration — 2026-08-10
+
+**This is a dated, cited explanation of why `semantic-leg.records.json` moved, not a
+silent overwrite.** The file was generated once, at the original CHAOS-3647 landing
+(tree `eee3d1571`), and was never regenerated again — three tickets later changed the
+measured system underneath it without the artifact ever reflecting them. This note
+names every one of those changes and states, for each, whether and how it moved the
+eight measured rows. Matches the spirit of `trials/chaos_3619/refusal_causes
+.DIVERGENCE_LEDGER` (append-only, dated, cited, directional) for a trial that has no
+existing pin-vs-recompute self-check of its own to hang a machine-checked ledger off.
+
+| | |
+| --- | --- |
+| Old artifact | tree `eee3d1571` (original CHAOS-3647 landing), never regenerated since |
+| New artifact | produced by `python -m trials.chaos_3647.runner` at branch `embedded-surface-approval-gate`, commit `528b3fd0483bc02dbb9ce39038cf1a376cf60ade`, feature tip `f3ac1d221b6959a982a4ba803d471988d0f14ed8` at branch time |
+| Store | live FalkorDB — `CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389`, `CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1`, `CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED=1` |
+| Embedder | `openai_text_embedding_3_small` (real model, both old and new) |
+| Corpus / oracles | unchanged — same eight named cases, same authorization probes |
+
+## What changed in the measured system, in landing order
+
+1. **CHAOS-3654 (PR #1631), "give the semantic retrieval leg a refusal/clarification
+   threshold."** Added `semantic_retrieval.assess_disposition`. Landed after the old
+   artifact, so the old artifact's H08 row ("How is Halcyon doing?", a nonexistent
+   entity) shows the semantic leg ranking 20 candidates with no refusal — the exact
+   shape this ticket fixed, just not yet reflected in any regenerated artifact.
+2. **CHAOS-3653 (PR #1637), "add the observation→entity hop to semantic subject
+   resolution."** Widens what `retrieve_candidates` returns: an authorized
+   observation's own subjects now enter the candidate pool, not only nodes whose own
+   name/vector matched directly.
+3. **CHAOS-3686 (PR #1656), "conversation-context resolution for pronouns and
+   prior-turn references."** Added `semantic_retrieval.resolve_conversational_reference`.
+   **Not exercised by this trial** — `legs.py::resolve_semantic` has no prior-turn state
+   to hand it (the corpus's own `follows_case_id` chain is not threaded into
+   `trials/chaos_3647` anywhere), so H04–H06 (the pronoun/prior-turn cases) show no
+   benefit from this ticket in this artifact. Flagged as a separate, real gap on issue
+   3666, not fixed here — it needs new state-threading through `runner.py`, a larger
+   piece of work than wiring in a policy call that already had everything it needed.
+4. **This change (issue 3666, harness wiring + probe fix, this PR).**
+   `legs.py::resolve_semantic` previously called `retrieve_candidates` directly and
+   reported every authorized candidate as the leg's answer — (1) and the disposition
+   policy it built were never actually exercised by what this trial measures.
+   `resolve_semantic` now calls `assess_disposition` and reports
+   `disposition_result.presented` as `subjects`, so what the trial measures matches
+   what a real caller would receive. Separately, `probes.py`'s `unrestricted_control`
+   pass condition (`authorization_filtered_count == 0`) predates (2): a query "aimed at
+   nothing restricted" can now legitimately, incidentally retrieve something restricted
+   through the wider hop net and have it correctly filtered, which the old condition
+   scored as a failure. Fixed to fail only when the control's own target isn't ranked.
+
+## The three-way delta, by case
+
+`both_correct` / `deterministic_only_correct` / `semantic_only_correct` /
+`neither_correct_neither_ranked` / `neither_correct_both_ranked` /
+`neither_correct_semantic_ranked_anyway` — see `records.py::Delta` for what each means.
+"Old" is the tree-`eee3d1571` artifact (pre 1–4 above); "post-hop/threshold" is a
+regeneration at commit `528b3fd04` **before** this PR's harness-wiring fix (captures
+(1)–(3) landing but not (4)); "new" is this artifact (captures all of (1)–(4)).
+
+| case | old (`eee3d1571`) | post-hop/threshold, pre-wiring | new (this artifact) |
+| --- | --- | --- | --- |
+| H01_acronym_resolution | both_correct | both_correct | both_correct |
+| H02_old_and_current_name | deterministic_only_correct | deterministic_only_correct | deterministic_only_correct |
+| H03_the_auth_work | neither_correct_semantic_ranked_anyway | neither_correct_both_ranked | neither_correct_both_ranked |
+| H04_pronoun_follow_up | neither_correct_semantic_ranked_anyway | neither_correct_semantic_ranked_anyway | neither_correct_neither_ranked |
+| H05_the_other_project_we_discussed | neither_correct_semantic_ranked_anyway | neither_correct_semantic_ranked_anyway | neither_correct_neither_ranked |
+| H06_prior_attempt_reference | neither_correct_semantic_ranked_anyway | neither_correct_semantic_ranked_anyway | neither_correct_neither_ranked |
+| H07_unresolved_needs_candidates | neither_correct_semantic_ranked_anyway | deterministic_only_correct | **both_correct** |
+| H08_no_match_must_not_widen | deterministic_only_correct | deterministic_only_correct | **both_correct** |
+
+**The headline: `neither_correct_semantic_ranked_anyway` — "neither leg was right, and
+the semantic leg ranked something anyway" — went from 5 of 8 cases to 0.** That bucket
+is named in `records.py` as "the most expensive class: a wrong answer costs more than a
+refusal, and this is the one a headline 'graph reaches more answers' figure would
+hide." It no longer has any members. H07 and H08 moved all the way to `both_correct`;
+H03 moved out of the worst bucket into a shared-failure one (both legs wrong, neither
+confidently so); H04–H06 moved from "semantic confidently wrong" to "semantic safely
+refuses, matching the deterministic baseline's own refusal" — the correct interim
+state pending the conversational-reference wiring named above.
+
+**What did not move, and should not be read as this change's doing:** H03's
+*deterministic* baseline itself now ranks 3 candidates where the original pin ranked
+none (`baseline_ranked: 0 → 3`). This is `trials.chaos_3619`'s own already-ledgered
+CHAOS-3648 (PR #1622) extractor change (`question_interpreter.extract_mentions`'s
+untyped path, see `refusal_causes.DIVERGENCE_LEDGER`'s `H03_the_auth_work` entry under
+`PHRASE_EXTRACTED_POST_3648`) — nothing in this PR touches extraction, and the
+deterministic leg's own code (`discovery.py`) is unchanged since its original landing.
+Named here only so a reader diffing this artifact against the original pin does not
+attribute someone else's already-documented change to this one.
+
+**Safety invariants, unmoved across all three artifacts:** `any_prose_disclosure:
+false`, `any_unauthorized_entity_ranked: false`, zero ineffective probes. The wider hop
+net changes what gets *retrieved*, never what gets *disclosed after authorization* —
+that boundary held identically before and after every change on this list.
+
+## Reproducing this
+
+```
+CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389 \
+CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1 \
+CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED=1 \
+uv run python -m trials.chaos_3647.runner
+```
+
+Run it at `eee3d1571` to reproduce the original artifact; at this PR's head to
+reproduce this one. `binding.commit`/`binding.feature_tip_commit`/`binding.tree_clean`
+in the artifact record which tree actually produced it — check that block before
+trusting any output as a measurement.

--- a/trials/chaos_3647/results/semantic-leg.records.json
+++ b/trials/chaos_3647/results/semantic-leg.records.json
@@ -18,7 +18,20 @@
     "proj_vertex",
     "wu_pulse_runbook",
     "svc_auth_gateway",
-    "pr_vertex_401"
+    "pr_vertex_401",
+    "team_cinder",
+    "team_atlas",
+    "svc_pulse_api",
+    "svc_ledger_api",
+    "proj_pulse",
+    "proj_acr",
+    "repo_identity",
+    "team_ember",
+    "repo_pulse",
+    "team_dorado",
+    "pr_ledger_990",
+    "repo_ledger",
+    "proj_solstice"
    ],
    "target_entity_id": "proj_quarry",
    "target_is_restricted": true,
@@ -43,7 +56,26 @@
     "wu_ledger_cutover",
     "svc_checkout",
     "wu_beacon_ingest",
-    "pr_identity_882"
+    "pr_identity_882",
+    "team_atlas",
+    "team_borealis",
+    "team_ember",
+    "proj_beacon",
+    "team_cinder",
+    "svc_pulse_api",
+    "proj_pulse",
+    "pr_vertex_401",
+    "svc_ledger_api",
+    "proj_acr",
+    "team_dorado",
+    "repo_ledger",
+    "proj_ledger_migration",
+    "pr_ledger_990",
+    "proj_lattice",
+    "proj_solstice",
+    "svc_auth_gateway",
+    "repo_pulse",
+    "proj_meridian"
    ],
    "target_entity_id": "proj_quarry",
    "target_is_restricted": true,
@@ -56,7 +88,7 @@
    ]
   },
   {
-   "authorization_filtered_count": 0,
+   "authorization_filtered_count": 1,
    "detail": "the identical query ranked lumen_proj_acr in its own partition cf_trial_org_lumen and returned it nowhere in cf_trial_org_helio; the group filter is what removed it, and the presence check is what makes that a measurement rather than an empty result",
    "effective": true,
    "principal_id": "principal_helio_analyst",
@@ -78,7 +110,14 @@
     "pr_pulse_212",
     "issue_acr_span_decl",
     "proj_pulse",
-    "team_ember"
+    "team_ember",
+    "repo_identity",
+    "proj_lattice",
+    "proj_meridian",
+    "svc_ledger_api",
+    "team_borealis",
+    "svc_pulse_api",
+    "pr_vertex_401"
    ],
    "target_entity_id": "lumen_proj_acr",
    "target_is_restricted": true,
@@ -86,11 +125,13 @@
    "target_ranked": false,
    "target_retrieved": false,
    "verdict": "pass",
-   "withheld_canonical_ids": []
+   "withheld_canonical_ids": [
+    "proj_quarry"
+   ]
   },
   {
-   "authorization_filtered_count": 0,
-   "detail": "an authorized target was ranked and nothing was withheld, so the filter is not simply withholding everything",
+   "authorization_filtered_count": 1,
+   "detail": "the control target ranked cleanly; 1 other, genuinely restricted entities were incidentally retrieved by a wider candidate net and correctly withheld -- the filter working under a broader retrieval, not the control being over-filtered",
    "effective": true,
    "principal_id": "principal_helio_analyst",
    "probe_id": "unrestricted_control",
@@ -115,7 +156,12 @@
     "pf_growth",
     "proj_beacon",
     "repo_checkout",
-    "wu_ledger_dual_write"
+    "wu_ledger_dual_write",
+    "pr_vertex_401",
+    "svc_pulse_api",
+    "svc_ledger_api",
+    "team_atlas",
+    "dep_ratelimitd"
    ],
    "target_entity_id": "proj_identity_rewrite",
    "target_is_restricted": false,
@@ -123,13 +169,15 @@
    "target_ranked": true,
    "target_retrieved": true,
    "verdict": "pass",
-   "withheld_canonical_ids": []
+   "withheld_canonical_ids": [
+    "proj_quarry"
+   ]
   }
  ],
  "binding": {
-  "branch": "chaos-3647-semantic-leg",
-  "commit": "5c28c208f6a3be197610329b3407854ddd9bf937",
-  "contract_manifest_sha256": "b14307dbbbf5b5dd84d0b9b79648c7c6bdbf35bda7f56511dfcfc63f02a3cd38",
+  "branch": "embedded-surface-approval-gate",
+  "commit": "528b3fd0483bc02dbb9ce39038cf1a376cf60ade",
+  "contract_manifest_sha256": "c74d62e6f1c4e8829b55f74a7a5c72ccea800a694b3df435eff04196b8ad2c2e",
   "corpus_manifest_sha256": "f12a7dcef216c8fedc19538fba1d284bfdf6968461e718bbfcee2a4fea1bd0c4",
   "corpus_version": "ask_dev_investigation_corpus.v1",
   "dependency_versions": {
@@ -139,7 +187,7 @@
    "redis": "6.4.0"
   },
   "execution_mode": "producer_invoked_directly_seam_real_orchestrator_bypassed",
-  "feature_tip_commit": "4b6489f5eadc0fc9969b51f3156278d6bbee71ab",
+  "feature_tip_commit": "f3ac1d221b6959a982a4ba803d471988d0f14ed8",
   "graph_arm_id": "graph_assisted_shadow_arm",
   "graph_attachment_encoding": "canonical_ids.v1",
   "graph_embedder_model_id": "openai_text_embedding_3_small",
@@ -169,7 +217,7 @@
     "classification": "both_correct",
     "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was proj_identity_rewrite, as expected",
     "semantic_correct": true,
-    "semantic_ranked": 8
+    "semantic_ranked": 4
    },
    "expected_answer": "direct",
    "forbidden_subject_ids": [],
@@ -261,17 +309,17 @@
       "borealis_wip",
       "doc_injected_runbook",
       "pr_pulse_212_merged",
-      "wg_identity_rewrite",
       "proj_identity_rewrite",
+      "wg_identity_rewrite",
       "oc_pulse_missing",
       "ci_pulse_green",
       "dep_ratelimitd",
       "ci_identity_blocked",
       "tr_pulse_suite",
       "wg_ratelimitd_removed",
+      "atlas_load",
       "frost_load",
       "borealis_load",
-      "atlas_load",
       "pr_ledger_990_merged",
       "pr_pulse_212",
       "rv_vertex_revoked",
@@ -321,9 +369,9 @@
       "ci_identity_blocked",
       "tr_pulse_suite",
       "wg_ratelimitd_removed",
+      "atlas_load",
       "frost_load",
       "borealis_load",
-      "atlas_load",
       "pr_ledger_990_merged",
       "rv_vertex_revoked",
       "dorado_outbound_reviews",
@@ -363,25 +411,21 @@
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
       "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_ratelimitd', 'pr_pulse_212']",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['proj_acr', 'team_atlas']",
       "precision_over_all": "fail",
-      "precision_over_all_detail": "7 stray candidates across 8 ranked",
+      "precision_over_all_detail": "3 stray candidates across 4 ranked",
       "resolved": true,
       "stray_candidates": [
-       "dep_ratelimitd",
-       "issue_acr_span_decl",
-       "pf_platform",
-       "pr_identity_882",
-       "pr_pulse_212",
-       "svc_pulse_api",
-       "wu_beacon_ingest"
+       "proj_acr",
+       "team_atlas",
+       "team_borealis"
       ],
       "subject_resolution_correct": true,
       "subject_resolution_detail": "rank-1 was proj_identity_rewrite, as expected",
       "subject_top_1": "pass",
       "subject_top_1_detail": "rank-1 was proj_identity_rewrite; expected proj_identity_rewrite",
       "subject_top_3": "pass",
-      "subject_top_3_detail": "top-3 ['proj_identity_rewrite', 'dep_ratelimitd', 'pr_pulse_212']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 ['proj_identity_rewrite', 'proj_acr', 'team_atlas']; expected proj_identity_rewrite"
      },
      "subjects": [
       {
@@ -392,84 +436,41 @@
         "cosine_similarity"
        ],
        "rank": 0,
-       "rrf_score": 0.14285714285714285,
+       "rrf_score": 0.16666666666666666,
        "signal": "fuzzy_label"
       },
       {
-       "canonical_id": "dep_ratelimitd",
-       "display_label": "ratelimitd",
+       "canonical_id": "proj_acr",
+       "display_label": "Agent Context Runtime",
+       "mechanism": "embedding_similarity",
+       "methods": [
+        "bm25",
+        "cosine_similarity"
+       ],
+       "rank": 8,
+       "rrf_score": 2.0,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "team_atlas",
+       "display_label": "Atlas",
        "mechanism": "embedding_similarity",
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 1,
-       "rrf_score": 0.1,
+       "rank": 9,
+       "rrf_score": 0.5,
        "signal": "fuzzy_label"
       },
       {
-       "canonical_id": "pr_pulse_212",
-       "display_label": "pulse#212 analytics rollout",
+       "canonical_id": "team_borealis",
+       "display_label": "Borealis",
        "mechanism": "embedding_similarity",
        "methods": [
         "cosine_similarity"
        ],
-       "rank": 2,
-       "rrf_score": 0.05555555555555555,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "issue_acr_span_decl",
-       "display_label": "ACR span declaration correction",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.034482758620689655,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "svc_pulse_api",
-       "display_label": "Pulse API",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.02857142857142857,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_identity_882",
-       "display_label": "identity#882 authcore 2.0 adoption",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.02631578947368421,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_beacon_ingest",
-       "display_label": "Beacon ingest throughput",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.024390243902439025,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pf_platform",
-       "display_label": "Platform Portfolio",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.022727272727272728,
+       "rank": 10,
+       "rrf_score": 0.3333333333333333,
        "signal": "fuzzy_label"
       }
      ],
@@ -495,7 +496,7 @@
     "classification": "deterministic_only_correct",
     "detail": "baseline: rank-1 was proj_identity_rewrite, as expected | semantic: rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
     "semantic_correct": false,
-    "semantic_ranked": 18
+    "semantic_ranked": 1
    },
    "expected_answer": "direct",
    "forbidden_subject_ids": [],
@@ -584,8 +585,8 @@
      ],
      "cosine_order": [
       "wi_borealis_wip",
-      "rv_borealis_normal",
       "team_borealis",
+      "rv_borealis_normal",
       "pr_pulse_212",
       "pr_pulse_212_merged",
       "repo_beacon",
@@ -680,28 +681,11 @@
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
       "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'team_borealis', 'wu_pulse_runbook']",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['wu_pulse_runbook']",
       "precision_over_all": "fail",
-      "precision_over_all_detail": "18 stray candidates across 18 ranked",
+      "precision_over_all_detail": "1 stray candidates across 1 ranked",
       "resolved": true,
       "stray_candidates": [
-       "dep_authcore",
-       "pr_identity_882",
-       "pr_ledger_990",
-       "pr_pulse_212",
-       "proj_beacon",
-       "proj_meridian",
-       "proj_solstice",
-       "repo_acr",
-       "repo_beacon",
-       "repo_checkout",
-       "repo_identity",
-       "repo_ledger",
-       "repo_pulse",
-       "team_atlas",
-       "team_borealis",
-       "wu_authcore_release",
-       "wu_beacon_ingest",
        "wu_pulse_runbook"
       ],
       "subject_resolution_correct": false,
@@ -709,7 +693,7 @@
       "subject_top_1": "fail",
       "subject_top_1_detail": "rank-1 was wu_pulse_runbook; expected proj_identity_rewrite",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['wu_pulse_runbook', 'team_borealis', 'pr_pulse_212']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 ['wu_pulse_runbook']; expected proj_identity_rewrite"
      },
      "subjects": [
       {
@@ -721,193 +705,6 @@
        ],
        "rank": 0,
        "rrf_score": 1.0,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "team_borealis",
-       "display_label": "Borealis",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 1,
-       "rrf_score": 0.3333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_pulse_212",
-       "display_label": "pulse#212 analytics rollout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 2,
-       "rrf_score": 0.25,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_beacon",
-       "display_label": "helio/beacon",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.16666666666666666,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_ledger",
-       "display_label": "helio/ledger",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.08333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_acr",
-       "display_label": "helio/acr",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.05555555555555555,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_authcore_release",
-       "display_label": "authcore 2.0 release",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.043478260869565216,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_identity",
-       "display_label": "helio/identity",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.041666666666666664,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_identity_882",
-       "display_label": "identity#882 authcore 2.0 adoption",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 8,
-       "rrf_score": 0.037037037037037035,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_solstice",
-       "display_label": "Solstice Billing",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 9,
-       "rrf_score": 0.034482758620689655,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_checkout",
-       "display_label": "helio/checkout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 10,
-       "rrf_score": 0.03125,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "dep_authcore",
-       "display_label": "authcore",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 11,
-       "rrf_score": 0.02702702702702703,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_pulse",
-       "display_label": "helio/pulse",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 12,
-       "rrf_score": 0.025,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_beacon",
-       "display_label": "Beacon Ingest",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 13,
-       "rrf_score": 0.023809523809523808,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "team_atlas",
-       "display_label": "Atlas",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 14,
-       "rrf_score": 0.023255813953488372,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_beacon_ingest",
-       "display_label": "Beacon ingest throughput",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 15,
-       "rrf_score": 0.022727272727272728,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_ledger_990",
-       "display_label": "ledger#990 dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 16,
-       "rrf_score": 0.022222222222222223,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_meridian",
-       "display_label": "Meridian Docs",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 17,
-       "rrf_score": 0.02040816326530612,
        "signal": "fuzzy_label"
       }
      ],
@@ -928,11 +725,11 @@
    "committed_subject_id": "proj_identity_rewrite",
    "delta": {
     "baseline_correct": false,
-    "baseline_ranked": 0,
-    "classification": "neither_correct_semantic_ranked_anyway",
-    "detail": "baseline: resolved nothing; expected proj_identity_rewrite | semantic: rank-1 was dep_authcore; expected proj_identity_rewrite",
+    "baseline_ranked": 3,
+    "classification": "neither_correct_both_ranked",
+    "detail": "baseline: rank-1 was proj_auth_gateway_hardening; expected proj_identity_rewrite | semantic: rank-1 was dep_authcore; expected proj_identity_rewrite",
     "semantic_correct": false,
-    "semantic_ranked": 18
+    "semantic_ranked": 1
    },
    "expected_answer": "direct",
    "forbidden_subject_ids": [],
@@ -942,7 +739,10 @@
      "bm25_order": [],
      "cosine_order": [],
      "leg": "deterministic_mentions",
-     "mentions": [],
+     "mentions": [
+      "auth work",
+      "auth"
+     ],
      "observation_hits": [],
      "prose_disclosures": [],
      "query": "What about the auth work?",
@@ -953,20 +753,50 @@
       "must_not_commit_detail": "the case expects a commitment",
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
-      "precision_at_3": "pass",
-      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
-      "precision_over_all": "pass",
-      "precision_over_all_detail": "no stray candidate across 0 ranked",
-      "resolved": false,
-      "stray_candidates": [],
+      "precision_at_3": "fail",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['svc_auth_gateway']",
+      "precision_over_all": "fail",
+      "precision_over_all_detail": "1 stray candidates across 3 ranked",
+      "resolved": true,
+      "stray_candidates": [
+       "svc_auth_gateway"
+      ],
       "subject_resolution_correct": false,
-      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
+      "subject_resolution_detail": "rank-1 was proj_auth_gateway_hardening; expected proj_identity_rewrite",
       "subject_top_1": "fail",
-      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
-      "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
+      "subject_top_1_detail": "rank-1 was proj_auth_gateway_hardening; expected proj_identity_rewrite",
+      "subject_top_3": "pass",
+      "subject_top_3_detail": "top-3 ['proj_auth_gateway_hardening', 'proj_identity_rewrite', 'svc_auth_gateway']; expected proj_identity_rewrite"
      },
-     "subjects": [],
+     "subjects": [
+      {
+       "canonical_id": "proj_auth_gateway_hardening",
+       "display_label": "Auth Gateway Hardening",
+       "mechanism": "lexical_fuzzy",
+       "methods": [],
+       "rank": 0,
+       "rrf_score": null,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_identity_rewrite",
+       "display_label": "Identity Platform Rewrite",
+       "mechanism": "lexical_fuzzy",
+       "methods": [],
+       "rank": 1,
+       "rrf_score": null,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "svc_auth_gateway",
+       "display_label": "Auth Gateway",
+       "mechanism": "lexical_fuzzy",
+       "methods": [],
+       "rank": 2,
+       "rrf_score": null,
+       "signal": "fuzzy_label"
+      }
+     ],
      "withheld_canonical_ids": []
     },
     {
@@ -1002,7 +832,7 @@
      "withheld_canonical_ids": []
     },
     {
-     "authorization_filtered_count": 0,
+     "authorization_filtered_count": 1,
      "bm25_order": [
       "wg_auth_hardening",
       "dp_identity_none",
@@ -1113,34 +943,19 @@
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
       "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_authcore', 'pr_identity_882']",
+      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['dep_authcore']",
       "precision_over_all": "fail",
-      "precision_over_all_detail": "16 stray candidates across 18 ranked",
+      "precision_over_all_detail": "1 stray candidates across 1 ranked",
       "resolved": true,
       "stray_candidates": [
-       "dep_authcore",
-       "init_identity_modernization",
-       "pr_identity_882",
-       "pr_ledger_990",
-       "proj_acr",
-       "proj_beacon",
-       "proj_ledger_migration",
-       "proj_payments_rewrite",
-       "repo_acr",
-       "repo_checkout",
-       "repo_identity",
-       "repo_ledger",
-       "svc_auth_gateway",
-       "svc_ledger_api",
-       "wu_authcore_release",
-       "wu_ledger_dual_write"
+       "dep_authcore"
       ],
       "subject_resolution_correct": false,
       "subject_resolution_detail": "rank-1 was dep_authcore; expected proj_identity_rewrite",
       "subject_top_1": "fail",
       "subject_top_1_detail": "rank-1 was dep_authcore; expected proj_identity_rewrite",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['dep_authcore', 'pr_identity_882', 'proj_auth_gateway_hardening']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 ['dep_authcore']; expected proj_identity_rewrite"
      },
      "subjects": [
       {
@@ -1153,198 +968,11 @@
        "rank": 0,
        "rrf_score": 1.0,
        "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_identity_882",
-       "display_label": "identity#882 authcore 2.0 adoption",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 1,
-       "rrf_score": 0.5,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_auth_gateway_hardening",
-       "display_label": "Auth Gateway Hardening",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "bm25",
-        "cosine_similarity"
-       ],
-       "rank": 2,
-       "rrf_score": 0.4583333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "svc_auth_gateway",
-       "display_label": "Auth Gateway",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "bm25",
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.3666666666666667,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_authcore_release",
-       "display_label": "authcore 2.0 release",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.3333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_acr",
-       "display_label": "Agent Context Runtime",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.047619047619047616,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_ledger_990",
-       "display_label": "ledger#990 dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.041666666666666664,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_identity_rewrite",
-       "display_label": "Identity Platform Rewrite",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.038461538461538464,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_dual_write",
-       "display_label": "Ledger dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 8,
-       "rrf_score": 0.037037037037037035,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_checkout",
-       "display_label": "helio/checkout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 9,
-       "rrf_score": 0.03333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_ledger",
-       "display_label": "helio/ledger",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 10,
-       "rrf_score": 0.02702702702702703,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_ledger_migration",
-       "display_label": "Ledger Migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 11,
-       "rrf_score": 0.02564102564102564,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_acr",
-       "display_label": "helio/acr",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 12,
-       "rrf_score": 0.025,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_identity",
-       "display_label": "helio/identity",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 13,
-       "rrf_score": 0.024390243902439025,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "svc_ledger_api",
-       "display_label": "Ledger API",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 14,
-       "rrf_score": 0.023255813953488372,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_beacon",
-       "display_label": "Beacon Ingest",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 15,
-       "rrf_score": 0.022222222222222223,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_payments_rewrite",
-       "display_label": "Payments Rewrite",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 16,
-       "rrf_score": 0.02127659574468085,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "init_identity_modernization",
-       "display_label": "Identity Modernization",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 17,
-       "rrf_score": 0.02,
-       "signal": "fuzzy_label"
       }
      ],
-     "withheld_canonical_ids": []
+     "withheld_canonical_ids": [
+      "proj_quarry"
+     ]
     }
    ],
    "permitted_candidate_ids": [
@@ -1363,10 +991,10 @@
    "delta": {
     "baseline_correct": false,
     "baseline_ranked": 0,
-    "classification": "neither_correct_semantic_ranked_anyway",
-    "detail": "baseline: resolved nothing; expected proj_identity_rewrite | semantic: rank-1 was team_atlas; expected proj_identity_rewrite",
+    "classification": "neither_correct_neither_ranked",
+    "detail": "baseline: resolved nothing; expected proj_identity_rewrite | semantic: resolved nothing; expected proj_identity_rewrite",
     "semantic_correct": false,
-    "semantic_ranked": 11
+    "semantic_ranked": 0
    },
    "expected_answer": "direct",
    "forbidden_subject_ids": [],
@@ -1436,7 +1064,7 @@
      "withheld_canonical_ids": []
     },
     {
-     "authorization_filtered_count": 0,
+     "authorization_filtered_count": 1,
      "bm25_order": [],
      "cosine_order": [
       "team_atlas",
@@ -1512,155 +1140,23 @@
       "must_not_commit_detail": "the case expects a commitment",
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
-      "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_ledger_990', 'repo_ledger', 'team_atlas']",
-      "precision_over_all": "fail",
-      "precision_over_all_detail": "11 stray candidates across 11 ranked",
-      "resolved": true,
-      "stray_candidates": [
-       "dep_ratelimitd",
-       "pr_ledger_990",
-       "proj_beacon",
-       "repo_acr",
-       "repo_beacon",
-       "repo_checkout",
-       "repo_identity",
-       "repo_ledger",
-       "team_atlas",
-       "wu_beacon_ingest",
-       "wu_ledger_dual_write"
-      ],
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
       "subject_resolution_correct": false,
-      "subject_resolution_detail": "rank-1 was team_atlas; expected proj_identity_rewrite",
+      "subject_resolution_detail": "resolved nothing; expected proj_identity_rewrite",
       "subject_top_1": "fail",
-      "subject_top_1_detail": "rank-1 was team_atlas; expected proj_identity_rewrite",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_identity_rewrite",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['team_atlas', 'repo_ledger', 'pr_ledger_990']; expected proj_identity_rewrite"
+      "subject_top_3_detail": "top-3 []; expected proj_identity_rewrite"
      },
-     "subjects": [
-      {
-       "canonical_id": "team_atlas",
-       "display_label": "Atlas",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 0,
-       "rrf_score": 1.0,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_ledger",
-       "display_label": "helio/ledger",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 1,
-       "rrf_score": 0.5,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_ledger_990",
-       "display_label": "ledger#990 dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 2,
-       "rrf_score": 0.25,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_dual_write",
-       "display_label": "Ledger dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.2,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_beacon",
-       "display_label": "helio/beacon",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.08333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_acr",
-       "display_label": "helio/acr",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.06666666666666667,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "dep_ratelimitd",
-       "display_label": "ratelimitd",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.058823529411764705,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_checkout",
-       "display_label": "helio/checkout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.05555555555555555,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_beacon_ingest",
-       "display_label": "Beacon ingest throughput",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 8,
-       "rrf_score": 0.05,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_beacon",
-       "display_label": "Beacon Ingest",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 9,
-       "rrf_score": 0.037037037037037035,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_identity",
-       "display_label": "helio/identity",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 10,
-       "rrf_score": 0.03125,
-       "signal": "fuzzy_label"
-      }
-     ],
-     "withheld_canonical_ids": []
+     "subjects": [],
+     "withheld_canonical_ids": [
+      "proj_quarry"
+     ]
     }
    ],
    "permitted_candidate_ids": [
@@ -1678,10 +1174,10 @@
    "delta": {
     "baseline_correct": false,
     "baseline_ranked": 0,
-    "classification": "neither_correct_semantic_ranked_anyway",
-    "detail": "baseline: resolved nothing; the case has two real candidates | semantic: the top-3 clarification set contains ['pf_platform', 'pr_pulse_212'], which the case does not permit as candidates",
+    "classification": "neither_correct_neither_ranked",
+    "detail": "baseline: resolved nothing; the case has two real candidates | semantic: resolved nothing; the case has two real candidates",
     "semantic_correct": false,
-    "semantic_ranked": 10
+    "semantic_ranked": 0
    },
    "expected_answer": "clarified",
    "forbidden_subject_ids": [],
@@ -1751,7 +1247,7 @@
      "withheld_canonical_ids": []
     },
     {
-     "authorization_filtered_count": 0,
+     "authorization_filtered_count": 1,
      "bm25_order": [],
      "cosine_order": [
       "wi_beacon_deleted",
@@ -1760,18 +1256,18 @@
       "wi_atlas_wip",
       "rv_vertex_cycles",
       "rv_atlas_queue",
-      "atlas_wip",
       "borealis_wip",
+      "atlas_wip",
       "wi_ember_partial",
       "pf_platform",
       "wi_quarry_redacted",
-      "ember_completed",
       "lattice_completions",
-      "borealis_completed",
       "atlas_completed",
+      "ember_completed",
+      "borealis_completed",
+      "solstice_completions",
       "beacon_completions",
       "meridian_completions",
-      "solstice_completions",
       "sh_ember_stalled",
       "lattice_touching_contributors",
       "pr_ledger_990_merged",
@@ -1795,8 +1291,8 @@
       "proj_meridian",
       "cl_borealis",
       "lattice_active_contributors",
-      "proj_acr",
       "wg_acr",
+      "proj_acr",
       "pr_ledger_990",
       "wu_ledger_dual_write",
       "cc_lattice_active",
@@ -1814,17 +1310,17 @@
       "wi_atlas_wip",
       "rv_vertex_cycles",
       "rv_atlas_queue",
-      "atlas_wip",
       "borealis_wip",
+      "atlas_wip",
       "wi_ember_partial",
       "wi_quarry_redacted",
-      "ember_completed",
       "lattice_completions",
-      "borealis_completed",
       "atlas_completed",
+      "ember_completed",
+      "borealis_completed",
+      "solstice_completions",
       "beacon_completions",
       "meridian_completions",
-      "solstice_completions",
       "sh_ember_stalled",
       "lattice_touching_contributors",
       "pr_ledger_990_merged",
@@ -1855,145 +1351,26 @@
       "case_id": "H05_the_other_project_we_discussed",
       "leg": "semantic_hybrid",
       "must_not_commit": "pass",
-      "must_not_commit_detail": "ranked 10 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
-      "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pf_platform', 'pr_pulse_212']",
-      "precision_over_all": "fail",
-      "precision_over_all_detail": "9 stray candidates across 10 ranked",
-      "resolved": true,
-      "stray_candidates": [
-       "pf_platform",
-       "pr_ledger_990",
-       "pr_pulse_212",
-       "proj_acr",
-       "proj_beacon",
-       "proj_ledger_migration",
-       "proj_meridian",
-       "repo_ledger",
-       "wu_ledger_dual_write"
-      ],
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
       "subject_resolution_correct": false,
-      "subject_resolution_detail": "the top-3 clarification set contains ['pf_platform', 'pr_pulse_212'], which the case does not permit as candidates",
+      "subject_resolution_detail": "resolved nothing; the case has two real candidates",
       "subject_top_1": "not_applicable",
       "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
       "subject_top_3": "not_applicable",
       "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
      },
-     "subjects": [
-      {
-       "canonical_id": "pf_platform",
-       "display_label": "Platform Portfolio",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 0,
-       "rrf_score": 0.1,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_identity_rewrite",
-       "display_label": "Identity Platform Rewrite",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 1,
-       "rrf_score": 0.03571428571428571,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_pulse_212",
-       "display_label": "pulse#212 analytics rollout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 2,
-       "rrf_score": 0.03225806451612903,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_beacon",
-       "display_label": "Beacon Ingest",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.03125,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_ledger_migration",
-       "display_label": "Ledger Migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.027777777777777776,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_ledger",
-       "display_label": "helio/ledger",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.02631578947368421,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_meridian",
-       "display_label": "Meridian Docs",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.02564102564102564,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_acr",
-       "display_label": "Agent Context Runtime",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.023809523809523808,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_ledger_990",
-       "display_label": "ledger#990 dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 8,
-       "rrf_score": 0.022727272727272728,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_dual_write",
-       "display_label": "Ledger dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 9,
-       "rrf_score": 0.022222222222222223,
-       "signal": "fuzzy_label"
-      }
-     ],
-     "withheld_canonical_ids": []
+     "subjects": [],
+     "withheld_canonical_ids": [
+      "proj_quarry"
+     ]
     }
    ],
    "permitted_candidate_ids": [
@@ -2012,10 +1389,10 @@
    "delta": {
     "baseline_correct": false,
     "baseline_ranked": 0,
-    "classification": "neither_correct_semantic_ranked_anyway",
-    "detail": "baseline: resolved nothing; expected proj_vertex | semantic: rank-1 was wu_ledger_cutover; expected proj_vertex",
+    "classification": "neither_correct_neither_ranked",
+    "detail": "baseline: resolved nothing; expected proj_vertex | semantic: resolved nothing; expected proj_vertex",
     "semantic_correct": false,
-    "semantic_ranked": 10
+    "semantic_ranked": 0
    },
    "expected_answer": "direct",
    "forbidden_subject_ids": [],
@@ -2085,7 +1462,7 @@
      "withheld_canonical_ids": []
     },
     {
-     "authorization_filtered_count": 0,
+     "authorization_filtered_count": 1,
      "bm25_order": [
       "rv_vertex_cycles",
       "wi_frost_outlier",
@@ -2104,13 +1481,13 @@
       "vertex_review_cycles",
       "sc_ledger_declared_complete",
       "wi_beacon_deleted",
-      "borealis_review_wait",
       "dorado_review_wait",
       "atlas_review_wait",
+      "borealis_review_wait",
       "tr_ledger_suite",
       "wu_ledger_cutover",
-      "borealis_wip",
       "atlas_wip",
+      "borealis_wip",
       "pr_vertex_401_cycles",
       "pr_pulse_212",
       "pr_ledger_990_merged",
@@ -2119,25 +1496,25 @@
       "proj_identity_rewrite",
       "wg_identity_rewrite",
       "sc_pulse_declared_complete",
-      "wu_ledger_backfill",
       "wi_ledger_backfill_open",
+      "wu_ledger_backfill",
       "ember_completed",
-      "beacon_completions",
       "borealis_completed",
-      "lattice_completions",
-      "atlas_completed",
-      "meridian_completions",
       "solstice_completions",
+      "atlas_completed",
+      "lattice_completions",
+      "beacon_completions",
+      "meridian_completions",
       "dp_ledger_prod",
       "wg_payments_rewrite_superseded",
       "repo_checkout",
       "wi_ledger_children",
       "proj_payments_rewrite",
       "wu_ledger_dual_write",
-      "dp_identity_none",
       "pr_ledger_990",
       "oc_ledger_present",
       "wu_ledger_schema",
+      "dp_identity_none",
       "cc_quarry_activity",
       "rv_dorado_outbound",
       "frost_cycle_p90",
@@ -2160,12 +1537,12 @@
       "vertex_review_cycles",
       "sc_ledger_declared_complete",
       "wi_beacon_deleted",
-      "borealis_review_wait",
       "dorado_review_wait",
       "atlas_review_wait",
+      "borealis_review_wait",
       "tr_ledger_suite",
-      "borealis_wip",
       "atlas_wip",
+      "borealis_wip",
       "pr_vertex_401_cycles",
       "pr_ledger_990_merged",
       "sc_acr_still_open",
@@ -2173,17 +1550,17 @@
       "sc_pulse_declared_complete",
       "wi_ledger_backfill_open",
       "ember_completed",
-      "beacon_completions",
       "borealis_completed",
-      "lattice_completions",
-      "atlas_completed",
-      "meridian_completions",
       "solstice_completions",
+      "atlas_completed",
+      "lattice_completions",
+      "beacon_completions",
+      "meridian_completions",
       "dp_ledger_prod",
       "wg_payments_rewrite_superseded",
       "wi_ledger_children",
-      "dp_identity_none",
       "oc_ledger_present",
+      "dp_identity_none",
       "cc_quarry_activity",
       "frost_cycle_p90",
       "doc_injected_runbook",
@@ -2200,143 +1577,23 @@
       "must_not_commit_detail": "the case expects a commitment",
       "no_forbidden_subject": "not_applicable",
       "no_forbidden_subject_detail": "the case forbids no subject",
-      "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_pulse_212', 'proj_ledger_migration', 'wu_ledger_cutover']",
-      "precision_over_all": "fail",
-      "precision_over_all_detail": "10 stray candidates across 10 ranked",
-      "resolved": true,
-      "stray_candidates": [
-       "pr_ledger_990",
-       "pr_pulse_212",
-       "proj_identity_rewrite",
-       "proj_ledger_migration",
-       "proj_payments_rewrite",
-       "repo_checkout",
-       "wu_ledger_backfill",
-       "wu_ledger_cutover",
-       "wu_ledger_dual_write",
-       "wu_ledger_schema"
-      ],
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
       "subject_resolution_correct": false,
-      "subject_resolution_detail": "rank-1 was wu_ledger_cutover; expected proj_vertex",
+      "subject_resolution_detail": "resolved nothing; expected proj_vertex",
       "subject_top_1": "fail",
-      "subject_top_1_detail": "rank-1 was wu_ledger_cutover; expected proj_vertex",
+      "subject_top_1_detail": "rank-1 was (nothing); expected proj_vertex",
       "subject_top_3": "fail",
-      "subject_top_3_detail": "top-3 ['wu_ledger_cutover', 'pr_pulse_212', 'proj_ledger_migration']; expected proj_vertex"
+      "subject_top_3_detail": "top-3 []; expected proj_vertex"
      },
-     "subjects": [
-      {
-       "canonical_id": "wu_ledger_cutover",
-       "display_label": "Ledger cutover",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 0,
-       "rrf_score": 0.07142857142857142,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_pulse_212",
-       "display_label": "pulse#212 analytics rollout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 1,
-       "rrf_score": 0.05555555555555555,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_ledger_migration",
-       "display_label": "Ledger Migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 2,
-       "rrf_score": 0.047619047619047616,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_identity_rewrite",
-       "display_label": "Identity Platform Rewrite",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.045454545454545456,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_backfill",
-       "display_label": "Ledger historical backfill",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.04,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_checkout",
-       "display_label": "helio/checkout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.027777777777777776,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_payments_rewrite",
-       "display_label": "Payments Rewrite",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.02631578947368421,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_dual_write",
-       "display_label": "Ledger dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.02564102564102564,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_ledger_990",
-       "display_label": "ledger#990 dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 8,
-       "rrf_score": 0.024390243902439025,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_schema",
-       "display_label": "Ledger schema migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 9,
-       "rrf_score": 0.023255813953488372,
-       "signal": "fuzzy_label"
-      }
-     ],
-     "withheld_canonical_ids": []
+     "subjects": [],
+     "withheld_canonical_ids": [
+      "proj_quarry"
+     ]
     }
    ],
    "permitted_candidate_ids": [
@@ -2352,12 +1609,12 @@
    "case_id": "H07_unresolved_needs_candidates",
    "committed_subject_id": null,
    "delta": {
-    "baseline_correct": false,
-    "baseline_ranked": 0,
-    "classification": "neither_correct_semantic_ranked_anyway",
-    "detail": "baseline: resolved nothing; the case has two real candidates | semantic: ranked forbidden subjects ['proj_solstice', 'proj_vertex']",
-    "semantic_correct": false,
-    "semantic_ranked": 18
+    "baseline_correct": true,
+    "baseline_ranked": 2,
+    "classification": "both_correct",
+    "detail": "baseline: offered ['proj_payments_rewrite', 'proj_zenith'] inside the top-3 horizon, all permitted, without committing | semantic: offered ['proj_zenith', 'proj_payments_rewrite'] inside the top-3 horizon, all permitted, without committing",
+    "semantic_correct": true,
+    "semantic_ranked": 2
    },
    "expected_answer": "clarified",
    "forbidden_subject_ids": [
@@ -2370,7 +1627,10 @@
      "bm25_order": [],
      "cosine_order": [],
      "leg": "deterministic_mentions",
-     "mentions": [],
+     "mentions": [
+      "payments work",
+      "payments"
+     ],
      "observation_hits": [],
      "prose_disclosures": [],
      "query": "how's the payments work going",
@@ -2378,23 +1638,42 @@
       "case_id": "H07_unresolved_needs_candidates",
       "leg": "deterministic_mentions",
       "must_not_commit": "pass",
-      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "must_not_commit_detail": "ranked 2 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
       "no_forbidden_subject": "pass",
       "no_forbidden_subject_detail": "no forbidden subject ranked",
       "precision_at_3": "pass",
       "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
       "precision_over_all": "pass",
-      "precision_over_all_detail": "no stray candidate across 0 ranked",
-      "resolved": false,
+      "precision_over_all_detail": "no stray candidate across 2 ranked",
+      "resolved": true,
       "stray_candidates": [],
-      "subject_resolution_correct": false,
-      "subject_resolution_detail": "resolved nothing; the case has two real candidates",
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "offered ['proj_payments_rewrite', 'proj_zenith'] inside the top-3 horizon, all permitted, without committing",
       "subject_top_1": "not_applicable",
       "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
       "subject_top_3": "not_applicable",
       "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
      },
-     "subjects": [],
+     "subjects": [
+      {
+       "canonical_id": "proj_payments_rewrite",
+       "display_label": "Payments Rewrite",
+       "mechanism": "lexical_fuzzy",
+       "methods": [],
+       "rank": 0,
+       "rrf_score": null,
+       "signal": "fuzzy_label"
+      },
+      {
+       "canonical_id": "proj_zenith",
+       "display_label": "Zenith Payments",
+       "mechanism": "lexical_fuzzy",
+       "methods": [],
+       "rank": 1,
+       "rrf_score": null,
+       "signal": "fuzzy_label"
+      }
+     ],
      "withheld_canonical_ids": []
     },
     {
@@ -2430,7 +1709,7 @@
      "withheld_canonical_ids": []
     },
     {
-     "authorization_filtered_count": 0,
+     "authorization_filtered_count": 1,
      "bm25_order": [
       "wg_payments_rewrite_superseded",
       "sc_payments_rewrite_cancelled",
@@ -2444,29 +1723,29 @@
       "wi_quarry_redacted"
      ],
      "cosine_order": [
-      "proj_zenith",
       "wg_zenith",
+      "proj_zenith",
       "proj_payments_rewrite",
       "sc_payments_rewrite_cancelled",
       "wg_payments_rewrite_superseded",
       "pr_vertex_401",
       "proj_solstice",
       "rv_vertex_cycles",
-      "borealis_wip",
       "atlas_wip",
+      "borealis_wip",
       "pr_pulse_212",
       "pr_vertex_401_cycles",
       "svc_checkout",
       "svc_pulse_api",
       "repo_checkout",
       "dp_pulse_prod",
-      "solstice_completions",
-      "meridian_completions",
-      "borealis_completed",
       "lattice_completions",
       "beacon_completions",
-      "atlas_completed",
+      "meridian_completions",
+      "borealis_completed",
       "ember_completed",
+      "solstice_completions",
+      "atlas_completed",
       "wu_ledger_cutover",
       "ia_cinder_displaced",
       "proj_ledger_migration",
@@ -2499,25 +1778,25 @@
      "mentions": [],
      "observation_hits": [
       "wg_payments_rewrite_superseded",
-      "sc_payments_rewrite_cancelled",
       "wg_zenith",
+      "sc_payments_rewrite_cancelled",
       "wi_beacon_deleted",
       "wi_ember_partial",
       "wi_borealis_wip",
       "rv_vertex_cycles",
       "wi_atlas_wip",
-      "borealis_wip",
-      "wi_quarry_redacted",
       "atlas_wip",
+      "wi_quarry_redacted",
+      "borealis_wip",
       "pr_vertex_401_cycles",
       "dp_pulse_prod",
-      "solstice_completions",
-      "meridian_completions",
-      "borealis_completed",
       "lattice_completions",
       "beacon_completions",
-      "atlas_completed",
+      "meridian_completions",
+      "borealis_completed",
       "ember_completed",
+      "solstice_completions",
+      "atlas_completed",
       "ia_cinder_displaced",
       "rv_vertex_revoked",
       "wi_beacon_demand",
@@ -2541,34 +1820,17 @@
       "case_id": "H07_unresolved_needs_candidates",
       "leg": "semantic_hybrid",
       "must_not_commit": "pass",
-      "must_not_commit_detail": "ranked 18 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
-      "no_forbidden_subject": "fail",
-      "no_forbidden_subject_detail": "ranked forbidden subjects ['proj_solstice', 'proj_vertex']",
-      "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['pr_vertex_401']",
-      "precision_over_all": "fail",
-      "precision_over_all_detail": "16 stray candidates across 18 ranked",
+      "must_not_commit_detail": "ranked 2 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "no_forbidden_subject": "pass",
+      "no_forbidden_subject_detail": "no forbidden subject ranked",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 2 ranked",
       "resolved": true,
-      "stray_candidates": [
-       "issue_vertex_tax_rounding",
-       "pr_pulse_212",
-       "pr_vertex_401",
-       "proj_beacon",
-       "proj_ledger_migration",
-       "proj_solstice",
-       "proj_tidal",
-       "proj_vertex",
-       "repo_checkout",
-       "repo_ledger",
-       "svc_checkout",
-       "svc_ledger_api",
-       "svc_pulse_api",
-       "wu_beacon_ingest",
-       "wu_ledger_cutover",
-       "wu_ledger_schema"
-      ],
-      "subject_resolution_correct": false,
-      "subject_resolution_detail": "ranked forbidden subjects ['proj_solstice', 'proj_vertex']",
+      "stray_candidates": [],
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "offered ['proj_zenith', 'proj_payments_rewrite'] inside the top-3 horizon, all permitted, without committing",
       "subject_top_1": "not_applicable",
       "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
       "subject_top_3": "not_applicable",
@@ -2584,7 +1846,7 @@
         "cosine_similarity"
        ],
        "rank": 0,
-       "rrf_score": 1.25,
+       "rrf_score": 0.75,
        "signal": "fuzzy_label"
       },
       {
@@ -2598,185 +1860,11 @@
        "rank": 1,
        "rrf_score": 0.6666666666666666,
        "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_vertex_401",
-       "display_label": "checkout#401 tax rounding",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 2,
-       "rrf_score": 0.16666666666666666,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_solstice",
-       "display_label": "Solstice Billing",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.14285714285714285,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_pulse_212",
-       "display_label": "pulse#212 analytics rollout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.09090909090909091,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "svc_checkout",
-       "display_label": "Checkout Service",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.07692307692307693,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "svc_pulse_api",
-       "display_label": "Pulse API",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.07142857142857142,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_checkout",
-       "display_label": "helio/checkout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.06666666666666667,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_cutover",
-       "display_label": "Ledger cutover",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 8,
-       "rrf_score": 0.041666666666666664,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_ledger_migration",
-       "display_label": "Ledger Migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 9,
-       "rrf_score": 0.038461538461538464,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "svc_ledger_api",
-       "display_label": "Ledger API",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 10,
-       "rrf_score": 0.03333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_tidal",
-       "display_label": "Tidal Notifications",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 11,
-       "rrf_score": 0.03225806451612903,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_ledger",
-       "display_label": "helio/ledger",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 12,
-       "rrf_score": 0.02631578947368421,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "issue_vertex_tax_rounding",
-       "display_label": "Vertex tax rounding",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 13,
-       "rrf_score": 0.02564102564102564,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_beacon_ingest",
-       "display_label": "Beacon ingest throughput",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 14,
-       "rrf_score": 0.025,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_schema",
-       "display_label": "Ledger schema migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 15,
-       "rrf_score": 0.024390243902439025,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_vertex",
-       "display_label": "Vertex Checkout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 16,
-       "rrf_score": 0.021739130434782608,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_beacon",
-       "display_label": "Beacon Ingest",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 17,
-       "rrf_score": 0.02127659574468085,
-       "signal": "fuzzy_label"
       }
      ],
-     "withheld_canonical_ids": []
+     "withheld_canonical_ids": [
+      "proj_quarry"
+     ]
     }
    ],
    "permitted_candidate_ids": [
@@ -2795,10 +1883,10 @@
    "delta": {
     "baseline_correct": true,
     "baseline_ranked": 0,
-    "classification": "deterministic_only_correct",
-    "detail": "baseline: nothing was ranked, which is the only correct resolution | semantic: the case names a subject that does not exist; the leg ranked 20 candidates anyway, led by repo_beacon",
-    "semantic_correct": false,
-    "semantic_ranked": 20
+    "classification": "both_correct",
+    "detail": "baseline: nothing was ranked, which is the only correct resolution | semantic: nothing was ranked, which is the only correct resolution",
+    "semantic_correct": true,
+    "semantic_ranked": 0
    },
    "expected_answer": "unavailable",
    "forbidden_subject_ids": [
@@ -2889,8 +1977,8 @@
       "proj_beacon",
       "wi_borealis_wip",
       "wi_beacon_demand",
-      "wu_ledger_backfill",
       "wi_ledger_backfill_open",
+      "wu_ledger_backfill",
       "pr_ledger_990_merged",
       "wi_beacon_deleted",
       "ia_beacon_allocation",
@@ -2968,265 +2056,23 @@
       "case_id": "H08_no_match_must_not_widen",
       "leg": "semantic_hybrid",
       "must_not_commit": "pass",
-      "must_not_commit_detail": "ranked 20 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
+      "must_not_commit_detail": "ranked 0 candidates; a single ranked candidate is a silent commitment where the case demands a clarification",
       "no_forbidden_subject": "pass",
       "no_forbidden_subject_detail": "no forbidden subject ranked",
-      "precision_at_3": "fail",
-      "precision_at_3_detail": "stray candidates inside the top-3 horizon ['repo_acr', 'repo_beacon', 'repo_ledger']",
-      "precision_over_all": "fail",
-      "precision_over_all_detail": "20 stray candidates across 20 ranked",
-      "resolved": true,
-      "stray_candidates": [
-       "pr_ledger_990",
-       "pr_pulse_212",
-       "proj_beacon",
-       "proj_ledger_migration",
-       "proj_meridian",
-       "proj_solstice",
-       "proj_zenith",
-       "repo_acr",
-       "repo_beacon",
-       "repo_checkout",
-       "repo_identity",
-       "repo_ledger",
-       "repo_pulse",
-       "svc_ledger_api",
-       "team_borealis",
-       "wu_beacon_ingest",
-       "wu_ledger_backfill",
-       "wu_ledger_cutover",
-       "wu_ledger_dual_write",
-       "wu_ledger_schema"
-      ],
-      "subject_resolution_correct": false,
-      "subject_resolution_detail": "the case names a subject that does not exist; the leg ranked 20 candidates anyway, led by repo_beacon",
+      "precision_at_3": "pass",
+      "precision_at_3_detail": "no stray candidate inside the top-3 horizon",
+      "precision_over_all": "pass",
+      "precision_over_all_detail": "no stray candidate across 0 ranked",
+      "resolved": false,
+      "stray_candidates": [],
+      "subject_resolution_correct": true,
+      "subject_resolution_detail": "nothing was ranked, which is the only correct resolution",
       "subject_top_1": "not_applicable",
       "subject_top_1_detail": "the case expects a clarification, so there is no committed subject to be rank-1",
       "subject_top_3": "not_applicable",
       "subject_top_3_detail": "the case expects a clarification, so there is no committed subject to be rank-1"
      },
-     "subjects": [
-      {
-       "canonical_id": "repo_beacon",
-       "display_label": "helio/beacon",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 0,
-       "rrf_score": 1.0,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_ledger",
-       "display_label": "helio/ledger",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 1,
-       "rrf_score": 0.3333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_acr",
-       "display_label": "helio/acr",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 2,
-       "rrf_score": 0.25,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_checkout",
-       "display_label": "helio/checkout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 3,
-       "rrf_score": 0.125,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_identity",
-       "display_label": "helio/identity",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 4,
-       "rrf_score": 0.1111111111111111,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_beacon",
-       "display_label": "Beacon Ingest",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 5,
-       "rrf_score": 0.1,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_backfill",
-       "display_label": "Ledger historical backfill",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 6,
-       "rrf_score": 0.07692307692307693,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_zenith",
-       "display_label": "Zenith Payments",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 7,
-       "rrf_score": 0.05263157894736842,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_solstice",
-       "display_label": "Solstice Billing",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 8,
-       "rrf_score": 0.05,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_beacon_ingest",
-       "display_label": "Beacon ingest throughput",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 9,
-       "rrf_score": 0.047619047619047616,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "repo_pulse",
-       "display_label": "helio/pulse",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 10,
-       "rrf_score": 0.041666666666666664,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_pulse_212",
-       "display_label": "pulse#212 analytics rollout",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 11,
-       "rrf_score": 0.038461538461538464,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_schema",
-       "display_label": "Ledger schema migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 12,
-       "rrf_score": 0.03571428571428571,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_dual_write",
-       "display_label": "Ledger dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 13,
-       "rrf_score": 0.03333333333333333,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "wu_ledger_cutover",
-       "display_label": "Ledger cutover",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 14,
-       "rrf_score": 0.03225806451612903,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "team_borealis",
-       "display_label": "Borealis",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 15,
-       "rrf_score": 0.02564102564102564,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "pr_ledger_990",
-       "display_label": "ledger#990 dual-write teardown",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 16,
-       "rrf_score": 0.021739130434782608,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "svc_ledger_api",
-       "display_label": "Ledger API",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 17,
-       "rrf_score": 0.02127659574468085,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_meridian",
-       "display_label": "Meridian Docs",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 18,
-       "rrf_score": 0.020833333333333332,
-       "signal": "fuzzy_label"
-      },
-      {
-       "canonical_id": "proj_ledger_migration",
-       "display_label": "Ledger Migration",
-       "mechanism": "embedding_similarity",
-       "methods": [
-        "cosine_similarity"
-       ],
-       "rank": 19,
-       "rrf_score": 0.02040816326530612,
-       "signal": "fuzzy_label"
-      }
-     ],
+     "subjects": [],
      "withheld_canonical_ids": []
     }
    ],
@@ -3284,37 +2130,43 @@
   "cases_measured": 8,
   "delta_classification_case_ids": {
    "both_correct": [
-    "H01_acronym_resolution"
-   ],
-   "deterministic_only_correct": [
-    "H02_old_and_current_name",
+    "H01_acronym_resolution",
+    "H07_unresolved_needs_candidates",
     "H08_no_match_must_not_widen"
    ],
-   "neither_correct_semantic_ranked_anyway": [
-    "H03_the_auth_work",
+   "deterministic_only_correct": [
+    "H02_old_and_current_name"
+   ],
+   "neither_correct_both_ranked": [
+    "H03_the_auth_work"
+   ],
+   "neither_correct_neither_ranked": [
     "H04_pronoun_follow_up",
     "H05_the_other_project_we_discussed",
-    "H06_prior_attempt_reference",
-    "H07_unresolved_needs_candidates"
+    "H06_prior_attempt_reference"
    ]
   },
   "delta_classification_counts": {
-   "both_correct": 1,
-   "deterministic_only_correct": 2,
-   "neither_correct_semantic_ranked_anyway": 5
+   "both_correct": 3,
+   "deterministic_only_correct": 1,
+   "neither_correct_both_ranked": 1,
+   "neither_correct_neither_ranked": 3
   },
   "prose_disclosures_by_leg": {},
   "subject_resolution_correct_by_leg": {
    "deterministic_mentions": [
     "H01_acronym_resolution",
     "H02_old_and_current_name",
+    "H07_unresolved_needs_candidates",
     "H08_no_match_must_not_widen"
    ],
    "deterministic_question": [
     "H08_no_match_must_not_widen"
    ],
    "semantic_hybrid": [
-    "H01_acronym_resolution"
+    "H01_acronym_resolution",
+    "H07_unresolved_needs_candidates",
+    "H08_no_match_must_not_widen"
    ]
   }
  }


### PR DESCRIPTION
## Issue / phase
Wave 3.2 / issue 3660 (Phase 2A shared-contract territory). Remaining-scope follow-up under issue 3666 (plain reference, not close-linked — this PR does not complete that issue; retention/deletion/audit/telemetry/docs remain out of its own broader scope, and this PR only touches the trial-measurement layer).

## Observable outcome
The trial that measures "does the semantic subject-resolution leg behave safely" now actually exercises the safety fixes it claims to measure. Concretely: regenerating the trial's committed artifact — stale since its original landing, never re-run since — shows the worst outcome class ("neither leg was right and the semantic leg ranked something anyway", named in the trial's own code as "the most expensive class: a wrong answer costs more than a refusal") drop from 5 of 8 measured cases to 0. Two cases move all the way to a fully-correct classification. A stale authorization-probe invariant that started false-failing under an earlier, unrelated retrieval-widening change is fixed with a stated reason, not silenced.

## Architecture boundary
- `trials/chaos_3647/legs.py`, `trials/chaos_3647/probes.py`, `trials/chaos_3647/results/semantic-leg.records.json` (regenerated artifact) + a new `regeneration-note.md` — all inside the trial harness for the semantic-retrieval leg, which is my exclusive `semantic_retrieval.py`'s own test-measurement scaffolding.
- One test file touched: `tests/context_fabric/test_chaos_3647_live_semantic.py` (one assertion updated to check the right layer — see below).
- Two new unit test files (fake-node harness, no live infra needed to run them).
- No shared/frozen contract file touched, no contract-owner protocol needed.

## Why this was needed
`legs.py::resolve_semantic` called `semantic_retrieval.retrieve_candidates` directly and reported every authorized candidate as the leg's measured answer — it never called `semantic_retrieval.assess_disposition`, the refusal/clarification policy built specifically so a caller never receives a fabricated top-1 pick from a diffuse, ungrounded ranking. The policy was real and unit-tested in isolation; the trial measuring whether it actually helps never exercised it. Concretely, before this change, the freshly-regenerated artifact still showed the "nonexistent entity" case ranking 25 confident candidates — the exact measured failure the refusal-threshold work fixed, just never wired into what gets measured.

Separately, `probes.py`'s `unrestricted_control` authorization probe had a pass condition (`authorization_filtered_count == 0`) that predates an earlier, unrelated change (the observation→entity hop) which legitimately widens what gets retrieved. That widening can now incidentally retrieve something restricted for a query aimed at nothing restricted, which the filter then correctly withholds — the probe's stale condition scored that as a failure. Every withheld id is, by construction, genuinely unauthorized (see `retrieve_candidates`'s own withholding logic), so this can only mean the filter working under a wider net, never the control being over-filtered. Fixed to fail only on the one real failure mode it exists for: the control's own target not being ranked at all.

## Scope / non-scope
**In scope:** wiring the existing disposition policy into what the trial measures; fixing the probe's stale invariant; regenerating and documenting the artifact.
**Explicitly out of scope, named rather than silently skipped:**
- Wiring `resolve_conversational_reference` (issue 3686) into this trial. It needs new prior-turn state threading — the corpus's own `follows_case_id` chain isn't read anywhere in `trials/chaos_3647` today — a materially larger piece of work than adding a policy call that already had everything it needed. The pronoun/prior-turn cases in this artifact correctly show the interim-safe state (semantic now refuses rather than confidently guessing wrong) but not yet a correct resolution.
- A pre-existing, unrelated live-test failure this run surfaced: `test_chaos_3647_live_semantic.py`'s `test_the_colloquial_cases_still_resolve_nothing_deterministically` now fails because the **deterministic** leg's own mention extraction (code this PR does not touch) now resolves "auth work" — traced to issue 3648's already-landed, already-ledgered extractor change (`trials/chaos_3619/refusal_causes.DIVERGENCE_LEDGER`'s `PHRASE_EXTRACTED_POST_3648` entry already documents exactly this). This test's assumption simply predates that ledgered change. Not fixed here — it exercises code this PR never touches — flagged as a follow-up.

## Base / head SHA
Base: `729d52005` (origin/feature/chaos-3498-context-fabric tip at branch time)
Head: `21c4a4f97a99cc8b7a49a51ca4854ccf6571b9be`

## Migrations
None.

## Security impact
No authorization-boundary code changed — `retrieve_candidates`'s withholding logic is untouched. The probe fix corrects a test-oracle false-positive, it does not relax any check: `any_unauthorized_entity_ranked: false` and `any_prose_disclosure: false` hold identically before and after, confirmed by the regenerated artifact and the live probe suite (all four probes pass, including the fixed one).

## RED-first evidence
- `tests/context_fabric/test_chaos_3666_semantic_leg_disposition.py`: 3 tests, each planting the exact shape `assess_disposition` distinguishes (no lexical grounding / genuine leader / tied candidates), all failing against the pre-fix `resolve_semantic` (missing `disposition` attribute / raw unbounded list), all passing after.
- `tests/context_fabric/test_chaos_3666_unrestricted_control_probe.py`: reproduces the exact live-observed shape (target ranked cleanly, one other restricted entity incidentally retrieved and correctly withheld) — fails against the pre-fix probe logic with the exact detail message seen live, passes after. Two regression-guard cases (target never ranked still fails; clean run still passes) confirm nothing else moved.

## Verification
- Focused: both new test files — 6 passed.
- Affected: `pytest tests/context_fabric/` — 1543 passed, 63 skipped (pre-existing, live/graphiti-extra gated).
- `ruff check` / mypy (worktree venv, full project) — clean.
- **Live, twice**: real FalkorDB + real OpenAI embeddings. (1) The existing live suite `test_chaos_3647_live_semantic.py` — 8 of 9 pass; the 1 failure is the pre-existing, unrelated, out-of-scope one described above, confirmed via full traceback to be about the deterministic leg this PR never touches. (2) The trial regenerated end to end, artifact committed with a dated, cited note (`trials/chaos_3647/results/regeneration-note.md`) explaining every contributing change since the artifact was last generated and the full before/after by case.

## Known limitations
- Conversational-reference wiring into this trial remains open (named above).
- The pre-existing deterministic-leg test failure remains open (named above), unrelated to and untouched by this PR.

## Rollout / rollback
No production code touched — `trials/` is test/measurement scaffolding only. Safe to revert independently.