### PR TITLE
Reserve two schema-only capability/request fields for the graph-routing wave (issue 3660 §8 items a, k)

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -16,7 +16,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_capabilities.v1.schema.json",
-        "sha256": "66f9dd47b340f1ca3b3d545761912e69a0833b1550868a8f45a6ab2836ec2050"
+        "sha256": "e213726e709177362829dedf284c8a8118d883725dd5b0b6b45b51197c4b491b"
       },
       "schema_version": "dev_capabilities.v1"
     },
@@ -112,7 +112,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_message_request.v1.schema.json",
-        "sha256": "258a495a3ac72ec52164b37164d71b4f01b60d8f1008b046965cd2f002c7b2bc"
+        "sha256": "2ac58a542edcc35e32b0f7a592920b4ab53a588b433ac00b9b224271a76011b5"
       },
       "schema_version": "dev_message_request.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_capabilities.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_capabilities.v1.schema.json
@@ -97,6 +97,11 @@
       "title": "Ask Dev",
       "type": "boolean"
     },
+    "ask_dev_graph_routing": {
+      "default": false,
+      "title": "Ask Dev Graph Routing",
+      "type": "boolean"
+    },
     "byo_llm": {
       "default": false,
       "title": "Byo Llm",

--- a/contracts/ask-dev/v1/schemas/dev_message_request.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_message_request.v1.schema.json
@@ -265,6 +265,20 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "client_contract_version": {
+      "anyOf": [
+        {
+          "maxLength": 128,
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Client Contract Version"
+    },
     "client_message_id": {
       "maxLength": 128,
       "minLength": 1,

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -492,6 +492,12 @@ class DevCapabilities(ContractModel):
     )
     contextual_entrypoints: bool = False
     evidence_resolver: bool = False
+    #: CHAOS-3660 §8(a). Reserves the capability flag for graph-assisted Ask
+    #: Dev routing (CHAOS-3502 wave), which is still feature-branch-only on
+    #: `main` today -- no runtime path here computes anything but the
+    #: ``False`` default, so no client observes this as ``True`` until the
+    #: wave's routing/answer-shape work itself lands.
+    ask_dev_graph_routing: bool = False
     administrator_safe_failure_reason: ShortText | None = None
 
     @model_validator(mode="after")
@@ -543,6 +549,17 @@ class DevMessageRequest(ContractModel):
     question_class: QuestionClass
     scope: DevScope
     requested_metric_ids: list[MetricID] = Field(default_factory=list, max_length=8)
+    #: CHAOS-3660 §8(k). Request-direction and additive: an old client that
+    #: never sends this key is indistinguishable from one whose absence
+    #: means "declares nothing", so no currently-issued request breaks by
+    #: this field existing. Reserves the slot a client uses to declare the
+    #: newest contract surface it can parse (the same version strings
+    #: ``DevCapabilities.supported_contract_versions`` already advertises).
+    #: Schema-only today: the wave's ``graph.state`` stream event this is
+    #: meant to gate emission of has not landed on `main` yet (CHAOS-3502),
+    #: so nothing here reads this field -- server-side validation and the
+    #: gating it enables are a later PR, once that surface exists to gate.
+    client_contract_version: Version | None = None
 
     @field_validator("question")
     @classmethod

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -103,6 +103,19 @@ def test_capability_gates_are_independent() -> None:
     assert capabilities.agent_context_runtime is False
 
 
+def test_ask_dev_graph_routing_defaults_false_on_every_existing_capabilities_payload() -> (
+    None
+):
+    """CHAOS-3660 §8(a). The canonical fixture predates this flag and never
+    sets it -- pinning the default explicitly rather than leaving the
+    backward-compatibility proof implicit in the parametrized fixture pass.
+    """
+    capabilities = DevCapabilities.model_validate(
+        positive_fixtures()["dev_capabilities.v1"]
+    )
+    assert capabilities.ask_dev_graph_routing is False
+
+
 def test_neutral_message_scope_without_surface_context_remains_valid() -> None:
     payload = deepcopy(positive_fixtures()["dev_message_request.v1"])
     payload["scope"]["direct_scope"] = "organization"
@@ -112,6 +125,23 @@ def test_neutral_message_scope_without_surface_context_remains_valid() -> None:
     request = DevMessageRequest.model_validate(payload)
 
     assert request.scope.surface_context is None
+
+
+def test_client_contract_version_is_absent_by_default_and_accepted_when_declared() -> (
+    None
+):
+    """CHAOS-3660 §8(k). Request-direction additive: an old client's
+    request (the canonical fixture, which never sets this) validates
+    unchanged, and a client that DOES declare a version round-trips it.
+    """
+    payload = deepcopy(positive_fixtures()["dev_message_request.v1"])
+    assert "client_contract_version" not in payload
+    request = DevMessageRequest.model_validate(payload)
+    assert request.client_contract_version is None
+
+    payload["client_contract_version"] = "dev_stream_event.v2"
+    declared = DevMessageRequest.model_validate(payload)
+    assert declared.client_contract_version == "dev_stream_event.v2"
 
 
 @pytest.mark.parametrize("route_id", ["deployment_detail", "incident_detail"])


### PR DESCRIPTION
## Summary

- `DevCapabilities` gains `ask_dev_graph_routing: bool = False` (issue 3660 §8 item a) — reserves the capability flag for graph-assisted Ask Dev routing (issue 3502 wave), which is still feature-branch-only.
- `DevMessageRequest` gains an optional, additive `client_contract_version: Version | None = None` (item k) — reserves the slot a client uses to declare the newest contract surface it can parse.
- **Both schema-only.** No runtime path on `main` computes anything but the defaults — the surfaces these fields are meant to gate (the routing feature itself, and the `graph.state` stream event) haven't landed on `main` yet. Server-side validation of the declared version and the emission gating it enables are a later PR, once `graph.state` exists to gate.
- Regenerates the checked-in v1 contract artifacts these two fields touch (v2 unaffected — neither model is redeclared there).

## Test plan

- [x] `pytest tests/api/dev/test_contracts.py tests/api/dev/test_contracts_v2.py` — 368 passed (includes 2 new tests pinning both fields' default/optional and accepted-when-declared behavior)
- [x] `pytest tests/api/dev` (full directory) — 2487 passed, 35 skipped, 1 xfailed
- [x] `python -m dev_health_ops.api.dev.export_contracts write` then `check` — verified 73 artifacts, no drift
- [x] `ruff check` / `mypy` on touched files — clean