### PR TITLE
Graph-grounded assembler: wire COMPLETED-outcome assembly and widen the internal-token denylist

### DIFF
--- a/src/dev_health_ops/api/dev/no_match_terminal.py
+++ b/src/dev_health_ops/api/dev/no_match_terminal.py
@@ -61,6 +61,9 @@ from .contracts import (
     ScopeResolutionOutcome,
 )
 from .contracts_v2 import PublicOutcome, ResolutionOutcome
+from .contracts_v2.base import QuestionIntentID
+from .graph_investigation_query import CohortDiscoveryFamily, GraphQueryOutcome
+from .investigation_contract import ComparisonShape, PacketLimitationKind
 from .orchestrator_states import RunState
 from .status_change_service import STATUS_REASON_CODES
 
@@ -112,6 +115,49 @@ def _underscore_members(values: Iterable[str]) -> frozenset[str]:
 #: ``DevError.code`` already is below.
 _EXTRA_INTERNAL_TOKENS: frozenset[str] = frozenset({"actual_completion", "ev1_"})
 
+#: CHAOS-3698. The graph-assisted routing seam (CHAOS-3502/3650) makes a new
+#: family of internal vocabulary reachable in user-visible prose for the
+#: first time: once ``orchestrator._graph_grounded_answer`` starts building
+#: real answers from graph packets, ``discovered_cohort``,
+#: ``deadline_exceeded``, ``provider_failure``, ``team_pressure``,
+#: ``project_capacity`` and every ``PacketLimitationKind`` member become
+#: values a producer could echo, exactly the CHAOS-3367/3377 leak class,
+#: reopened against this vocabulary. #1681 (ops main) registered
+#: ``GraphQueryOutcome``/``CohortDiscoveryFamily`` here already but silently
+#: dropped ``PacketLimitationKind`` and the ``discovered_cohort`` intent/
+#: comparison-shape token -- this closes both gaps rather than leaving a
+#: partial union that looks complete.
+#:
+#: Only ``QuestionIntentID.DISCOVERED_COHORT``/``ComparisonShape.
+#: DISCOVERED_COHORT`` are pulled from their enums, not the enums wholesale:
+#: those two enums carry members well beyond the graph route (every Wave 3.1
+#: launch intent, every comparison shape), and widening the union to all of
+#: them is a broader change than this leak class needs -- CHAOS-3693 (filed,
+#: unstarted) is the deliberate follow-up for "every StrEnum is covered-or-
+#: excluded" as a structural guard, not this fix.
+#:
+#: Deliberately NOT unioned, with the reason stated here rather than left
+#: silent (the exact omission that caused this issue):
+#: * ``graph_arm.query_service.GraphMechanism`` -- "Trial metadata only --
+#:   never reaches the wire" per its own docstring; it has no path to any
+#:   producer-authored or model-authored string this scan runs over.
+#: * ``evidence_service.EvidenceAvailability`` -- a real, pre-existing
+#:   leak-shaped vocabulary (``no_matches``, ``unauthorized``,
+#:   ``unconfigured``, ...), but not part of CHAOS-3698's reported instance
+#:   and not newly made reachable by this leg; tracked as a candidate for
+#:   the CHAOS-3693 structural guard rather than folded into this fix.
+_GRAPH_ASSISTED_INTERNAL_TOKENS: frozenset[str] = (
+    _underscore_members(member.value for member in GraphQueryOutcome)
+    | _underscore_members(member.value for member in CohortDiscoveryFamily)
+    | _underscore_members(member.value for member in PacketLimitationKind)
+    | _underscore_members(
+        (
+            QuestionIntentID.DISCOVERED_COHORT.value,
+            ComparisonShape.DISCOVERED_COHORT.value,
+        )
+    )
+)
+
 #: Every internal vocabulary token that must never reach a user-visible
 #: string, derived from the live enums. See the module docstring for why only
 #: underscore-bearing members are kept.
@@ -127,6 +173,7 @@ INTERNAL_TOKEN_DENYLIST: frozenset[str] = (
         get_args(DevActualCompletion.model_fields["state"].annotation)
     )
     | _EXTRA_INTERNAL_TOKENS
