### PR TITLE
issue 3632: document-provider config fails closed; reason-coded telemetry

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/backend.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/backend.py
@@ -418,6 +418,34 @@ class CloudEmbedder:
         )
 
     def _client(self) -> Any:
+        # Issue 3632: refuse before constructing the client, not just before
+        # reporting `semantic`. The OpenAI SDK falls back to an AMBIENT
+        # OPENAI_API_KEY environment variable whenever `api_key=None` is
+        # passed explicitly -- so a bare, unconfigured `CloudEmbedder()`
+        # (which correctly reports `semantic=False`, implying "cannot
+        # embed") would silently succeed anyway if the process happens to
+        # have OPENAI_API_KEY set for an unrelated reason (this repo's own
+        # Ask Dev LLM features, for one). Confirmed directly: with a real
+        # process env var set and the socket layer blocked, `create()`
+        # attempted a live connection before this guard existed. A caller
+        # that reaches here without going through `from_environment()` (for
+        # instance `to_graphiti_document_nodes`, which calls `create()`
+        # unconditionally for every embedder, unlike `to_graphiti_nodes`'s
+        # deterministic-only special case) must not be able to send document
+        # text to a provider this instance's own credential state never
+        # explicitly authorized -- "fail closed ... when providers/text
+        # indexing are disallowed" is exactly this case, and org policy for
+        # whether a provider may be used is expressed by whether an api_key
+        # was explicitly supplied through this class's own convention.
+        if not self.api_key:
+            raise RuntimeError(
+                "CloudEmbedder has no api_key configured, so it cannot "
+                "embed -- refusing to fall back to an ambient "
+                "OPENAI_API_KEY/environment credential this instance never "
+                "explicitly received. `semantic` already reports False for "
+                "exactly this reason; this guard makes that promise true "
+                "rather than advisory"
+            )
         module = graphiti_module("embedder.openai")
         return module.OpenAIEmbedder(
             config=module.OpenAIEmbedderConfig(

--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -51,6 +51,18 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
+# Prometheus telemetry for the document lifecycle (issue 3632). Imported
+# from outside context_fabric deliberately: this is the arm depending on
+# shared repo infrastructure, not the reverse -- `test_no_production_module_
+# imports_the_arm_at_module_scope` in test_chaos_3617_containment.py only
+# forbids the OTHER direction. `dev_health_ops.metrics.prometheus` has no
+# dependency on graphiti-core or falkordb, so importing it here does not
+# widen what "the arm is optional and removable" means.
+from dev_health_ops.metrics.prometheus import (
+    record_context_fabric_document_removed,
+    record_context_fabric_documents_indexed,
+)
+
 from .backend import (
     DeterministicEmbedder,
     EmbeddingBackend,
@@ -448,6 +460,10 @@ class GraphArmStore:
             ),
             operation="write_projection",
         )
+        # Telemetry only after the write above actually completed -- a raise
+        # from add_nodes_and_edges_bulk must not record documents as indexed
+        # that were never durably written.
+        record_context_fabric_documents_indexed(len(document_nodes))
         indexed_through = max(
             (
                 *(node.observed_at for node in projection.nodes),
@@ -690,6 +706,11 @@ class GraphArmStore:
             self._partition,
             reason.value,
         )
+        # Telemetry only on an actual deletion -- a no-op (already absent,
+        # never approved) must not inflate a counter that is supposed to
+        # measure real index shrinkage.
+        if removed:
+            record_context_fabric_document_removed(reason.value)
         return removed
 
 

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -5,6 +5,7 @@ Defines application-level counters, histograms, and gauges for:
   - ClickHouse query latency
   - LLM API calls (OpenAI / Anthropic)
   - GitHub API calls (requests by endpoint/status, rate limit remaining)
+  - Context Fabric graph arm: embedded-surface document indexing/removal
 
 Usage:
     from dev_health_ops.metrics.prometheus import (
@@ -19,6 +20,8 @@ Usage:
         GITHUB_RATE_LIMIT_REMAINING,
         record_github_api_request,
         record_github_rate_limit,
+        record_context_fabric_documents_indexed,
+        record_context_fabric_document_removed,
     )
 """
 
@@ -327,6 +330,31 @@ if _PROMETHEUS_AVAILABLE:
         "starved), not just that one run failed.",
     )
 
+    # ---------------------------------------------------------------------------
+    # Context Fabric graph arm: embedded-surface document lifecycle (issue 3632)
+    #
+    # Content-safe by construction: neither counter's labels ever carry a
+    # title, body or canonical id -- only a closed reason-code vocabulary
+    # (context_fabric.graph_arm.store.DocumentRemovalReason's own values).
+    # ---------------------------------------------------------------------------
+    CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_context_fabric_documents_indexed_total",
+        "Documents written as nodes to the context-fabric graph trial "
+        "store, cumulative across all partitions. Incremented once per "
+        "document per successful projection write -- a write that raises "
+        "increments nothing, since no node was actually written.",
+    )
+
+    CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_context_fabric_documents_removed_total",
+        "Documents removed from the context-fabric graph trial store via "
+        "GraphArmStore.remove_document, by reason. Incremented only when a "
+        "node was actually deleted -- a no-op removal (already absent, or "
+        "never approved in the first place) increments nothing, so this "
+        "counter measures real index shrinkage, not call volume.",
+        ["reason"],
+    )
+
 else:
     # Graceful no-ops when prometheus_client is unavailable
     CELERY_TASKS_TOTAL = _noop_counter()
@@ -357,6 +385,8 @@ else:
     ASK_DEV_RETENTION_SWEEP_TOTAL = _noop_counter()
     ASK_DEV_RETENTION_SWEEP_PURGED_TOTAL = _noop_counter()
     ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP = _noop_gauge()
+    CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL = _noop_counter()
+    CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL = _noop_counter()
 
 
 # ---------------------------------------------------------------------------
@@ -465,6 +495,32 @@ def record_ask_dev_retention_sweep(
         ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP.set(
             timestamp if timestamp is not None else time.time()
         )
+
+
+def record_context_fabric_documents_indexed(count: int) -> None:
+    """Record ``count`` documents written as nodes in one projection write.
+
+    ``count`` rather than a one-at-a-time call: the write side embeds and
+    writes an entire batch per ``write_projection`` call, and recording once
+    per call (with the real count) avoids a metrics-loop for something the
+    caller already has as a single number.
+    """
+
+    if count:
+        CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL.inc(count)
+
+
+def record_context_fabric_document_removed(reason: str) -> None:
+    """Record one document actually removed from the graph store.
+
+    ``reason`` is expected to be one of
+    ``context_fabric.graph_arm.store.DocumentRemovalReason``'s values --
+    passed as a plain ``str`` here (not the enum type) so this module stays
+    free of a dependency on the optional graph arm, matching every other
+    entry in this file.
+    """
+
+    CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(reason=reason).inc()
 
 
 @contextmanager

--- a/tests/context_fabric/test_chaos_3617_semantic_claims.py
+++ b/tests/context_fabric/test_chaos_3617_semantic_claims.py
@@ -441,6 +441,55 @@ class TestEmbedderContracts:
         with pytest.raises(RuntimeError, match="Refusing to fall back"):
             CloudEmbedder.from_environment()
 
+    @pytest.mark.asyncio
+    async def test_a_bare_cloud_embedder_cannot_embed_via_an_ambient_credential(
+        self, monkeypatch
+    ) -> None:
+        """Issue 3632: ``semantic=False`` must be load-bearing, not advisory.
+
+        The gap this closes: ``CloudEmbedder(api_key=None)`` correctly
+        reports ``semantic=False`` -- but the underlying OpenAI SDK falls
+        back to an AMBIENT ``OPENAI_API_KEY`` environment variable whenever
+        an explicit ``api_key=None`` is passed through. Confirmed directly
+        (not assumed): before this guard existed, setting ``OPENAI_API_KEY``
+        in the process environment and calling ``create()`` on a bare,
+        unconfigured ``CloudEmbedder()`` attempted a real outbound
+        connection using that ambient credential -- one this instance never
+        explicitly received through the arm's own credential convention
+        (:meth:`CloudEmbedder.from_environment`).
+
+        This matters specifically for the issue 3632 document path:
+        ``to_graphiti_document_nodes`` calls ``embedder.create()``
+        unconditionally for every embedder (unlike ``to_graphiti_nodes``'s
+        deterministic-only special case), so a bare ``CloudEmbedder()``
+        reaching that path would send a document's body text to a provider
+        under a credential this instance's own state says it does not have
+        -- exactly the "fail closed ... when providers/text indexing are
+        disallowed" acceptance criterion this ticket names.
+
+        Socket-blocked rather than network-mocked, so this proves NO
+        connection is attempted, not merely that one eventually fails.
+        """
+
+        import socket
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-ambient-not-explicitly-passed")
+
+        def _blocked_connect(self, *_args, **_kwargs):
+            raise AssertionError(
+                "CloudEmbedder.create() attempted a real socket connection "
+                "with no api_key configured -- it must refuse before "
+                "constructing a client at all, never after"
+            )
+
+        monkeypatch.setattr(socket.socket, "connect", _blocked_connect)
+
+        embedder = CloudEmbedder()
+        assert embedder.semantic is False
+
+        with pytest.raises(RuntimeError, match="refusing to fall back"):
+            await embedder.create(input_data=["a document's body text"])
+
     def test_the_cloud_embedder_reads_the_repos_credential_convention(
         self, monkeypatch
     ) -> None:

--- a/tests/context_fabric/test_chaos_3632_telemetry_and_config.py
+++ b/tests/context_fabric/test_chaos_3632_telemetry_and_config.py
@@ -1,0 +1,221 @@
+"""Issue 3632's remaining two open acceptance items: production config
+fail-closed behavior, and reason-coded document telemetry.
+
+**Config.** ``GraphArmStore.write_projection`` reads the acceptance text's
+"fail closed ... when providers/text indexing are disallowed" through two
+already-existing, independently-tested mechanisms:
+
+* :func:`~.flags.graph_projection_enabled` defaults off
+  (``test_chaos_3617_operational_controls.py::TestFlagsDefaultOff``);
+* :meth:`~.backend.CloudEmbedder.from_environment` refuses to degrade to a
+  hash embedder when no credential is configured
+  (``test_chaos_3617_semantic_claims.py::TestEmbedderContracts::
+  test_the_cloud_embedder_refuses_to_degrade_silently``, and this ticket's
+  own ``test_a_bare_cloud_embedder_cannot_embed_via_an_ambient_credential``,
+  which closed a real gap where a bare, unconfigured ``CloudEmbedder()``
+  could still embed via an ambient environment credential it never
+  explicitly received).
+
+What neither of those proves on its own: that a real
+``GraphArmStore.write_projection`` call carrying an approved document
+actually surfaces that refusal, and does so *before* any data reaches the
+store -- not after a partial write. That is what
+``TestWriteProjectionFailsClosed`` below measures.
+
+**Telemetry.** ``record_context_fabric_documents_indexed`` /
+``record_context_fabric_document_removed`` (``metrics/prometheus.py``) are
+unit-tested in isolation in ``tests/test_prometheus_metrics.py``. What that
+cannot measure: whether ``write_projection``/``remove_document`` actually
+call them, with the real counts and reason codes a live run produces. That
+is ``TestTelemetryReflectsRealOperations`` below.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from dev_health_ops.context_fabric.graph_arm import build_projection, fixtures
+from dev_health_ops.context_fabric.graph_arm.backend import CloudEmbedder
+from dev_health_ops.context_fabric.graph_arm.store import (
+    DocumentRemovalReason,
+    GraphArmStore,
+)
+from dev_health_ops.metrics.prometheus import (
+    CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL,
+    CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL,
+)
+from tests.context_fabric import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+_APPROVED_DOCUMENT_ID = "doc_nfm_readme"
+_NEVER_APPROVED_DOCUMENT_ID = "doc_unapproved_thread"
+
+
+def _unique_org(prefix: str) -> str:
+    return f"{prefix}{uuid.uuid4().hex[:12]}"
+
+
+def _reorg(batch, org_id: str):
+    def rebind(record):
+        return dataclasses.replace(record, org_id=org_id)
+
+    return dataclasses.replace(
+        batch,
+        org_id=org_id,
+        entities=tuple(rebind(item) for item in batch.entities),
+        relationships=tuple(rebind(item) for item in batch.relationships),
+        observations=tuple(rebind(item) for item in batch.observations),
+        documents=tuple(rebind(item) for item in batch.documents),
+    )
+
+
+class TestWriteProjectionFailsClosed:
+    async def test_a_bare_cloud_embedder_writes_nothing_and_refuses(
+        self, monkeypatch
+    ) -> None:
+        """A real ``write_projection`` call, not just the isolated guard.
+
+        Against the real live store rather than a deliberately-unreachable
+        endpoint: constructing ``GraphArmStore.for_org`` schedules FalkorDB's
+        own background connection task as a side effect of construction
+        (confirmed against ``partition_exists_for``'s own docstring), which
+        made an artificially-unreachable endpoint race a spurious
+        connection-refused error against the embedder guard this test
+        actually wants to prove. The live store sidesteps that race, and the
+        proof is stronger for it: ``count_nodes() == 0`` afterward means the
+        refusal happened strictly before ``add_nodes_and_edges_bulk`` ever
+        ran, not merely that the call eventually raised.
+        """
+
+        config = live_gate.require_live_store()
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+        live_gate.require_flag_state()
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        org_id = _unique_org("orgfailclosed")
+        projection = build_projection(_reorg(fixtures.alpha_batch(), org_id))
+        assert projection.approved_documents, (
+            "the fixture must carry at least one approved document, or this "
+            "test cannot reach the document-embedding path at all"
+        )
+
+        store = GraphArmStore.for_org(
+            org_id,
+            config=config,
+            embedder=CloudEmbedder(),  # bare -- api_key=None, semantic=False
+        )
+        try:
+            with pytest.raises(RuntimeError, match="refusing to fall back"):
+                await store.write_projection(projection)
+            assert await store.count_nodes() == 0, (
+                "the refusal must happen before any node reaches the store -- "
+                "a partial write here would mean 'fail closed' only bounded "
+                "how much leaked, not whether anything did"
+            )
+        finally:
+            try:
+                await store.purge_org()
+            finally:
+                await store.close()
+
+
+@pytest_asyncio.fixture
+async def alpha_store(monkeypatch) -> AsyncIterator[GraphArmStore]:
+    config = live_gate.require_live_store()
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+    live_gate.require_flag_state()
+
+    org_id = _unique_org("orgtelemetry")
+    projection = build_projection(_reorg(fixtures.alpha_batch(), org_id))
+    store = GraphArmStore.for_org(org_id, config=config)
+    try:
+        await store.build_indices()
+        await store.write_projection(projection)
+        yield store
+    finally:
+        try:
+            await store.purge_org()
+        finally:
+            await store.close()
+
+
+class TestTelemetryReflectsRealOperations:
+    async def test_write_projection_records_the_real_indexed_count(
+        self, monkeypatch
+    ) -> None:
+        """Positive control: a fresh org's write increments by exactly the
+        number of approved documents the fixture carries (one), not by a
+        fixed or guessed amount.
+        """
+
+        config = live_gate.require_live_store()
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+        live_gate.require_flag_state()
+
+        org_id = _unique_org("orgtelemetryindex")
+        projection = build_projection(_reorg(fixtures.alpha_batch(), org_id))
+        assert len(projection.approved_documents) == 1, (
+            "test assumes exactly one approved document; fixture drifted"
+        )
+
+        before = CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL._value.get()
+
+        store = GraphArmStore.for_org(org_id, config=config)
+        try:
+            await store.build_indices()
+            await store.write_projection(projection)
+        finally:
+            try:
+                await store.purge_org()
+            finally:
+                await store.close()
+
+        after = CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL._value.get()
+        assert after == before + 1
+
+    async def test_remove_document_records_the_reason_it_was_given(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        before = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason=DocumentRemovalReason.POLICY_FORBIDDEN.value
+        )._value.get()
+
+        removed = await alpha_store.remove_document(
+            _APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.POLICY_FORBIDDEN
+        )
+
+        assert removed is True
+        after = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason=DocumentRemovalReason.POLICY_FORBIDDEN.value
+        )._value.get()
+        assert after == before + 1
+
+    async def test_a_no_op_removal_does_not_inflate_the_counter(
+        self, alpha_store: GraphArmStore
+    ) -> None:
+        """Negative control, paired with the test above: removing a document
+        that was never approved (never reached a node) must not be counted
+        as a real removal -- the counter measures index shrinkage, not call
+        volume.
+        """
+
+        before = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason=DocumentRemovalReason.APPROVAL_REVOKED.value
+        )._value.get()
+
+        removed = await alpha_store.remove_document(
+            _NEVER_APPROVED_DOCUMENT_ID, reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+
+        assert removed is False
+        after = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason=DocumentRemovalReason.APPROVAL_REVOKED.value
+        )._value.get()
+        assert after == before

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 from prometheus_client import REGISTRY
 
 from dev_health_ops.metrics.prometheus import (
+    CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL,
+    CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL,
     GITHUB_API_REQUESTS_TOTAL,
     GITHUB_RATE_LIMIT_REMAINING,
+    record_context_fabric_document_removed,
+    record_context_fabric_documents_indexed,
     record_github_api_request,
     record_github_rate_limit,
 )
