### PR TITLE
CHAOS-3689: wire SUBJECTLESS_COHORT_DISCOVERY through discover_cohort

### DIFF
--- a/src/dev_health_ops/context_fabric/graph_arm/query_service.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/query_service.py
@@ -28,18 +28,38 @@ narrower than the trial's ``discovery.search_candidates``),
 driver synthesis — mirrors the trial's own PR1 scope, which never
 synthesized drivers either).
 
-**Increment 3 (this revision) adds ``SEEDED_EXPLICIT_COHORT``** (CHAOS-3688),
-following the trial's own construction
-(``trials/chaos_3619/graph_leg.py``'s ``assemble_packet``) exactly: every
-mention resolves the same EXACT-only way, the first resolved candidate
-becomes the anchor subject, and :func:`~.cohort.build_cohort` walks two hops
-out from it over live edges (:func:`~.subject_resolution._live_cohort_edges`)
-to discover peers — never a cohort built directly from "the other named
-mentions". ``SUBJECTLESS_COHORT_DISCOVERY`` still returns
-``PROVIDER_FAILURE`` with a diagnostic naming the mechanism — it needs
-``cohort_discovery.discover_cohort`` wired in, tracked as CHAOS-3689. Every
-path is an honest "not yet" where it applies, never a silent wrong answer,
-never a crash a caller has to guard against separately.
+**Increment 3 adds ``SEEDED_EXPLICIT_COHORT``** (CHAOS-3688), following the
+trial's own construction (``trials/chaos_3619/graph_leg.py``'s
+``assemble_packet``) exactly: every mention resolves the same EXACT-only
+way, the first resolved candidate becomes the anchor subject, and
+:func:`~.cohort.build_cohort` walks two hops out from it over live edges
+(:func:`~.subject_resolution._live_cohort_edges`) to discover peers — never
+a cohort built directly from "the other named mentions".
+
+**Increment 4 (this revision) completes CHAOS-3689: ``SUBJECTLESS_COHORT_
+DISCOVERY``.** The request already carries the one production-classified
+signal this mode needs beyond ``(intent_id, cardinality)`` —
+``request.cohort_discovery_family: CohortDiscoveryFamily`` — never derived
+here (mirrors every other classification signal this module reads rather
+than computes). :data:`_COHORT_DISCOVERY_QUESTION_FAMILY` is the closed,
+exhaustively-tested 2-entry table from that wire vocabulary onto
+:class:`~dev_health_ops.api.dev.investigation_contract.QuestionFamilyID`,
+the vocabulary :func:`~.cohort_discovery.discover_cohort` actually speaks —
+a plain dict subscript with no default branch, so a
+``CohortDiscoveryFamily`` value this table does not cover raises rather
+than silently guessing a family.
+
+Following the trial's own second entry mode
+(``trials/chaos_3619/graph_leg.py``'s ``discover_cohort_for``/
+``assemble_cohort_packet``) exactly: :func:`~.live_snapshot.
+_live_graph_snapshot` (CHAOS-3689's adapter PR) supplies the live
+``nodes``/``edges`` :func:`~.cohort_discovery.discover_cohort` — reused
+AS-IS, unmodified — needs; the discovered cohort's own members (canonical-
+id order, the same non-ranking discipline as the trial) become the
+traversal seeds, never a single anchor subject, because there is none.
+Like ``SEEDED_EXPLICIT_COHORT``, this mode attributes no drivers — a scope-
+enumerated cohort has no subject for ``discover_drivers`` to explain, the
+same scope boundary the trial itself already drew and documented.
 """
 
 from __future__ import annotations
@@ -58,15 +78,21 @@ from dev_health_ops.api.dev.contracts_v2.base import (
 )
 from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
 from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
     GraphInvestigationQuery,
     GraphInvestigationRequest,
     GraphQueryOutcome,
     GraphQueryResult,
 )
-from dev_health_ops.api.dev.investigation_contract import ComparisonShape
+from dev_health_ops.api.dev.investigation_contract import (
+    ComparisonShape,
+    QuestionFamilyID,
+)
 
 from .cohort import build_cohort
+from .cohort_discovery import discover_cohort
 from .flags import graph_read_enabled
+from .live_snapshot import _live_graph_snapshot
 from .packet_builder import (
     ProductionJobContext,
     build_production_packet,
@@ -89,6 +115,35 @@ __all__ = [
     "ProductionGraphInvestigationQuery",
     "mechanism_for",
 ]
+
+#: CHAOS-3689's closed, exhaustively-tested table from the wire's
+#: classification vocabulary onto the one ``discover_cohort`` actually
+#: speaks. Exactly two entries, mirroring ``CohortDiscoveryFamily``'s own
+#: "there is no 'unclassifiable' member" docstring: every member of that
+#: enum must appear here, and ``test_chaos_3689_query_service.py`` asserts
+#: it against ``CohortDiscoveryFamily.__members__`` directly, not against a
+#: hand-copied list that could drift.
+#:
+#: ``TEAM_PRESSURE`` maps to ``PRESSURE_SIGNALS`` rather than
+#: ``STRUGGLING_TEAMS`` -- both are TEAM-kind, ``DISCOVERED_COHORT``-
+#: eligible families, and ``cohort_discovery.FAMILY_PRESSURE_METRICS``'s own
+#: comment says the two "share one metric set... a reader who asked either
+#: would expect the same evidence to count", so the choice is behaviour-
+#: equivalent either way. ``PRESSURE_SIGNALS`` was picked for the closer
+#: name match to the wire classifier itself, not for any behavioural
+#: reason.
+_COHORT_DISCOVERY_QUESTION_FAMILY: dict[CohortDiscoveryFamily, QuestionFamilyID] = {
+    CohortDiscoveryFamily.TEAM_PRESSURE: QuestionFamilyID.PRESSURE_SIGNALS,
+    CohortDiscoveryFamily.PROJECT_CAPACITY: QuestionFamilyID.PROJECT_CAPACITY,
+}
+
+#: The traversal seed cap for a discovered cohort's readout, mirroring
+#: ``trials/chaos_3619/graph_leg.py``'s ``MAX_COHORT_SEEDS`` exactly (same
+#: reasoning: "read the neighbourhood of every entity in the tenant" is the
+#: sweep the contract refuses, so a cohort larger than this is read
+#: partially -- and that is disclosed by the packet's own truncation
+#: machinery, not silently).
+_MAX_COHORT_SEEDS = 12
 
 
 class GraphMechanism(StrEnum):
@@ -348,18 +403,17 @@ class ProductionGraphInvestigationQuery:
                 return await self._complete_seeded_explicit_cohort(
                     request, store, watermark
                 )
-            # SUBJECTLESS_COHORT_DISCOVERY (CHAOS-3689): still needs
-            # cohort_discovery.discover_cohort wired in -- a separate,
-            # tracked follow-up, not bundled here. Naming the mechanism
-            # rather than a bare "not implemented" is what makes this
-            # diagnostic actionable.
-            return GraphQueryResult(
-                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
-                diagnostic=_diagnostic(
-                    "execution",
-                    f"mechanism {mechanism.value} selected; packet "
-                    "assembly for this mechanism is a tracked follow-up",
-                ),
+            # The only remaining member: GraphMechanism.UNSUPPORTED already
+            # returned above, and SEEDED_SINGULAR_SUBJECT/SEEDED_EXPLICIT_
+            # COHORT are handled above this. Explicit rather than an
+            # unconditional fall-through, so a fifth mechanism added later
+            # fails loudly here instead of silently routing to this path.
+            if mechanism is GraphMechanism.SUBJECTLESS_COHORT_DISCOVERY:
+                return await self._complete_subjectless_cohort_discovery(
+                    request, store, watermark
+                )
+            raise AssertionError(  # pragma: no cover - exhaustiveness guard
+                f"unreachable: mechanism {mechanism!r} has no dispatch arm"
             )
         except asyncio.CancelledError:
             return GraphQueryResult(
@@ -541,6 +595,124 @@ class ProductionGraphInvestigationQuery:
                 diagnostic=_diagnostic(
                     "execution",
                     f"mechanism {GraphMechanism.SEEDED_EXPLICIT_COHORT.value}: "
+                    f"{type(exc).__name__}",
+                ),
+            )
+        return GraphQueryResult(outcome=GraphQueryOutcome.COMPLETED, packet=packet)
+
+    async def _complete_subjectless_cohort_discovery(
+        self,
+        request: GraphInvestigationRequest,
+        store: _WatermarkStore,
+        watermark: IndexWatermark,
+    ) -> GraphQueryResult:
+        """``SUBJECTLESS_COHORT_DISCOVERY``'s COMPLETED path (CHAOS-3689).
+
+        The second entry mode: no mention, no seed, no anchor subject.
+        ``request.cohort_discovery_family`` is the one production-classified
+        signal this mode needs beyond ``(intent_id, cardinality)`` --
+        :data:`_COHORT_DISCOVERY_QUESTION_FAMILY` maps it onto the
+        ``QuestionFamilyID`` :func:`~.cohort_discovery.discover_cohort`
+        speaks, a plain dict subscript with no default: a family this table
+        does not cover is a bug in the table, not a runtime condition to
+        guess through, and ``KeyError`` is caught by the broad ``except``
+        below the same as any other unexpected failure.
+
+        :func:`~.live_snapshot._live_graph_snapshot` (CHAOS-3689's adapter
+        PR) supplies the live ``nodes``/``edges`` -- the first live caller
+        ``discover_cohort`` has ever had; every prior use was the trial's
+        own in-memory ``build_projection`` output.
+        ``discover_cohort`` itself is reused completely unmodified.
+
+        Following the trial's own second entry mode
+        (``trials/chaos_3619/graph_leg.py``'s ``discover_cohort_for``/
+        ``assemble_cohort_packet``) exactly: the discovered cohort's own
+        members, in canonical-id order (never a strength/relevance ranking
+        this arm does not own), become the traversal seeds, capped at
+        :data:`_MAX_COHORT_SEEDS` -- a cohort larger than that is read
+        partially, disclosed by the packet's own truncation machinery
+        rather than by an unbounded neighbourhood read. No drivers are
+        attributed, the same scope boundary ``SEEDED_EXPLICIT_COHORT``
+        already draws: a scope-enumerated cohort has no subject for
+        ``discover_drivers`` to explain.
+
+        An unsupported family (structurally unreachable given the closed
+        table above, but not assumed to be), no comparable cohort
+        (``discovery.is_comparable`` false -- too few members, or no shared
+        comparison dimension), or any other unexpected failure during
+        discovery or packet assembly all reach ``PROVIDER_FAILURE`` with a
+        diagnostic naming the mechanism -- an honest, explicit degradation,
+        never a guess and never an uncaught exception a caller would have
+        to guard against separately.
+        """
+
+        traversal_store = cast(_TraversalStore, store)
+        try:
+            question_family = _COHORT_DISCOVERY_QUESTION_FAMILY[
+                request.cohort_discovery_family
+            ]
+            nodes, edges = await _live_graph_snapshot(
+                traversal_store._driver, request.org_id, traversal_store.partition
+            )
+            discovery = discover_cohort(
+                question_family=question_family,
+                nodes=nodes,
+                edges=edges,
+                authorized_entity_ids=request.authorized_entity_ids,
+                as_of=request.window_end,
+            )
+            if not discovery.is_comparable:
+                return GraphQueryResult(
+                    outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                    diagnostic=_diagnostic(
+                        "execution",
+                        f"mechanism "
+                        f"{GraphMechanism.SUBJECTLESS_COHORT_DISCOVERY.value}: "
+                        "the discovered cohort has too few members or no "
+                        "shared comparison dimension",
+                    ),
+                )
+            # Sorted explicitly here rather than trusted from
+            # discover_cohort's own output order: discover_cohort DOES
+            # already iterate candidates in canonical-id order internally,
+            # but this wiring's own "never a strength/relevance ranking"
+            # guarantee should not depend on a caller reading that far into
+            # a function this PR reuses unmodified -- an implementation
+            # detail there is free to change without this seam silently
+            # inheriting a different, unintended seed order.
+            seeds = sorted(
+                member.canonical_id for member in discovery.proposal.members
+            )[:_MAX_COHORT_SEEDS]
+            reader = self._reader_factory(traversal_store)
+            readout = await reader.neighbourhood(
+                org_id=request.org_id,
+                seed_canonical_ids=seeds,
+                authorized_entity_ids=tuple(request.authorized_entity_ids),
+            )
+            packet = build_production_packet(
+                readout=readout,
+                job=ProductionJobContext(
+                    job_id=f"graph_query_{request.run_id}",
+                    intent_id=request.intent_id,
+                    run_id=request.run_id,
+                    job_statement=_job_statement(request.intent_id),
+                    comparison_shape=ComparisonShape.DISCOVERED_COHORT,
+                    window_start=request.window_start,
+                    window_end=request.window_end,
+                ),
+                cohort=discovery.proposal,
+                watermark=watermark,
+                signer=self._signer_factory(),
+                produced_at=datetime.now(UTC),
+                staleness_tolerance=self._staleness_tolerance,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return GraphQueryResult(
+                outcome=GraphQueryOutcome.PROVIDER_FAILURE,
+                diagnostic=_diagnostic(
+                    "execution",
+                    f"mechanism "
+                    f"{GraphMechanism.SUBJECTLESS_COHORT_DISCOVERY.value}: "
                     f"{type(exc).__name__}",
                 ),
             )

--- a/tests/context_fabric/test_chaos_3678_query_service.py
+++ b/tests/context_fabric/test_chaos_3678_query_service.py
@@ -23,9 +23,10 @@ Three halves, matching the module's own documented scope:
   ``PROVIDER_FAILURE`` naming the mechanism rather than a partial-silent
   success.
 
-``SUBJECTLESS_COHORT_DISCOVERY`` remains untouched — still reaches
-``PROVIDER_FAILURE`` with a diagnostic naming the mechanism, the honest,
-current behaviour until ``cohort_discovery`` is wired in as CHAOS-3689.
+``SUBJECTLESS_COHORT_DISCOVERY`` graduated to a real ``COMPLETED`` path in
+CHAOS-3689 -- see ``test_chaos_3689_query_service.py``, which owns that
+mechanism's coverage the same way ``test_chaos_3678_subject_resolution.py``
+owns ``_resolve_exact_subjects``'s.
 """
 
 from __future__ import annotations
