### PR TITLE
CHAOS-3125: port PagerDuty escalation policies

### DIFF
--- a/internal/providerfoundation/pagerduty_pagination.go
+++ b/internal/providerfoundation/pagerduty_pagination.go
@@ -1,0 +1,85 @@
+package providerfoundation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const maximumPagerDutyPerPage = 100
+
+// PagerDutyOffsetOptions mirrors PagerDuty REST v2's bounded offset contract.
+// The provider returns an envelope containing the named collection and a
+// required boolean `more` marker; an advertised next page with no rows is an
+// invalid/non-progressing response and must fail closed.
+type PagerDutyOffsetOptions struct {
+	Path     string
+	DataKey  string
+	PerPage  int
+	MaxPages int
+}
+
+func CollectPagerDutyOffsetPages(
+	ctx context.Context,
+	client *HTTPClient,
+	options PagerDutyOffsetOptions,
+) (PageCollection, error) {
+	if ctx == nil || client == nil || strings.TrimSpace(options.Path) == "" ||
+		strings.TrimSpace(options.DataKey) == "" || options.PerPage < 1 ||
+		options.PerPage > maximumPagerDutyPerPage || options.MaxPages < 1 ||
+		options.MaxPages > maximumProviderPages {
+		return PageCollection{}, ErrPaginationInvalid
+	}
+	result := PageCollection{}
+	offset := 0
+	for {
+		if result.Pages >= options.MaxPages {
+			result.CapReached = true
+			return result, nil
+		}
+		query := url.Values{
+			"limit":  {strconv.Itoa(options.PerPage)},
+			"offset": {strconv.Itoa(offset)},
+		}
+		target, err := pageURL(options.Path, query)
+		if err != nil {
+			return PageCollection{}, err
+		}
+		response, err := client.Do(ctx, http.MethodGet, target, nil)
+		if err != nil {
+			return result, err
+		}
+		payload, err := decodeJSONObject(response)
+		if err != nil {
+			return result, err
+		}
+		rawItems, ok := payload[options.DataKey]
+		if !ok || string(rawItems) == "null" {
+			return result, ErrPaginationInvalid
+		}
+		var items []json.RawMessage
+		if err := json.Unmarshal(rawItems, &items); err != nil {
+			return result, ErrPaginationInvalid
+		}
+		rawMore, ok := payload["more"]
+		if !ok || string(rawMore) == "null" {
+			return result, ErrPaginationInvalid
+		}
+		var more bool
+		if err := json.Unmarshal(rawMore, &more); err != nil {
+			return result, ErrPaginationInvalid
+		}
+		result.Pages++
+		result.Items = append(result.Items, items...)
+		if !more {
+			return result, nil
+		}
+		if len(items) == 0 {
+			return result, ErrPaginationInvalid
+		}
+		offset += len(items)
+	}
+}

--- a/internal/providerfoundation/pagination_test.go
+++ b/internal/providerfoundation/pagination_test.go
@@ -183,6 +183,53 @@ func TestGitLabPaginationUsesHeaderThenItemCountFallback(t *testing.T) {
 	}
 }
 