@@ -72,3 +76,64 @@ class TestGitHubApiMetrics:
         """Rate limit gauge is registered in the default Prometheus registry."""
         metric_names = [m.name for m in REGISTRY.collect()]
         assert "devhealth_github_rate_limit_remaining" in metric_names
+
+
+class TestContextFabricDocumentMetrics:
+    """Context Fabric graph arm: embedded-surface document lifecycle
+    (issue 3632)."""
+
+    def test_indexed_counter_increments_by_the_given_count(self):
+        before = CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL._value.get()
+
+        record_context_fabric_documents_indexed(3)
+
+        after = CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL._value.get()
+        assert after == before + 3
+
+    def test_indexed_counter_is_a_no_op_for_zero(self):
+        """A batch with no documents must not even touch the counter --
+        distinguishes "zero documents written" from "one call that happened
+        to write zero", which matters for a rate-based alert reading this
+        counter's call frequency, not just its value.
+        """
+
+        before = CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL._value.get()
+
+        record_context_fabric_documents_indexed(0)
+
+        after = CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL._value.get()
+        assert after == before
+
+    def test_removed_counter_increments_with_its_reason_label(self):
+        before = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason="approval_revoked"
+        )._value.get()
+
+        record_context_fabric_document_removed("approval_revoked")
+
+        after = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason="approval_revoked"
+        )._value.get()
+        assert after == before + 1
+
+    def test_removed_counter_tracks_reasons_independently(self):
+        record_context_fabric_document_removed("policy_forbidden")
+        record_context_fabric_document_removed("cross_tenant")
+
+        policy_forbidden = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason="policy_forbidden"
+        )._value.get()
+        cross_tenant = CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(
+            reason="cross_tenant"
+        )._value.get()
+
+        assert policy_forbidden >= 1
+        assert cross_tenant >= 1
+
+    def test_indexed_counter_registered_in_default_registry(self):
+        metric_names = [m.name for m in REGISTRY.collect()]
+        assert "devhealth_context_fabric_documents_indexed" in metric_names
+
+    def test_removed_counter_registered_in_default_registry(self):
+        metric_names = [m.name for m in REGISTRY.collect()]
+        assert "devhealth_context_fabric_documents_removed" in metric_names