+    | _GRAPH_ASSISTED_INTERNAL_TOKENS
 )
 
 # NOT included, deliberately: ``ToolID``. A round-2 review argued that a

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -43,6 +43,7 @@ from dev_health_ops.llm.agent.errors import (
 )
 from dev_health_ops.llm.budget import budget_idempotency_scope
 from dev_health_ops.metrics.prometheus import (
+    ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL,
     ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL,
     ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL,
     ASK_DEV_PLAN_REGISTRY_GAP_TOTAL,
@@ -65,6 +66,7 @@ from .answer_validator import (
     completion_truncation_detail,
     validate_answer_candidate,
 )
+from .canonical_enrichment import CanonicalEnrichmentAccessor, EnrichmentGap
 from .contracts import (
     V1_SCOPE_LIST_LIMIT,
     AnswerStatus,
@@ -107,11 +109,13 @@ from .contracts_v2.narrative import DevNarrative
 from .contracts_v2.plan import DevInvestigationPlan
 from .contracts_v2.subject import DevEntityRefV2
 from .evidence_service import EvidenceService
+from .graph_evidence_admission import extract_evidence_candidates
 from .graph_investigation_query import (
     GraphInvestigationQuery,
     GraphInvestigationRequest,
     GraphQueryOutcome,
 )
+from .investigation_contract import AskDevInvestigationPacket, InvestigationOutcome
 from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
 from .investigation_shadow import (
@@ -149,7 +153,11 @@ from .qua_promotion import (
 )
 from .qua_shadow import QUAShadowRecord, QuestionUnderstandingShadow
 from .question_interpreter import classify_cohort_discovery_family
-from .scope_service import MAX_CANDIDATES, ScopeResolutionService
+from .scope_service import (
+    MAX_CANDIDATES,
+    ScopeResolutionService,
+    scope_request_from_scope,
+)
 from .status_answer_render import (
     build_deterministic_status_claims,
     deterministic_answer_status,
@@ -399,6 +407,45 @@ SERVER_GROUNDED_WARNING = (
     "server-verified data is reported here."
 )
 
+#: CHAOS-3502/3650: the graph-assisted counterpart of ``SERVER_GROUNDED_
+#: SUMMARY``/``WARNING`` above -- same "server statement about the shape of
+#: what follows" class of copy, naming no source, entity or domain fact. Used
+#: by ``_graph_grounded_answer`` for every answer it assembles, degraded or
+#: not; ``direct_summary`` never varies by degrade cause (that distinction
+#: lives in the two WARNING constants below, added independently -- CHAOS-3502
+#: forbids conflating "evidence was refused" with "an enrichment source was
+#: unavailable" into one message).
+GRAPH_GROUNDED_SUMMARY = (
+    "This result was assembled by the server from graph-discovered evidence "
+    "that the canonical evidence service verified for this request."
+)
+#: CHAOS-3650 drop-and-disclose: at least one graph-discovered evidence
+#: candidate was canonically REFUSED (the service looked at it and declined
+#: to admit it -- UNAUTHORIZED or NO_MATCHES, never UNCONFIGURED/UNAVAILABLE,
+#: see ``EvidenceAdmission.refused``) and was excluded from this answer.
+#: Never fabricated, never silently dropped -- disclosed here.
+GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED = (
+    "Some graph-discovered evidence could not be canonically verified and "
+    "was excluded from this answer."
+)
+#: A distinct cause from the one above: a canonical enrichment source
+#: (status/health/workload/readiness) was unavailable for this scope, not
+#: that evidence was refused. Kept as its own message rather than merged
+#: with ``GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED`` -- CHAOS-3502's ruling
+#: forbids conflating the two causes, and a reader benefits from knowing
+#: which one actually applies to their answer.
+GRAPH_GROUNDED_WARNING_ENRICHMENT_GAP = (
+    "Some canonical enrichment sources were unavailable for this request."
+)
+#: No live model call backs a graph-assembled answer (mirrors
+#: ``_budget_answer``/``_deterministic_status_answer``'s own
+#: ``DevModelMetadata`` construction off ``self._provider_source``/
+#: ``self._provider_family`` with no live ``decision_result`` to read a
+#: fingerprint from) -- a fixed, content-safe sentinel rather than an empty
+#: string, so a stored run row can tell "no model call happened because the
+#: graph route answered" apart from a genuinely missing fingerprint.
+GRAPH_ROUTING_MODEL_FINGERPRINT = "graph_routing.v1"
+
 #: ``dev_runs.grounding_validation_status`` values for the two demoted
 #: guards (a ``String(32)`` column, no CHECK constraint -- both fit).
 #:
@@ -417,6 +464,15 @@ GUARD_DEMOTED_GROUNDING_FLOOR_STATUS = "advisory_grounding_floor"
 #: way a grounding-floor violation is -- never a hard FAILED, which would
 #: throw away real evidence the run already retrieved.
 GUARD_DEMOTED_REFUSAL_STATUS = "advisory_refused_with_grounding"
+#: CHAOS-3502/3650. Set on every ``finish(RunState.COMPLETED, ...)`` this
+#: leg's own assembler produces -- clean or degraded alike (degraded-vs-clean
+#: is already independently visible on ``DevAnswer.status``: DEGRADED vs
+#: PARTIAL; this column instead answers "which route produced this",
+#: matching what ``GUARD_DEMOTED_*`` already means for its own two paths).
+#: Never set on the no-material fallthrough or the assembly-raised path --
+#: a bare ``RunState.COMPLETED`` with no status stays exactly what it means
+#: today (legacy loop or a demoted guard).
+GRAPH_ASSISTED_GROUNDING_STATUS = "graph_assisted"
 
 _LEGACY_GUARD_TERMINALS: dict[str, tuple[str, str]] = {
     "resolve_scope_ambiguous": (
@@ -1051,6 +1107,62 @@ def graph_routing_runtime_enabled() -> bool:
     return os.getenv(GRAPH_ROUTING_RUNTIME_FLAG) == "1"
 
 
+#: CHAOS-3502/3650. The two ``InvestigationOutcome`` members that assert the
+#: investigation reached a real judgment -- ``AskDevInvestigationPacket``'s
+#: own ``validate_supported_outcome_asserts_a_judgment`` validator GUARANTEES
+#: ``evidence_coverage.evidence_index`` is non-empty whenever the packet's
+#: outcome is one of these two, so gating assembly on membership here means
+#: ``extract_evidence_candidates`` always has at least one candidate to
+#: admit. The other three members (NEEDS_CLARIFICATION, NO_MATCH,
+#: UNSUPPORTED) may carry an empty index, so attempting assembly for them
+#: would be attempting admission over nothing this packet ever claimed to
+#: have found -- the same "COMPLETED-with-no-material still falls through"
+#: rule, applied one layer earlier, before spending an admission round-trip.
+_GRAPH_ASSEMBLY_SUPPORTED_OUTCOMES = frozenset(
+    {InvestigationOutcome.SUPPORTED, InvestigationOutcome.SUPPORTED_WITH_GAPS}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphAssemblyOutcome:
+    """What ``_graph_grounded_answer`` actually did with one COMPLETED graph
+    result -- CHAOS-3502/3650.
+
+    ``answer`` is ``None`` exactly when there was no material to ground an
+    answer on (the CHAOS-3290 floor, applied via ``_assemble_grounded_
+    answer``'s own guard) -- the "COMPLETED-with-no-material still falls
+    through" rule. ``evidence_refused``/``enrichment_gap`` are two
+    INDEPENDENT causes of degradation, carried separately rather than
+    collapsed into one flag: CHAOS-3502's ruling forbids conflating "the
+    canonical evidence service refused a candidate" with "a canonical
+    enrichment source was unavailable" -- they are different failures with
+    different user-facing meanings, and a caller (telemetry, warnings) must
+    be able to tell them apart even though both make ``degraded`` True on
+    the assembled ``DevAnswer`` itself.
+    """
+
+    answer: DevAnswer | None
+    evidence_refused: bool
+    enrichment_gap: bool
+
+
+def _graph_assembly_outcome_label(evidence_refused: bool, enrichment_gap: bool) -> str:
+    """The closed ``ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL`` label for one
+    successfully-assembled answer. Never called when ``answer is None``
+    (that case is ``"no_material"``, decided by the caller) -- see
+    ``metrics.prometheus.ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL`` for the full
+    outcome vocabulary this is one half of.
+    """
+
+    if evidence_refused and enrichment_gap:
+        return "assembled_degraded_both"
+    if evidence_refused:
+        return "assembled_degraded_evidence_refused"
+    if enrichment_gap:
+        return "assembled_degraded_enrichment_gap"
+    return "assembled_clean"
+
+
 class DevOrchestrator:
     """Execute one Ask Dev message as a bounded state machine."""
 
@@ -1076,6 +1188,7 @@ class DevOrchestrator:
         investigation_packet_producer: InvestigationPacketProducer | None = None,
         graph_investigation_query: GraphInvestigationQuery | None = None,
         evidence_service: EvidenceService | None = None,
+        canonical_enrichment: CanonicalEnrichmentAccessor | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -1132,16 +1245,23 @@ class DevOrchestrator:
         # ``graph_investigation_query.py`` and CHAOS-3502/CHAOS-3664 for the
         # canonical-admission bridge that finishes this seam.
         self._graph_investigation_query = graph_investigation_query
-        # CHAOS-3502 increment 2c: ``None`` is the flag-off path, same shape
-        # as ``graph_investigation_query`` immediately above -- ``run()``
-        # does not read this attribute yet. Landed ahead of the routing
-        # branch that will call ``evidence_service.admit()`` on packet-
-        # extracted candidates (``graph_evidence_admission.
-        # extract_evidence_candidates``, CHAOS-3680) so that branch's own
-        # design (CHAOS-3660, pending sign-off) can assume the collaborator
-        # already exists rather than bundling its construction with the
-        # first PR that actually calls it.
+        # CHAOS-3502 increment 2c (now consumed): ``EvidenceService.admit()``
+        # is called on packet-extracted candidates
+        # (``graph_evidence_admission.extract_evidence_candidates``) by
+        # ``_graph_grounded_answer`` below. ``None`` remains the flag-off
+        # path, byte-identical to this collaborator not existing -- the
+        # COMPLETED branch in ``run()`` gates assembly on this being set,
+        # same as ``graph_investigation_query`` above.
         self._evidence_service = evidence_service
+        # CHAOS-3502/3650: the third and final collaborator this leg's
+        # assembler needs. ``None`` is ALSO a flag-off path, independent of
+        # the two above -- a caller that wires ``graph_investigation_query``/
+        # ``evidence_service`` before this exists sees the exact same
+        # assembly-deferred fallthrough the COMPLETED branch always had,
+        # never a crash on a collaborator nobody constructed yet
+        # (production does not wire any of the three today; see
+        # CHAOS-3697).
+        self._canonical_enrichment = canonical_enrichment
         self._composer = PromptComposer(registry)
 
     async def run(
@@ -3042,21 +3162,56 @@ class DevOrchestrator:
                         error=error("cancelled", "The request was cancelled."),
                     )
                 if graph_result.outcome is GraphQueryOutcome.COMPLETED:
-                    # CHAOS-3502: assembly (candidate extraction -> canonical
-                    # admission -> _graph_grounded_answer) is not yet wired
-                    # here -- it depends on Lane A's packet refactor and
-                    # Lane C's canonical enrichment type, both still pending
-                    # on CHAOS-3660 as of this landing. The graph result is
-                    # never silently discarded: the outcome counter/log
-                    # above already recorded a real COMPLETED call, distinct
-                    # from every failure/unavailable reason below.
-                    logger.info(
-                        "ask_dev.orchestrator.graph_routing_completed_assembly_deferred",
-                        extra={"run_id": run_id},
+                    # CHAOS-3502/3650: assembly. Both dependencies this
+                    # branch used to wait on are landed --
+                    # build_production_packet (Lane A) and
+                    # CanonicalEnrichmentAccessor (Lane C, CHAOS-3664) -- so a
+                    # COMPLETED call with a genuinely supported packet now
+                    # becomes a real, disclosed answer instead of an
+                    # observed-only no-op.
+                    #
+                    # DECISION (CHAOS-3650): drop-and-disclose, not
+                    # withheld-evidence-finding -- matching packet_builder.
+                    # py's own CHAOS-3650 choice at the driver layer (#1644).
+                    # A canonically refused evidence candidate is excluded
+                    # from this answer and the exclusion is disclosed via
+                    # GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED; it is never
+                    # admitted, never fabricated a replacement handle for,
+                    # and never aborts the run or an unrelated sibling
+                    # candidate. See ``_graph_grounded_answer``'s own
+                    # docstring for the full reasoning.
+                    #
+                    # ``GraphQueryResult``'s own ``__post_init__`` guarantees
+                    # ``packet is not None`` iff ``outcome is COMPLETED`` --
+                    # narrowed here for mypy, not a new runtime check.
+                    assert graph_result.packet is not None
+                    graph_answer = await self._attempt_graph_grounded_answer(
+                        run_id=run_id,
+                        answer_id=answer_id,
+                        conversation_id=conversation_id,
+                        resolution=resolution,
+                        authorized_scope=authorized_scope,
+                        org_id=org_id,
+                        permission_fingerprint=permission_fingerprint,
+                        packet=graph_result.packet,
                     )
+                    if graph_answer is not None:
+                        return await finish(
+                            RunState.COMPLETED,
+                            answer=graph_answer,
+                            grounding_validation_status=(
+                                GRAPH_ASSISTED_GROUNDING_STATUS
+                            ),
+                        )
+                    # No material (or the collaborator/packet-outcome gate
+                    # never attempted assembly, or assembly raised) -- falls
+                    # through to the legacy loop below, exactly like every
+                    # other non-CANCELLED outcome. ``_attempt_graph_grounded_
+                    # answer`` already logged/counted which of those three
+                    # this was; they are never conflated with each other.
                 # Every other outcome -- DISABLED, UNAVAILABLE, STALE,
                 # PROVIDER_FAILURE, DEADLINE_EXCEEDED, and
-                # COMPLETED-with-assembly-deferred immediately above -- falls
+                # COMPLETED-with-no-graph-answer immediately above -- falls
                 # through to the legacy loop below. Per the Wave 3.2 handoff
                 # §4: graph outage, lag, or unavailability must never break
                 # existing Ask Dev behavior, and this question's legacy
@@ -5051,6 +5206,299 @@ class DevOrchestrator:
         """
 
         return preflight is not None
+
+    async def _attempt_graph_grounded_answer(
+        self,
+        *,
+        run_id: str,
+        answer_id: str,
+        conversation_id: str,
+        resolution: DevScopeResolution,
+        authorized_scope: DevScope,
+        org_id: str,
+        permission_fingerprint: str,
+        packet: AskDevInvestigationPacket,
+    ) -> DevAnswer | None:
+        """The gate, observability and exception-containment wrapper around
+        :meth:`_graph_grounded_answer` -- CHAOS-3502/3650.
+
+        Three, and only three, outcomes leave this function, and each is
+        logged and counted under a DISTINCT name so none is ever conflated
+        with another (CHAOS-3502's ruling: "never conflate states"):
+
+        * ``graph_routing_completed_assembled`` (INFO) /
+          ``ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL{outcome=assembled_*}`` --
+          real material, degraded or clean.
+        * ``graph_routing_completed_no_material`` (INFO) /
+          ``{outcome="no_material"}`` -- assembly was attempted (both gates
+          below passed) but admission + enrichment together produced
+          nothing to ground an answer on. This is the "COMPLETED-with-
+          no-material still falls through" rule.
+        * ``graph_routing_completed_assembly_raised`` (ERROR, ``exc_info=
+          True``) / ``{outcome="assembly_raised"}`` -- an unexpected
+          exception during admission or enrichment. Logged loud and
+          distinct from the two ordinary outcomes above precisely so a
+          genuine bug can never look like a routine fall-through in the
+          logs (CHAOS-3502 Condition 3) -- but still degrades to the
+          legacy loop rather than aborting the run, mirroring
+          ``GraphInvestigationQuery``'s own "must never raise for an
+          ordinary condition" posture extended to this seam's own
+          assembly step.
+
+          ``except Exception`` deliberately does not need to special-case
+          ``asyncio.CancelledError``: since Python 3.8,
+          ``asyncio.CancelledError`` subclasses ``BaseException``, not
+          ``Exception`` (verified directly against this interpreter, not
+          assumed), so a cancellation propagates through this catch
+          unchanged and the run still ends up ``RunState.CANCELLED``
+          through the ordinary cancellation path above this branch.
+
+          Deliberately kept broad rather than narrowed to named exception
+          types, unlike ``packet_builder.py``'s own "narrow, deliberate,
+          documented" precedent (catching only ``CanonicalEvidenceRefusedError``
+          at :func:`~.packet_builder.build_packet`'s driver loop). That
+          precedent's boundary is ONE custom exception type this codebase
+          itself defines and raises for exactly one condition; this
+          boundary spans ``self._evidence_service.admit()`` (whose own
+          ``entitlement``/``authorizer`` collaborators are caller-supplied
+          Protocols with no fixed exception contract -- an
+          ``AskDevEntitlementAuthorizer`` or a database-backed
+          ``EvidenceScopeAuthorizer`` may raise anything) and
+          ``_assemble_grounded_answer``'s own ``DevAnswer(...)``
+          construction, which is known to raise a concrete
+          ``pydantic.ValidationError`` if a future change ever reintroduces
+          the metric ``evidence_ref_ids`` mismatch Condition 4's scrub
+          exists to prevent (reproduced live during this leg's own
+          verification: temporarily removing the scrub raised exactly this,
+          caught here, degrading to a clean fallthrough rather than a
+          crash). Naming only that one concrete type and leaving the
+          entitlement/authorizer surface behind a second, unnamed catch
+          would not be real narrowing -- it would be false completeness
+          over a boundary whose real exception vocabulary is not owned
+          here. The full observability Condition 3 requires (ERROR level,
+          ``exc_info=True``, a distinct counter value, and cancellation
+          verified never to be swallowed) is what makes keeping this catch
+          broad safe rather than a silence.
+
+        A fourth case -- the gate below never passing at all (no
+        ``canonical_enrichment`` wired, or the packet's own outcome does not
+        assert a judgment) -- reuses the pre-existing
+        ``graph_routing_completed_assembly_deferred`` log name with no
+        counter increment: assembly was never attempted, so there is no
+        assembly outcome to report, and the existing
+        ``ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL{outcome=completed}`` increment
+        from the call site above already recorded the transport-level
+        COMPLETED call.
+        """
+
+        if (
+            self._canonical_enrichment is None
+            or packet.outcome not in _GRAPH_ASSEMBLY_SUPPORTED_OUTCOMES
+        ):
+            logger.info(
+                "ask_dev.orchestrator.graph_routing_completed_assembly_deferred",
+                extra={"run_id": run_id},
+            )
+            return None
+        try:
+            outcome = await self._graph_grounded_answer(
+                answer_id=answer_id,
+                conversation_id=conversation_id,
+                resolution=resolution,
+                scope=authorized_scope,
+                org_id=org_id,
+                permission_fingerprint=permission_fingerprint,
+                packet=packet,
+                now=datetime.now(UTC),
+            )
+        except Exception as exc:  # noqa: BLE001 -- see docstring: contained and counted, never re-raised
+            logger.error(
+                "ask_dev.orchestrator.graph_routing_completed_assembly_raised",
+                extra={"run_id": run_id, "exception_type": type(exc).__name__},
+                exc_info=True,
+            )
+            ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL.labels(outcome="assembly_raised").inc()
+            return None
+        if outcome.answer is None:
+            logger.info(
+                "ask_dev.orchestrator.graph_routing_completed_no_material",
+                extra={"run_id": run_id},
+            )
+            ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL.labels(outcome="no_material").inc()
+            return None
+        label = _graph_assembly_outcome_label(
+            outcome.evidence_refused, outcome.enrichment_gap
+        )
+        logger.info(
+            "ask_dev.orchestrator.graph_routing_completed_assembled",
+            extra={
+                "run_id": run_id,
+                "evidence_refused": outcome.evidence_refused,
+                "enrichment_gap": outcome.enrichment_gap,
+            },
+        )
+        ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL.labels(outcome=label).inc()
+        return outcome.answer
+
+    async def _graph_grounded_answer(
+        self,
+        *,
+        answer_id: str,
+        conversation_id: str,
+        resolution: DevScopeResolution,
+        scope: DevScope,
+        org_id: str,
+        permission_fingerprint: str,
+        packet: AskDevInvestigationPacket,
+        now: datetime,
+    ) -> GraphAssemblyOutcome:
+        """The graph-frame path's own assembler -- CHAOS-3502/3650.
+
+        Extract candidates -> canonical admission -> a degrade-not-abort
+        join with canonical enrichment -> :meth:`_assemble_grounded_answer`.
+        Callers must only invoke this once ``self._evidence_service`` and
+        ``self._canonical_enrichment`` are both known non-``None`` (asserted
+        below) and ``packet.outcome`` has already been checked against
+        :data:`_GRAPH_ASSEMBLY_SUPPORTED_OUTCOMES` -- see
+        :meth:`_attempt_graph_grounded_answer` for both gates and the
+        exception containment this function relies on its caller for.
+
+        **Drop-and-disclose (CHAOS-3650's chosen behavior).** A candidate
+        the canonical evidence service REFUSED (``EvidenceAdmission.
+        refused`` -- ``UNAUTHORIZED``/``NO_MATCHES``, a considered "no", never
+        confused with ``UNCONFIGURED``/``UNAVAILABLE``) is excluded from
+        ``canonical_evidence`` and never admitted, fabricated, or retried;
+        the run still completes on whatever admissible material remains
+        (this function's caller never raises the run to FAILED/
+        INSUFFICIENT_EVIDENCE over a refusal), and the exclusion is
+        disclosed via ``GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED`` -- never
+        silently swallowed. Matches ``packet_builder.py``'s own CHAOS-3650
+        choice at the driver layer (#1644): drop the unsupported unit, keep
+        the rest, disclose narrowly, never abort. A conflicting/adversarial
+        but canonically ADMISSIBLE record is not touched by any of this --
+        it is simply admitted like any other candidate and stays usable as
+        counter-evidence, exactly as CHAOS-3650's acceptance requires.
+
+        **Two independent degrade causes, never conflated (CHAOS-3502).**
+        ``evidence_refused`` (a candidate was canonically refused) and
+        ``enrichment_gap`` (a canonical enrichment source was unavailable)
+        are computed and returned separately on :class:`GraphAssemblyOutcome`
+        -- each gets its own warning string and its own telemetry label, so
+        a caller can always tell which cause (or both) applies, even though
+        both make the underlying ``DevAnswer.status`` ``DEGRADED`` the same
+        way (``_assemble_grounded_answer`` takes one ``degraded: bool``).
+
+        **The metric evidence-vocabulary mismatch (recon finding, CHAOS-3502
+        Condition 4).** ``CanonicalEnrichmentAccessor``'s metrics are
+        ``MetricQueryService.query(...).contract_refs(scope)`` verbatim,
+        whose ``evidence_ref_ids`` cite ``MetricSourceRef.ref_id`` -- a
+        completely different id vocabulary from the signed
+        ``EvidenceReferenceSigner`` handles this function admits above.
+        ``DevAnswer.validate_answer_invariants`` requires every metric's
+        ``evidence_ref_ids`` to be a subset of the answer's own evidence
+        ids, so passing these through unmodified would raise on
+        construction the moment a metric carried any source ref at all.
+        Confirmed at the call site, not assumed from the shape of the code:
+        ``production_runtime.py``'s own ``query_metric.v1`` tool handler
+        hits the identical mismatch and resolves it with
+        ``item.model_copy(update={"evidence_ref_ids": []})`` -- this reuses
+        that exact precedent rather than inventing a second one.
+        **Documented limitation**: this DROPS the metric's own provenance
+        link with nothing to reconcile it against (the two vocabularies do
+        not name the same records) -- a graph-assisted answer's metrics
+        carry no evidence citation at all, the same as every legacy-loop
+        metric today. See ``test_chaos_3650_graph_grounded_assembler.py``
+        for the test pinning this scrub, so a future change that starts
+        emitting real linkage here fails loudly instead of silently.
+        """
+
+        assert self._evidence_service is not None
+        assert self._canonical_enrichment is not None
+
+        candidates = extract_evidence_candidates(packet)
+        admission = await self._evidence_service.admit(
+            org_id=org_id,
+            permission_fingerprint=permission_fingerprint,
+            scope_request=scope_request_from_scope(scope),
+            candidates=candidates,
+        )
+        canonical_evidence: list[DevEvidenceRef] = []
+        evidence_refused = False
+        for item in admission.admissions:
+            if item.evidence is not None:
+                canonical_evidence.append(item.evidence)
+            elif item.refused:
+                evidence_refused = True
+            # An UNCONFIGURED (no resolver wired for this source_system) or
+            # UNAVAILABLE (transient) candidate is dropped the same way --
+            # neither a canonical refusal (nothing to disclose as "refused"
+            # under CHAOS-3650's own vocabulary) nor material this answer
+            # can cite.
+
+        enrichment = await self._canonical_enrichment.enrich(
+            org_id=org_id,
+            permission_fingerprint=permission_fingerprint,
+            scope=scope,
+            now=now,
+        )
+        canonical_metrics = [
+            metric.model_copy(update={"evidence_ref_ids": []})
+            for metric in enrichment.metrics
+        ]
+
+        enrichment_gap = any(
+            isinstance(value, EnrichmentGap)
+            and value is not EnrichmentGap.NOT_APPLICABLE
+            for value in (
+                enrichment.status,
+                enrichment.health,
+                enrichment.workload,
+                enrichment.readiness,
+            )
+        )
+        degraded = evidence_refused or enrichment_gap
+        warnings: list[str] = []
+        if evidence_refused:
+            warnings.append(GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED)
+        if enrichment_gap:
+            warnings.append(GRAPH_GROUNDED_WARNING_ENRICHMENT_GAP)
+
+        degraded_sources: list[str] = []
+        if evidence_refused:
+            degraded_sources.append("graph_evidence_admission")
+        if enrichment_gap:
+            degraded_sources.append("canonical_enrichment")
+        coverage = DevCoverage(
+            required_source_count=2,
+            available_source_count=2 - len(degraded_sources),
+            unavailable_required_sources=[],
+            stale_required_sources=[],
+            degraded_required_sources=degraded_sources,
+            as_of=now,
+        )
+
+        answer = self._assemble_grounded_answer(
+            answer_id=answer_id,
+            conversation_id=conversation_id,
+            resolution=resolution,
+            coverage=coverage,
+            canonical_metrics=canonical_metrics,
+            canonical_evidence=canonical_evidence,
+            degraded=degraded,
+            model=DevModelMetadata(
+                provider_source=self._provider_source,
+                provider_family=self._provider_family,
+                model_fingerprint=GRAPH_ROUTING_MODEL_FINGERPRINT,
+            ),
+            now=now,
+            direct_summary=GRAPH_GROUNDED_SUMMARY,
+            warnings=warnings,
+        )
+        return GraphAssemblyOutcome(
+            answer=answer,
+            evidence_refused=evidence_refused,
+            enrichment_gap=enrichment_gap,
+        )
 
     def _server_grounded_answer(
         self,

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -226,6 +226,36 @@ if _PROMETHEUS_AVAILABLE:
         ["outcome"],
     )
 
+    # CHAOS-3502/3650: a SEPARATE axis from the routing-outcome counter above.
+    # That counter measures the transport/investigation call
+    # (GraphQueryOutcome); this one measures what the ORCHESTRATOR did with a
+    # COMPLETED result once it tried to assemble a real answer from it. The
+    # two must stay distinct counters -- collapsing them would conflate "the
+    # graph route completed" with "the graph route produced a usable
+    # answer", which is exactly the state-conflation CHAOS-3502's ruling
+    # forbids. Only incremented when assembly is actually attempted (i.e.
+    # canonical_enrichment is wired and the packet's own outcome asserts a
+    # judgment) -- a gate-skip (collaborator not wired, packet not
+    # supported) has no assembly outcome to report and is observable through
+    # the existing log line instead.
+    ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_ask_dev_graph_assembly_outcome_total",
+        "Attempts to assemble a graph-grounded DevAnswer from a COMPLETED "
+        "graph-routing packet (CHAOS-3502/3650), by outcome: 'assembled_clean' "
+        "(no evidence refused, no enrichment gap), "
+        "'assembled_degraded_evidence_refused' (the canonical evidence "
+        "service refused at least one candidate -- drop-and-disclose, never "
+        "an abort), 'assembled_degraded_enrichment_gap' (a canonical "
+        "enrichment source was unavailable), 'assembled_degraded_both', "
+        "'no_material' (admission + enrichment together produced nothing to "
+        "ground an answer on -- falls through to the legacy loop, same as "
+        "today), or 'assembly_raised' (an unexpected exception during "
+        "admission/enrichment -- caught, logged at ERROR, never surfaced as "
+        "RunState.FAILED). Content-safe: the label is this closed outcome "
+        "vocabulary, never question or entity text.",
+        ["outcome"],
+    )
+
     ASK_DEV_NARRATIVE_FALLBACK_TOTAL = _prometheus_client_module.Counter(
         "devhealth_ask_dev_narrative_fallback_total",
         "Ask Dev narrative provider calls that fell back to the deterministic "
@@ -387,6 +417,7 @@ else:
     ASK_DEV_INTERNAL_TOKEN_LEAK_TOTAL = _noop_counter()
     ASK_DEV_PLAN_REGISTRY_GAP_TOTAL = _noop_counter()
     ASK_DEV_GRAPH_ROUTING_OUTCOME_TOTAL = _noop_counter()
+    ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL = _noop_counter()
     ASK_DEV_NARRATIVE_FALLBACK_TOTAL = _noop_counter()
     ASK_DEV_QUA_SHADOW_TOTAL = _noop_counter()
     ASK_DEV_QUA_COMMIT_TOTAL = _noop_counter()

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -767,6 +767,7 @@ async def run_preflight_orchestrator(
     investigation_packet_producer: Any = None,
     graph_investigation_query: Any = None,
     evidence_service: Any = None,
+    canonical_enrichment: Any = None,
 ) -> RunOutput:
     """One full orchestrator run with the preflight wired the way production wires it.
 
@@ -789,13 +790,17 @@ async def run_preflight_orchestrator(
     actual rows a live run leaves behind, not a fake recorder's captured
     call list.
 
-    ``graph_investigation_query``/``evidence_service`` default to ``None``
-    (flag-off, same as production when the org feature is off) --
-    CHAOS-3502's routing-branch suite passes a real
+    ``graph_investigation_query``/``evidence_service``/``canonical_enrichment``
+    default to ``None`` (flag-off, same as production when the org feature is
+    off) -- CHAOS-3502's routing-branch suite passes a real
     ``FakeGraphInvestigationQuery`` plus a minimal ``EvidenceService`` here
     so a genuine ``DISCOVERED_COHORT`` ``preflight_result`` (only the real
     interpreter/preflight pipeline produces one) drives the actual routing
     branch in ``DevOrchestrator.run()``, not a construction-only smoke test.
+    ``canonical_enrichment`` (CHAOS-3650) is the third collaborator the
+    graph-grounded assembler needs; every existing caller leaves it unset,
+    which keeps the COMPLETED-branch assembly attempt gated off exactly as
+    it was before that assembler existed.
     """
 
     catalog = SeededCatalog(entities, fail_search=fail_search)
@@ -845,6 +850,7 @@ async def run_preflight_orchestrator(
         investigation_packet_producer=investigation_packet_producer,
         graph_investigation_query=graph_investigation_query,
         evidence_service=evidence_service,
+        canonical_enrichment=canonical_enrichment,
     )
     result = await orchestrator.run(
         request=request,

--- a/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
+++ b/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
@@ -1,0 +1,578 @@
+"""CHAOS-3502/CHAOS-3650: the graph-routing assembler itself.
+
+Drives the real orchestrator seam (``run_preflight_orchestrator`` -- a
+genuine ``DISCOVERED_COHORT`` ``preflight_result`` only comes from the real
+interpreter/preflight pipeline) with a real ``EvidenceService`` and a real
+``CanonicalEnrichmentAccessor``, both backed by minimal fakes at their own
+sub-collaborator boundaries. This is the "increment-2 assembler"
+``graph_evidence_admission.extract_evidence_candidates``'s own docstring
+says was "not yet built" -- the tests here are what proves it now is.
+
+Covers, per the CHAOS-3502/3650 sign-off:
+* drop-and-disclose: a canonically refused candidate is excluded and
+  disclosed, never admitted, never aborts the run;
+* the two degrade causes (evidence refused vs. enrichment gap) stay
+  independently distinguishable in ``warnings``, never conflated;
+* "COMPLETED-with-no-material still falls through" -- byte-identical to
+  the pre-existing fallthrough behavior;
+* the broad exception boundary is loud (ERROR + distinct telemetry) and
+  does not swallow a genuine ``asyncio.CancelledError``;
+* the metric ``evidence_ref_ids`` scrub (the recon's own landmine finding)
+  is pinned so a future change that starts emitting real linkage here
+  fails loudly instead of silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from dev_health_ops.api.dev.canonical_enrichment import CanonicalEnrichmentAccessor
+from dev_health_ops.api.dev.contract_fixtures import (
+    positive_fixtures as v1_positive_fixtures,
+)
+from dev_health_ops.api.dev.contracts import AnswerStatus, DevMetricRef, FreshnessState
+from dev_health_ops.api.dev.evidence_service import (
+    EvidenceRecord,
+    EvidenceReferenceSigner,
+    EvidenceService,
+)
+from dev_health_ops.api.dev.investigation_contract import AskDevInvestigationPacket
+from dev_health_ops.api.dev.investigation_contract.fixtures import (
+    positive_fixtures as packet_positive_fixtures,
+)
+from dev_health_ops.api.dev.orchestrator import (
+    GRAPH_ASSISTED_GROUNDING_STATUS,
+    GRAPH_GROUNDED_WARNING_ENRICHMENT_GAP,
+    GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED,
+    GRAPH_ROUTING_RUNTIME_FLAG,
+)
+from dev_health_ops.api.dev.orchestrator_states import RunState
+from dev_health_ops.api.dev.scope_service import (
+    AuthorizedEntity,
+    EntityKind,
+    ResolvedTimeRange,
+    ScopeResolution,
+    ScopeResolutionOutcome,
+)
+from dev_health_ops.metrics.prometheus import ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL
+from tests._chaos_3292_preflight import ORG_ID, Recorder, run_preflight_orchestrator
+from tests._chaos_3502_graph_investigation_fake import FakeGraphInvestigationQuery
+
+#: A real, zero-mention, cohort-discovery-shaped question -- same fixture
+#: question ``test_chaos_3502_graph_routing_branch.py`` uses, so this suite
+#: exercises the identical real DISCOVERED_COHORT/TEAM_PRESSURE
+#: classification path.
+_DISCOVERED_COHORT_QUESTION = "Which teams are struggling right now?"
+
+_EVIDENCE_SIGNING_SECRET = "chaos-3650-assembler-test-secret-at-least-32-bytes"
+_ADMIT_LOCATOR = "graph-loc-admit"
+_REFUSE_LOCATOR = "graph-loc-refuse"
+
+_AUTHORIZED_TEAM_ID = "team_platform"
+
+
+def _graph_arm_packet(locators: list[str]) -> AskDevInvestigationPacket:
+    """The published packet fixture, with its first N evidence-index
+    entries repointed at ``context_fabric_graph_arm`` locators.
+
+    ``source_system``/``record_locator`` are never referenced by ANY
+    packet validator (confirmed by inspection of ``investigation_contract/
+    packet.py`` -- zero hits for either field name in any ``@model_
+    validator``), so this is a safe, surgical edit that leaves every
+    entity/driver/path cross-reference the fixture already satisfies
+    untouched. The fixture's remaining entries stay ``work_graph``/
+    ``review``/``work_item`` sourced -- no resolver in this suite is
+    registered for those, so they are silently dropped as UNCONFIGURED,
+    exactly like any other source this org has not wired a resolver for.
+    """
+
+    payload = deepcopy(packet_positive_fixtures()["ask_dev_investigation_packet.v1"])
+    entries = payload["evidence_coverage"]["evidence_index"]
+    assert len(locators) <= len(entries)
+    for entry, locator in zip(entries, locators):
+        entry["evidence"]["source_system"] = "context_fabric_graph_arm"
+        entry["evidence"]["record_locator"] = locator
+    return AskDevInvestigationPacket.model_validate(payload)
+
+
+def _time_range() -> ResolvedTimeRange:
+    now = datetime(2026, 8, 10, 12, tzinfo=UTC)
+    return ResolvedTimeRange(
+        timezone="UTC",
+        utc_start=now - timedelta(days=30),
+        utc_end=now,
+        local_start=(now - timedelta(days=30)).isoformat(),
+        local_end=now.isoformat(),
+        comparison_utc_start=now - timedelta(days=60),
+        comparison_utc_end=now - timedelta(days=30),
+        comparison_local_start=(now - timedelta(days=60)).isoformat(),
+        comparison_local_end=(now - timedelta(days=30)).isoformat(),
+    )
+
+
+class _OrgAuthorizer:
+    """Grants the organization ref plus one fixed authorized team entity --
+    just enough for ``EvidenceService.admit()``'s own re-authorization
+    check to pass for a record genuinely about that team."""
+
+    async def resolve(self, org_id, permission_fingerprint, request):
+        del permission_fingerprint, request
+        return ScopeResolution(
+            outcome=ScopeResolutionOutcome.EXACT,
+            entities=(
+                AuthorizedEntity(EntityKind.ORGANIZATION, org_id, "Org"),
+                AuthorizedEntity(EntityKind.TEAM, _AUTHORIZED_TEAM_ID, "Platform"),
+            ),
+            team_filters=(),
+            candidates=(),
+            time_range=_time_range(),
+        )
+
+
+class _Entitlement:
+    async def require(self, org_id: str) -> None:
+        del org_id
+
+
+class _RaisingEntitlement:
+    """Simulates an unexpected failure BEFORE ``admit()`` reaches its own
+    per-candidate exception handling (``entitlement.require`` runs first,
+    unguarded) -- the one path that reaches ``_attempt_graph_grounded_
+    answer``'s broad ``except Exception`` for real, rather than being
+    absorbed as an ordinary UNAVAILABLE/UNCONFIGURED admission the way a
+    resolver's own exception already is.
+    """
+
+    async def require(self, org_id: str) -> None:
+        del org_id
+        raise RuntimeError("entitlement backend unavailable")
+
+
+class _CancellingEntitlement:
+    """A genuine ``asyncio.CancelledError`` from inside admission -- must
+    propagate THROUGH the broad ``except Exception`` boundary, never be
+    absorbed as an ordinary fallthrough (CHAOS-3502 Condition 3)."""
+
+    async def require(self, org_id: str) -> None:
+        del org_id
+        raise asyncio.CancelledError()
+
+
+class _GraphArmResolver:
+    """One locator admits, one is canonically refused (NO_MATCHES) --
+    mirrors ``test_evidence_service.py``'s own ``_MixedOutcomeResolver`` at
+    the admission layer, narrowed to the two outcomes this suite needs."""
+
+    source_system = "context_fabric_graph_arm"
+
+    async def resolve(self, *, org_id, scope, candidate):
+        del org_id, scope
+        if candidate.locator == _REFUSE_LOCATOR:
+            return None
+        return EvidenceRecord(
+            source_system=self.source_system,
+            source_version="test.v1",
+            entity_type="team",
+            entity_id=_AUTHORIZED_TEAM_ID,
+            display_label="Platform team pressure signal",
+            observed_at=datetime(2026, 8, 9, tzinfo=UTC),
+            freshness=FreshnessState.FRESH,
+            provenance="native",
+            confidence=1.0,
+            repository_ids=(),
+        )
+
+
+def _evidence_service(*, entitlement=None) -> EvidenceService:
+    return EvidenceService(
+        entitlement=entitlement or _Entitlement(),
+        authorizer=_OrgAuthorizer(),
+        signer=EvidenceReferenceSigner(_EVIDENCE_SIGNING_SECRET),
+        native_adapters=(),
+        candidate_resolvers=(_GraphArmResolver(),),
+    )
+
+
+class _StatusSource:
+    def __init__(self, *, raise_error: bool = False) -> None:
+        self.raise_error = raise_error
+
+    async def status_snapshot(self, org_id, permission_fingerprint, request):
+        del org_id, permission_fingerprint, request
+        if self.raise_error:
+            raise RuntimeError("status source unavailable")
+        return "status-ok"
+
+
+class _TeamRuleSource:
+    async def evaluate_team(self, **kwargs):
+        del kwargs
+        return "ok"
+
+
+class _WorkloadSource:
+    async def evaluate_workload(self, **kwargs):
+        del kwargs
+        return "ok"
+
+
+class _ReadinessSource:
+    async def evaluate_project(self, **kwargs):
+        del kwargs
+        return "ok"
+
+    async def evaluate_team(self, **kwargs):
+        del kwargs
+        return "ok"
+
+
+class _MetricSource:
+    """Empty by default -- ``_enrich_metrics`` then contributes nothing,
+    which is what every test not specifically pinning the evidence-ref-ids
+    scrub wants. ``metric_refs`` lets the scrub test inject a real
+    ``dev_metric_ref.v1`` fixture carrying non-empty ``evidence_ref_ids``
+    from a vocabulary ``EvidenceService.admit()`` never minted.
+    """
+
+    def __init__(self, metric_refs: tuple = ()) -> None:
+        self.metric_refs = metric_refs
+
+    def list_metrics(self, scope):
+        del scope
+        return (
+            (SimpleNamespace(metric_id="items_completed"),) if self.metric_refs else ()
+        )
+
+    async def query(self, org_id, permission_fingerprint, request, *, now=None):
+        del org_id, permission_fingerprint, request, now
+        return SimpleNamespace(contract_refs=lambda scope: self.metric_refs)
+
+
+def _canonical_enrichment(
+    *, status_raises: bool = False, metric_refs: tuple = ()
+) -> CanonicalEnrichmentAccessor:
+    return CanonicalEnrichmentAccessor(
+        status=_StatusSource(raise_error=status_raises),
+        health=_TeamRuleSource(),
+        workload=_WorkloadSource(),
+        readiness=_ReadinessSource(),
+        metrics=_MetricSource(metric_refs=metric_refs),
+    )
+
+
+class _GroundingStatusRecorder(Recorder):
+    """Captures ``terminal()``'s own ``grounding_validation_status`` kwarg,
+    which the base ``Recorder`` fake (shared by every other suite) discards
+    -- mirrors the module's own documented convention of subclassing for
+    one extra capture point (see its docstring re: ``record_subject_set``).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.grounding_validation_statuses: list[str | None] = []
+
+    async def terminal(self, **values) -> None:
+        self.grounding_validation_statuses.append(
+            values.get("grounding_validation_status")
+        )
+        await super().terminal(**values)
+
+
+# ---------------------------------------------------------------------------
+# Drop-and-disclose: clean admission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_with_admissible_evidence_produces_a_graph_grounded_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    packet = _graph_arm_packet([_ADMIT_LOCATOR])
+    fake = FakeGraphInvestigationQuery(packet=packet)
+    recorder = _GroundingStatusRecorder()
+
+    output = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3650-clean",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+        canonical_enrichment=_canonical_enrichment(),
+        recorder_factory=lambda: recorder,
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    answer = output.result.answer
+    assert answer is not None
+    assert answer.status is AnswerStatus.PARTIAL
+    assert len(answer.evidence) == 1
+    assert answer.warnings == []
+    assert recorder.grounding_validation_statuses[-1] == GRAPH_ASSISTED_GROUNDING_STATUS
+    # The legacy model-tool-choice loop must never even start: the graph
+    # path returned directly through finish().
+    assert output.calls == []
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3650: drop-and-disclose on a canonical refusal, never an abort
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_refused_candidate_degrades_but_never_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    packet = _graph_arm_packet([_ADMIT_LOCATOR, _REFUSE_LOCATOR])
+    fake = FakeGraphInvestigationQuery(packet=packet)
+
+    output = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3650-degrade",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+        canonical_enrichment=_canonical_enrichment(),
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    assert output.result.state is not RunState.FAILED
+    assert output.result.state is not RunState.INSUFFICIENT_EVIDENCE
+    answer = output.result.answer
+    assert answer is not None
+    assert answer.status is AnswerStatus.DEGRADED
+    # Exactly the admitted record -- the refused one never appears.
+    assert len(answer.evidence) == 1
+    assert GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED in answer.warnings
+    # CHAOS-3502 Condition 5: the two degrade causes are independent -- no
+    # enrichment gap was injected here, so its warning must be absent.
+    assert GRAPH_GROUNDED_WARNING_ENRICHMENT_GAP not in answer.warnings
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3502 Condition 5: the two degrade causes stay independently visible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_enrichment_gap_degrades_independently_of_evidence_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    packet = _graph_arm_packet([_ADMIT_LOCATOR])
+    fake = FakeGraphInvestigationQuery(packet=packet)
+
+    output = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3650-enrichment-gap",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+        canonical_enrichment=_canonical_enrichment(status_raises=True),
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    answer = output.result.answer
+    assert answer is not None
+    assert answer.status is AnswerStatus.DEGRADED
+    assert GRAPH_GROUNDED_WARNING_ENRICHMENT_GAP in answer.warnings
+    # No evidence was refused this time -- the OTHER cause's warning must
+    # not appear just because the answer is degraded for a different reason.
+    assert GRAPH_GROUNDED_WARNING_EVIDENCE_REFUSED not in answer.warnings
+
+
+# ---------------------------------------------------------------------------
+# "COMPLETED-with-no-material still falls through" (binding condition 2 of
+# the team-lead scope message)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_with_no_material_still_falls_through(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    # Every candidate refused, no metrics -- admission + enrichment together
+    # produce nothing to ground an answer on.
+    packet = _graph_arm_packet([_REFUSE_LOCATOR])
+    fake = FakeGraphInvestigationQuery(packet=packet)
+
+    with caplog.at_level(logging.INFO, logger="dev_health_ops.api.dev.orchestrator"):
+        output = await run_preflight_orchestrator(
+            question=_DISCOVERED_COHORT_QUESTION,
+            entities=[],
+            org_id=ORG_ID,
+            script_id="chaos3650-no-material",
+            graph_investigation_query=fake,
+            evidence_service=_evidence_service(),
+            canonical_enrichment=_canonical_enrichment(),
+        )
+
+    # Falls through to the legacy loop and still answers -- never FAILED,
+    # never a graph-assisted grounding status.
+    assert output.result.state is not RunState.FAILED
+    assert output.result.answer is not None
+    assert output.calls, "the legacy loop must actually have run"
+    assert any(
+        record.message == "ask_dev.orchestrator.graph_routing_completed_no_material"
+        for record in caplog.records
+    )
+    assert not any(
+        record.message == "ask_dev.orchestrator.graph_routing_completed_assembled"
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3502 Condition 3: the broad exception boundary is loud and distinct,
+# and never swallows a genuine cancellation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_exception_during_assembly_falls_through_and_is_counted(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    packet = _graph_arm_packet([_ADMIT_LOCATOR])
+    fake = FakeGraphInvestigationQuery(packet=packet)
+    before = ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL.labels(
+        outcome="assembly_raised"
+    )._value.get()
+
+    with caplog.at_level(logging.ERROR, logger="dev_health_ops.api.dev.orchestrator"):
+        output = await run_preflight_orchestrator(
+            question=_DISCOVERED_COHORT_QUESTION,
+            entities=[],
+            org_id=ORG_ID,
+            script_id="chaos3650-raised",
+            graph_investigation_query=fake,
+            evidence_service=_evidence_service(entitlement=_RaisingEntitlement()),
+            canonical_enrichment=_canonical_enrichment(),
+        )
+
+    # Degrades to the legacy loop -- never surfaced as a hard failure.
+    assert output.result.state is not RunState.FAILED
+    assert output.result.state is not RunState.CANCELLED
+    assert output.result.answer is not None
+
+    after = ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL.labels(
+        outcome="assembly_raised"
+    )._value.get()
+    assert after == before + 1
+
+    error_records = [
+        record
+        for record in caplog.records
+        if record.message
+        == "ask_dev.orchestrator.graph_routing_completed_assembly_raised"
+    ]
+    assert len(error_records) == 1
+    assert error_records[0].levelno == logging.ERROR
+    # exc_info=True was passed -- the record must actually carry exception
+    # information, not just a bare message at ERROR level.
+    assert error_records[0].exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_a_genuine_cancellation_during_assembly_is_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verified directly against this interpreter (CHAOS-3502 Condition 3),
+    not assumed from memory: ``asyncio.CancelledError`` subclasses
+    ``BaseException``, not ``Exception``, so it must propagate straight
+    through ``_attempt_graph_grounded_answer``'s broad ``except Exception``
+    rather than being absorbed as a routine fallthrough.
+    """
+
+    assert not issubclass(asyncio.CancelledError, Exception)
+    assert issubclass(asyncio.CancelledError, BaseException)
+
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    packet = _graph_arm_packet([_ADMIT_LOCATOR])
+    fake = FakeGraphInvestigationQuery(packet=packet)
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_preflight_orchestrator(
+            question=_DISCOVERED_COHORT_QUESTION,
+            entities=[],
+            org_id=ORG_ID,
+            script_id="chaos3650-cancelled",
+            graph_investigation_query=fake,
+            evidence_service=_evidence_service(entitlement=_CancellingEntitlement()),
+            canonical_enrichment=_canonical_enrichment(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3502 Condition 4: the metric evidence_ref_ids scrub is pinned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enrichment_metric_evidence_ref_ids_are_scrubbed_before_assembly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CanonicalEnrichmentAccessor``'s metrics cite ``MetricSourceRef.
+    ref_id``s -- a vocabulary distinct from the signed evidence handles
+    ``EvidenceService.admit()`` mints. Without the scrub, ``DevAnswer.
+    validate_answer_invariants`` would reject construction (a real
+    ``ev_01`` id that is not among this answer's own admitted evidence),
+    and the whole graph answer would silently fall through as
+    ``assembly_raised`` instead of shipping the metric. This test proves
+    the metric ships AND that its evidence linkage is empty, not
+    mismatched -- pinning the documented limitation rather than leaving it
+    to accidentally keep working.
+    """
+
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    packet = _graph_arm_packet([_ADMIT_LOCATOR])
+    fake = FakeGraphInvestigationQuery(packet=packet)
+    metric_payload = deepcopy(v1_positive_fixtures()["dev_metric_ref.v1"])
+    # The published fixture already carries a real, non-empty
+    # evidence_ref_ids ("ev_01") from a vocabulary this suite's
+    # EvidenceService never minted -- exactly the mismatch under test.
+    assert metric_payload["evidence_ref_ids"]
+    # Re-keyed away from the stock fixture's own ("metric_01", value=12):
+    # the legacy model-tool-choice loop's own canned answer
+    # (``_chaos_3292_preflight.answer_payload``) embeds that SAME stock
+    # ``dev_metric_ref.v1`` fixture, so asserting against the unmodified
+    # values would pass even if this leg's assembly never ran at all and
+    # the run silently fell through to the legacy loop instead -- a false
+    # green that would have hidden the exact ``assembly_raised`` regression
+    # this test exists to catch (confirmed live: this test passed on a
+    # revert that disabled assembly entirely, before this re-keying was
+    # added).
+    metric_payload["metric_ref_id"] = "metric_graph_scrub_test_01"
+    metric_payload["value"] = 987654.0
+    metric_ref = DevMetricRef.model_validate(metric_payload)
+
+    output = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3650-metric-scrub",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+        canonical_enrichment=_canonical_enrichment(metric_refs=(metric_ref,)),
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    answer = output.result.answer
+    assert answer is not None
+    assert len(answer.metrics) == 1
+    assert answer.metrics[0].evidence_ref_ids == []
+    # And the metric's other fields survived untouched -- only the
+    # mismatched evidence link was dropped, nothing else about the metric.
+    assert answer.metrics[0].metric_ref_id == metric_payload["metric_ref_id"]
+    assert answer.metrics[0].value == metric_payload["value"]

--- a/tests/api/dev/test_chaos_3698_graph_denylist.py
+++ b/tests/api/dev/test_chaos_3698_graph_denylist.py
@@ -1,0 +1,123 @@
+"""CHAOS-3698: the graph-assisted vocabulary is reachable in user-visible
+prose the moment the graph-routing assembler (CHAOS-3502/3650) starts
+building real ``DevAnswer``s from graph packets, and the fail-closed
+internal-token backstop (``no_match_terminal.INTERNAL_TOKEN_DENYLIST``) must
+cover it before that happens -- not after.
+
+These are string-level negative controls, mirroring
+``test_no_match_terminal.py``'s own convention (see its module docstring):
+assert the LITERAL tokens a producer could echo are caught, rather than that
+some mapping function exists. A test that only checks the union contains an
+enum reference passes with the enum member renamed or the union silently
+narrowed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import QuestionIntentID
+from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphQueryOutcome,
+)
+from dev_health_ops.api.dev.investigation_contract import (
+    ComparisonShape,
+    PacketLimitationKind,
+)
+from dev_health_ops.api.dev.no_match_terminal import (
+    INTERNAL_TOKEN_DENYLIST,
+    internal_token_leak,
+    internal_token_leak_field,
+)
+
+#: Named by CHAOS-3698's own report: exactly the tokens that were 0 hits in
+#: this module before the fix, written out here as literals -- never derived
+#: from the module under test, per the same "a control that imports its own
+#: expected string cannot fail when the code is wrong" reasoning
+#: ``test_no_match_terminal.py`` states for the PRD tokens.
+_CHAOS_3698_REPORTED_TOKENS = (
+    "deadline_exceeded",
+    "provider_failure",
+    "team_pressure",
+    "project_capacity",
+    "discovered_cohort",
+)
+
+
+@pytest.mark.parametrize("token", _CHAOS_3698_REPORTED_TOKENS)
+def test_the_reported_missing_tokens_are_now_in_the_denylist(token: str) -> None:
+    assert token in INTERNAL_TOKEN_DENYLIST
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        GraphQueryOutcome.DEADLINE_EXCEEDED,
+        GraphQueryOutcome.PROVIDER_FAILURE,
+        CohortDiscoveryFamily.TEAM_PRESSURE,
+        CohortDiscoveryFamily.PROJECT_CAPACITY,
+        QuestionIntentID.DISCOVERED_COHORT,
+        ComparisonShape.DISCOVERED_COHORT,
+        *PacketLimitationKind,
+    ],
+)
+def test_every_underscore_bearing_graph_vocabulary_member_is_denylisted(
+    member,
+) -> None:
+    """Every underscore-bearing member of the four graph-assisted enums this
+    fix unions in, checked by iterating the LIVE enum classes rather than a
+    hand-copied list -- if a member is renamed or a new one is added, this
+    test walks it automatically instead of silently missing it.
+    """
+
+    if "_" not in member.value:
+        pytest.skip(f"{member!r} has no underscore -- not in scope for the denylist")
+    assert member.value in INTERNAL_TOKEN_DENYLIST
+
+
+@pytest.mark.parametrize("token", _CHAOS_3698_REPORTED_TOKENS)
+def test_internal_token_leak_catches_a_graph_token_in_model_authored_prose(
+    token: str,
+) -> None:
+    """The actual backstop function, not just set membership: a sentence a
+    model could plausibly author, naming the internal token inline, must be
+    caught by :func:`internal_token_leak` -- the live call
+    ``orchestrator.finish()`` makes over every terminal.
+    """
+
+    sentence = f"The result depends on {token} signals for this request."
+    assert internal_token_leak([sentence]) == token
+
+
+def test_internal_token_leak_field_names_the_field_for_a_graph_token() -> None:
+    leaked = internal_token_leak_field(
+        [("direct_summary", "This cohort was found via team_pressure discovery.")]
+    )
+    assert leaked == ("direct_summary", "team_pressure")
+
+
+def test_packet_limitation_kind_disclosure_text_is_caught_if_echoed_raw() -> None:
+    """A ``PacketLimitationKind`` member is graph-arm-internal vocabulary
+    (``authorization_filtered``, ``truncated_traversal``, ...) that a
+    producer could plausibly echo raw into a limitation sentence instead of
+    translating it -- exactly the class of leak ``completion_truncation_
+    detail`` was fixed for under CHAOS-3377. Any member reaching prose
+    verbatim must be caught.
+    """
+
+    sentence = (
+        "This answer is limited: truncated_traversal was reported by the graph arm."
+    )
+    assert internal_token_leak([sentence]) == "truncated_traversal"
+
+
+def test_ordinary_prose_naming_no_graph_token_is_not_flagged() -> None:
+    """Negative control, mirroring ``test_internal_token_leak_ignores_
+    ordinary_prose`` in the sibling module: healthy prose about teams and
+    projects must not trip the widened union."""
+
+    sentence = (
+        "The Platform team is under pressure this sprint due to project capacity."
+    )
+    assert internal_token_leak([sentence]) is None


### PR DESCRIPTION
## Summary

Closes the last functional hole in the graph-assisted Ask Dev beta: when the graph-routing seam completes a real investigation (`GraphQueryOutcome.COMPLETED`), the orchestrator now assembles a real, disclosed answer from it instead of silently falling through to the legacy model-tool-choice loop (issue 3502). Canonically refused evidence degrades that answer honestly rather than aborting the run (issue 3650, "drop-and-disclose" — the same choice `packet_builder.py`'s driver-layer fix already made). Also widens the fail-closed internal-token denylist to cover the graph vocabulary this new path makes reachable in user-visible prose for the first time (issue 3698).

## What changed

- **`orchestrator.py`**: new `_graph_grounded_answer`/`_attempt_graph_grounded_answer` methods. Chain: extract packet-carried evidence candidates → `EvidenceService.admit()` → split admitted vs. canonically-refused (refused candidates excluded and disclosed, never admitted, never abort) → join with `CanonicalEnrichmentAccessor` (a canonical enrichment-source gap is a second, independently-disclosed degrade cause) → `_assemble_grounded_answer` → `finish(RunState.COMPLETED, ..., grounding_validation_status="graph_assisted")`. "COMPLETED-with-no-material" still falls through to the legacy loop, unchanged. New `canonical_enrichment` constructor param (`None`-default, same flag-off shape as the existing `graph_investigation_query`/`evidence_service` params — production does not wire any of the three today, confirmed and intentionally out of scope here; see issue 3697).
  - Four distinguishable assembly outcomes — `assembled_clean` / `assembled_degraded_evidence_refused` / `assembled_degraded_enrichment_gap` / `assembled_degraded_both` / `no_material` / `assembly_raised` — each with its own log event name and `ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL` counter label, never conflated with each other or with the pre-existing `graph_routing_completed_assembly_deferred` gate-skip case.
  - Handles a real vocabulary-mismatch defect found during recon: `CanonicalEnrichmentAccessor`'s metrics cite a different evidence-id vocabulary than signed evidence handles, which would otherwise raise `pydantic.ValidationError` on `DevAnswer` construction. Scrubbed the same way production's existing `query_metric.v1` tool already does — documented as a known limitation, pinned by a dedicated test.
- **`no_match_terminal.py`**: widens `INTERNAL_TOKEN_DENYLIST` with `GraphQueryOutcome`, `CohortDiscoveryFamily`, `PacketLimitationKind`, and the `discovered_cohort` intent/comparison-shape token — all newly reachable in model-authored prose once this leg's assembly path ships real answers. Deliberate exclusions (`GraphMechanism`, `EvidenceAvailability`) documented with reasons at the exclusion site.
- **`metrics/prometheus.py`**: new `ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL` counter (+ no-op fallback).
- **Tests** (2 new files, 34 tests): the assembler's degrade-not-abort path, the two independent degrade causes, the no-material fallthrough boundary, exception containment (including a live-verified `asyncio.CancelledError` propagation, never swallowed), and the metric evidence-ref-ids scrub; plus the widened denylist with each token individually planted in a plausible sentence and caught by the live `internal_token_leak()` backstop, not just asserted as set membership.
- **`tests/_chaos_3292_preflight.py`**: additive `canonical_enrichment` passthrough kwarg (default `None`, no behavior change for existing callers).

## Explicitly out of scope

Production wiring of `graph_investigation_query`/`evidence_service`/`canonical_enrichment` into `BoundedDevRuntime` — confirmed the graph route is unreachable in production regardless of this change (tracked separately as issue 3697, whose `xfail(strict=True)` RED test on this branch stays XFAIL after this PR, verified).

## Verification

- `ci/local_validate.sh`: **GATE PASSED, 10/10 declared stages executed** (`lint_format, lint_check, typecheck, ch_probe, ch_scratch_create, ch_migrate, unit_suite, ch_argmax_proof, ch_declared_state_history_tests, ch_migration_075_reconcile_tests`).
- Full unit suite: **15937 passed, 383 skipped, 5 xfailed, 0 failed**.
- Every new guard has an observed fail-before/pass-after pair (temporarily disabling the guard, confirming the specific new test fails meaningfully, restoring, confirming it passes again) — details in the issue threads.