### PR TITLE
issue 3689: live-store reconstruction of GraphNode/GraphEdge (adapter)

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/live_snapshot.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/live_snapshot.py
@@ -1,0 +1,255 @@
+"""Issue 3689 (adapter PR): the live-store equivalent of ``build_projection``.
+
+``cohort_discovery.discover_cohort`` (issue 3645/3667, D's module) takes
+``nodes: Sequence[GraphNode]``/``edges: Sequence[GraphEdge]`` -- exactly
+what ``build_projection`` returns from an in-memory ``IngestionBatch``. That
+is the ONLY place :class:`~.projection.GraphNode`/
+:class:`~.projection.GraphEdge` were ever constructed until this module:
+nothing in the arm previously reconstructed them from a live partition, so
+``discover_cohort`` had never actually run against production data --
+:func:`~.query_service.mechanism_for` could select
+``SUBJECTLESS_COHORT_DISCOVERY`` but nothing could feed it.
+
+:func:`_live_graph_snapshot` closes that, by reading the SAME partition-scoped
+queries every other live reader already uses
+(:data:`~.readback._ENTITY_QUERY`/:data:`~.readback._OBSERVATION_QUERY`/
+:data:`~.readback._EDGE_QUERY`) and reconstructing ``GraphNode``/
+``GraphEdge`` instances that are equal, field-for-field, to what
+``build_projection`` would have produced for the same batch -- proven, not
+assumed, by ``test_chaos_3689_live_snapshot.py``'s differential oracle,
+which writes a real fixture through the real write path and compares this
+module's reconstruction against ``build_projection``'s in-memory output for
+the identical batch.
+
+**uuid is derived, never read back.** Neither ``_ENTITY_QUERY`` nor
+``_EDGE_QUERY`` exposes a node's or edge's own uuid as a column (there is no
+such column to add: FalkorDB's internal node id is not the arm's uuid).
+Every uuid here is recomputed via :mod:`.identity`'s own deterministic
+functions (``node_uuid``/``observation_uuid``/``relationship_uuid``) from
+data the queries DO return -- the exact functions ``projection.py`` uses on
+write, so a correct reconstruction produces the identical uuid the write
+side minted, which the oracle asserts directly rather than assuming.
+
+**Two known, pre-existing, out-of-scope gaps**, neither introduced by this
+module and both documented (with reasons) in the oracle's own exclusion
+list rather than silently tolerated:
+
+* ``AliasRecord.provider`` -- ``backend.to_graphiti_nodes`` flattens an
+  entity's aliases into ``cf_alias_{kind}`` VALUE-only strings and never
+  persists ``provider`` at all. No live reader can recover what the write
+  side never wrote; this module reconstructs every alias with
+  ``provider=None``.
+* ``outcome``/``supersedes``/``prior_attempt_ids`` on an observation's
+  ``attributes`` -- these fold into ``node.attributes`` on the trial's
+  in-memory side (``projection._observation_node``), which means they are
+  written to the store as ``cf_attr_outcome``/etc. via ``to_graphiti_nodes``'s
+  generic attribute loop -- but none of the three is a member of
+  :data:`~.projection.READBACK_ATTRIBUTE_KEYS`, so ``_attributes_from_row``
+  (the SAME helper every live reader already uses) cannot recover them
+  either. This is a pre-existing gap in the declared read-back vocabulary,
+  not something this adapter PR widens -- ``READBACK_ATTRIBUTE_KEYS`` is a
+  shared, cross-lane vocabulary and growing it is a separate decision.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+
+from . import identity
+from .backend import parse_triple_fact
+from .projection import GraphEdge, GraphNode
+from .readback import (
+    _ALIAS_SEPARATOR,
+    _EDGE_QUERY,
+    _ENTITY_QUERY,
+    _OBSERVATION_QUERY,
+    _as_datetime,
+    _as_optional_datetime,
+    _attributes_from_row,
+    _rows,
+)
+from .records import AliasRecord
+from .vocabulary import AliasKind, GraphEntityKind, GraphObservationKind
+
+#: Empty, matching subject_resolution.py's own convention: the one function
+#: this module exports is package-private (CHAOS-3617's "no caller-supplied
+#: partition parameter" guard -- test_chaos_3617_no_caller_supplied_
+#: partition.py -- forces every new live-data helper taking a raw partition
+#: string to be non-public), so there is nothing for __all__ to name.
+__all__: list[str] = []
+
+#: ``{kind.value}`` column suffix -> AliasKind, mirroring backend.py's
+#: ``cf_alias_{kind.value}`` write convention exactly.
+_ALIAS_KIND_BY_COLUMN: dict[str, AliasKind] = {
+    f"alias_{kind.value}": kind for kind in AliasKind
+}
+
+
+def _split_multivalued(raw: object) -> tuple[str, ...]:
+    """A comma-joined multi-valued property, split.
+
+    Empty/``None`` becomes ``()`` -- "the property was never set" and "it was
+    set to an empty string" must not be distinguishable outcomes, matching
+    every other multi-valued property this arm reads back
+    (``cf_repository_ids``, ``cf_subject_canonical_ids``).
+    """
+
+    if not raw:
+        return ()
+    return tuple(item for item in str(raw).split(",") if item)
+
+
+def _aliases_from_row(record: dict[str, Any]) -> tuple[AliasRecord, ...]:
+    """Every alias on one entity row, reassembled from its ``cf_alias_*``
+    columns. ``provider`` is always ``None`` -- see the module docstring's
+    "known gap": the write side never persists it.
+
+    Sorted so the reconstruction is a function of the stored data, not of
+    dict/column iteration order -- the oracle compares this against an
+    in-memory reference built by iterating ``EntityRecord.aliases`` in
+    a fixed, author-written order, and an unsorted reconstruction would
+    report drift that is really nondeterminism.
+    """
+
+    aliases: list[AliasRecord] = []
+    for column, kind in _ALIAS_KIND_BY_COLUMN.items():
+        raw = record.get(column)
+        if not raw:
+            continue
+        for value in str(raw).split(_ALIAS_SEPARATOR):
+            if value:
+                aliases.append(AliasRecord(kind=kind, value=value, provider=None))
+    return tuple(sorted(aliases, key=lambda alias: (alias.kind.value, alias.value)))
+
+
+async def _live_graph_snapshot(
+    driver: Any, org_id: str, partition: str
+) -> tuple[tuple[GraphNode, ...], tuple[GraphEdge, ...]]:
+    """Reconstruct this partition's entities, observations and edges as
+    :class:`~.projection.GraphNode`/:class:`~.projection.GraphEdge`.
+
+    ``org_id``/``partition`` are supplied by the caller (mirroring
+    :class:`~.readback.LiveGraphReader`), never read back per-row: both are
+    already known before this function is called, and a caller cannot use a
+    read-back value as an authorization claim any more than a query
+    parameter can (see ``identity.assert_partition_matches_org``, which
+    every store-derived caller already runs before reaching here).
+
+    Edges whose source or target canonical id has no corresponding entity
+    row are skipped, not raised on: ``_EDGE_QUERY`` matches ``Entity``-
+    labelled nodes on both ends unconditionally, and this arm's own schema
+    never connects a RELATES_TO edge to anything but an entity, so this
+    should not happen against a partition this arm wrote -- but a
+    ``GraphEdge`` cannot be constructed without a real
+    :class:`~.vocabulary.GraphEntityKind` for both ends, and skipping is
+    honest where inventing one would not be.
+    """
+
+    entity_rows = await _rows(driver, _ENTITY_QUERY, partition=partition)
+    observation_rows = await _rows(driver, _OBSERVATION_QUERY, partition=partition)
+    edge_rows = await _rows(driver, _EDGE_QUERY, partition=partition)
+
+    entity_kinds: dict[str, GraphEntityKind] = {}
+    nodes: list[GraphNode] = []
+
+    for record in entity_rows:
+        kind = GraphEntityKind(record["entity_kind"])
+        canonical_id = record["canonical_id"]
+        entity_kinds[canonical_id] = kind
+        nodes.append(
+            GraphNode(
+                uuid=identity.node_uuid(org_id, kind, canonical_id),
+                org_id=org_id,
+                partition=partition,
+                entity_kind=kind,
+                observation_kind=None,
+                canonical_id=canonical_id,
+                display_label=record["display_label"],
+                source_class=SourceClass(record["source_class"]),
+                observed_at=_as_datetime(record["observed_at"]),
+                aliases=_aliases_from_row(record),
+                attributes=_attributes_from_row(record),
+                repository_ids=_split_multivalued(record.get("repository_ids")),
+                valid_from=_as_optional_datetime(record.get("valid_from")),
+                valid_to=_as_optional_datetime(record.get("valid_to")),
+            )
+        )
+
+    for record in observation_rows:
+        obs_kind = GraphObservationKind(record["observation_kind"])
+        if obs_kind is GraphObservationKind.DOCUMENT:
+            # An approved document (issue 3632's write side) is written as
+            # an observation-shaped node -- deliberately, so it is
+            # BM25/vector-searchable through the same mechanism as any
+            # other observation -- but it is represented in-memory as an
+            # UnstructuredDocumentRecord, and GraphProjection.nodes never
+            # contains one (documents live in .approved_documents, a
+            # structurally distinct field/type). A faithful reconstruction
+            # of what build_projection's .nodes actually contains must
+            # exclude it the same way, or this function's output would
+            # disagree with its own docstring's claim for every partition
+            # that has ever written a document -- confirmed by the
+            # differential oracle, which fails on this exact case without
+            # this guard.
+            continue
+        canonical_id = record["canonical_id"]
+        nodes.append(
+            GraphNode(
+                uuid=identity.observation_uuid(org_id, obs_kind, canonical_id),
+                org_id=org_id,
+                partition=partition,
+                entity_kind=None,
+                observation_kind=obs_kind,
+                canonical_id=canonical_id,
+                display_label=record["title"],
+                source_class=SourceClass(record["source_class"]),
+                observed_at=_as_datetime(record["observed_at"]),
+                aliases=(),
+                attributes=_attributes_from_row(record),
+                repository_ids=_split_multivalued(record.get("repository_ids")),
+                valid_from=_as_optional_datetime(record.get("valid_from")),
+                valid_to=_as_optional_datetime(record.get("valid_to")),
+            )
+        )
+
+    edges: list[GraphEdge] = []
+    for record in edge_rows:
+        source_id, relationship, target_id = parse_triple_fact(record["fact"])
+        source_kind = entity_kinds.get(source_id)
+        target_kind = entity_kinds.get(target_id)
+        if source_kind is None or target_kind is None:
+            continue
+        contributor_count = record.get("contributor_count")
+        edges.append(
+            GraphEdge(
+                uuid=identity.relationship_uuid(
+                    org_id,
+                    relationship.value,
+                    source_kind,
+                    source_id,
+                    target_kind,
+                    target_id,
+                ),
+                org_id=org_id,
+                partition=partition,
+                relationship=relationship,
+                source_uuid=identity.node_uuid(org_id, source_kind, source_id),
+                source_kind=source_kind,
+                source_canonical_id=source_id,
+                target_uuid=identity.node_uuid(org_id, target_kind, target_id),
+                target_kind=target_kind,
+                target_canonical_id=target_id,
+                source_class=SourceClass(record["source_class"]),
+                observed_at=_as_datetime(record["observed_at"]),
+                valid_from=_as_optional_datetime(record.get("valid_from")),
+                valid_to=_as_optional_datetime(record.get("valid_to")),
+                contributor_count=(
+                    int(contributor_count) if contributor_count is not None else None
+                ),
+                observation_ids=_split_multivalued(record.get("observation_ids")),
+            )
+        )
+
+    return tuple(nodes), tuple(edges)

--- a/src/dev_health_ops/context_fabric/graph_arm/readback.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/readback.py
@@ -874,6 +874,18 @@ class ProjectionGraphReader:
 #: :data:`~.projection.READBACK_ATTRIBUTE_KEYS`. That drift is caught by
 #: ``test_every_declared_attribute_has_a_column_in_both_queries``, which
 #: fails when a key is declared without a column or a column without a key.
+#:
+#: ``repository_ids``/``valid_from``/``valid_to`` (issue 3689's adapter PR):
+#: ``backend.to_graphiti_nodes`` has always written ``cf_repository_ids``
+#: (both node kinds) and ``cf_valid_from``/``cf_valid_to`` (when the record
+#: carried them), but nothing read them back until
+#: ``live_snapshot.live_graph_snapshot`` needed a faithful, live-store
+#: reconstruction of :class:`~.projection.GraphNode` -- which the temporal
+#: fields matter for directly: :mod:`.cohort_discovery`'s comparability
+#: gates read ``node.valid_from``/``.valid_to`` to decide whether a
+#: measurement is still in force. Purely additive (two/three more nullable
+#: columns on an unchanged ``MATCH``/``WHERE``), so every existing consumer
+#: of these two queries is unaffected.
 
 _ENTITY_QUERY = """
 MATCH (n:Entity)