### PR DESCRIPTION
## Issue / phase
Slice 2 of issue 3632's remaining acceptance criteria (write side, read-side trust gate, and targeted-deletion slice 1 are merged). This PR covers two of the still-open items: "fail closed ... when providers/text indexing are disallowed", and the telemetry half of "add provider policy, budget, retention, deletion, and audit behavior." Branch and title are deliberately token-free per the standing multi-PR rule (a literal issue-number token in a partial PR's branch/title/body has auto-closed this issue three times now via this workspace's Linear-GitHub integration, regardless of close-linking intent).

## Observable outcome

**Config.** A bare, unconfigured `CloudEmbedder()` can no longer embed via an ambient `OPENAI_API_KEY` environment variable it never explicitly received -- `semantic=False` is now load-bearing, not just advisory. A real `write_projection` call with such an embedder raises before any node reaches the store, verified against the live store (`count_nodes() == 0` afterward).

**Telemetry.** Two Prometheus counters, reason-coded and content-safe: `devhealth_context_fabric_documents_indexed_total` and `devhealth_context_fabric_documents_removed_total{reason}`, both verified to reflect real `write_projection`/`remove_document` calls against a live store, not just their isolated helper functions.

## Architecture boundary

**The config gap, found while checking the document path specifically.** Two fail-closed mechanisms already existed and were independently tested: `graph_projection_enabled()` defaults off, and `CloudEmbedder.from_environment()` refuses to degrade to a hash embedder when no credential is configured. Checking whether that coverage actually reaches the *document* write path (which calls the embedder unconditionally for every embedder, unlike the entity path's deterministic-only special case) surfaced a real hole: `CloudEmbedder._client()` passed `api_key=None` straight to the OpenAI SDK, which falls back to an ambient `OPENAI_API_KEY` env var whenever the explicit param is `None`. Confirmed directly (not assumed): with that env var set for an unrelated reason (this repo already uses it for Ask Dev's own LLM features) and the socket layer blocked, `CloudEmbedder().create()` attempted a real outbound connection using the ambient credential -- one the instance's own state (`semantic=False`) said it did not have.

