### PR TITLE
CHAOS-3124: port GitLab security provider parity

### DIFF
--- a/internal/providersync/gitlab_security_effects_clickhouse.go
+++ b/internal/providersync/gitlab_security_effects_clickhouse.go
@@ -1,0 +1,208 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitLabSecurityClickHouseEffects is the tenant-fenced persistence boundary
+// for security_alerts. The schema is supplied by the real migrated
+// ClickHouse chain; this file intentionally contains no local DDL.
+type GitLabSecurityClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitLabSecurityClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "gitlab" || claim.Dataset != "security" ||
+		effect.Destination != "security_alerts" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeGitLabSecurityRows(effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO security_alerts (org_id, repo_id, alert_id, source, severity, state, package_name, cve_id, url, title, description, created_at, fixed_at, dismissed_at, last_synced)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(
+			row.OrgID, row.RepoID, row.AlertID, row.Source, row.Severity,
+			row.State, row.PackageName, row.CVEID, row.URL, row.Title,
+			row.Description, row.CreatedAt, row.FixedAt, row.DismissedAt,
+			row.LastSynced,
+		); err != nil {
+			return err
+		}
+	}
+	// A lease can expire while PrepareBatch is building a large effect. Do not
+	// send a batch after that boundary; the caller can retry the same frozen
+	// manifest under a fresh lease.
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitLabSecurityClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "gitlab" || claim.Dataset != "security" ||
+		effect.Destination != "security_alerts" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeGitLabSecurityRows(effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectGitLabSecurityAlert(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func decodeGitLabSecurityRows(effect EffectBatch) ([]gitLabSecurityAlertRow, error) {
+	rows, err := decodeEffectRows[gitLabSecurityAlertRow](effect)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		key := row.OrgID + "\x00" + row.RepoID + "\x00" + row.AlertID
+		if _, duplicate := seen[key]; duplicate {
+			return nil, errors.Join(providerfoundation.ErrSinkDuplicate, ErrEffectRecoveryUnsafe)
+		}
+		seen[key] = struct{}{}
+	}
+	return rows, nil
+}
+
+func (sink GitLabSecurityClickHouseEffects) inspectGitLabSecurityAlert(
+	ctx context.Context,
+	expected gitLabSecurityAlertRow,
+) (EffectInspection, error) {
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	rows, err := sink.Conn.Query(ctx, `SELECT org_id, repo_id, alert_id, source, severity, state, package_name, cve_id, url, title, description, created_at, fixed_at, dismissed_at, last_synced FROM security_alerts FINAL WHERE org_id = ? AND repo_id = ? AND alert_id = ?`, expected.OrgID, expected.RepoID, expected.AlertID)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual gitLabSecurityAlertRow
+	found := 0
+	for rows.Next() {
+		if err := rows.Scan(
+			&actual.OrgID, &actual.RepoID, &actual.AlertID, &actual.Source,
+			&actual.Severity, &actual.State, &actual.PackageName, &actual.CVEID,
+			&actual.URL, &actual.Title, &actual.Description, &actual.CreatedAt,
+			&actual.FixedAt, &actual.DismissedAt, &actual.LastSynced,
+		); err != nil {
+			return EffectConflict, err
+		}
+		found++
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return gitLabSecurityReadbackDecision(found, expected, actual), nil
+}
+
+func gitLabSecurityReadbackDecision(
+	found int,
+	expected, actual gitLabSecurityAlertRow,
+) EffectInspection {
+	if found > 1 {
+		return EffectConflict
+	}
+	return compareGitLabSecurityAlertVersion(expected, actual, found == 1)
+}
+
+func compareGitLabSecurityAlertVersion(
+	expected, actual gitLabSecurityAlertRow,
+	found bool,
+) EffectInspection {
+	if !found || actual.LastSynced.IsZero() || actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) {
+		return EffectConflict
+	}
+	if actual.OrgID != expected.OrgID || actual.RepoID != expected.RepoID ||
+		actual.AlertID != expected.AlertID || actual.Source != expected.Source ||
+		!stringPointersEqual(actual.Severity, expected.Severity) ||
+		!stringPointersEqual(actual.State, expected.State) ||
+		!stringPointersEqual(actual.PackageName, expected.PackageName) ||
+		!stringPointersEqual(actual.CVEID, expected.CVEID) ||
+		!stringPointersEqual(actual.URL, expected.URL) ||
+		!stringPointersEqual(actual.Title, expected.Title) ||
+		!stringPointersEqual(actual.Description, expected.Description) ||
+		!actual.CreatedAt.UTC().Equal(expected.CreatedAt.UTC()) ||
+		!timePointersEqual(actual.FixedAt, expected.FixedAt) ||
+		!timePointersEqual(actual.DismissedAt, expected.DismissedAt) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitLabSecurityClickHouseEffects{}
+var _ EffectReadback = GitLabSecurityClickHouseEffects{}

--- a/internal/providersync/gitlab_security_effects_integration_test.go
+++ b/internal/providersync/gitlab_security_effects_integration_test.go
@@ -1,0 +1,214 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// This integration proof authors no DDL.  security_alerts is created by the
+// real 032/033 migrations and rebuilt by 042 so org_id is the first component
+// of the ReplacingMergeTree key.  A hand-written table here would only prove a
+// second schema and could never catch drift in the production migration chain.
+func TestGitLabSecurityEffectsAgainstMigratedSchema(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+	conn := gitLabSecurityMigratedConnection(t, ctx)
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink := GitLabSecurityClickHouseEffects{Conn: conn, Lease: lease}
+
+	t.Run("migration exposes concrete tenant key and payload columns", func(t *testing.T) {
+		rows, err := conn.Query(ctx, `
+SELECT name, type
+FROM system.columns
+WHERE database = currentDatabase() AND table = 'security_alerts'
+ORDER BY name`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		columns := make(map[string]string)
+		for rows.Next() {
+			var name, columnType string
+			if err := rows.Scan(&name, &columnType); err != nil {
+				t.Fatal(err)
+			}
+			columns[name] = columnType
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		want := map[string]string{
+			"org_id":       "String",
+			"repo_id":      "UUID",
+			"alert_id":     "String",
+			"source":       "String",
+			"severity":     "Nullable(String)",
+			"state":        "Nullable(String)",
+			"package_name": "Nullable(String)",
+			"cve_id":       "Nullable(String)",
+			"url":          "Nullable(String)",
+			"title":        "Nullable(String)",
+			"description":  "Nullable(String)",
+			"created_at":   "DateTime64(3, 'UTC')",
+			"fixed_at":     "Nullable(DateTime64(3, 'UTC'))",
+			"dismissed_at": "Nullable(DateTime64(3, 'UTC'))",
+			"last_synced":  "DateTime64(3, 'UTC')",
+		}
+		if len(columns) != len(want) {
+			t.Fatalf("migrated security_alerts columns=%v want exactly=%v", columns, want)
+		}
+		for name, expected := range want {
+			if got := strings.ReplaceAll(columns[name], " ", ""); got != strings.ReplaceAll(expected, " ", "") {
+				t.Fatalf("column %s type=%q want=%q (all=%v)", name, columns[name], expected, columns)
+			}
+		}
+
+		var engine, sortingKey string
+		if err := conn.QueryRow(ctx, `
+SELECT engine, sorting_key
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'security_alerts'`).Scan(&engine, &sortingKey); err != nil {
+			t.Fatal(err)
+		}
+		if engine != "ReplacingMergeTree" {
+			t.Fatalf("security_alerts engine=%q want ReplacingMergeTree", engine)
+		}
+		if normalized := strings.ReplaceAll(sortingKey, " ", ""); normalized != "org_id,repo_id,alert_id" {
+			t.Fatalf("security_alerts sorting key=%q want org_id,repo_id,alert_id", sortingKey)
+		}
+	})
+
+	// Stop background merges so count() proves physical replay/version rows;
+	// InspectEffect still uses FINAL and must resolve the logical winner.
+	if err := conn.Exec(ctx, `SYSTEM STOP MERGES security_alerts`); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Exec(ctx, `SYSTEM START MERGES security_alerts`); err != nil {
+			t.Errorf("resume security_alerts merges: %v", err)
+		}
+	})
+
+	claim := nativeTestClaim("gitlab", "security")
+	foreignClaim := claim
+	foreignClaim.OrgID = "org-gitlab-foreign"
+	now := time.Date(2026, 8, 10, 12, 0, 0, 123000000, time.UTC)
+
+	t.Run("same natural key remains tenant fenced", func(t *testing.T) {
+		foreign := gitLabSecurityIntegrationRow(foreignClaim, "tenant-collision", now)
+		current := gitLabSecurityIntegrationRow(claim, "tenant-collision", now)
+		if err := sink.WriteEffect(ctx, foreignClaim, gitLabSecurityIntegrationEffect(t, foreign)); err != nil {
+			t.Fatal(err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, current)); err != nil || inspection != EffectAbsent {
+			t.Fatalf("foreign row inspection=%s error=%v", inspection, err)
+		}
+		if err := sink.WriteEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, current)); err != nil {
+			t.Fatal(err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, current)); err != nil || inspection != EffectExact {
+			t.Fatalf("current row inspection=%s error=%v", inspection, err)
+		}
+		assertGitLabSecurityPhysicalRows(t, ctx, conn, current, 2)
+	})
+
+	t.Run("FINAL selects newer replay version", func(t *testing.T) {
+		stale := gitLabSecurityIntegrationRow(claim, "versioned", now)
+		newer := stale
+		newer.LastSynced = now.Add(time.Minute)
+		newer.Title = gitLabSecurityStringPointer("newer")
+		if err := sink.WriteEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, stale)); err != nil {
+			t.Fatal(err)
+		}
+		if err := sink.WriteEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, newer)); err != nil {
+			t.Fatal(err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, stale)); err != nil || inspection != EffectConflict {
+			t.Fatalf("stale row inspection=%s error=%v", inspection, err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, newer)); err != nil || inspection != EffectExact {
+			t.Fatalf("newer row inspection=%s error=%v", inspection, err)
+		}
+		assertGitLabSecurityPhysicalRows(t, ctx, conn, stale, 2)
+	})
+}
+
+func gitLabSecurityMigratedConnection(t *testing.T, ctx context.Context) driver.Conn {
+	t.Helper()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func gitLabSecurityIntegrationRow(claim Claim, alertID string, synced time.Time) gitLabSecurityAlertRow {
+	created := synced.Add(-time.Hour)
+	severity := "high"
+	state := "detected"
+	cve := "CVE-2026-3124"
+	url := "https://gitlab.example/acme/api/-/security/vulnerability/" + alertID
+	packageName := "example-package"
+	return gitLabSecurityAlertRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		AlertID: alertID, Source: "gitlab_vulnerability", Severity: &severity,
+		State: &state, PackageName: &packageName, CVEID: &cve, URL: &url,
+		Title: gitLabSecurityStringPointer("security finding"), CreatedAt: created,
+		LastSynced: synced,
+	}
+}
+
+func gitLabSecurityIntegrationEffect(t *testing.T, row gitLabSecurityAlertRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, []gitLabSecurityAlertRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func assertGitLabSecurityPhysicalRows(
+	t *testing.T,
+	ctx context.Context,
+	conn driver.Conn,
+	row gitLabSecurityAlertRow,
+	want uint64,
+) {
+	t.Helper()
+	var got uint64
+	if err := conn.QueryRow(ctx, `
+SELECT count()
+FROM security_alerts
+WHERE repo_id = ? AND alert_id = ?`, row.RepoID, row.AlertID).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("physical security_alerts rows=%d want=%d (%s)", got, want, fmt.Sprintf("%s/%s", row.OrgID, row.AlertID))
+	}
+}
+
+func gitLabSecurityStringPointer(value string) *string { return &value }