@@ -883,6 +895,9 @@ RETURN n.cf_canonical_id AS canonical_id,
        n.name AS display_label,
        n.cf_source_class AS source_class,
        n.cf_observed_at AS observed_at,
+       n.cf_repository_ids AS repository_ids,
+       n.cf_valid_from AS valid_from,
+       n.cf_valid_to AS valid_to,
        n.cf_alias_alias AS alias_alias,
        n.cf_alias_acronym AS alias_acronym,
        n.cf_alias_previous_name AS alias_previous_name,
@@ -922,6 +937,8 @@ RETURN n.cf_canonical_id AS canonical_id,
        n.cf_source_class AS source_class,
        n.cf_observed_at AS observed_at,
        n.cf_repository_ids AS repository_ids,
+       n.cf_valid_from AS valid_from,
+       n.cf_valid_to AS valid_to,
        n.cf_subject_canonical_ids AS subject_canonical_ids,
        n.outcome AS outcome,
        n.cf_attr_corpus_is_adversarial AS attr_corpus_is_adversarial,
@@ -941,6 +958,12 @@ RETURN n.cf_canonical_id AS canonical_id,
        n.cf_attr_superseded_by AS attr_superseded_by
 """
 
+#: ``contributor_count`` (issue 3689's adapter PR): ``backend.
+#: to_graphiti_edges`` has always written ``cf_contributor_count`` when the
+#: relationship record carried one (``fixtures.py`` uses real, non-None
+#: values), but nothing read it back until ``live_snapshot`` needed a
+#: faithful reconstruction of :class:`~.projection.GraphEdge`. Purely
+#: additive, same reasoning as the node columns above.
 _EDGE_QUERY = """
 MATCH (s:Entity)-[e:RELATES_TO]->(t:Entity)
 WHERE e.group_id = $partition