Fixed in `backend.py`: `_client()` now refuses before constructing the client at all if `api_key` is falsy. This makes `semantic=False` a true guarantee rather than a self-report.

**Telemetry lives in `metrics/prometheus.py`**, the repo's existing, single Prometheus metrics module (Celery, ClickHouse, LLM, GitHub, investment, Ask Dev retention already extend it) -- not a new domain-metrics framework. Both new counters register on the same default registry `_observability.py`'s `Instrumentator()` already exposes at `/metrics`; no change to `_observability.py` was needed. `record_context_fabric_document_removed` takes `reason` as a plain `str`, not the `DocumentRemovalReason` enum, so `metrics/prometheus.py` stays free of any dependency on the optional graph arm -- matching every other entry in that module and the arm's own "optional and removable" containment discipline.

## Scope / non-scope
**In scope:** the `CloudEmbedder` fail-closed fix; `documents_indexed_total` / `documents_removed_total{reason}` counters and their wiring into `write_projection`/`remove_document`.

**Deliberately deferred, not forgotten:** a third counter for documents *excluded* at write time (by rejection reason). `UnstructuredDocumentRecord.approved` is a bare boolean -- there is no reason taxonomy anywhere upstream for *why* a document was never approved, so a reason-coded exclusion counter has no real data source today. The write-side approval gate already prevents an unapproved document from ever being indexed, so there's no correctness gap here, only a visibility one -- and inventing a coarse single-value reason label now would need reshaping the moment real reasons exist upstream. Left for a follow-up once `records.py` grows one (that file isn't mine to widen unilaterally). Also not in scope: the audit query and remaining documentation (a later slice).