+func TestPagerDutyOffsetPaginationUsesReturnedLengthAndMore(t *testing.T) {
+	t.Parallel()
+	doer := &paginationDoer{responses: []paginationResponse{
+		{body: `{"escalation_policies":[{"id":"one"},{"id":"two"}],"more":true}`},
+		{body: `{"escalation_policies":[{"id":"three"}],"more":false}`},
+	}}
+	client := paginationClient(t, "pagerduty", "https://api.pagerduty.com", doer)
+	result, err := CollectPagerDutyOffsetPages(context.Background(), client, PagerDutyOffsetOptions{
+		Path: "/escalation_policies", DataKey: "escalation_policies", PerPage: 100, MaxPages: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Pages != 2 || result.CapReached || len(result.Items) != 3 {
+		t.Fatalf("result=%+v", result)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+}
+
+func TestPagerDutyOffsetPaginationRejectsMalformedOrNonProgressingPages(t *testing.T) {
+	t.Parallel()
+	for name, body := range map[string]string{
+		"missing collection": `{"more":false}`,
+		"null collection":    `{"escalation_policies":null,"more":false}`,
+		"missing more":       `{"escalation_policies":[]}`,
+		"null more":          `{"escalation_policies":[],"more":null}`,
+		"wrong more type":    `{"escalation_policies":[],"more":"false"}`,
+		"empty progress":     `{"escalation_policies":[],"more":true}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			doer := &paginationDoer{responses: []paginationResponse{{body: body}}}
+			client := paginationClient(t, "pagerduty", "https://api.pagerduty.com", doer)
+			_, err := CollectPagerDutyOffsetPages(context.Background(), client, PagerDutyOffsetOptions{
+				Path: "/escalation_policies", DataKey: "escalation_policies", PerPage: 100, MaxPages: 10,
+			})
+			if !errors.Is(err, ErrPaginationInvalid) {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
 func TestGitLabMalformedNextPageStopsWithoutSpeculation(t *testing.T) {
 	t.Parallel()
 	doer := &paginationDoer{responses: []paginationResponse{{

--- a/internal/providersync/pagerduty_escalation_policies_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_escalation_policies_effects_clickhouse.go
@@ -1,0 +1,216 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// The current migrated operational table predates the Go ordering columns.
+// Keep the effect row complete for parity/readback validation, but write only
+// columns that the canonical migration actually provides. The follow-up
+// migration lane owns making source_revision durable in ClickHouse.
+const pagerDutyEscalationPoliciesColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,name,description,is_deleted,deleted_at"
+
+type PagerDutyEscalationPoliciesClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink PagerDutyEscalationPoliciesClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pagerDutyEscalationPolicyRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validatePagerDutyEscalationPolicyRows(claim, rows); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(
+		ctx, "INSERT INTO operational_escalation_policies ("+pagerDutyEscalationPoliciesColumns+")",
+	)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyEscalationPolicyValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyEscalationPoliciesClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pagerDutyEscalationPolicyRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validatePagerDutyEscalationPolicyRows(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectEscalationPolicy(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyEscalationPoliciesClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "escalation-policies" ||
+		effect.Destination != "operational_escalation_policies" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func validatePagerDutyEscalationPolicyRows(
+	claim Claim, rows []pagerDutyEscalationPolicyRow,
+) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.SourceEntityType != "escalation_policy" ||
+			row.ExternalID == "" || row.Name == "" || row.ID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyEscalationPolicyOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyEscalationPolicyValues(row pagerDutyEscalationPolicyRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence, row.Name, row.Description, row.IsDeleted,
+		row.DeletedAt,
+	}
+}
+
+func (sink PagerDutyEscalationPoliciesClickHouseEffects) inspectEscalationPolicy(
+	ctx context.Context, expected pagerDutyEscalationPolicyRow,
+) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(
+		ctx,
+		"SELECT "+pagerDutyEscalationPoliciesColumns+
+			" FROM operational_escalation_policies FINAL WHERE org_id = ? AND id = ? LIMIT 1",
+		expected.OrgID, expected.ID,
+	)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual pagerDutyEscalationPolicyRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyEscalationPolicyScanValues(&actual)...); err != nil {
+			return EffectConflict, err
+		}
+		if err := fillPagerDutyEscalationPolicyOrdering(&actual); err != nil {
+			return EffectConflict, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return comparePagerDutyEscalationPolicyVersion(expected, actual, found), nil
+}
+
+func pagerDutyEscalationPolicyScanValues(row *pagerDutyEscalationPolicyRow) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.Name, &row.Description, &row.IsDeleted,
+		&row.DeletedAt,
+	}
+}
+
+func comparePagerDutyEscalationPolicyVersion(
+	expected, actual pagerDutyEscalationPolicyRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = PagerDutyEscalationPoliciesClickHouseEffects{}
+var _ EffectReadback = PagerDutyEscalationPoliciesClickHouseEffects{}

--- a/internal/providersync/pagerduty_escalation_policies_effects_integration_test.go
+++ b/internal/providersync/pagerduty_escalation_policies_effects_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyEscalationPoliciesEffectUsesMigratedClickHouseAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Apply the production migration chain, including Python migration steps,
+	// before opening the Go connection. This keeps the proof against the real
+	// operational_escalation_policies schema rather than a test-only DDL copy.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	normalizedAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	row, err := normalizePagerDutyEscalationPolicy(
+		claim, "acme", pagerDutyEscalationPolicyPayload{
+			ID: "PESCAL1", Name: "Primary", UpdatedAt: "2026-08-01T10:00:00Z",
+		}, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effect, err := effectBatchFromValues(
+		"operational_escalation_policies", EffectReadbackRequired,
+		[]pagerDutyEscalationPolicyRow{row},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutyEscalationPoliciesClickHouseEffects{
+		Conn:  conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("after write inspection=%s error=%v", inspection, err)
+	}
+	// A recovery replay uses the durable effect payload and must classify as
+	// exact without manufacturing a new source revision.
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+	}
+
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	otherRow := row
+	otherRow.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyEscalationPolicyOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	otherEffect, err := effectBatchFromValues(
+		"operational_escalation_policies", EffectReadbackRequired,
+		[]pagerDutyEscalationPolicyRow{otherRow},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, otherEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, effect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign row changed tenant readback inspection=%s error=%v", inspection, err)
+	}
+}

--- a/internal/providersync/pagerduty_escalation_policies_effects_test.go
+++ b/internal/providersync/pagerduty_escalation_policies_effects_test.go
@@ -1,0 +1,47 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyEscalationPoliciesEffectRejectsForeignTenantAndOrderingTamper(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	row, err := normalizePagerDutyEscalationPolicy(
+		claim, "acme", pagerDutyEscalationPolicyPayload{ID: "PESCAL1", Name: "Primary"},
+		time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := row
+	foreign.OrgID = "org-other"
+	if err := validatePagerDutyEscalationPolicyRows(claim, []pagerDutyEscalationPolicyRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	tampered := row
+	tampered.Name = "forged"
+	if err := validatePagerDutyEscalationPolicyRows(claim, []pagerDutyEscalationPolicyRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	if err := validatePagerDutyEscalationPolicyRows(claim, []pagerDutyEscalationPolicyRow{row, row}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate row error=%v", err)
+	}
+}
+
+func TestPagerDutyEscalationPoliciesEffectRejectsWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	sink := PagerDutyEscalationPoliciesClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_escalation_policies"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid request error=%v", err)
+	}
+	if err := sink.WriteEffect(
+		context.Background(), claim, EffectBatch{Destination: "other"},
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_escalation_policies_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_escalation_policies_generic_oracle_test.go
@@ -1,0 +1,75 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyEscalationPolicyRowForOracle(
+	t *testing.T, input map[string]any,
+) pagerDutyEscalationPolicyRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutyEscalationPolicyPayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyEscalationPolicy(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload,
+		observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyEscalationPolicyCases() []oracleCase {
+	return []oracleCase{
+		{ID: "updated_html_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PESCAL1", "type": "escalation_policy", "name": "Primary",
+				"summary": "Ignored summary", "updated_at": "2026-08-01T10:00:00.123456Z",
+				"html_url": "https://acme.pagerduty.com/escalation_policies/PESCAL1",
+			},
+		}},
+		{ID: "created_self_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PESCAL2", "type": "escalation_policy", "summary": "Secondary",
+				"created_at": "2026-07-31T09:00:00Z", "self": "/escalation_policies/PESCAL2",
+			},
+		}},
+		{ID: "observed_time_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PESCAL3", "type": "escalation_policy", "name": "Tertiary",
+			},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyEscalationPolicyRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/escalation-policies/row", oraclePagerDutyEscalationPolicyCases(),
+		buildPagerDutyEscalationPolicyRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_escalation_policies_route.go
+++ b/internal/providersync/pagerduty_escalation_policies_route.go
@@ -1,0 +1,276 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyEscalationPoliciesMaxPages = 10_000
+	pagerDutyEscalationPoliciesMaxRows  = 100_000
+	pagerDutyEscalationPoliciesPerPage  = 100
+)
+
+// pagerDutyEscalationPolicyPayload is the provider-owned subset needed by the
+// canonical Python EscalationPolicy normalizer. Unknown PagerDuty fields are
+// intentionally ignored, as they are not part of the persisted contract.
+type pagerDutyEscalationPolicyPayload struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Summary   string `json:"summary"`
+	SelfURL   string `json:"self"`
+	HTMLURL   string `json:"html_url"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// pagerDutyEscalationPolicyRow mirrors every field on Python's canonical
+// operational.EscalationPolicy dataclass, including its persisted ordering
+// fields. The generic oracle compares this complete row against the live
+// Python normalizer rather than a hand-picked subset.
+type pagerDutyEscalationPolicyRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	Name                   string     `json:"name"`
+	Description            *string    `json:"description"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+// PagerDutyEscalationPoliciesRouteHandler owns only source collection and
+// canonical normalization. Route registration and worker wiring remain with
+// the integration lane so this provider slice cannot activate itself.
+type PagerDutyEscalationPoliciesRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutyEscalationPoliciesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyEscalationPoliciesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutyEscalationPoliciesRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutyEscalationPoliciesMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutyEscalationPoliciesMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyEscalationPoliciesPerPage
+	}
+	if pages < 1 || pages > pagerDutyEscalationPoliciesMaxPages || rows < 1 ||
+		rows > pagerDutyEscalationPoliciesMaxRows || perPage < 1 || perPage > pagerDutyEscalationPoliciesPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutyEscalationPoliciesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" || claim.Provider != "pagerduty" ||
+		claim.Dataset != "escalation-policies" || client == nil || client.Provider != "pagerduty" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyEscalationPoliciesCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/escalation_policies", DataKey: "escalation_policies",
+			PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	rows := make([]pagerDutyEscalationPolicyRow, 0, len(pages.Items))
+	for _, raw := range pages.Items {
+		var payload pagerDutyEscalationPolicyPayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, err := normalizePagerDutyEscalationPolicy(
+			claim, providerInstance, payload, normalizedAt,
+		)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues(
+		"operational_escalation_policies", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  map[string]any{"escalation_policies_synced": len(rows)},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func pagerDutyProviderInstance(credential providerfoundation.Credential) (string, error) {
+	instance := strings.TrimSpace(credential.Config["subdomain"])
+	if instance == "" {
+		if value, ok := credential.Secret("subdomain"); ok && value.Configured() {
+			instance = strings.TrimSpace(value.Reveal())
+		}
+	}
+	if instance == "" {
+		return "", providerfoundation.ErrNormalizationInvalid
+	}
+	return strings.ToLower(instance), nil
+}
+
+func normalizePagerDutyEscalationPolicy(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyEscalationPolicyPayload,
+	normalizedAt time.Time,
+) (pagerDutyEscalationPolicyRow, error) {
+	rawID := payload.ID
+	externalID := strings.TrimSpace(rawID)
+	if externalID == "" {
+		return pagerDutyEscalationPolicyRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutySourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyEscalationPolicyRow{}, err
+	}
+	var sourceURL *string
+	if payload.HTMLURL != "" {
+		value := payload.HTMLURL
+		sourceURL = &value
+	} else if payload.SelfURL != "" {
+		value := payload.SelfURL
+		sourceURL = &value
+	}
+	name := payload.Name
+	if name == "" {
+		name = payload.Summary
+	}
+	if name == "" {
+		name = rawID
+	}
+	row := pagerDutyEscalationPolicyRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "escalation_policy", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt, Name: name,
+	}
+	if err := fillPagerDutyEscalationPolicyOrdering(&row); err != nil {
+		return pagerDutyEscalationPolicyRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutySourceTime(
+	payload pagerDutyEscalationPolicyPayload, observedAt time.Time,
+) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func fillPagerDutyEscalationPolicyOrdering(row *pagerDutyEscalationPolicyRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"name", row.Name},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_escalation_policy", row.OrgID, row.Provider,
+		row.ProviderInstanceID, row.ExternalID, row.SourceVersionAt,
+		row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey, row.SourceRevision, row.IngestRevision =
+		id, conflict, sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+var _ CompleteRouteHandler = PagerDutyEscalationPoliciesRouteHandler{}

--- a/internal/providersync/pagerduty_escalation_policies_route_test.go
+++ b/internal/providersync/pagerduty_escalation_policies_route_test.go
@@ -1,0 +1,215 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyEscalationPoliciesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutyEscalationPoliciesDoer struct {
+	t         *testing.T
+	responses []pagerDutyEscalationPoliciesResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyEscalationPoliciesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutyEscalationPoliciesRouteUsesOffsetPaginationAndCanonicalRow(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyEscalationPoliciesDoer{t: t, responses: []pagerDutyEscalationPoliciesResponse{
+		{body: `{"escalation_policies":[
+			{"id":"PESCAL1","type":"escalation_policy","name":"Primary","num_loops":2,"updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/escalation_policies/PESCAL1"},
+			{"id":"PESCAL2","type":"escalation_policy","summary":"Secondary","created_at":"2026-07-31T09:00:00Z"}],"more":true}`},
+		{body: `{"escalation_policies":[{"id":"PESCAL3","type":"escalation_policy","name":"Tertiary"}],"more":false}`},
+	}}
+	client := pagerDutyEscalationPoliciesTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "},
+	}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyEscalationPoliciesRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_escalation_policies" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 ||
+		batch.Evidence.CapReached || batch.Watermark != nil {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+	row := mustPagerDutyEscalationPolicyRow(t, batch.Effects[0].Rows[0])
+	if row.Provider != "pagerduty" || row.ProviderInstanceID != "acme" ||
+		row.SourceEntityType != "escalation_policy" || row.ExternalID != "PESCAL1" ||
+		row.Name != "Primary" || row.SourceURL == nil ||
+		*row.SourceURL != "https://acme.pagerduty.com/escalation_policies/PESCAL1" ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!row.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) ||
+		row.SourceRevision == nil || row.IngestRevision == nil || row.OrderingContract != 2 {
+		t.Fatalf("row=%+v", row)
+	}
+	if secondary := mustPagerDutyEscalationPolicyRow(t, batch.Effects[0].Rows[1]); secondary.Name != "Secondary" {
+		t.Fatalf("secondary=%+v", secondary)
+	}
+	if tertiary := mustPagerDutyEscalationPolicyRow(t, batch.Effects[0].Rows[2]); tertiary.Name != "Tertiary" ||
+		!tertiary.SourceVersionAt.Equal(row.ObservedAt) {
+		t.Fatalf("tertiary=%+v", tertiary)
+	}
+}
+
+func TestPagerDutyEscalationPoliciesRoutePreservesRetryAndPermanentErrorSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	clientRetryDoer := &pagerDutyEscalationPoliciesDoer{t: t, responses: []pagerDutyEscalationPoliciesResponse{
+		{status: http.StatusTooManyRequests, headers: http.Header{"Retry-After": {"0"}}, body: `{"message":"slow down"}`},
+		{body: `{"escalation_policies":[],"more":false}`},
+	}}
+	retryClient := pagerDutyEscalationPoliciesTestClient(t, clientRetryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutyEscalationPoliciesRouteHandler{}).Collect(
+		context.Background(), claim, credential, retryClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil || len(clientRetryDoer.requests) != 2 || len(batch.Effects) != 1 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(clientRetryDoer.requests))
+	}
+
+	authDoer := &pagerDutyEscalationPoliciesDoer{t: t, responses: []pagerDutyEscalationPoliciesResponse{
+		{status: http.StatusUnauthorized, body: `{"message":"bad token"}`},
+	}}
+	authClient := pagerDutyEscalationPoliciesTestClient(t, authDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	_, err = (PagerDutyEscalationPoliciesRouteHandler{}).Collect(
+		context.Background(), claim, credential, authClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication ||
+		len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+}
+
+func TestPagerDutyEscalationPoliciesRouteFailsClosedOnPaginationCapAndMissingInstance(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	client := pagerDutyEscalationPoliciesTestClient(t, &pagerDutyEscalationPoliciesDoer{
+		t: t, responses: []pagerDutyEscalationPoliciesResponse{{
+			body: `{"escalation_policies":[{"id":"one"}],"more":true}`,
+		}}}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	_, err := (PagerDutyEscalationPoliciesRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, credential, client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	_, err = (PagerDutyEscalationPoliciesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{Provider: "pagerduty"}, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("missing instance error=%v", err)
+	}
+}
+
+func TestPagerDutyEscalationPoliciesRouteStopsWhenLeaseExpiresBetweenPages(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "escalation-policies")
+	doer := &pagerDutyEscalationPoliciesDoer{t: t, responses: []pagerDutyEscalationPoliciesResponse{
+		{body: `{"escalation_policies":[{"id":"one"}],"more":true}`},
+		{body: `{"escalation_policies":[],"more":false}`},
+	}}
+	asserts := 0
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutyEscalationPoliciesRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(doer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(doer.requests), asserts)
+	}
+}
+
+func pagerDutyEscalationPoliciesTestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyEscalationPolicyRow(t *testing.T, raw []byte) pagerDutyEscalationPolicyRow {
+	t.Helper()
+	var row pagerDutyEscalationPolicyRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/testdata/mutation-plans/pagerduty_escalation_policies.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_escalation_policies.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty escalation-policy route, pagination, and identity guards",
+  "build": ["go", "build", "./internal/providersync/"],
+  "$limitation": "This plan covers the provider-owned offset paginator, full-row normalization, and route identity guard. Executor registration, capability/matrix wiring, tombstone reconciliation, and deployment activation remain intentionally outside this provider-only slice.",
+  "mutations": [
+    {
+      "id": "P1-offset-advances-by-returned-page-length",
+      "file": "internal/providerfoundation/pagerduty_pagination.go",
+      "find": "\t\toffset += len(items)",
+      "replace": "\t\toffset += len(items) * 0",
+      "rationale": "PagerDuty's offset is the number of rows returned, not the configured limit; a wrong advancement repeats or skips source rows and is exposed by the second request URI.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyEscalationPoliciesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P2-more-false-terminates-pagination",
+      "file": "internal/providerfoundation/pagerduty_pagination.go",
+      "find": "\t\tif !more {\n\t\t\treturn result, nil\n\t\t}",
+      "replace": "\t\tif false && !more {\n\t\t\treturn result, nil\n\t\t}",
+      "rationale": "The provider's explicit more=false marker is the only authoritative end-of-snapshot signal; ignoring it causes an unnecessary request and cannot report a complete bounded result.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyEscalationPoliciesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "P3-missing-more-fails-closed",
+      "file": "internal/providerfoundation/pagerduty_pagination.go",
+      "find": "\t\trawMore, ok := payload[\"more\"]\n\t\tif !ok || string(rawMore) == \"null\" {\n\t\t\treturn result, ErrPaginationInvalid\n\t\t}",
+      "replace": "\t\trawMore, ok := payload[\"more\"]\n\t\tif !ok {\n\t\t\treturn result, ErrPaginationInvalid\n\t\t}",
+      "rationale": "A missing progress marker is malformed, not an empty successful snapshot; accepting it would erase the distinction between a valid terminal page and an unproven response.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyEscalationPoliciesRouteFailsClosedOnPaginationCapAndMissingInstance$", "./internal/providersync/"], ["go", "test", "-count=1", "-run", "^TestPagerDutyOffsetPaginationRejectsMalformedOrNonProgressingPages$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "P4-empty-more-page-must-fail-closed",
+      "file": "internal/providerfoundation/pagerduty_pagination.go",
+      "find": "\t\tif len(items) == 0 {\n\t\t\treturn result, ErrPaginationInvalid\n\t\t}",
+      "replace": "\t\tif false && len(items) == 0 {\n\t\t\treturn result, ErrPaginationInvalid\n\t\t}",
+      "rationale": "PagerDuty can advertise more pages only when the offset made progress; an empty page with more=true must never spin or be accepted as complete.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOffsetPaginationRejectsMalformedOrNonProgressingPages$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "P5-subdomain-is-required-for-operational-identity",
+      "file": "internal/providersync/pagerduty_escalation_policies_route.go",
+      "find": "\tif instance == \"\" {\n\t\treturn \"\", providerfoundation.ErrNormalizationInvalid\n\t}",
+      "replace": "\tif instance == \"\" {\n\t\tinstance = \"api.pagerduty.com\"\n\t}",
+      "rationale": "Python requires the verified PagerDuty account subdomain for provider_instance_id; falling back to the API host would merge accounts and fork canonical IDs.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyEscalationPoliciesRouteFailsClosedOnPaginationCapAndMissingInstance$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
@@ -23,4 +23,3 @@ oracle_registry.register(
         },
     )
 )
-

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue.py
@@ -15,7 +15,7 @@ import io
 import pathlib
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from internal.providersync.testdata import oracle_registry
@@ -99,7 +99,9 @@ def _fetch(
     issue = _object(case["raw_issue"])
     label_events = [_object(event) for event in case.get("label_events", [])]
     client = _Client(issue, label_events)
-    work_items_module.get_metrics_dependencies = lambda: _Dependencies(client)
+    work_items_module.get_metrics_dependencies = cast(
+        Any, lambda: _Dependencies(client)
+    )
     repo = work_items_module.DiscoveredRepo(
         repo_id=UUID(case["repo_id"]),
         full_name=case["repo_full_name"],

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_status-transition.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_status-transition.py
@@ -8,7 +8,7 @@ import io
 import pathlib
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from internal.providersync.testdata import oracle_registry
@@ -87,7 +87,9 @@ def _fetch(case: dict[str, Any]) -> list[WorkItemStatusTransition]:
     issue = _object(case["raw_issue"])
     label_events = [_object(event) for event in case.get("label_events", [])]
     client = _Client(issue, label_events)
-    work_items_module.get_metrics_dependencies = lambda: _Dependencies(client)
+    work_items_module.get_metrics_dependencies = cast(
+        Any, lambda: _Dependencies(client)
+    )
     repo = work_items_module.DiscoveredRepo(
         repo_id=UUID(case["repo_id"]),
         full_name=case["repo_full_name"],

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_escalation-policies_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_escalation-policies_row.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(
+        field.name for field in fields(_module().CanonicalEscalationPolicy)
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.EscalationPolicy.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.escalation_policy(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/escalation-policies/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -85,6 +85,10 @@ _OPERATIONAL_ORDERING_RULES_SOURCE = _source(
 )
 _OPERATIONAL_SOURCE = _source("dev_health_ops/models/operational.py")
 _OPERATIONAL_IDENTITY_SOURCE = _source("dev_health_ops/models/operational_identity.py")
+_PAGERDUTY_MODELS_SOURCE = _source("dev_health_ops/providers/pagerduty/models.py")
+_PAGERDUTY_NORMALIZE_SOURCE = _source("dev_health_ops/providers/pagerduty/normalize.py")
+_NORMALIZE_COMMON_SOURCE = _source("dev_health_ops/providers/normalize_common.py")
+_DATETIME_SOURCE = _source("dev_health_ops/utils/datetime.py")
 _OPERATIONAL_MIGRATION_SOURCE = _source(
     "dev_health_ops/providers/operational_migration.py"
 )
@@ -830,6 +834,32 @@ def _target_jira_normalize() -> None:
     )
 
 
+def _target_pagerduty_normalize() -> None:
+    """Load the live PagerDuty normalizer and its canonical model chain."""
+    _load_source_module(
+        "dev_health_ops.models.operational_ordering_types",
+        _OPERATIONAL_ORDERING_SOURCE,
+    )
+    _load_source_module(
+        "dev_health_ops.models.operational_ordering_codec",
+        _OPERATIONAL_ORDERING_CODEC_SOURCE,
+    )
+    _load_source_module(
+        "dev_health_ops.models.operational_ordering",
+        _OPERATIONAL_ORDERING_RULES_SOURCE,
+    )
+    _load_source_module("dev_health_ops.models.operational", _OPERATIONAL_SOURCE)
+    _load_source_module(
+        "dev_health_ops.models.operational_identity", _OPERATIONAL_IDENTITY_SOURCE
+    )
+    _load_source_module("dev_health_ops.models.work_items", _WORK_ITEMS_MODEL_SOURCE)
+    _load_source_module("dev_health_ops.utils.datetime", _DATETIME_SOURCE)
+    _load_source_module(
+        "dev_health_ops.providers.normalize_common", _NORMALIZE_COMMON_SOURCE
+    )
+    _load_source_module(
+        "dev_health_ops.providers.pagerduty.models", _PAGERDUTY_MODELS_SOURCE
+    )
 def _target_feature_policy() -> None:
     """Load the policy's real type and registry inputs without licensing init."""
     _load_source_module("dev_health_ops.licensing.types", _LICENSE_TYPES_SOURCE)
@@ -1068,6 +1098,11 @@ ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
         _JIRA_NORMALIZE_SOURCE,
         _target_jira_normalize,
     ),
+    _PAGERDUTY_NORMALIZE_SOURCE: (
+        "dev_health_ops.providers.pagerduty.normalize",
+        _PAGERDUTY_NORMALIZE_SOURCE,
+        _target_pagerduty_normalize,
+    ),
     _FEATURE_POLICY_SOURCE: (
         "dev_health_ops.licensing.feature_policy",
         _FEATURE_POLICY_SOURCE,
@@ -1125,8 +1160,10 @@ def _install_namespace() -> None:
         "dev_health_ops.providers.github",
         "dev_health_ops.providers.gitlab",
         "dev_health_ops.providers.jira",
+        "dev_health_ops.providers.pagerduty",
         "dev_health_ops.providers.launchdarkly",
         "dev_health_ops.providers.linear",
+        "dev_health_ops.utils",
         "dev_health_ops.storage",
         "dev_health_ops.sync",
         "dev_health_ops.workers",

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -860,6 +860,8 @@ def _target_pagerduty_normalize() -> None:
     _load_source_module(
         "dev_health_ops.providers.pagerduty.models", _PAGERDUTY_MODELS_SOURCE
     )
+
+
 def _target_feature_policy() -> None:
     """Load the policy's real type and registry inputs without licensing init."""
     _load_source_module("dev_health_ops.licensing.types", _LICENSE_TYPES_SOURCE)


### PR DESCRIPTION
## Scope

Port PagerDuty escalation-policy collection and concrete typed operational effects/readback.

## Evidence

- Live Python differential oracle
- Real migrated ClickHouse integration
- Shared mutation harness: 5/5 killed
- Fast Go, vet, and static gates green

## Boundaries

- No registry, matrix, config, deployment, stream ownership, or cutover wiring
- Ordering-column persistence remains CHAOS-3721

Linear: CHAOS-3125

SCREENSHOT-WAIVER: Backend-only provider implementation; no rendered UI changes.