@@ -949,7 +972,8 @@ RETURN e.fact AS fact,
        e.created_at AS observed_at,
        e.cf_observation_ids AS observation_ids,
        e.valid_at AS valid_from,
-       e.invalid_at AS valid_to
+       e.invalid_at AS valid_to,
+       e.cf_contributor_count AS contributor_count
 """
 
 #: What the STORE says produced this partition's vectors.

--- a/tests/context_fabric/test_chaos_3689_live_snapshot.py
+++ b/tests/context_fabric/test_chaos_3689_live_snapshot.py
@@ -1,0 +1,329 @@
+"""Issue 3689 (adapter PR): the differential oracle for ``live_snapshot``.
+
+``cohort_discovery.discover_cohort`` was built and tested against
+``build_projection``'s in-memory output; nothing before this PR ever fed it
+a live partition. ``live_snapshot._live_graph_snapshot`` is the adapter that
+does -- and the only thing that can prove it reconstructs
+:class:`~.projection.GraphNode`/:class:`~.projection.GraphEdge` correctly is
+running BOTH the real write path and the new read path over the SAME batch
+and comparing what they produce. No type checker or code index can answer
+that; only execution can.
+
+Fixtures come from ``fixtures.alpha_batch()`` (the real producer, run
+through the real ``build_projection`` -> ``store.write_projection`` path --
+never a hand-authored ``GraphNode``/``GraphEdge``), plus one small,
+dedicated batch that adds a node with a validity interval, because
+``alpha_batch()``'s only ``valid_from``/``valid_to`` signal is on an EDGE
+(``_EDGE_QUERY`` already read that back before this PR) -- the adapter's
+own NEW node-level columns (``cf_valid_from``/``cf_valid_to`` on
+``_ENTITY_QUERY``/``_OBSERVATION_QUERY``) need a node that actually carries
+them to be exercised at all.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.context_fabric.graph_arm import build_projection, fixtures
+from dev_health_ops.context_fabric.graph_arm.live_snapshot import _live_graph_snapshot
+from dev_health_ops.context_fabric.graph_arm.projection import (
+    GraphEdge,
+    GraphNode,
+    GraphProjection,
+)
+from dev_health_ops.context_fabric.graph_arm.records import EntityRecord
+from dev_health_ops.context_fabric.graph_arm.store import GraphArmStore
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+from tests.context_fabric import live_gate
+
+pytestmark = [pytest.mark.graphiti, pytest.mark.asyncio]
+
+
+def _unique_org(prefix: str) -> str:
+    return f"{prefix}{uuid.uuid4().hex[:12]}"
+
+
+def _reorg(batch, org_id: str):
+    def rebind(record):
+        return dataclasses.replace(record, org_id=org_id)
+
+    return dataclasses.replace(
+        batch,
+        org_id=org_id,
+        entities=tuple(rebind(item) for item in batch.entities),
+        relationships=tuple(rebind(item) for item in batch.relationships),
+        observations=tuple(rebind(item) for item in batch.observations),
+        documents=tuple(rebind(item) for item in batch.documents),
+    )
+
+
+def _with_a_temporally_bounded_entity(batch):
+    """Adds one entity with a real ``valid_from``/``valid_to`` interval.
+
+    ``alpha_batch()`` never sets these on a node (only on one edge), so
+    without this addition the oracle below would compare ``None`` against
+    ``None`` on every node -- passing, but proving nothing about the two new
+    columns this PR added to ``_ENTITY_QUERY``.
+    """
+
+    bounded = EntityRecord(
+        org_id=batch.org_id,
+        kind=GraphEntityKind.INITIATIVE,
+        canonical_id="init_temporally_bounded",
+        display_label="A time-boxed initiative",
+        source_class=SourceClass.WORK_GRAPH,
+        observed_at=fixtures.WINDOW_END,
+        valid_from=datetime(2026, 2, 1, tzinfo=UTC),
+        valid_to=datetime(2026, 5, 31, tzinfo=UTC),
+    )
+    return dataclasses.replace(batch, entities=(*batch.entities, bounded))
+
+
+#: Two known, pre-existing gaps neither the write side nor any EXISTING live
+#: reader can round-trip -- see live_snapshot.py's own module docstring for
+#: the full explanation of each. Documented here, not silently tolerated:
+#: excluding ``aliases``/``attributes`` wholesale would also hide a REAL
+#: regression in the parts of each that ARE recoverable, so only the
+#: specific known-lossy sub-parts are dropped before comparing.
+_ALIAS_PROVIDER_GAP = (
+    "backend.to_graphiti_nodes flattens AliasRecord into cf_alias_{kind} "
+    "VALUE-only strings and never persists .provider -- no live reader can "
+    "recover what the write side never wrote"
+)
+#: ``attributes`` is compared as an INCLUDE-list, not an exclude-list: only
+#: keys READBACK_ATTRIBUTE_KEYS declares recoverable. Any OTHER key an
+#: EntityRecord/ObservationRecord happens to carry (``archived``,
+#: ``outcome``, ``supersedes``, ``prior_attempt_ids`` are all real examples
+#: the alpha fixture already exercises) still reaches the store via
+#: to_graphiti_nodes's generic ``cf_attr_{key}`` loop, but
+#: _attributes_from_row -- the SAME helper every live reader already uses,
+#: not something this adapter invented -- only ever reads back the declared
+#: set. An exclude-list naming each such key one at a time would need a new
+#: entry every time a fixture used a new one; this include-list names the
+#: actual boundary once. Pre-existing gap in the declared read-back
+#: vocabulary; not something this adapter PR widens.
+_ATTRIBUTE_RECOVERY_GAP_REASON = (
+    "attributes outside READBACK_ATTRIBUTE_KEYS reach the store but no "
+    "live reader -- including this adapter -- can read them back; "
+    "comparing only the declared set is comparing what live_snapshot "
+    "actually claims to reconstruct, not silently tolerating a narrower "
+    "claim than the one in its own docstring"
+)
+
+
+def _stable_node(node: GraphNode) -> dict[str, object]:
+    """Every ``GraphNode`` field, derived from ``dataclasses.fields`` so a
+    field added later is compared by default rather than silently skipped.
+    """
+
+    from dev_health_ops.context_fabric.graph_arm.projection import (
+        READBACK_ATTRIBUTE_KEYS,
+    )
+
+    compared: dict[str, object] = {}
+    for field in dataclasses.fields(GraphNode):
+        value = getattr(node, field.name)
+        if field.name == "aliases":
+            # provider dropped -- see _ALIAS_PROVIDER_GAP.
+            value = tuple(sorted((alias.kind.value, alias.value) for alias in value))
+        elif field.name == "attributes":
+            value = {
+                key: val for key, val in value.items() if key in READBACK_ATTRIBUTE_KEYS
+            }
+        compared[field.name] = value
+    return compared
+
+
+def _stable_edge(edge: GraphEdge) -> dict[str, object]:
+    """Every ``GraphEdge`` field, the same way. ``observation_ids`` is
+    sorted before comparing: it round-trips through a comma-joined store
+    property with no ordering guarantee either at write or at read, and
+    order was never a claim either side makes -- only membership is.
+    """
+
+    compared: dict[str, object] = {}
+    for field in dataclasses.fields(GraphEdge):
+        value = getattr(edge, field.name)
+        if field.name == "observation_ids":
+            value = tuple(sorted(value))
+        compared[field.name] = value
+    return compared
+
+
+class TestAttributeComparisonIsNotVacuous:
+    """Anti-vacuity for the include-list in ``_stable_node``: if
+    ``READBACK_ATTRIBUTE_KEYS`` were ever empty, or the fixture never
+    populated any declared key, ``test_every_node_matches_field_for_field``
+    would pass by comparing an empty ``attributes`` dict on both sides --
+    mirrors test_chaos_3617_live_store.py's own anti-vacuity discipline for
+    exactly this reason.
+    """
+
+    def test_the_declared_key_set_is_not_empty(self) -> None:
+        from dev_health_ops.context_fabric.graph_arm.projection import (
+            READBACK_ATTRIBUTE_KEYS,
+        )
+
+        assert READBACK_ATTRIBUTE_KEYS
+
+    def test_the_fixture_actually_populates_a_declared_key(self) -> None:
+        from dev_health_ops.context_fabric.graph_arm.projection import (
+            READBACK_ATTRIBUTE_KEYS,
+        )
+
+        batch = fixtures.alpha_batch()
+        used_keys = {key for entity in batch.entities for key in entity.attributes} | {
+            key for observation in batch.observations for key in observation.attributes
+        }
+        assert used_keys & set(READBACK_ATTRIBUTE_KEYS), (
+            "the fixture never sets a single declared-recoverable attribute "
+            "key -- the node comparison's attributes field would agree on "
+            "{} vs {} for every node, which is not a measurement"
+        )
+
+
+@pytest_asyncio.fixture
+async def snapshot_store(
+    monkeypatch,
+) -> AsyncIterator[tuple[GraphArmStore, GraphProjection]]:
+    config = live_gate.require_live_store()
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED", "1")
+    live_gate.require_flag_state()
+
+    org_id = _unique_org("orglivesnapshot")
+    batch = _with_a_temporally_bounded_entity(_reorg(fixtures.alpha_batch(), org_id))
+    projection = build_projection(batch)
+    store = GraphArmStore.for_org(org_id, config=config)
+    try:
+        await store.build_indices()
+        await store.write_projection(projection)
+        yield store, projection
+    finally:
+        try:
+            await store.purge_org()
+        finally:
+            await store.close()
+
+
+class TestLiveSnapshotMatchesTheInMemoryReference:
+    async def test_every_node_matches_field_for_field(
+        self, snapshot_store: tuple[GraphArmStore, GraphProjection]
+    ) -> None:
+        store, projection = snapshot_store
+        live_nodes, _live_edges = await _live_graph_snapshot(
+            store.driver, store.org_id, store.partition
+        )
+
+        assert live_nodes, "the live reconstruction returned no nodes; vacuous"
+        assert len(live_nodes) == len(projection.nodes), (
+            "node count differs -- something was dropped or duplicated on "
+            "the way through the live store"
+        )
+
+        by_id_live = {node.canonical_id: node for node in live_nodes}
+        by_id_reference = {node.canonical_id: node for node in projection.nodes}
+        assert set(by_id_live) == set(by_id_reference)
+
+        mismatches = {
+            canonical_id: (
+                _stable_node(by_id_reference[canonical_id]),
+                _stable_node(by_id_live[canonical_id]),
+            )
+            for canonical_id in by_id_reference
+            if _stable_node(by_id_reference[canonical_id])
+            != _stable_node(by_id_live[canonical_id])
+        }
+        assert not mismatches, mismatches
+
+    async def test_every_edge_matches_field_for_field(
+        self, snapshot_store: tuple[GraphArmStore, GraphProjection]
+    ) -> None:
+        store, projection = snapshot_store
+        _live_nodes, live_edges = await _live_graph_snapshot(
+            store.driver, store.org_id, store.partition
+        )
+
+        assert live_edges, "the live reconstruction returned no edges; vacuous"
+        assert len(live_edges) == len(projection.edges), (
+            "edge count differs -- something was dropped or duplicated on "
+            "the way through the live store"
+        )
+
+        def _key(edge: GraphEdge) -> tuple[str, str, str]:
+            return (
+                edge.relationship.value,
+                edge.source_canonical_id,
+                edge.target_canonical_id,
+            )
+
+        by_key_live = {_key(edge): edge for edge in live_edges}
+        by_key_reference = {_key(edge): edge for edge in projection.edges}
+        assert set(by_key_live) == set(by_key_reference)
+
+        mismatches = {
+            key: (_stable_edge(by_key_reference[key]), _stable_edge(by_key_live[key]))
+            for key in by_key_reference
+            if _stable_edge(by_key_reference[key]) != _stable_edge(by_key_live[key])
+        }
+        assert not mismatches, mismatches
+
+    async def test_uuids_match_the_write_sides_own_identity_derivation(
+        self, snapshot_store: tuple[GraphArmStore, GraphProjection]
+    ) -> None:
+        """The binding condition, checked directly rather than folded only
+        into the field-for-field comparison above: a correct-but-different
+        uuid scheme would still "match" a differential run only against
+        itself if this weren't asserted against the WRITE side's own uuids.
+        """
+
+        store, projection = snapshot_store
+        live_nodes, live_edges = await _live_graph_snapshot(
+            store.driver, store.org_id, store.partition
+        )
+
+        live_uuid_by_id = {node.canonical_id: node.uuid for node in live_nodes}
+        reference_uuid_by_id = {
+            node.canonical_id: node.uuid for node in projection.nodes
+        }
+        assert live_uuid_by_id == reference_uuid_by_id
+
+        def _key(edge: GraphEdge) -> tuple[str, str, str]:
+            return (
+                edge.relationship.value,
+                edge.source_canonical_id,
+                edge.target_canonical_id,
+            )
+
+        live_edge_uuid_by_key = {_key(edge): edge.uuid for edge in live_edges}
+        reference_edge_uuid_by_key = {
+            _key(edge): edge.uuid for edge in projection.edges
+        }
+        assert live_edge_uuid_by_key == reference_edge_uuid_by_key
+
+    async def test_the_temporally_bounded_node_round_trips_its_validity_window(
+        self, snapshot_store: tuple[GraphArmStore, GraphProjection]
+    ) -> None:
+        """The specific case the field-for-field comparison above would
+        already catch, isolated and asserted directly so a future reader
+        does not have to infer it from a big dict diff.
+        """
+
+        store, _projection = snapshot_store
+        live_nodes, _live_edges = await _live_graph_snapshot(
+            store.driver, store.org_id, store.partition
+        )
+
+        (bounded,) = (
+            node
+            for node in live_nodes
+            if node.canonical_id == "init_temporally_bounded"
+        )
+        assert bounded.valid_from == datetime(2026, 2, 1, tzinfo=UTC)
+        assert bounded.valid_to == datetime(2026, 5, 31, tzinfo=UTC)