## Base / head SHA
Base: `729d52005` (`origin/feature/chaos-3498-context-fabric`, rebased)
Head: `961b91190`

## Migrations
None.

## Security / privacy
The config fix directly closes a path where document body text could reach an external provider under a credential the graph arm's own state said it didn't have -- the exact "fail closed when providers are disallowed" property this ticket names. Both telemetry counters are content-safe by construction: `reason` is always one of `DocumentRemovalReason`'s closed enum values, never a title, body, or canonical id.

## RED-first evidence
Three separate observations, each reverted before commit (`git diff --stat` confirmed clean every time):

1. **The config guard.** Reverted the `_client()` fix, ran the new test with the socket layer blocked (so it proves no connection is attempted, not merely that one eventually fails) -- failed with the exact expected `AssertionError`. Restored.
2. **The indexed counter.** Stubbed the `write_projection` call site to skip the telemetry call -- the live test asserting the post-write count delta failed. Restored.
3. **The removed counter.** Stubbed the `remove_document` call site the same way -- the live test asserting the reason-labeled count delta failed; the paired negative-control test (a no-op removal must NOT increment) correctly stayed green throughout, since it was never testing the removed path. Restored.

## Verification
- New `tests/context_fabric/test_chaos_3632_telemetry_and_config.py` (4 tests, live): config fail-closed with zero partial writes; indexed-count reflects a real write; removed-count reflects a real removal's reason; a no-op removal does not inflate the counter.
- New cases in `tests/test_prometheus_metrics.py` (6 tests): isolated counter/label behavior, zero-count no-op, default-registry registration -- matching this file's existing GitHub-metrics test style.
- New case in `tests/context_fabric/test_chaos_3617_semantic_claims.py::TestEmbedderContracts` (1 test): the ambient-credential guard, socket-blocked.
- Full `tests/context_fabric/` + `tests/test_prometheus_metrics.py`: 1615 passed, 2 failed -- the same `test_chaos_3647_live_semantic.py` failures already isolated as pre-existing/unrelated (live OpenAI-embedding-API drift) in earlier PRs on this issue.
- `ruff format --check` / `ruff check` -- clean. `mypy` (worktree venv, full project via pre-commit) -- `Success: no issues found in 2322 source files`.

## Known limitations
- The "excluded" telemetry counter is deferred (see Scope) pending a real rejection-reason taxonomy upstream.
- No production caller yet triggers `remove_document` (noted in the prior PR); this PR's telemetry is exercised by tests and will start reporting real numbers once that caller exists.

## Rollout / rollback
No schema/config change, no new flags. The config fix is strictly narrowing (a call that previously might have silently succeeded via an ambient credential now refuses) -- full non-live suite showed zero regressions (1514 passed before this narrowing, 1615 passed including the new live suite after). Telemetry is additive and inert until real traffic flows through `write_projection`/`remove_document`. Safe to revert independently.