--- a/internal/providersync/gitlab_security_effects_test.go
+++ b/internal/providersync/gitlab_security_effects_test.go
@@ -1,0 +1,147 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func gitLabSecurityEffect(t *testing.T, rows ...gitLabSecurityAlertRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func validGitLabSecurityRow(claim Claim) gitLabSecurityAlertRow {
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	fixedAt := now.Add(time.Minute)
+	dismissedAt := now.Add(2 * time.Minute)
+	return gitLabSecurityAlertRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		AlertID: "gitlab_vuln:1", Source: "gitlab_vulnerability",
+		Severity: ptrString("high"), State: ptrString("detected"),
+		CVEID: ptrString("CVE-2026-0001"), URL: ptrString("https://example.invalid/1"),
+		Title: ptrString("finding"), Description: ptrString("description"),
+		CreatedAt: now, FixedAt: &fixedAt, DismissedAt: &dismissedAt, LastSynced: now,
+	}
+}
+
+func ptrString(value string) *string { return &value }
+
+func TestGitLabSecurityEffectsRejectCrossTenantAndDuplicateRowsBeforeClickHouse(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	sink := GitLabSecurityClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	foreign := validGitLabSecurityRow(claim)
+	foreign.OrgID = "other-org"
+	if err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t, foreign)); err == nil {
+		t.Fatal("foreign row passed sink validation")
+	}
+	row := validGitLabSecurityRow(claim)
+	err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t, row, row))
+	if !errors.Is(err, providerfoundation.ErrSinkDuplicate) {
+		t.Fatalf("duplicate error=%v", err)
+	}
+}
+
+func TestGitLabSecurityEffectsCheckLeaseBeforePrepareAndQuery(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	sink := GitLabSecurityClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return providerfoundation.ErrLeaseLost
+		}),
+	}
+	row := validGitLabSecurityRow(claim)
+	if err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t, row)); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("write error=%v", err)
+	}
+	inspection, err := sink.InspectEffect(context.Background(), claim, gitLabSecurityEffect(t, row))
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || inspection != EffectConflict {
+		t.Fatalf("inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabSecurityEffectsAllowLegitimateEmptyEffect(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	sink := GitLabSecurityClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	if err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := sink.InspectEffect(context.Background(), claim, gitLabSecurityEffect(t))
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestCompareGitLabSecurityAlertVersionChecksFullPayloadAndTimestamp(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	expected := validGitLabSecurityRow(claim)
+	if got := compareGitLabSecurityAlertVersion(expected, expected, true); got != EffectExact {
+		t.Fatalf("exact=%s", got)
+	}
+	if got := compareGitLabSecurityAlertVersion(expected, gitLabSecurityAlertRow{}, false); got != EffectAbsent {
+		t.Fatalf("absent=%s", got)
+	}
+	stale := expected
+	stale.LastSynced = stale.LastSynced.Add(-time.Second)
+	if got := compareGitLabSecurityAlertVersion(expected, stale, true); got != EffectAbsent {
+		t.Fatalf("stale=%s", got)
+	}
+	newer := expected
+	newer.LastSynced = newer.LastSynced.Add(time.Second)
+	if got := compareGitLabSecurityAlertVersion(expected, newer, true); got != EffectConflict {
+		t.Fatalf("newer=%s", got)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*gitLabSecurityAlertRow)
+	}{
+		{name: "org_id", mutate: func(row *gitLabSecurityAlertRow) { row.OrgID = "other-org" }},
+		{name: "repo_id", mutate: func(row *gitLabSecurityAlertRow) { row.RepoID = "2f2d6f7c-2f28-4d6b-a0b7-48ec4d77a4f0" }},
+		{name: "alert_id", mutate: func(row *gitLabSecurityAlertRow) { row.AlertID = "gitlab_vuln:changed" }},
+		{name: "source", mutate: func(row *gitLabSecurityAlertRow) { row.Source = "gitlab_dependency" }},
+		{name: "severity", mutate: func(row *gitLabSecurityAlertRow) { row.Severity = ptrString("low") }},
+		{name: "state", mutate: func(row *gitLabSecurityAlertRow) { row.State = ptrString("resolved") }},
+		{name: "package_name", mutate: func(row *gitLabSecurityAlertRow) { row.PackageName = ptrString("pkg") }},
+		{name: "cve_id", mutate: func(row *gitLabSecurityAlertRow) { row.CVEID = ptrString("CVE-2026-0002") }},
+		{name: "url", mutate: func(row *gitLabSecurityAlertRow) { row.URL = ptrString("https://example.invalid/changed") }},
+		{name: "title", mutate: func(row *gitLabSecurityAlertRow) { row.Title = ptrString("changed") }},
+		{name: "description", mutate: func(row *gitLabSecurityAlertRow) { row.Description = ptrString("changed") }},
+		{name: "created_at", mutate: func(row *gitLabSecurityAlertRow) { row.CreatedAt = row.CreatedAt.Add(time.Second) }},
+		{name: "fixed_at", mutate: func(row *gitLabSecurityAlertRow) { changed := row.FixedAt.Add(time.Second); row.FixedAt = &changed }},
+		{name: "dismissed_at", mutate: func(row *gitLabSecurityAlertRow) {
+			changed := row.DismissedAt.Add(time.Second)
+			row.DismissedAt = &changed
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := expected
+			test.mutate(&changed)
+			if got := compareGitLabSecurityAlertVersion(expected, changed, true); got != EffectConflict {
+				t.Fatalf("changed=%s", got)
+			}
+		})
+	}
+}
+
+func TestGitLabSecurityReadbackRejectsAmbiguousRows(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	row := validGitLabSecurityRow(claim)
+	if got := gitLabSecurityReadbackDecision(2, row, row); got != EffectConflict {
+		t.Fatalf("ambiguous rows=%s", got)
+	}
+}

--- a/internal/providersync/gitlab_security_generic_oracle_test.go
+++ b/internal/providersync/gitlab_security_generic_oracle_test.go
@@ -1,0 +1,278 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+var oracleGitLabSecurityNormalizedAt = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+var oracleGitLabSecurityGoOnlyFields = map[string]string{
+	"org_id":      "stamped from the Go claim for tenant-scoped persistence",
+	"repo_id":     "provided by the Go route after repository identity resolution",
+	"last_synced": "stamped from normalizedAt by the Go route",
+}
+
+func decodeGitLabSecurityOracleMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var decoded map[string]any
+	if err := decoder.Decode(&decoded); err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+func buildGitLabSecurityVulnerabilityRowForOracle(t *testing.T, input map[string]any) gitLabSecurityAlertRow {
+	t.Helper()
+	claim := nativeTestClaim("gitlab", "security")
+	row, include, err := normalizeGitLabSecurityAlert(
+		claim, input["repo_id"].(string), "gitlab_vulnerability",
+		decodeGitLabSecurityOracleMap(t, input["raw_alert"]), oracleGitLabSecurityNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !include {
+		t.Fatal("vulnerability oracle item did not produce a row")
+	}
+	return row
+}
+
+func buildGitLabSecurityDependencyRowForOracle(t *testing.T, input map[string]any) gitLabSecurityAlertRow {
+	t.Helper()
+	claim := nativeTestClaim("gitlab", "security")
+	row, include, err := normalizeGitLabSecurityAlert(
+		claim, input["repo_id"].(string), "gitlab_dependency",
+		func() map[string]any {
+			payload := decodeGitLabSecurityOracleMap(t, input["raw_alert"])
+			payload["package_name"] = input["package_name"]
+			return payload
+		}(), oracleGitLabSecurityNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !include {
+		t.Fatal("dependency oracle item did not produce a row")
+	}
+	return row
+}
+
+func oracleGitLabSecurityVulnerabilityCases() []oracleCase {
+	return []oracleCase{
+		{
+			ID: "full_mapping",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_alert": map[string]any{
+					"id": 101, "severity": "high", "state": "detected", "name": "SQL Injection",
+					"created_at":  "2026-01-15T10:30:00.000Z",
+					"identifiers": []any{map[string]any{"type": "other", "name": "ignored"}, map[string]any{"type": "cve", "name": "CVE-2026-1234"}},
+					"links":       map[string]any{"url": "https://gitlab.example/vuln/101"},
+				},
+			},
+		},
+		{
+			ID: "optional_fields_missing",
+			Input: map[string]any{
+				"repo_id":   "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_alert": map[string]any{"id": 202, "severity": "low", "state": "resolved", "name": "XSS", "created_at": "2026-01-16T10:30:00Z"},
+			},
+		},
+	}
+}
+
+func oracleGitLabSecurityDependencyCases() []oracleCase {
+	return []oracleCase{{
+		ID: "dependency_mapping",
+		Input: map[string]any{
+			"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "package_name": "lodash",
+			"raw_alert": map[string]any{"id": 303, "severity": "critical", "url": "https://gitlab.example/vuln/303", "name": "Prototype Pollution"},
+		},
+	}}
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabSecurityVulnerabilityRows(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/security/vulnerability", oracleGitLabSecurityVulnerabilityCases(),
+		buildGitLabSecurityVulnerabilityRowForOracle, oracleGitLabSecurityGoOnlyFields,
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabSecurityDependencyRows(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/security/dependency", oracleGitLabSecurityDependencyCases(),
+		buildGitLabSecurityDependencyRowForOracle, oracleGitLabSecurityGoOnlyFields,
+	)
+}
+
+type gitLabSecurityTraversalTraceRow struct {
+	AlertID string `json:"alert_id"`
+	Source  string `json:"source"`
+}
+
+type gitLabSecurityTraversalTrace struct {
+	ProducerRequests  []string                          `json:"producer_requests"`
+	UsageRequestCount int                               `json:"usage_request_count"`
+	Rows              []gitLabSecurityTraversalTraceRow `json:"rows"`
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabSecurityTraversal(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/security/trace", oracleGitLabSecurityTraversalCases(),
+		buildGitLabSecurityTraversalTrace, nil,
+	)
+}
+
+func oracleGitLabSecurityTraversalCases() []oracleCase {
+	return []oracleCase{
+		{
+			ID: "single_page_window",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "max_alerts": 1000,
+				"since": "2026-07-22T00:00:00Z", "until": "2026-07-23T12:00:00Z",
+				"findings": []any{
+					map[string]any{"id": 1, "created_at": "2026-07-21T10:00:00Z", "name": "old"},
+					map[string]any{"id": 2, "created_at": "2026-07-22T10:00:00Z", "name": "in"},
+					map[string]any{"id": 3, "created_at": "2026-07-23T13:00:00Z", "name": "after"},
+				},
+				"dependencies": []any{map[string]any{"name": "pkg", "vulnerabilities": []any{map[string]any{"id": 4, "name": "dependency"}}}},
+				"response_headers": map[string]any{
+					"findings": map[string]any{"X-Next-Page": "2"}, "dependencies": map[string]any{"X-Next-Page": "2"},
+				},
+			},
+		},
+		{
+			ID: "plain_forbidden_optional_endpoint",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "max_alerts": 1000,
+				"since": "2026-07-01T00:00:00Z", "until": "2026-12-31T00:00:00Z",
+				"findings_status": http.StatusForbidden, "findings": []any{},
+				"dependencies": []any{map[string]any{"name": "pkg", "vulnerabilities": []any{map[string]any{"id": 5, "name": "dependency"}}}},
+			},
+		},
+		{
+			ID: "core_failure_stops_second_endpoint",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "max_alerts": 1000,
+				"since": "2026-07-01T00:00:00Z", "until": "2026-12-31T00:00:00Z",
+				"findings_status": http.StatusBadRequest,
+				"dependencies":    []any{map[string]any{"name": "pkg", "vulnerabilities": []any{map[string]any{"id": 6, "name": "not fetched"}}}},
+			},
+		},
+	}
+}
+
+func buildGitLabSecurityTraversalTrace(t *testing.T, input map[string]any) gitLabSecurityTraversalTrace {
+	t.Helper()
+	responses := map[string]gitLabSecurityHTTPResponse{
+		"/api/v4/projects/123": {body: `{"id":123,"name":"api","path_with_namespace":"acme/api"}`},
+	}
+	for _, endpoint := range []struct {
+		path string
+		key  string
+	}{
+		{path: "/api/v4/projects/123/vulnerability_findings", key: "findings"},
+		{path: "/api/v4/projects/123/dependencies", key: "dependencies"},
+	} {
+		body, err := json.Marshal(input[endpoint.key])
+		if err != nil {
+			t.Fatal(err)
+		}
+		status := http.StatusOK
+		if value, ok := input[endpoint.key+"_status"].(int); ok {
+			status = value
+		}
+		headers := http.Header{}
+		if configured, ok := input["response_headers"].(map[string]any); ok {
+			if endpointHeaders, ok := configured[endpoint.key].(map[string]any); ok {
+				for key, value := range endpointHeaders {
+					headers.Set(key, stringValue(value))
+				}
+			}
+		}
+		responses[endpoint.path] = gitLabSecurityHTTPResponse{status: status, headers: headers, body: string(body)}
+	}
+	doer := &gitLabSecurityRouteDoer{responses: responses}
+	claim := nativeTestClaim("gitlab", "security")
+	claim.SinceAt = oracleGitLabSecurityTraceTime(t, input, "since")
+	claim.BeforeAt = oracleGitLabSecurityTraceTime(t, input, "until")
+	maxAlerts, ok := input["max_alerts"].(int)
+	if !ok {
+		t.Fatalf("max_alerts=%T", input["max_alerts"])
+	}
+	batch, err := (GitLabSecurityRouteHandler{MaxAlerts: maxAlerts}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), oracleGitLabSecurityNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trace := gitLabSecurityTraversalTrace{
+		ProducerRequests:  make([]string, 0, len(doer.requests)),
+		UsageRequestCount: batch.Evidence.Requests,
+		Rows:              make([]gitLabSecurityTraversalTraceRow, 0),
+	}
+	for _, request := range doer.requests {
+		trace.ProducerRequests = append(trace.ProducerRequests, oracleGitLabSecurityRequestPath(request))
+	}
+	if len(batch.Effects) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	for _, raw := range batch.Effects[0].Rows {
+		var row gitLabSecurityAlertRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		trace.Rows = append(trace.Rows, gitLabSecurityTraversalTraceRow{AlertID: row.AlertID, Source: row.Source})
+	}
+	return trace
+}
+
+func oracleGitLabSecurityTraceTime(t *testing.T, input map[string]any, key string) *time.Time {
+	t.Helper()
+	value, ok := input[key].(string)
+	if !ok || value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &parsed
+}
+
+func oracleGitLabSecurityRequestPath(request *http.Request) string {
+	query := request.URL.Query()
+	encoded := url.Values{}
+	keys := make([]string, 0, len(query))
+	for key := range query {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		values := append([]string(nil), query[key]...)
+		sort.Strings(values)
+		for _, value := range values {
+			encoded.Add(key, value)
+		}
+	}
+	if encoded.Encode() == "" {
+		return request.URL.Path
+	}
+	return request.URL.Path + "?" + encoded.Encode()
+}

