### PR TITLE
Add 6 additive dev_feedback reasons with a schema-level unspecified-exclusivity constraint (issue 3660 §8 items f, j)

### DIFF
--- a/contracts/ask-dev/v1/examples/negative/dev_feedback.v1.unspecified_combined_with_a_specific_reason.json
+++ b/contracts/ask-dev/v1/examples/negative/dev_feedback.v1.unspecified_combined_with_a_specific_reason.json
@@ -1,0 +1,12 @@
+{
+  "answer_id": "answer_01",
+  "comment": "The evidence answered my question.",
+  "created_at": "2026-07-28T12:00:00Z",
+  "feedback_id": "feedback_01",
+  "rating": "helpful",
+  "reasons": [
+    "unclear",
+    "unspecified"
+  ],
+  "schema_version": "dev_feedback.v1"
+}

--- a/contracts/ask-dev/v1/examples/positive/dev_feedback.v1.unspecified_alone.json
+++ b/contracts/ask-dev/v1/examples/positive/dev_feedback.v1.unspecified_alone.json
@@ -1,0 +1,11 @@
+{
+  "answer_id": "answer_01",
+  "comment": null,
+  "created_at": "2026-07-28T12:00:00Z",
+  "feedback_id": "feedback_02",
+  "rating": "not_helpful",
+  "reasons": [
+    "unspecified"
+  ],
+  "schema_version": "dev_feedback.v1"
+}

--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -355,16 +355,27 @@
           "case": "unsupported_reason",
           "path": "examples/negative/dev_feedback.v1.unsupported_reason.json",
           "sha256": "5f75d350e9d62af9b524fb5b0225f2741375b16cfad38b58b819b85b0509723f"
+        },
+        {
+          "case": "unspecified_combined_with_a_specific_reason",
+          "path": "examples/negative/dev_feedback.v1.unspecified_combined_with_a_specific_reason.json",
+          "sha256": "9a2bc84c5703621fbc95549c99b5cab0fa87054b1a7f355bc7100039237c86e4"
         }
       ],
       "positive": {
         "path": "examples/positive/dev_feedback.v1.json",
         "sha256": "f4e15f005ae9314210900993a791b5ab358375997f7dc28b30d4d76487101ba0"
       },
-      "positive_variants": [],
+      "positive_variants": [
+        {
+          "case": "unspecified_alone",
+          "path": "examples/positive/dev_feedback.v1.unspecified_alone.json",
+          "sha256": "dcc828a05f8b35e522bf62b61a7be0502df2c7ffde041d084ae2494e83226522"
+        }
+      ],
       "schema": {
         "path": "schemas/dev_feedback.v1.schema.json",
-        "sha256": "9c792cd80995e4e6eba066d50e495d77e0337621dffaf12fd59ed468af69b545"
+        "sha256": "f4354fbad987b827bec6a8e0aa753838361758072dc6a656e375a7ce06536185"
       },
       "schema_version": "dev_feedback.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_feedback.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_feedback.v1.schema.json
@@ -53,12 +53,32 @@
           "wrong_scope",
           "stale_data",
           "unclear",
-          "useful"
+          "useful",
+          "wrong_subject",
+          "wrong_cohort",
+          "wrong_driver",
+          "unsafe_certainty",
+          "other",
+          "unspecified"
         ],
         "type": "string"
       },
-      "maxItems": 6,
+      "maxItems": 12,
       "minItems": 1,
+      "oneOf": [
+        {
+          "const": [
+            "unspecified"
+          ]
+        },
+        {
+          "not": {
+            "contains": {
+              "const": "unspecified"
+            }
+          }
+        }
+      ],
       "title": "Reasons",
       "type": "array"
     },

--- a/src/dev_health_ops/api/dev/contract_fixtures.py
+++ b/src/dev_health_ops/api/dev/contract_fixtures.py
@@ -424,6 +424,20 @@ def positive_variant_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
     return {
         "dev_scope.v1": [("team_direct_scope", _team_scope())],
         "dev_scope_resolution.v1": [("team_direct_scope", _team_scope_resolution())],
+        "dev_feedback.v1": [
+            (
+                "unspecified_alone",
+                {
+                    "schema_version": "dev_feedback.v1",
+                    "feedback_id": "feedback_02",
+                    "answer_id": "answer_01",
+                    "rating": "not_helpful",
+                    "reasons": ["unspecified"],
+                    "comment": None,
+                    "created_at": NOW,
+                },
+            )
+        ],
     }
 
 