### PR DESCRIPTION
## Issue / phase
Adapter PR for issue 3689 (subjectless cohort discovery), split from the query_service wiring per the orchestrator's explicit call: this is reusable infrastructure at a correctness-sensitive boundary, and gets its own independently-verifiable evidence rather than riding along inside a new mechanism's PR. This PR alone does **not** complete issue 3689 -- branch and title are deliberately token-free per the standing multi-PR rule; the follow-up wiring PR (family table + mechanism route + stub replacement) will use the literal token since it completes the issue.

## Observable outcome
`cohort_discovery.discover_cohort` (issue 3645/3667, D's module) takes `nodes: Sequence[GraphNode]`/`edges: Sequence[GraphEdge]` -- exactly what `build_projection` returns from an in-memory `IngestionBatch`. Checked directly: that is the **only** place `GraphNode`/`GraphEdge` were ever constructed anywhere in this codebase. Nothing reconstructed them from a live partition, which means `discover_cohort` had never actually run against production data -- `query_service.mechanism_for` could select `SUBJECTLESS_COHORT_DISCOVERY`, but nothing existed to feed it.

After this PR: `live_snapshot._live_graph_snapshot(driver, org_id, partition)` reconstructs a partition's entities/observations/edges as `GraphNode`/`GraphEdge` instances that are equal, field-for-field, to what `build_projection` would have produced for the identical batch -- proven by a differential oracle that writes a real fixture through the real write path and compares.

## Architecture boundary
**Package-private, not public.** `test_chaos_3617_no_caller_supplied_partition.py`'s guard (AST-scans for any public callable taking a partition-like parameter) caught this against the real full suite, not by inspection -- `_live_graph_snapshot` takes `partition: str` and was originally named without the leading underscore. Renamed to match `subject_resolution.py`'s own `_live_entities`/`_live_cohort_edges` convention: importable cross-module (the query_service wiring PR will do exactly that), never public.

**uuid is derived, never read back.** Neither `_ENTITY_QUERY` nor `_EDGE_QUERY` exposes a node's or edge's own uuid as a column -- there is none to add; FalkorDB's internal id is not the arm's uuid. Every uuid here is recomputed via `identity.node_uuid`/`observation_uuid`/`relationship_uuid`, the exact functions `projection.py` uses on write, and the oracle asserts equality against the write side's own uuids directly (not merely as a side effect of the broader field comparison).

**`readback.py` widened by five nullable columns** across `_ENTITY_QUERY`/`_OBSERVATION_QUERY`/`_EDGE_QUERY` (`repository_ids`+`valid_from`+`valid_to` on the two node queries, `contributor_count` on the edge query). All five were already being **written** by `backend.py` (confirmed by reading the write side, not assumed) but never read back by any existing consumer. This mattered directly: `cohort_discovery`'s own comparability gates read `node.valid_from`/`.valid_to` to decide whether a measurement is still in force, so a reconstruction without them would silently misjudge every temporally-bounded record. Purely additive -- unchanged `MATCH`/`WHERE`, more `RETURN` columns -- so every existing consumer of these three declared queries is unaffected, confirmed by the full live suite (1609 passed).

## Scope / non-scope
**In scope:** `_live_graph_snapshot`; the `readback.py` column widening it needs; the differential oracle proving it.

**Not in scope:** wiring this into `query_service.py` (the follow-up PR, which completes issue 3689 -- `CohortDiscoveryFamily` -> `QuestionFamilyID` table, the `SUBJECTLESS_COHORT_DISCOVERY` mechanism route, replacing the current honest `PROVIDER_FAILURE` stub -- reusing `discover_cohort` and this adapter as-is, per the orchestrator's explicit "reuse D's discover_cohort AS-IS" instruction).

## Base / head SHA
Base: `31cf3da46` (`origin/feature/chaos-3498-context-fabric`)
Head: `3aa5231f5`

## Migrations
None. No schema change; the widened queries add nullable columns already populated by the existing write path.

## Security / privacy
No new write surface, no new authorization boundary. `org_id`/`partition` are supplied by the caller (mirroring `LiveGraphReader`), never read back per-row -- the same "a caller-supplied value is never trusted as an authorization claim" discipline every other live reader in this package already follows.

## RED-first evidence
Two separate observations, both directly informing the final design (not merely asserted in hindsight):

1. **The attributes include-list.** An earlier version of the oracle used a 3-key exclude-list (`outcome`/`supersedes`/`prior_attempt_ids`), discovered from the first failing comparison run. A **fourth** key (`archived`) then failed the same oracle on a different node -- proof the ad-hoc exclude-list approach was already insufficient, which is what motivated switching to the include-list (`attributes` compared only against keys in `projection.READBACK_ATTRIBUTE_KEYS`) this PR actually ships.
2. **The temporal round-trip.** Reverted the entity-node `valid_from`/`valid_to` reconstruction to always return `None` and watched both `test_every_node_matches_field_for_field` and `test_the_temporally_bounded_node_round_trips_its_validity_window` fail with the expected mismatch; restored (`git diff` confirmed clean).

## Verification
Live, against a real running FalkorDB (`dev-health-ops-graph-trial-store`, `docker compose --profile graph-trial`):
- New `tests/context_fabric/test_chaos_3689_live_snapshot.py`: writes `fixtures.alpha_batch()` (the real producer -- never a hand-authored `GraphNode`/`GraphEdge`) plus one dedicated entity carrying a real `valid_from`/`valid_to` window (the fixture's only existing temporal signal is on an edge, not a node, so it wouldn't have exercised the new node-level columns at all) through the real `build_projection` -> `store.write_projection` path, then compares `_live_graph_snapshot`'s reconstruction against `build_projection`'s in-memory output for the identical batch -- field-for-field via `dataclasses.fields()` (not a hand-picked subset), uuid equality asserted directly, the temporal window asserted directly.
- A genuine, previously-unknown mismatch surfaced and was fixed during this work: approved documents (issue 3632) are written as observation-shaped nodes (so they're BM25/vector-searchable through the same mechanism as any other observation), which means `_OBSERVATION_QUERY` already matches them -- but `GraphProjection.nodes` never contains one (documents live in `.approved_documents`, a structurally distinct type). `_live_graph_snapshot` now explicitly excludes document-kind observations to match what `.nodes` actually contains; caught by the oracle itself, not by inspection.
- Full `tests/context_fabric/` suite: 1609 passed, 2 failed -- the same `test_chaos_3647_live_semantic.py` failures already isolated as pre-existing/unrelated (live OpenAI-embedding-API drift) across every prior PR on this issue.
- `ruff format --check` / `ruff check` -- clean. `mypy` (worktree venv, full project via pre-commit) -- `Success: no issues found in 2327 source files`.

## Known limitations
Two pre-existing, out-of-scope gaps surfaced (not introduced) and documented with reasons in both the module docstring and the oracle's own comparator, rather than silently tolerated:
- `AliasRecord.provider` is never persisted by `backend.to_graphiti_nodes` (only `kind`+`value` survive the `cf_alias_{kind}` flattening) -- no live reader can recover what the write side never wrote.
- Any attribute key outside `projection.READBACK_ATTRIBUTE_KEYS` (`archived`, `outcome`, `supersedes`, `prior_attempt_ids` are real examples the alpha fixture already exercises) reaches the store via the generic `cf_attr_{key}` write loop but no live reader -- including this one -- can read it back, since `READBACK_ATTRIBUTE_KEYS` is the declared, closed read-back vocabulary every reader shares. Widening it is a separate, cross-lane decision, not something this adapter PR does unilaterally.

## Rollout / rollback
No schema/config change, no new flag. `_live_graph_snapshot` is additive and package-private -- nothing calls it yet (the wiring PR is next), so this PR has no observable effect on any existing code path. The `readback.py` query widening is backward-compatible for every existing consumer. Safe to revert independently.