### PR TITLE
Reserve a schema-only record_locator field on DevEvidenceRef (issue 3633 / issue 3660 §8(i))

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -78,7 +78,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "d0df8dccbf190a280412e6d4872006459072128d87c7cf8d9e9facc016ab62a3"
+        "sha256": "8712d49d50e56e71030e3dbe27e70c9387a749ee0367c712e48b6940eb5df17f"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -156,7 +156,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "e156ced39c676bae4e08f5c5e5acc86a4d7120b472ab628ba20f1a605a8ce6fc"
+        "sha256": "8c92ecc438cef1331ef130862bc75bf565c4111e74d8a03b67eb229e620d41ae"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -213,7 +213,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_ref.v1.schema.json",
-        "sha256": "ec835b4334f2f627a14fbb361244b403fd8faed8825b051122e16780918cdf2b"
+        "sha256": "4f523fa4b63df80da741a75e0483384467b74e082bcd0648f9bd12d863422620"
       },
       "schema_version": "dev_evidence_ref.v1"
     },
@@ -232,7 +232,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_evidence_expansion.v1.schema.json",
-        "sha256": "615e2e20b938e0e1181dcd5681495352f30d515f7a45f3fb0dd6879d6cdc0628"
+        "sha256": "d3ab1a7dfe7c667ab05f58b210f9cf7274d7dc7b34d1c1861baf708e86023d38"
       },
       "schema_version": "dev_evidence_expansion.v1"
     },
@@ -345,7 +345,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_tool_result.v1.schema.json",
-        "sha256": "21698013ea1dac591a15bcd965431c102d5a9e49a108ad97c08db748b5fdfd56"
+        "sha256": "d06aedb5245ea51239d7020e4202a8c9cd97499bd1b7448e05bef4f379c596a2"
       },
       "schema_version": "dev_tool_result.v1"
     },
@@ -383,7 +383,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "379012a91746699a38240c4e679bc2d7100c7fb4ff0c99cb966cb55e46045e39"
+        "sha256": "e828ee78e46df0ea49d070c873f263588fc6cc1012f0728d2326d1f9577f1649"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
@@ -514,6 +514,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
@@ -636,6 +636,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_evidence_expansion.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_evidence_expansion.v1.schema.json
@@ -156,6 +156,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_evidence_ref.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_evidence_ref.v1.schema.json
@@ -168,6 +168,21 @@
       "title": "Provenance",
       "type": "string"
     },
+    "record_locator": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Record Locator"
+    },
     "repository_ids": {
       "items": {
         "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
@@ -726,6 +726,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_tool_result.v1.schema.json
@@ -659,6 +659,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v2/manifest.json
+++ b/contracts/ask-dev/v2/manifest.json
@@ -378,7 +378,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer_frame.v1.schema.json",
-        "sha256": "f97f7b9f048097263e72fde3c52e6a74c917a05bf1ec0108e4ee2b7a1eeaad83"
+        "sha256": "a4819a0c7c693d34703d5d6803da17aae19df619b6cee0eccc1e693ce14195e5"
       },
       "schema_version": "dev_answer_frame.v1"
     },
@@ -466,7 +466,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer.v2.schema.json",
-        "sha256": "ebfc2e2045fd6a3029224a7829b528f9f1b2c52e7bb377c34f32feba96b31f88"
+        "sha256": "27b9e5f9328fab2f4f3658f62a7da00ae6ef0967db6c9ae8afa98dd6bb37f2d8"
       },
       "schema_version": "dev_answer.v2"
     },
@@ -485,7 +485,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_stream_event.v2.schema.json",
-        "sha256": "487dcc43af039b9bc2c3c7fea833e85d472a9160b7adeba9767e3cb5f4d590df"
+        "sha256": "2f3a526681553793456e128bf03d67cd6d2e99c3b2e965894d37b1cb1f6c2dfd"
       },
       "schema_version": "dev_stream_event.v2"
     }

--- a/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer.v2.schema.json
@@ -1303,6 +1303,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_answer_frame.v1.schema.json
@@ -1020,6 +1020,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
+++ b/contracts/ask-dev/v2/schemas/dev_stream_event.v2.schema.json
@@ -1464,6 +1464,21 @@
           "title": "Provenance",
           "type": "string"
         },
+        "record_locator": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Record Locator"
+        },
         "repository_ids": {
           "items": {
             "maxLength": 128,

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -593,6 +593,20 @@ class DevEvidenceRef(ContractModel):
     ) = None
     repository_ids: list[OpaqueID] = Field(default_factory=list, max_length=20)
     valid_entity_ids: list[OpaqueID] = Field(default_factory=list, max_length=20)
+    #: CHAOS-3633 / CHAOS-3660 §8(i). Reserves the wire slot for the SOURCE's
+    #: own identity for this specific record, distinct from ``entity_id``
+    #: (the entity the record is *about*). Schema-only on ``main`` today:
+    #: the canonical evidence-admission path that will populate it
+    #: (``EvidenceService.admit``, still feature-branch-only -- see
+    #: CHAOS-3650/3632/3685) has not landed here yet, so nothing on this
+    #: branch sets, reads, or signs it. Additive and optional so every ref
+    #: minted by ``search``/``expand`` today -- and every already-persisted
+    #: ``dev_answer.v1`` evidence ref -- is completely unaffected: no
+    #: current code path constructs a ``DevEvidenceRef`` with this field, so
+    #: it is always its ``None`` default until the admission-path port lands
+    #: (a separate PR) and starts setting it and binding it into the signed
+    #: HMAC.
+    record_locator: OpaqueID | None = None
     flags: DevEvidenceFlags
 
 

--- a/tests/api/dev/test_chaos_3297_s3_version_skew.py
+++ b/tests/api/dev/test_chaos_3297_s3_version_skew.py
@@ -149,7 +149,7 @@ def test_tolerant_parse_changes_nothing_else() -> None:
     frame = DevAnswerFrame.model_validate(patched)
     reserialized = frame.model_dump(mode="json")
     for key, value in original.items():
-        if key in {"metrics", "coverage"}:
+        if key in {"metrics", "coverage", "evidence"}:
             continue
         assert reserialized[key] == value, key
 
@@ -171,6 +171,24 @@ def test_tolerant_parse_changes_nothing_else() -> None:
         "degraded_required_sources"
     }
     assert reserialized_coverage["degraded_required_sources"] == []
