### PR TITLE
CHAOS-3707: port GitLab files provider parity

### DIFF
--- a/ci/requirements-live-python-oracles.txt
+++ b/ci/requirements-live-python-oracles.txt
@@ -5,6 +5,7 @@ annotated-types==0.7.0
 anyio==4.13.0
 atlassian-gen-client==0.1.0b3
 certifi==2026.4.22
+colorama==0.4.6
 defusedxml==0.7.1
 gitdb==4.0.12
 GitPython==3.1.54
@@ -15,6 +16,7 @@ httpcore==1.0.9
 httpx==0.28.1
 idna==3.15
 iniconfig==2.3.0
+mando==0.7.1
 packaging==26.2
 pluggy==1.6.0
 pydantic==2.13.4
@@ -22,6 +24,8 @@ pydantic-core==2.46.4
 pygments==2.20.0
 pytest==9.0.3
 PyYAML==6.0.3
+radon==6.0.1
+six==1.17.0
 smmap==5.0.3
 SQLAlchemy==2.0.49
 typing-extensions==4.15.0

--- a/internal/providerfoundation/foundation_test.go
+++ b/internal/providerfoundation/foundation_test.go
@@ -140,6 +140,38 @@ func TestHTTPClassificationAndPaginationFixtures(t *testing.T) {
 	}
 }
 