--- a/internal/providersync/gitlab_security_route.go
+++ b/internal/providersync/gitlab_security_route.go
@@ -1,0 +1,424 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	// The Python helper passes the processor batch size through to the code
+	// client. The code client itself requests exactly one 100-record page for
+	// each security endpoint; that frozen single-page boundary is intentional.
+	defaultGitLabSecurityMaxAlerts = 1_000
+	gitLabSecurityPerPage          = 100
+)
+
+// gitLabSecurityAlertRow is the sink-ready form of SecurityAlertData. The
+// provider's code client owns source mapping; the route adds tenant/repo
+// identity and the retry-stable last_synced value at this boundary.
+type gitLabSecurityAlertRow struct {
+	OrgID       string     `json:"org_id"`
+	RepoID      string     `json:"repo_id"`
+	AlertID     string     `json:"alert_id"`
+	Source      string     `json:"source"`
+	Severity    *string    `json:"severity"`
+	State       *string    `json:"state"`
+	PackageName *string    `json:"package_name"`
+	CVEID       *string    `json:"cve_id"`
+	URL         *string    `json:"url"`
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	CreatedAt   time.Time  `json:"created_at"`
+	FixedAt     *time.Time `json:"fixed_at"`
+	DismissedAt *time.Time `json:"dismissed_at"`
+	LastSynced  time.Time  `json:"last_synced"`
+}
+
+// GitLabSecurityRouteHandler mirrors
+// processors.gitlab._fetch_gitlab_security_alerts_sync. It deliberately has
+// no switch/registry wiring in this slice; the parent lane owns activation.
+type GitLabSecurityRouteHandler struct{ MaxAlerts int }
+
+type gitLabSecurityResponseObserver struct {
+	attempts    *int
+	lastStatus  int
+	lastHeaders http.Header
+}
+
+type gitLabSecurityCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	observe  *gitLabSecurityResponseObserver
+}
+
+func (doer gitLabSecurityCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.observe.attempts)++
+	response, err := doer.delegate.Do(request)
+	if response != nil {
+		doer.observe.lastStatus = response.StatusCode
+		doer.observe.lastHeaders = response.Header.Clone()
+	}
+	return response, err
+}
+
+func (handler GitLabSecurityRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "security" || client == nil || client.Provider != "gitlab" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxAlerts := handler.MaxAlerts
+	if maxAlerts == 0 {
+		maxAlerts = defaultGitLabSecurityMaxAlerts
+	}
+	if maxAlerts < 1 {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	projectID, err := gitLabProjectID(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+
+	requests := 0
+	observer := &gitLabSecurityResponseObserver{attempts: &requests}
+	counted := *client
+	counted.Doer = gitLabSecurityCountingDoer{delegate: client.Doer, observe: observer}
+	root := providerRelativePath(&counted, "api", "v4", "projects", projectID)
+	var project repositoryPayload
+	if err := fetchObject(ctx, &counted, root, &project); err != nil {
+		// Project resolution is not optional in the Python client: without its
+		// returned numeric id and full name no security row can be scoped.
+		return CompleteRouteBatch{}, err
+	}
+	parsedProjectID, err := project.ID.Int64()
+	if err != nil || parsedProjectID < 1 || strconv.FormatInt(parsedProjectID, 10) != projectID {
+		return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+	}
+	fullName := gitLabProjectFullName(project)
+	repoID, err := repositoryIdentity(fullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+
+	findings, findingPages, err := fetchGitLabSecurityObjects(
+		ctx, &counted, root+"/vulnerability_findings", observer,
+	)
+	findingsOptional, fatal := gitLabSecurityEndpointDecision(ctx, err, observer)
+	if fatal != nil {
+		return CompleteRouteBatch{}, fatal
+	}
+	if err != nil {
+		if !findingsOptional {
+			return gitLabSecurityBatch(claim, fullName, parsedProjectID, normalizedAt, nil, requests, findingPages)
+		}
+		// The Python processor catches any optional security fetch exception and
+		// continues with the alerts already accumulated by the helper. A failed
+		// endpoint therefore contributes no rows but does not block the other
+		// optional endpoint; control-plane cancellation/lease/rate-limit errors
+		// were returned above.
+		findings, findingPages = nil, 0
+	}
+
+	dependencies, dependencyPages, err := fetchGitLabSecurityObjects(
+		ctx, &counted, root+"/dependencies", observer,
+	)
+	dependenciesOptional, fatal := gitLabSecurityEndpointDecision(ctx, err, observer)
+	if fatal != nil {
+		return CompleteRouteBatch{}, fatal
+	}
+	if err != nil {
+		if !dependenciesOptional {
+			return gitLabSecurityBatch(claim, fullName, parsedProjectID, normalizedAt, nil, requests, findingPages+dependencyPages)
+		}
+		dependencies, dependencyPages = nil, 0
+	}
+
+	// GitLabCodeClient.get_security_alerts slices the combined source list,
+	// before processors.gitlab applies its since filter. Preserve that order.
+	combined := make([]gitLabSecurityObject, 0, len(findings)+len(dependencies))
+	combined = append(combined, findings...)
+	combined = append(combined, dependencies...)
+	if len(combined) > maxAlerts {
+		combined = combined[:maxAlerts]
+	}
+	rows := make([]gitLabSecurityAlertRow, 0, len(combined))
+	for _, object := range combined {
+		row, include, normalizeErr := normalizeGitLabSecurityAlert(
+			claim, repoID, object.Source, object.Payload, normalizedAt,
+		)
+		if normalizeErr != nil {
+			return CompleteRouteBatch{}, normalizeErr
+		}
+		if !include {
+			// The Python processor discards mapped alerts with a missing or
+			// malformed created_at before constructing the persisted model.
+			continue
+		}
+		if securityAlertOutsideWindow(row.CreatedAt, claim) {
+			continue
+		}
+		rows = append(rows, row)
+	}
+
+	return gitLabSecurityBatch(claim, fullName, parsedProjectID, normalizedAt, rows, requests, findingPages+dependencyPages)
+}
+
+type gitLabSecurityObject struct {
+	Source  string
+	Payload map[string]any
+}
+
+func fetchGitLabSecurityObjects(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	path string,
+	observer *gitLabSecurityResponseObserver,
+) ([]gitLabSecurityObject, int, error) {
+	// GitLabCodeClient calls the security endpoints directly with only
+	// per_page; unlike the provider's generic paginator it does not add a
+	// page=1 parameter. Preserve that request shape as well as its deliberate
+	// one-page/no-X-Next-Page traversal boundary.
+	query := url.Values{"per_page": {strconv.Itoa(gitLabSecurityPerPage)}}
+	response, err := client.Do(ctx, http.MethodGet, path+"?"+query.Encode(), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if response == nil || response.Body == nil {
+		return nil, 0, providerfoundation.ErrNormalizationInvalid
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 2<<20))
+	if err != nil {
+		return nil, 0, err
+	}
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal(body, &rawItems); err != nil {
+		return nil, 0, providerfoundation.ErrNormalizationInvalid
+	}
+	objects := make([]gitLabSecurityObject, 0, len(rawItems))
+	source := "gitlab_vulnerability"
+	if strings.HasSuffix(path, "/dependencies") {
+		source = "gitlab_dependency"
+	}
+	for _, raw := range rawItems {
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.UseNumber()
+		var payload map[string]any
+		if err := decoder.Decode(&payload); err != nil || payload == nil {
+			return nil, 1, providerfoundation.ErrNormalizationInvalid
+		}
+		if source == "gitlab_dependency" {
+			for _, rawVulnerability := range gitLabSecurityList(payload["vulnerabilities"]) {
+				vulnerability, ok := rawVulnerability.(map[string]any)
+				if !ok {
+					return nil, 1, providerfoundation.ErrNormalizationInvalid
+				}
+				// _map_dependency_alert receives both the dependency package
+				// and its vulnerability. Flatten only at the Go normalization
+				// boundary; the raw request shape remains unchanged.
+				flattened := cloneGitLabSecurityMap(vulnerability)
+				flattened["package_name"] = payload["name"]
+				objects = append(objects, gitLabSecurityObject{Source: source, Payload: flattened})
+			}
+			continue
+		}
+		objects = append(objects, gitLabSecurityObject{Source: source, Payload: payload})
+	}
+	return objects, 1, nil
+}
+
+func gitLabSecurityEndpointDecision(
+	ctx context.Context,
+	err error,
+	observer *gitLabSecurityResponseObserver,
+) (optional bool, fatal error) {
+	if err == nil {
+		return true, nil
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, providerfoundation.ErrLeaseLost) || errors.Is(err, ErrLeaseLost) {
+		return false, err
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) {
+		if providerErr.Class == providerfoundation.ErrorRateLimited ||
+			(providerErr.StatusCode == http.StatusForbidden && gitLabSecurityRateLimited(observer.lastHeaders)) {
+			return false, err
+		}
+		if providerErr.StatusCode == http.StatusForbidden || providerErr.StatusCode == http.StatusNotFound {
+			return true, nil
+		}
+	}
+	// A non-optional exception aborts get_security_alerts before its second
+	// endpoint, and the processor catches the whole call as an empty result.
+	// Return false so the route emits the same empty successful batch without
+	// manufacturing partial rows from the endpoint fetched first.
+	return false, nil
+}
+
+func gitLabSecurityBatch(
+	claim Claim,
+	fullName string,
+	projectID int64,
+	normalizedAt time.Time,
+	rows []gitLabSecurityAlertRow,
+	requests int,
+	pages int,
+) (CompleteRouteBatch, error) {
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Result:    map[string]any{"security_alerts_synced": len(rows), "repo": fullName, "project_id": projectID},
+		Watermark: claim.BeforeAt,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: requests, Pages: pages, Records: len(rows),
+		},
+	}, nil
+}
+
+func gitLabSecurityRateLimited(headers http.Header) bool {
+	if headers == nil {
+		return false
+	}
+	return strings.TrimSpace(gitLabSecurityHeader(headers, "Retry-After")) != "" ||
+		strings.TrimSpace(gitLabSecurityHeader(headers, "RateLimit-Remaining")) == "0"
+}
+
+func gitLabSecurityHeader(headers http.Header, name string) string {
+	for key, values := range headers {
+		if strings.EqualFold(key, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func normalizeGitLabSecurityAlert(
+	claim Claim,
+	repoID string,
+	source string,
+	payload map[string]any,
+	normalizedAt time.Time,
+) (gitLabSecurityAlertRow, bool, error) {
+	row := gitLabSecurityAlertRow{
+		OrgID: claim.OrgID, RepoID: repoID, Source: source, LastSynced: normalizedAt,
+	}
+	switch source {
+	case "gitlab_vulnerability":
+		id := strings.TrimSpace(stringValue(payload["id"]))
+		if id == "" {
+			return gitLabSecurityAlertRow{}, false, providerfoundation.ErrNormalizationInvalid
+		}
+		row.AlertID = "gitlab_vuln:" + id
+		row.Severity = gitLabSecurityOptionalString(payload["severity"])
+		row.State = gitLabSecurityOptionalString(payload["state"])
+		row.Title = gitLabSecurityOptionalString(payload["name"])
+		if links, ok := payload["links"].(map[string]any); ok {
+			row.URL = gitLabSecurityOptionalString(links["url"])
+		}
+		for _, identifier := range gitLabSecurityList(payload["identifiers"]) {
+			item, ok := identifier.(map[string]any)
+			if ok && stringValue(item["type"]) == "cve" {
+				row.CVEID = gitLabSecurityOptionalString(item["name"])
+				break
+			}
+		}
+		createdAt := parseGitLabSecurityTime(payload["created_at"])
+		if createdAt == nil {
+			return row, false, nil
+		}
+		row.CreatedAt = createdAt.UTC().Truncate(time.Millisecond)
+	case "gitlab_dependency":
+		id := strings.TrimSpace(stringValue(payload["id"]))
+		if id == "" {
+			return gitLabSecurityAlertRow{}, false, providerfoundation.ErrNormalizationInvalid
+		}
+		row.AlertID = "gitlab_dep:" + id
+		row.Severity = gitLabSecurityOptionalString(payload["severity"])
+		row.PackageName = gitLabSecurityOptionalString(payload["package_name"])
+		row.URL = gitLabSecurityOptionalString(payload["url"])
+		row.Title = gitLabSecurityOptionalString(payload["name"])
+		// The dependency API has no vulnerability timestamp. Python uses
+		// datetime.now(timezone.utc); normalizedAt is the route's stable,
+		// executor-supplied equivalent so retries converge.
+		row.CreatedAt = normalizedAt
+	default:
+		return gitLabSecurityAlertRow{}, false, providerfoundation.ErrNormalizationInvalid
+	}
+	if err := row.validate(claim); err != nil {
+		return gitLabSecurityAlertRow{}, false, err
+	}
+	return row, true, nil
+}
+
+func gitLabSecurityList(value any) []any {
+	items, _ := value.([]any)
+	return items
+}
+
+func cloneGitLabSecurityMap(input map[string]any) map[string]any {
+	cloned := make(map[string]any, len(input)+1)
+	for key, value := range input {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func parseGitLabSecurityTime(value any) *time.Time {
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.Replace(text, "Z", "+00:00", 1))
+	if err != nil {
+		return nil
+	}
+	parsed = parsed.UTC()
+	return &parsed
+}
+
+func gitLabSecurityOptionalString(value any) *string {
+	text := strings.TrimSpace(stringValue(value))
+	if text == "" {
+		return nil
+	}
+	return &text
+}
+
+func (row gitLabSecurityAlertRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || row.AlertID == "" ||
+		(row.Source != "gitlab_vulnerability" && row.Source != "gitlab_dependency") ||
+		row.CreatedAt.IsZero() || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	if _, err := uuid.Parse(row.RepoID); err != nil {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitLabSecurityRouteHandler{}

--- a/internal/providersync/gitlab_security_route_test.go
+++ b/internal/providersync/gitlab_security_route_test.go
@@ -1,0 +1,373 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitLabSecurityRouteDoer struct {
+	responses map[string]gitLabSecurityHTTPResponse
+	requests  []*http.Request
+}
+
+type gitLabSecurityHTTPResponse struct {
+	status  int
+	headers http.Header
+	body    string
+}
+
+func (doer *gitLabSecurityRouteDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.requests = append(doer.requests, request)
+	response, ok := doer.responses[request.URL.Path]
+	if !ok {
+		return nil, errors.New("unexpected GitLab security request: " + request.URL.String())
+	}
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	headers := response.headers
+	if headers == nil {
+		headers = http.Header{"Content-Type": []string{"application/json"}}
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func gitLabSecurityRouteClient(t *testing.T, doer providerfoundation.HTTPDoer) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"gitlab", "https://gitlab.example", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func gitLabSecurityRouteFixtures() map[string]gitLabSecurityHTTPResponse {
+	return map[string]gitLabSecurityHTTPResponse{
+		"/api/v4/projects/123": {body: `{"id":123,"name":"api","path_with_namespace":"acme/api"}`},
+		"/api/v4/projects/123/vulnerability_findings": {headers: http.Header{"X-Next-Page": []string{"2"}}, body: `[
+            {"id":1,"severity":"low","state":"detected","name":"old","created_at":"2026-07-21T10:00:00Z"},
+            {"id":2,"severity":"high","state":"detected","name":"in-window","created_at":"2026-07-22T10:00:00Z","identifiers":[{"type":"other","name":"x"},{"type":"cve","name":"CVE-2026-0002"}],"links":{"url":"https://gitlab.example/a/2"}},
+            {"id":3,"severity":"critical","state":"detected","name":"after","created_at":"2026-07-23T13:00:00Z"}
+        ]`},
+		"/api/v4/projects/123/dependencies": {headers: http.Header{"X-Next-Page": []string{"2"}}, body: `[
+            {"name":"widget","vulnerabilities":[{"id":4,"severity":"medium","name":"dep","url":"https://gitlab.example/d/4"}]}
+        ]`},
+	}
+}
+
+func TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	claim := nativeTestClaim("gitlab", "security")
+	since := time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	claim.SinceAt, claim.BeforeAt = &since, &before
+	normalizedAt := time.Date(2026, 7, 23, 12, 30, 0, 987654321, time.UTC)
+
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 3 || batch.Evidence.Requests != 3 || batch.Evidence.Pages != 2 ||
+		batch.Evidence.Records != 1 || batch.Evidence.CapReached {
+		t.Fatalf("requests=%d evidence=%+v", len(doer.requests), batch.Evidence)
+	}
+	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark=%v", batch.Watermark)
+	}
+	for _, request := range doer.requests[1:] {
+		if request.URL.Query().Get("page") != "" || request.URL.Query().Get("per_page") != "100" {
+			t.Fatalf("single-page request=%s", request.URL.String())
+		}
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "security_alerts" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	var row gitLabSecurityAlertRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &row); err != nil {
+		t.Fatal(err)
+	}
+	if row.AlertID != "gitlab_vuln:2" || row.Source != "gitlab_vulnerability" ||
+		row.OrgID != claim.OrgID || row.PackageName != nil || row.CVEID == nil ||
+		*row.CVEID != "CVE-2026-0002" || row.URL == nil ||
+		!row.CreatedAt.Equal(time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)) ||
+		!row.LastSynced.Equal(normalizedAt.UTC().Truncate(time.Millisecond)) {
+		t.Fatalf("row=%+v", row)
+	}
+}
+
+func TestGitLabSecurityRouteSlicesCombinedAlertsBeforeWindowFiltering(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	claim := nativeTestClaim("gitlab", "security")
+	since := time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC)
+	claim.SinceAt = &since
+	batch, err := (GitLabSecurityRouteHandler{MaxAlerts: 1}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 {
+		// The first vulnerability is before the claim window; Python applies
+		// max_alerts in the code client before processors applies `since`.
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+}
+
+func TestGitLabSecurityRouteDegradesPlainOptionalErrors(t *testing.T) {
+	t.Parallel()
+	for path, status := range map[string]int{
+		"/api/v4/projects/123/vulnerability_findings": http.StatusForbidden,
+		"/api/v4/projects/123/dependencies":           http.StatusNotFound,
+	} {
+		doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+		doer.responses[path] = gitLabSecurityHTTPResponse{status: status, body: `{"message":"unavailable"}`}
+		batch, err := (GitLabSecurityRouteHandler{}).Collect(
+			context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+			gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+		)
+		if err != nil {
+			t.Fatalf("path=%s error=%v", path, err)
+		}
+		if len(batch.Effects) != 1 || batch.Watermark == nil {
+			t.Fatalf("path=%s batch=%+v", path, batch)
+		}
+		if path == "/api/v4/projects/123/vulnerability_findings" &&
+			(len(batch.Effects[0].Rows) != 1 || !strings.Contains(string(batch.Effects[0].Rows[0]), "gitlab_dep:4")) {
+			t.Fatalf("path=%s rows=%s", path, batch.Effects[0].Rows)
+		}
+		if path == "/api/v4/projects/123/dependencies" && len(batch.Effects[0].Rows) != 3 {
+			t.Fatalf("path=%s rows=%d", path, len(batch.Effects[0].Rows))
+		}
+	}
+}
+
+func TestGitLabSecurityRoutePropagatesRateLimitWithoutWatermark(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	doer.responses["/api/v4/projects/123/dependencies"] = gitLabSecurityHTTPResponse{
+		status: http.StatusTooManyRequests, body: `{"message":"slow down"}`,
+	}
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("rate-limited batch advanced state: %+v", batch)
+	}
+}
+
+func TestGitLabSecurityRoutePropagatesHeaderQualifiedForbiddenRateLimit(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	doer.responses["/api/v4/projects/123/dependencies"] = gitLabSecurityHTTPResponse{
+		status:  http.StatusForbidden,
+		headers: http.Header{"RateLimit-Remaining": []string{"0"}},
+		body:    `{"message":"throttled"}`,
+	}
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication {
+		t.Fatalf("error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("header-qualified forbidden batch advanced state: %+v", batch)
+	}
+}
+
+func TestGitLabSecurityRouteMirrorsCoreFailureAsEmptySuccess(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	doer.responses["/api/v4/projects/123/vulnerability_findings"] = gitLabSecurityHTTPResponse{
+		status: http.StatusBadRequest, body: `{"message":"invalid"}`,
+	}
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if err != nil || len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 ||
+		batch.Evidence.Requests != 2 || batch.Watermark == nil {
+		t.Fatalf("error=%v batch=%+v", err, batch)
+	}
+}
+
+func TestGitLabSecurityRouteRejectsProjectMismatchAndLeaseBeforeRequests(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name       string
+		project    string
+		leaseError error
+		want       error
+	}{
+		{name: "project mismatch", project: `{"id":999,"path_with_namespace":"acme/api"}`, want: providerfoundation.ErrNormalizationInvalid},
+		{name: "lease lost", project: `{"id":123,"path_with_namespace":"acme/api"}`, leaseError: providerfoundation.ErrLeaseLost, want: providerfoundation.ErrLeaseLost},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+			doer.responses["/api/v4/projects/123"] = gitLabSecurityHTTPResponse{body: test.project}
+			client := gitLabSecurityRouteClient(t, doer)
+			if test.leaseError != nil {
+				client.Lease = providerfoundation.LeaseGuardFunc(func(context.Context) error { return test.leaseError })
+			}
+			batch, err := (GitLabSecurityRouteHandler{}).Collect(
+				context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+				client, time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+			)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error=%v want=%v", err, test.want)
+			}
+			if len(batch.Effects) != 0 || batch.Watermark != nil {
+				t.Fatalf("incomplete batch=%+v", batch)
+			}
+			if test.leaseError != nil && len(doer.requests) != 0 {
+				t.Fatalf("lease made requests=%d", len(doer.requests))
+			}
+		})
+	}
+}
+
+func TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests(t *testing.T) {
+	t.Parallel()
+	normalizedAt := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name       string
+		claim      Claim
+		client     *providerfoundation.HTTPClient
+		normalized time.Time
+		maxAlerts  int
+	}{
+		{
+			name: "wrong_claim_provider",
+			claim: func() Claim {
+				claim := nativeTestClaim("gitlab", "security")
+				claim.Provider = "github"
+				return claim
+			}(),
+			client: gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+		},
+		{
+			name:   "wrong_claim_dataset",
+			claim:  nativeTestClaim("gitlab", "commits"),
+			client: gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+		},
+		{
+			name:   "nil_client",
+			claim:  nativeTestClaim("gitlab", "security"),
+			client: nil,
+		},
+		{
+			name:  "wrong_client_provider",
+			claim: nativeTestClaim("gitlab", "security"),
+			client: func() *providerfoundation.HTTPClient {
+				client := gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()})
+				client.Provider = "github"
+				return client
+			}(),
+		},
+		{
+			name:  "nil_client_base_URL",
+			claim: nativeTestClaim("gitlab", "security"),
+			client: func() *providerfoundation.HTTPClient {
+				client := gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()})
+				client.BaseURL = nil
+				return client
+			}(),
+		},
+		{
+			name:       "zero_normalized_at",
+			claim:      nativeTestClaim("gitlab", "security"),
+			client:     gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+			normalized: time.Time{},
+		},
+		{
+			name:      "negative_max_alerts",
+			claim:     nativeTestClaim("gitlab", "security"),
+			client:    gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+			maxAlerts: -1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := test.normalized
+			if now.IsZero() && test.name != "zero_normalized_at" {
+				now = normalizedAt
+			}
+			batch, err := (GitLabSecurityRouteHandler{MaxAlerts: test.maxAlerts}).Collect(
+				context.Background(), test.claim, providerfoundation.Credential{}, test.client, now,
+			)
+			if !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v", err)
+			}
+			if len(batch.Effects) != 0 || len(batch.Evidence.Provider) != 0 {
+				t.Fatalf("invalid configuration returned batch=%+v", batch)
+			}
+			if test.client != nil {
+				if doer, ok := test.client.Doer.(*gitLabSecurityRouteDoer); ok && len(doer.requests) != 0 {
+					t.Fatalf("invalid configuration made %d requests", len(doer.requests))
+				}
+			}
+		})
+	}
+}
+
+func TestGitLabSecurityRouteNormalizesDependencyCreatedAtAndPackage(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	claim := nativeTestClaim("gitlab", "security")
+	normalizedAt := time.Date(2026, 7, 23, 12, 30, 0, 987654321, time.UTC)
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, raw := range batch.Effects[0].Rows {
+		var row gitLabSecurityAlertRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		if row.AlertID != "gitlab_dep:4" {
+			continue
+		}
+		if row.PackageName == nil || *row.PackageName != "widget" || row.State != nil ||
+			!row.CreatedAt.Equal(normalizedAt.UTC().Truncate(time.Millisecond)) {
+			t.Fatalf("dependency row=%+v", row)
+		}
+		return
+	}
+	t.Fatal("dependency row was not emitted")
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_security.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_security.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": 1,
+  "name": "GitLab security provider parity (CHAOS-3124)",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "Provider-local proof only: the route, concrete security_alerts row normalization, lease-fenced ClickHouse effects, migrated-schema integration test, and live Python differential oracle. This slice deliberately excludes registry, capability matrix, config, worker construction, scheduler, deployment activation, and unrelated provider behavior.",
+  "mutations": [
+    {
+      "id": "R1-claim-provider-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "claim.Provider != \"gitlab\"",
+      "replace": "false",
+      "rationale": "the security route must reject a claim owned by another provider before project resolution",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/wrong_claim_provider$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R2-claim-dataset-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "claim.Dataset != \"security\"",
+      "replace": "false",
+      "rationale": "security credentials must not be reused for another GitLab dataset",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/wrong_claim_dataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R3-client-provider-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "client.Provider != \"gitlab\"",
+      "replace": "false",
+      "rationale": "the request semantics require a GitLab-resolved HTTP client",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/wrong_client_provider$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R4-base-url-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "client.BaseURL == nil",
+      "replace": "false",
+      "rationale": "path construction must not run without an authority URL",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/nil_client_base_URL$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R5-normalized-at-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "client.BaseURL == nil || normalizedAt.IsZero()",
+      "replace": "client.BaseURL == nil || false",
+      "rationale": "retry-stable last_synced requires an executor-supplied normalization instant",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/zero_normalized_at$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R6-positive-cap-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "if maxAlerts < 1 {",
+      "replace": "if false {",
+      "rationale": "non-positive caps are invalid configuration, not an empty fetch",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/negative_max_alerts$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R7-project-binding",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "strconv.FormatInt(parsedProjectID, 10) != projectID",
+      "replace": "false",
+      "rationale": "the fetched project must be the exact numeric project claimed by the unit",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsProjectMismatchAndLeaseBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R8-physical-request-evidence",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "(*doer.observe.attempts)++",
+      "replace": "(*doer.observe.attempts) += 0",
+      "rationale": "accepted evidence must count every physical project and endpoint request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R9-millisecond-normalization",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)\n\n\tfindings",
+      "replace": "normalizedAt = normalizedAt.UTC()\n\n\tfindings",
+      "rationale": "rows must match Python/DateTime64 millisecond precision across retries",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R10-optional-findings-degrade",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "if providerErr.StatusCode == http.StatusForbidden || providerErr.StatusCode == http.StatusNotFound {",
+      "replace": "if false {",
+      "rationale": "a plain forbidden/not-found optional endpoint must degrade while the other source remains usable",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteDegradesPlainOptionalErrors$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R11-combined-cap-before-window",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "if len(combined) > maxAlerts {",
+      "replace": "if false {",
+      "rationale": "the real GitLab client caps the combined source list before processor window filtering",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteSlicesCombinedAlertsBeforeWindowFiltering$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R12-vulnerability-alert-id",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "row.AlertID = \"gitlab_vuln:\" + id",
+      "replace": "row.AlertID = id",
+      "rationale": "source-qualified alert identity is part of the migrated natural key",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R13-cve-normalization",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "row.CVEID = gitLabSecurityOptionalString(item[\"name\"])",
+      "replace": "row.CVEID = nil",
+      "rationale": "the first identifier of type cve must populate the concrete cve_id column",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R14-dependency-created-at",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "row.CreatedAt = normalizedAt",
+      "replace": "row.CreatedAt = time.Time{}",
+      "rationale": "dependency findings have no provider timestamp and use the stable route normalization instant",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteNormalizesDependencyCreatedAtAndPackage$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E1-duplicate-natural-key",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "return nil, errors.Join(providerfoundation.ErrSinkDuplicate, ErrEffectRecoveryUnsafe)",
+      "replace": "return nil, errors.New(\"duplicate row\")",
+      "rationale": "recovery cannot safely acknowledge an effect containing duplicate physical natural keys",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityEffectsRejectCrossTenantAndDuplicateRowsBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E2-newer-version-conflict",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "actual.LastSynced.UTC().After(expected.LastSynced.UTC())",
+      "replace": "false",
+      "rationale": "readback must reject an older effect after a newer persisted version wins",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitLabSecurityAlertVersionChecksFullPayloadAndTimestamp$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E3-tenant-payload-comparison",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "actual.OrgID != expected.OrgID",
+      "replace": "false",
+      "rationale": "readback must compare every concrete tenant-scoped row field, not just the timestamp",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitLabSecurityAlertVersionChecksFullPayloadAndTimestamp$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E4-duplicate-final-row",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "if found > 1 {",
+      "replace": "if false {",
+      "rationale": "ambiguous FINAL readback must not be treated as an exact acknowledgement",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityReadbackRejectsAmbiguousRows$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/_gitlab_security_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_gitlab_security_common.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+import pathlib
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass, fields
+from datetime import datetime
+from typing import Any
+from urllib.parse import parse_qsl, urlencode
+
+import httpx
+
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/gitlab.py"
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+
+
+def parse_time(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def request_path(request: httpx.Request) -> str:
+    pairs = sorted(parse_qsl(request.url.query.decode(), keep_blank_values=True))
+    query = urlencode(pairs)
+    return f"{request.url.path}?{query}" if query else request.url.path
+
+
+def _endpoint_name(path: str) -> str:
+    if path.endswith("/vulnerability_findings"):
+        return "findings"
+    if path.endswith("/dependencies"):
+        return "dependencies"
+    return "project"
+
+
+def _headers(case: dict[str, Any], endpoint: str) -> dict[str, str]:
+    configured = case.get("response_headers", {}).get(endpoint, {})
+    return {str(key): str(value) for key, value in configured.items()}
+
+
+def run_producer(
+    case: dict[str, Any], *, apply_until: bool
+) -> tuple[list[Any], list[str], int]:
+    """Execute the real processor helper with deterministic HTTP responses."""
+
+    processor = load_live_module(PROCESSOR_SOURCE)
+    code_client = load_live_module(CODE_CLIENT_SOURCE)
+    requests: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request_path(request))
+        path = request.url.path
+        endpoint = _endpoint_name(path)
+        if path == "/api/v4/projects/123":
+            payload: Any = case.get(
+                "project", {"id": 123, "name": "api", "path_with_namespace": "acme/api"}
+            )
+        elif endpoint == "findings":
+            payload = case.get("findings", [])
+        elif endpoint == "dependencies":
+            payload = case.get("dependencies", [])
+        else:
+            raise AssertionError(f"unexpected producer request: {request.url}")
+        status = int(case.get(f"{endpoint}_status", 200))
+        return httpx.Response(
+            status,
+            json=payload,
+            headers=_headers(case, endpoint),
+            request=request,
+        )
+
+    client = code_client.GitLabCodeClient(
+        private_token="oracle",
+        base_url="https://gitlab.test",
+        max_retries=1,
+        transport=httpx.MockTransport(handler),
+    )
+
+    @asynccontextmanager
+    async def client_factory(_connector: object):
+        async with client:
+            yield client
+
+    processor._gitlab_code_client_from_connector = client_factory
+    usage: list[dict[str, Any]] = []
+    # The optional GitLab endpoints deliberately exercise the producer's
+    # warning-and-degrade path.  The Go oracle subprocess consumes stdout as
+    # JSON, so suppress application logging for this isolated producer call;
+    # the trace still records the concrete request/status effects below.
+    previous_disable = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        rows = processor._fetch_gitlab_security_alerts_sync(
+            object(),
+            123,
+            case["repo_id"],
+            case["max_alerts"],
+            parse_time(case.get("since")),
+            usage,
+        )
+    finally:
+        logging.disable(previous_disable)
+    if apply_until and (until := parse_time(case.get("until"))) is not None:
+        rows = processor._filter_after(rows, until, "created_at")
+    usage_request_count = sum(int(item.get("request_count") or 0) for item in usage)
+    if usage_request_count != len(requests):
+        raise ValueError(
+            "security producer usage observations lost physical requests: "
+            f"usage={usage_request_count} requests={len(requests)}"
+        )
+    return rows, requests, usage_request_count
+
+
+@dataclass(frozen=True)
+class SecurityTraversalRow:
+    alert_id: str
+    source: str
+
+
+@dataclass(frozen=True)
+class SecurityTraversalTrace:
+    producer_requests: list[str]
+    usage_request_count: int
+    rows: list[SecurityTraversalRow]
+
+
+def traversal_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(SecurityTraversalTrace))
+
+
+def build_traversal(case: dict[str, Any]) -> dict[str, Any]:
+    rows, requests, usage_request_count = run_producer(case, apply_until=True)
+    return asdict(
+        SecurityTraversalTrace(
+            producer_requests=requests,
+            usage_request_count=usage_request_count,
+            rows=[SecurityTraversalRow(row.alert_id, row.source) for row in rows],
+        )
+    )

--- a/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
@@ -19,8 +19,9 @@ oracle_registry.register(
             pathlib.Path(MODEL_SOURCE).read_text(), "GitPullRequestReview"
         ),
         excluded_fields={
-            "last_synced": "stamped from the Go collection instant, not the Python mapper",
+            "last_synced": (
+                "stamped from the Go collection instant, not the Python mapper"
+            ),
         },
     )
 )
-

--- a/internal/providersync/testdata/oracle_pairs/gitlab_security_dependency.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_security_dependency.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    return frozenset(client.SecurityAlertData.__annotations__)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    dependency = {"name": case["package_name"]}
+    row = client._map_dependency_alert(dependency, case["raw_alert"])
+    return vars(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/security/dependency",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "created_at": "the Python dependency mapper uses wall-clock now while Go uses the executor normalized instant",
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_security_trace.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_security_trace.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._gitlab_security_common import (
+    build_traversal,
+    traversal_fields,
+)
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/security/trace",
+        build_row=build_traversal,
+        reflected_fields=traversal_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_security_vulnerability.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_security_vulnerability.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    return frozenset(client.SecurityAlertData.__annotations__)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    row = client._map_vulnerability_finding(case["raw_alert"])
+    return vars(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/security/vulnerability",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue.py
@@ -99,7 +99,11 @@ def _fetch(
     issue = _object(case["raw_issue"])
     label_events = [_object(event) for event in case.get("label_events", [])]
     client = _Client(issue, label_events)
-    work_items_module.get_metrics_dependencies = lambda: _Dependencies(client)
+    setattr(
+        work_items_module,
+        "get_metrics_dependencies",
+        lambda: _Dependencies(client),
+    )
     repo = work_items_module.DiscoveredRepo(
         repo_id=UUID(case["repo_id"]),
         full_name=case["repo_full_name"],

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_status-transition.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_status-transition.py
@@ -87,7 +87,11 @@ def _fetch(case: dict[str, Any]) -> list[WorkItemStatusTransition]:
     issue = _object(case["raw_issue"])
     label_events = [_object(event) for event in case.get("label_events", [])]
     client = _Client(issue, label_events)
-    work_items_module.get_metrics_dependencies = lambda: _Dependencies(client)
+    setattr(
+        work_items_module,
+        "get_metrics_dependencies",
+        lambda: _Dependencies(client),
+    )
     repo = work_items_module.DiscoveredRepo(
         repo_id=UUID(case["repo_id"]),
         full_name=case["repo_full_name"],

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -622,7 +622,7 @@ def _target_gitlab_processor() -> None:
     # review class used by the PR-family row oracle. Its kwargs-shaped output
     # preserves the pair's field projection (without SQLAlchemy's private
     # instance state) while security continues to exercise the typed model.
-    git_models.GitPullRequestReview = _GitPullRequestReview
+    setattr(git_models, "GitPullRequestReview", _GitPullRequestReview)
     _install_module(
         "dev_health_ops.processors.base_git",
         {

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -58,6 +58,7 @@ _GITLAB_REPOSITORY_SOURCE = _source("dev_health_ops/providers/gitlab/repository.
 _GITLAB_PROCESSOR_SOURCE = _source("dev_health_ops/processors/gitlab.py")
 _FETCH_UTILS_SOURCE = _source("dev_health_ops/processors/fetch_utils.py")
 _GIT_MODEL_SOURCE = _source("dev_health_ops/models/git.py")
+_CONNECTOR_MODELS_SOURCE = _source("dev_health_ops/connectors/models.py")
 _REPOSITORY_ROWS_SOURCE = _source("dev_health_ops/storage/repository_rows.py")
 _RELEASE_REF_SOURCE = _source("dev_health_ops/processors/release_ref.py")
 _TESTOPS_SCHEMAS_SOURCE = _source("dev_health_ops/metrics/testops_schemas.py")
@@ -403,21 +404,10 @@ def _target_gitlab_code_client() -> None:
         "dev_health_ops.providers.gitlab.ratelimit", _GITLAB_RATELIMIT_SOURCE
     )
     _load_source_module("dev_health_ops.providers.gitlab.budget", _GITLAB_BUDGET_SOURCE)
-    _install_module(
-        "dev_health_ops.connectors.models",
-        {
-            "Repository": type(
-                "Repository",
-                (),
-                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
-            ),
-            "SecurityAlertData": type(
-                "SecurityAlertData",
-                (),
-                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
-            ),
-        },
-    )
+    # The live security mapping returns SecurityAlertData. Load the checked-in
+    # dataclass so constructor shape and annotations remain production-owned;
+    # a kwargs container would let a field drift without the oracle noticing.
+    _load_source_module("dev_health_ops.connectors.models", _CONNECTOR_MODELS_SOURCE)
 
 
 _GITHUB_PROCESSOR_SOURCE = _source("dev_health_ops/processors/github.py")
@@ -607,18 +597,19 @@ def _target_gitlab_processor() -> None:
         "dev_health_ops.analytics.complexity",
         {"DEFAULT_COMPLEXITY_CONFIG_PATH": None, "ComplexityScanner": object},
     )
-    _install_module(
-        "dev_health_ops.connectors.models",
-        {
-            name: object
-            for name in ("Author", "Repository", "RepoStats", "SecurityAlertData")
-        },
-    )
+    _load_source_module("dev_health_ops.connectors.models", _CONNECTOR_MODELS_SOURCE)
     _install_module("dev_health_ops.metrics.sinks.ingestion", {"IngestionSink": object})
 
     class _Incident:
         def __init__(self, **kwargs: Any) -> None:
             self.__dict__.update(kwargs)
+
+    # The security helper constructs git_models.SecurityAlert directly after
+    # the live GitLab code-client normalizer returns SecurityAlertData. Load
+    # the checked-in ORM model rather than replacing it with a kwargs stub:
+    # this keeps the oracle on the production typed model and catches schema
+    # drift in the same constructor/field boundary the processor uses.
+    git_models = _load_source_module("dev_health_ops.models.git", _GIT_MODEL_SOURCE)
 
     class _GitPullRequestReview:
         # The live mapper constructs this model directly. Keep the stand-in
@@ -627,20 +618,11 @@ def _target_gitlab_processor() -> None:
         def __init__(self, **kwargs: Any) -> None:
             self.__dict__.update(kwargs)
 
-    _install_module(
-        "dev_health_ops.models.git",
-        {
-            "CiPipelineRun": object,
-            "Deployment": object,
-            "GitBlame": object,
-            "GitCommit": object,
-            "GitCommitStat": object,
-            "GitPullRequest": object,
-            "GitPullRequestReview": _GitPullRequestReview,
-            "Incident": _Incident,
-            "Repo": object,
-        },
-    )
+    # Keep the production model module for SecurityAlert and override only the
+    # review class used by the PR-family row oracle. Its kwargs-shaped output
+    # preserves the pair's field projection (without SQLAlchemy's private
+    # instance state) while security continues to exercise the typed model.
+    git_models.GitPullRequestReview = _GitPullRequestReview
     _install_module(
         "dev_health_ops.processors.base_git",
         {
@@ -986,6 +968,11 @@ ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
     _GIT_MODEL_SOURCE: (
         "dev_health_ops.models.git",
         _GIT_MODEL_SOURCE,
+        lambda: None,
+    ),
+    _CONNECTOR_MODELS_SOURCE: (
+        "dev_health_ops.connectors.models",
+        _CONNECTOR_MODELS_SOURCE,
         lambda: None,
     ),
     _REPOSITORY_ROWS_SOURCE: (


### PR DESCRIPTION
## Scope

Port GitLab security collection and typed ClickHouse effects/readback with tenant, lease, pagination, retry, and watermark parity.

## Evidence

- Live Python oracle with non-empty execution proof
- Real migrated ClickHouse integration
- Shared mutation harness: 18/18 killed
- Full providersync and vet green

## Boundaries

- No registry, matrix, config, deployment, or cutover wiring

Linear: CHAOS-3124

SCREENSHOT-WAIVER: Backend-only provider implementation; no rendered UI changes.