+
+    # Each ``evidence`` ref gained ``record_locator`` the same way --
+    # CHAOS-3633 / CHAOS-3660 §8(i), schema-only reservation, no populating
+    # code path exists on this branch today. Same posture as ``coverage``
+    # above: every original evidence-ref key keeps its exact value, and the
+    # only addition per ref is the new key at its empty (``None``) default,
+    # since a pre-s3 evidence ref cannot have known about a locator that
+    # did not exist yet.
+    original_evidence = original["evidence"]
+    reserialized_evidence = reserialized["evidence"]
+    assert len(reserialized_evidence) == len(original_evidence)
+    for original_ref, reserialized_ref in zip(
+        original_evidence, reserialized_evidence, strict=True
+    ):
+        for key, value in original_ref.items():
+            assert reserialized_ref[key] == value, f"evidence.{key}"
+        assert set(reserialized_ref) - set(original_ref) == {"record_locator"}
+        assert reserialized_ref["record_locator"] is None
 
 
 def test_tolerant_parse_does_not_touch_a_metric_with_real_evidence() -> None:

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -19,6 +19,7 @@ from dev_health_ops.api.dev.contracts import (
     CONTRACT_MODELS,
     DevAnswer,
     DevCapabilities,
+    DevEvidenceRef,
     DevMessageRequest,
     DevScope,
     DevScopeResolution,
@@ -39,6 +40,24 @@ from dev_health_ops.api.dev.scope_service import (
 @pytest.mark.parametrize("schema_version", CONTRACT_MODELS)
 def test_positive_fixture_validates(schema_version: str) -> None:
     CONTRACT_MODELS[schema_version].model_validate(positive_fixtures()[schema_version])
+
+
+def test_record_locator_is_absent_by_default_on_every_existing_evidence_ref() -> None:
+    """CHAOS-3633 / CHAOS-3660 §8(i). The canonical fixture predates this
+    field and never sets it -- ``test_positive_fixture_validates`` already
+    proves ``dev_evidence_ref.v1`` still validates without it, so this
+    fixture is itself the backward-compatibility proof. This test pins the
+    actual value down explicitly rather than leaving that proof implicit.
+    """
+    ref = DevEvidenceRef.model_validate(positive_fixtures()["dev_evidence_ref.v1"])
+    assert ref.record_locator is None
+
+
+def test_record_locator_accepts_an_opaque_id_when_present() -> None:
+    payload = deepcopy(positive_fixtures()["dev_evidence_ref.v1"])
+    payload["record_locator"] = "loc_pr_review_01"
+    ref = DevEvidenceRef.model_validate(payload)
+    assert ref.record_locator == "loc_pr_review_01"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds an additive, optional `record_locator: OpaqueID | None = None` field to `DevEvidenceRef` (issue 3633), the first slice of the wave's shared-contract package (issue 3660 §8, item i).
- **Schema-only on `main` today.** The canonical evidence-admission path that will populate this field (`EvidenceService.admit()`, the resolver protocol, the signer's HMAC-binding for this field) is still feature-branch-only (issue 3650 / 3632 / 3685) and has **not** landed on `main` yet — verified there is no `admit()`/`EvidenceAdmission`/`EvidenceCandidateResolver` anywhere on this branch. So nothing here sets, reads, or emits a populated value. Every existing evidence ref (`search`/`expand`, and every already-persisted `dev_answer.v1` reference) is byte-for-byte unaffected.
- Runtime population lands as a separate, later PR once the admission-path feature itself merges to `main`. Per the wave's contract-package plan, emission of this (and every other new wire surface in the package) stays feature-flagged until web's schema-tolerance work deploys — this field alone changes nothing observable on the wire until then.
- Regenerates the checked-in `contracts/ask-dev/v1` and `v2` JSON Schema artifacts this field touches (`dev_evidence_ref.v1` gains one additive property; every schema keeps `additionalProperties: false`).

## Why the extra test-file change

`test_chaos_3297_s3_version_skew.py`'s `test_tolerant_parse_changes_nothing_else` is a byte-identical round-trip proof over a frozen pre-existing fixture. Adding `record_locator` correctly made it fail (a new `record_locator: null` key now appears in each re-serialized `evidence[]` entry) — that's the guard doing its job. Fixed by extending the check with the same precedent already used in that file for `coverage.degraded_required_sources`: every original evidence-ref key keeps its exact value, and the only addition is the new key at its empty default.

## Test plan

- [x] `pytest tests/api/dev/test_contracts.py tests/api/dev/test_contracts_v2.py tests/api/dev/test_evidence_service.py` — 379 passed (includes 2 new tests pinning the field's optional/additive behavior)
- [x] `pytest tests/api/dev/test_chaos_3297_s3_version_skew.py` — 9 passed (version-skew byte-identical proof extended, not weakened)
- [x] `pytest tests/api/dev` (full directory) — 2487 passed, 35 skipped, 1 xfailed
- [x] `python -m dev_health_ops.api.dev.export_contracts write` / `export_contracts_v2 write`, then `check` — verified 73 + 102 artifacts, no drift
- [x] `ruff check` / `mypy` on touched files — clean