### PR TITLE
Wire graph route collaborators in the production runtime

### DIFF
--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -71,6 +71,7 @@ from dev_health_ops.metrics.prometheus import (
 )
 from dev_health_ops.models.settings import SettingCategory
 
+from .canonical_enrichment import CanonicalEnrichmentAccessor
 from .contracts import (
     DevActualCompletion,
     DevAnswer,
@@ -109,6 +110,7 @@ from .evidence_service import (
     EvidenceReferenceSigner,
     EvidenceService,
 )
+from .graph_investigation_query import GraphInvestigationQuery
 from .investigation_plans import PlanExecutor
 from .investigation_plans.plan_documents import CORE_PLANS_BY_INTENT
 from .investigation_plans.wave_3_1_plans import (
@@ -2574,7 +2576,20 @@ async def _assemble_production_runtime(
     # organization gate as preflight -- a plan can only run once a subject
     # is committed, and only the preflight commits one.
     plan_executor: PlanExecutor | None = None
+    graph_investigation_query: GraphInvestigationQuery | None = None
+    canonical_enrichment: CanonicalEnrichmentAccessor | None = None
     if wave_3_1_enabled:
+        # Keep the optional graph arm out of production module import time.
+        # Organization policy is evaluated first, so a policy-off request
+        # never imports or constructs the arm.
+        from dev_health_ops.context_fabric.graph_arm.query_service import (
+            ProductionGraphInvestigationQuery,
+        )
+
+        # The graph-assisted enrichment path and authored-plan path share the
+        # exact same canonical service instances. Their construction is
+        # side-effect free; organization policy controls their presence, and
+        # the independent runtime kill switch controls execution.
         plan_executor_runtime = _ProductionPlanExecutorRuntime(
             status_service=status_service,
             metric_service=metric_service,
@@ -2582,6 +2597,23 @@ async def _assemble_production_runtime(
             data_health_service=data_health_service,
             evidence_signer=evidence_signer,
         )
+        team_health_service = TeamHealthService(
+            plan_executor_runtime, status_change_source
+        )
+        team_workload_service = TeamWorkloadService(
+            plan_executor_runtime, status_change_source, team_workload_source
+        )
+        operational_deficiency_service = OperationalDeficiencyService(
+            plan_executor_runtime, status_change_source, team_workload_source
+        )
+        canonical_enrichment = CanonicalEnrichmentAccessor(
+            status=status_service,
+            health=team_health_service,
+            workload=team_workload_service,
+            readiness=operational_deficiency_service,
+            metrics=metric_service,
+        )
+        graph_investigation_query = ProductionGraphInvestigationQuery()
         # CHAOS-3297 stack #3: every CHAOS-3303/3304/3305/3393 service is
         # constructed over the SAME PlanExecutorRuntime instance the six
         # core plans' steps use -- never a second, parallel query path.
@@ -2609,15 +2641,9 @@ async def _assemble_production_runtime(
             registry=build_registry_with_wave_3_1(
                 plan_executor_runtime,
                 project_health=project_health_service,
-                team_health=TeamHealthService(
-                    plan_executor_runtime, status_change_source
-                ),
-                team_workload=TeamWorkloadService(
-                    plan_executor_runtime, status_change_source, team_workload_source
-                ),
-                operational_deficiency=OperationalDeficiencyService(
-                    plan_executor_runtime, status_change_source, team_workload_source
-                ),
+                team_health=team_health_service,
+                team_workload=team_workload_service,
+                operational_deficiency=operational_deficiency_service,
                 # CHAOS-3393: PortfolioStatusService batches over the SAME
                 # ProjectHealthService instance the health.project.v1 step
                 # above uses -- never a second, parallel query path.
@@ -2651,6 +2677,9 @@ async def _assemble_production_runtime(
             else None
         ),
         plan_executor=plan_executor,
+        graph_investigation_query=graph_investigation_query,
+        evidence_service=evidence_service if wave_3_1_enabled else None,
+        canonical_enrichment=canonical_enrichment,
     )
 
 

--- a/src/dev_health_ops/api/dev/runtime.py
+++ b/src/dev_health_ops/api/dev/runtime.py
@@ -10,9 +10,12 @@ from typing import Literal
 from dev_health_ops.llm.agent.contracts import AgentLLMProvider
 
 from .answer_frames import narrative_fallback
+from .canonical_enrichment import CanonicalEnrichmentAccessor
 from .contracts import DevContractVersions, DevMessageRequest
 from .contracts_v2.base import QuestionIntentID
 from .contracts_v2.plan import DevInvestigationPlan
+from .evidence_service import EvidenceService
+from .graph_investigation_query import GraphInvestigationQuery
 from .investigation_plans import PlanExecutor
 from .investigation_shadow import InvestigationPacketProducer, InvestigationShadow
 from .orchestrator import (
@@ -81,6 +84,12 @@ class BoundedDevRuntime:
     #: the absence of an object rather than a branch inside one.
     investigation_shadow: InvestigationShadow | None = None
     investigation_packet_producer: InvestigationPacketProducer | None = None
+    #: Server-owned graph-assisted collaborators. Production constructs all
+    #: three once in its composition root; the runtime carries those exact
+    #: instances into each per-run orchestrator.
+    graph_investigation_query: GraphInvestigationQuery | None = None
+    evidence_service: EvidenceService | None = None
+    canonical_enrichment: CanonicalEnrichmentAccessor | None = None
 
     async def run(
         self,
@@ -112,6 +121,9 @@ class BoundedDevRuntime:
             qua_shadow=self.qua_shadow,
             investigation_shadow=self.investigation_shadow,
             investigation_packet_producer=self.investigation_packet_producer,
+            graph_investigation_query=self.graph_investigation_query,
+            evidence_service=self.evidence_service,
+            canonical_enrichment=self.canonical_enrichment,
         )
         return await orchestrator.run(
             request=request,

--- a/tests/api/dev/test_chaos_3697_graph_route_production_wiring.py
+++ b/tests/api/dev/test_chaos_3697_graph_route_production_wiring.py
@@ -1,45 +1,11 @@
-"""Issue 3697: the graph-assisted Ask Dev route is unreachable in
-production, and the runtime flag is never even the deciding factor.
+"""Regression coverage for the production graph-route composition root.
 
-``BoundedDevRuntime.run()`` (``runtime.py``) constructs the real
-``DevOrchestrator`` production actually serves. That constructor call
-passes none of ``graph_investigation_query``, ``evidence_service``, or
-``canonical_enrichment`` -- confirmed by grep over the whole ``src/`` tree:
-zero keyword-argument call sites for either of the first two anywhere, and
-the third does not exist as a parameter at all yet on this branch. So all
-three default to ``None`` on every real request, independent of the
-organization feature-policy gate, the runtime kill switch
-(``graph_routing_runtime_enabled()``), or anything an operator does.
-
-The routing gate at ``orchestrator.py``'s cohort-discovery branch reads:
-
-    and self._graph_investigation_query is not None
-    and self._evidence_service is not None
-    and graph_routing_runtime_enabled()
-
-Both identity checks are ``False`` in production, so the ``and``-chain
-short-circuits before ``graph_routing_runtime_enabled()`` is ever
-evaluated. Turning the runtime flag on today changes nothing.
-
-Concretely, in ``production_runtime.py``:
-
-* ``_assemble_production_runtime`` builds a real ``EvidenceService`` (see
-  its own ``evidence_service = EvidenceService(...)`` call) -- and then
-  never threads it into the ``BoundedDevRuntime`` it returns.
-  ``BoundedDevRuntime`` (``runtime.py``) has no field for it at all.
-* No code path anywhere in ``production_runtime.py`` constructs a
-  ``GraphInvestigationQuery`` in the first place.
-
-Existing coverage (``test_chaos_3502_graph_routing_seam.py``,
-``test_chaos_3502_graph_routing_branch.py``) never catches this: every one
-of those tests hand-constructs
-``DevOrchestrator(**kwargs, graph_investigation_query=..., evidence_service=...)``
-directly. That proves the constructor *accepts* the collaborators; it
-proves nothing about whether the real composition root ever *passes* one --
-which is exactly why this defect shipped invisibly. This file drives the
-real path instead: ``production_runtime.build_production_runtime()`` ->
-``BoundedDevRuntime.run()`` -> the real ``DevOrchestrator(...)`` call site
-in ``runtime.py`` -- and inspects what THAT call actually received.
+The defect was invisible to tests that hand-constructed ``DevOrchestrator``
+with graph collaborators. These tests instead drive the real path from
+``build_production_runtime()`` through ``BoundedDevRuntime.run()`` and inspect
+what that call site supplies. An enabled organization must receive all three
+shared collaborators; a policy-off organization must retain their ``None``
+state, and the independent runtime kill switch must still default off.
 """
 
 from __future__ import annotations
@@ -84,7 +50,9 @@ class _ConstructionObserved(Exception):
     the real runtime handed the real constructor."""
 
 
-async def _build_runtime(monkeypatch: pytest.MonkeyPatch) -> Any:
+async def _build_runtime(
+    monkeypatch: pytest.MonkeyPatch, *, wave_3_1_enabled: bool = True
+) -> Any:
     """The real production composition root
     (``production_runtime.build_production_runtime``), with only the
     provider resolution and the JWT secret stubbed -- the same seam
@@ -111,6 +79,11 @@ async def _build_runtime(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setattr(
         production_runtime, "resolve_production_provider", resolve_provider
     )
+
+    async def resolve_wave_policy(_session: Any, _org_id: str) -> bool:
+        return wave_3_1_enabled
+
+    monkeypatch.setattr(production_runtime, "_wave_3_1_enabled", resolve_wave_policy)
     monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret-32-bytes-long")
     return await production_runtime.build_production_runtime(
         cast(Any, object()),
@@ -162,12 +135,9 @@ async def _capture_orchestrator_construction(
     return captured
 
 
-#: The 14 keyword arguments runtime.py's DevOrchestrator(...) call site
-#: passes today (verified against the actual source at the top of this
-#: file's module docstring investigation). Used ONLY by the positive
-#: control below to prove the capturing harness genuinely observed a real
-#: construction -- never asserted against directly in the RED test itself,
-#: which only cares about the three that are ABSENT from this set.
+#: The 17 keyword arguments runtime.py's DevOrchestrator(...) call site
+#: passes. Used by the positive control below to prove the capturing harness
+#: genuinely observed the real construction seam.
 _KWARGS_RUNTIME_PY_ACTUALLY_PASSES = frozenset(
     {
         "provider",
@@ -184,6 +154,9 @@ _KWARGS_RUNTIME_PY_ACTUALLY_PASSES = frozenset(
         "qua_shadow",
         "investigation_shadow",
         "investigation_packet_producer",
+        "graph_investigation_query",
+        "evidence_service",
+        "canonical_enrichment",
     }
 )
 
@@ -192,23 +165,18 @@ _KWARGS_RUNTIME_PY_ACTUALLY_PASSES = frozenset(
 async def test_the_capturing_harness_genuinely_observes_a_real_construction(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Positive control for the RED test below -- deliberately NOT xfail,
-    and MUST keep passing.
+    """Positive control for the wiring regression test below.
 
-    ``xfail`` swallows any failure the marked test raises, not only the one
-    it is meant to demonstrate. If the interception in
+    If the interception in
     ``_capture_orchestrator_construction`` ever silently stops working --
     the ``DevOrchestrator(...)`` call site moves, gets wrapped in a
     factory, the import binding changes, or the probe exception fires
-    before ``captured`` is populated -- the RED test still reports
-    ``XFAIL`` (an assertion failure inside ``pytest.raises`` also
-    satisfies it), which reads as "expected failure, all fine" while the
-    harness has quietly stopped observing anything about production wiring
-    at all. That is the exact failure shape this whole issue is about, one
-    layer up: a measurement that fails toward "fine" instead of loudly.
+    before ``captured`` is populated -- this test fails loudly instead of
+    letting the collaborator assertions claim coverage over an unobserved
+    construction.
 
     This test asserts the harness actually captured a construction: the
-    exact 14 keyword names ``runtime.py`` really passes today, populated
+    exact 17 keyword names ``runtime.py`` passes, populated
     with real values (not just present-but-empty) -- ``registry`` is a
     genuine ``AskDevToolRegistry``, and ``provider`` is the exact
     ``_FakeProvider`` instance this test's own stub handed to
@@ -226,15 +194,14 @@ async def test_the_capturing_harness_genuinely_observes_a_real_construction(
 
     assert captured, (
         "the capturing DevOrchestrator subclass never ran -- the "
-        "interception itself is broken, which would make the RED test "
-        "below meaningless (an XFAIL that observes nothing still reports "
-        "XFAIL)"
+        "interception itself is broken, which would make the wiring test "
+        "below meaningless"
     )
     assert set(captured) == _KWARGS_RUNTIME_PY_ACTUALLY_PASSES, (
         "runtime.py's DevOrchestrator(...) call site no longer passes the "
         "keyword set this harness was written against -- update "
         "_KWARGS_RUNTIME_PY_ACTUALLY_PASSES to match the real call site "
-        "before trusting the RED test's absence claim again"
+        "before trusting the wiring claim again"
     )
     assert captured["registry"] is not None
     assert type(captured["registry"]).__name__ == "AskDevToolRegistry"
@@ -246,41 +213,19 @@ async def test_the_capturing_harness_genuinely_observes_a_real_construction(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Issue 3697: the graph-assisted route is unreachable in production "
-        "-- BoundedDevRuntime.run() never wires graph_investigation_query, "
-        "evidence_service, or canonical_enrichment into DevOrchestrator. "
-        "Landing this test RED (rather than deferring it) is deliberate: it "
-        "must be visible on the feature branch as a known, tracked gap, not "
-        "silently absent. strict=True is load-bearing, not decorative -- it "
-        "flips this to a hard CI failure the instant any leg of the fix "
-        "lands without this marker being removed in the SAME change, so the "
-        "fix and the test that proves it can never drift apart silently."
-    ),
-)
 @pytest.mark.asyncio
-async def test_production_runtime_never_wires_the_graph_route_collaborators(
+async def test_production_runtime_wires_the_graph_route_collaborators(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Issue 3697, RED (xfail-strict; see the marker above for why it is
-    landed failing rather than deferred). The cohort-discovery routing gate
+    """The cohort-discovery routing gate
     requires ``graph_investigation_query``, ``evidence_service``, AND (once
     wired) ``canonical_enrichment`` to all be non-``None`` before it even
     asks ``graph_routing_runtime_enabled()``. This asserts on the ACTUAL
     ``DevOrchestrator`` the production composition root builds -- not one
     this test built by hand -- so it fails for the same reason the route
     fails to activate in production, not for an unrelated mistake in the
-    test itself.
-
-    MUST currently fail: none of the three collaborators reach the
-    constructor today. ``.get()`` is used deliberately for
-    ``canonical_enrichment``, which is not even a ``DevOrchestrator``
-    parameter yet on this branch (concurrent, unrelated lane work) -- a
-    missing key reads as ``None`` here, same as an explicit ``None``, so
-    this test does not crash ahead of that landing and starts holding it to
-    the same bar the moment it does.
+    test itself. The helper explicitly enables the organization policy so
+    collaborator presence makes the runtime kill switch the deciding gate.
     """
 
     bounded_runtime = await _build_runtime(monkeypatch)
@@ -307,18 +252,40 @@ async def test_production_runtime_never_wires_the_graph_route_collaborators(
         "canonical_enrichment is not threaded from the production "
         "composition root into DevOrchestrator"
     )
+    assert (
+        captured["graph_investigation_query"]
+        is bounded_runtime.graph_investigation_query
+    )
+    assert captured["evidence_service"] is bounded_runtime.evidence_service
+    assert captured["canonical_enrichment"] is bounded_runtime.canonical_enrichment
+
+
+@pytest.mark.asyncio
+async def test_production_runtime_keeps_graph_collaborators_off_for_policy_off_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bounded_runtime = await _build_runtime(monkeypatch, wave_3_1_enabled=False)
+    try:
+        captured = await _capture_orchestrator_construction(
+            monkeypatch, bounded_runtime
+        )
+    finally:
+        await bounded_runtime.aclose()
+
+    assert captured["graph_investigation_query"] is None
+    assert captured["evidence_service"] is None
+    assert captured["canonical_enrichment"] is None
 
 
 def test_graph_routing_runtime_flag_defaults_off_in_a_production_shaped_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Companion to the RED test above -- NOT equivalent evidence, and this
-    one legitimately passes today. Two independent reasons it will keep
-    passing once the wiring gap above is fixed: (1) the runtime kill switch
+    """Companion to the wiring test above. Two independent reasons it
+    passes: (1) the runtime kill switch
     (``GRAPH_ROUTING_RUNTIME_FLAG``) already defaults off on its own,
     unrelated to whether the collaborators get wired; and (2) the routing
     gate is an ``and`` of collaborator-presence and this flag, so even
-    after the collaborators start reaching the constructor, an operator
+    after the collaborators reach the constructor, an operator
     still has to explicitly opt in for the route to activate. This guards
     against a fix that makes the route always-on instead of genuinely
     flag-controlled.

--- a/tests/context_fabric/test_chaos_3617_containment.py
+++ b/tests/context_fabric/test_chaos_3617_containment.py
@@ -199,11 +199,13 @@ class TestGraphitiIsOptional:
 
 class TestNoProductionCoupling:
     def test_no_production_module_imports_the_arm_at_module_scope(self) -> None:
-        """One lazy registration point, and no others.
+        """Optional graph dependencies never load at production import time.
 
         ``derived_store_registry`` imports the arm inside a function so org
-        deletion can visit the trial store; that is the *only* reference the
-        production tree is allowed to hold.
+        deletion can visit the store. The approved Ask Dev composition root
+        likewise imports its query implementation only after organization
+        policy enables the graph route. Neither may become a module-scope
+        dependency of the default production runtime.
         """
 
         src = _REPO_ROOT / "src" / "dev_health_ops"


### PR DESCRIPTION
## Outcome

Makes the graph-assisted Ask Dev route reachable for organization-policy-enabled runtimes while preserving both policy-off and runtime-flag-off behavior.

## Scope and architecture boundary

- Carries a production graph query, the existing shared evidence service, and canonical enrichment through `BoundedDevRuntime` into the real orchestrator construction.
- Reuses the same status, metric, health, workload, and readiness services as authored native plans.
- Keeps the optional graph arm out of production module import time; construction occurs only after organization policy enables the route.
- Graph discovery remains non-authoritative; canonical services retain authorization, admission, evidence, and measurable truth.

Non-scope: no contract, migration, deployment, retention, telemetry, or Web rendering changes.

## Provenance

- Base: `7a79d46ec`
- Head: `a1a62d72a`
- Branch: `fix/askdev-graph-route-wiring`
- Linear: issue 3697, Phase 1 production routing

## Flags and rollback

Organization policy controls collaborator presence. The independent graph-routing runtime flag remains off by default and is still the deciding execution switch for enabled organizations. Rollback is the single commit or either existing flag; no data migration is involved.

## RED-first evidence

- Baseline: `.venv/bin/pytest -q --runxfail tests/api/dev/test_*graph_route_production_wiring.py::test_production_runtime_never_wires_the_graph_route_collaborators`
- Result on untouched base: `1 failed`; first missing collaborator was the production graph query.

## Verification

- Focused composition and containment: `5 passed`
- Neighboring production runtime, routing, query, and assembler suites: `124 passed, 2 skipped`
- `PATH="$PWD/.venv/bin:$PATH" bash ci/local_validate.sh`
- Full gate: `PASSED`, `declared=10 executed=10`
- Full unit suite: `15939 passed, 383 skipped, 4 xfailed`
- Live ClickHouse argMax, declared-state history, and migration reconciliation stages passed.

## Security and product safety

Policy-off organizations receive no graph collaborators. The evidence service is shared rather than duplicated, so authorization and admission cannot diverge. The query implementation remains lazy and server-owned; no graph-native route, tool, or client-controlled traversal is exposed.

SCREENSHOT-WAIVER: backend-only composition-root change; no rendered UI changes.