### PR TITLE
Publish a sanctioned source-health label table with a binding totality test (issue 3660 §8(g))

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -431,6 +431,11 @@
       "case": "internal_prose_denylist",
       "path": "vocabulary/internal_prose_denylist.v1.json",
       "sha256": "621ed38192bb17f3c9e9f826a3b3572c29cc8cd58865c77e9ea4ad9296990e7a"
+    },
+    {
+      "case": "source_health_labels",
+      "path": "vocabulary/source_health_labels.v1.json",
+      "sha256": "f141c442d84b55d59d40e5b20deba5ad810ee8d5a7c91f59c68545006d66ef7e"
     }
   ]
 }

--- a/contracts/ask-dev/v1/vocabulary/source_health_labels.v1.json
+++ b/contracts/ask-dev/v1/vocabulary/source_health_labels.v1.json
@@ -1,0 +1,31 @@
+{
+  "labels": {
+    "change_summary.v1": "Change summary",
+    "ci_run": "CI runs",
+    "code_change": "Code changes",
+    "cognitive_load": "Cognitive load",
+    "data_health.v1": "Data health",
+    "deficiency_inventory": "Deficiency inventory",
+    "deployment": "Deployments",
+    "get_evidence.v1": "Evidence expansion",
+    "health_profile": "Health profile",
+    "incident": "Incidents",
+    "investment_allocation": "Investment allocation",
+    "list_metrics.v1": "Metric catalog",
+    "operational_control": "Operational controls",
+    "pull_request": "Pull requests",
+    "query_metric.v1": "Metric query",
+    "resolve_scope.v1": "Scope resolution",
+    "review": "Reviews",
+    "search_evidence.v1": "Evidence search",
+    "source_health": "Source health",
+    "status_change": "Status changes",
+    "status_snapshot.v1": "Status snapshot",
+    "test_report": "Test reports",
+    "tool_results": "Tool results",
+    "work_graph": "Work graph",
+    "work_graph_neighbors.v1": "Work graph",
+    "work_item": "Work items"
+  },
+  "schema_version": "ask_dev_source_health_labels.v1"
+}

--- a/src/dev_health_ops/api/dev/export_contracts.py
+++ b/src/dev_health_ops/api/dev/export_contracts.py
@@ -16,8 +16,73 @@ from .contract_fixtures import (
     positive_variant_fixtures,
     stream_fixtures,
 )
-from .contracts import CONTRACT_MODELS, DevStreamEvent, validate_stream
+from .contracts import CONTRACT_MODELS, DevStreamEvent, ToolID, validate_stream
+from .contracts_v2.base import SourceClass
 from .status_change_service import STATUS_REASON_CODES
