### PR TITLE
fix: enforce fail-closed graph routing entitlement

### DIFF
--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -115,6 +115,10 @@ from .graph_investigation_query import (
     GraphInvestigationRequest,
     GraphQueryOutcome,
 )
+from .graph_routing_policy import (
+    GraphRoutingEntitlementAuthorizer,
+    GraphRoutingPolicyDeniedError,
+)
 from .investigation_contract import AskDevInvestigationPacket, InvestigationOutcome
 from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
@@ -1189,6 +1193,7 @@ class DevOrchestrator:
         graph_investigation_query: GraphInvestigationQuery | None = None,
         evidence_service: EvidenceService | None = None,
         canonical_enrichment: CanonicalEnrichmentAccessor | None = None,
+        graph_routing_entitlement: GraphRoutingEntitlementAuthorizer | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -1259,10 +1264,33 @@ class DevOrchestrator:
         # ``evidence_service`` before this exists sees the exact same
         # assembly-deferred fallthrough the COMPLETED branch always had,
         # never a crash on a collaborator nobody constructed yet
-        # (production does not wire any of the three today; see
-        # CHAOS-3697).
+        # (production wires all three only when the Wave 3.1 organization
+        # gate is enabled; see CHAOS-3697).
         self._canonical_enrichment = canonical_enrichment
+        # Production supplies the canonical organization-level authorizer at
+        # this seam. A missing authorizer remains the legacy direct-test
+        # compatibility path; production composition never leaves it unset
+        # when the graph collaborators are present.
+        self._graph_routing_entitlement = graph_routing_entitlement
         self._composer = PromptComposer(registry)