@@ -729,7 +743,16 @@ def negative_fixtures() -> dict[str, list[tuple[str, dict[str, Any]]]]:
                     "dev_feedback.v1",
                     lambda value: value.__setitem__("reasons", ["train_model"]),
                 ),
-            )
+            ),
+            (
+                "unspecified_combined_with_a_specific_reason",
+                changed(
+                    "dev_feedback.v1",
+                    lambda value: value.__setitem__(
+                        "reasons", ["unclear", "unspecified"]
+                    ),
+                ),
+            ),
         ],
         "dev_stream_event.v1": [
             (

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -1189,6 +1189,31 @@ class DevToolResult(ContractModel):
         return self
 
 
+#: CHAOS-3660 §8(f)/(j). The 6 members added alongside the original 6:
+#: ``wrong_subject``/``wrong_cohort``/``wrong_driver`` (additive siblings of
+#: the pre-existing, narrower ``wrong_scope`` -- never folded into it),
+#: ``unsafe_certainty``, ``other`` (a specific-but-unlisted reason), and
+#: ``unspecified`` -- a neutral "declined to say" value, distinct from
+#: ``other``, closing the "web fabricates ``unclear``" data-honesty gap on
+#: a one-click thumbs-down. ``max_length`` below is 12 to match this
+#: doubled vocabulary size (was 6, coincidentally equal to the vocabulary
+#: size at the time) -- this is a genuine simultaneous-selection cap, not
+#: an accident of the old count.
+_DEV_FEEDBACK_REASONS_JSON_SCHEMA_EXTRA: dict[str, Any] = {
+    # ``reasons`` is either EXACTLY ["unspecified"], or contains no
+    # "unspecified" at all -- a neutral "declined to say" can never sit
+    # alongside a specific reason (that would contradict the "declined"
+    # signal), and it can never be silently dropped from a mixed
+    # selection either. Expressed IN THE SCHEMA (not just the Python-side
+    # validator below) so a client validating locally catches the same
+    # violation the server would.
+    "oneOf": [
+        {"const": ["unspecified"]},
+        {"not": {"contains": {"const": "unspecified"}}},
+    ]
+}
+
+
 class DevFeedback(ContractModel):
     schema_version: Literal["dev_feedback.v1"]
     feedback_id: OpaqueID
@@ -1202,8 +1227,18 @@ class DevFeedback(ContractModel):
             "stale_data",
             "unclear",
             "useful",
+            "wrong_subject",
+            "wrong_cohort",
+            "wrong_driver",
+            "unsafe_certainty",
+            "other",
+            "unspecified",
         ]
-    ] = Field(min_length=1, max_length=6)
+    ] = Field(
+        min_length=1,
+        max_length=12,
+        json_schema_extra=_DEV_FEEDBACK_REASONS_JSON_SCHEMA_EXTRA,
+    )
     comment: (
         Annotated[str, StringConstraints(min_length=1, max_length=2_048)] | None
     ) = Field(
@@ -1211,6 +1246,16 @@ class DevFeedback(ContractModel):
         json_schema_extra={"x-max-utf8-bytes": 2_048},
     )
     created_at: AwareDatetime
+
+    @field_validator("reasons")
+    @classmethod
+    def enforce_unspecified_exclusivity(cls, value: list[str]) -> list[str]:
+        if "unspecified" in value and value != ["unspecified"]:
+            raise ValueError(
+                "'unspecified' must be the only reason when present, "
+                "never combined with a specific reason"
+            )
+        return value
 
     @field_validator("comment")
     @classmethod

--- a/src/dev_health_ops/api/dev/persistence/service.py
+++ b/src/dev_health_ops/api/dev/persistence/service.py
@@ -183,6 +183,12 @@ _RUN_STATES = _TERMINAL_RUN_STATES | frozenset(
         "answer_validation",
     }
 )