+
+#: CHAOS-3660 §8(g). ``DevCoverage.{unavailable,stale,degraded}_required_
+#: sources`` (``contracts.py``) is a free-form ``list[OpaqueID]``, populated
+#: today by exactly two orchestrator-side producers plus one ad-hoc literal
+#: -- traced by reading every assignment site, not guessed:
+#:
+#: * ``Orchestrator._coverage_from_tool_results`` labels each required
+#:   source with the ``ToolID`` value of the tool that was supposed to
+#:   supply it (e.g. ``"query_metric.v1"``) -- already a *disclosed*
+#:   vocabulary, the same reasoning ``no_match_terminal.py`` gives for
+#:   excluding ``ToolID`` from the internal-token denylist.
+#: * ``Orchestrator._coverage_with_plan_sources`` labels each mandatory/
+#:   conditional plan requirement with its ``SourceClass`` value
+#:   (``contracts_v2/base.py``) -- that enum's own docstring: "the same
+#:   token is what ``dev_coverage``'s ... disclose". Deliberately disjoint
+#:   from the ``ToolID`` half (see that function's own docstring), so the
+#:   two vocabularies never collide on one label.
+#: * ``Orchestrator._budget_exhausted_answer`` uses the one hardcoded
+#:   literal ``"tool_results"`` for its single-source budget-exhaustion
+#:   fallback -- not a member of either enum, so listed explicitly.
+#:
+#: No backend label table existed for ANY of this before (confirmed: web's
+#: ``SCOPE_OUTCOME_LABELS`` is the only precedent, and it names a completely
+#: different vocabulary -- scope-resolution outcomes, not source ids -- and
+#: ``data_health_service.NATIVE_EVIDENCE_SOURCES`` is a DIFFERENT wire
+#: surface, ``DevSourceHealth``/``DevDataHealth.source_system``, not this
+#: one -- confirmed by direct string comparison, they don't even share
+#: member spelling, e.g. ``"pull_requests"`` there vs ``"pull_request"``
+#: here).
+#: ``test_source_health_labels_cover_every_known_required_source_producer``
+#: is a totality check against this exact union, not a guess at what
+#: "should" be covered -- see that test's own docstring for what it can and
+#: cannot promise.
+SOURCE_HEALTH_LABELS: dict[str, str] = {
+    # ToolID producers (Orchestrator._coverage_from_tool_results).
+    ToolID.RESOLVE_SCOPE.value: "Scope resolution",
+    ToolID.LIST_METRICS.value: "Metric catalog",
+    ToolID.QUERY_METRIC.value: "Metric query",
+    ToolID.STATUS_SNAPSHOT.value: "Status snapshot",
+    ToolID.CHANGE_SUMMARY.value: "Change summary",
+    ToolID.WORK_GRAPH_NEIGHBORS.value: "Work graph",
+    ToolID.SEARCH_EVIDENCE.value: "Evidence search",
+    ToolID.GET_EVIDENCE.value: "Evidence expansion",
+    ToolID.DATA_HEALTH.value: "Data health",
+    # SourceClass producers (Orchestrator._coverage_with_plan_sources).
+    SourceClass.STATUS_CHANGE.value: "Status changes",
+    SourceClass.WORK_ITEM.value: "Work items",
+    SourceClass.WORK_GRAPH.value: "Work graph",
+    SourceClass.PULL_REQUEST.value: "Pull requests",
+    SourceClass.CODE_CHANGE.value: "Code changes",
+    SourceClass.REVIEW.value: "Reviews",
+    SourceClass.CI_RUN.value: "CI runs",
+    SourceClass.TEST_REPORT.value: "Test reports",
+    SourceClass.DEPLOYMENT.value: "Deployments",
+    SourceClass.INCIDENT.value: "Incidents",
+    SourceClass.OPERATIONAL_CONTROL.value: "Operational controls",
+    SourceClass.SOURCE_HEALTH.value: "Source health",
+    SourceClass.COGNITIVE_LOAD.value: "Cognitive load",
+    SourceClass.INVESTMENT_ALLOCATION.value: "Investment allocation",
+    SourceClass.HEALTH_PROFILE.value: "Health profile",
+    SourceClass.DEFICIENCY_INVENTORY.value: "Deficiency inventory",
+    # Orchestrator._budget_exhausted_answer's one hardcoded literal.
+    "tool_results": "Tool results",
+}
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 ARTIFACT_ROOT = REPOSITORY_ROOT / "contracts" / "ask-dev" / "v1"
@@ -172,6 +237,19 @@ def expected_artifacts() -> dict[str, str]:
         }
     )
     artifacts["vocabulary/internal_prose_denylist.v1.json"] = denylist_contents
+    # CHAOS-3660 §8(g). Published so web has ONE sanctioned source of truth
+    # for rendering a raw DevCoverage required-source id, instead of
+    # inventing its own labels ad hoc the way it does today for scope-
+    # resolution outcomes (``SCOPE_OUTCOME_LABELS``) -- see
+    # ``SOURCE_HEALTH_LABELS``'s own module-level docstring for exactly
+    # which producers this covers and why.
+    source_health_labels_contents = _json(
+        {
+            "schema_version": "ask_dev_source_health_labels.v1",
+            "labels": SOURCE_HEALTH_LABELS,
+        }
+    )
+    artifacts["vocabulary/source_health_labels.v1.json"] = source_health_labels_contents
     manifest = {
         "schema_version": "ask_dev_contract_manifest.v1",
         "compatibility": "additive-within-v1",
@@ -185,7 +263,12 @@ def expected_artifacts() -> dict[str, str]:
                 "case": "internal_prose_denylist",
                 "path": "vocabulary/internal_prose_denylist.v1.json",
                 "sha256": _sha256(denylist_contents),
-            }
+            },
+            {
+                "case": "source_health_labels",
+                "path": "vocabulary/source_health_labels.v1.json",
+                "sha256": _sha256(source_health_labels_contents),
+            },
         ],
     }
     artifacts["manifest.json"] = _json(manifest)

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -24,9 +24,12 @@ from dev_health_ops.api.dev.contracts import (
     DevScope,
     DevScopeResolution,
     DevStreamEvent,
+    ToolID,
     validate_stream,
 )
+from dev_health_ops.api.dev.contracts_v2.base import SourceClass
 from dev_health_ops.api.dev.export_contracts import (
+    SOURCE_HEALTH_LABELS,
     check_artifacts,
     expected_artifacts,
 )
