### PR TITLE
fix: enforce server-owned graph authorization scope

### DIFF
--- a/src/dev_health_ops/api/dev/graph_investigation_query.py
+++ b/src/dev_health_ops/api/dev/graph_investigation_query.py
@@ -54,17 +54,21 @@ Why this shape, briefly (full reasoning in the CHAOS-3660 proposal comment):
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from typing import Protocol
 
+from .contracts import DevScope
 from .contracts_v2.base import Cardinality, QuestionIntentID
 from .contracts_v2.subject import DevSubjectMention
 from .investigation_contract import AskDevInvestigationPacket
 
 __all__ = [
     "CohortDiscoveryFamily",
+    "GraphAuthorizationScope",
+    "GraphAuthorizationResolver",
     "GraphInvestigationRequest",
     "GraphQueryOutcome",
     "GraphQueryResult",
@@ -109,6 +113,43 @@ class CohortDiscoveryFamily(StrEnum):
     #: PROJECT_CAPACITY. Project-kind candidates, capacity-metric
     #: corroboration.
     PROJECT_CAPACITY = "project_capacity"
+
+
+@dataclass(frozen=True, slots=True)
+class GraphAuthorizationScope:
+    """Server-owned, tenant-scoped candidate envelope for one graph run.
+
+    The graph arm receives this envelope after the canonical organization
+    entitlement has been checked.  Candidate IDs are derived from the same
+    tenant-filtered scope catalog used by Ask Dev's native tools; graph
+    membership never contributes authorization.  ``complete`` is explicit so
+    a bounded page can never be mistaken for the complete authorized universe.
+    """
+
+    organization_id: str
+    permission_fingerprint: str
+    scope: DevScope
+    cohort_discovery_family: CohortDiscoveryFamily
+    authorized_entity_ids: frozenset[str]
+    complete: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.organization_id.strip():
+            raise ValueError("Graph authorization scope requires an organization")
+        if not self.permission_fingerprint.strip():
+            raise ValueError(
+                "Graph authorization scope requires a permission fingerprint"
+            )
+        if self.scope.organization_id != self.organization_id:
+            raise ValueError("Graph authorization scope scope does not match org")
+        if any(not entity_id.strip() for entity_id in self.authorized_entity_ids):
+            raise ValueError("Graph authorization scope contains an empty entity ID")
+
+
+GraphAuthorizationResolver = Callable[
+    [str, str, CohortDiscoveryFamily, DevScope],
+    Awaitable[GraphAuthorizationScope | None],
+]
 
 
 class GraphQueryOutcome(StrEnum):
@@ -215,6 +256,26 @@ class GraphInvestigationRequest:
     #: is exactly the kind of closed vocabulary CHAOS-3500 should define and
     #: own; this proposal does not presume it.
     budget_hints: dict[str, int] = field(default_factory=dict)
+    #: The server-owned envelope that produced ``authorized_entity_ids``.
+    #: Production supplies it for every graph call; keeping the field
+    #: optional preserves the frozen request shape for existing arm-level
+    #: tests and callers that exercise the transport in isolation.
+    authorization_scope: GraphAuthorizationScope | None = None
+
+    def __post_init__(self) -> None:
+        scope = self.authorization_scope
+        if scope is None:
+            return
+        if scope.organization_id != self.org_id:
+            raise ValueError(
+                "Graph authorization scope organization does not match request"
+            )
+        if scope.cohort_discovery_family is not self.cohort_discovery_family:
+            raise ValueError("Graph authorization scope family does not match request")
+        if scope.authorized_entity_ids != self.authorized_entity_ids:
+            raise ValueError(
+                "Graph authorization scope IDs do not match request authorization"
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -111,6 +111,9 @@ from .contracts_v2.subject import DevEntityRefV2
 from .evidence_service import EvidenceService
 from .graph_evidence_admission import extract_evidence_candidates
 from .graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphAuthorizationResolver,
+    GraphAuthorizationScope,
     GraphInvestigationQuery,
     GraphInvestigationRequest,
     GraphQueryOutcome,
@@ -1194,6 +1197,7 @@ class DevOrchestrator:
         evidence_service: EvidenceService | None = None,
         canonical_enrichment: CanonicalEnrichmentAccessor | None = None,
         graph_routing_entitlement: GraphRoutingEntitlementAuthorizer | None = None,
+        graph_authorization_resolver: GraphAuthorizationResolver | None = None,
     ) -> None:
         self._provider = provider
         self._provider_source = provider_source
@@ -1272,6 +1276,11 @@ class DevOrchestrator:
         # compatibility path; production composition never leaves it unset
         # when the graph collaborators are present.
         self._graph_routing_entitlement = graph_routing_entitlement
+        # The graph route may only receive a complete, server-owned candidate
+        # envelope derived from the canonical tenant catalog.  ``None`` is a
+        # fail-closed compatibility state for direct callers that have not
+        # supplied this production composition seam.
+        self._graph_authorization_resolver = graph_authorization_resolver
         self._composer = PromptComposer(registry)
 
     async def _graph_route_is_entitled(self, *, org_id: str) -> bool:
@@ -1291,6 +1300,51 @@ class DevOrchestrator:
             # entered.
             return False
         return True
+
+    async def _graph_authorization_scope(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        cohort_discovery_family: CohortDiscoveryFamily,
+        authorized_scope: DevScope,
+    ) -> GraphAuthorizationScope | None:
+        """Resolve a complete server-owned graph candidate envelope.
+
+        A missing resolver, catalog failure, incomplete page, empty roster, or
+        mismatched envelope returns no graph candidate set. The caller
+        terminalizes that state rather than allowing an otherwise eligible
+        subjectless cohort question to fall through to unrestricted legacy
+        execution. Graph data is never consulted to fill a missing
+        authorization set.
+        """
+
+        resolver = self._graph_authorization_resolver
+        if resolver is None:
+            return None
+        try:
+            scope = await resolver(
+                org_id,
+                permission_fingerprint,
+                cohort_discovery_family,
+                authorized_scope,
+            )
+        except Exception:
+            logger.warning(
+                "ask_dev.orchestrator.graph_authorization_unavailable",
+                extra={"reason": "resolver_failure"},
+            )
+            return None
+        if scope is None or not scope.complete or not scope.authorized_entity_ids:
+            return None
+        if (
+            scope.organization_id != org_id
+            or scope.permission_fingerprint != permission_fingerprint
+            or scope.cohort_discovery_family is not cohort_discovery_family
+            or scope.scope != authorized_scope
+        ):
+            return None
+        return scope
 
     async def run(
         self,
@@ -3122,7 +3176,8 @@ class DevOrchestrator:
             # never called at all, exactly like any other gate failure --
             # never a guess passed across the wire.
             cohort_discovery_family = classify_cohort_discovery_family(request.question)
-            if (
+            graph_authorization_scope: GraphAuthorizationScope | None = None
+            graph_route_eligible = (
                 preflight_result is not None
                 and preflight_result.interpretation.intent.intent_id
                 is QuestionIntentID.DISCOVERED_COHORT
@@ -3130,8 +3185,35 @@ class DevOrchestrator:
                 and self._graph_investigation_query is not None
                 and self._evidence_service is not None
                 and graph_routing_runtime_enabled()
-                and await self._graph_route_is_entitled(org_id=org_id)
+            )
+            if graph_route_eligible and await self._graph_route_is_entitled(
+                org_id=org_id
             ):
+                assert cohort_discovery_family is not None
+                graph_authorization_scope = await self._graph_authorization_scope(
+                    org_id=org_id,
+                    permission_fingerprint=permission_fingerprint,
+                    cohort_discovery_family=cohort_discovery_family,
+                    authorized_scope=authorized_scope,
+                )
+                if graph_authorization_scope is None:
+                    # An entitled graph route without a complete server-owned
+                    # candidate envelope has no safe universe to traverse.
+                    # Do not let it fall through to the unrestricted legacy
+                    # model/tool loop for a subjectless cohort question.
+                    return await finish(
+                        RunState.INSUFFICIENT_EVIDENCE,
+                        error=error(
+                            "source_unavailable",
+                            "The authorized graph scope is unavailable.",
+                            retryable=True,
+                        ),
+                    )
+
+            if graph_authorization_scope is not None:
+                assert preflight_result is not None
+                assert cohort_discovery_family is not None
+                assert self._graph_investigation_query is not None
                 graph_deadline = datetime.now(UTC) + timedelta(
                     seconds=max(0.0, remaining())
                 )
@@ -3142,17 +3224,13 @@ class DevOrchestrator:
                     cardinality=preflight_result.interpretation.intent.cardinality,
                     mentions=preflight_result.interpretation.mentions,
                     question_text=request.question,
-                    # CHAOS-3502 known limitation, not silently assumed: no
-                    # code anywhere in this codebase yet derives "every
-                    # entity this principal may see in this org" --
-                    # graph_arm.readback.derive_authorized_entity_ids raises
-                    # AuthorizationDerivationNotImplementedError for the
-                    # identical reason. Empty is the SAFE default here (the
-                    # graph route refuses everything rather than
-                    # over-authorizing), not yet a USEFUL one -- real
-                    # derivation is separate, explicit follow-up work, not
-                    # guessed at in this seam.
-                    authorized_entity_ids=frozenset(),
+                    # CHAOS-3670: the complete candidate universe is derived
+                    # by the production composition root from the canonical,
+                    # tenant-filtered scope catalog. Graph membership never
+                    # supplies or widens this set.
+                    authorized_entity_ids=(
+                        graph_authorization_scope.authorized_entity_ids
+                    ),
                     # CHAOS-3678: the SAME scope every other tool/metric
                     # execution for this run is bounded by -- see
                     # ``StepContext(scope=authorized_scope, ...)`` above.
@@ -3166,6 +3244,7 @@ class DevOrchestrator:
                     # never enters this block when classification failed.
                     cohort_discovery_family=cohort_discovery_family,
                     deadline=graph_deadline,
+                    authorization_scope=graph_authorization_scope,
                 )
                 graph_result = await self._graph_investigation_query.investigate(
                     graph_request

--- a/src/dev_health_ops/api/dev/production_runtime.py
+++ b/src/dev_health_ops/api/dev/production_runtime.py
@@ -93,6 +93,8 @@ from .contracts import (
     DevStatusFact,
     DevToolRequest,
     DevToolResult,
+    DirectScope,
+    EntityType,
     FreshnessState,
     ToolID,
 )
@@ -110,7 +112,11 @@ from .evidence_service import (
     EvidenceReferenceSigner,
     EvidenceService,
 )
-from .graph_investigation_query import GraphInvestigationQuery
+from .graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphAuthorizationScope,
+    GraphInvestigationQuery,
+)
 from .graph_routing_policy import CanonicalGraphRoutingEntitlementAuthorizer
 from .investigation_plans import PlanExecutor
 from .investigation_plans.plan_documents import CORE_PLANS_BY_INTENT
@@ -135,6 +141,7 @@ from .question_interpreter import QuestionInterpreter
 from .runtime import BoundedDevRuntime, DevRuntimeUnavailable
 from .scope_catalog import ClickHouseAuthorizedEntityCatalog
 from .scope_service import (
+    MAX_CANDIDATES,
     MODEL_SEARCHABLE_ENTITY_KINDS,
     EntityKind,
     ScopeRequestCache,
@@ -1626,6 +1633,143 @@ async def _assemble_production_runtime(
     scope_service = ScopeResolutionService(
         ClickHouseAuthorizedEntityCatalog(clickhouse), cache=ScopeRequestCache()
     )
+
+    async def resolve_graph_authorization(
+        requested_org_id: str,
+        requested_permission_fingerprint: str,
+        family: CohortDiscoveryFamily,
+        authorized_scope: DevScope,
+    ) -> GraphAuthorizationScope | None:
+        """Derive the bounded graph candidate universe from the canonical catalog.
+
+        The graph arm receives only a complete page from the same
+        tenant-filtered catalog used by native Ask Dev scope resolution.  A
+        catalog outage, empty roster, or roster larger than the bound is an
+        explicit incomplete envelope and therefore falls back to the legacy
+        path; no graph membership or model text is consulted.
+        """
+
+        if (
+            requested_org_id != org_id
+            or requested_permission_fingerprint != permission_fingerprint
+        ):
+            return None
+
+        def requested_candidate_ids() -> frozenset[str] | None:
+            """Map the committed request scope to a catalog entity set.
+
+            Team-to-repository/project expansion is deliberately unavailable
+            here: the canonical catalog does not grant that relationship, so
+            a narrower scope that cannot be represented by the graph family
+            fails closed instead of widening to the organization roster.
+            An empty set means the committed scope is organization-wide and
+            therefore selects the complete catalog page.
+            """
+
+            if authorized_scope.organization_id != requested_org_id:
+                return None
+
+            expected_type = (
+                EntityType.TEAM
+                if family is CohortDiscoveryFamily.TEAM_PRESSURE
+                else EntityType.PROJECT
+            )
+            if authorized_scope.surface_context is not None and any(
+                ref.entity_type is not expected_type
+                for ref in authorized_scope.surface_context.entity_refs
+            ):
+                return None
+            if any(
+                ref.entity_type is not expected_type
+                for ref in authorized_scope.entity_refs
+            ):
+                return None
+
+            requested = {
+                ref.entity_id
+                for ref in authorized_scope.entity_refs
+                if ref.entity_type is expected_type
+            }
+            if authorized_scope.team_ids:
+                if family is not CohortDiscoveryFamily.TEAM_PRESSURE:
+                    return None
+                requested.update(authorized_scope.team_ids)
+
+            if family is CohortDiscoveryFamily.TEAM_PRESSURE:
+                if authorized_scope.direct_scope not in {
+                    DirectScope.ORGANIZATION,
+                    DirectScope.TEAM,
+                }:
+                    return None
+            elif authorized_scope.direct_scope not in {
+                DirectScope.ORGANIZATION,
+                DirectScope.PROJECT,
+            }:
+                return None
+
+            return frozenset(requested)
+
+        requested_ids = requested_candidate_ids()
+        if requested_ids is None:
+            return GraphAuthorizationScope(
+                organization_id=requested_org_id,
+                permission_fingerprint=requested_permission_fingerprint,
+                scope=authorized_scope,
+                cohort_discovery_family=family,
+                authorized_entity_ids=frozenset(),
+                complete=False,
+            )
+        if family is CohortDiscoveryFamily.TEAM_PRESSURE:
+            (
+                entities,
+                total,
+                catalog_available,
+            ) = await scope_service.organization_committed_teams(
+                requested_org_id,
+                requested_permission_fingerprint,
+                limit=MAX_CANDIDATES,
+            )
+        elif family is CohortDiscoveryFamily.PROJECT_CAPACITY:
+            (
+                entities,
+                total,
+                catalog_available,
+            ) = await scope_service.organization_committed_projects(
+                requested_org_id,
+                requested_permission_fingerprint,
+                limit=MAX_CANDIDATES,
+            )
+        else:
+            return None
+
+        if requested_ids:
+            entities = [
+                entity for entity in entities if entity.canonical_id in requested_ids
+            ]
+
+        ids = frozenset(entity.canonical_id for entity in entities)
+        complete = (
+            catalog_available
+            and total > 0
+            and total <= MAX_CANDIDATES
+            and (
+                (not requested_ids and len(entities) == total and len(ids) == total)
+                or (
+                    bool(requested_ids)
+                    and len(entities) == len(requested_ids)
+                    and ids == requested_ids
+                )
+            )
+        )
+        return GraphAuthorizationScope(
+            organization_id=requested_org_id,
+            permission_fingerprint=requested_permission_fingerprint,
+            scope=authorized_scope,
+            cohort_discovery_family=family,
+            authorized_entity_ids=ids,
+            complete=complete,
+        )
+
     metric_service = MetricQueryService(ClickHouseMetricSource(clickhouse))
     # CHAOS-3297 stack #3: kept as a NAMED reference (not inlined into
     # StatusChangeService's constructor call the way it was before this
@@ -2684,6 +2828,9 @@ async def _assemble_production_runtime(
         evidence_service=evidence_service if wave_3_1_enabled else None,
         canonical_enrichment=canonical_enrichment,
         graph_routing_entitlement=graph_routing_entitlement,
+        graph_authorization_resolver=(
+            resolve_graph_authorization if wave_3_1_enabled else None
+        ),
     )
 
 

--- a/src/dev_health_ops/api/dev/runtime.py
+++ b/src/dev_health_ops/api/dev/runtime.py
@@ -15,7 +15,10 @@ from .contracts import DevContractVersions, DevMessageRequest
 from .contracts_v2.base import QuestionIntentID
 from .contracts_v2.plan import DevInvestigationPlan
 from .evidence_service import EvidenceService
-from .graph_investigation_query import GraphInvestigationQuery
+from .graph_investigation_query import (
+    GraphAuthorizationResolver,
+    GraphInvestigationQuery,
+)
 from .graph_routing_policy import GraphRoutingEntitlementAuthorizer
 from .investigation_plans import PlanExecutor
 from .investigation_shadow import InvestigationPacketProducer, InvestigationShadow
@@ -96,6 +99,9 @@ class BoundedDevRuntime:
     #: are constructed; the orchestrator checks it immediately before route
     #: entry, leaving the runtime kill switch independent.
     graph_routing_entitlement: GraphRoutingEntitlementAuthorizer | None = None
+    #: Complete server-owned graph candidate envelope resolver. ``None`` is
+    #: fail-closed for direct callers and for organizations outside Wave 3.1.
+    graph_authorization_resolver: GraphAuthorizationResolver | None = None
 
     async def run(
         self,
@@ -131,6 +137,7 @@ class BoundedDevRuntime:
             evidence_service=self.evidence_service,
             canonical_enrichment=self.canonical_enrichment,
             graph_routing_entitlement=self.graph_routing_entitlement,
+            graph_authorization_resolver=self.graph_authorization_resolver,
         )
         return await orchestrator.run(
             request=request,

--- a/src/dev_health_ops/api/dev/scope_catalog.py
+++ b/src/dev_health_ops/api/dev/scope_catalog.py
@@ -75,6 +75,18 @@ _ORGANIZATION_PROJECT_ENTITIES_SQL = """
     LIMIT {limit:UInt32}
 """
 
+#: Bounded, deterministic organization team roster for graph candidate
+#: derivation.  This is intentionally a separate query from substring
+#: search: the graph route needs the complete tenant-filtered candidate
+#: universe (or an explicit incomplete result), not model-supplied labels.
+_ORGANIZATION_TEAM_ENTITIES_SQL = """
+    SELECT id AS canonical_id, name AS label, count() OVER () AS total_authorized
+    FROM teams FINAL
+    WHERE org_id = {org_id:String} AND is_active = 1
+    ORDER BY lowerUTF8(name), canonical_id
+    LIMIT {limit:UInt32}
+"""
+
 
 def _entity_sort_key(entity: AuthorizedEntity) -> tuple[str, str, str]:
     return (entity.label.casefold(), entity.kind.value, entity.canonical_id)
@@ -349,6 +361,30 @@ class ClickHouseAuthorizedEntityCatalog:
         entities = [
             AuthorizedEntity(
                 kind=EntityKind.PROJECT,
+                canonical_id=str(row["canonical_id"]),
+                label=str(row["label"]),
+            )
+            for row in rows
+            if row.get("canonical_id")
+        ]
+        total = int(rows[0]["total_authorized"])
+        return entities, total
+
+    async def organization_team_entities(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[AuthorizedEntity], int]:
+        """Return a bounded, tenant-filtered team page and true total."""
+
+        rows = await query_dicts(
+            self._client,
+            _ORGANIZATION_TEAM_ENTITIES_SQL,
+            {"org_id": org_id, "limit": limit},
+        )
+        if not rows:
+            return [], 0
+        entities = [
+            AuthorizedEntity(
+                kind=EntityKind.TEAM,
                 canonical_id=str(row["canonical_id"]),
                 label=str(row["label"]),
             )

--- a/src/dev_health_ops/api/dev/scope_service.py
+++ b/src/dev_health_ops/api/dev/scope_service.py
@@ -458,6 +458,17 @@ class AuthorizedEntityCatalog(Protocol):
         """
         ...
 
+    async def organization_team_entities(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[AuthorizedEntity], int]:
+        """Return up to ``limit`` authorized teams and the true total.
+
+        The graph candidate resolver uses this tenant-filtered roster for
+        team-pressure questions.  The true total lets that resolver reject a
+        truncated page rather than widening or silently sampling authority.
+        """
+        ...
+
 
 class ScopeRequestCache:
     """Small request-local LRU; never share this object across requests."""
@@ -1541,6 +1552,41 @@ class ScopeResolutionService:
                 entities, total = cached
                 return entities, total, True
             entities, total = await self._catalog.organization_project_entities(
+                org_id, limit=limit
+            )
+            self._cache.put(cache_key, (entities, total))
+            return entities, total, True
+        except Exception:
+            return [], 0, False
+
+    async def organization_committed_teams(
+        self,
+        org_id: str,
+        permission_fingerprint: str,
+        *,
+        limit: int,
+    ) -> tuple[list[AuthorizedEntity], int, bool]:
+        """Return the complete bounded team universe for graph routing.
+
+        A graph cohort must not receive a partial organization roster as if it
+        were complete.  This mirrors the project enumeration cache and keeps
+        catalog failures distinct from an authoritative empty roster.
+        """
+
+        try:
+            watermark = await self._catalog.watermark(org_id, (EntityKind.TEAM,))
+            cache_key = self._cache_key(
+                "organization_graph_teams",
+                org_id,
+                permission_fingerprint,
+                {"limit": limit},
+                watermark,
+            )
+            cached = self._cache.get(cache_key)
+            if isinstance(cached, tuple) and len(cached) == 2:
+                entities, total = cached
+                return entities, total, True
+            entities, total = await self._catalog.organization_team_entities(
                 org_id, limit=limit
             )
             self._cache.put(cache_key, (entities, total))

--- a/src/dev_health_ops/api/dev/terminal_frames.py
+++ b/src/dev_health_ops/api/dev/terminal_frames.py
@@ -191,6 +191,7 @@ ORCHESTRATOR_ERROR_CODES = frozenset(
         "scope_ambiguous",
         "scope_forbidden",
         "scope_not_found",
+        "source_unavailable",
         "tool_limit_reached",
         "tool_unavailable",
         # CHAOS-3541
@@ -211,6 +212,7 @@ PUBLIC_OUTCOME_BY_ERROR_CODE: Mapping[str, PublicOutcome] = {
     "tool_unavailable": PublicOutcome.TEMPORARILY_UNAVAILABLE,
     "provider_unavailable": PublicOutcome.TEMPORARILY_UNAVAILABLE,
     "provider_not_configured": PublicOutcome.TEMPORARILY_UNAVAILABLE,
+    "source_unavailable": PublicOutcome.TEMPORARILY_UNAVAILABLE,
     "rate_limited": PublicOutcome.TEMPORARILY_UNAVAILABLE,
     "feature_not_enabled": PublicOutcome.UNSUPPORTED,
     "model_not_supported": PublicOutcome.UNSUPPORTED,

--- a/tests/_chaos_3292_preflight.py
+++ b/tests/_chaos_3292_preflight.py
@@ -43,6 +43,10 @@ from dev_health_ops.api.dev.evidence_service import (
     EvidenceRecord,
     EvidenceReferenceSigner,
 )
+from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphAuthorizationScope,
+)
 from dev_health_ops.api.dev.orchestrator import DevOrchestrator, OrchestratorResult
 from dev_health_ops.api.dev.orchestrator_states import RunState
 from dev_health_ops.api.dev.question_interpreter import QuestionInterpreter
@@ -254,6 +258,21 @@ class SeededCatalog:
             entity
             for owner, entity in self.entities
             if owner == org_id and entity.kind is EntityKind.PROJECT
+        ]
+        matched.sort(key=_label_sort_key)
+        return matched[:limit], len(matched)
+
+    async def organization_team_entities(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[AuthorizedEntity], int]:
+        """Mirror the production tenant-filtered team roster."""
+
+        if self.fail_search:
+            raise RuntimeError("catalog unavailable")
+        matched = [
+            entity
+            for owner, entity in self.entities
+            if owner == org_id and entity.kind is EntityKind.TEAM
         ]
         matched.sort(key=_label_sort_key)
         return matched[:limit], len(matched)
@@ -769,6 +788,7 @@ async def run_preflight_orchestrator(
     evidence_service: Any = None,
     canonical_enrichment: Any = None,
     graph_routing_entitlement: Any = None,
+    graph_authorization_resolver: Any = None,
 ) -> RunOutput:
     """One full orchestrator run with the preflight wired the way production wires it.
 
@@ -807,8 +827,54 @@ async def run_preflight_orchestrator(
     it was before that assembler existed.
     """
 
-    catalog = SeededCatalog(entities, fail_search=fail_search)
+    seeded_entities = list(entities)
+    if graph_investigation_query is not None and not any(
+        owner == org_id and entity.kind is EntityKind.TEAM
+        for owner, entity in seeded_entities
+    ):
+        # Subjectless graph tests still need an explicit authorized universe.
+        # This is a fixture-only roster row, not an authorization fallback in
+        # production; the production resolver reads the tenant catalog.
+        seeded_entities.append((org_id, PLATFORM_TEAM))
+    catalog = SeededCatalog(seeded_entities, fail_search=fail_search)
     scope_service = ScopeResolutionService(catalog, cache=ScopeRequestCache())
+    if graph_authorization_resolver is None and graph_investigation_query is not None:
+
+        async def seeded_graph_authorization(
+            requested_org_id: str,
+            requested_permission_fingerprint: str,
+            family: CohortDiscoveryFamily,
+            authorized_scope: DevScope,
+        ) -> GraphAuthorizationScope | None:
+            if family is CohortDiscoveryFamily.TEAM_PRESSURE:
+                selected, total = await catalog.organization_team_entities(
+                    requested_org_id, limit=25
+                )
+            else:
+                selected, total = await catalog.organization_project_entities(
+                    requested_org_id, limit=25
+                )
+            requested_ids = set(authorized_scope.team_ids)
+            if requested_ids and family is CohortDiscoveryFamily.TEAM_PRESSURE:
+                selected = [
+                    entity
+                    for entity in selected
+                    if entity.canonical_id in requested_ids
+                ]
+            ids = frozenset(entity.canonical_id for entity in selected)
+            complete = bool(ids) and len(selected) == total <= 25
+            if requested_ids and family is CohortDiscoveryFamily.TEAM_PRESSURE:
+                complete = ids == requested_ids
+            return GraphAuthorizationScope(
+                organization_id=requested_org_id,
+                permission_fingerprint=requested_permission_fingerprint,
+                scope=authorized_scope,
+                cohort_discovery_family=family,
+                authorized_entity_ids=ids,
+                complete=complete,
+            )
+
+        graph_authorization_resolver = seeded_graph_authorization
     mint = sequential_ids()
     preflight = (
         SubjectPreflight(
@@ -856,6 +922,7 @@ async def run_preflight_orchestrator(
         evidence_service=evidence_service,
         canonical_enrichment=canonical_enrichment,
         graph_routing_entitlement=graph_routing_entitlement,
+        graph_authorization_resolver=graph_authorization_resolver,
     )
     result = await orchestrator.run(
         request=request,

--- a/tests/api/dev/test_chaos_3502_graph_routing_branch.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_branch.py
@@ -276,6 +276,38 @@ async def test_the_request_carries_the_classified_cohort_discovery_family(
 
 
 @pytest.mark.asyncio
+async def test_missing_server_owned_graph_scope_never_enters_graph_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent/incomplete canonical candidate envelope fails closed."""
+
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    fake = FakeGraphInvestigationQuery(outcome=GraphQueryOutcome.COMPLETED)
+
+    async def no_scope(*_values: object) -> None:
+        return None
+
+    output = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos3670-no-scope",
+        graph_investigation_query=fake,
+        evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
+        graph_authorization_resolver=no_scope,
+    )
+
+    assert fake.received_requests == []
+    assert output.calls == []
+    assert output.provider is not None
+    assert output.provider.tool_ids == []
+    assert output.result.state is RunState.INSUFFICIENT_EVIDENCE
+    assert output.result.error is not None
+    assert output.result.error.code == "source_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_an_unclassifiable_cohort_question_never_calls_the_seam(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/api/dev/test_chaos_3697_graph_route_production_wiring.py
+++ b/tests/api/dev/test_chaos_3697_graph_route_production_wiring.py
@@ -23,6 +23,10 @@ from dev_health_ops.api.dev import production_runtime
 from dev_health_ops.api.dev import runtime as runtime_module
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import DevMessageRequest
+from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphAuthorizationScope,
+)
 from dev_health_ops.api.dev.graph_routing_policy import (
     CanonicalGraphRoutingEntitlementAuthorizer,
     GraphRoutingPolicyDeniedError,
@@ -279,7 +283,7 @@ async def _capture_orchestrator_construction(
     return captured
 
 
-#: The 18 keyword arguments runtime.py's DevOrchestrator(...) call site
+#: The 19 keyword arguments runtime.py's DevOrchestrator(...) call site
 #: passes. Used by the positive control below to prove the capturing harness
 #: genuinely observed the real construction seam.
 _KWARGS_RUNTIME_PY_ACTUALLY_PASSES = frozenset(
@@ -302,6 +306,7 @@ _KWARGS_RUNTIME_PY_ACTUALLY_PASSES = frozenset(
         "evidence_service",
         "canonical_enrichment",
         "graph_routing_entitlement",
+        "graph_authorization_resolver",
     }
 )
 
@@ -321,7 +326,7 @@ async def test_the_capturing_harness_genuinely_observes_a_real_construction(
     construction.
 
     This test asserts the harness actually captured a construction: the
-    exact 18 keyword names ``runtime.py`` passes, populated
+    exact 19 keyword names ``runtime.py`` passes, populated
     with real values (not just present-but-empty) -- ``registry`` is a
     genuine ``AskDevToolRegistry``, and ``provider`` is the exact
     ``_FakeProvider`` instance this test's own stub handed to
@@ -411,6 +416,11 @@ async def test_production_runtime_wires_the_graph_route_collaborators(
         captured["graph_routing_entitlement"]
         is bounded_runtime.graph_routing_entitlement
     )
+    assert captured["graph_authorization_resolver"] is not None
+    assert (
+        captured["graph_authorization_resolver"]
+        is bounded_runtime.graph_authorization_resolver
+    )
 
 
 @pytest.mark.asyncio
@@ -429,6 +439,7 @@ async def test_production_runtime_keeps_graph_collaborators_off_for_policy_off_o
     assert captured["evidence_service"] is None
     assert captured["canonical_enrichment"] is None
     assert captured["graph_routing_entitlement"] is None
+    assert captured["graph_authorization_resolver"] is None
 
 
 def test_graph_routing_runtime_flag_defaults_off_in_a_production_shaped_environment(
@@ -488,6 +499,25 @@ async def test_production_route_checks_persisted_graph_entitlement_before_query(
             )
 
         bounded_runtime = await _build_persisted_runtime(monkeypatch, session, org_id)
+
+        async def route_probe_scope(
+            requested_org_id: str,
+            requested_permission_fingerprint: str,
+            family: CohortDiscoveryFamily,
+            authorized_scope: Any,
+        ) -> GraphAuthorizationScope:
+            # This test isolates the persisted entitlement gate. The separate
+            # production-composition regression owns canonical ClickHouse
+            # candidate derivation; this route probe has no graph catalog.
+            return GraphAuthorizationScope(
+                organization_id=requested_org_id,
+                permission_fingerprint=requested_permission_fingerprint,
+                scope=authorized_scope,
+                cohort_discovery_family=family,
+                authorized_entity_ids=frozenset({"team-probe"}),
+            )
+
+        bounded_runtime.graph_authorization_resolver = route_probe_scope
         if not authorizer_wired:
             bounded_runtime.graph_routing_entitlement = None
         graph_probe = _GraphQueryProbe(bounded_runtime.graph_investigation_query)

--- a/tests/api/dev/test_production_runtime.py
+++ b/tests/api/dev/test_production_runtime.py
@@ -11,6 +11,11 @@ import pytest
 from dev_health_ops.api.dev import platform_auto_certification, production_runtime
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
 from dev_health_ops.api.dev.contracts import DevScope, DevToolRequest, ToolID
+from dev_health_ops.api.dev.graph_investigation_query import (
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+    GraphQueryResult,
+)
 from dev_health_ops.api.dev.platform_auto_certification import (
     PlatformAutoCertifier,
 )
@@ -20,6 +25,10 @@ from dev_health_ops.api.dev.tool_registry import (
     TOOL_CONTRACT_VERSION,
     ToolExecutionContext,
 )
+from dev_health_ops.context_fabric.graph_arm.query_service import (
+    ProductionGraphInvestigationQuery,
+)
+from dev_health_ops.licensing import FeatureDecision, FeatureDecisionReason
 from dev_health_ops.llm.agent.budget_policy import BUDGET_POLICY_VERSION
 from dev_health_ops.llm.agent.openai_compatible import READINESS_VERSION
 from dev_health_ops.llm.agent.policy import AgentProviderCandidate, AgentProviderSource
@@ -44,6 +53,20 @@ class FakeProvider:
 
     async def aclose(self) -> None:
         self.closed = True
+
+
+class RecordingGraphQuery:
+    """Observe the production orchestrator's bounded graph-query request."""
+
+    def __init__(self) -> None:
+        self.requests: list[GraphInvestigationRequest] = []
+
+    async def investigate(self, request: GraphInvestigationRequest) -> GraphQueryResult:
+        self.requests.append(request)
+        return GraphQueryResult(
+            outcome=GraphQueryOutcome.DISABLED,
+            diagnostic="test observation boundary",
+        )
 
 
 class FakeSettingsService:
@@ -1944,3 +1967,117 @@ async def test_the_runtime_carries_platform_staleness_to_the_router(
     )
 
     assert runtime.platform_certification_stale is True
+
+
+@pytest.mark.asyncio
+async def test_production_composition_supplies_canonical_graph_authorization_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3670 regression: graph routing must receive canonical candidates.
+
+    This keeps the real production composition and the real orchestrator
+    preflight path, replacing only the bounded graph-query implementation with
+    a recorder so the request supplied at that stable seam is observable.
+    The catalog rows below model the tenant-filtered canonical team roster; the
+    graph is not involved in deriving or authorizing them.
+    """
+
+    from tests._chaos_3292_preflight import (
+        PLATFORM_TEAM,
+        AuthorizedEntity,
+        EntityKind,
+        run_preflight_orchestrator,
+    )
+
+    org_id = "00000000-0000-0000-0000-000000000001"
+    other_team = AuthorizedEntity(EntityKind.TEAM, "team-other", "Other")
+
+    async def resolve_provider(_session, *, org_id: str):
+        assert org_id == "00000000-0000-0000-0000-000000000001"
+        return ProductionProviderResolution(
+            provider=cast(Any, FakeProvider()),
+            source=AgentProviderSource.PLATFORM,
+            family="openai",
+            model="certified-model",
+            provider_label="OpenAI compatible",
+            model_label="certified-model",
+        )
+
+    async def allow_feature(
+        _session: object, _org_uuid: object, feature_key: str
+    ) -> FeatureDecision:
+        return FeatureDecision(
+            feature_key,
+            True,
+            FeatureDecisionReason.ENABLED_BY_ORG_OVERRIDE,
+        )
+
+    async def canonical_catalog_query(
+        _client: object, sql: str, _params: dict[str, object]
+    ) -> list[dict[str, object]]:
+        if "FROM teams" not in sql:
+            return []
+        if "maxOrNull" in sql:
+            return [{"watermark": "2026-08-10T00:00:00+00:00"}]
+        return [
+            {
+                "canonical_id": PLATFORM_TEAM.canonical_id,
+                "label": PLATFORM_TEAM.label,
+                "repository_id": None,
+                "total_authorized": 1,
+            },
+            {
+                "canonical_id": other_team.canonical_id,
+                "label": other_team.label,
+                "repository_id": None,
+                "total_authorized": 2,
+            },
+        ]
+
+    monkeypatch.setattr(
+        production_runtime, "resolve_production_provider", resolve_provider
+    )
+    monkeypatch.setattr(production_runtime, "evaluate_org_feature_async", allow_feature)
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.graph_routing_policy.evaluate_org_feature_async",
+        allow_feature,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", canonical_catalog_query
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-evidence-signing-secret-32-bytes")
+    monkeypatch.setenv("ASK_DEV_GRAPH_ROUTING_ENABLED", "1")
+
+    runtime = await production_runtime.build_production_runtime(
+        cast(Any, object()),
+        org_id=org_id,
+        permission_fingerprint="permissions_01",
+        clickhouse=cast(Any, object()),
+    )
+    try:
+        assert isinstance(
+            runtime.graph_investigation_query, ProductionGraphInvestigationQuery
+        )
+        recorder = RecordingGraphQuery()
+        runtime.graph_investigation_query = recorder
+
+        output = await run_preflight_orchestrator(
+            question="Which teams are struggling right now?",
+            entities=[(org_id, PLATFORM_TEAM), (org_id, other_team)],
+            org_id=org_id,
+            script_id="chaos3670-production-composition",
+            scope_overrides={"team_ids": [PLATFORM_TEAM.canonical_id]},
+            graph_investigation_query=runtime.graph_investigation_query,
+            evidence_service=runtime.evidence_service,
+            canonical_enrichment=runtime.canonical_enrichment,
+            graph_routing_entitlement=runtime.graph_routing_entitlement,
+            graph_authorization_resolver=runtime.graph_authorization_resolver,
+        )
+
+        assert output.result.answer is not None
+        assert len(recorder.requests) == 1
+        assert recorder.requests[0].authorized_entity_ids == frozenset(
+            {PLATFORM_TEAM.canonical_id}
+        )
+    finally:
+        await runtime.aclose()

--- a/tests/api/dev/test_scope_catalog.py
+++ b/tests/api/dev/test_scope_catalog.py
@@ -359,3 +359,43 @@ async def test_organization_repository_ids_empty_org_reports_zero_total(
 
     assert ids == []
     assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_organization_team_entities_is_tenant_scoped_and_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, Any] = {}
+
+    async def fake_query_dicts(
+        _client: object, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        observed.update(sql=sql, params=params)
+        rows = [
+            {
+                "canonical_id": "team-inactive",
+                "label": "Inactive",
+                "is_active": 0,
+            },
+            {"canonical_id": "team-a", "label": "Platform", "is_active": 1},
+        ]
+        if "is_active = 1" in sql:
+            rows = [row for row in rows if row["is_active"] == 1]
+        for row in rows:
+            row["total_authorized"] = len(rows)
+        return rows
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.dev.scope_catalog.query_dicts", fake_query_dicts
+    )
+    catalog = ClickHouseAuthorizedEntityCatalog(object())
+
+    entities, total = await catalog.organization_team_entities("org-a", limit=25)
+
+    assert [entity.canonical_id for entity in entities] == ["team-a"]
+    assert entities[0].kind is EntityKind.TEAM
+    assert total == 1
+    assert observed["params"] == {"org_id": "org-a", "limit": 25}
+    assert "FROM teams FINAL" in observed["sql"]
+    assert "count() OVER ()" in observed["sql"]
+    assert "is_active = 1" in observed["sql"]

--- a/tests/api/dev/test_scope_service.py
+++ b/tests/api/dev/test_scope_service.py
@@ -70,10 +70,12 @@ class FakeCatalog:
         self.watermark_calls = 0
         self.organization_repository_ids_calls = 0
         self.organization_project_entities_calls = 0
+        self.organization_team_entities_calls = 0
         self.fail_exact = False
         self.fail_watermark = False
         self.fail_organization_repository_ids = False
         self.fail_organization_project_entities = False
+        self.fail_organization_team_entities = False
 
     async def watermark(self, org_id: str, kinds: tuple[EntityKind, ...]) -> str:
         self.watermark_calls += 1
@@ -145,6 +147,18 @@ class FakeCatalog:
             key=lambda entity: (entity.label.casefold(), entity.canonical_id),
         )
         return projects[:limit], len(projects)
+
+    async def organization_team_entities(
+        self, org_id: str, *, limit: int
+    ) -> tuple[list[AuthorizedEntity], int]:
+        self.organization_team_entities_calls += 1
+        if self.fail_organization_team_entities:
+            raise RuntimeError("organization team catalog unavailable")
+        teams = sorted(
+            (entity for entity in self.entities if entity.kind is EntityKind.TEAM),
+            key=lambda entity: (entity.label.casefold(), entity.canonical_id),
+        )
+        return teams[:limit], len(teams)
 
 
 def _entity(
@@ -1190,6 +1204,44 @@ async def test_organization_committed_projects_is_request_cached() -> None:
 
     assert first == second
     assert catalog.organization_project_entities_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_organization_committed_teams_returns_tenant_filtered_complete_page() -> (
+    None
+):
+    entities = [
+        _entity(EntityKind.TEAM, "team-z", "Zulu"),
+        _entity(EntityKind.TEAM, "team-a", "Alpha"),
+        _entity(EntityKind.PROJECT, "project-a", "Project"),
+    ]
+    catalog = FakeCatalog(entities)
+    service = ScopeResolutionService(catalog)
+
+    teams, total, catalog_available = await service.organization_committed_teams(
+        "org-a", "perm-a", limit=25
+    )
+
+    assert [entity.canonical_id for entity in teams] == ["team-a", "team-z"]
+    assert all(entity.kind is EntityKind.TEAM for entity in teams)
+    assert total == 2
+    assert catalog_available is True
+    assert catalog.organization_team_entities_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_organization_committed_teams_fails_closed_on_catalog_error() -> None:
+    catalog = FakeCatalog([_entity(EntityKind.TEAM, "team-a", "Alpha")])
+    catalog.fail_organization_team_entities = True
+    service = ScopeResolutionService(catalog)
+
+    teams, total, catalog_available = await service.organization_committed_teams(
+        "org-a", "perm-a", limit=25
+    )
+
+    assert teams == []
+    assert total == 0
+    assert catalog_available is False
 
 
 # --- CHAOS-3256: resolve named entities before executing status tools ---


### PR DESCRIPTION
Closes CHAOS-3670

## Summary
- derive graph candidate authorization from the tenant-bound canonical scope catalog
- carry and validate the active DevScope before graph routing
- fail closed on missing, incomplete, mismatched, repository, or page scope envelopes
- exclude inactive teams from the canonical candidate roster

## Verification
- focused RED to GREEN: 3 passed
- adjacent backend suite: 162 passed
- graph-arm suite: 51 passed, 2 skipped
- Ruff format/check passed
- full mypy passed across 2,427 files
- commit-hook mypy passed across 2,354 files using the owning ops virtualenv
- independent re-review: 155 passed; no remaining High/Medium production-path findings

SCREENSHOT-WAIVER: backend-only authorization and scope enforcement; no rendered UI changes.