@@ -392,35 +393,21 @@ class TestUnsupportedMechanism:
         assert "no graph mechanism" in result.diagnostic
 
 
-class TestSubjectlessCohortDiscoveryIsNotYetImplemented:
-    pytestmark = pytest.mark.asyncio
-
-    """The remaining honest boundary: selected, not yet executed.
-
-    SEEDED_SINGULAR_SUBJECT and SEEDED_EXPLICIT_COHORT both graduated to
-    real COMPLETED paths (see ``TestSeededSingularSubjectCompletes`` and
-    ``TestSeededExplicitCohortCompletes`` below) -- SUBJECTLESS_COHORT_
-    DISCOVERY has not, since it needs ``cohort_discovery`` wired in as a
-    separate follow-up (CHAOS-3689).
-    """
-
-    async def test_subjectless_cohort_discovery_reaches_provider_failure(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
-        store = _FakeStore(watermark=_fresh_watermark())
-        service = _query(store)
-        result = await service.investigate(
-            _request(
-                intent_id=QuestionIntentID.DISCOVERED_COHORT,
-                cardinality=Cardinality.ORGANIZATION_WIDE,
-            )
-        )
-        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
-        assert result.packet is None
-        assert result.diagnostic is not None
-        assert "subjectless_cohort_discovery" in result.diagnostic
-
+# SUBJECTLESS_COHORT_DISCOVERY graduated to a real COMPLETED path in
+# CHAOS-3689 -- this file used to carry a
+# TestSubjectlessCohortDiscoveryIsNotYetImplemented class here, asserting
+# every call reached PROVIDER_FAILURE naming the mechanism. That claim is no
+# longer true, and leaving the class in place would have kept "passing" for
+# an entirely different, misleading reason: `_FakeStore`'s default `_driver`
+# is `None`, and a real completion attempt against a `None` driver raises
+# `AttributeError` inside `_complete_subjectless_cohort_discovery`'s own
+# broad `except Exception`, which ALSO reaches `PROVIDER_FAILURE` with
+# "subjectless_cohort_discovery" in the diagnostic -- the same assertions,
+# for a crash rather than an honest "not implemented". Removed rather than
+# left to pass for the wrong reason; see
+# ``test_chaos_3689_query_service.py`` for this mechanism's real coverage
+# (the family table, the live-snapshot wiring, and both the refusal and
+# COMPLETED paths).
 
 _TEST_SIGNING_SECRET = "chaos-3678-query-service-test-signing-secret-not-real"
 

--- a/tests/context_fabric/test_chaos_3689_query_service.py
+++ b/tests/context_fabric/test_chaos_3689_query_service.py
@@ -1,0 +1,412 @@
+"""CHAOS-3689: ``SUBJECTLESS_COHORT_DISCOVERY``'s real COMPLETED path.
+
+Two halves:
+
+* :data:`~.query_service._COHORT_DISCOVERY_QUESTION_FAMILY` -- the closed
+  family table, tested for exhaustiveness against
+  ``CohortDiscoveryFamily.__members__`` directly (never a hand-copied list
+  that could drift) and for landing only on families
+  ``cohort_discovery.discover_cohort`` actually supports.
+* ``ProductionGraphInvestigationQuery.investigate``'s
+  ``SUBJECTLESS_COHORT_DISCOVERY`` dispatch -- what this file proves is the
+  WIRING (family lookup -> live snapshot -> ``discover_cohort`` -> packet
+  assembly), not ``discover_cohort``'s own comparability logic, which has
+  its own extensive direct coverage
+  (``test_chaos_3645_cohort_discovery.py``, ``test_chaos_3667_cohort_
+  ranking.py``) and its own live-corroboration thresholds this file does
+  not attempt to reverse-engineer through a hand-built fixture. The one
+  positive COMPLETED-path test therefore mocks ``discover_cohort`` at the
+  ``query_service`` module boundary -- exactly the "already covered
+  elsewhere" boundary ``TestSeededExplicitCohortCompletes`` in
+  ``test_chaos_3678_query_service.py`` draws for ``cohort.build_cohort``.
+  The refusal path is exercised for real, unmocked, against an empty live
+  snapshot -- no reason to fake a result that trivially reproduces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import (
+    Cardinality,
+    QuestionIntentID,
+    SourceClass,
+)
+from dev_health_ops.api.dev.evidence_service import EvidenceReferenceSigner
+from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+)
+from dev_health_ops.api.dev.investigation_contract import (
+    CohortInclusionBasis,
+    ComparisonDimension,
+)
+from dev_health_ops.context_fabric.graph_arm import (
+    query_service as query_service_module,
+)
+from dev_health_ops.context_fabric.graph_arm.cohort import (
+    CohortCandidate,
+    CohortEntryMode,
+    CohortProposal,
+)
+from dev_health_ops.context_fabric.graph_arm.cohort_discovery import (
+    FAMILY_CANDIDATE_KINDS,
+    CohortDiscovery,
+)
+from dev_health_ops.context_fabric.graph_arm.query_service import (
+    _COHORT_DISCOVERY_QUESTION_FAMILY,
+    _MAX_COHORT_SEEDS,
+    ProductionGraphInvestigationQuery,
+)
+from dev_health_ops.context_fabric.graph_arm.readback import InvestigationReadout
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+
+_TEST_SIGNING_SECRET = "chaos-3689-query-service-test-signing-secret-not-real"
+_RUN_UUID = "5c9a3f9e-1111-4222-8333-444455556666"
+
+
+def _soon() -> datetime:
+    return datetime.now(UTC) + timedelta(seconds=30)
+
+
+def _fresh_watermark() -> IndexWatermark:
+    return IndexWatermark(indexed_through=datetime.now(UTC), records_indexed=1)
+
+
+def _request(
+    *,
+    cohort_discovery_family: CohortDiscoveryFamily = CohortDiscoveryFamily.PROJECT_CAPACITY,
+    org_id: str = "org_query_service_test",
+    run_id: str = _RUN_UUID,
+    authorized_entity_ids: frozenset[str] = frozenset({"proj_a", "proj_b", "team_x"}),
+) -> GraphInvestigationRequest:
+    return GraphInvestigationRequest(
+        org_id=org_id,
+        run_id=run_id,
+        intent_id=QuestionIntentID.DISCOVERED_COHORT,
+        cardinality=Cardinality.ORGANIZATION_WIDE,
+        mentions=(),
+        question_text="Which projects are capacity-constrained right now?",
+        authorized_entity_ids=authorized_entity_ids,
+        window_start=datetime(2026, 5, 12, tzinfo=UTC),
+        window_end=datetime(2026, 8, 9, tzinfo=UTC),
+        cohort_discovery_family=cohort_discovery_family,
+        deadline=_soon(),
+    )
+
+
+class TestCohortDiscoveryFamilyTable:
+    def test_every_family_is_mapped(self) -> None:
+        """No default branch: every member of the wire enum must appear as
+        a literal key, checked against ``__members__`` directly rather than
+        a hand-copied list that could silently stop tracking the enum.
+        """
+
+        assert set(_COHORT_DISCOVERY_QUESTION_FAMILY) == set(
+            CohortDiscoveryFamily.__members__.values()
+        )
+
+    def test_the_table_is_not_accidentally_empty(self) -> None:
+        """Anti-vacuity: the exhaustiveness check above would pass
+        trivially if both sides were empty.
+        """
+
+        assert _COHORT_DISCOVERY_QUESTION_FAMILY
+
+    def test_every_mapped_family_is_one_discover_cohort_actually_supports(
+        self,
+    ) -> None:
+        """A family this table maps to but ``FAMILY_CANDIDATE_KINDS`` does
+        not cover would raise ``UnsupportedCohortFamilyError`` on every
+        real call -- a table that type-checks but always refuses.
+        """
+
+        unsupported = {
+            family: question_family
+            for family, question_family in _COHORT_DISCOVERY_QUESTION_FAMILY.items()
+            if question_family not in FAMILY_CANDIDATE_KINDS
+        }
+        assert not unsupported, unsupported
+
+
+@dataclass
+class _FakeDriver:
+    """Dispatches on which of the three declared queries was issued --
+    ``_live_graph_snapshot`` calls all three (entity/observation/edge)
+    unconditionally, unlike ``SEEDED_EXPLICIT_COHORT``'s narrower
+    ``_live_entities``/``_live_cohort_edges``, which only ever issue two.
+    """
+
+    entity_rows: list[dict] = field(default_factory=list)
+    observation_rows: list[dict] = field(default_factory=list)
+    edge_rows: list[dict] = field(default_factory=list)
+    queries_seen: list[str] = field(default_factory=list)
+
+    async def execute_query(self, query: str, **params: object) -> tuple:
+        self.queries_seen.append(query)
+        if "RELATES_TO" in query:
+            return (self.edge_rows, None, None)
+        if "cf_is_entity = true" in query:
+            return (self.entity_rows, None, None)
+        return (self.observation_rows, None, None)
+
+
+def _entity_row(
+    canonical_id: str,
+    display_label: str,
+    *,
+    kind: str = GraphEntityKind.PROJECT.value,
+) -> dict:
+    return {
+        "canonical_id": canonical_id,
+        "entity_kind": kind,
+        "display_label": display_label,
+        "source_class": SourceClass.WORK_GRAPH.value,
+        "observed_at": "2026-05-01T00:00:00+00:00",
+    }
+
+
+@dataclass
+class _FakeStore:
+    watermark: IndexWatermark | None = None
+    partition: str = "cf_query_service_test"
+    _driver: object = None
+
+    async def read_watermark(self) -> IndexWatermark:
+        assert self.watermark is not None
+        return self.watermark
+
+    async def close(self) -> None:
+        return None
+
+
+def _factory(store: _FakeStore):
+    def _build(_org_id: str) -> _FakeStore:
+        return store
+
+    return _build
+
+
+@dataclass
+class _FakeReader:
+    readout: InvestigationReadout
+    calls: list[dict] = field(default_factory=list)
+
+    async def neighbourhood(
+        self,
+        *,
+        org_id: str,
+        seed_canonical_ids,
+        authorized_entity_ids,
+        max_hops: int = 3,
+        budgets=None,
+    ) -> InvestigationReadout:
+        self.calls.append(
+            {
+                "org_id": org_id,
+                "seed_canonical_ids": list(seed_canonical_ids),
+                "authorized_entity_ids": list(authorized_entity_ids),
+            }
+        )
+        return self.readout
+
+
+def _service(
+    *, driver: _FakeDriver, reader: _FakeReader
+) -> ProductionGraphInvestigationQuery:
+    store = _FakeStore(watermark=_fresh_watermark(), _driver=driver)
+    return ProductionGraphInvestigationQuery(
+        store_factory=_factory(store),
+        reader_factory=lambda _store: reader,
+        signer_factory=lambda: EvidenceReferenceSigner(_TEST_SIGNING_SECRET),
+    )
+
+
+def _empty_readout() -> InvestigationReadout:
+    return InvestigationReadout(
+        org_id="org_query_service_test",
+        partition="cf_query_service_test",
+        seed_canonical_ids=(),
+        authorized_entity_ids=(),
+    )
+
+
+class TestSubjectlessCohortDiscoveryRefuses:
+    """The real (unmocked) path: an empty live snapshot -> an empty,
+    incomparable discovery -> PROVIDER_FAILURE naming the mechanism.
+    Exercises the actual wiring end to end -- family lookup,
+    ``_live_graph_snapshot``, ``discover_cohort`` -- without needing a
+    hand-built corroborated-pressure fixture to reach a refusal.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_candidates_reaches_provider_failure_naming_the_mechanism(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver()
+        reader = _FakeReader(readout=_empty_readout())
+        service = _service(driver=driver, reader=reader)
+
+        result = await service.investigate(_request())
+
+        assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
+        assert result.packet is None
+        assert result.diagnostic is not None
+        assert "subjectless_cohort_discovery" in result.diagnostic
+        # Proves the wiring actually reached discover_cohort rather than
+        # failing earlier (a store/driver error would ALSO produce
+        # PROVIDER_FAILURE naming the mechanism -- see the module's broad
+        # except -- so this distinguishes "reached and refused" from
+        # "crashed before reaching").
+        assert not reader.calls, (
+            "no comparable cohort means no seeds, which means neighbourhood() "
+            "must never have been called at all"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_live_snapshot_is_fetched_from_this_requests_own_partition(
+        self, monkeypatch
+    ) -> None:
+        """A targeted proof of the adapter wiring itself: all three
+        declared queries are actually issued against the real driver, not
+        skipped or short-circuited.
+        """
+
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver()
+        reader = _FakeReader(readout=_empty_readout())
+        service = _service(driver=driver, reader=reader)
+
+        await service.investigate(_request())
+
+        assert any("RELATES_TO" in query for query in driver.queries_seen)
+        assert any("cf_is_entity = true" in query for query in driver.queries_seen)
+        assert any("cf_is_entity = false" in query for query in driver.queries_seen)
+
+
+def _canned_discovery(*, members: tuple[str, ...]) -> CohortDiscovery:
+    """A comparable ``CohortDiscovery`` for the mocked positive path --
+    not a claim about what real corroborated pressure data would look
+    like, only a valid shape ``build_production_packet`` accepts. Real
+    corroboration thresholds are ``discover_cohort``'s own tested
+    responsibility, not this wiring test's.
+    """
+
+    candidates = tuple(
+        CohortCandidate(
+            canonical_id=canonical_id,
+            kind=GraphEntityKind.PROJECT,
+            display_label=canonical_id,
+            basis_anchors=((CohortInclusionBasis.SHARED_TEAM_OWNERSHIP, ("team_x",)),),
+        )
+        for canonical_id in members
+    )
+    return CohortDiscovery(
+        proposal=CohortProposal(
+            subject_id="",
+            members=candidates,
+            exclusions=(),
+            dimensions=(ComparisonDimension.DELIVERY_THROUGHPUT,),
+            truncated=False,
+            truncated_count=0,
+            authorization_filtered_count=0,
+            entry_mode=CohortEntryMode.SCOPE_ENUMERATED,
+        ),
+        candidate_kinds=(GraphEntityKind.PROJECT,),
+        universe_size=len(members),
+        authorization_filtered_count=0,
+    )
+
+
+class TestSubjectlessCohortDiscoveryCompletes:
+    """The mocked positive path -- see the module docstring for why
+    ``discover_cohort`` itself is mocked here rather than fed a hand-built
+    corroborated fixture.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_comparable_cohort_completes_with_a_real_packet(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        driver = _FakeDriver(
+            entity_rows=[
+                _entity_row("proj_a", "Project A"),
+                _entity_row("proj_b", "Project B"),
+            ]
+        )
+        readout = InvestigationReadout(
+            org_id="org_query_service_test",
+            partition="cf_query_service_test",
+            seed_canonical_ids=("proj_a", "proj_b"),
+            authorized_entity_ids=("proj_a", "proj_b", "team_x"),
+        )
+        reader = _FakeReader(readout=readout)
+        service = _service(driver=driver, reader=reader)
+
+        discovery = _canned_discovery(members=("proj_a", "proj_b"))
+        monkeypatch.setattr(
+            query_service_module, "discover_cohort", lambda **_kwargs: discovery
+        )
+
+        result = await service.investigate(_request())
+
+        assert result.outcome is GraphQueryOutcome.COMPLETED
+        assert result.packet is not None
+        assert result.packet.comparison_cohort.comparison_shape.value == (
+            "discovered_cohort"
+        )
+        assert sorted(
+            member.canonical_id for member in result.packet.comparison_cohort.members
+        ) == ["proj_a", "proj_b"]
+        # No drivers attributed -- the same scope boundary
+        # SEEDED_EXPLICIT_COHORT already draws (no subject to explain).
+        assert not result.packet.driver_analysis.candidates
+        assert len(reader.calls) == 1
+        assert sorted(reader.calls[0]["seed_canonical_ids"]) == ["proj_a", "proj_b"]
+
+    @pytest.mark.asyncio
+    async def test_seeds_are_capped_at_max_cohort_seeds_in_canonical_id_order(
+        self, monkeypatch
+    ) -> None:
+        """Never a strength/relevance ranking this arm does not own --
+        canonical-id order, capped, mirroring the trial's own
+        ``cohort_seeds_from`` exactly.
+        """
+
+        monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        many_members = tuple(f"proj_{i:02d}" for i in range(_MAX_COHORT_SEEDS + 5))
+        driver = _FakeDriver(entity_rows=[_entity_row(m, m) for m in many_members])
+        readout = InvestigationReadout(
+            org_id="org_query_service_test",
+            partition="cf_query_service_test",
+            seed_canonical_ids=many_members[:_MAX_COHORT_SEEDS],
+            authorized_entity_ids=many_members,
+        )
+        reader = _FakeReader(readout=readout)
+        service = _service(driver=driver, reader=reader)
+
+        # Shuffle the discovery's own member order to prove the CAP+ORDER
+        # comes from this wiring's own slicing, not from an
+        # already-sorted discover_cohort output it happens to inherit.
+        shuffled = tuple(reversed(many_members))
+        discovery = _canned_discovery(members=shuffled)
+        monkeypatch.setattr(
+            query_service_module, "discover_cohort", lambda **_kwargs: discovery
+        )
+
+        result = await service.investigate(
+            _request(authorized_entity_ids=frozenset(many_members))
+        )
+
+        assert result.outcome is GraphQueryOutcome.COMPLETED
+        assert len(reader.calls) == 1
+        seeds = reader.calls[0]["seed_canonical_ids"]
+        assert len(seeds) == _MAX_COHORT_SEEDS
+        assert seeds == sorted(many_members)[:_MAX_COHORT_SEEDS]


### PR DESCRIPTION
## Issue / phase
Completes CHAOS-3689 (literal token deliberate -- this PR closes it, per the standing multi-PR rule confirmed by the orchestrator). The wiring half, following the adapter PR (#1675, merged) that gave `cohort_discovery.discover_cohort` its first live caller. The second and last honest stub in `query_service.py`'s mechanism dispatch graduates to a real `COMPLETED` path.

## Observable outcome
A `DISCOVERED_COHORT`/`ORGANIZATION_WIDE` request now runs the full second entry mode against the live store: family classification -> live snapshot -> cohort discovery -> packet assembly -> `COMPLETED`, or an honest `PROVIDER_FAILURE` naming the mechanism when the discovered cohort is not comparable. The beta now ships all three graph-assisted entry modes (`SEEDED_SINGULAR_SUBJECT`, `SEEDED_EXPLICIT_COHORT`, `SUBJECTLESS_COHORT_DISCOVERY`) with real `COMPLETED` paths.

## Architecture boundary

**Family table.** `_COHORT_DISCOVERY_QUESTION_FAMILY`: a closed, 2-entry dict from `CohortDiscoveryFamily` (the wire's own classification signal, arriving on `request.cohort_discovery_family` -- never derived here, same discipline as `(intent_id, cardinality)`) onto `QuestionFamilyID` (`discover_cohort`'s own vocabulary). Plain subscript, no default branch: an uncovered family raises rather than guessing, caught by the same broad `except` every other mechanism's completion path already uses.

`TEAM_PRESSURE` maps to `PRESSURE_SIGNALS` rather than `STRUGGLING_TEAMS` -- both are TEAM-kind, `DISCOVERED_COHORT`-eligible families, and `cohort_discovery.FAMILY_PRESSURE_METRICS`'s own comment says the two share one identical metric set, so the choice is behaviour-equivalent either way; `PRESSURE_SIGNALS` was picked for the closer name match to the classifier itself -- recorded as a judgment call, not a behavioural claim (flagged to and accepted by the orchestrator during scoping).

**The COMPLETED path** mirrors the trial's own second entry mode (`trials/chaos_3619/graph_leg.py`'s `discover_cohort_for`/`assemble_cohort_packet`) exactly: `_live_graph_snapshot` (the adapter PR) supplies live nodes/edges, `discover_cohort` runs completely unmodified, the discovered cohort's own members (sorted by canonical id -- never a strength/relevance ranking this arm does not own) become the traversal seeds capped at the trial's own `MAX_COHORT_SEEDS=12`, and no drivers are attributed (the same scope boundary `SEEDED_EXPLICIT_COHORT` already draws: no subject, nothing for `discover_drivers` to explain).

The dispatch's previously-unconditional fallthrough is now an explicit `if mechanism is SUBJECTLESS_COHORT_DISCOVERY` arm, with a final `raise AssertionError` for a fifth mechanism this dispatch does not yet know about -- an exhaustiveness guard over `GraphMechanism`'s four members, not a runtime condition a caller could trigger.

## Scope / non-scope
**In scope:** the family table; the `SUBJECTLESS_COHORT_DISCOVERY` completion method; the dispatch wiring; fixing a test that would otherwise have kept "passing" for a misleading reason (see below).

**Not in scope:** nothing further -- this closes CHAOS-3689.

## Base / head SHA
Base: `4f76fcbfe` (`origin/feature/chaos-3498-context-fabric`, the adapter PR's own merge commit)
Head: `4134bfcde`

## Migrations
None.

## Security / privacy
`discover_cohort` applies authorization on the way in (unchanged -- reused as-is); this PR adds no new authorization logic, only the live-fetch and packet-assembly plumbing around an already-authorized call.

## RED-first evidence
Two real bugs this PR's own tests caught during development (not merely a planted mutation, though one of those is included too):
1. The canned test discovery initially omitted `CohortEntryMode.SCOPE_ENUMERATED` (defaults to `SUBJECT_ANCHORED`), which `build_production_packet`'s own "a scope-enumerated cohort must not name a subject" validation correctly rejected with `ValueError` -- a real `packet_builder` invariant catching a real test-fixture mistake, not a bug in the wiring itself.
2. The seed list was not actually sorted by canonical id despite the docstring's claim -- it relied implicitly on `discover_cohort`'s own internal sort order. Caught by a test that deliberately shuffles the canned discovery's member order before asserting the seeds arrive sorted; fixed by sorting explicitly in this wiring rather than depending on an unstated upstream guarantee.
3. The family table's exhaustiveness guard: removed the `PROJECT_CAPACITY` entry and watched both the exhaustiveness test and every `COMPLETED`-path test (which default to that family) fail with the expected errors; restored (`git diff` confirmed clean).

## Test-integrity fix
`test_chaos_3678_query_service.py` carried `TestSubjectlessCohortDiscoveryIsNotYetImplemented`, asserting every call reached `PROVIDER_FAILURE` naming the mechanism. That claim is no longer true, and the class would have kept "passing" for an entirely different, misleading reason: `_FakeStore`'s default `_driver` is `None`, and a real completion attempt against a `None` driver raises `AttributeError` inside the new method's own broad `except`, which ALSO reaches `PROVIDER_FAILURE` with `"subjectless_cohort_discovery"` in the diagnostic -- same assertions, wrong reason (a crash, not an honest "not implemented"). Removed rather than left green by accident; this mechanism's real coverage now lives in `test_chaos_3689_query_service.py`.

## Verification
- New `tests/context_fabric/test_chaos_3689_query_service.py` (7 tests): family-table exhaustiveness and support-coverage; a real (unmocked) refusal path against an empty live snapshot, including a direct check that all three declared queries (entity/observation/edge) are actually issued against the driver; a mocked-`discover_cohort` positive `COMPLETED` path (`discover_cohort`'s own comparability/corroboration logic has its own extensive direct coverage in `test_chaos_3645_cohort_discovery.py`/`test_chaos_3667_cohort_ranking.py` -- this file proves the wiring, matching the exact scope boundary `TestSeededExplicitCohortCompletes` already draws for `cohort.build_cohort`); seed capping/ordering.
- Full `tests/context_fabric/` suite: 1626 passed, 1 failed -- the same `test_chaos_3647_live_semantic.py` failure already isolated as pre-existing/unrelated (live OpenAI-embedding-API drift) across every prior PR on this issue.
- `ruff format --check` / `ruff check` -- clean. `mypy` (worktree venv, full project via pre-commit) -- `Success: no issues found in 2328 source files`.

## Known limitations
The one positive `COMPLETED`-path test mocks `discover_cohort` rather than driving it with a hand-built corroborated-pressure fixture -- reproducing `_corroboration`'s exact elevated-metric thresholds through fake driver rows risked a fragile test coupled to internal numeric details `discover_cohort`'s own test suite already owns and verifies directly. The refusal path (empty snapshot -> incomparable -> `PROVIDER_FAILURE`) is exercised for real, unmocked, proving the actual wiring chain end to end for at least one real outcome.

## Rollout / rollback
No schema/config change, no new flag. Reachable only via `QuestionIntentID.DISCOVERED_COHORT` + `Cardinality.ORGANIZATION_WIDE`, which was already routing to this mechanism and receiving an honest `PROVIDER_FAILURE` -- this PR changes what happens on that existing path from "always refuses" to "may complete", strictly additive from a caller's perspective. Safe to revert independently.