### PR TITLE
Conversational-reference seam for the semantic trial (not wired into the corpus run — documented why)

### DIFF
--- a/tests/context_fabric/test_chaos_3666_conversational_reference_in_trial.py
+++ b/tests/context_fabric/test_chaos_3666_conversational_reference_in_trial.py
@@ -1,0 +1,208 @@
+"""issue 3666: the semantic trial leg gets a fair chance to use conversation
+context before falling through to retrieval.
+
+``semantic_retrieval.resolve_conversational_reference`` (issue 3686) is real,
+merged, and unit-tested in isolation. ``resolve_semantic_with_context`` is
+the seam that would let a caller with real prior-turn state use it before
+falling through to the existing disposition-gated semantic leg -- proven
+correct here with synthetic bare-reference queries ("how's it going?",
+"what about it?"), deliberately NOT this trial's own corpus questions.
+
+**Why not the corpus questions.** ``_is_pure_conversational_reference``
+returns ``False`` on all eight corpus ambiguity cases, including the two
+``follows_case_id`` cases (H04 "what's holding it up?", H05 "what about the
+other project we discussed?") -- both carry real content ("holding", "we
+discussed") beyond a bare pronoun by the function's own narrow, deliberately
+non-corpus-tuned definition. So this function is NOT wired into
+``trials/chaos_3647/runner.py``: doing so would move zero lines of the
+trial artifact, since no corpus question would ever route through it. See
+``resolve_semantic_with_context``'s own docstring for the full reasoning.
+These tests exist to prove the mechanism is correct and ready for a real
+conversation-state source, independent of this trial's corpus.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.context_fabric.graph_arm import semantic_retrieval
+from dev_health_ops.context_fabric.graph_arm.readback import EntityLookupRow
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+from trials.chaos_3647.legs import resolve_semantic_with_context
+
+from . import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+_PARTITION = "cf_trial_org_test"
+
+
+@dataclass
+class _FakeNode:
+    uuid: str
+    name: str
+    group_id: str = _PARTITION
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def _entity_node(
+    uuid: str,
+    canonical_id: str,
+    label: str,
+    *,
+    kind: str = GraphEntityKind.PROJECT.value,
+    source_class: str = SourceClass.WORK_GRAPH.value,
+) -> _FakeNode:
+    return _FakeNode(
+        uuid=uuid,
+        name=label,
+        attributes={
+            "cf_canonical_id": canonical_id,
+            "cf_entity_kind": kind,
+            "cf_source_class": source_class,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class _SemanticEmbedder:
+    model_id: str = "test_semantic_double.v1"
+    semantic: bool = True
+
+    async def create(self, input_data: Any) -> list[float]:
+        return [0.0] * 8
+
+
+@dataclass(frozen=True)
+class _FakeStore:
+    driver: Any
+    partition: str
+    embedder: Any
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, *, bm25: list, cosine: list) -> None:
+    live_gate.require_graphiti_extra()
+    from graphiti_core.search import search_utils
+
+    async def fake_fulltext(driver, query, search_filter, group_ids, limit):
+        return list(bm25)
+
+    async def fake_similarity(
+        driver, search_vector, search_filter, group_ids, limit, *args, **kwargs
+    ):
+        return list(cosine)
+
+    monkeypatch.setattr(search_utils, "node_fulltext_search", fake_fulltext)
+    monkeypatch.setattr(search_utils, "node_similarity_search", fake_similarity)
+
+
+def _install_entity_lookup(
+    monkeypatch: pytest.MonkeyPatch, rows: tuple[EntityLookupRow, ...]
+) -> None:
+    async def fake_lookup(driver, partition, canonical_ids):
+        return tuple(row for row in rows if row.canonical_id in canonical_ids)
+
+    monkeypatch.setattr(semantic_retrieval, "_entities_by_canonical_id", fake_lookup)
+
+
+class TestResolveSemanticWithContext:
+    async def test_a_bare_reference_with_a_valid_prior_subject_resolves_via_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A genuine bare reference (not H04's literal text -- see the
+        module docstring for why) with a real, single, authorized prior
+        subject must resolve to it -- not refuse.
+        """
+
+        _install(monkeypatch, bm25=[], cosine=[])
+        _install_entity_lookup(
+            monkeypatch,
+            (
+                EntityLookupRow(
+                    canonical_id="proj_identity_rewrite",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Identity Platform Rewrite",
+                    source_class=SourceClass.WORK_GRAPH,
+                ),
+            ),
+        )
+
+        resolution = await resolve_semantic_with_context(
+            question="how's it going?",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_identity_rewrite"}),
+            prior_subject_ids=("proj_identity_rewrite",),
+        )
+
+        assert resolution.top_n(10) == ("proj_identity_rewrite",)
+        assert resolution.disposition == "conversational_reference"
+
+    async def test_a_bare_reference_with_no_prior_context_falls_through_to_refusal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No prior turn at all -- the exact H04 shape before this change.
+        Must behave identically to plain ``resolve_semantic``: refuse, not
+        crash, not silently invent a candidate.
+        """
+
+        _install(monkeypatch, bm25=[], cosine=[])
+
+        resolution = await resolve_semantic_with_context(
+            question="what's holding it up?",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_identity_rewrite"}),
+            prior_subject_ids=(),
+        )
+
+        assert resolution.subjects == ()
+        assert resolution.disposition == "refuse"
+
+    async def test_an_ambiguous_prior_context_falls_through_not_a_guess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two equally plausible prior subjects -- a bare reference cannot
+        choose between them, so this must fall through rather than pick one.
+        """
+
+        _install(monkeypatch, bm25=[], cosine=[])
+
+        resolution = await resolve_semantic_with_context(
+            question="what about it?",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_a", "proj_b"}),
+            prior_subject_ids=("proj_a", "proj_b"),
+        )
+
+        assert resolution.subjects == ()
+        assert resolution.disposition != "conversational_reference"
+
+    async def test_a_substantive_query_is_untouched_even_with_prior_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The H06 shape: real content in the query ("kept cycling in
+        review") must never be hijacked into a bare-reference resolution
+        just because a prior turn exists -- it needs the hop, not this leg.
+        """
+
+        # A direct entity hit stands in for whatever ordinary retrieval would
+        # find -- the fallthrough path is what's under test here, not the
+        # hop mechanism itself (that's covered by test_chaos_3653_observation_hop.py).
+        direct = _entity_node("u_direct", "proj_vertex", "Vertex Platform")
+        _install(monkeypatch, bm25=[direct], cosine=[direct])
+
+        resolution = await resolve_semantic_with_context(
+            question="What happened with the project that kept cycling in review?",
+            store=_FakeStore(object(), _PARTITION, _SemanticEmbedder()),
+            authorized_entity_ids=frozenset({"proj_vertex", "proj_identity_rewrite"}),
+            prior_subject_ids=("proj_identity_rewrite",),
+        )
+
+        assert resolution.disposition != "conversational_reference"
+        assert resolution.top_n(10) == ("proj_vertex",), (
+            "a substantive query must resolve through ordinary retrieval, "
+            "never be redirected to the prior turn's subject"
+        )

--- a/trials/chaos_3647/legs.py
+++ b/trials/chaos_3647/legs.py
@@ -44,11 +44,14 @@ from typing import TYPE_CHECKING, Any
 from dev_health_ops.context_fabric.graph_arm.discovery import search_candidates
 from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
     assess_disposition,
+    resolve_conversational_reference,
     retrieve_candidates,
 )
 from trials.chaos_3619.graph_leg import mention_texts
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Sequence
+
     from dev_health_ops.context_fabric.graph_arm.projection import GraphProjection
     from dev_health_ops.context_fabric.graph_arm.semantic_retrieval import (
         RetrievalStore,
@@ -62,6 +65,7 @@ __all__ = [
     "prose_disclosures_in",
     "resolve_deterministic",
     "resolve_semantic",
+    "resolve_semantic_with_context",
 ]
 
 #: The candidate horizon every leg is measured over. One number, shared, so
@@ -301,4 +305,91 @@ async def resolve_semantic(
         observation_hits=retrieval.observation_hits,
         disposition=disposition_result.disposition.value,
         disposition_reason=disposition_result.reason,
+    )
+
+
+async def resolve_semantic_with_context(
+    *,
+    question: str,
+    store: RetrievalStore,
+    authorized_entity_ids: frozenset[str],
+    prior_subject_ids: Sequence[str],
+    limit: int = LEG_LIMIT,
+) -> LegResolution:
+    """issue 3666: give the semantic leg a fair chance to use conversation
+    context before falling through to ordinary retrieval.
+
+    ``prior_subject_ids`` must be what a PRIOR LEG RUN actually resolved for
+    the turn this question follows -- never the oracle's expected/correct
+    answer. Seeding from ground truth would test whether the wiring exists,
+    not whether ``resolve_conversational_reference`` correctly carries
+    forward whatever the mechanism itself concluded, right or wrong; see the
+    module docstring's "no leg is handed the answer" rule, which this
+    respects rather than routes around.
+
+    Tries :func:`~.semantic_retrieval.resolve_conversational_reference`
+    first, but only commits to its answer when it actually resolves. Every
+    refusal path there — the query carries real content, no prior context,
+    an ambiguous or unauthorized or deleted prior subject — falls through to
+    :func:`resolve_semantic` unchanged, so a case with no prior turn (every
+    case that is not a follow-up) sees identical behaviour to before this
+    function existed.
+
+    **Not wired into ``runner.py``, and this is a documented finding, not an
+    oversight.** ``_is_pure_conversational_reference`` was checked directly
+    against all eight corpus ambiguity questions before any of this was
+    built: it returns ``False`` on every one, including the two
+    ``follows_case_id`` cases (H04 "what's holding it up?" — "holding" is
+    real content; H05 "what about the other project we discussed?" — "we
+    discussed" is real content). Building the dependency-ordered,
+    state-threading runner restructure this function was designed to slot
+    into would therefore move zero lines of the trial artifact for THIS
+    corpus — no case's literal text would ever route through it. Widening
+    the deictic vocabulary to make H04/H05 qualify would be exactly the
+    corpus-specific tuning the safety principles forbid, so that path is
+    closed too. The conversational-reference capability is real, correct
+    (proven by the four unit tests beside this function), and reachable —
+    it is simply corpus-unmeasurable by design for this trial's eight
+    cases. H04–H06's current "safely refuses instead of confidently wrong"
+    state is therefore the correct terminal state for this corpus, not an
+    unfinished capability — real measurement of this leg waits on a real
+    conversation-state source (production's own interpreter/routing;
+    see the CHAOS-3686-successor ticket's own framing: wiring
+    ``prior_subject_ids`` to a real source was always a separate, later
+    concern). A future reader regenerating this trial and seeing a flat
+    H04–H06 delta should read this paragraph before concluding the
+    capability regressed or was never finished.
+    """
+
+    if prior_subject_ids:
+        reference = await resolve_conversational_reference(
+            question,
+            store=store,
+            prior_subject_ids=prior_subject_ids,
+            authorized_entity_ids=authorized_entity_ids,
+        )
+        if reference.candidate is not None:
+            candidate = reference.candidate
+            return LegResolution(
+                leg=LegId.SEMANTIC_HYBRID,
+                query=question,
+                subjects=(
+                    RankedSubject(
+                        canonical_id=candidate.canonical_id,
+                        display_label=candidate.display_label,
+                        rank=0,
+                        signal=candidate.signal.value,
+                        mechanism=candidate.mechanism.value,
+                    ),
+                ),
+                authorization_filtered_count=0,
+                disposition="conversational_reference",
+                disposition_reason=reference.reason,
+            )
+
+    return await resolve_semantic(
+        question=question,
+        store=store,
+        authorized_entity_ids=authorized_entity_ids,
+        limit=limit,
     )


### PR DESCRIPTION
## Issue / phase
Wave 3.2 / issue 3660 (Phase 2A shared-contract territory). Remaining-scope follow-up under issue 3666 (plain reference, not close-linked — this PR does not complete that issue).

## Observable outcome
A caller with real prior-turn state (a canonical id already resolved for an earlier turn) can now ask the semantic trial leg to try conversational-reference resolution before falling through to ordinary retrieval, via a new `resolve_semantic_with_context`. Proven correct with four unit tests. **Not wired into the trial's own runner** — this PR documents, in detail, in the code itself, why that would be pointless for this corpus rather than silently leaving the capability unused with no explanation.

## Why this exists but isn't wired into `runner.py`
The original plan (posted on issue 3666, and initially approved) was to restructure `trials/chaos_3647/runner.py` to run the 8 corpus ambiguity cases in `follows_case_id` dependency order, threading each case's own leg-produced resolution forward as `prior_subject_ids` for cases that follow it — so `resolve_conversational_reference` (issue 3686, merged, unit-tested) would finally get exercised by something.

Before building that restructure, I checked `semantic_retrieval._is_pure_conversational_reference` directly against all eight corpus question texts. It returns `False` on every one, including both `follows_case_id` cases:
- H04, "what's holding it up?" — "holding" is real content beyond a bare pronoun.
- H05, "what about the other project we discussed?" — "we discussed" is real content.

So the full runner restructure — even built correctly — would move **zero lines** of the trial artifact for this corpus: no case's literal text would ever route through the mechanism. Widening the deictic vocabulary to make H04/H05 qualify would be exactly the corpus-specific tuning the project's safety principles forbid. Building the restructure anyway, for a change that provably cannot move any measured number, is unscoped effort with no evidence to show for it — flagged and confirmed with the orchestrator before reversing course from the original plan.

## What this PR lands instead
Just the seam, proven correct in isolation, ready for a real conversation-state source (production's own interpreter/routing — issue 3686's own description already scoped "wiring `prior_subject_ids` to a real source" as a separate, later concern). `resolve_semantic_with_context`'s own docstring, and the test module's docstring, both state the "corpus-unmeasurable by design" finding at length, so a future reader regenerating the trial and seeing a flat H04–H06 delta reads that explanation rather than concluding the capability regressed or was never finished.

## Architecture boundary
One function added to `trials/chaos_3647/legs.py` (mine, tightly coupled to my exclusive `semantic_retrieval.py`). One new test file. No `runner.py` change, no artifact regeneration (nothing to regenerate — the artifact is provably unaffected). No shared/frozen contract touched.

## Scope / non-scope
**In scope:** the `resolve_semantic_with_context` seam and its correctness proof.
**Explicitly out of scope, and why:** wiring it into `trials/chaos_3647/runner.py`'s case loop (would move zero artifact lines, named above); widening `_is_pure_conversational_reference`'s vocabulary to fit this corpus (forbidden corpus-tuning); wiring to a real conversation-state source (issue 3686's own stated future concern, needs production interpreter/routing work outside this arm).

## Base / head SHA
Base: `fbb8558e4` (origin/feature/chaos-3498-context-fabric tip at branch time)
Head: `b23c29f364818bdbbb9dcdf36e77cec887bd3b58`

## Migrations
None.

## Security impact
None — `resolve_semantic_with_context` only calls existing, already-reviewed functions (`resolve_conversational_reference`, `resolve_semantic`), with the same authorization re-check `resolve_conversational_reference` already performs against the current grant, never trusting a prior turn's authorization forward.

## RED-first evidence
`tests/context_fabric/test_chaos_3666_conversational_reference_in_trial.py` written first against the nonexistent function (`ImportError`), then implemented; all 4 tests pass.

## Verification
- Focused: 4 passed.
- Affected: `pytest tests/context_fabric/` — 1548 passed, 67 skipped (pre-existing, live/graphiti-extra gated).
- `ruff check` / `ruff format --check` / mypy (worktree venv, full project) — clean.
- No live-store round trip needed or added: no new store read/write, pure composition over existing functions, same test-harness precedent as prior PRs in this series.

## Known limitations
- H04–H06 remain at "safely refuses" in the trial artifact — correctly, per the finding above, not a regression or an open gap in this PR's own scope.
- Real, corpus-independent measurement of this capability needs a real conversation-state source; not attempted here.

## Rollout / rollback
No behavior change to any existing path — new function, zero call sites yet outside its own tests. Safe to merge and revert independently.