@@ -423,6 +426,39 @@ def test_contract_schemas_are_provider_neutral_and_closed() -> None:
     assert 'additionalProperties": false' in schemas
     for provider_specific in ("openai_api_key", "anthropic_api_key", "tool_choice"):
         assert provider_specific not in schemas
+
+
+def test_source_health_labels_cover_every_known_required_source_producer() -> None:
+    """CHAOS-3660 §8(g). ``SOURCE_HEALTH_LABELS`` must have an entry for
+    every id ``DevCoverage.{unavailable,stale,degraded}_required_sources``
+    can actually carry -- derived here from the two live enums that feed
+    it (``ToolID``, ``SourceClass``) plus the one hardcoded literal
+    (``"tool_results"``), not a hand list independently re-typed.
+
+    Honesty about what this proves: it is a totality check against every
+    producer identified by reading ``orchestrator.py``'s
+    ``_coverage_from_tool_results``/``_coverage_with_plan_sources``/
+    ``_budget_exhausted_answer`` -- the only three call sites in the
+    codebase that assign into these three ``DevCoverage`` fields (verified
+    by grep, not assumed). It cannot dynamically catch a hypothetical
+    FUTURE fourth producer emitting a still-different literal; the
+    exact-equality assertion below at least ensures a member removed from
+    either enum (or the union going stale some other way) fails loudly
+    here rather than silently leaving a dead label.
+    """
+    expected = (
+        frozenset(member.value for member in ToolID)
+        | frozenset(member.value for member in SourceClass)
+        | {"tool_results"}
+    )
+    assert set(SOURCE_HEALTH_LABELS) == expected
+
+    published = json.loads(
+        expected_artifacts()["vocabulary/source_health_labels.v1.json"]
+    )
+    assert set(published["labels"]) == expected
+    for source_id, label in SOURCE_HEALTH_LABELS.items():
+        assert label, f"{source_id} has an empty label"
 
 
 @pytest.mark.parametrize("schema_version", CONTRACT_MODELS)


### PR DESCRIPTION
## Summary

No backend label table existed for `DevCoverage`'s required-source ids before this — confirmed `no_match_terminal.py`'s `SCOPE_OUTCOME_LABELS` precedent names a completely different vocabulary (scope-resolution outcomes), and web has been inventing its own labels ad hoc for this one.

**Traced the actual producers by reading every assignment site** (grep-confirmed — the only three in the codebase that assign into `DevCoverage.{unavailable,stale,degraded}_required_sources`):
- `Orchestrator._coverage_from_tool_results` labels each source with its `ToolID` value (e.g. `"query_metric.v1"`)
- `Orchestrator._coverage_with_plan_sources` labels each with its `SourceClass` value (`contracts_v2/base.py`) — deliberately disjoint from the `ToolID` half, per that function's own docstring
- `Orchestrator._budget_exhausted_answer` uses one hardcoded literal (`"tool_results"`)

**This corrects an assumption in my original design doc**, which cited `data_health_service.NATIVE_EVIDENCE_SOURCES` — confirmed by direct string comparison that vocabulary belongs to a *different* wire surface entirely (`DevSourceHealth`/`DevDataHealth.source_system`), not `DevCoverage`'s required-source lists (they don't even share spelling: `"pull_requests"` there vs `"pull_request"` here).

`SOURCE_HEALTH_LABELS` (`export_contracts.py`) is keyed by the exact union `ToolID ∪ SourceClass ∪ {"tool_results"}` — computed from the live enums, never hand-retyped — and published as `vocabulary/source_health_labels.v1.json`, same checked-artifact pattern as the existing internal-token denylist.

**The binding totality test** asserts exact equality between the label table's keys and that same live union, both in Python and against the published artifact. Plant-verified: removed one `SourceClass` entry, confirmed the test failed naming exactly that member, restored, confirmed green.

Honest about scope, stated in the test's own docstring: this covers every producer identified today (three call sites, confirmed by grep) — it cannot dynamically catch a hypothetical future fourth producer emitting a still-different literal, only guarantee the two enums plus the one known literal stay in sync with the table.

## Test plan

- [x] `tests/api/dev/test_contracts.py` — 1 new test (plant-verified: removed a `SourceClass` member from the label table, confirmed the exact failure, restored)
- [x] `pytest tests/api/dev/test_contracts.py` — 91 passed
- [x] `pytest tests/api/dev` (full directory) — 2490 passed, 35 skipped, 1 xfailed
- [x] `python -m dev_health_ops.api.dev.export_contracts write` then `check` — 74 artifacts, no drift
- [x] `ruff check` / `mypy` on touched files — clean