### PR TITLE
Split credentials/test 404 into three distinct, reason-coded outcomes

### DIFF
--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -19,7 +19,11 @@ from dev_health_ops.api.admin.schemas import (
     TestConnectionRequest,
     TestConnectionResponse,
 )
-from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.api.services.configuration import (
+    CredentialLookupOutcome,
+    IntegrationCredentialsService,
+)
+from dev_health_ops.api.utils.errors import error_detail
 from dev_health_ops.credentials.resolver import github_credentials_from_mapping
 from dev_health_ops.exceptions import (
     APIException,
@@ -343,9 +347,37 @@ async def test_connection(
     if not creds:
         # Prefer credential_id (UUID) lookup; fall back to provider+name
         if payload.credential_id:
-            creds, stored = await svc.get_decrypted_credentials_by_id(
+            # issue 3694: a by-id lookup can be falsy for three DISTINCT
+            # reasons (see CredentialLookupOutcome) -- only NOT_FOUND
+            # stays 404 (the cross-tenant not-found-as-forbidden posture
+            # is unchanged; get_by_id already scopes to this org). A row
+            # that exists in THIS org but is unusable (no stored payload,
+            # or a decrypt failure) is a distinct, reason-coded 422:
+            # the client asked to test something real that this org
+            # genuinely has, and "not found" would be a lie.
+            (
+                creds,
+                stored,
+                outcome,
+            ) = await svc.get_decrypted_credentials_by_id_with_outcome(
                 payload.credential_id
             )
+            if not creds and outcome is not CredentialLookupOutcome.OK:
+                if outcome is CredentialLookupOutcome.NOT_FOUND:
+                    raise HTTPException(status_code=404, detail="Credential not found")
+                reason_code = (
+                    "credential_missing_payload"
+                    if outcome is CredentialLookupOutcome.NO_PAYLOAD
+                    else "credential_unreadable"
+                )
+                raise HTTPException(
+                    status_code=422,
+                    detail=error_detail(
+                        "Stored credential exists but cannot be used for a "
+                        "test connection",
+                        reason_code=reason_code,
+                    ),
+                )
         else:
             creds = await svc.get_decrypted_credentials(payload.provider, payload.name)
         if not creds:

--- a/src/dev_health_ops/api/services/configuration/__init__.py
+++ b/src/dev_health_ops/api/services/configuration/__init__.py
@@ -32,6 +32,7 @@ from ._helpers import (
 from .generic import SettingsService
 from .integration_credentials import (
     AmbiguousCredentialError,
+    CredentialLookupOutcome,
     IntegrationCredentialsService,
 )
 from .jira_activity_inference import JiraActivityInferenceService
@@ -41,6 +42,7 @@ from .team_membership import TeamMembershipService
 
 __all__ = [
     "AmbiguousCredentialError",
+    "CredentialLookupOutcome",
     "IntegrationCredentialsService",
     "JiraActivityInferenceService",
     "SettingsService",

--- a/src/dev_health_ops/api/services/configuration/integration_credentials.py
+++ b/src/dev_health_ops/api/services/configuration/integration_credentials.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from enum import StrEnum
 from typing import Any, Final
 
 from sqlalchemy import select
@@ -15,6 +16,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.utils.logging import sanitize_for_log
 from dev_health_ops.core.encryption import decrypt_value, encrypt_value
+from dev_health_ops.metrics.prometheus import (
+    INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL,
+)
 from dev_health_ops.models.settings import IntegrationCredential
 from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
@@ -84,6 +88,36 @@ def _validate_pagerduty_descriptor(
         raise ValueError("PagerDuty config auth_mode must match credentials")
 
 
+class CredentialLookupOutcome(StrEnum):
+    """issue 3694. Why a by-id credential lookup came back unusable --
+    :meth:`IntegrationCredentialsService.get_decrypted_credentials_by_id`
+    collapses all three into a single ``(None, ...)`` return, which is
+    correct for its existing callers (none of them need the reason) but
+    wrong for a caller that must tell a client WHY, e.g. whether to retry
+    the same request (never, for any of these) or re-enter the credential
+    (only ``NO_PAYLOAD``/``DECRYPT_FAILED``, never ``NOT_FOUND``, which
+    means there is nothing to re-enter).
+
+    Deliberately does NOT distinguish "row absent" from "row exists in a
+    different org" -- both are ``NOT_FOUND``, preserving the existing
+    not-found-as-forbidden cross-tenant posture (:meth:`get_by_id` already
+    scopes its query to ``self.org_id``, so a different org's row is
+    indistinguishable from no row at all by the time this code sees it,
+    and must stay that way)."""
+
+    #: Case 1: no row (absent, or scoped to a different org -- the two are
+    #: indistinguishable by design; see the class docstring).
+    NOT_FOUND = "not_found"
+    #: Case 2: the row exists but ``credentials_encrypted`` is falsy.
+    NO_PAYLOAD = "no_payload"
+    #: Case 3: the row exists with a payload, but ``decrypt_value``/
+    #: ``json.loads`` raised -- a key-mismatch class of failure, silent to
+    #: every existing caller before this enum existed.
+    DECRYPT_FAILED = "decrypt_failed"
+    #: The lookup succeeded; ``decrypted`` is a real, usable dict.
+    OK = "ok"
+
+
 class AmbiguousCredentialError(ValueError):
     """Raised when a provider has multiple active credentials and no
     explicit name/id was given to disambiguate."""
@@ -139,21 +173,53 @@ class IntegrationCredentialsService:
     ) -> tuple[dict[str, Any] | None, IntegrationCredential | None]:
         """Get credentials as a decrypted dictionary, looked up by ID.
 
-        Returns (decrypted_dict, credential_record) tuple.
+        Returns (decrypted_dict, credential_record) tuple. A thin,
+        outcome-discarding wrapper over
+        :meth:`get_decrypted_credentials_by_id_with_outcome` for the
+        existing callers that only ever needed "did this work", never
+        "why not" (issue 3694) -- their behavior is unchanged.
+        """
+        (
+            decrypted,
+            cred,
+            _outcome,
+        ) = await self.get_decrypted_credentials_by_id_with_outcome(credential_id)
+        return decrypted, cred
+
+    async def get_decrypted_credentials_by_id_with_outcome(
+        self,
+        credential_id: str,
+    ) -> tuple[
+        dict[str, Any] | None, IntegrationCredential | None, CredentialLookupOutcome
+    ]:
+        """Same lookup as :meth:`get_decrypted_credentials_by_id`, plus WHY
+        a falsy result is falsy (issue 3694) -- see
+        :class:`CredentialLookupOutcome` for what each case means and why
+        ``NOT_FOUND`` alone stays 404-shaped for cross-tenant safety.
+
+        Case 3 (``DECRYPT_FAILED``) also increments
+        ``INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL`` -- a key-mismatch
+        class of failure was previously only a ``logger.error`` line, not
+        countable/alertable.
         """
         cred: Any | None = await self.get_by_id(credential_id)
-        if cred is None or not cred.credentials_encrypted:
-            return None, cred
+        if cred is None:
+            return None, None, CredentialLookupOutcome.NOT_FOUND
+        if not cred.credentials_encrypted:
+            return None, cred, CredentialLookupOutcome.NO_PAYLOAD
 
         try:
             decrypted = decrypt_value(cred.credentials_encrypted)
-            return json.loads(decrypted), cred
+            return json.loads(decrypted), cred, CredentialLookupOutcome.OK
         except (ValueError, json.JSONDecodeError):
             logger.error(
                 "Failed to decrypt/parse integration config for id=%s",
                 sanitize_for_log(str(credential_id)),
             )
-            return None, cred
+            INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL.labels(
+                provider=sanitize_for_log(str(getattr(cred, "provider", "unknown")))
+            ).inc()
+            return None, cred, CredentialLookupOutcome.DECRYPT_FAILED
 
     async def get_decrypted_credentials(
         self,

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -328,6 +328,21 @@ if _PROMETHEUS_AVAILABLE:
         "starved), not just that one run failed.",
     )
 
+    # ---------------------------------------------------------------------------
+    # Integration credentials (issue 3694)
+    # ---------------------------------------------------------------------------
+    INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_integration_credential_decrypt_failed_total",
+        "Stored integration credential rows whose credentials_encrypted "
+        "payload existed but decrypt_value/json.loads raised when read -- "
+        "a key-mismatch class of failure (e.g. a rotated "
+        "SETTINGS_ENCRYPTION_KEY that can no longer decrypt rows written "
+        "under the old one). Every increment means a real credential a "
+        "caller believed was configured is now unusable; this must trend "
+        "to zero, never merely be a grep-able log line.",
+        ["provider"],
+    )
+
 else:
     # Graceful no-ops when prometheus_client is unavailable
     CELERY_TASKS_TOTAL = _noop_counter()
@@ -358,6 +373,7 @@ else:
     ASK_DEV_RETENTION_SWEEP_TOTAL = _noop_counter()
     ASK_DEV_RETENTION_SWEEP_PURGED_TOTAL = _noop_counter()
     ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP = _noop_gauge()
+    INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL = _noop_counter()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/admin/test_credential_lookup_outcome.py
+++ b/tests/api/admin/test_credential_lookup_outcome.py
@@ -1,0 +1,281 @@
+"""issue 3694: get_decrypted_credentials_by_id conflated three distinct
+"falsy" reasons into one -- (1) no row at all, (2) a row with no stored
+payload, (3) a row whose payload exists but fails to decrypt (a
+key-mismatch class of failure, previously silent to every caller). This
+tests CredentialLookupOutcome / get_decrypted_credentials_by_id_with_outcome
+at the service layer against a REAL (sqlite) session -- not a mock of the
+decrypt call -- so case 3 is plant-verified against the real
+decrypt_value/json.loads path, not assumed.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+from dev_health_ops.api.services.configuration import (
+    CredentialLookupOutcome,
+    IntegrationCredentialsService,
+)
+from dev_health_ops.metrics.prometheus import (
+    INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IntegrationCredential
+from tests._helpers import tables_of
+
+_TABLES = tables_of(IntegrationCredential)
+
+ORG_ID = str(uuid.uuid4())
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "cred-lookup-outcome.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed(
+    session_maker, *, name: str = "default", credentials: dict | None = None
+) -> str:
+    """Seed one real, decryptable credential row and return its id.
+
+    ``name`` defaults to "default" but every test that seeds MORE THAN
+    ONE row in the same org must pass distinct names -- the service's own
+    ``set()`` is an upsert keyed on (org_id, provider, name), so two
+    same-named seeds silently collapse into ONE row and corrupting one
+    would corrupt the other's expected-clean payload too.
+    """
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        cred = await svc.set(
+            provider="github",
+            credentials=credentials or {"token": "ghp_real"},
+            name=name,
+        )
+        await session.commit()
+        return str(cred.id)
+
+
+async def _corrupt_encrypted_payload(session_maker, credential_id: str) -> None:
+    """Overwrite the row's ciphertext with garbage that cannot decrypt --
+    the real path a key rotation or storage corruption would produce.
+    Direct SQL, bypassing the service's own encrypt/decrypt entirely, so
+    this genuinely exercises decrypt_value/json.loads raising, not a
+    mocked-away shortcut."""
+    async with session_maker() as session:
+        await session.execute(
+            update(IntegrationCredential)
+            .where(IntegrationCredential.id == uuid.UUID(credential_id))
+            .values(credentials_encrypted="not-valid-ciphertext-at-all")
+        )
+        await session.commit()
+
+
+async def _blank_out_payload(session_maker, credential_id: str) -> None:
+    async with session_maker() as session:
+        await session.execute(
+            update(IntegrationCredential)
+            .where(IntegrationCredential.id == uuid.UUID(credential_id))
+            .values(credentials_encrypted=None)
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_ok_case_returns_the_real_decrypted_dict(session_maker):
+    credential_id = await _seed(session_maker, credentials={"token": "ghp_real"})
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        (
+            decrypted,
+            cred,
+            outcome,
+        ) = await svc.get_decrypted_credentials_by_id_with_outcome(credential_id)
+
+    assert outcome is CredentialLookupOutcome.OK
+    assert decrypted == {"token": "ghp_real"}
+    assert cred is not None
+
+
+@pytest.mark.asyncio
+async def test_not_found_case_for_a_genuinely_absent_id(session_maker):
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        (
+            decrypted,
+            cred,
+            outcome,
+        ) = await svc.get_decrypted_credentials_by_id_with_outcome(str(uuid.uuid4()))
+
+    assert outcome is CredentialLookupOutcome.NOT_FOUND
+    assert decrypted is None
+    assert cred is None
+
+
+@pytest.mark.asyncio
+async def test_not_found_case_for_a_different_orgs_row(session_maker):
+    """Cross-tenant posture unchanged: a row that exists, but scoped to a
+    DIFFERENT org, is indistinguishable from no row at all -- still
+    NOT_FOUND, never a different outcome that would leak its existence."""
+    credential_id = await _seed(session_maker)
+
+    async with session_maker() as session:
+        other_org_svc = IntegrationCredentialsService(session, str(uuid.uuid4()))
+        (
+            decrypted,
+            cred,
+            outcome,
+        ) = await other_org_svc.get_decrypted_credentials_by_id_with_outcome(
+            credential_id
+        )
+
+    assert outcome is CredentialLookupOutcome.NOT_FOUND
+    assert decrypted is None
+    assert cred is None
+
+
+@pytest.mark.asyncio
+async def test_no_payload_case_when_the_row_has_nothing_stored(session_maker):
+    credential_id = await _seed(session_maker)
+    await _blank_out_payload(session_maker, credential_id)
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        (
+            decrypted,
+            cred,
+            outcome,
+        ) = await svc.get_decrypted_credentials_by_id_with_outcome(credential_id)
+
+    assert outcome is CredentialLookupOutcome.NO_PAYLOAD
+    assert decrypted is None
+    # Distinct from NOT_FOUND: the row itself IS returned -- it exists.
+    assert cred is not None
+
+
+@pytest.mark.asyncio
+async def test_decrypt_failed_case_is_plant_verified_against_a_real_corrupt_row(
+    session_maker,
+):
+    """Plant-verified per the issue's own requirement: corrupt a REAL
+    encrypted payload (not a mock) and observe the case-3 path actually
+    fire against the real decrypt_value/json.loads call."""
+    credential_id = await _seed(session_maker)
+    await _corrupt_encrypted_payload(session_maker, credential_id)
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        (
+            decrypted,
+            cred,
+            outcome,
+        ) = await svc.get_decrypted_credentials_by_id_with_outcome(credential_id)
+
+    assert outcome is CredentialLookupOutcome.DECRYPT_FAILED
+    assert decrypted is None
+    # Distinct from NOT_FOUND and NO_PAYLOAD: the row exists and HAD a
+    # payload -- it just can't be read anymore.
+    assert cred is not None
+
+
+@pytest.mark.asyncio
+async def test_decrypt_failed_case_increments_the_structured_metric(session_maker):
+    """The issue's other explicit requirement: a decrypt failure must be
+    COUNTABLE, not just a grep-able log line."""
+    credential_id = await _seed(session_maker)
+    await _corrupt_encrypted_payload(session_maker, credential_id)
+
+    before = INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL.labels(
+        provider="github"
+    )._value.get()
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        await svc.get_decrypted_credentials_by_id_with_outcome(credential_id)
+
+    after = INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL.labels(
+        provider="github"
+    )._value.get()
+    assert after == before + 1, (
+        "a real decrypt failure must increment "
+        "INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL, labeled by provider"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_payload_case_never_increments_the_decrypt_failure_metric(
+    session_maker,
+):
+    """Case 2 (no payload) must NOT be conflated with case 3 in the
+    metric either -- only a genuine decrypt failure counts."""
+    credential_id = await _seed(session_maker)
+    await _blank_out_payload(session_maker, credential_id)
+
+    before = INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL.labels(
+        provider="github"
+    )._value.get()
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        await svc.get_decrypted_credentials_by_id_with_outcome(credential_id)
+
+    after = INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL.labels(
+        provider="github"
+    )._value.get()
+    assert after == before, "a missing payload is not a decrypt failure"
+
+
+@pytest.mark.asyncio
+async def test_the_two_tuple_wrapper_is_unchanged_for_every_existing_caller(
+    session_maker,
+):
+    """get_decrypted_credentials_by_id (the pre-existing 2-tuple method)
+    must behave byte-for-byte as before for all of its existing callers,
+    across all three falsy cases plus the OK case -- it is a thin,
+    outcome-discarding wrapper, not a second implementation that could
+    drift from the outcome-aware one."""
+    ok_id = await _seed(session_maker, name="ok", credentials={"token": "ghp_real"})
+    no_payload_id = await _seed(session_maker, name="no-payload")
+    await _blank_out_payload(session_maker, no_payload_id)
+    decrypt_failed_id = await _seed(session_maker, name="decrypt-failed")
+    await _corrupt_encrypted_payload(session_maker, decrypt_failed_id)
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+
+        decrypted, cred = await svc.get_decrypted_credentials_by_id(ok_id)
+        assert decrypted == {"token": "ghp_real"}
+        assert cred is not None
+
+        decrypted, cred = await svc.get_decrypted_credentials_by_id(no_payload_id)
+        assert decrypted is None
+        assert cred is not None
+
+        decrypted, cred = await svc.get_decrypted_credentials_by_id(decrypt_failed_id)
+        assert decrypted is None
+        assert cred is not None
+
+        decrypted, cred = await svc.get_decrypted_credentials_by_id(str(uuid.uuid4()))
+        assert decrypted is None
+        assert cred is None

--- a/tests/test_admin_credentials.py
+++ b/tests/test_admin_credentials.py
@@ -16,6 +16,7 @@ from httpx import ASGITransport, AsyncClient
 from dev_health_ops.api.admin import get_session, router
 from dev_health_ops.api.admin.middleware import get_admin_org_id, require_admin
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.configuration import CredentialLookupOutcome
 
 admin_router_module = import_module("dev_health_ops.api.admin.routers.credentials")
 
@@ -311,7 +312,11 @@ async def test_test_connection_by_credential_id(client):
         ) as mock_test,
     ):
         svc = AsyncMock()
-        svc.get_decrypted_credentials_by_id.return_value = ({"token": "ghp_test"}, cred)
+        svc.get_decrypted_credentials_by_id_with_outcome.return_value = (
+            {"token": "ghp_test"},
+            cred,
+            CredentialLookupOutcome.OK,
+        )
         svc.get.return_value = cred
         mock_svc_cls.return_value = svc
         mock_test.return_value = (True, {"user": "test-user"})
@@ -326,17 +331,25 @@ async def test_test_connection_by_credential_id(client):
     data = resp.json()
     assert data["success"] is True
     assert data["details"] == {"user": "test-user"}
-    svc.get_decrypted_credentials_by_id.assert_awaited_once_with("cred-1")
+    svc.get_decrypted_credentials_by_id_with_outcome.assert_awaited_once_with("cred-1")
     svc.update_test_result.assert_awaited_once_with("github", True, None, "default")
 
 
 @pytest.mark.asyncio
 async def test_test_connection_by_credential_id_not_found(client):
+    """issue 3694 case 1: no row at all (or a different org's row --
+    indistinguishable by design). Stays 404, the cross-tenant
+    not-found-as-forbidden posture is unchanged."""
+
     with patch(
         "dev_health_ops.api.admin.routers.credentials.IntegrationCredentialsService"
     ) as mock_svc_cls:
         svc = AsyncMock()
-        svc.get_decrypted_credentials_by_id.return_value = (None, None)
+        svc.get_decrypted_credentials_by_id_with_outcome.return_value = (
+            None,
+            None,
+            CredentialLookupOutcome.NOT_FOUND,
+        )
         mock_svc_cls.return_value = svc
 
         resp = await client.post(
@@ -347,6 +360,71 @@ async def test_test_connection_by_credential_id_not_found(client):
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Credential not found"
+
+
+@pytest.mark.asyncio
+async def test_test_connection_by_credential_id_no_payload_is_422(client):
+    """issue 3694 case 2: the row exists (within this org) but has no
+    stored credentials_encrypted payload. Distinct from case 1 -- this is
+    NOT "not found", it is "found but unusable" -- a reason-coded 422,
+    never a 404 (a 404 here would be a lie: the row genuinely exists)."""
+
+    cred = _mock_credential(provider="github", name="default")
+    with patch(
+        "dev_health_ops.api.admin.routers.credentials.IntegrationCredentialsService"
+    ) as mock_svc_cls:
+        svc = AsyncMock()
+        svc.get_decrypted_credentials_by_id_with_outcome.return_value = (
+            None,
+            cred,
+            CredentialLookupOutcome.NO_PAYLOAD,
+        )
+        mock_svc_cls.return_value = svc
+
+        resp = await client.post(
+            "/api/v1/admin/credentials/test",
+            json={"provider": "github", "credential_id": "cred-1"},
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["reason_code"] == "credential_missing_payload"
+    # No secret material of any kind belongs in this response.
+    assert "token" not in str(detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_test_connection_by_credential_id_decrypt_failed_is_422(client):
+    """issue 3694 case 3: the row exists with a payload, but decryption
+    failed (key-mismatch class). Distinct reason code from case 2 -- both
+    are "exists but unusable", but a caller diagnosing this needs to tell
+    "nothing was ever stored" apart from "something was stored and is now
+    unreadable"."""
+
+    cred = _mock_credential(provider="github", name="default")
+    with patch(
+        "dev_health_ops.api.admin.routers.credentials.IntegrationCredentialsService"
+    ) as mock_svc_cls:
+        svc = AsyncMock()
+        svc.get_decrypted_credentials_by_id_with_outcome.return_value = (
+            None,
+            cred,
+            CredentialLookupOutcome.DECRYPT_FAILED,
+        )
+        mock_svc_cls.return_value = svc
+
+        resp = await client.post(
+            "/api/v1/admin/credentials/test",
+            json={"provider": "github", "credential_id": "cred-1"},
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["reason_code"] == "credential_unreadable"
+    assert detail["reason_code"] != "credential_missing_payload"
+    assert "token" not in str(detail).lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context
Follow-up to the live-e2e 404 investigation, tracked as issue 3694 (related: issue 3692). Lane-W traced the 404 one hop deeper than the fixture-lifecycle fix: `get_decrypted_credentials_by_id` (`api/services/configuration/integration_credentials.py:136-156`) yields a falsy result for THREE distinct reasons, and the router collapses all three into one 404.

**Diagnostic first step, before any code** (per the issue): downloaded the failing live-e2e run's (31377918912) `dev-health-ops-api-log` artifact and grepped for `"Failed to decrypt/parse integration config"` -- absent from all 35 lines, no ERROR-level entries at all. **Case 3 (decrypt/key-mismatch) is ruled out as the cause of that specific CI incident** -- issue 3692's fixture-lifecycle fix is the correct explanation there. This PR still closes the underlying three-state conflation on its own merits; the issue's scope stands independent of which case caused any one incident.

## What changed
1. **`CredentialLookupOutcome(StrEnum)`**: `NOT_FOUND` / `NO_PAYLOAD` / `DECRYPT_FAILED` / `OK`.
2. **New `IntegrationCredentialsService.get_decrypted_credentials_by_id_with_outcome`**, returning `(decrypted, cred, outcome)`. The existing 2-tuple `get_decrypted_credentials_by_id` (4 other call sites, none of which need the reason) becomes a thin, outcome-discarding wrapper -- byte-for-byte unchanged behavior, verified by a dedicated test exercising all four outcomes through the old signature.
3. **`POST /credentials/test`** (credential_id path -- the issue's own scope):
   - `NOT_FOUND` stays a plain `404 "Credential not found"`. **Cross-tenant posture unchanged**: `get_by_id` already scopes to the caller's org, so a different org's row was already indistinguishable from absent before this change -- this PR does not touch that.
   - `NO_PAYLOAD` / `DECRYPT_FAILED` become a `422` with a distinct `reason_code` (`credential_missing_payload` / `credential_unreadable`) via the existing `error_detail()` helper. No secret material in either response.
4. **New `INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL`** counter (labeled `provider`, `metrics/prometheus.py`, matching the module's existing Counter/noop-fallback convention), incremented on every real decrypt failure -- countable/alertable now, not just a `logger.error` line.

## Scope / non-scope
- In scope: the four files above + tests, matching the issue's exact function/endpoint reference.
- **Not in scope, deliberately**: `GET /credentials/{id}/repos` has the identical conflation (same `get_decrypted_credentials_by_id` falsy-collapse pattern) but the issue's stated scope is `POST /credentials/test` only. Flagging as a candidate follow-up rather than silently expanding this PR's blast radius.

## Verification
```
.venv/bin/ruff check / format --check           # clean
.venv/bin/mypy <6 changed files>                # clean
.venv/bin/python -m pytest tests/test_admin_credentials.py tests/api/admin/test_credential_lookup_outcome.py -q
  # 28 passed
.venv/bin/python -m pytest tests/api/admin/ tests/test_admin_credentials.py tests/test_prometheus_metrics.py \
  tests/test_credential_capacity_invariants.py tests/test_credential_resolver.py \
  tests/test_maintenance_scrub_error_text.py tests/test_integration_credential_error_sanitize.py \
  tests/test_sync_planner.py tests/test_compose_config.py tests/api/dev/test_chaos_3300_plan_registry_gap.py -q
  # 939 passed, 0 failed (the shared prometheus.py Counter/noop convention change didn't
  # collide with the plan-registry-gap counter test)
.venv/bin/python -m pytest tests/test_env_isolation_contract.py -q
  # 17 passed -- no new os.getenv reads, no scrub-list drift
```
Pre-commit hook (full-tree mypy, 2183 source files): clean.

## RED-first / plant-verified evidence
- `tests/api/admin/test_credential_lookup_outcome.py`'s decrypt-failure test corrupts a REAL encrypted payload via direct SQL against a real sqlite session (never mocks `decrypt_value`/`json.loads`), per the issue's own "plant-verified" requirement.
- Mutation-verified, not assumed: removed the counter's `.inc()` call -> the metric test failed for the right reason, restored. Collapsed the router's outcome branch back to unconditional 404 -> both new 422 tests failed for the right reason, restored.
- Two pre-existing tests in `test_admin_credentials.py` (`test_test_connection_by_credential_id`, `test_test_connection_by_credential_id_not_found`) mocked the OLD method signature the router no longer calls for this path -- would have broken silently under `AsyncMock`'s auto-attribute behavior. Updated to the new outcome-aware mock shape.

## Security impact
None beyond the intended fix. No new authorization surface; `NOT_FOUND`'s cross-tenant-safe behavior is explicitly preserved and tested. No secret material added to any response (asserted directly in the new 422 tests).

## Rollout / rollback
Additive service method + one router branch + one new metric. Revert is a pure file-level revert with no migration or config implications.