+
+    async def _graph_route_is_entitled(self, *, org_id: str) -> bool:
+        """Check the canonical org gate immediately before graph entry."""
+
+        if self._graph_routing_entitlement is None:
+            # Graph collaborators without their organization-level policy
+            # authorizer are an incomplete production composition. Fail
+            # closed rather than treating an omitted policy gate as allow.
+            return False
+        try:
+            await self._graph_routing_entitlement.require(org_id)
+        except GraphRoutingPolicyDeniedError:
+            # The canonical authorizer owns both explicit-purchase policy and
+            # fail-closed storage errors. A denied org falls through to the
+            # existing bounded provider path; GraphInvestigationQuery is not
+            # entered.
+            return False
+        return True
 
     async def run(
         self,
@@ -3081,11 +3109,10 @@ class DevOrchestrator:
             # since PLAN_ID_BY_INTENT gives it a compat-only token,
             # CHAOS-3652), so gating this on self._plan_executor being
             # wired would tie graph routing to an unrelated collaborator.
-            # Both organization opt-in (self._evidence_service/
-            # self._graph_investigation_query only get constructed when the
-            # org feature is on, production_runtime.py's job) and the
-            # runtime kill switch are required -- independent gates, same
-            # shape as every other flag pair in this file.
+            # Wave 3.1 composition supplies the collaborators, while the
+            # independent graph entitlement is checked immediately below;
+            # the runtime kill switch remains a separate gate, same shape as
+            # every other flag pair in this file.
             #
             # CHAOS-3689/CHAOS-3660: computed unconditionally (cheap, pure
             # lexical matching, no side effects) rather than gated behind
@@ -3103,6 +3130,7 @@ class DevOrchestrator:
                 and self._graph_investigation_query is not None
                 and self._evidence_service is not None
                 and graph_routing_runtime_enabled()
+                and await self._graph_route_is_entitled(org_id=org_id)
             ):
                 graph_deadline = datetime.now(UTC) + timedelta(
                     seconds=max(0.0, remaining())

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -111,6 +111,7 @@ from .evidence_service import (
     EvidenceService,
 )
 from .graph_investigation_query import GraphInvestigationQuery
+from .graph_routing_policy import CanonicalGraphRoutingEntitlementAuthorizer
 from .investigation_plans import PlanExecutor
 from .investigation_plans.plan_documents import CORE_PLANS_BY_INTENT
 from .investigation_plans.wave_3_1_plans import (
@@ -2578,6 +2579,7 @@ async def _assemble_production_runtime(
     plan_executor: PlanExecutor | None = None
     graph_investigation_query: GraphInvestigationQuery | None = None
     canonical_enrichment: CanonicalEnrichmentAccessor | None = None
+    graph_routing_entitlement: CanonicalGraphRoutingEntitlementAuthorizer | None = None
     if wave_3_1_enabled:
         # Keep the optional graph arm out of production module import time.
         # Organization policy is evaluated first, so a policy-off request
@@ -2614,6 +2616,7 @@ async def _assemble_production_runtime(
             metrics=metric_service,
         )
         graph_investigation_query = ProductionGraphInvestigationQuery()
+        graph_routing_entitlement = CanonicalGraphRoutingEntitlementAuthorizer(session)
         # CHAOS-3297 stack #3: every CHAOS-3303/3304/3305/3393 service is
         # constructed over the SAME PlanExecutorRuntime instance the six
         # core plans' steps use -- never a second, parallel query path.
@@ -2680,6 +2683,7 @@ async def _assemble_production_runtime(
         graph_investigation_query=graph_investigation_query,
         evidence_service=evidence_service if wave_3_1_enabled else None,
         canonical_enrichment=canonical_enrichment,
+        graph_routing_entitlement=graph_routing_entitlement,
     )
 
 

--- a/src/dev_health_ops/api/dev/runtime.py
+++ b/src/dev_health_ops/api/dev/runtime.py
@@ -16,6 +16,7 @@ from .contracts_v2.base import QuestionIntentID
 from .contracts_v2.plan import DevInvestigationPlan
 from .evidence_service import EvidenceService
 from .graph_investigation_query import GraphInvestigationQuery
+from .graph_routing_policy import GraphRoutingEntitlementAuthorizer
 from .investigation_plans import PlanExecutor
 from .investigation_shadow import InvestigationPacketProducer, InvestigationShadow
 from .orchestrator import (
@@ -90,6 +91,11 @@ class BoundedDevRuntime:
     graph_investigation_query: GraphInvestigationQuery | None = None
     evidence_service: EvidenceService | None = None
     canonical_enrichment: CanonicalEnrichmentAccessor | None = None
+    #: The independent organization-level graph entitlement. Production
+    #: carries the canonical authorizer only when the Wave 3.1 collaborators
+    #: are constructed; the orchestrator checks it immediately before route
+    #: entry, leaving the runtime kill switch independent.
+    graph_routing_entitlement: GraphRoutingEntitlementAuthorizer | None = None
 
     async def run(
         self,
@@ -124,6 +130,7 @@ class BoundedDevRuntime:
             graph_investigation_query=self.graph_investigation_query,
             evidence_service=self.evidence_service,
             canonical_enrichment=self.canonical_enrichment,
+            graph_routing_entitlement=self.graph_routing_entitlement,
         )
         return await orchestrator.run(
             request=request,

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -768,6 +768,7 @@ async def run_preflight_orchestrator(
     graph_investigation_query: Any = None,
     evidence_service: Any = None,
     canonical_enrichment: Any = None,
+    graph_routing_entitlement: Any = None,
 ) -> RunOutput:
     """One full orchestrator run with the preflight wired the way production wires it.
 
@@ -797,6 +798,9 @@ async def run_preflight_orchestrator(
     so a genuine ``DISCOVERED_COHORT`` ``preflight_result`` (only the real
     interpreter/preflight pipeline produces one) drives the actual routing
     branch in ``DevOrchestrator.run()``, not a construction-only smoke test.
+    Routing tests must also pass an explicit ``graph_routing_entitlement``;
+    the production orchestrator fails closed when graph collaborators are
+    present without that organization-level authorizer.
     ``canonical_enrichment`` (CHAOS-3650) is the third collaborator the
     graph-grounded assembler needs; every existing caller leaves it unset,
     which keeps the COMPLETED-branch assembly attempt gated off exactly as
@@ -851,6 +855,7 @@ async def run_preflight_orchestrator(
         graph_investigation_query=graph_investigation_query,
         evidence_service=evidence_service,
         canonical_enrichment=canonical_enrichment,
+        graph_routing_entitlement=graph_routing_entitlement,
     )
     result = await orchestrator.run(
         request=request,

--- a/tests/api/dev/test_chaos_3502_graph_routing_branch.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_branch.py
@@ -121,6 +121,7 @@ async def test_every_fallthrough_outcome_is_observed_and_still_answers(
             script_id=f"chaos3502-{outcome.value}",
             graph_investigation_query=fake,
             evidence_service=_evidence_service(),
+            graph_routing_entitlement=_Entitlement(),
         )
 
     assert len(fake.received_requests) == 1, (
@@ -178,6 +179,7 @@ async def test_cancelled_outcome_terminates_the_run_directly(
             script_id="chaos3502-cancelled",
             graph_investigation_query=fake,
             evidence_service=_evidence_service(),
+            graph_routing_entitlement=_Entitlement(),
         )
 
     assert output.result.state is RunState.CANCELLED
@@ -225,6 +227,7 @@ async def test_flag_off_is_byte_identical_to_collaborators_never_wired(
         script_id="chaos3502-flag-off",
         graph_investigation_query=fake,
         evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
     )
     assert fake.received_requests == [], (
         "flag off must mean the graph seam is never called, even though "
@@ -262,6 +265,7 @@ async def test_the_request_carries_the_classified_cohort_discovery_family(
         script_id="chaos3689-family",
         graph_investigation_query=fake,
         evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
     )
 
     assert len(fake.received_requests) == 1
@@ -293,6 +297,7 @@ async def test_an_unclassifiable_cohort_question_never_calls_the_seam(
         script_id="chaos3689-unclassifiable",
         graph_investigation_query=fake,
         evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
     )
     assert fake.received_requests == [], (
         "an unclassifiable cohort-discovery family must mean the graph seam "

--- a/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
+++ b/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
@@ -305,6 +305,7 @@ async def test_completed_with_admissible_evidence_produces_a_graph_grounded_answ
         script_id="chaos3650-clean",
         graph_investigation_query=fake,
         evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
         canonical_enrichment=_canonical_enrichment(),
         recorder_factory=lambda: recorder,
     )
@@ -341,6 +342,7 @@ async def test_a_refused_candidate_degrades_but_never_aborts(
         script_id="chaos3650-degrade",
         graph_investigation_query=fake,
         evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
         canonical_enrichment=_canonical_enrichment(),
     )
 
@@ -378,6 +380,7 @@ async def test_an_enrichment_gap_degrades_independently_of_evidence_refusal(
         script_id="chaos3650-enrichment-gap",
         graph_investigation_query=fake,
         evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
         canonical_enrichment=_canonical_enrichment(status_raises=True),
     )
 
@@ -415,6 +418,7 @@ async def test_completed_with_no_material_still_falls_through(
             script_id="chaos3650-no-material",
             graph_investigation_query=fake,
             evidence_service=_evidence_service(),
+            graph_routing_entitlement=_Entitlement(),
             canonical_enrichment=_canonical_enrichment(),
         )
 
@@ -458,6 +462,7 @@ async def test_an_unexpected_exception_during_assembly_falls_through_and_is_coun
             script_id="chaos3650-raised",
             graph_investigation_query=fake,
             evidence_service=_evidence_service(entitlement=_RaisingEntitlement()),
+            graph_routing_entitlement=_Entitlement(),
             canonical_enrichment=_canonical_enrichment(),
         )
 
@@ -510,6 +515,7 @@ async def test_a_genuine_cancellation_during_assembly_is_not_swallowed(
             script_id="chaos3650-cancelled",
             graph_investigation_query=fake,
             evidence_service=_evidence_service(entitlement=_CancellingEntitlement()),
+            graph_routing_entitlement=_Entitlement(),
             canonical_enrichment=_canonical_enrichment(),
         )
 
@@ -564,6 +570,7 @@ async def test_enrichment_metric_evidence_ref_ids_are_scrubbed_before_assembly(
         script_id="chaos3650-metric-scrub",
         graph_investigation_query=fake,
         evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
         canonical_enrichment=_canonical_enrichment(metric_refs=(metric_ref,)),
     )
 

--- a/tests/api/dev/test_chaos_3697_graph_route_production_wiring.py
+++ b/tests/api/dev/test_chaos_3697_graph_route_production_wiring.py
@@ -11,14 +11,22 @@ state, and the independent runtime kill switch must still default off.
 from __future__ import annotations
 
 import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any, cast
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from dev_health_ops.api.dev import production_runtime
 from dev_health_ops.api.dev import runtime as runtime_module
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import DevMessageRequest
+from dev_health_ops.api.dev.graph_routing_policy import (
+    CanonicalGraphRoutingEntitlementAuthorizer,
+    GraphRoutingPolicyDeniedError,
+)
 from dev_health_ops.api.dev.orchestrator import (
     GRAPH_ROUTING_RUNTIME_FLAG,
     DevOrchestrator,
@@ -26,7 +34,17 @@ from dev_health_ops.api.dev.orchestrator import (
     graph_routing_runtime_enabled,
 )
 from dev_health_ops.api.dev.production_runtime import ProductionProviderResolution
+from dev_health_ops.licensing.feature_policy import FeatureDecisionReason
+from dev_health_ops.licensing.registry import (
+    ASK_DEV_GRAPH_ROUTING_FEATURE,
+    ASK_DEV_WAVE_3_1_FEATURE,
+)
 from dev_health_ops.llm.agent.policy import AgentProviderSource
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride, OrgLicense
+from dev_health_ops.models.users import Organization
+from tests._chaos_3292_preflight import organization_resolution, request_for
+from tests._helpers import tables_of
 
 
 class _FakeProvider:
@@ -48,6 +66,100 @@ class _ConstructionObserved(Exception):
     """Raised by the capturing stand-in the instant construction finishes,
     so this test never has to drive a full agentic run just to observe what
     the real runtime handed the real constructor."""
+
+
+class _GraphRouteObserved(BaseException):
+    """Stop the real run after the production graph query is entered."""
+
+
+class _LegacyFallbackObserved(BaseException):
+    """Stop the real run when the denied route reaches the legacy provider."""
+
+
+class _FallbackProbeProvider:
+    async def decide(self, **_values: Any) -> Any:
+        raise _LegacyFallbackObserved()
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _GraphQueryProbe:
+    """Delegate to the real query, then stop so route entry is observable."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.calls = 0
+
+    async def investigate(self, request: Any) -> Any:
+        self.calls += 1
+        await self._inner.investigate(request)
+        raise _GraphRouteObserved() from None
+
+
+@asynccontextmanager
+async def _persistence_session(
+    *, graph_entitled: bool
+) -> AsyncIterator[tuple[AsyncSession, uuid.UUID]]:
+    """Seed the exact feature-decision tables used by production policy."""
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(
+                Base.metadata.create_all,
+                tables=tables_of(
+                    Organization, FeatureFlag, OrgFeatureOverride, OrgLicense
+                ),
+            )
+
+        org_id = uuid.uuid4()
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            wave_feature = FeatureFlag(
+                key=ASK_DEV_WAVE_3_1_FEATURE,
+                name="Ask Dev Wave 3.1",
+                category="ai",
+                min_tier="community",
+            )
+            graph_feature = FeatureFlag(
+                key=ASK_DEV_GRAPH_ROUTING_FEATURE,
+                name="Ask Dev Graph Routing",
+                category="ai",
+                min_tier="community",
+            )
+            session.add_all(
+                [
+                    Organization(
+                        id=org_id,
+                        slug=f"graph-entitlement-{org_id.hex}",
+                        name="Graph Entitlement Regression",
+                        tier="community",
+                    ),
+                    wave_feature,
+                    graph_feature,
+                    OrgLicense(org_id=org_id, tier="community"),
+                ]
+            )
+            await session.flush()
+            session.add(
+                OrgFeatureOverride(
+                    org_id=org_id,
+                    feature_id=wave_feature.id,
+                    is_enabled=True,
+                )
+            )
+            if graph_entitled:
+                session.add(
+                    OrgFeatureOverride(
+                        org_id=org_id,
+                        feature_id=graph_feature.id,
+                        is_enabled=True,
+                    )
+                )
+            await session.commit()
+            yield session, org_id
+    finally:
+        await engine.dispose()
 
 
 async def _build_runtime(
@@ -88,6 +200,38 @@ async def _build_runtime(
     return await production_runtime.build_production_runtime(
         cast(Any, object()),
         org_id="org_01",
+        permission_fingerprint="permissions_01",
+        clickhouse=cast(Any, object()),
+    )
+
+
+async def _build_persisted_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+) -> Any:
+    async def resolve_provider(
+        _session: Any, *, org_id: str
+    ) -> ProductionProviderResolution:
+        del org_id
+        return ProductionProviderResolution(
+            provider=cast(Any, _FallbackProbeProvider()),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="certified-model",
+            provider_label="OpenAI compatible",
+            model_label="certified-model",
+        )
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret-32-bytes-long")
+    monkeypatch.setenv("ASK_DEV_GRAPH_ROUTING_ENABLED", "1")
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+    return await production_runtime.build_production_runtime(
+        session,
+        org_id=str(org_id),
         permission_fingerprint="permissions_01",
         clickhouse=cast(Any, object()),
     )
@@ -135,7 +279,7 @@ async def _capture_orchestrator_construction(
     return captured
 
 
-#: The 17 keyword arguments runtime.py's DevOrchestrator(...) call site
+#: The 18 keyword arguments runtime.py's DevOrchestrator(...) call site
 #: passes. Used by the positive control below to prove the capturing harness
 #: genuinely observed the real construction seam.
 _KWARGS_RUNTIME_PY_ACTUALLY_PASSES = frozenset(
@@ -157,6 +301,7 @@ _KWARGS_RUNTIME_PY_ACTUALLY_PASSES = frozenset(
         "graph_investigation_query",
         "evidence_service",
         "canonical_enrichment",
+        "graph_routing_entitlement",
     }
 )
 
@@ -176,7 +321,7 @@ async def test_the_capturing_harness_genuinely_observes_a_real_construction(
     construction.
 
     This test asserts the harness actually captured a construction: the
-    exact 17 keyword names ``runtime.py`` passes, populated
+    exact 18 keyword names ``runtime.py`` passes, populated
     with real values (not just present-but-empty) -- ``registry`` is a
     genuine ``AskDevToolRegistry``, and ``provider`` is the exact
     ``_FakeProvider`` instance this test's own stub handed to
@@ -252,12 +397,20 @@ async def test_production_runtime_wires_the_graph_route_collaborators(
         "canonical_enrichment is not threaded from the production "
         "composition root into DevOrchestrator"
     )
+    assert captured.get("graph_routing_entitlement") is not None, (
+        "the canonical graph entitlement authorizer is not threaded from "
+        "the production composition root into DevOrchestrator"
+    )
     assert (
         captured["graph_investigation_query"]
         is bounded_runtime.graph_investigation_query
     )
     assert captured["evidence_service"] is bounded_runtime.evidence_service
     assert captured["canonical_enrichment"] is bounded_runtime.canonical_enrichment
+    assert (
+        captured["graph_routing_entitlement"]
+        is bounded_runtime.graph_routing_entitlement
+    )
 
 
 @pytest.mark.asyncio
@@ -275,6 +428,7 @@ async def test_production_runtime_keeps_graph_collaborators_off_for_policy_off_o
     assert captured["graph_investigation_query"] is None
     assert captured["evidence_service"] is None
     assert captured["canonical_enrichment"] is None
+    assert captured["graph_routing_entitlement"] is None
 
 
 def test_graph_routing_runtime_flag_defaults_off_in_a_production_shaped_environment(
@@ -293,3 +447,82 @@ def test_graph_routing_runtime_flag_defaults_off_in_a_production_shaped_environm
 
     monkeypatch.delenv(GRAPH_ROUTING_RUNTIME_FLAG, raising=False)
     assert graph_routing_runtime_enabled() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("graph_entitled", "authorizer_wired"),
+    [
+        pytest.param(False, True, id="persistence-denied"),
+        pytest.param(True, True, id="persistence-allowed"),
+        pytest.param(True, False, id="collaborators-without-authorizer"),
+    ],
+)
+async def test_production_route_checks_persisted_graph_entitlement_before_query(
+    monkeypatch: pytest.MonkeyPatch,
+    graph_entitled: bool,
+    authorizer_wired: bool,
+) -> None:
+    """The real production run must gate GraphInvestigationQuery by org policy.
+
+    Wave 3.1 is enabled for both rows, while ``ask_dev_graph_routing`` is
+    independently absent/present. The probe delegates to the real production
+    query and only then stops, so a denied org cannot satisfy this test by
+    returning a synthetic disabled result from a mocked query. The third case
+    deliberately removes the authorizer while leaving the graph collaborators
+    present; that incomplete composition must fail closed before query entry.
+    """
+
+    async with _persistence_session(graph_entitled=graph_entitled) as (
+        session,
+        org_id,
+    ):
+        authorizer = CanonicalGraphRoutingEntitlementAuthorizer(session)
+        if graph_entitled:
+            await authorizer.require(str(org_id))
+        else:
+            with pytest.raises(GraphRoutingPolicyDeniedError) as denied:
+                await authorizer.require(str(org_id))
+            assert (
+                denied.value.reason is FeatureDecisionReason.EXPLICIT_PURCHASE_REQUIRED
+            )
+
+        bounded_runtime = await _build_persisted_runtime(monkeypatch, session, org_id)
+        if not authorizer_wired:
+            bounded_runtime.graph_routing_entitlement = None
+        graph_probe = _GraphQueryProbe(bounded_runtime.graph_investigation_query)
+        bounded_runtime.graph_investigation_query = graph_probe
+
+        async def resolve_scope(**values: Any) -> Any:
+            return organization_resolution(values["requested_scope"])
+
+        bounded_runtime.scope_resolver = resolve_scope
+        try:
+            with pytest.raises(BaseException) as observed:
+                await bounded_runtime.run(
+                    request=request_for(
+                        "Which teams are struggling right now?",
+                        organization_id=str(org_id),
+                    ),
+                    org_id=str(org_id),
+                    user_id=str(uuid.uuid4()),
+                    permission_fingerprint="permissions_01",
+                    run_id=str(uuid.uuid4()),
+                    conversation_id=str(uuid.uuid4()),
+                    answer_id=str(uuid.uuid4()),
+                    cancellation=asyncio.Event(),
+                    recorder=NullRunRecorder(),
+                    event_sink=lambda _event: asyncio.sleep(0),
+                )
+        finally:
+            await bounded_runtime.aclose()
+
+        if graph_entitled and authorizer_wired:
+            assert isinstance(observed.value, _GraphRouteObserved)
+            assert graph_probe.calls == 1
+        else:
+            assert isinstance(observed.value, _LegacyFallbackObserved)
+            assert graph_probe.calls == 0, (
+                "an organization without an effective graph entitlement "
+                "entered the graph route before policy was checked"
+            )


### PR DESCRIPTION
## Summary

- Thread the existing canonical organization graph-routing authorizer through the production runtime and orchestrator.
- Fail closed before `GraphInvestigationQuery` when the authorizer is denied or omitted, while keeping the runtime kill switch and Wave 3.1 collaborator laziness independent.
- Add a persistence-backed production composition/run regression for allowed, denied, and missing-authorizer cases.

## Review correction

The initial implementation treated an omitted graph authorizer as allow for direct-test compatibility. That was unsafe whenever graph collaborators were present. The corrected implementation treats the omission as deny; routing tests now pass an explicit allow-authorizer where route entry is intentional.

## Verification

- Exact baseline red command: `PATH="$(pwd)/.venv/bin:$PATH" pytest tests/api/dev/test_chaos_3697_graph_route_production_wiring.py -q` at `216d0bdd2ae6191712d56ef09aa9e22ccbff4424` → `5 passed, 1 failed`; the persistence-denied org entered the graph query.
- Focused post-correction suites: `48 passed`.
- Broad authorization/composition/assembler/security suites: `156 passed`.
- Full mypy: `Success: no issues found in 2354 source files`.
- Ruff format/check: clean.
- Pre-commit and pre-push hooks: Ruff format, Ruff lint, full mypy, and commit-message attribution checks passed with the owning worktree `.venv`.

## Follow-up

A separate database transaction follow-up remains unverified and is not addressed by this pull request.

SCREENSHOT-WAIVER: backend-only wiring and test change; no rendered UI surface changed.