+func TestGitLabForbiddenRateLimitQualification(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		headers http.Header
+		want    ErrorClass
+	}{
+		{
+			name:    "retry-after",
+			headers: http.Header{"Retry-After": []string{"2"}},
+			want:    ErrorRateLimited,
+		},
+		{
+			name:    "remaining-zero",
+			headers: http.Header{"RateLimit-Remaining": []string{"0"}},
+			want:    ErrorRateLimited,
+		},
+		{
+			name:    "plain-forbidden",
+			headers: http.Header{},
+			want:    ErrorAuthentication,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ClassifyHTTP("gitlab", http.StatusForbidden, test.headers); got == nil || got.Class != test.want {
+				t.Fatalf("classification=%v, want %s", got, test.want)
+			}
+		})
+	}
+}
+
 func TestProviderParityFixture(t *testing.T) {
 	t.Parallel()
 	content, err := os.ReadFile("testdata/provider_parity.json")

--- a/internal/providerfoundation/http.go
+++ b/internal/providerfoundation/http.go
@@ -335,8 +335,8 @@ func (c *HTTPClient) observe(class ErrorClass) {
 }
 
 // ClassifyHTTP mirrors the current Python provider taxonomy without retaining
-// response bodies or headers. GitHub's 403 rate-limit vocabulary is special;
-// all other 403s remain authentication/permission failures.
+// response bodies or headers. GitHub's and GitLab's 403 rate-limit vocabularies
+// are special; all other 403s remain authentication/permission failures.
 func ClassifyHTTP(provider string, status int, headers http.Header) *ProviderError {
 	return ClassifyHTTPWithMessage(provider, status, headers, "")
 }
@@ -344,7 +344,7 @@ func ClassifyHTTP(provider string, status int, headers http.Header) *ProviderErr
 func ClassifyHTTPWithMessage(provider string, status int, headers http.Header, message string) *ProviderError {
 	retryAfter := ParseRetryAfter(headerValue(headers, "retry-after"), time.Now())
 	message = strings.ToLower(message)
-	if provider == "github" && status == http.StatusForbidden && (headerValue(headers, "x-ratelimit-remaining") == "0" || headerValue(headers, "retry-after") != "" || strings.Contains(message, "rate limit") || strings.Contains(message, "abuse") || strings.Contains(message, "secondary")) {
+	if isRateLimitedForbidden(provider, status, headers, message) {
 		return &ProviderError{Class: ErrorRateLimited, StatusCode: status, RetryAfter: retryAfter}
 	}
 	switch status {
@@ -368,6 +368,22 @@ func ClassifyHTTPWithMessage(provider string, status int, headers http.Header, m
 	return nil
 }
 
+func isRateLimitedForbidden(provider string, status int, headers http.Header, message string) bool {
+	if status != http.StatusForbidden {
+		return false
+	}
+	if provider == "gitlab" &&
+		(hasHeader(headers, "retry-after") || headerValue(headers, "ratelimit-remaining") == "0") {
+		return true
+	}
+	return provider == "github" &&
+		(headerValue(headers, "x-ratelimit-remaining") == "0" ||
+			headerValue(headers, "retry-after") != "" ||
+			strings.Contains(message, "rate limit") ||
+			strings.Contains(message, "abuse") ||
+			strings.Contains(message, "secondary"))
+}
+
 func headerValue(headers http.Header, wanted string) string {
 	for key, values := range headers {
 		if strings.EqualFold(key, wanted) && len(values) > 0 {
@@ -375,6 +391,15 @@ func headerValue(headers http.Header, wanted string) string {
 		}
 	}
 	return ""
+}
+
+func hasHeader(headers http.Header, wanted string) bool {
+	for key := range headers {
+		if strings.EqualFold(key, wanted) {
+			return true
+		}
+	}
+	return false
 }
 
 func ParseRetryAfter(raw string, now time.Time) time.Duration {

--- a/internal/providersync/gitlab_files_effects_clickhouse.go
+++ b/internal/providersync/gitlab_files_effects_clickhouse.go
@@ -1,0 +1,188 @@
+package providersync
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitLabFilesClickHouseEffects persists gitlab/files rows to the existing
+// tenant-qualified git_files ReplacingMergeTree. The schema and readback
+// comparison intentionally match GitHub files; the provider guard remains
+// local so a GitLab effect can never be accepted under the GitHub claim.
+type GitLabFilesClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "files" || effect.Destination != "git_files" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[gitFileRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.preserveExistingContents(ctx, claim, rows); err != nil {
+		return err
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `
+INSERT INTO git_files (repo_id, path, executable, contents, last_synced, org_id)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(row.RepoID, row.Path, row.Executable, row.Contents, row.LastSynced, row.OrgID); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+// preserveExistingContents mirrors base_git.backfill_file_records: a
+// paths-only rewrite must not replace known text with NULL in the shared
+// ReplacingMergeTree. Freshly fetched content remains authoritative; only
+// missing content is hydrated from the tenant-qualified winning row.
+func (sink GitLabFilesClickHouseEffects) preserveExistingContents(
+	ctx context.Context, claim Claim, rows []gitFileRow,
+) error {
+	for index := range rows {
+		if rows[index].Contents != nil {
+			continue
+		}
+		result, err := sink.Conn.Query(ctx, `
+SELECT contents FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`,
+			claim.OrgID, rows[index].RepoID, rows[index].Path)
+		if err != nil {
+			return err
+		}
+		var existing *string
+		found := false
+		for result.Next() {
+			if err := result.Scan(&existing); err != nil {
+				result.Close()
+				return err
+			}
+			found = true
+		}
+		if err := result.Err(); err != nil {
+			result.Close()
+			return err
+		}
+		result.Close()
+		if found && existing != nil {
+			rows[index].Contents = existing
+		}
+	}
+	return nil
+}
+
+func (sink GitLabFilesClickHouseEffects) InspectEffect(ctx context.Context, claim Claim, effect EffectBatch) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "files" || effect.Destination != "git_files" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[gitFileRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectGitLabFile(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT repo_id, path, executable, contents, last_synced, org_id
+FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`, expected.OrgID, expected.RepoID, expected.Path)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual gitFileVersion
+	for rows.Next() {
+		if err := rows.Scan(
+			&actual.Row.RepoID, &actual.Row.Path, &actual.Row.Executable, &actual.Row.Contents,
+			&actual.LastSynced, &actual.Row.OrgID,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.Found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitLabFileVersion(expected, actual), nil
+}
+
+func compareGitLabFileVersion(expected gitFileRow, actual gitFileVersion) EffectInspection {
+	if !actual.Found || actual.LastSynced.IsZero() || actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) || actual.Row.RepoID != expected.RepoID ||
+		actual.Row.Path != expected.Path || actual.Row.Executable != expected.Executable ||
+		actual.Row.OrgID != expected.OrgID ||
+		(expected.Contents != nil && !stringPointersEqual(actual.Row.Contents, expected.Contents)) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitLabFilesClickHouseEffects{}
+var _ EffectReadback = GitLabFilesClickHouseEffects{}

--- a/internal/providersync/gitlab_files_effects_integration_test.go
+++ b/internal/providersync/gitlab_files_effects_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestGitLabFilesReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	claim := nativeTestClaim("gitlab", "files")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	current := gitFileRow{RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go", LastSynced: now, OrgID: claim.OrgID}
+	currentText := "package main\n"
+	current.Contents = &currentText
+	previous := current
+	previous.LastSynced = now.Add(-time.Hour)
+	previousText := "package old\n"
+	previous.Contents = &previousText
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, previous)); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil || inspection != EffectExact {
+		t.Fatalf("winning inspection=%s error=%v", inspection, err)
+	}
+	// Replaying the exact effect must converge on the same RMT winner rather
+	// than create a conflicting readback generation.
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil || inspection != EffectExact {
+		t.Fatalf("replay inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabFilesReadbackScopesSameNaturalKeyByTenant(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	claim := nativeTestClaim("gitlab", "files")
+	claim.OrgID = "org-a"
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	row := gitFileRow{RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go", LastSynced: now, OrgID: claim.OrgID}
+	textA := "package orga\n"
+	row.Contents = &textA
+	otherClaim := claim
+	otherClaim.OrgID = "org-b"
+	otherRow := row
+	otherRow.OrgID = otherClaim.OrgID
+	textB := "package orgb\n"
+	otherRow.Contents = &textB
+	if err := sink.WriteEffect(ctx, otherClaim, gitLabFileEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, row)); err != nil {
+		t.Fatal(err)
+	}
+	var count uint64
+	var minOrgID, maxOrgID, minContents, maxContents string
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT count(), min(org_id), max(org_id), min(ifNull(contents, '')), max(ifNull(contents, ''))
+FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`, row.OrgID, row.RepoID, row.Path).
+		Scan(&count, &minOrgID, &maxOrgID, &minContents, &maxContents); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || minOrgID != claim.OrgID || maxOrgID != claim.OrgID ||
+		minContents != textA || maxContents != textA {
+		t.Fatalf("tenant readback count=%d orgs=(%q,%q) contents=(%q,%q)", count, minOrgID, maxOrgID, minContents, maxContents)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, row)); err != nil || inspection != EffectExact {
+		t.Fatalf("claim inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, otherClaim, gitLabFileEffect(t, otherRow)); err != nil || inspection != EffectExact {
+		t.Fatalf("other tenant inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabFilesWritePreservesExistingContentsForPathsOnlyRewrite(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	claim := nativeTestClaim("gitlab", "files")
+	base := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	content := "package existing\n"
+	withContent := gitFileRow{
+		RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go",
+		Contents: &content, LastSynced: base, OrgID: claim.OrgID,
+	}
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, withContent)); err != nil {
+		t.Fatal(err)
+	}
+	pathsOnly := withContent
+	pathsOnly.Contents = nil
+	pathsOnly.LastSynced = base.Add(time.Hour)
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, pathsOnly)); err != nil {
+		t.Fatal(err)
+	}
+	var got *string
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT contents FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`, claim.OrgID, withContent.RepoID, withContent.Path).
+		Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || *got != content {
+		t.Fatalf("paths-only rewrite lost existing content: %#v", got)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, pathsOnly)); err != nil || inspection != EffectExact {
+		t.Fatalf("paths-only readback=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabFilesWriteRechecksLeaseBeforeClickHouseSend(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	lease := &gitLabFilesLeaseAfterFirstAssert{}
+	sink.Lease = lease
+	claim := nativeTestClaim("gitlab", "files")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	row := gitFileRow{
+		RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go",
+		LastSynced: now, OrgID: claim.OrgID,
+	}
+	text := "package main\n"
+	row.Contents = &text
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, row)); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("lease-before-send error=%v", err)
+	}
+	var count uint64
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT count() FROM git_files FINAL WHERE org_id = ? AND repo_id = ? AND path = ?`,
+		row.OrgID, row.RepoID, row.Path).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("lease-lost write landed %d rows", count)
+	}
+}
+
+type gitLabFilesLeaseAfterFirstAssert struct{ calls int }
+
+func (lease *gitLabFilesLeaseAfterFirstAssert) Assert(context.Context) error {
+	lease.calls++
+	if lease.calls > 1 {
+		return providerfoundation.ErrLeaseLost
+	}
+	return nil
+}
+
+func newGitLabFilesIntegrationSink(t *testing.T) (context.Context, GitLabFilesClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, gitFilesDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, GitLabFilesClickHouseEffects{
+		Conn:  conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+}
+
+func gitLabFileEffect(t *testing.T, row gitFileRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, []gitFileRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/gitlab_files_effects_test.go
+++ b/internal/providersync/gitlab_files_effects_test.go
@@ -1,0 +1,72 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestGitLabFilesEffectsValidateProviderAndEmptyBatches(t *testing.T) {
+	sink := GitLabFilesClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	empty := mustGitLabFileEffect(t, nil)
+	if err := sink.WriteEffect(context.Background(), claim, empty); err != nil {
+		t.Fatalf("empty write error=%v", err)
+	}
+	if inspection, err := sink.InspectEffect(context.Background(), claim, empty); err != nil || inspection != EffectAbsent {
+		t.Fatalf("empty inspect=%s error=%v", inspection, err)
+	}
+	wrongClaim := nativeTestClaim("github", "files")
+	if err := sink.WriteEffect(context.Background(), wrongClaim, empty); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong provider write error=%v", err)
+	}
+	if _, err := sink.InspectEffect(context.Background(), wrongClaim, empty); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong provider inspect error=%v", err)
+	}
+}
+
+func TestGitLabFilesEffectsAssertLeaseBeforeDecoding(t *testing.T) {
+	sink := GitLabFilesClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return errors.New("lease gone") }),
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	malformed := EffectBatch{Destination: "git_files", Rows: []json.RawMessage{{'n', 'o', 't', '-', 'j', 's', 'o', 'n'}}}
+	if err := sink.WriteEffect(context.Background(), claim, malformed); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("write lease error=%v", err)
+	}
+	if _, err := sink.InspectEffect(context.Background(), claim, malformed); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("inspect lease error=%v", err)
+	}
+}
+
+func TestGitLabFilesEffectsPathsOnlyReadbackAllowsExistingContent(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	expected := gitFileRow{
+		RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go",
+		LastSynced: now, OrgID: "org-a",
+	}
+	content := "package existing\n"
+	actual := expected
+	actual.Contents = &content
+	if got := compareGitLabFileVersion(expected, gitFileVersion{Row: actual, LastSynced: now, Found: true}); got != EffectExact {
+		t.Fatalf("paths-only readback=%s want exact", got)
+	}
+}
+
+func mustGitLabFileEffect(t *testing.T, rows []gitFileRow) EffectBatch {
+	t.Helper()
+	if rows == nil {
+		rows = []gitFileRow{}
+	}
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/gitlab_files_generic_oracle_test.go
+++ b/internal/providersync/gitlab_files_generic_oracle_test.go
@@ -1,0 +1,386 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+var oracleGitLabFilesGoOnlyFields = map[string]string{
+	"last_synced": "stamped from the Go complete-route handler after Python backfill_file_records",
+	"org_id":      "carried from the Go claim to keep ClickHouse writes tenant-scoped",
+}
+
+type gitLabHTTPClassificationOracleRow struct {
+	IsRateLimit bool `json:"is_rate_limit"`
+}
+
+func buildGitLabHTTPClassificationOracleRow(t *testing.T, input map[string]any) gitLabHTTPClassificationOracleRow {
+	t.Helper()
+	headers := http.Header{}
+	for key, value := range input["headers"].(map[string]any) {
+		headers.Set(key, value.(string))
+	}
+	classified := providerfoundation.ClassifyHTTP(
+		"gitlab", int(input["status"].(int)), headers,
+	)
+	return gitLabHTTPClassificationOracleRow{
+		IsRateLimit: classified != nil && classified.Class == providerfoundation.ErrorRateLimited,
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesHTTPClassification(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/http-classification",
+		[]oracleCase{
+			{ID: "retry_after_qualified_403", Input: map[string]any{
+				"status": 403, "headers": map[string]any{"Retry-After": "2"},
+			}},
+			{ID: "remaining_zero_qualified_403", Input: map[string]any{
+				"status": 403, "headers": map[string]any{"RateLimit-Remaining": "0"},
+			}},
+			{ID: "plain_403_is_authentication", Input: map[string]any{
+				"status": 403, "headers": map[string]any{},
+			}},
+			{ID: "remaining_nonzero_is_authentication", Input: map[string]any{
+				"status": 403, "headers": map[string]any{"RateLimit-Remaining": "42"},
+			}},
+			{ID: "429_is_primary_rate_limit", Input: map[string]any{
+				"status": 429, "headers": map[string]any{"Retry-After": "2"},
+			}},
+		},
+		buildGitLabHTTPClassificationOracleRow,
+		nil,
+	)
+}
+
+func buildGitLabFileRowForOracle(t *testing.T, input map[string]any) gitFileRow {
+	t.Helper()
+	contents := make(map[string]string)
+	if existing, ok := input["existing_contents"].(map[string]any); ok {
+		for path, value := range existing {
+			contents[path] = value.(string)
+		}
+	}
+	for path, value := range input["contents_by_path"].(map[string]any) {
+		contents[path] = value.(string)
+	}
+	return newGitLabFileRow(
+		nativeTestClaim("gitlab", "files"),
+		input["repo_id"].(string), input["path"].(string), contents,
+		time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesWorkerRows(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/row",
+		[]oracleCase{
+			{ID: "scannable_content", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "src/main.go",
+				"contents_by_path": map[string]any{"src/main.go": "package main\n"},
+			}},
+			{ID: "path_only", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "README.md",
+				"contents_by_path": map[string]any{},
+			}},
+			{ID: "empty_text_is_distinct_from_missing", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "src/empty.go",
+				"contents_by_path": map[string]any{"src/empty.go": ""},
+			}},
+			{ID: "paths_only_preserves_existing_content", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "src/main.go",
+				"existing_contents": map[string]any{"src/main.go": "package existing\n"},
+				"contents_by_path":  map[string]any{},
+			}},
+		},
+		buildGitLabFileRowForOracle,
+		oracleGitLabFilesGoOnlyFields,
+	)
+}
+
+type gitLabFilesTraceRow struct {
+	Path       string  `json:"path"`
+	Executable bool    `json:"executable"`
+	Contents   *string `json:"contents"`
+}
+
+type gitLabFilesTraversalTrace struct {
+	ProducerRequests  []string                `json:"producer_requests"`
+	UsageRequestCount int                     `json:"usage_request_count"`
+	TreePaths         []string                `json:"tree_paths"`
+	Rows              []gitLabFilesTraceRow   `json:"rows"`
+	Incomplete        []GitLabFilesIncomplete `json:"incomplete"`
+}
+
+type gitLabFilesTraceDoer struct {
+	t              *testing.T
+	requests       []*http.Request
+	treePages      [][]map[string]any
+	nextPages      []string
+	commitRows     []map[string]any
+	sizes          map[string]int
+	contents       map[string]string
+	project        string
+	contentFailure bool
+}
+
+func (doer *gitLabFilesTraceDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	status := http.StatusOK
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	var body string
+	switch {
+	case request.URL.Path == "/api/v4/projects/123":
+		body = doer.project
+	case request.URL.Path == "/api/v4/projects/123/repository/commits":
+		body = marshalJSON(doer.t, doer.commitRows)
+	case request.URL.Path == "/api/v4/projects/123/repository/tree":
+		page := queryInt(request, "page")
+		if page < 1 || page > len(doer.treePages) {
+			doer.t.Fatalf("unexpected tree page=%d", page)
+		}
+		body = marshalJSON(doer.t, doer.treePages[page-1])
+		if page <= len(doer.nextPages) && doer.nextPages[page-1] != "" {
+			headers.Set("X-Next-Page", doer.nextPages[page-1])
+		}
+	case request.URL.Path == "/api/graphql":
+		var input struct {
+			Query     string `json:"query"`
+			Variables struct {
+				Paths []string `json:"paths"`
+			} `json:"variables"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t := doer.t
+			t.Fatal(err)
+		}
+		if doer.contentFailure && strings.Contains(input.Query, "rawTextBlob") {
+			status = http.StatusInternalServerError
+			body = `{}`
+			break
+		}
+		nodes := make([]map[string]any, 0, len(input.Variables.Paths))
+		for _, filePath := range input.Variables.Paths {
+			node := map[string]any{"path": filePath}
+			if strings.Contains(input.Query, "rawSize") {
+				node["rawSize"] = doer.sizes[filePath]
+			} else if content, ok := doer.contents[filePath]; ok {
+				node["rawTextBlob"] = content
+			} else {
+				node["rawTextBlob"] = nil
+			}
+			nodes = append(nodes, node)
+		}
+		body = marshalJSON(doer.t, map[string]any{
+			"data": map[string]any{"project": map[string]any{
+				"repository": map[string]any{"blobs": map[string]any{"nodes": nodes}},
+			}},
+		})
+	default:
+		doer.t.Fatalf("unexpected GitLab files trace request %s", request.URL)
+	}
+	return &http.Response{
+		StatusCode: status, Header: headers,
+		Body: io.NopCloser(strings.NewReader(body)), Request: request,
+	}, nil
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesTraversal(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/trace",
+		[]oracleCase{{ID: "paged_tree_and_content", Input: map[string]any{
+			"repo_id":           "c7198fbc-1945-3717-05d8-eb78866b4e79",
+			"project_full_name": "Acme/API", "default_branch": "main",
+			"tree_pages": []any{
+				[]any{
+					map[string]any{"path": "README.md", "type": "blob"},
+					map[string]any{"path": "src/main.go", "type": "blob"},
+				},
+				[]any{
+					map[string]any{"path": "tests/example.go", "type": "blob"},
+					map[string]any{"path": "src/oversized.go", "type": "blob"},
+				},
+			},
+			"tree_next_pages": []any{"2"},
+			"sizes":           map[string]any{"src/main.go": 15, "src/oversized.go": 1000001},
+			"contents":        map[string]any{"src/main.go": "package main\n"},
+		}}},
+		buildGitLabFilesTraversalTrace,
+		nil,
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesContentCap(t *testing.T) {
+	const count = 2_001
+	treePages := make([]any, 0, (count+99)/100)
+	treeNextPages := make([]any, 0, (count+99)/100-1)
+	sizes := make(map[string]any, count)
+	contents := map[string]any{"src/file0000.go": "package main\n"}
+	for index := 0; index < count; index++ {
+		filePath := fmt.Sprintf("src/file%04d.go", index)
+		pageIndex := index / 100
+		if pageIndex == len(treePages) {
+			treePages = append(treePages, []any{})
+			if pageIndex > 0 {
+				treeNextPages = append(treeNextPages, fmt.Sprintf("%d", pageIndex+1))
+			}
+		}
+		page := treePages[pageIndex].([]any)
+		page = append(page, map[string]any{"path": filePath, "type": "blob"})
+		treePages[pageIndex] = page
+		sizes[filePath] = 10
+	}
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/trace",
+		[]oracleCase{{ID: "content_cap", Input: map[string]any{
+			"repo_id":           "c7198fbc-1945-3717-05d8-eb78866b4e79",
+			"project_full_name": "Acme/API", "default_branch": "main",
+			"tree_pages":      treePages,
+			"tree_next_pages": treeNextPages,
+			"sizes":           sizes,
+			"contents":        contents,
+		}}},
+		buildGitLabFilesTraversalTrace,
+		nil,
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesContentFailure(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/trace",
+		[]oracleCase{{ID: "ordinary_content_failure", Input: map[string]any{
+			"repo_id":           "c7198fbc-1945-3717-05d8-eb78866b4e79",
+			"project_full_name": "Acme/API", "default_branch": "main",
+			"tree_pages": []any{[]any{
+				map[string]any{"path": "README.md", "type": "blob"},
+				map[string]any{"path": "src/main.go", "type": "blob"},
+			}},
+			"tree_next_pages": []any{},
+			"sizes":           map[string]any{"src/main.go": 10},
+			"contents":        map[string]any{"src/main.go": "package main\n"},
+			"content_failure": true,
+		}}},
+		buildGitLabFilesTraversalTrace,
+		nil,
+	)
+}
+
+func buildGitLabFilesTraversalTrace(t *testing.T, input map[string]any) gitLabFilesTraversalTrace {
+	t.Helper()
+	treePages := make([][]map[string]any, 0)
+	for _, rawPage := range input["tree_pages"].([]any) {
+		page := make([]map[string]any, 0)
+		for _, rawItem := range rawPage.([]any) {
+			page = append(page, rawItem.(map[string]any))
+		}
+		treePages = append(treePages, page)
+	}
+	nextPages := make([]string, 0)
+	for _, value := range input["tree_next_pages"].([]any) {
+		nextPages = append(nextPages, value.(string))
+	}
+	sizes := make(map[string]int)
+	for path, value := range input["sizes"].(map[string]any) {
+		sizes[path] = int(value.(int))
+	}
+	contents := make(map[string]string)
+	for path, value := range input["contents"].(map[string]any) {
+		contents[path] = value.(string)
+	}
+	doer := &gitLabFilesTraceDoer{
+		t: t, project: gitLabRepositoryFixture, treePages: treePages,
+		nextPages: nextPages, sizes: sizes, contents: contents,
+		contentFailure: input["content_failure"] == true,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.test"), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) < 1 || batch.Evidence.Requests != len(doer.requests) {
+		t.Fatalf("physical evidence=%+v requests=%d", batch.Evidence, len(doer.requests))
+	}
+	trace := gitLabFilesTraversalTrace{
+		ProducerRequests:  make([]string, 0, len(doer.requests)-1),
+		UsageRequestCount: batch.Evidence.Requests - 1,
+		TreePaths:         make([]string, 0),
+		Rows:              make([]gitLabFilesTraceRow, 0),
+		Incomplete:        make([]GitLabFilesIncomplete, 0),
+	}
+	if raw, ok := batch.Result[gitLabFilesIncompleteResultKey]; ok {
+		var encoded []byte
+		encoded, err = json.Marshal(raw)
+		if err != nil || json.Unmarshal(encoded, &trace.Incomplete) != nil {
+			t.Fatalf("decode files incomplete evidence: %v", err)
+		}
+	}
+	for _, request := range doer.requests[1:] {
+		trace.ProducerRequests = append(trace.ProducerRequests, gitLabFilesTraceRequestURI(request))
+	}
+	for _, page := range treePages {
+		for _, item := range page {
+			if item["type"] == "blob" && item["path"] != nil {
+				trace.TreePaths = append(trace.TreePaths, item["path"].(string))
+			}
+		}
+	}
+	for _, effect := range batch.Effects {
+		if effect.Destination != "git_files" {
+			continue
+		}
+		for _, raw := range effect.Rows {
+			var row gitFileRow
+			if err := json.Unmarshal(raw, &row); err != nil {
+				t.Fatal(err)
+			}
+			trace.Rows = append(trace.Rows, gitLabFilesTraceRow{
+				Path: row.Path, Executable: row.Executable, Contents: row.Contents,
+			})
+		}
+	}
+	sort.Slice(trace.Rows, func(left, right int) bool { return trace.Rows[left].Path < trace.Rows[right].Path })
+	return trace
+}
+
+func gitLabFilesTraceRequestURI(request *http.Request) string {
+	uri := request.URL.RequestURI()
+	return strings.Replace(uri, "/api/v4/projects/123/", "/api/v4/projects/{project}/", 1)
+}
+
+func marshalJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(encoded)
+}
+
+func queryInt(request *http.Request, key string) int {
+	value := request.URL.Query().Get(key)
+	var parsed int
+	if _, err := fmt.Sscanf(value, "%d", &parsed); err != nil {
+		return 0
+	}
+	return parsed
+}

--- a/internal/providersync/gitlab_files_route.go
+++ b/internal/providersync/gitlab_files_route.go
@@ -1,0 +1,545 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	defaultGitLabFilesPerPage  = 100
+	defaultGitLabFilesMaxPages = 10_000
+	gitLabFileContentMaxBytes  = 1_000_000
+	gitLabFileContentMaxFiles  = 2_000
+	gitLabFileContentBatch     = 50
+	gitLabGraphQLResponseLimit = 64 << 20
+)
+
+// ErrGitLabFilesTraversalFailed marks a tree traversal that did not establish
+// a complete path inventory. Content traversal is deliberately softer: the
+// Python producer preserves available paths, records typed incompleteness, and
+// leaves the watermark nil so the content window is retried.
+var ErrGitLabFilesTraversalFailed = errors.New("gitlab files traversal failed")
+
+const gitLabFilesIncompleteResultKey = "gitlab_files_incomplete"
+
+// GitLabFilesIncomplete is durable evidence that the path inventory landed
+// but content coverage did not. It is intentionally JSON-safe because the
+// complete-route snapshot persists Result before effects are committed.
+type GitLabFilesIncomplete struct {
+	Cause    string `json:"cause"`
+	Subject  string `json:"subject"`
+	Limit    int    `json:"limit,omitempty"`
+	Observed int    `json:"observed,omitempty"`
+}
+
+type gitLabFilesContentStatus struct {
+	Incomplete []GitLabFilesIncomplete
+}
+
+func (status *gitLabFilesContentStatus) addIncomplete(cause string, limit, observed int) {
+	for _, existing := range status.Incomplete {
+		if existing.Cause == cause {
+			return
+		}
+	}
+	status.Incomplete = append(status.Incomplete, GitLabFilesIncomplete{
+		Cause: cause, Subject: "gitlab/files", Limit: limit, Observed: observed,
+	})
+}
+
+// GitLabFilesRouteHandler owns only the gitlab/files unit. GitLab's blame
+// dataset has a separate destination and remains outside this route.
+//
+// The handler follows the live Python producer's project -> bounded commit
+// ref -> recursive tree -> scanner-filtered GraphQL blob sequence. Tree
+// traversal errors fail closed so an incomplete path inventory cannot become
+// a successful empty effect. Ordinary content errors preserve paths, emit
+// typed incompleteness, and leave the watermark nil; rate limits still
+// propagate (D16 policy is recorded on CHAOS-3188).
+type GitLabFilesRouteHandler struct {
+	PerPage   int
+	MaxPages  int
+	MaxFiles  int
+	MaxBytes  int
+	BatchSize int
+}
+
+type gitLabFilesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer gitLabFilesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+type gitLabTreePayload struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+}
+
+type gitLabCommitRefPayload struct {
+	ID string `json:"id"`
+}
+
+type gitLabBlobNode struct {
+	Path        string          `json:"path"`
+	RawSize     json.RawMessage `json:"rawSize"`
+	RawTextBlob *string         `json:"rawTextBlob"`
+}
+
+func (handler GitLabFilesRouteHandler) limits() (int, int, int, int, int, error) {
+	perPage, maxPages, maxFiles, maxBytes, batchSize :=
+		handler.PerPage, handler.MaxPages, handler.MaxFiles, handler.MaxBytes, handler.BatchSize
+	if perPage == 0 {
+		perPage = defaultGitLabFilesPerPage
+	}
+	if maxPages == 0 {
+		maxPages = defaultGitLabFilesMaxPages
+	}
+	if maxFiles == 0 {
+		maxFiles = gitLabFileContentMaxFiles
+	}
+	if maxBytes == 0 {
+		maxBytes = gitLabFileContentMaxBytes
+	}
+	if batchSize == 0 {
+		batchSize = gitLabFileContentBatch
+	}
+	if perPage < 1 || perPage > defaultGitLabFilesPerPage || maxPages < 1 ||
+		maxPages > defaultGitLabFilesMaxPages || maxFiles < 1 ||
+		maxFiles > gitLabFileContentMaxFiles || maxBytes < 1 || batchSize < 1 ||
+		batchSize > gitLabFileContentBatch {
+		return 0, 0, 0, 0, 0, ErrInvalidConfiguration
+	}
+	return perPage, maxPages, maxFiles, maxBytes, batchSize, nil
+}
+
+func (handler GitLabFilesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "files" || client == nil || client.Provider != "gitlab" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	perPage, maxPages, maxFiles, maxBytes, batchSize, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	projectID, err := gitLabProjectID(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	requests := 0
+	counted := *client
+	counted.Doer = gitLabFilesCountingDoer{delegate: client.Doer, attempts: &requests}
+	root := providerRelativePath(&counted, "api", "v4", "projects", projectID)
+	var project repositoryPayload
+	if err := fetchObject(ctx, &counted, root, &project); err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	parsedProjectID, err := project.ID.Int64()
+	if err != nil || parsedProjectID < 1 || strconv.FormatInt(parsedProjectID, 10) != projectID {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(providerfoundation.ErrNormalizationInvalid)
+	}
+	fullName := gitLabProjectFullName(project)
+	repoID, err := repositoryIdentity(fullName)
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	branch := project.DefaultBranch
+	if branch == "" {
+		branch = "main"
+	}
+
+	treeRef, _, err := gitLabFilesTreeRef(
+		ctx, &counted, root, branch, claim.BeforeAt,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	if treeRef == "" {
+		return gitLabFilesBatch(claim, fullName, nil, nil, requests, 0)
+	}
+
+	tree, err := providerfoundation.CollectGitLabPageParamPages(ctx, &counted,
+		providerfoundation.GitLabPageOptions{
+			Path: root + "/repository/tree",
+			Query: url.Values{
+				"ref": {treeRef}, "recursive": {"true"},
+			},
+			PerPage: perPage, MaxPages: maxPages,
+		})
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	if tree.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	paths := make([]string, 0, len(tree.Items))
+	for _, raw := range tree.Items {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+			return CompleteRouteBatch{}, gitLabFilesTraversalError(providerfoundation.ErrNormalizationInvalid)
+		}
+		var item gitLabTreePayload
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return CompleteRouteBatch{}, gitLabFilesTraversalError(providerfoundation.ErrNormalizationInvalid)
+		}
+		if item.Type == "blob" && item.Path != "" {
+			paths = append(paths, item.Path)
+		}
+	}
+	contents, contentStatus, err := fetchGitLabFileContents(
+		ctx, &counted, fullName, treeRef, paths, maxFiles, maxBytes, batchSize,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	rows := make([]gitFileRow, 0, len(paths))
+	for _, filePath := range paths {
+		row := newGitLabFileRow(claim, repoID, filePath, contents, normalizedAt)
+		if err := row.validate(claim); err != nil {
+			return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+		}
+		rows = append(rows, row)
+	}
+	return gitLabFilesBatch(
+		claim, fullName, rows, contentStatus.Incomplete, requests, tree.Pages,
+	)
+}
+
+func gitLabFilesTraversalError(err error) error {
+	if err == nil {
+		return ErrGitLabFilesTraversalFailed
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrGitLabFilesTraversalFailed, err)
+}
+
+func gitLabFilesTreeRef(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	root, branch string,
+	beforeAt *time.Time,
+) (string, int, error) {
+	if beforeAt == nil {
+		return branch, 0, nil
+	}
+	page, err := providerfoundation.CollectGitLabPageParamPages(ctx, client,
+		providerfoundation.GitLabPageOptions{
+			Path: root + "/repository/commits",
+			Query: url.Values{
+				"ref_name": {branch}, "until": {beforeAt.UTC().Format(time.RFC3339Nano)},
+			},
+			PerPage: 1, MaxPages: 1, SinglePage: true,
+		})
+	if err != nil {
+		return "", 0, err
+	}
+	if len(page.Items) == 0 {
+		return "", page.Pages, nil
+	}
+	var commit gitLabCommitRefPayload
+	if err := json.Unmarshal(page.Items[0], &commit); err != nil || strings.TrimSpace(commit.ID) == "" {
+		return "", page.Pages, providerfoundation.ErrNormalizationInvalid
+	}
+	return commit.ID, page.Pages, nil
+}
+
+func fetchGitLabFileContents(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	projectFullName, ref string,
+	paths []string,
+	maxFiles, maxBytes, batchSize int,
+) (map[string]string, gitLabFilesContentStatus, error) {
+	status := gitLabFilesContentStatus{}
+	allScannable := make([]string, 0, len(paths))
+	for _, filePath := range paths {
+		if !gitLabFileContentEligible(filePath) {
+			continue
+		}
+		allScannable = append(allScannable, filePath)
+	}
+	scannable := allScannable
+	if len(scannable) > maxFiles {
+		status.addIncomplete("content_cap", maxFiles, len(scannable))
+		scannable = scannable[:maxFiles]
+	}
+	if len(scannable) == 0 {
+		return map[string]string{}, status, nil
+	}
+
+	eligible := make([]string, 0, len(scannable))
+	requests := 0
+	for start := 0; start < len(scannable); start += batchSize {
+		end := min(start+batchSize, len(scannable))
+		nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, scannable[start:end], "path rawSize")
+		if err != nil {
+			if !gitLabFilesContentErrorDegradable(err) {
+				return nil, status, err
+			}
+			status.addIncomplete("content_size_fetch", 0, end-start)
+			eligible = append(eligible, scannable[start:end]...)
+			continue
+		}
+		requests++
+		for _, node := range nodes {
+			if node.Path == "" {
+				continue
+			}
+			size, err := gitLabRawSize(node.RawSize)
+			if err != nil {
+				status.addIncomplete("content_size_decode", 0, 1)
+				eligible = append(eligible, node.Path)
+				continue
+			}
+			if size == nil || *size <= maxBytes {
+				eligible = append(eligible, node.Path)
+			}
+		}
+	}
+
+	contents := make(map[string]string, len(eligible))
+	for start := 0; start < len(eligible); start += batchSize {
+		end := min(start+batchSize, len(eligible))
+		nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, eligible[start:end], "path rawTextBlob")
+		if err != nil {
+			if !gitLabFilesContentErrorDegradable(err) {
+				return nil, status, err
+			}
+			status.addIncomplete("content_fetch", 0, end-start)
+			continue
+		}
+		requests++
+		for _, node := range nodes {
+			if node.Path != "" && node.RawTextBlob != nil {
+				contents[node.Path] = *node.RawTextBlob
+			}
+		}
+	}
+	return contents, status, nil
+}
+
+func gitLabFilesContentErrorDegradable(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, providerfoundation.ErrLeaseLost) || errors.Is(err, providerfoundation.ErrBudgetUnavailable) {
+		return false
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) && providerErr.Class == providerfoundation.ErrorRateLimited {
+		return false
+	}
+	return true
+}
+
+func fetchGitLabGraphQLBlobs(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	projectFullName, ref string,
+	paths []string,
+	fields string,
+) ([]gitLabBlobNode, error) {
+	body, err := json.Marshal(map[string]any{
+		"query": gitLabBlobQuery(fields),
+		"variables": map[string]any{
+			"fullPath": projectFullName, "ref": ref, "paths": paths,
+		},
+	})
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	response, err := client.Do(ctx, http.MethodPost, gitLabGraphQLPath(client), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if response == nil || response.Body == nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(io.LimitReader(response.Body, gitLabGraphQLResponseLimit+1))
+	if err != nil || len(payload) > gitLabGraphQLResponseLimit {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	var envelope struct {
+		Data struct {
+			Project *struct {
+				Repository *struct {
+					Blobs *struct {
+						Nodes []gitLabBlobNode `json:"nodes"`
+					} `json:"blobs"`
+				} `json:"repository"`
+			} `json:"project"`
+		} `json:"data"`
+		Errors json.RawMessage `json:"errors"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	trimmedErrors := bytes.TrimSpace(envelope.Errors)
+	if len(trimmedErrors) > 0 && !bytes.Equal(trimmedErrors, []byte("null")) && !bytes.Equal(trimmedErrors, []byte("[]")) {
+		return nil, providerfoundation.ErrGraphQLResponse
+	}
+	if envelope.Data.Project == nil || envelope.Data.Project.Repository == nil ||
+		envelope.Data.Project.Repository.Blobs == nil {
+		return nil, providerfoundation.ErrGraphQLResponse
+	}
+	return envelope.Data.Project.Repository.Blobs.Nodes, nil
+}
+
+func gitLabRawSize(raw json.RawMessage) (*int, error) {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	var value int
+	if err := json.Unmarshal(raw, &value); err != nil || value < 0 {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	return &value, nil
+}
+
+func gitLabBlobQuery(fields string) string {
+	return "query($fullPath: ID!, $ref: String!, $paths: [String!]!) {\n" +
+		"  project(fullPath: $fullPath) {\n" +
+		"    repository {\n" +
+		"      blobs(ref: $ref, paths: $paths) {\n" +
+		"        nodes { " + fields + " }\n" +
+		"      }\n" +
+		"    }\n" +
+		"  }\n" +
+		"}"
+}
+
+func gitLabGraphQLPath(client *providerfoundation.HTTPClient) string {
+	base := strings.TrimSuffix(client.BaseURL.EscapedPath(), "/")
+	if strings.HasSuffix(base, "/api/v4") {
+		return strings.TrimSuffix(base, "/api/v4") + "/api/graphql"
+	}
+	return base + "/api/graphql"
+}
+
+func gitLabFileContentEligible(filePath string) bool {
+	for _, segment := range strings.Split(filePath, "/") {
+		switch segment {
+		case "migrations":
+			return false
+		case "tests":
+			return false
+		case "venv":
+			return false
+		case ".venv":
+			return false
+		case "node_modules":
+			return false
+		case "dist":
+			return false
+		case "build":
+			return false
+		case ".next":
+			return false
+		case "vendor":
+			return false
+		}
+	}
+	base := path.Base(filePath)
+	if base == "__init__.py" {
+		return false
+	}
+	if strings.HasSuffix(base, ".min.js") {
+		return false
+	}
+	if strings.HasSuffix(base, ".d.ts") {
+		return false
+	}
+	if strings.HasSuffix(base, ".config.js") {
+		return false
+	}
+	if strings.HasSuffix(base, ".config.ts") {
+		return false
+	}
+	if strings.HasSuffix(base, ".config.mjs") {
+		return false
+	}
+	switch strings.ToLower(path.Ext(base)) {
+	case ".py", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".go", ".rs", ".java", ".kt", ".kts", ".rb", ".php", ".c", ".h", ".cpp", ".cc", ".hpp", ".cs", ".swift", ".scala", ".m", ".mm", ".lua", ".vue":
+		return true
+	default:
+		return false
+	}
+}
+
+func newGitLabFileRow(claim Claim, repoID, filePath string, contents map[string]string, normalizedAt time.Time) gitFileRow {
+	row := gitFileRow{RepoID: repoID, Path: filePath, LastSynced: normalizedAt.UTC().Truncate(time.Millisecond), OrgID: claim.OrgID}
+	if content, ok := contents[filePath]; ok {
+		row.Contents = &content
+	}
+	return row
+}
+
+func gitLabFilesBatch(
+	claim Claim,
+	fullName string,
+	rows []gitFileRow,
+	incomplete []GitLabFilesIncomplete,
+	requests, pages int,
+) (CompleteRouteBatch, error) {
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	inventoryStatus := "complete"
+	if len(rows) == 0 {
+		inventoryStatus = "empty"
+		if pages == 0 && claim.BeforeAt != nil {
+			inventoryStatus = "no_commit_at_bound"
+		}
+	}
+	result := map[string]any{
+		"files_synced": len(rows), "inventory_status": inventoryStatus, "repo": fullName,
+	}
+	if len(incomplete) != 0 {
+		result[gitLabFilesIncompleteResultKey] = append([]GitLabFilesIncomplete(nil), incomplete...)
+	}
+	watermark := claim.BeforeAt
+	capReached := false
+	if len(incomplete) != 0 {
+		watermark = nil
+		for _, partial := range incomplete {
+			if partial.Cause == "content_cap" {
+				capReached = true
+				break
+			}
+		}
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  result, Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: requests, Pages: pages, Records: len(rows), CapReached: capReached,
+		},
+	}, nil
+}
+
+var _ CompleteRouteHandler = GitLabFilesRouteHandler{}

--- a/internal/providersync/gitlab_files_route_test.go
+++ b/internal/providersync/gitlab_files_route_test.go
@@ -1,0 +1,609 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitLabFilesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type gitLabFilesDoer struct {
+	t             *testing.T
+	requests      []*http.Request
+	treeResponses map[string]gitLabFilesResponse
+	graphQLSize   gitLabFilesResponse
+	graphQLText   gitLabFilesResponse
+	project       gitLabFilesResponse
+	commits       gitLabFilesResponse
+	contentCalls  int
+	treeCalls     int
+}
+
+func (doer *gitLabFilesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	response := gitLabFilesResponse{body: `{}`}
+	switch {
+	case request.URL.Path == "/api/v4/projects/123":
+		response = doer.project
+	case request.URL.Path == "/api/v4/projects/123/repository/tree":
+		doer.treeCalls++
+		response = doer.treeResponses[request.URL.Query().Get("page")]
+	case request.URL.Path == "/api/v4/projects/123/repository/commits":
+		response = doer.commits
+	case request.URL.Path == "/api/graphql":
+		doer.contentCalls++
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			doer.t.Fatal(err)
+		}
+		if strings.Contains(string(body), "rawSize") {
+			response = doer.graphQLSize
+		} else if strings.Contains(string(body), "rawTextBlob") {
+			response = doer.graphQLText
+		} else {
+			doer.t.Fatalf("unexpected GitLab GraphQL query=%s", body)
+		}
+	default:
+		doer.t.Fatalf("unexpected GitLab files request %s", request.URL)
+	}
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	headers := response.headers
+	if headers == nil {
+		headers = http.Header{"Content-Type": []string{"application/json"}}
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func gitLabFilesFixtureDoer(t *testing.T) *gitLabFilesDoer {
+	t.Helper()
+	return &gitLabFilesDoer{
+		t:       t,
+		project: gitLabFilesResponse{body: gitLabRepositoryFixture},
+		treeResponses: map[string]gitLabFilesResponse{
+			"1": {
+				body: `[{
+					"path":"README.md","type":"blob","size":20
+				},{"path":"src/main.go","type":"blob","size":15}]`,
+				headers: http.Header{"X-Next-Page": []string{"2"}},
+			},
+			"2": {
+				body: `[{
+					"path":"tests/example.go","type":"blob","size":20
+				},{"path":"src/types.d.ts","type":"blob","size":20}]`,
+				headers: http.Header{"X-Next-Page": []string{"3"}},
+			},
+			"3": {
+				body: `[{"path":"src/data.bin","type":"blob","size":8}]`,
+			},
+		},
+		graphQLSize: gitLabFilesResponse{
+			body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/main.go","rawSize":15}]}}}}}`,
+		},
+		graphQLText: gitLabFilesResponse{
+			body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/main.go","rawTextBlob":"package main\n"}]}}}}}`,
+		},
+	}
+}
+
+func TestGitLabFilesRouteTraversesTreeAndWritesNonEmptyInventory(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 987654321, time.UTC)
+	batch, err := (GitLabFilesRouteHandler{PerPage: 2, MaxPages: 4}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 6 || doer.treeCalls != 3 || doer.contentCalls != 2 {
+		t.Fatalf("requests=%d tree=%d content=%d", len(doer.requests), doer.treeCalls, doer.contentCalls)
+	}
+	if got := doer.requests[1].URL.Query(); got.Get("ref") != "main" || got.Get("recursive") != "true" ||
+		got.Get("page") != "1" || got.Get("per_page") != "2" {
+		t.Fatalf("tree query=%s", got.Encode())
+	}
+	if got := doer.requests[2].URL.Query().Get("page"); got != "2" {
+		t.Fatalf("second tree page=%q", got)
+	}
+	if got := doer.requests[3].URL.Query().Get("page"); got != "3" {
+		t.Fatalf("third tree page=%q", got)
+	}
+	if batch.Evidence.Provider != "gitlab" || batch.Evidence.Dataset != "files" ||
+		batch.Evidence.Requests != 6 || batch.Evidence.Pages != 3 || batch.Evidence.Records != 5 ||
+		batch.Evidence.CapReached || batch.Watermark != nil {
+		t.Fatalf("evidence=%+v watermark=%v", batch.Evidence, batch.Watermark)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "git_files" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 5 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	rows := make(map[string]gitFileRow)
+	for _, raw := range batch.Effects[0].Rows {
+		var row gitFileRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		rows[row.Path] = row
+	}
+	if len(rows) != 5 || rows["src/main.go"].Contents == nil ||
+		*rows["src/main.go"].Contents != "package main\n" || rows["README.md"].Contents != nil ||
+		rows["tests/example.go"].Contents != nil || rows["src/types.d.ts"].Contents != nil ||
+		rows["src/data.bin"].Contents != nil {
+		t.Fatalf("rows=%+v", rows)
+	}
+	for _, row := range rows {
+		if row.OrgID != claim.OrgID || !row.LastSynced.Equal(normalizedAt.UTC().Truncate(time.Millisecond)) {
+			t.Fatalf("row scope/timestamp=%+v", row)
+		}
+	}
+	if batch.Result["inventory_status"] != "complete" || batch.Result["files_synced"] != 5 {
+		t.Fatalf("result=%+v", batch.Result)
+	}
+}
+
+func TestGitLabFilesRouteUsesPythonBoundRefAndDistinguishesNoCommit(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.commits = gitLabFilesResponse{body: `[]`}
+	claim := nativeTestClaim("gitlab", "files")
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 2 || doer.requests[1].URL.Query().Get("ref_name") != "main" ||
+		doer.requests[1].URL.Query().Get("until") != "2026-07-31T23:59:59Z" {
+		t.Fatalf("bound requests=%v", doer.requests)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(*claim.BeforeAt) || batch.Evidence.Pages != 0 ||
+		batch.Result["inventory_status"] != "no_commit_at_bound" {
+		t.Fatalf("batch=%+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteReportsLegitimateEmptyTree(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{"1": {body: `[]`}}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 || batch.Evidence.Pages != 1 ||
+		batch.Result["inventory_status"] != "empty" {
+		t.Fatalf("batch=%+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteFailsClosedOnTreePaginationCap(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{PerPage: 2, MaxPages: 1}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("capped traversal returned effects/watermark: %+v", batch)
+	}
+	if len(doer.requests) != 2 || doer.contentCalls != 0 {
+		t.Fatalf("requests=%d content=%d", len(doer.requests), doer.contentCalls)
+	}
+}
+
+func TestGitLabFilesRouteRejectsMalformedTreeItem(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{"1": {body: `[null]`}}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("malformed tree error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("malformed tree returned effects/watermark: %+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteDegradesGraphQLPayloadErrorToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{
+		body: `{"errors":[{"message":"repository unavailable"}]}`,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("GraphQL payload batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" {
+		t.Fatalf("GraphQL payload incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteDegradesMissingGraphQLRepositoryToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{body: `{"data":{"project":null}}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("missing GraphQL repository batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" {
+		t.Fatalf("missing GraphQL repository incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRoutePreservesEmptyTextAsPresentContent(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{
+		"1": {body: `[{"path":"src/empty.go","type":"blob","size":0}]`},
+	}
+	doer.graphQLSize = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/empty.go","rawSize":0}]}}}}}`,
+	}
+	doer.graphQLText = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/empty.go","rawTextBlob":""}]}}}}}`,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row gitFileRow
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 1 ||
+		json.Unmarshal(batch.Effects[0].Rows[0], &row) != nil || row.Contents == nil || *row.Contents != "" {
+		t.Fatalf("empty content row=%+v", row)
+	}
+}
+
+func TestGitLabFilesRouteDegradesGraphQLContentErrorToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusInternalServerError, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("content failure batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" || incomplete[0].Subject != "gitlab/files" {
+		t.Fatalf("content failure incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRoutePreservesRateLimitPropagation(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusTooManyRequests, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("rate error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("rate failure returned effects/watermark: %+v", batch)
+	}
+}
+
+func TestGitLabFilesRoutePreservesQualifiedForbiddenRateLimitPropagation(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{
+		status:  http.StatusForbidden,
+		body:    `{}`,
+		headers: http.Header{"RateLimit-Remaining": []string{"0"}},
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("qualified forbidden error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("qualified forbidden returned effects/watermark: %+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteDegradesUnqualifiedForbiddenToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusForbidden, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("plain forbidden batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" {
+		t.Fatalf("plain forbidden incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteDegradesGraphQLTextFailureToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLText = gitLabFilesResponse{status: http.StatusInternalServerError, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("text failure batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_fetch" {
+		t.Fatalf("text failure incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteMarksContentCapIncompleteWithoutWatermark(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{
+		"1": {body: `[{"path":"src/a.go","type":"blob"},{"path":"src/b.go","type":"blob"},{"path":"src/c.go","type":"blob"}]`},
+	}
+	doer.commits = gitLabFilesResponse{body: `[{"id":"commit-cap"}]`}
+	doer.graphQLSize = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/a.go","rawSize":10},{"path":"src/b.go","rawSize":10}]}}}}}`,
+	}
+	doer.graphQLText = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/a.go","rawTextBlob":"a"},{"path":"src/b.go","rawTextBlob":"b"}]}}}}}`,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	bound := time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC)
+	claim.BeforeAt = &bound
+	batch, err := (GitLabFilesRouteHandler{MaxFiles: 2}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 3 || batch.Watermark != nil || !batch.Evidence.CapReached {
+		t.Fatalf("cap batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_cap" || incomplete[0].Limit != 2 || incomplete[0].Observed != 3 {
+		t.Fatalf("cap incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteReraisesGraphQLRateLimit(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusTooManyRequests, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	_, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("rate error=%v", err)
+	}
+}
+
+func TestGitLabFilesRouteCountsPhysicalRetryAttempts(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	client, err := providerfoundation.NewHTTPClient(
+		"gitlab", "https://gitlab.example", &retryingGitLabFilesDoer{delegate: doer},
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{PerPage: 2, MaxPages: 4}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Evidence.Requests != 7 || len(doer.requests) != 6 {
+		t.Fatalf("evidence=%+v requests=%d", batch.Evidence, len(doer.requests))
+	}
+}
+
+type retryingGitLabFilesDoer struct {
+	delegate *gitLabFilesDoer
+	used     bool
+}
+
+func (doer *retryingGitLabFilesDoer) Do(request *http.Request) (*http.Response, error) {
+	if request.URL.Path == "/api/v4/projects/123/repository/tree" && !doer.used {
+		doer.used = true
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Request:    request,
+		}, nil
+	}
+	return doer.delegate.Do(request)
+}
+
+func TestGitLabFilesRouteRejectsBlameClaim(t *testing.T) {
+	claim := nativeTestClaim("gitlab", "blame")
+	_, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, gitLabFilesFixtureDoer(t), "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong dataset error=%v", err)
+	}
+}
+
+type deniedGitLabFilesBudget struct{}
+
+func (deniedGitLabFilesBudget) Acquire(context.Context, providerfoundation.BudgetKey) (providerfoundation.Reservation, error) {
+	return nil, providerfoundation.ErrBudgetUnavailable
+}
+
+func TestGitLabFilesRoutePropagatesBudgetDenialBeforeProviderWork(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	client := gitLabRepositoryClient(t, doer, "https://gitlab.example")
+	client.Budget = deniedGitLabFilesBudget{}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	_, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, time.Now().UTC(),
+	)
+	if !errors.Is(err, providerfoundation.ErrBudgetUnavailable) {
+		t.Fatalf("budget error=%v", err)
+	}
+	if len(doer.requests) != 0 {
+		t.Fatalf("budget denial still reached provider: requests=%d", len(doer.requests))
+	}
+}
+
+func TestGitLabFileContentEligibilityMatchesComplexityScannerConfig(t *testing.T) {
+	for _, test := range []struct {
+		path string
+		want bool
+	}{
+		{path: "src/main.go", want: true},
+		{path: "README.md", want: false},
+		{path: "tests/example.go", want: false},
+		{path: "migrations/001.go", want: false},
+		{path: "venv/lib.go", want: false},
+		{path: ".venv/lib.go", want: false},
+		{path: "node_modules/pkg/index.js", want: false},
+		{path: "dist/bundle.js", want: false},
+		{path: "build/generated.go", want: false},
+		{path: ".next/server.js", want: false},
+		{path: "vendor/module.go", want: false},
+		{path: "src/__init__.py", want: false},
+		{path: "src/types.d.ts", want: false},
+		{path: "src/app.min.js", want: false},
+		{path: "src/app.config.js", want: false},
+		{path: "src/app.config.ts", want: false},
+		{path: "src/app.config.mjs", want: false},
+		{path: "src/data.bin", want: false},
+	} {
+		if got := gitLabFileContentEligible(test.path); got != test.want {
+			t.Fatalf("eligible(%q)=%v want %v", test.path, got, test.want)
+		}
+	}
+}
+
+func TestGitLabFilesRouteSkipsTreeEntriesAndRejectsProjectMismatch(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{"1": {body: `[{"path":"src","type":"tree"}]`}}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil || len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 {
+		t.Fatalf("tree-only batch=%+v error=%v", batch, err)
+	}
+	mismatch := gitLabFilesFixtureDoer(t)
+	mismatch.project = gitLabFilesResponse{body: `{"id":999,"path_with_namespace":"Acme/API"}`}
+	_, err = (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, mismatch, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("project mismatch error=%v", err)
+	}
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_files.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_files.json
@@ -1,0 +1,288 @@
+{
+  "schema_version": 1,
+  "name": "gitlab/files provider-local parity (CHAOS-3707)",
+  "build": ["go", "build", "./..."],
+  "$limitation": "Provider-only plan. Live ClickHouse proofs require the integration Docker service; if unavailable, those mutation verdicts remain unverified rather than being treated as skipped coverage.",
+  "mutations": [
+    {
+      "id": "gitlab-forbidden-retry-after-qualification",
+      "file": "internal/providerfoundation/http.go",
+      "find": "if provider == \"gitlab\" &&\n\t\t(hasHeader(headers, \"retry-after\") || headerValue(headers, \"ratelimit-remaining\") == \"0\") {",
+      "replace": "if provider == \"gitlab\" &&\n\t\t(false || headerValue(headers, \"ratelimit-remaining\") == \"0\") {",
+      "rationale": "GitLab's header-qualified 403 contract treats a present Retry-After as a rate limit even when the remaining counter is absent; this clause is shared by every native route using providerfoundation.ClassifyHTTP",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabForbiddenRateLimitQualification$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "gitlab-forbidden-remaining-zero-qualification",
+      "file": "internal/providerfoundation/http.go",
+      "find": "if provider == \"gitlab\" &&\n\t\t(hasHeader(headers, \"retry-after\") || headerValue(headers, \"ratelimit-remaining\") == \"0\") {",
+      "replace": "if provider == \"gitlab\" &&\n\t\t(hasHeader(headers, \"retry-after\") || false) {",
+      "rationale": "GitLab's RateLimit-Remaining: 0 is an independent qualified-403 signal and must propagate as rate limited through the GitLab files GraphQL route",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFilesRoutePreservesQualifiedForbiddenRateLimitPropagation$", "./internal/providersync/"]]
+    },
+    {
+      "id": "tree-cap-fails-closed",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if tree.CapReached {",
+      "replace": "if false {",
+      "rationale": "a recursive tree that reaches its page cap is incomplete and must not produce a successful effect or advance the watermark",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteFailsClosedOnTreePaginationCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "no-commit-at-bound-is-legitimate-empty",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if len(page.Items) == 0 {",
+      "replace": "if len(page.Items) == 0 && false {",
+      "rationale": "the Python producer returns no file inventory when no commit exists at the requested upper bound; changing this clause would fabricate a tree ref and lose the explicit no-commit outcome",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteUsesPythonBoundRefAndDistinguishesNoCommit$", "./internal/providersync/"]]
+    },
+    {
+      "id": "malformed-tree-entry-fails-closed",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if err := json.Unmarshal(raw, &object); err != nil || object == nil {",
+      "replace": "if err := json.Unmarshal(raw, &object); err != nil && object == nil {",
+      "rationale": "a null or non-object tree item is malformed traversal evidence, not a legitimate empty entry; silently skipping it would allow a partial inventory to watermark",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteRejectsMalformedTreeItem$", "./internal/providersync/"]]
+    },
+    {
+      "id": "tree-only-entries-are-not-files",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if item.Type == \"blob\" && item.Path != \"\" {",
+      "replace": "if item.Path != \"\" {",
+      "rationale": "directories and other GitLab tree entries must not become git_files rows",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteSkipsTreeEntriesAndRejectsProjectMismatch$", "./internal/providersync/"]]
+    },
+    {
+      "id": "content-file-cap-emits-incomplete",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if len(scannable) > maxFiles {",
+      "replace": "if false {",
+      "rationale": "the 2,000-file content cap must remain observable as typed incomplete evidence with no watermark while every tree path still lands",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteMarksContentCapIncompleteWithoutWatermark$", "./internal/providersync/"], ["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 PYTHONPATH=\"$PWD/src\" DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"${DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR:?missing}\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForGitLabFilesContentCap$' ./internal/providersync/"]]
+    },
+    {
+      "id": "oversized-content-is-skipped",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if size == nil || *size <= maxBytes {",
+      "replace": "if size == nil {",
+      "rationale": "rawSize over one megabyte must not cross the GraphQL text pass, while the file path still remains in git_files",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 PYTHONPATH=\"$PWD/src\" DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"${DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR:?missing}\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForGitLabFilesTraversal$' ./internal/providersync/"]]
+    },
+    {
+      "id": "ordinary-text-failure-degrades",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, eligible[start:end], \"path rawTextBlob\")\n\t\tif err != nil {\n\t\t\tif !gitLabFilesContentErrorDegradable(err) {",
+      "replace": "nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, eligible[start:end], \"path rawTextBlob\")\n\t\tif err != nil {\n\t\t\tif gitLabFilesContentErrorDegradable(err) {",
+      "rationale": "ordinary GraphQL text failures must produce paths-only rows with typed incompleteness and no watermark, while rate limits remain fatal",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteDegradesGraphQLTextFailureToPathsOnly$", "./internal/providersync/"]]
+    },
+    {
+      "id": "empty-text-preserves-nullability-distinction",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if node.Path != \"\" && node.RawTextBlob != nil {",
+      "replace": "if node.Path != \"\" && node.RawTextBlob == nil {",
+      "rationale": "an explicitly returned empty string is present content and must remain distinct from a missing or binary blob represented by NULL",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRoutePreservesEmptyTextAsPresentContent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "graphql-errors-preserve-paths",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if len(trimmedErrors) > 0 && !bytes.Equal(trimmedErrors, []byte(\"null\")) && !bytes.Equal(trimmedErrors, []byte(\"[]\")) {\n\t\treturn nil, providerfoundation.ErrGraphQLResponse\n\t}",
+      "replace": "if len(trimmedErrors) > 0 && !bytes.Equal(trimmedErrors, []byte(\"null\")) && !bytes.Equal(trimmedErrors, []byte(\"[]\")) {\n\t\treturn nil, nil\n\t}",
+      "rationale": "a GraphQL 200 response containing errors is an ordinary content failure: preserve path rows, emit typed incompleteness, and suppress the watermark",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteDegradesGraphQLPayloadErrorToPathsOnly$", "./internal/providersync/"]]
+    },
+    {
+      "id": "graphql-shape-preserves-paths",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if envelope.Data.Project == nil || envelope.Data.Project.Repository == nil ||\n\t\tenvelope.Data.Project.Repository.Blobs == nil {",
+      "replace": "if false {",
+      "rationale": "missing project/repository/blob data is incomplete content evidence: preserve path rows and leave the watermark nil",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteDegradesMissingGraphQLRepositoryToPathsOnly$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-migrations",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"migrations\":\n\t\t\treturn false",
+      "replace": "case \"migrations\":\n\t\t\treturn true",
+      "rationale": "the migrations exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-tests",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"tests\":\n\t\t\treturn false",
+      "replace": "case \"tests\":\n\t\t\treturn true",
+      "rationale": "the tests exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-venv",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"venv\":\n\t\t\treturn false",
+      "replace": "case \"venv\":\n\t\t\treturn true",
+      "rationale": "the venv exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-dot-venv",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \".venv\":\n\t\t\treturn false",
+      "replace": "case \".venv\":\n\t\t\treturn true",
+      "rationale": "the dot-venv exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-node-modules",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"node_modules\":\n\t\t\treturn false",
+      "replace": "case \"node_modules\":\n\t\t\treturn true",
+      "rationale": "the node_modules exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-dist",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"dist\":\n\t\t\treturn false",
+      "replace": "case \"dist\":\n\t\t\treturn true",
+      "rationale": "the dist exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-build",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"build\":\n\t\t\treturn false",
+      "replace": "case \"build\":\n\t\t\treturn true",
+      "rationale": "the build exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-next",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \".next\":\n\t\t\treturn false",
+      "replace": "case \".next\":\n\t\t\treturn true",
+      "rationale": "the .next exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-vendor",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"vendor\":\n\t\t\treturn false",
+      "replace": "case \"vendor\":\n\t\t\treturn true",
+      "rationale": "the vendor exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-init",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if base == \"__init__.py\" {\n\t\treturn false",
+      "replace": "if base == \"__init__.py\" {\n\t\treturn true",
+      "rationale": "the __init__.py exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-min-js",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".min.js\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".min.js\") {\n\t\treturn true",
+      "rationale": "the minified JavaScript exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-d-ts",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".d.ts\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".d.ts\") {\n\t\treturn true",
+      "rationale": "the declaration-file exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-config-js",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".config.js\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".config.js\") {\n\t\treturn true",
+      "rationale": "the config.js exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-config-ts",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".config.ts\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".config.ts\") {\n\t\treturn true",
+      "rationale": "the config.ts exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-config-mjs",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".config.mjs\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".config.mjs\") {\n\t\treturn true",
+      "rationale": "the config.mjs exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "normalized-at-is-clickhouse-precision",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "LastSynced: normalizedAt.UTC().Truncate(time.Millisecond)",
+      "replace": "LastSynced: normalizedAt.UTC()",
+      "rationale": "git_files.last_synced is DateTime64(3); keeping sub-millisecond collection time would make route bytes differ from real ClickHouse readback",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteTraversesTreeAndWritesNonEmptyInventory$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-provider-fence",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != \"gitlab\" ||",
+      "replace": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || false ||",
+      "rationale": "GitLab effects must reject a GitHub claim even though both providers share the physical git_files table",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesEffectsValidateProviderAndEmptyBatches$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-lease-before-decode",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != \"gitlab\" ||\n\t\tclaim.Dataset != \"files\" || effect.Destination != \"git_files\" {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {",
+      "replace": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != \"gitlab\" ||\n\t\tclaim.Dataset != \"files\" || effect.Destination != \"git_files\" {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err == nil {",
+      "rationale": "a lost lease must stop an effect before decoding or doing any persistence work",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesEffectsAssertLeaseBeforeDecoding$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-lease-before-send",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "if err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()",
+      "replace": "return batch.Send()",
+      "rationale": "lease loss after batch preparation must abort before ClickHouse acknowledgement; otherwise a stale worker can commit after ownership expires",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesWriteRechecksLeaseBeforeClickHouseSend$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-preserve-existing-contents",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "if rows[index].Contents != nil {",
+      "replace": "if true {",
+      "rationale": "a paths-only rewrite must hydrate the tenant-qualified winning contents before inserting a newer ReplacingMergeTree version",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesWritePreservesExistingContentsForPathsOnlyRewrite$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-readback-final-row",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files FINAL",
+      "replace": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files",
+      "rationale": "ReplacingMergeTree readback must observe one winning tenant-qualified row, not mixed versions reconstructed from unreduced parts",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesReadbackResolvesWinningReplacingMergeTreeVersion$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-readback-tenant-fence",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files FINAL\nWHERE org_id = ? AND repo_id = ? AND path = ?",
+      "replace": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files FINAL\nWHERE repo_id = ? AND path = ?",
+      "rationale": "the same repository/path natural key must remain isolated for two tenants in the shared ClickHouse table",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesReadbackScopesSameNaturalKeyByTenant$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-replay-converges",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "return batch.Send()",
+      "replace": "return nil",
+      "rationale": "an identical replay must be proven against real RMT readback; skipping the send would make recovery falsely look exact only if the row was already present",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesReadbackResolvesWinningReplacingMergeTreeVersion$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/_gitlab_files_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_gitlab_files_common.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import pathlib
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+from urllib.parse import parse_qsl, unquote, urlencode
+
+import httpx
+
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/gitlab.py"
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    if value is None or value == "":
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _request_path(request: httpx.Request) -> str:
+    pairs = sorted(parse_qsl(request.url.query.decode(), keep_blank_values=True))
+    query = urlencode(pairs)
+    path = unquote(request.url.path)
+    marker = "/api/v4/projects/"
+    if path.startswith(marker):
+        suffix = path[len(marker) :]
+        _, separator, remainder = suffix.partition("/repository")
+        if separator:
+            path = f"{marker}{{project}}/repository{remainder}"
+    return f"{path}?{query}" if query else path
+
+
+@dataclass(frozen=True)
+class FileTraceRow:
+    path: str
+    executable: bool
+    contents: str | None
+
+
+@dataclass(frozen=True)
+class FileTraversalTrace:
+    producer_requests: list[str]
+    usage_request_count: int
+    tree_paths: list[str]
+    rows: list[FileTraceRow]
+    incomplete: list[dict[str, Any]]
+
+
+def reflected_trace_fields() -> frozenset[str]:
+    return frozenset(
+        {"producer_requests", "usage_request_count", "tree_paths", "rows", "incomplete"}
+    )
+
+
+def run_python_producer(case: dict[str, Any]) -> FileTraversalTrace:
+    logging.disable(logging.CRITICAL)
+    processor = load_live_module(PROCESSOR_SOURCE)
+    base_git = load_live_module(BASE_GIT_SOURCE)
+    code_client_module = load_live_module(CODE_CLIENT_SOURCE)
+
+    # Keep the real worker and persistence boundary in the execution path;
+    # only the unrelated commit-stats/blame gates are fixed to this files unit.
+    async def needs(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(files=True, blame=False, commit_stats=False)
+
+    async def no_blame(*_args: Any, **_kwargs: Any) -> bool:
+        return False
+
+    processor.check_backfill_needs = needs
+    processor.blame_backfill_needed = no_blame
+    processor.backfill_file_records = base_git.backfill_file_records
+    processor.historical_backfill_day = base_git.historical_backfill_day
+    processor.write_historical_complexity = lambda **_kwargs: None
+
+    requests: list[str] = []
+    tree_pages = case.get("tree_pages", [[]])
+    tree_next_pages = case.get("tree_next_pages", [])
+    commit_rows = case.get("commit_rows", [])
+    sizes = {str(path): int(value) for path, value in case.get("sizes", {}).items()}
+    contents = {
+        str(path): str(value) for path, value in case.get("contents", {}).items()
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(_request_path(request))
+        if request.url.path.endswith("/repository/commits"):
+            return httpx.Response(200, json=commit_rows, request=request)
+        if request.url.path.endswith("/repository/tree"):
+            page = int(request.url.params.get("page", "1"))
+            index = page - 1
+            payload = tree_pages[index] if index < len(tree_pages) else []
+            headers: dict[str, str] = {}
+            if index < len(tree_next_pages) and tree_next_pages[index]:
+                headers["X-Next-Page"] = str(tree_next_pages[index])
+            return httpx.Response(200, json=payload, headers=headers, request=request)
+        if request.url.path == "/api/graphql":
+            body = json_loads(request.content)
+            variables = body["variables"]
+            paths = [str(path) for path in variables["paths"]]
+            query = str(body["query"])
+            if case.get("content_failure") and "rawTextBlob" in query:
+                return httpx.Response(500, json={}, request=request)
+            if "rawSize" in query:
+                nodes = [
+                    {"path": path, "rawSize": sizes.get(path, 100)} for path in paths
+                ]
+            else:
+                nodes = [
+                    {"path": path, "rawTextBlob": contents.get(path)} for path in paths
+                ]
+            return httpx.Response(
+                200,
+                json={"data": {"project": {"repository": {"blobs": {"nodes": nodes}}}}},
+                request=request,
+            )
+        raise AssertionError(f"unexpected producer request: {request.url}")
+
+    client = code_client_module.GitLabCodeClient(
+        private_token="oracle",
+        base_url="https://gitlab.test",
+        max_retries=1,
+        transport=httpx.MockTransport(handler),
+    )
+
+    @asynccontextmanager
+    async def client_factory(_connector: object):
+        async with client:
+            yield client
+
+    processor._gitlab_code_client_from_connector = client_factory
+    usage: list[dict[str, Any]] = []
+    inserted: list[Any] = []
+
+    class Sink:
+        async def get_git_file_contents_by_path(self, _repo_id: Any) -> dict[str, str]:
+            return {}
+
+        async def insert_git_file_data(self, rows: list[Any]) -> None:
+            inserted.extend(rows)
+
+    until = _parse_time(case.get("until"))
+    asyncio.run(
+        processor._backfill_gitlab_missing_data(
+            SimpleNamespace(),
+            Sink(),
+            object(),
+            SimpleNamespace(id=case["repo_id"]),
+            case.get("project_full_name", "Acme/API"),
+            case.get("default_branch", "main"),
+            None,
+            include_files=True,
+            include_blame=False,
+            include_commit_stats=False,
+            until=until,
+            usage_sink=usage,
+        )
+    )
+    usage_request_count = sum(int(item.get("request_count") or 0) for item in usage)
+    if usage_request_count != len(requests):
+        raise ValueError(
+            "GitLab files producer usage observations lost physical requests: "
+            f"usage={usage_request_count} requests={len(requests)}"
+        )
+    rows = sorted(
+        (
+            FileTraceRow(
+                path=str(getattr(row, "path")),
+                executable=bool(getattr(row, "executable")),
+                contents=getattr(row, "contents", None),
+            )
+            for row in inserted
+        ),
+        key=lambda row: row.path,
+    )
+    tree_paths = [
+        str(item["path"])
+        for page in tree_pages
+        for item in page
+        if isinstance(item, dict) and item.get("type") == "blob" and item.get("path")
+    ]
+    scanner = processor.ComplexityScanner(
+        config_path=processor.DEFAULT_COMPLEXITY_CONFIG_PATH
+    )
+    scannable_count = sum(1 for path in tree_paths if scanner.should_process(path))
+    incomplete: list[dict[str, Any]] = []
+    if scannable_count > 2_000:
+        incomplete.append(
+            {
+                "cause": "content_cap",
+                "subject": "gitlab/files",
+                "limit": 2_000,
+                "observed": scannable_count,
+            }
+        )
+    if case.get("content_failure"):
+        incomplete.append(
+            {
+                "cause": "content_fetch",
+                "subject": "gitlab/files",
+                "limit": 0,
+                "observed": scannable_count,
+            }
+        )
+    return FileTraversalTrace(
+        producer_requests=requests,
+        usage_request_count=usage_request_count,
+        tree_paths=tree_paths,
+        rows=rows,
+        incomplete=incomplete,
+    )
+
+
+def json_loads(value: bytes) -> dict[str, Any]:
+    import json
+
+    decoded = json.loads(value)
+    if not isinstance(decoded, dict):
+        raise ValueError(f"GraphQL request was not an object: {decoded!r}")
+    return decoded
+
+
+def build_traversal(case: dict[str, Any]) -> dict[str, Any]:
+    return asdict(run_python_producer(case))

--- a/internal/providersync/testdata/oracle_pairs/gitlab_files_http-classification.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_files_http-classification.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+RATE_LIMIT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/ratelimit.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return dataclass_field_names(
+        RATE_LIMIT_SOURCE.read_text(), "GitLabRateLimitClassification"
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    code_client = load_live_module(CODE_CLIENT_SOURCE)
+    classification = code_client.classify_gitlab_status(
+        status=int(case["status"]), headers=case.get("headers", {})
+    )
+    return asdict(classification)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/files/http-classification",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "reason": "Go's shared ProviderError exposes the stable rate-limit class but not GitLab's provider-local primary/secondary reason",
+            "retry_after_seconds": "Go's shared ProviderError stores retry delay as a duration and this oracle pins classification, not provider-specific delay serialization",
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_files_row.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_files_row.py
@@ -1,0 +1,69 @@
+"""GitLab files row oracle over the live worker persistence boundary.
+
+The pair executes ``backfill_file_records`` from the real Python worker
+module, not a hand-written GitFile constructor. The fake sink only records the
+objects handed to the persistence boundary; it does not normalize or select
+fields on the producer's behalf.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return class_annotated_field_names(MODEL_SOURCE.read_text(), "GitFile")
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    base_git = load_live_module(BASE_GIT_SOURCE)
+    inserted: list[Any] = []
+
+    class Sink:
+        async def get_git_file_contents_by_path(self, _repo_id: Any) -> dict[str, str]:
+            return {
+                str(path): str(value)
+                for path, value in case.get("existing_contents", {}).items()
+            }
+
+        async def insert_git_file_data(self, rows: list[Any]) -> None:
+            inserted.extend(rows)
+
+    async def run() -> None:
+        await base_git.backfill_file_records(
+            Sink(),
+            case["repo_id"],
+            [case["path"]],
+            case.get("project_full_name", "Acme/API"),
+            contents_by_path={
+                str(path): str(value)
+                for path, value in case.get("contents_by_path", {}).items()
+            },
+        )
+
+    asyncio.run(run())
+    if len(inserted) != 1:
+        raise ValueError(f"GitLab files worker produced {len(inserted)} rows")
+    return vars(inserted[0])
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/files/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "last_synced": "Python GitFile defaults this persistence timestamp after backfill_file_records; Go carries the normalized collection instant",
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_files_trace.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_files_trace.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._gitlab_files_common import (
+    build_traversal,
+    reflected_trace_fields,
+)
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/files/trace",
+        build_row=build_traversal,
+        reflected_fields=reflected_trace_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
@@ -19,8 +19,9 @@ oracle_registry.register(
             pathlib.Path(MODEL_SOURCE).read_text(), "GitPullRequestReview"
         ),
         excluded_fields={
-            "last_synced": "stamped from the Go collection instant, not the Python mapper",
+            "last_synced": (
+                "stamped from the Go collection instant, not the Python mapper"
+            ),
         },
     )
 )
-

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue.py
@@ -99,7 +99,11 @@ def _fetch(
     issue = _object(case["raw_issue"])
     label_events = [_object(event) for event in case.get("label_events", [])]
     client = _Client(issue, label_events)
-    work_items_module.get_metrics_dependencies = lambda: _Dependencies(client)
+    setattr(
+        work_items_module,
+        "get_metrics_dependencies",
+        lambda: _Dependencies(client),
+    )
     repo = work_items_module.DiscoveredRepo(
         repo_id=UUID(case["repo_id"]),
         full_name=case["repo_full_name"],

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_status-transition.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_status-transition.py
@@ -87,7 +87,11 @@ def _fetch(case: dict[str, Any]) -> list[WorkItemStatusTransition]:
     issue = _object(case["raw_issue"])
     label_events = [_object(event) for event in case.get("label_events", [])]
     client = _Client(issue, label_events)
-    work_items_module.get_metrics_dependencies = lambda: _Dependencies(client)
+    setattr(
+        work_items_module,
+        "get_metrics_dependencies",
+        lambda: _Dependencies(client),
+    )
     repo = work_items_module.DiscoveredRepo(
         repo_id=UUID(case["repo_id"]),
         full_name=case["repo_full_name"],

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -46,6 +46,7 @@ _JIRA_BUDGET_SOURCE = _source("dev_health_ops/providers/jira/budget.py")
 _LAUNCHDARKLY_BUDGET_SOURCE = _source("dev_health_ops/providers/launchdarkly/budget.py")
 _DATASET_ADAPTERS_SOURCE = _source("dev_health_ops/processors/dataset_adapters.py")
 _BASE_GIT_SOURCE = _source("dev_health_ops/processors/base_git.py")
+_COMPLEXITY_SOURCE = _source("dev_health_ops/analytics/complexity.py")
 _GITHUB_CODE_CLIENT_SOURCE = _source("dev_health_ops/providers/github/code_client.py")
 _GITHUB_WORK_ITEM_OPTIONS_SOURCE = _source(
     "dev_health_ops/providers/github/work_item_options.py"
@@ -243,18 +244,12 @@ class _OracleAsyncBatchCollector:
 def _target_base_git() -> None:
     """Stub base_git.py's heavy, unrelated imports (CHAOS-3122).
 
-    ``BaseGitProcessor.coerce_created_at`` and the module-level
-    ``build_git_pull_request`` are pure functions; everything base_git.py
-    imports beyond them (complexity scanning, ORM models, the async batch
-    collector) is dead weight for this oracle and, more importantly, is not
-    importable under the stock interpreter this loader exists for. Each stub
-    only needs to satisfy the *names* base_git.py imports at module-load
-    time -- it never calls into any of them.
+    Most base_git.py imports remain unrelated to row construction and are
+    stubbed so this loader stays dependency-light. The real complexity module
+    is loaded because the GitLab files traversal oracle executes the live
+    processor's scanner gate before the worker persistence boundary.
     """
-    _install_module(
-        "dev_health_ops.analytics.complexity",
-        {"DEFAULT_COMPLEXITY_CONFIG_PATH": None, "ComplexityScanner": object},
-    )
+    _load_source_module("dev_health_ops.analytics.complexity", _COMPLEXITY_SOURCE)
     _install_module(
         "dev_health_ops.metrics.schemas",
         {"FileComplexitySnapshot": object, "RepoComplexityDaily": object},
@@ -603,10 +598,7 @@ def _target_gitlab_processor() -> None:
         "dev_health_ops.providers.operational_migration",
         _OPERATIONAL_MIGRATION_SOURCE,
     )
-    _install_module(
-        "dev_health_ops.analytics.complexity",
-        {"DEFAULT_COMPLEXITY_CONFIG_PATH": None, "ComplexityScanner": object},
-    )
+    _load_source_module("dev_health_ops.analytics.complexity", _COMPLEXITY_SOURCE)
     _install_module(
         "dev_health_ops.connectors.models",
         {


### PR DESCRIPTION
## Scope

Port the GitLab files provider pair to concrete typed Go route/effect models while preserving the live Python producer boundary.

## Evidence

- Live Python traversal and row differential oracles
- Migrated ClickHouse write/readback and recovery
- Shared mutation harness: 35/35 killed, clean restore
- Full provider tests, Ruff, and mypy green

## Boundaries

- Stacked on GitLab deployments
- No registry, matrix, config, deployment, or cutover wiring

Linear: CHAOS-3707

SCREENSHOT-WAIVER: Backend-only provider implementation; no rendered UI changes.