+#: CHAOS-3660 §8(f)/(j). The 6 members below the blank line are additive
+#: siblings, none folded onto the pre-existing, narrower ``wrong_scope``.
+#: Mirrors ``router.DevFeedbackCreateRequest.reasons`` and
+#: ``contracts.DevFeedback.reasons`` -- all three must widen together, or a
+#: newly-additive reason the contract declares valid gets silently
+#: rejected at whichever of the three gates was not updated.
 _FEEDBACK_REASONS = frozenset(
     {
         "incorrect",
@@ -191,6 +197,12 @@ _FEEDBACK_REASONS = frozenset(
         "stale_data",
         "unclear",
         "useful",
+        "wrong_subject",
+        "wrong_cohort",
+        "wrong_driver",
+        "unsafe_certainty",
+        "other",
+        "unspecified",
     }
 )
 _FORBIDDEN_METADATA_KEYS = frozenset(
@@ -3508,6 +3520,16 @@ class DevPersistenceService:
         normalized_reasons = sorted(set(reasons))
         if not set(normalized_reasons).issubset(_FEEDBACK_REASONS):
             raise DevPersistenceValidationError("invalid feedback reason")
+        # CHAOS-3660 §8(f)/(j) defense in depth: the router's own request
+        # model enforces this first, but this method holds its own
+        # invariant rather than trusting every caller to have gone through
+        # that gate.
+        if "unspecified" in normalized_reasons and normalized_reasons != [
+            "unspecified"
+        ]:
+            raise DevPersistenceValidationError(
+                "'unspecified' feedback reason must stand alone"
+            )
         comment = _bounded_text(comment, field="feedback comment", max_bytes=2048)
         answer = await self.session.scalar(
             select(DevMessage).where(

--- a/src/dev_health_ops/api/dev/router.py
+++ b/src/dev_health_ops/api/dev/router.py
@@ -27,7 +27,14 @@ from fastapi import (
 from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+    field_validator,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api._health import _analytics_db_url
@@ -137,6 +144,14 @@ class DevConversationRenameRequest(StrictRequestModel):
 
 
 class DevFeedbackCreateRequest(StrictRequestModel):
+    """CHAOS-3660 §8(f)/(j). ``reasons`` mirrors ``contracts.DevFeedback.
+    reasons`` -- request-body validation gate, not the wire response model
+    itself -- so this list and ``persistence.service._FEEDBACK_REASONS``
+    (the third, persistence-layer gate) must be widened in lockstep with
+    the contract, or a client sending a newly-additive reason gets
+    rejected here despite the contract declaring it valid.
+    """
+
     rating: Literal["helpful", "not_helpful"]
     reasons: list[
         Literal[
@@ -146,11 +161,27 @@ class DevFeedbackCreateRequest(StrictRequestModel):
             "stale_data",
             "unclear",
             "useful",
+            "wrong_subject",
+            "wrong_cohort",
+            "wrong_driver",
+            "unsafe_certainty",
+            "other",
+            "unspecified",
         ]
-    ] = Field(min_length=1, max_length=6)
+    ] = Field(min_length=1, max_length=12)
     comment: (
         Annotated[str, StringConstraints(min_length=1, max_length=2_048)] | None
     ) = None
+
+    @field_validator("reasons")
+    @classmethod
+    def enforce_unspecified_exclusivity(cls, value: list[str]) -> list[str]:
+        if "unspecified" in value and value != ["unspecified"]:
+            raise ValueError(
+                "'unspecified' must be the only reason when present, "
+                "never combined with a specific reason"
+            )
+        return value
 
 
 class DevConversationListResponse(StrictRequestModel):

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -20,6 +20,7 @@ from dev_health_ops.api.dev.contracts import (
     DevAnswer,
     DevCapabilities,
     DevEvidenceRef,
+    DevFeedback,
     DevMessageRequest,
     DevScope,
     DevScopeResolution,
@@ -161,6 +162,50 @@ def test_client_contract_version_is_absent_by_default_and_accepted_when_declared
     payload["client_contract_version"] = "dev_stream_event.v2"
     declared = DevMessageRequest.model_validate(payload)
     assert declared.client_contract_version == "dev_stream_event.v2"
+
+
+def test_feedback_reasons_accepts_the_six_new_additive_members() -> None:
+    """CHAOS-3660 §8(f)/(j). None of the 6 new reasons were folded onto the
+    pre-existing, narrower ``wrong_scope`` -- each validates as its own
+    sibling value.
+    """
+    payload = deepcopy(positive_fixtures()["dev_feedback.v1"])
+    for reason in (
+        "wrong_subject",
+        "wrong_cohort",
+        "wrong_driver",
+        "unsafe_certainty",
+        "other",
+    ):
+        feedback = DevFeedback.model_validate({**payload, "reasons": [reason]})
+        assert feedback.reasons == [reason]
+
+
+def test_feedback_unspecified_reason_must_stand_alone() -> None:
+    """CHAOS-3660 §8(f)/(j). 'unspecified' is exactly ["unspecified"] or
+    contains no "unspecified" at all -- the constraint the server actually
+    enforces at runtime (pydantic), asserted here directly.
+
+    The exported JSON Schema's ``reasons`` property carries the SAME
+    constraint as a real ``oneOf``/``not``/``contains`` combinator (see
+    ``_DEV_FEEDBACK_REASONS_JSON_SCHEMA_EXTRA`` in contracts.py), so a
+    client validating locally catches the same violation -- hand-verified
+    during implementation against a real Draft 2020-12 validator
+    (``jsonschema==4.26.0``, not a project dependency, so not re-asserted
+    here as a permanent test) over exactly these cases:
+    ``["unspecified"]`` valid, ``["unclear", "wrong_subject"]`` valid,
+    ``["unclear", "unspecified"]`` and ``["unspecified", "unclear"]``
+    invalid, ``[]`` invalid (``minItems``).
+    """
+    payload = deepcopy(positive_fixtures()["dev_feedback.v1"])
+
+    alone = DevFeedback.model_validate({**payload, "reasons": ["unspecified"]})
+    assert alone.reasons == ["unspecified"]
+
+    with pytest.raises(ValidationError, match="only reason"):
+        DevFeedback.model_validate({**payload, "reasons": ["unclear", "unspecified"]})
+    with pytest.raises(ValidationError, match="only reason"):
+        DevFeedback.model_validate({**payload, "reasons": ["unspecified", "unclear"]})
 
 
 @pytest.mark.parametrize("route_id", ["deployment_detail", "incident_detail"])

--- a/tests/api/dev/test_persistence.py
+++ b/tests/api/dev/test_persistence.py
@@ -787,6 +787,73 @@ async def test_validated_answer_feedback_and_safe_tool_metadata_round_trip(persi
 
 
 @pytest.mark.asyncio
+async def test_feedback_accepts_the_additive_reasons_and_rejects_mixed_unspecified(
+    persistence,
+):
+    """CHAOS-3660 §8(f)/(j). ``_FEEDBACK_REASONS`` is one of three
+    independent copies of this vocabulary (contracts.DevFeedback, router's
+    request model, this persistence-layer allowlist) -- this proves the
+    NEW reasons actually made it through to the layer that would silently
+    reject them if only the wire contract had been widened.
+    """
+    maker, org_id, _other_org_id, user_id, _other_user_id = persistence
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        conversation = await service.create_conversation(
+            org_id=org_id, user_id=user_id, current_scope={}
+        )
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            client_message_id=uuid.uuid4(),
+            question="What changed?",
+            scope_snapshot={},
+        )
+        answer_id = uuid.uuid4()
+        payload = _validated_answer(conversation.id, answer_id)
+        await service.append_assistant_answer(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=conversation.id,
+            answer_payload=payload,
+            validator=_identity_validator,
+            scope_snapshot={},
+        )
+
+        additive = await service.record_feedback(
+            org_id=org_id,
+            user_id=user_id,
+            answer_id=answer_id,
+            rating="not_helpful",
+            reasons=["wrong_subject", "wrong_cohort", "wrong_driver"],
+        )
+        assert sorted(additive.reasons) == [
+            "wrong_cohort",
+            "wrong_driver",
+            "wrong_subject",
+        ]
+
+        alone = await service.record_feedback(
+            org_id=org_id,
+            user_id=user_id,
+            answer_id=answer_id,
+            rating="not_helpful",
+            reasons=["unspecified"],
+        )
+        assert alone.reasons == ["unspecified"]
+
+        with pytest.raises(DevPersistenceValidationError, match="stand alone"):
+            await service.record_feedback(
+                org_id=org_id,
+                user_id=user_id,
+                answer_id=answer_id,
+                rating="not_helpful",
+                reasons=["unclear", "unspecified"],
+            )
+
+
+@pytest.mark.asyncio
 async def test_deletion_expiry_and_cleanup_are_bounded_idempotent_and_content_free(
     persistence,
 ):

--- a/tests/api/dev/test_router.py
+++ b/tests/api/dev/test_router.py
@@ -1848,6 +1848,70 @@ async def test_dev_feedback_is_scoped_to_the_target_conversation(dev_api_context
 
 
 @pytest.mark.asyncio
+async def test_dev_feedback_accepts_additive_reasons_and_rejects_mixed_unspecified(
+    dev_api_context,
+):
+    """CHAOS-3660 §8(f)/(j), full HTTP stack. ``DevFeedbackCreateRequest``
+    is a SEPARATE request-body model from ``contracts.DevFeedback`` -- this
+    proves a client sending a newly-additive reason is actually accepted
+    at the real API surface, not just by the wire contract's own schema.
+    """
+    client = dev_api_context.client
+    maker = dev_api_context.maker
+    org_id = dev_api_context.org_id
+    user_id = dev_api_context.user_id
+
+    create = await client.post(
+        "/api/v1/dev/conversations",
+        json={"current_scope": _scope_payload(org_id)},
+    )
+    assert create.status_code == 201
+    conversation_id = create.json()["conversation_id"]
+
+    answer_id = uuid.uuid4()
+    async with maker() as session:
+        service = DevPersistenceService(session)
+        await service.append_user_message_and_run(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=uuid.UUID(conversation_id),
+            client_message_id=uuid.uuid4(),
+            question="What changed?",
+            scope_snapshot={},
+        )
+        await service.append_assistant_answer(
+            org_id=org_id,
+            user_id=user_id,
+            conversation_id=uuid.UUID(conversation_id),
+            answer_payload={
+                "schema_version": "dev_answer.v1",
+                "answer_id": str(answer_id),
+                "conversation_id": conversation_id,
+                "summary": "The answer is stored for feedback testing.",
+                "claims": [],
+                "metrics": [],
+                "evidence": [],
+            },
+            validator=lambda payload: payload,
+            scope_snapshot={},
+        )
+        await session.commit()
+
+    additive = await client.post(
+        f"/api/v1/dev/answers/{answer_id}/feedback",
+        json={"rating": "not_helpful", "reasons": ["wrong_subject"]},
+    )
+    assert additive.status_code == 200
+    assert additive.json()["reasons"] == ["wrong_subject"]
+
+    mixed_unspecified = await client.post(
+        f"/api/v1/dev/answers/{answer_id}/feedback",
+        json={"rating": "not_helpful", "reasons": ["unclear", "unspecified"]},
+    )
+    assert mixed_unspecified.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_dev_evidence_expansion_requires_owned_answer_relationship(
     dev_api_context, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## Summary

`contracts.DevFeedback.reasons` gains 6 new members alongside the original 6 — `wrong_subject`/`wrong_cohort`/`wrong_driver` (additive siblings of the pre-existing, narrower `wrong_scope`, never folded into it), `unsafe_certainty`, `other`, and `unspecified` (a neutral "declined to say" value, distinct from `other`, closing the "web fabricates `unclear`" data-honesty gap on a one-click thumbs-down). `max_length` raised 6 → 12 to match the doubled vocabulary — a genuine simultaneous-selection cap, not an accident of the old count, per the standing ruling.

**Unspecified-exclusivity, enforced in two places** per the ruling that it "goes in the schema": `reasons` is exactly `["unspecified"]` or contains no `"unspecified"` at all.
1. A pydantic `field_validator` — what the server actually runs.
2. A hand-written `oneOf`/`not`/`contains` combinator injected via `json_schema_extra` so the **exported JSON Schema** expresses the same constraint for a client validating locally. Cross-checked both against a real Draft 2020-12 validator during implementation (not a project dependency, so not embedded as a permanent test) over the representative cases the pydantic-side test covers.

**Widened two more independent copies of the same vocabulary** that would otherwise silently reject the new reasons despite the wire contract declaring them valid:
- `router.DevFeedbackCreateRequest` — the actual request-body gate a client hits, separate from `contracts.DevFeedback`.
- `persistence.service._FEEDBACK_REASONS` — a third, persistence-layer allowlist, now also holding its own unspecified-exclusivity check as defense in depth rather than trusting every caller went through the router.

Plant-verified: reverted `_FEEDBACK_REASONS` alone (router left widened) and confirmed the new end-to-end HTTP test fails with `422` at exactly that gate; restored, confirmed green.

Safe in the request direction: `reasons` is client→server, so no old client ever needs to *parse* an unknown value here — only the server validates incoming requests, and it now accepts the wider vocabulary.

## Test plan

- [x] `tests/api/dev/test_contracts.py` — 2 new tests (additive-members acceptance, unspecified-exclusivity at both pydantic and schema layers)
- [x] `tests/api/dev/test_persistence.py` — 1 new test (additive reasons + exclusivity at the persistence layer)
- [x] `tests/api/dev/test_router.py` — 1 new test (full HTTP stack, plant-verified against the persistence-layer gate)
- [x] `pytest tests/api/dev/test_contracts.py tests/api/dev/test_persistence.py tests/api/dev/test_router.py` — 148 passed
- [x] `pytest tests/api/dev` (full directory) — 2495 passed, 35 skipped, 1 xfailed
- [x] `python -m dev_health_ops.api.dev.export_contracts write` then `check` (v1: 75 artifacts) / `export_contracts_v2 write`+`check` (v2: 102, unaffected)
- [x] `ruff check` / `mypy` on touched files — clean