### PR TITLE
CHAOS-3726: port PagerDuty business-services parity

### DIFF
--- a/internal/providersync/jira_incidents_route.go
+++ b/internal/providersync/jira_incidents_route.go
@@ -592,6 +592,26 @@ func encodeJiraOperationalValue(value any) (string, byte, []byte, error) {
 		return "datetime", 1, []byte(typed.UTC().Format("2006-01-02T15:04:05.000000Z")), nil
 	case uuid.UUID:
 		return "uuid", 1, []byte(strings.ToLower(typed.String())), nil
+	case int:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int8:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int16:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int32:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int64:
+		return "integer", 1, []byte(strconv.FormatInt(typed, 10)), nil
+	case uint:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint8:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint16:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint32:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint64:
+		return "integer", 1, []byte(strconv.FormatUint(typed, 10)), nil
 	case float64:
 		encoded := make([]byte, 8)
 		binary.BigEndian.PutUint64(encoded, math.Float64bits(typed))

--- a/internal/providersync/pagerduty_business_services_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_business_services_effects_clickhouse.go
@@ -1,0 +1,335 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// The migrated operational_services table predates durable ordering columns.
+// The effect row remains complete for parity and readback validation; this
+// insert list is the exact production ClickHouse schema.
+const pagerDutyBusinessServicesColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,name,description,service_type,owning_team_id,escalation_policy_id,is_deleted,deleted_at"
+
+// PagerDutyBusinessServicesClickHouseEffects persists a complete business
+// services snapshot and reconciles omitted active rows into typed tombstones.
+// ProviderInstanceID and the tenant predicates fence one PagerDuty account
+// from another account's shared operational_services table.
+type PagerDutyBusinessServicesClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+	Now                func() time.Time
+}
+
+func (sink PagerDutyBusinessServicesClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pagerDutyBusinessServiceRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validatePagerDutyBusinessServiceRows(claim, rows); err != nil {
+		return err
+	}
+	providerInstance, err := sink.providerInstance(rows)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveBusinessServices(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.snapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyBusinessServiceRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyBusinessServiceTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(
+		ctx, "INSERT INTO operational_services ("+pagerDutyBusinessServicesColumns+")",
+	)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyBusinessServiceValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyBusinessServicesClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pagerDutyBusinessServiceRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validatePagerDutyBusinessServiceRows(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	providerInstance, err := sink.providerInstance(expected)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveBusinessServices(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	exact, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadBusinessService(
+			ctx, claim, providerInstance, row.ID,
+		)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyBusinessServiceVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	// A complete source snapshot is exact only when no active business service
+	// remains outside the returned source identity set. Omitted rows must have
+	// become tombstones, not merely disappear from the effect payload.
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected) && absent == 0:
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink PagerDutyBusinessServicesClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "business-services" ||
+		effect.Destination != "operational_services" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func validatePagerDutyBusinessServiceRows(
+	claim Claim, rows []pagerDutyBusinessServiceRow,
+) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "business_service" || row.ExternalID == "" ||
+			row.Name == "" || row.ServiceType == nil || *row.ServiceType != "business" ||
+			row.OwningTeamID != nil || row.EscalationPolicyID != nil || row.ID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() ||
+			row.LastSynced.IsZero() || (row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyBusinessServiceOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func (sink PagerDutyBusinessServicesClickHouseEffects) providerInstance(
+	rows []pagerDutyBusinessServiceRow,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, row := range rows {
+		rowInstance := strings.ToLower(strings.TrimSpace(row.ProviderInstanceID))
+		if rowInstance == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = rowInstance
+		}
+		if instance != rowInstance {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func pagerDutyBusinessServiceValues(row pagerDutyBusinessServiceRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence, row.Name, row.Description, row.ServiceType,
+		row.OwningTeamID, row.EscalationPolicyID, row.IsDeleted, row.DeletedAt,
+	}
+}
+
+func pagerDutyBusinessServiceScanValues(row *pagerDutyBusinessServiceRow) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.Name, &row.Description, &row.ServiceType,
+		&row.OwningTeamID, &row.EscalationPolicyID, &row.IsDeleted, &row.DeletedAt,
+	}
+}
+
+func (sink PagerDutyBusinessServicesClickHouseEffects) loadActiveBusinessServices(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyBusinessServiceRow, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutyBusinessServicesColumns+
+			" FROM operational_services FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+		claim.OrgID, claim.Provider, providerInstance, "business_service",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	active := make([]pagerDutyBusinessServiceRow, 0)
+	for rows.Next() {
+		var row pagerDutyBusinessServiceRow
+		if err := rows.Scan(pagerDutyBusinessServiceScanValues(&row)...); err != nil {
+			return nil, err
+		}
+		if err := fillPagerDutyBusinessServiceOrdering(&row); err != nil {
+			return nil, err
+		}
+		active = append(active, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return active, nil
+}
+
+func (sink PagerDutyBusinessServicesClickHouseEffects) loadBusinessService(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyBusinessServiceRow, bool, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutyBusinessServicesColumns+
+			" FROM operational_services FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "business_service", id,
+	)
+	if err != nil {
+		return pagerDutyBusinessServiceRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyBusinessServiceRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyBusinessServiceScanValues(&actual)...); err != nil {
+			return pagerDutyBusinessServiceRow{}, false, err
+		}
+		if err := fillPagerDutyBusinessServiceOrdering(&actual); err != nil {
+			return pagerDutyBusinessServiceRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyBusinessServiceRow{}, false, err
+	}
+	return actual, found, nil
+}
+
+func comparePagerDutyBusinessServiceVersion(
+	expected, actual pagerDutyBusinessServiceRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func (sink PagerDutyBusinessServicesClickHouseEffects) snapshotObservedAt(
+	rows []pagerDutyBusinessServiceRow, claim Claim,
+) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	if sink.Now != nil {
+		return sink.Now().UTC().Truncate(time.Microsecond)
+	}
+	if claim.BeforeAt != nil && !claim.BeforeAt.IsZero() {
+		return claim.BeforeAt.UTC().Truncate(time.Microsecond)
+	}
+	return time.Now().UTC().Truncate(time.Microsecond)
+}
+
+var _ EffectSink = PagerDutyBusinessServicesClickHouseEffects{}
+var _ EffectReadback = PagerDutyBusinessServicesClickHouseEffects{}

--- a/internal/providersync/pagerduty_business_services_effects_integration_test.go
+++ b/internal/providersync/pagerduty_business_services_effects_integration_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyBusinessServicesEffectUsesMigratedClickHouseTombstonesAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Apply the production migration chain, including the canonical operational
+	// services table, rather than creating a test-only relaxed schema.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "business-services")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	rowA, err := normalizePagerDutyBusinessService(
+		claim, "acme", pagerDutyBusinessServicePayload{
+			ID: "PBS1", Name: "Payments", Description: stringPtr("Checkout"),
+		}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowB, err := normalizePagerDutyBusinessService(
+		claim, "acme", pagerDutyBusinessServicePayload{ID: "PBS2", Name: "Support"},
+		initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialEffect, err := effectBatchFromValues(
+		"operational_services", EffectReadbackRequired,
+		[]pagerDutyBusinessServiceRow{rowA, rowB},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutyBusinessServicesClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "Acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+		Now:   func() time.Time { return initialAt },
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, initialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after initial write inspection=%s error=%v", inspection, err)
+	}
+
+	// A later complete snapshot omits PBS2. The sink must fence that omission
+	// with a strictly newer tombstone while retaining the active PBS1 row.
+	updatedAt := initialAt.Add(time.Hour)
+	rowAUpdated, err := normalizePagerDutyBusinessService(
+		claim, "acme", pagerDutyBusinessServicePayload{
+			ID: "PBS1", Name: "Payments updated", UpdatedAt: updatedAt.Format(time.RFC3339Nano),
+		}, updatedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partialEffect, err := effectBatchFromValues(
+		"operational_services", EffectReadbackRequired,
+		[]pagerDutyBusinessServiceRow{rowAUpdated},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink.Now = func() time.Time { return updatedAt }
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("tombstone write inspection=%s error=%v", inspection, err)
+	}
+	var deleted bool
+	var deletedAt time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_deleted, deleted_at
+FROM operational_services FINAL
+WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND external_id = ?`,
+		claim.OrgID, "pagerduty", "acme", "business_service", "PBS2",
+	).Scan(&deleted, &deletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted || !deletedAt.Equal(updatedAt) {
+		t.Fatalf("missing-business-service tombstone deleted=%v deleted_at=%s want %s", deleted, deletedAt, updatedAt)
+	}
+
+	// The durable effect payload can be replayed after the write. Exact
+	// readback must remain stable and must not create a second logical row.
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+	}
+
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	otherRow := rowAUpdated
+	otherRow.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyBusinessServiceOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	otherEffect, err := effectBatchFromValues(
+		"operational_services", EffectReadbackRequired,
+		[]pagerDutyBusinessServiceRow{otherRow},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, otherEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign row changed readback inspection=%s error=%v", inspection, err)
+	}
+}

--- a/internal/providersync/pagerduty_business_services_effects_test.go
+++ b/internal/providersync/pagerduty_business_services_effects_test.go
@@ -1,0 +1,102 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyBusinessServicesEffectRejectsForeignScopeOrderingTamperAndMixedInstances(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "business-services")
+	row, err := normalizePagerDutyBusinessService(
+		claim, "acme", pagerDutyBusinessServicePayload{
+			ID: "PBS1", Name: "Payments", Description: stringPtr("Checkout"),
+		}, time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := row
+	foreign.OrgID = "org-other"
+	if err := validatePagerDutyBusinessServiceRows(claim, []pagerDutyBusinessServiceRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := row
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyBusinessServiceOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyBusinessServiceRows(claim, []pagerDutyBusinessServiceRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutyBusinessServicesClickHouseEffects{}).providerInstance(
+		[]pagerDutyBusinessServiceRow{row, foreignInstance},
+	); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := row
+	tampered.Name = "forged"
+	if err := validatePagerDutyBusinessServiceRows(claim, []pagerDutyBusinessServiceRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	inconsistent := row
+	inconsistent.IsDeleted = true
+	if err := fillPagerDutyBusinessServiceOrdering(&inconsistent); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyBusinessServiceRows(claim, []pagerDutyBusinessServiceRow{inconsistent}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("deleted flag consistency error=%v", err)
+	}
+	if err := validatePagerDutyBusinessServiceRows(claim, []pagerDutyBusinessServiceRow{row, row}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate row error=%v", err)
+	}
+}
+
+func TestPagerDutyBusinessServicesTombstoneBumpsSourceVersionAndPreservesIdentity(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "business-services")
+	row, err := normalizePagerDutyBusinessService(
+		claim, "acme", pagerDutyBusinessServicePayload{ID: "PBS1", Name: "Payments"},
+		time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tombstone, err := pagerDutyBusinessServiceTombstone(row, row.SourceVersionAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tombstone.ID != row.ID || tombstone.ExternalID != row.ExternalID ||
+		!tombstone.SourceVersionAt.Equal(row.SourceVersionAt.Add(time.Microsecond)) ||
+		!tombstone.ObservedAt.Equal(tombstone.SourceVersionAt) ||
+		!tombstone.LastSynced.Equal(tombstone.SourceVersionAt) || !tombstone.IsDeleted ||
+		tombstone.DeletedAt == nil || !tombstone.DeletedAt.Equal(tombstone.SourceVersionAt) ||
+		tombstone.SourceRevision == nil || tombstone.IngestRevision == nil ||
+		tombstone.OrderingContract != 2 {
+		t.Fatalf("tombstone=%+v", tombstone)
+	}
+	if tombstone.SourceRevision.Cmp(row.SourceRevision) <= 0 {
+		t.Fatalf("tombstone source revision did not advance: old=%s new=%s", row.SourceRevision, tombstone.SourceRevision)
+	}
+}
+
+func TestPagerDutyBusinessServicesEffectRejectsUnsafeEmptySnapshotWithoutInstance(t *testing.T) {
+	if _, err := (PagerDutyBusinessServicesClickHouseEffects{}).providerInstance(nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+}
+
+func TestPagerDutyBusinessServicesEffectRejectsWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "business-services")
+	sink := PagerDutyBusinessServicesClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_services"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid request error=%v", err)
+	}
+	if err := sink.WriteEffect(
+		context.Background(), claim, EffectBatch{Destination: "other"},
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_business_services_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_business_services_generic_oracle_test.go
@@ -1,0 +1,77 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyBusinessServiceRowForOracle(
+	t *testing.T, input map[string]any,
+) pagerDutyBusinessServiceRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutyBusinessServicePayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "business-services")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyBusinessService(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload,
+		observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyBusinessServiceCases() []oracleCase {
+	return []oracleCase{
+		{ID: "updated_html_url_description", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PBS1", "type": "business_service", "name": "Payments",
+				"summary": "Ignored summary", "description": "Checkout path",
+				"updated_at": "2026-08-01T10:00:00.123456Z",
+				"html_url":   "https://acme.pagerduty.com/business_services/PBS1",
+			},
+		}},
+		{ID: "created_self_url_summary", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PBS2", "type": "business_service", "summary": "Support",
+				"created_at": "2026-07-31T09:00:00Z",
+				"self":       "/business_services/PBS2",
+			},
+		}},
+		{ID: "observed_time_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PBS3", "type": "business_service", "name": "Operations",
+			},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyBusinessServiceRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/business-services/row", oraclePagerDutyBusinessServiceCases(),
+		buildPagerDutyBusinessServiceRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_business_services_route.go
+++ b/internal/providersync/pagerduty_business_services_route.go
@@ -1,0 +1,299 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyBusinessServicesMaxPages = 10_000
+	pagerDutyBusinessServicesMaxRows  = 100_000
+	pagerDutyBusinessServicesPerPage  = 100
+)
+
+// pagerDutyBusinessServicePayload is the provider-owned subset consumed by
+// Python's PagerDutyNormalizer.business_service. Unknown PagerDuty fields are
+// intentionally ignored because they are not part of the persisted contract.
+type pagerDutyBusinessServicePayload struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Summary     string  `json:"summary"`
+	SelfURL     string  `json:"self"`
+	HTMLURL     string  `json:"html_url"`
+	Description *string `json:"description"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+// pagerDutyBusinessServiceRow mirrors every field on Python's canonical
+// OperationalService dataclass. Business services and technical services
+// share the ClickHouse table, so source_entity_type and service_type are both
+// part of the row's typed identity and ordering input.
+type pagerDutyBusinessServiceRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	Name                   string     `json:"name"`
+	Description            *string    `json:"description"`
+	ServiceType            *string    `json:"service_type"`
+	OwningTeamID           *string    `json:"owning_team_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+// PagerDutyBusinessServicesRouteHandler owns source collection and canonical
+// normalization only. Route registration, switches, and worker wiring stay
+// with the integration lane.
+type PagerDutyBusinessServicesRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutyBusinessServicesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyBusinessServicesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutyBusinessServicesRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutyBusinessServicesMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutyBusinessServicesMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyBusinessServicesPerPage
+	}
+	if pages < 1 || pages > pagerDutyBusinessServicesMaxPages || rows < 1 ||
+		rows > pagerDutyBusinessServicesMaxRows || perPage < 1 || perPage > pagerDutyBusinessServicesPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutyBusinessServicesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "business-services" ||
+		client == nil || client.Provider != "pagerduty" || client.BaseURL == nil ||
+		normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyBusinessServicesCountingDoer{
+		delegate: client.Doer, attempts: &requests,
+	}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/business_services", DataKey: "business_services",
+			PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	rows := make([]pagerDutyBusinessServiceRow, 0, len(pages.Items))
+	for _, raw := range pages.Items {
+		var payload pagerDutyBusinessServicePayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, err := normalizePagerDutyBusinessService(
+			claim, providerInstance, payload, normalizedAt,
+		)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues(
+		"operational_services", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  map[string]any{"business_services_synced": len(rows)},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutyBusinessService(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyBusinessServicePayload,
+	normalizedAt time.Time,
+) (pagerDutyBusinessServiceRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyBusinessServiceRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyBusinessServiceSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyBusinessServiceRow{}, err
+	}
+	var sourceURL *string
+	if payload.HTMLURL != "" {
+		value := payload.HTMLURL
+		sourceURL = &value
+	} else if payload.SelfURL != "" {
+		value := payload.SelfURL
+		sourceURL = &value
+	}
+	name := payload.Name
+	if name == "" {
+		name = payload.Summary
+	}
+	if name == "" {
+		name = payload.ID
+	}
+	serviceType := "business"
+	row := pagerDutyBusinessServiceRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "business_service", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt, Name: name,
+		Description: payload.Description, ServiceType: &serviceType,
+	}
+	if err := fillPagerDutyBusinessServiceOrdering(&row); err != nil {
+		return pagerDutyBusinessServiceRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyBusinessServiceSourceTime(
+	payload pagerDutyBusinessServicePayload, observedAt time.Time,
+) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func fillPagerDutyBusinessServiceOrdering(row *pagerDutyBusinessServiceRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"name", row.Name},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"service_type", jiraStringValue(row.ServiceType)},
+		jiraOperationalField{"owning_team_id", jiraStringValue(row.OwningTeamID)},
+		jiraOperationalField{"escalation_policy_id", jiraStringValue(row.EscalationPolicyID)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_service", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func pagerDutyBusinessServiceTombstone(
+	row pagerDutyBusinessServiceRow, observedAt time.Time,
+) (pagerDutyBusinessServiceRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyBusinessServiceRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)
+	if version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt = version
+	row.ObservedAt = version
+	row.LastSynced = version
+	row.IsDeleted = true
+	row.DeletedAt = &version
+	row.SourceRevision = nil
+	row.SourceConflictKey = ""
+	row.IngestRevision = nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyBusinessServiceOrdering(&row); err != nil {
+		return pagerDutyBusinessServiceRow{}, err
+	}
+	return row, nil
+}
+
+var _ CompleteRouteHandler = PagerDutyBusinessServicesRouteHandler{}

--- a/internal/providersync/pagerduty_business_services_route_test.go
+++ b/internal/providersync/pagerduty_business_services_route_test.go
@@ -1,0 +1,219 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyBusinessServicesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutyBusinessServicesDoer struct {
+	t         *testing.T
+	responses []pagerDutyBusinessServicesResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyBusinessServicesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutyBusinessServicesRouteUsesOffsetPaginationAndCanonicalRow(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyBusinessServicesDoer{t: t, responses: []pagerDutyBusinessServicesResponse{
+		{body: `{"business_services":[
+			{"id":"PBS1","type":"business_service","name":"Payments","description":"Checkout path","updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/business_services/PBS1"},
+			{"id":"PBS2","type":"business_service","summary":"Support","created_at":"2026-07-31T09:00:00Z"}],"more":true}`},
+		{body: `{"business_services":[{"id":"PBS3","type":"business_service","name":"Operations"}],"more":false}`},
+	}}
+	client := pagerDutyBusinessServicesTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "business-services")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "},
+	}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyBusinessServicesRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_services" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 ||
+		batch.Evidence.CapReached || batch.Watermark != nil {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[0].URL.Path; got != "/business_services" {
+		t.Fatalf("first path=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+	row := mustPagerDutyBusinessServiceRow(t, batch.Effects[0].Rows[0])
+	if row.Provider != "pagerduty" || row.ProviderInstanceID != "acme" ||
+		row.SourceEntityType != "business_service" || row.ExternalID != "PBS1" ||
+		row.Name != "Payments" || row.Description == nil || *row.Description != "Checkout path" ||
+		row.ServiceType == nil || *row.ServiceType != "business" || row.SourceURL == nil ||
+		*row.SourceURL != "https://acme.pagerduty.com/business_services/PBS1" ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!row.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) ||
+		row.SourceRevision == nil || row.IngestRevision == nil || row.OrderingContract != 2 {
+		t.Fatalf("row=%+v", row)
+	}
+	if secondary := mustPagerDutyBusinessServiceRow(t, batch.Effects[0].Rows[1]); secondary.Name != "Support" {
+		t.Fatalf("secondary=%+v", secondary)
+	}
+	if tertiary := mustPagerDutyBusinessServiceRow(t, batch.Effects[0].Rows[2]); tertiary.Name != "Operations" ||
+		!tertiary.SourceVersionAt.Equal(row.ObservedAt) {
+		t.Fatalf("tertiary=%+v", tertiary)
+	}
+}
+
+func TestPagerDutyBusinessServicesRoutePreservesRetryAndPermanentErrorSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "business-services")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	clientRetryDoer := &pagerDutyBusinessServicesDoer{t: t, responses: []pagerDutyBusinessServicesResponse{
+		{status: http.StatusTooManyRequests, headers: http.Header{"Retry-After": {"0"}}, body: `{"message":"slow down"}`},
+		{body: `{"business_services":[],"more":false}`},
+	}}
+	retryClient := pagerDutyBusinessServicesTestClient(t, clientRetryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutyBusinessServicesRouteHandler{}).Collect(
+		context.Background(), claim, credential, retryClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil || len(clientRetryDoer.requests) != 2 || len(batch.Effects) != 1 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(clientRetryDoer.requests))
+	}
+
+	authDoer := &pagerDutyBusinessServicesDoer{t: t, responses: []pagerDutyBusinessServicesResponse{
+		{status: http.StatusUnauthorized, body: `{"message":"bad token"}`},
+	}}
+	authClient := pagerDutyBusinessServicesTestClient(t, authDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	_, err = (PagerDutyBusinessServicesRouteHandler{}).Collect(
+		context.Background(), claim, credential, authClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication ||
+		len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+}
+
+func TestPagerDutyBusinessServicesRouteFailsClosedOnPaginationCapAndMissingInstance(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "business-services")
+	client := pagerDutyBusinessServicesTestClient(t, &pagerDutyBusinessServicesDoer{
+		t: t, responses: []pagerDutyBusinessServicesResponse{{
+			body: `{"business_services":[{"id":"one"}],"more":true}`,
+		}}}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	_, err := (PagerDutyBusinessServicesRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, credential, client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	_, err = (PagerDutyBusinessServicesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{Provider: "pagerduty"}, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("missing instance error=%v", err)
+	}
+}
+
+func TestPagerDutyBusinessServicesRouteStopsWhenLeaseExpiresBetweenPages(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "business-services")
+	doer := &pagerDutyBusinessServicesDoer{t: t, responses: []pagerDutyBusinessServicesResponse{
+		{body: `{"business_services":[{"id":"one"}],"more":true}`},
+		{body: `{"business_services":[],"more":false}`},
+	}}
+	asserts := 0
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutyBusinessServicesRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(doer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(doer.requests), asserts)
+	}
+}
+
+func pagerDutyBusinessServicesTestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyBusinessServiceRow(t *testing.T, raw []byte) pagerDutyBusinessServiceRow {
+	t.Helper()
+	var row pagerDutyBusinessServiceRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/pagerduty_incidents_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_incidents_effects_clickhouse.go
@@ -1,0 +1,559 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/big"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const pagerDutyIncidentColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,service_id,service_external_id,escalation_policy_id,title,description,started_at,resolved_at,is_deleted,deleted_at"
+const pagerDutyAlertColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,service_id,incident_id,title,description,triggered_at,acknowledged_at,resolved_at,is_deleted,deleted_at"
+const pagerDutyLogEntryColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,incident_id,event_type,body,actor_type,actor_id,occurred_at"
+const pagerDutyNoteColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,incident_id,body,author_user_id,created_at"
+
+// PagerDutyIncidentFamilyClickHouseEffects is the sink for the four atomic
+// Python incident-family destinations. It deliberately does not reconcile
+// omitted rows: these datasets are windowed incident streams, not complete
+// catalog snapshots. Every write and readback is tenant/provider-instance
+// scoped and lease fenced.
+type PagerDutyIncidentFamilyClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	switch effect.Destination {
+	case "operational_incidents":
+		rows, err := decodeEffectRows[pagerDutyIncidentRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyIncidentRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeIncidentRows(ctx, rows)
+	case "operational_alerts":
+		rows, err := decodeEffectRows[pagerDutyAlertRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyAlertRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeAlertRows(ctx, rows)
+	case "operational_incident_timeline_events":
+		rows, err := decodeEffectRows[pagerDutyLogEntryRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyLogEntryRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeLogEntryRows(ctx, rows)
+	case "operational_incident_notes":
+		rows, err := decodeEffectRows[pagerDutyNoteRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyNoteRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeNoteRows(ctx, rows)
+	default:
+		return ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	switch effect.Destination {
+	case "operational_incidents":
+		rows, err := decodeEffectRows[pagerDutyIncidentRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyIncidentRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectIncidentRows(ctx, claim, rows)
+	case "operational_alerts":
+		rows, err := decodeEffectRows[pagerDutyAlertRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyAlertRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectAlertRows(ctx, claim, rows)
+	case "operational_incident_timeline_events":
+		rows, err := decodeEffectRows[pagerDutyLogEntryRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyLogEntryRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectLogEntryRows(ctx, claim, rows)
+	case "operational_incident_notes":
+		rows, err := decodeEffectRows[pagerDutyNoteRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyNoteRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectNoteRows(ctx, claim, rows)
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || strings.TrimSpace(sink.ProviderInstanceID) == "" {
+		return ErrInvalidConfiguration
+	}
+	validDataset := (claim.Dataset == "incidents" && effect.Destination == "operational_incidents") ||
+		(claim.Dataset == "incident-alerts" && effect.Destination == "operational_alerts") ||
+		(claim.Dataset == "incident-log-entries" && effect.Destination == "operational_incident_timeline_events") ||
+		(claim.Dataset == "incident-notes" && effect.Destination == "operational_incident_notes")
+	if !validDataset {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeIncidentRows(
+	ctx context.Context, rows []pagerDutyIncidentRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incidents ("+pagerDutyIncidentColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyIncidentValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeAlertRows(
+	ctx context.Context, rows []pagerDutyAlertRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_alerts ("+pagerDutyAlertColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyAlertValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeLogEntryRows(
+	ctx context.Context, rows []pagerDutyLogEntryRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incident_timeline_events ("+pagerDutyLogEntryColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyLogEntryValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeNoteRows(
+	ctx context.Context, rows []pagerDutyNoteRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incident_notes ("+pagerDutyNoteColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyNoteValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func validatePagerDutyIncidentRows(claim Claim, providerInstance string, rows []pagerDutyIncidentRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||
+			row.SourceEntityType != "incident" || row.ExternalID == "" || row.ID == "" ||
+			row.Title == "" || row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 || row.SourceVersionAt.IsZero() ||
+			row.ObservedAt.IsZero() || row.LastSynced.IsZero() || (row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyIncidentOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 || canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyAlertRows(claim Claim, providerInstance string, rows []pagerDutyAlertRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||
+			row.SourceEntityType != "alert" || row.ExternalID == "" || row.ID == "" ||
+			row.Title == "" || row.IncidentID == nil || *row.IncidentID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil || row.SourceConflictKey == "" ||
+			row.OrderingContract != 2 || row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyAlertOrdering(&canonical); err != nil || canonical.ID != row.ID ||
+			canonical.SourceConflictKey != row.SourceConflictKey || canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 || canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyLogEntryRows(claim Claim, providerInstance string, rows []pagerDutyLogEntryRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) || row.SourceEntityType != "log_entry" ||
+			row.ExternalID == "" || row.ID == "" || row.IncidentID == "" || row.EventType == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil || row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyLogEntryOrdering(&canonical); err != nil || canonical.ID != row.ID ||
+			canonical.SourceConflictKey != row.SourceConflictKey || canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 || canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyNoteRows(claim Claim, providerInstance string, rows []pagerDutyNoteRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) || row.SourceEntityType != "note" ||
+			row.ExternalID == "" || row.ID == "" || row.IncidentID == "" || row.SourceRevision == nil ||
+			row.IngestRevision == nil || row.SourceConflictKey == "" || row.OrderingContract != 2 || row.SourceVersionAt.IsZero() ||
+			row.ObservedAt.IsZero() || row.LastSynced.IsZero() {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyNoteOrdering(&canonical); err != nil || canonical.ID != row.ID ||
+			canonical.SourceConflictKey != row.SourceConflictKey || canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 || canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyProviderInstanceMatches(row, expected string) bool {
+	return row != "" && row == strings.ToLower(row) && strings.ToLower(strings.TrimSpace(expected)) == row
+}
+
+func pagerDutyIncidentValues(row pagerDutyIncidentRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.ServiceID, row.ServiceExternalID, row.EscalationPolicyID, row.Title, row.Description, row.StartedAt, row.ResolvedAt, row.IsDeleted, row.DeletedAt}
+}
+
+func pagerDutyAlertValues(row pagerDutyAlertRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.ServiceID, row.IncidentID, row.Title, row.Description, row.TriggeredAt, row.AcknowledgedAt, row.ResolvedAt, row.IsDeleted, row.DeletedAt}
+}
+
+func pagerDutyLogEntryValues(row pagerDutyLogEntryRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.IncidentID, row.EventType, row.Body, row.ActorType, row.ActorID, row.OccurredAt}
+}
+
+func pagerDutyNoteValues(row pagerDutyNoteRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.IncidentID, row.Body, row.AuthorUserID, row.CreatedAt}
+}
+
+func pagerDutyIncidentScanValues(row *pagerDutyIncidentRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.ServiceID, &row.ServiceExternalID, &row.EscalationPolicyID, &row.Title, &row.Description, &row.StartedAt, &row.ResolvedAt, &row.IsDeleted, &row.DeletedAt}
+}
+
+func pagerDutyAlertScanValues(row *pagerDutyAlertRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.ServiceID, &row.IncidentID, &row.Title, &row.Description, &row.TriggeredAt, &row.AcknowledgedAt, &row.ResolvedAt, &row.IsDeleted, &row.DeletedAt}
+}
+
+func pagerDutyLogEntryScanValues(row *pagerDutyLogEntryRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.IncidentID, &row.EventType, &row.Body, &row.ActorType, &row.ActorID, &row.OccurredAt}
+}
+
+func pagerDutyNoteScanValues(row *pagerDutyNoteRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.IncidentID, &row.Body, &row.AuthorUserID, &row.CreatedAt}
+}
+
+func equalPagerDutyRow(expected, actual any) bool {
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	return expectedErr == nil && actualErr == nil && bytes.Equal(expectedJSON, actualJSON)
+}
+
+func inspectPagerDutyRows[T any](
+	rows []T,
+	id func(T) string,
+	sourceRevision func(T) *big.Int,
+	load func(string) (T, bool, error),
+) (EffectInspection, error) {
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	exact, absent := 0, 0
+	for _, expected := range rows {
+		actual, found, err := load(id(expected))
+		if err != nil {
+			return EffectConflict, err
+		}
+		if !found || sourceRevision(actual) == nil {
+			absent++
+			continue
+		}
+		comparison := sourceRevision(actual).Cmp(sourceRevision(expected))
+		switch {
+		case comparison < 0:
+			absent++
+		case comparison > 0:
+			return EffectConflict, nil
+		case !equalPagerDutyRow(expected, actual):
+			return EffectConflict, nil
+		default:
+			exact++
+		}
+	}
+	switch {
+	case exact == len(rows):
+		return EffectExact, nil
+	case absent == len(rows):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectIncidentRows(
+	ctx context.Context, claim Claim, rows []pagerDutyIncidentRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyIncidentRow) string { return row.ID }, func(row pagerDutyIncidentRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyIncidentRow, bool, error) {
+		return sink.loadIncidentRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectAlertRows(
+	ctx context.Context, claim Claim, rows []pagerDutyAlertRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyAlertRow) string { return row.ID }, func(row pagerDutyAlertRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyAlertRow, bool, error) {
+		return sink.loadAlertRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectLogEntryRows(
+	ctx context.Context, claim Claim, rows []pagerDutyLogEntryRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyLogEntryRow) string { return row.ID }, func(row pagerDutyLogEntryRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyLogEntryRow, bool, error) {
+		return sink.loadLogEntryRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectNoteRows(
+	ctx context.Context, claim Claim, rows []pagerDutyNoteRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyNoteRow) string { return row.ID }, func(row pagerDutyNoteRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyNoteRow, bool, error) {
+		return sink.loadNoteRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadIncidentRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyIncidentRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyIncidentColumns+" FROM operational_incidents FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "incident", id)
+	if err != nil {
+		return pagerDutyIncidentRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyIncidentRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyIncidentScanValues(&row)...); err != nil {
+			return pagerDutyIncidentRow{}, false, err
+		}
+		if err := fillPagerDutyIncidentOrdering(&row); err != nil {
+			return pagerDutyIncidentRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyIncidentRow{}, false, err
+	}
+	return row, found, nil
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadAlertRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyAlertRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyAlertColumns+" FROM operational_alerts FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "alert", id)
+	if err != nil {
+		return pagerDutyAlertRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyAlertRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyAlertScanValues(&row)...); err != nil {
+			return pagerDutyAlertRow{}, false, err
+		}
+		if err := fillPagerDutyAlertOrdering(&row); err != nil {
+			return pagerDutyAlertRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyAlertRow{}, false, err
+	}
+	return row, found, nil
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadLogEntryRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyLogEntryRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyLogEntryColumns+" FROM operational_incident_timeline_events FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "log_entry", id)
+	if err != nil {
+		return pagerDutyLogEntryRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyLogEntryRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyLogEntryScanValues(&row)...); err != nil {
+			return pagerDutyLogEntryRow{}, false, err
+		}
+		if err := fillPagerDutyLogEntryOrdering(&row); err != nil {
+			return pagerDutyLogEntryRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyLogEntryRow{}, false, err
+	}
+	return row, found, nil
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadNoteRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyNoteRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyNoteColumns+" FROM operational_incident_notes FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "note", id)
+	if err != nil {
+		return pagerDutyNoteRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyNoteRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyNoteScanValues(&row)...); err != nil {
+			return pagerDutyNoteRow{}, false, err
+		}
+		if err := fillPagerDutyNoteOrdering(&row); err != nil {
+			return pagerDutyNoteRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyNoteRow{}, false, err
+	}
+	return row, found, nil
+}
+
+var _ EffectSink = PagerDutyIncidentFamilyClickHouseEffects{}
+var _ EffectReadback = PagerDutyIncidentFamilyClickHouseEffects{}

--- a/internal/providersync/pagerduty_incidents_effects_integration_test.go
+++ b/internal/providersync/pagerduty_incidents_effects_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyIncidentFamilyEffectsUseMigratedClickHouseAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Apply the production migration chain. This test must exercise the exact
+	// canonical tables, not a relaxed test-only schema.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	normalizedAt := time.Date(2026, 7, 19, 19, 0, 0, 123456000, time.UTC)
+	claim := nativeTestClaim("pagerduty", "incidents")
+	incident, err := normalizePagerDutyIncident(claim, "acme", pagerDutyIncidentPayload{
+		ID: "PI1", Title: stringPtr("Database outage"), Status: stringPtr("triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:00:00Z"), UpdatedAt: stringPtr("2026-07-17T12:01:00Z"),
+	}, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alertClaim := nativeTestClaim("pagerduty", "incident-alerts")
+	alert, err := normalizePagerDutyAlert(alertClaim, "acme", pagerDutyAlertPayload{
+		ID: "PA1", Summary: stringPtr("Disk alert"), Status: stringPtr("triggered"), Severity: stringPtr("critical"),
+		CreatedAt: stringPtr("2026-07-17T12:02:00Z"), UpdatedAt: stringPtr("2026-07-17T12:03:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logClaim := nativeTestClaim("pagerduty", "incident-log-entries")
+	entry, err := normalizePagerDutyLogEntry(logClaim, "acme", pagerDutyLogEntryPayload{
+		ID: "PL1", Type: stringPtr("status_change"), Summary: stringPtr("Triggered"), CreatedAt: stringPtr("2026-07-17T12:04:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noteClaim := nativeTestClaim("pagerduty", "incident-notes")
+	note, err := normalizePagerDutyNote(noteClaim, "acme", pagerDutyNotePayload{
+		ID: "PN1", Content: stringPtr("Investigating"), CreatedAt: stringPtr("2026-07-17T12:05:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sink := PagerDutyIncidentFamilyClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "Acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	cases := []struct {
+		name   string
+		claim  Claim
+		effect EffectBatch
+		table  string
+	}{
+		{name: "incidents", claim: claim, effect: mustPagerDutyIncidentEffect(t, incident), table: "operational_incidents"},
+		{name: "alerts", claim: alertClaim, effect: mustPagerDutyAlertEffect(t, alert), table: "operational_alerts"},
+		{name: "log_entries", claim: logClaim, effect: mustPagerDutyLogEntryEffect(t, entry), table: "operational_incident_timeline_events"},
+		{name: "notes", claim: noteClaim, effect: mustPagerDutyNoteEffect(t, note), table: "operational_incident_notes"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if inspection, err := sink.InspectEffect(ctx, testCase.claim, testCase.effect); err != nil || inspection != EffectAbsent {
+				t.Fatalf("before write inspection=%s error=%v", inspection, err)
+			}
+			if err := sink.WriteEffect(ctx, testCase.claim, testCase.effect); err != nil {
+				t.Fatal(err)
+			}
+			if inspection, err := sink.InspectEffect(ctx, testCase.claim, testCase.effect); err != nil || inspection != EffectExact {
+				t.Fatalf("after write inspection=%s error=%v", inspection, err)
+			}
+			if err := sink.WriteEffect(ctx, testCase.claim, testCase.effect); err != nil {
+				t.Fatalf("replay write: %v", err)
+			}
+			if inspection, err := sink.InspectEffect(ctx, testCase.claim, testCase.effect); err != nil || inspection != EffectExact {
+				t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+			}
+			var count uint64
+			if err := conn.QueryRow(ctx, "SELECT count() FROM "+testCase.table+" FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ?", testCase.claim.OrgID, "pagerduty", "acme").Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 {
+				t.Fatalf("rows=%d", count)
+			}
+		})
+	}
+
+	foreign := claim
+	foreign.OrgID = "org-other"
+	foreignEffect := mustPagerDutyIncidentEffect(t, incident)
+	if err := sink.WriteEffect(ctx, foreign, foreignEffect); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		// The row itself still carries org-acme, so the scope fence must reject it
+		// before ClickHouse can mutate the other tenant.
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+}
+
+func mustPagerDutyIncidentEffect(t *testing.T, row pagerDutyIncidentRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_incidents", EffectReadbackRequired, []pagerDutyIncidentRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func mustPagerDutyAlertEffect(t *testing.T, row pagerDutyAlertRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_alerts", EffectReadbackRequired, []pagerDutyAlertRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func mustPagerDutyLogEntryEffect(t *testing.T, row pagerDutyLogEntryRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_incident_timeline_events", EffectReadbackRequired, []pagerDutyLogEntryRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func mustPagerDutyNoteEffect(t *testing.T, row pagerDutyNoteRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_incident_notes", EffectReadbackRequired, []pagerDutyNoteRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/pagerduty_incidents_effects_test.go
+++ b/internal/providersync/pagerduty_incidents_effects_test.go
@@ -1,0 +1,104 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyIncidentFamilyEffectsValidateEachTypedDestinationAndScope(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	normalizedAt := time.Date(2026, 7, 19, 19, 0, 0, 0, time.UTC)
+	incident, err := normalizePagerDutyIncident(claim, "acme", pagerDutyIncidentPayload{
+		ID: "PI1", Title: stringPtr("Incident"), Status: stringPtr("triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:00:00Z"), UpdatedAt: stringPtr("2026-07-17T12:01:00Z"),
+	}, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{incident}); err != nil {
+		t.Fatal(err)
+	}
+	alertClaim := claim
+	alertClaim.Dataset = "incident-alerts"
+	alert, err := normalizePagerDutyAlert(alertClaim, "acme", pagerDutyAlertPayload{
+		ID: "PA1", Summary: stringPtr("Alert"), Status: stringPtr("triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:02:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyAlertRows(alertClaim, "acme", []pagerDutyAlertRow{alert}); err != nil {
+		t.Fatal(err)
+	}
+	logClaim := claim
+	logClaim.Dataset = "incident-log-entries"
+	entry, err := normalizePagerDutyLogEntry(logClaim, "acme", pagerDutyLogEntryPayload{
+		ID: "PL1", Type: stringPtr("status_change"), Summary: stringPtr("Triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:03:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyLogEntryRows(logClaim, "acme", []pagerDutyLogEntryRow{entry}); err != nil {
+		t.Fatal(err)
+	}
+	noteClaim := claim
+	noteClaim.Dataset = "incident-notes"
+	note, err := normalizePagerDutyNote(noteClaim, "acme", pagerDutyNotePayload{
+		ID: "PN1", Content: stringPtr("Investigating"), CreatedAt: stringPtr("2026-07-17T12:04:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyNoteRows(noteClaim, "acme", []pagerDutyNoteRow{note}); err != nil {
+		t.Fatal(err)
+	}
+
+	foreign := incident
+	foreign.OrgID = "org-other"
+	if err := fillPagerDutyIncidentOrdering(&foreign); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	mixed := incident
+	mixed.ProviderInstanceID = "other"
+	if err := fillPagerDutyIncidentOrdering(&mixed); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{mixed}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign instance error=%v", err)
+	}
+	tampered := incident
+	tampered.Title = "tampered"
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	contractTampered := incident
+	contractTampered.OrderingContract = 3
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{contractTampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering contract tamper error=%v", err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{incident, incident}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate error=%v", err)
+	}
+}
+
+func TestPagerDutyIncidentFamilyEffectsRejectWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	sink := PagerDutyIncidentFamilyClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_incidents"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("nil context error=%v", err)
+	}
+	if err := sink.WriteEffect(context.Background(), claim, EffectBatch{Destination: "wrong"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+	if _, err := sink.InspectEffect(context.Background(), claim, EffectBatch{Destination: "operational_incidents"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid readback error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_incidents_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_incidents_generic_oracle_test.go
@@ -1,0 +1,225 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyIncidentRowForOracle(t *testing.T, input map[string]any) pagerDutyIncidentRow {
+	t.Helper()
+	var payload pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incidents")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyIncident(claim, strings.ToLower(input["provider_instance_id"].(string)), payload, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func buildPagerDutyAlertRowForOracle(t *testing.T, input map[string]any) pagerDutyAlertRow {
+	t.Helper()
+	var payload pagerDutyAlertPayload
+	var incident pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = json.Marshal(input["incident"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &incident); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incident-alerts")
+	claim.OrgID = input["org_id"].(string)
+	providerInstance := strings.ToLower(input["provider_instance_id"].(string))
+	parent, err := normalizePagerDutyIncident(claim, providerInstance, incident, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizePagerDutyAlert(claim, providerInstance, payload, parent.ID, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func buildPagerDutyLogEntryRowForOracle(t *testing.T, input map[string]any) pagerDutyLogEntryRow {
+	t.Helper()
+	var payload pagerDutyLogEntryPayload
+	var incident pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = json.Marshal(input["incident"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &incident); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incident-log-entries")
+	claim.OrgID = input["org_id"].(string)
+	providerInstance := strings.ToLower(input["provider_instance_id"].(string))
+	parent, err := normalizePagerDutyIncident(claim, providerInstance, incident, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizePagerDutyLogEntry(claim, providerInstance, payload, parent.ID, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func buildPagerDutyNoteRowForOracle(t *testing.T, input map[string]any) pagerDutyNoteRow {
+	t.Helper()
+	var payload pagerDutyNotePayload
+	var incident pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = json.Marshal(input["incident"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &incident); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	claim.OrgID = input["org_id"].(string)
+	providerInstance := strings.ToLower(input["provider_instance_id"].(string))
+	parent, err := normalizePagerDutyIncident(claim, providerInstance, incident, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizePagerDutyNote(claim, providerInstance, payload, parent.ID, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func pagerDutyIncidentOracleBase() map[string]any {
+	return map[string]any{
+		"org_id": "org-acme", "provider_instance_id": "Acme",
+		"observed_at": "2026-07-19T19:00:00.987654Z",
+	}
+}
+
+func pagerDutyIncidentOracleParent() map[string]any {
+	return map[string]any{
+		"id": "PI-PARENT", "type": "incident", "incident_number": 7,
+		"title": "Parent", "status": "triggered", "urgency": "high",
+		"created_at": "2026-07-17T12:00:00.123456Z", "updated_at": "2026-07-17T12:01:00.654321Z",
+		"service": map[string]any{"id": "PSVC1"}, "priority": map[string]any{"id": "P1", "summary": "P1"},
+		"html_url": "https://acme.pagerduty.com/incidents/PI-PARENT",
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyIncidentRows(t *testing.T) {
+	base := pagerDutyIncidentOracleBase()
+	cases := []oracleCase{
+		{ID: "resolved_full", Input: map[string]any{
+			"org_id": base["org_id"], "provider_instance_id": base["provider_instance_id"], "observed_at": base["observed_at"],
+			"payload": map[string]any{
+				"id": "PI1", "type": "incident", "incident_number": 42, "title": "Database outage", "status": "resolved", "urgency": "high",
+				"created_at": "2026-07-17T12:00:00.123456Z", "updated_at": "2026-07-18T10:00:00.654321Z", "resolved_at": "2026-07-18T09:00:00Z",
+				"last_status_change_at": "2026-07-18T09:01:00Z", "service": map[string]any{"id": "PSVC1"}, "priority": map[string]any{"id": "P1", "summary": "P1"},
+				"html_url": "https://acme.pagerduty.com/incidents/PI1",
+			},
+		}},
+		{ID: "acknowledged_created_self", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME", "observed_at": base["observed_at"],
+			"payload": map[string]any{"id": "PI2", "type": "incident", "summary": "Support", "status": "acknowledged", "urgency": "low", "created_at": "2026-07-17T13:00:00Z", "self": "/incidents/PI2"},
+		}},
+		{ID: "observed_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": base["observed_at"],
+			"payload": map[string]any{"id": "PI3", "type": "incident", "title": "Fallback", "status": "triggered", "urgency": "unknown", "priority": map[string]any{"id": "P9"}},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incidents/row", cases, buildPagerDutyIncidentRowForOracle, nil)
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyAlertRows(t *testing.T) {
+	cases := []oracleCase{
+		{ID: "resolved_critical", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PA1", "type": "alert", "summary": "Disk alert", "status": "resolved", "severity": "critical", "created_at": "2026-07-17T12:02:00Z", "updated_at": "2026-07-17T12:04:00Z", "self": "/incidents/PI-PARENT/alerts/PA1"},
+		}},
+		{ID: "triggered_warning", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PA2", "summary": "Warning", "status": "triggered", "severity": "warning", "created_at": "2026-07-17T12:05:00Z"},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incident-alerts/row", cases, buildPagerDutyAlertRowForOracle, nil)
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyLogEntryRows(t *testing.T) {
+	cases := []oracleCase{
+		{ID: "typed_summary", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PL1", "type": "status_change", "summary": "Triggered", "created_at": "2026-07-17T12:03:00Z", "updated_at": "2026-07-17T12:04:00Z", "html_url": "https://acme.pagerduty.com/log_entries/PL1"},
+		}},
+		{ID: "message_default_type", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PL2", "message": "Fallback message", "created_at": "2026-07-17T12:05:00Z"},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incident-log-entries/row", cases, buildPagerDutyLogEntryRowForOracle, nil)
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyNoteRows(t *testing.T) {
+	cases := []oracleCase{
+		{ID: "content_with_user", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PN1", "content": "Investigating", "created_at": "2026-07-17T12:06:00Z", "updated_at": "2026-07-17T12:07:00Z", "user": map[string]any{"id": "PU1"}},
+		}},
+		{ID: "empty_content", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PN2", "content": nil, "created_at": "2026-07-17T12:08:00Z"},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incident-notes/row", cases, buildPagerDutyNoteRowForOracle, nil)
+}

--- a/internal/providersync/pagerduty_incidents_ordering.go
+++ b/internal/providersync/pagerduty_incidents_ordering.go
@@ -1,0 +1,136 @@
+package providersync
+
+import "github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+
+func fillPagerDutyIncidentOrdering(row *pagerDutyIncidentRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"service_id", jiraStringValue(row.ServiceID)},
+		jiraOperationalField{"service_external_id", jiraStringValue(row.ServiceExternalID)},
+		jiraOperationalField{"escalation_policy_id", jiraStringValue(row.EscalationPolicyID)},
+		jiraOperationalField{"title", row.Title},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"started_at", jiraTimeValue(row.StartedAt)},
+		jiraOperationalField{"resolved_at", jiraTimeValue(row.ResolvedAt)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_incident", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func fillPagerDutyAlertOrdering(row *pagerDutyAlertRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"service_id", jiraStringValue(row.ServiceID)},
+		jiraOperationalField{"incident_id", jiraStringValue(row.IncidentID)},
+		jiraOperationalField{"title", row.Title},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"triggered_at", jiraTimeValue(row.TriggeredAt)},
+		jiraOperationalField{"acknowledged_at", jiraTimeValue(row.AcknowledgedAt)},
+		jiraOperationalField{"resolved_at", jiraTimeValue(row.ResolvedAt)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_alert", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func fillPagerDutyLogEntryOrdering(row *pagerDutyLogEntryRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"incident_id", row.IncidentID},
+		jiraOperationalField{"event_type", row.EventType},
+		jiraOperationalField{"body", jiraStringValue(row.Body)},
+		jiraOperationalField{"actor_type", jiraStringValue(row.ActorType)},
+		jiraOperationalField{"actor_id", jiraStringValue(row.ActorID)},
+		jiraOperationalField{"occurred_at", jiraTimeValue(row.OccurredAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_incident_timeline_event", row.OrgID, row.Provider,
+		row.ProviderInstanceID, row.ExternalID, row.SourceVersionAt,
+		row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func fillPagerDutyNoteOrdering(row *pagerDutyNoteRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"incident_id", row.IncidentID},
+		jiraOperationalField{"body", row.Body},
+		jiraOperationalField{"author_user_id", jiraStringValue(row.AuthorUserID)},
+		jiraOperationalField{"created_at", jiraTimeValue(row.CreatedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_incident_note", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}

--- a/internal/providersync/pagerduty_incidents_route.go
+++ b/internal/providersync/pagerduty_incidents_route.go
@@ -1,0 +1,1192 @@
+package providersync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"math"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyIncidentFamilyMaxPages      = 10_000
+	pagerDutyIncidentFamilyMaxRows       = 100_000
+	pagerDutyIncidentFamilyPerPage       = 100
+	pagerDutyIncidentFamilyEnrichmentCap = 100
+)
+
+// PagerDuty's incident family has one parent stream and three independently
+// persisted child streams. The family handler owns the shared parent cursor,
+// cap, and completion rules while keeping one typed effect per Python sink
+// boundary. It intentionally does not register or activate a worker route.
+type PagerDutyIncidentFamilyRouteHandler struct {
+	MaxPages      int
+	MaxRows       int
+	PerPage       int
+	EnrichmentCap int
+}
+
+type pagerDutyIncidentReferencePayload struct {
+	ID      string  `json:"id"`
+	Summary *string `json:"summary"`
+}
+
+type pagerDutyIncidentPayload struct {
+	ID                 string                             `json:"id"`
+	Type               *string                            `json:"type"`
+	Summary            *string                            `json:"summary"`
+	SelfURL            *string                            `json:"self"`
+	HTMLURL            *string                            `json:"html_url"`
+	CreatedAt          *string                            `json:"created_at"`
+	UpdatedAt          *string                            `json:"updated_at"`
+	IncidentNumber     *int                               `json:"incident_number"`
+	Title              *string                            `json:"title"`
+	Status             *string                            `json:"status"`
+	Urgency            *string                            `json:"urgency"`
+	ResolvedAt         *string                            `json:"resolved_at"`
+	LastStatusChangeAt *string                            `json:"last_status_change_at"`
+	Service            *pagerDutyIncidentReferencePayload `json:"service"`
+	Priority           *pagerDutyIncidentReferencePayload `json:"priority"`
+}
+
+type pagerDutyAlertPayload struct {
+	ID        string  `json:"id"`
+	Type      *string `json:"type"`
+	Summary   *string `json:"summary"`
+	SelfURL   *string `json:"self"`
+	HTMLURL   *string `json:"html_url"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+	Status    *string `json:"status"`
+	Severity  *string `json:"severity"`
+}
+
+type pagerDutyLogEntryPayload struct {
+	ID        string  `json:"id"`
+	Type      *string `json:"type"`
+	Summary   *string `json:"summary"`
+	Message   *string `json:"message"`
+	SelfURL   *string `json:"self"`
+	HTMLURL   *string `json:"html_url"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+}
+
+type pagerDutyNotePayload struct {
+	ID        string                             `json:"id"`
+	Type      *string                            `json:"type"`
+	SelfURL   *string                            `json:"self"`
+	HTMLURL   *string                            `json:"html_url"`
+	CreatedAt *string                            `json:"created_at"`
+	UpdatedAt *string                            `json:"updated_at"`
+	Content   *string                            `json:"content"`
+	User      *pagerDutyIncidentReferencePayload `json:"user"`
+}
+
+// Each row mirrors the complete Python canonical dataclass field set. The
+// ordering fields are included in the durable effect payload even though the
+// migrated ClickHouse tables intentionally store only their production
+// projection.
+type pagerDutyIncidentRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ServiceID              *string    `json:"service_id"`
+	ServiceExternalID      *string    `json:"service_external_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	Title                  string     `json:"title"`
+	Description            *string    `json:"description"`
+	StartedAt              *time.Time `json:"started_at"`
+	ResolvedAt             *time.Time `json:"resolved_at"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+type pagerDutyAlertRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ServiceID              *string    `json:"service_id"`
+	IncidentID             *string    `json:"incident_id"`
+	Title                  string     `json:"title"`
+	Description            *string    `json:"description"`
+	TriggeredAt            *time.Time `json:"triggered_at"`
+	AcknowledgedAt         *time.Time `json:"acknowledged_at"`
+	ResolvedAt             *time.Time `json:"resolved_at"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+type pagerDutyLogEntryRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	IncidentID             string     `json:"incident_id"`
+	EventType              string     `json:"event_type"`
+	Body                   *string    `json:"body"`
+	ActorType              *string    `json:"actor_type"`
+	ActorID                *string    `json:"actor_id"`
+	OccurredAt             *time.Time `json:"occurred_at"`
+}
+
+type pagerDutyNoteRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	IncidentID             string     `json:"incident_id"`
+	Body                   string     `json:"body"`
+	AuthorUserID           *string    `json:"author_user_id"`
+	CreatedAt              *time.Time `json:"created_at"`
+}
+
+type pagerDutyIncidentFamilyCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyIncidentFamilyCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+type pagerDutyIncidentFamilyEndpoint struct {
+	path      string
+	decode    func([]byte) ([]json.RawMessage, bool, error)
+	paginated bool
+}
+
+type pagerDutyIncidentsEnvelope struct {
+	Incidents []json.RawMessage `json:"incidents"`
+	More      *bool             `json:"more"`
+}
+
+type pagerDutyAlertsEnvelope struct {
+	Alerts []json.RawMessage `json:"alerts"`
+	More   *bool             `json:"more"`
+}
+
+type pagerDutyLogEntriesEnvelope struct {
+	LogEntries []json.RawMessage `json:"log_entries"`
+	More       *bool             `json:"more"`
+}
+
+type pagerDutyNotesEnvelope struct {
+	Notes []json.RawMessage `json:"notes"`
+}
+
+func decodePagerDutyIncidents(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyIncidentsEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Incidents == nil || envelope.More == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.Incidents, *envelope.More, nil
+}
+
+func decodePagerDutyAlerts(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyAlertsEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Alerts == nil || envelope.More == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.Alerts, *envelope.More, nil
+}
+
+func decodePagerDutyLogEntries(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyLogEntriesEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.LogEntries == nil || envelope.More == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.LogEntries, *envelope.More, nil
+}
+
+func decodePagerDutyNotes(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyNotesEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Notes == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.Notes, false, nil
+}
+
+func pagerDutyIncidentChildEndpoint(client *providerfoundation.HTTPClient, incidentID, dataset string) (pagerDutyIncidentFamilyEndpoint, error) {
+	if client == nil || strings.TrimSpace(incidentID) == "" {
+		return pagerDutyIncidentFamilyEndpoint{}, providerfoundation.ErrNormalizationInvalid
+	}
+	base := providerRelativePath(client, "incidents", incidentID)
+	switch dataset {
+	case "incident-alerts":
+		return pagerDutyIncidentFamilyEndpoint{path: base + "/alerts", decode: decodePagerDutyAlerts, paginated: true}, nil
+	case "incident-log-entries":
+		return pagerDutyIncidentFamilyEndpoint{path: base + "/log_entries", decode: decodePagerDutyLogEntries, paginated: true}, nil
+	case "incident-notes":
+		return pagerDutyIncidentFamilyEndpoint{path: base + "/notes", decode: decodePagerDutyNotes, paginated: false}, nil
+	default:
+		return pagerDutyIncidentFamilyEndpoint{}, ErrInvalidConfiguration
+	}
+}
+
+type pagerDutyIncidentPageCollection struct {
+	Items      []json.RawMessage
+	Pages      int
+	CapReached bool
+}
+
+func pagerDutyIncidentFamilyLimits(handler PagerDutyIncidentFamilyRouteHandler) (int, int, int, int, error) {
+	maxPages, maxRows, perPage, cap := handler.MaxPages, handler.MaxRows, handler.PerPage, handler.EnrichmentCap
+	if maxPages == 0 {
+		maxPages = pagerDutyIncidentFamilyMaxPages
+	}
+	if maxRows == 0 {
+		maxRows = pagerDutyIncidentFamilyMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyIncidentFamilyPerPage
+	}
+	if cap == 0 {
+		cap = pagerDutyIncidentFamilyEnrichmentCap
+	}
+	if maxPages < 1 || maxPages > pagerDutyIncidentFamilyMaxPages || maxRows < 1 ||
+		maxRows > pagerDutyIncidentFamilyMaxRows || perPage < 1 || perPage > pagerDutyIncidentFamilyPerPage ||
+		cap < 0 || cap > pagerDutyIncidentFamilyMaxRows {
+		return 0, 0, 0, 0, ErrInvalidConfiguration
+	}
+	return maxPages, maxRows, perPage, cap, nil
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || client == nil || client.Provider != "pagerduty" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	if claim.Dataset != "incidents" && claim.Dataset != "incident-alerts" &&
+		claim.Dataset != "incident-log-entries" && claim.Dataset != "incident-notes" {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, cap, err := pagerDutyIncidentFamilyLimits(handler)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	if claim.Dataset != "incidents" {
+		if value, present := claim.DatasetOptions["enabled"]; present {
+			enabled, ok := value.(bool)
+			if !ok {
+				return CompleteRouteBatch{}, ErrInvalidConfiguration
+			}
+			if !enabled {
+				return handler.emptyPagerDutyIncidentFamilyBatch(claim, 0, 0)
+			}
+		}
+	}
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyIncidentFamilyCountingDoer{delegate: client.Doer, attempts: &requests}
+	parentEndpoint := pagerDutyIncidentFamilyEndpoint{
+		path: "/incidents", decode: decodePagerDutyIncidents, paginated: true,
+	}
+	query := url.Values{}
+	if claim.SinceAt != nil {
+		query.Set("since", claim.SinceAt.UTC().Format(time.RFC3339Nano))
+	}
+	if claim.BeforeAt != nil {
+		query.Set("until", claim.BeforeAt.UTC().Format(time.RFC3339Nano))
+	}
+	parents, err := collectPagerDutyIncidentFamilyPages(
+		ctx, &counted, parentEndpoint, query, perPage, maxPages, maxRows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if parents.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	if claim.Dataset == "incidents" {
+		return handler.collectPagerDutyIncidents(claim, providerInstance, normalizedAt, parents, requests)
+	}
+	if value, present := claim.DatasetOptions["enrichment_cap"]; present {
+		cap, err = pagerDutyIncidentFamilyMaxRowsOption(value, cap)
+		if err != nil || cap > pagerDutyIncidentFamilyMaxRows {
+			return CompleteRouteBatch{}, ErrInvalidConfiguration
+		}
+	}
+	return handler.collectPagerDutyEnrichment(
+		ctx, claim, providerInstance, &counted, normalizedAt, parents, &requests,
+		perPage, maxPages, maxRows, cap,
+	)
+}
+
+func collectPagerDutyIncidentFamilyPages(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	endpoint pagerDutyIncidentFamilyEndpoint,
+	baseQuery url.Values,
+	perPage, maxPages, maxRows int,
+) (pagerDutyIncidentPageCollection, error) {
+	if ctx == nil || client == nil || endpoint.decode == nil || strings.TrimSpace(endpoint.path) == "" ||
+		perPage < 1 || maxPages < 1 || maxRows < 1 {
+		return pagerDutyIncidentPageCollection{}, providerfoundation.ErrPaginationInvalid
+	}
+	result := pagerDutyIncidentPageCollection{Items: make([]json.RawMessage, 0)}
+	offset := 0
+	for {
+		if result.Pages >= maxPages {
+			result.CapReached = true
+			return result, nil
+		}
+		items, more, err := requestPagerDutyIncidentFamilyPage(
+			ctx, client, endpoint, baseQuery, offset, perPage,
+		)
+		if err != nil {
+			return result, err
+		}
+		result.Pages++
+		if len(items) > maxRows-len(result.Items) {
+			return result, ErrPaginationCapExceeded
+		}
+		result.Items = append(result.Items, items...)
+		if !more {
+			return result, nil
+		}
+		if len(result.Items) == maxRows {
+			return result, ErrPaginationCapExceeded
+		}
+		if len(items) == 0 {
+			return result, providerfoundation.ErrPaginationInvalid
+		}
+		offset += len(items)
+	}
+}
+
+func requestPagerDutyIncidentFamilyPage(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	endpoint pagerDutyIncidentFamilyEndpoint,
+	baseQuery url.Values,
+	offset, perPage int,
+) ([]json.RawMessage, bool, error) {
+	query := make(url.Values, len(baseQuery)+2)
+	for key, values := range baseQuery {
+		query[key] = append([]string(nil), values...)
+	}
+	if endpoint.paginated {
+		query.Set("limit", strconv.Itoa(perPage))
+		query.Set("offset", strconv.Itoa(offset))
+	}
+	target := endpoint.path
+	if encoded := query.Encode(); encoded != "" {
+		target += "?" + encoded
+	}
+	response, err := client.Do(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return endpoint.decode(body)
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) collectPagerDutyIncidents(
+	claim Claim,
+	providerInstance string,
+	normalizedAt time.Time,
+	parents pagerDutyIncidentPageCollection,
+	requests int,
+) (CompleteRouteBatch, error) {
+	rows := make([]pagerDutyIncidentRow, 0, len(parents.Items))
+	var watermark *time.Time
+	for _, raw := range parents.Items {
+		payload, err := decodePagerDutyIncidentPayload(raw)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		createdAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		if pagerDutyIncidentOutsideWindow(createdAt, claim) {
+			continue
+		}
+		row, err := normalizePagerDutyIncident(claim, providerInstance, payload, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+		watermark = pagerDutyMaxTime(watermark, createdAt)
+	}
+	effect, err := effectBatchFromValues("operational_incidents", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Result:    map[string]any{"incidents_synced": len(rows)},
+		Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: parents.Pages, Records: len(rows), CapReached: parents.CapReached,
+		},
+	}, nil
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) emptyPagerDutyIncidentFamilyBatch(
+	claim Claim, requests, pages int,
+) (CompleteRouteBatch, error) {
+	destination, resultKey := pagerDutyIncidentFamilyDestination(claim.Dataset)
+	var (
+		effect EffectBatch
+		err    error
+	)
+	switch claim.Dataset {
+	case "incident-alerts":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, []pagerDutyAlertRow{})
+	case "incident-log-entries":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, []pagerDutyLogEntryRow{})
+	case "incident-notes":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, []pagerDutyNoteRow{})
+	default:
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  map[string]any{resultKey: 0},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: requests, Pages: pages,
+		},
+	}, nil
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) collectPagerDutyEnrichment(
+	ctx context.Context,
+	claim Claim,
+	providerInstance string,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+	parents pagerDutyIncidentPageCollection,
+	requests *int,
+	perPage, maxPages, maxRows, cap int,
+) (CompleteRouteBatch, error) {
+	destination, resultKey := pagerDutyIncidentFamilyDestination(claim.Dataset)
+	if destination == "" {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	alertRows := make([]pagerDutyAlertRow, 0)
+	logEntryRows := make([]pagerDutyLogEntryRow, 0)
+	noteRows := make([]pagerDutyNoteRow, 0)
+	watermark := pagerDutyTimePointer(claim.SinceAt)
+	var earliestUndrained *time.Time
+	childPages := 0
+	childRecords := 0
+	for _, raw := range parents.Items {
+		incident, err := decodePagerDutyIncidentPayload(raw)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		createdAt, err := pagerDutyOptionalTime(incident.CreatedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		if pagerDutyIncidentOutsideWindow(createdAt, claim) {
+			continue
+		}
+		incidentRow, err := normalizePagerDutyIncident(claim, providerInstance, incident, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		watermark = pagerDutyMaxTime(watermark, createdAt)
+		if cap == 0 {
+			continue
+		}
+		endpoint, err := pagerDutyIncidentChildEndpoint(client, incident.ID, claim.Dataset)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		childCount := 0
+		undrained := false
+		offset := 0
+		for {
+			if childPages >= maxPages {
+				return CompleteRouteBatch{}, ErrPaginationCapExceeded
+			}
+			items, more, requestErr := requestPagerDutyIncidentFamilyPage(
+				ctx, client, endpoint, nil, offset, perPage,
+			)
+			if requestErr != nil {
+				return CompleteRouteBatch{}, requestErr
+			}
+			childPages++
+			remaining := cap - childCount
+			take := len(items)
+			if take > remaining {
+				take = remaining
+			}
+			if take > 0 {
+				if childRecords > maxRows-take {
+					return CompleteRouteBatch{}, ErrPaginationCapExceeded
+				}
+				for _, childRaw := range items[:take] {
+					switch claim.Dataset {
+					case "incident-alerts":
+						payload, decodeErr := decodePagerDutyAlertPayload(childRaw)
+						if decodeErr != nil {
+							return CompleteRouteBatch{}, decodeErr
+						}
+						row, normalizeErr := normalizePagerDutyAlert(claim, providerInstance, payload, incidentRow.ID, normalizedAt)
+						if normalizeErr != nil {
+							return CompleteRouteBatch{}, normalizeErr
+						}
+						alertRows = append(alertRows, row)
+					case "incident-log-entries":
+						payload, decodeErr := decodePagerDutyLogEntryPayload(childRaw)
+						if decodeErr != nil {
+							return CompleteRouteBatch{}, decodeErr
+						}
+						row, normalizeErr := normalizePagerDutyLogEntry(claim, providerInstance, payload, incidentRow.ID, normalizedAt)
+						if normalizeErr != nil {
+							return CompleteRouteBatch{}, normalizeErr
+						}
+						logEntryRows = append(logEntryRows, row)
+					case "incident-notes":
+						payload, decodeErr := decodePagerDutyNotePayload(childRaw)
+						if decodeErr != nil {
+							return CompleteRouteBatch{}, decodeErr
+						}
+						row, normalizeErr := normalizePagerDutyNote(claim, providerInstance, payload, incidentRow.ID, normalizedAt)
+						if normalizeErr != nil {
+							return CompleteRouteBatch{}, normalizeErr
+						}
+						noteRows = append(noteRows, row)
+					}
+				}
+				childCount += take
+				childRecords += take
+			}
+			if childCount == cap {
+				undrained = more || len(items) > remaining
+				break
+			}
+			if !more {
+				break
+			}
+			if len(items) == 0 {
+				return CompleteRouteBatch{}, providerfoundation.ErrPaginationInvalid
+			}
+			offset += len(items)
+		}
+		if undrained {
+			earliestUndrained = pagerDutyMinTime(earliestUndrained, createdAt)
+		}
+	}
+	if earliestUndrained != nil && (watermark == nil || earliestUndrained.Before(*watermark)) {
+		watermark = earliestUndrained
+	}
+	var effect EffectBatch
+	var err error
+	switch claim.Dataset {
+	case "incident-alerts":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, alertRows)
+	case "incident-log-entries":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, logEntryRows)
+	case "incident-notes":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, noteRows)
+	default:
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Result:    map[string]any{resultKey: childRecords},
+		Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: valueOrZero(requests),
+			Pages: parents.Pages + childPages, Records: childRecords,
+		},
+	}, nil
+}
+
+func valueOrZero(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func pagerDutyIncidentFamilyDestination(dataset string) (string, string) {
+	switch dataset {
+	case "incidents":
+		return "operational_incidents", "incidents_synced"
+	case "incident-alerts":
+		return "operational_alerts", "alerts_synced"
+	case "incident-log-entries":
+		return "operational_incident_timeline_events", "log_entries_synced"
+	case "incident-notes":
+		return "operational_incident_notes", "notes_synced"
+	default:
+		return "", ""
+	}
+}
+
+func pagerDutyIncidentOutsideWindow(createdAt *time.Time, claim Claim) bool {
+	if createdAt == nil {
+		return false
+	}
+	if claim.SinceAt != nil && createdAt.Before(claim.SinceAt.UTC()) {
+		return true
+	}
+	return claim.BeforeAt != nil && createdAt.After(claim.BeforeAt.UTC())
+}
+
+func pagerDutyMaxTime(current, candidate *time.Time) *time.Time {
+	if candidate == nil {
+		return current
+	}
+	if current == nil || candidate.After(*current) {
+		copy := candidate.UTC().Truncate(time.Microsecond)
+		return &copy
+	}
+	return current
+}
+
+func pagerDutyMinTime(current, candidate *time.Time) *time.Time {
+	if candidate == nil {
+		return current
+	}
+	if current == nil || candidate.Before(*current) {
+		copy := candidate.UTC().Truncate(time.Microsecond)
+		return &copy
+	}
+	return current
+}
+
+func pagerDutyTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := value.UTC().Truncate(time.Microsecond)
+	return &copy
+}
+
+func decodePagerDutyIncidentPayload(raw json.RawMessage) (pagerDutyIncidentPayload, error) {
+	var payload pagerDutyIncidentPayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyIncidentPayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func decodePagerDutyAlertPayload(raw json.RawMessage) (pagerDutyAlertPayload, error) {
+	var payload pagerDutyAlertPayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyAlertPayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func decodePagerDutyLogEntryPayload(raw json.RawMessage) (pagerDutyLogEntryPayload, error) {
+	var payload pagerDutyLogEntryPayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyLogEntryPayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func decodePagerDutyNotePayload(raw json.RawMessage) (pagerDutyNotePayload, error) {
+	var payload pagerDutyNotePayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyNotePayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func pagerDutyOptionalTime(value *string) (*time.Time, error) {
+	if value == nil || *value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, *value)
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	result := parsed.UTC().Truncate(time.Microsecond)
+	return &result, nil
+}
+
+func pagerDutyIncidentSourceTime(updatedAt, createdAt *string, observedAt time.Time) (time.Time, error) {
+	value := updatedAt
+	if value == nil || *value == "" {
+		value = createdAt
+	}
+	if parsed, err := pagerDutyOptionalTime(value); err != nil {
+		return time.Time{}, err
+	} else if parsed != nil {
+		return *parsed, nil
+	}
+	return observedAt.UTC().Truncate(time.Microsecond), nil
+}
+
+func pagerDutyStringOrFallback(values ...*string) string {
+	for _, value := range values {
+		if value != nil && *value != "" {
+			return *value
+		}
+	}
+	return ""
+}
+
+func pagerDutyURL(htmlURL, selfURL *string) *string {
+	if htmlURL != nil && *htmlURL != "" {
+		value := *htmlURL
+		return &value
+	}
+	if selfURL != nil {
+		value := *selfURL
+		return &value
+	}
+	return nil
+}
+
+func pagerDutyReferenceValue(reference *pagerDutyIncidentReferencePayload) *string {
+	if reference == nil {
+		return nil
+	}
+	if reference.Summary != nil && *reference.Summary != "" {
+		value := *reference.Summary
+		return &value
+	}
+	value := reference.ID
+	return &value
+}
+
+func pagerDutyNormalizeStatus(raw *string) *string {
+	if raw == nil {
+		return nil
+	}
+	var value string
+	switch *raw {
+	case "triggered":
+		value = "open"
+	case "acknowledged":
+		value = "acknowledged"
+	case "resolved":
+		value = "resolved"
+	default:
+		return nil
+	}
+	return &value
+}
+
+func pagerDutyNormalizeIncidentSeverity(raw *string) *string {
+	if raw == nil {
+		return nil
+	}
+	if *raw != "high" && *raw != "low" {
+		return nil
+	}
+	value := *raw
+	return &value
+}
+
+func pagerDutyNormalizeAlertSeverity(raw *string) *string {
+	values := map[string]string{"critical": "critical", "error": "high", "warning": "medium", "info": "info"}
+	if raw == nil {
+		return nil
+	}
+	value, ok := values[*raw]
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func pagerDutyNormalizeIncidentPriority(reference *pagerDutyIncidentReferencePayload) *string {
+	value := pagerDutyReferenceValue(reference)
+	if value == nil {
+		return nil
+	}
+	var normalized string
+	switch *value {
+	case "P1":
+		normalized = "high"
+	case "P2":
+		normalized = "medium"
+	case "P3", "P4":
+		normalized = "low"
+	default:
+		return nil
+	}
+	return &normalized
+}
+
+func pagerDutyCanonicalReferenceID(orgID, providerInstance, family, externalID string) *string {
+	if strings.TrimSpace(externalID) == "" {
+		return nil
+	}
+	parts := []string{orgID, "pagerduty", providerInstance, family, strings.TrimSpace(externalID)}
+	for _, part := range parts {
+		if part == "" {
+			return nil
+		}
+	}
+	quoted := make([]string, len(parts))
+	for index, part := range parts {
+		quoted[index] = strconv.QuoteToASCII(part)
+	}
+	digest := sha256.Sum256([]byte("[" + strings.Join(quoted, ",") + "]"))
+	value := hex.EncodeToString(digest[:])
+	return &value
+}
+
+func normalizePagerDutyIncident(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyIncidentPayload,
+	normalizedAt time.Time,
+) (pagerDutyIncidentRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyIncidentRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	createdAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	resolvedAt, err := pagerDutyOptionalTime(payload.ResolvedAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	lastStatusChangeAt, err := pagerDutyOptionalTime(payload.LastStatusChangeAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	if payload.Status == nil || *payload.Status != "resolved" {
+		resolvedAt = nil
+	} else if resolvedAt == nil {
+		resolvedAt = lastStatusChangeAt
+	}
+	row := pagerDutyIncidentRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "incident", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, RawStatus: payload.Status, RawSeverity: payload.Urgency,
+		RawPriority:        pagerDutyReferenceValue(payload.Priority),
+		NormalizedStatus:   pagerDutyNormalizeStatus(payload.Status),
+		NormalizedSeverity: pagerDutyNormalizeIncidentSeverity(payload.Urgency),
+		NormalizedPriority: pagerDutyNormalizeIncidentPriority(payload.Priority),
+		Title:              pagerDutyStringOrFallback(payload.Title, payload.Summary, &payload.ID),
+		SourceEventAt:      createdAt, StartedAt: createdAt, ResolvedAt: resolvedAt,
+	}
+	if payload.IncidentNumber != nil && *payload.IncidentNumber != 0 {
+		sourceEventID := strconv.Itoa(*payload.IncidentNumber)
+		row.SourceEventID = &sourceEventID
+	}
+	if payload.Service != nil {
+		serviceExternalID := payload.Service.ID
+		row.ServiceExternalID = &serviceExternalID
+		row.ServiceID = pagerDutyCanonicalReferenceID(claim.OrgID, providerInstance, "operational_service", serviceExternalID)
+	}
+	if err := fillPagerDutyIncidentOrdering(&row); err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	return row, nil
+}
+
+func normalizePagerDutyAlert(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyAlertPayload,
+	incidentID string,
+	normalizedAt time.Time,
+) (pagerDutyAlertRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" || incidentID == "" {
+		return pagerDutyAlertRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyAlertRow{}, err
+	}
+	triggeredAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyAlertRow{}, err
+	}
+	resolvedAt := (*time.Time)(nil)
+	if payload.Status != nil && *payload.Status == "resolved" {
+		resolvedAt, err = pagerDutyOptionalTime(payload.UpdatedAt)
+		if err != nil {
+			return pagerDutyAlertRow{}, err
+		}
+		if resolvedAt == nil {
+			resolvedAt, err = pagerDutyOptionalTime(payload.CreatedAt)
+			if err != nil {
+				return pagerDutyAlertRow{}, err
+			}
+			if resolvedAt == nil {
+				copy := sourceVersionAt
+				resolvedAt = &copy
+			}
+		}
+	}
+	row := pagerDutyAlertRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "alert", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, RawStatus: payload.Status, RawSeverity: payload.Severity,
+		NormalizedStatus:   pagerDutyNormalizeStatus(payload.Status),
+		NormalizedSeverity: pagerDutyNormalizeAlertSeverity(payload.Severity),
+		IncidentID:         &incidentID, Title: pagerDutyStringOrFallback(payload.Summary, &payload.ID),
+		TriggeredAt: triggeredAt, ResolvedAt: resolvedAt,
+	}
+	if err := fillPagerDutyAlertOrdering(&row); err != nil {
+		return pagerDutyAlertRow{}, err
+	}
+	return row, nil
+}
+
+func normalizePagerDutyLogEntry(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyLogEntryPayload,
+	incidentID string,
+	normalizedAt time.Time,
+) (pagerDutyLogEntryRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" || incidentID == "" {
+		return pagerDutyLogEntryRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyLogEntryRow{}, err
+	}
+	occurredAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyLogEntryRow{}, err
+	}
+	eventType := "pagerduty_log_entry"
+	if payload.Type != nil && *payload.Type != "" {
+		eventType = *payload.Type
+	}
+	row := pagerDutyLogEntryRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "log_entry", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, IncidentID: incidentID, EventType: eventType,
+		Body:      pagerDutyFirstPresent(payload.Summary, payload.Message),
+		ActorType: pagerDutyStringPointer("pagerduty"), OccurredAt: occurredAt,
+	}
+	if err := fillPagerDutyLogEntryOrdering(&row); err != nil {
+		return pagerDutyLogEntryRow{}, err
+	}
+	return row, nil
+}
+
+func normalizePagerDutyNote(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyNotePayload,
+	incidentID string,
+	normalizedAt time.Time,
+) (pagerDutyNoteRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" || incidentID == "" {
+		return pagerDutyNoteRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyNoteRow{}, err
+	}
+	createdAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyNoteRow{}, err
+	}
+	row := pagerDutyNoteRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "note", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, IncidentID: incidentID, Body: pagerDutyStringValue(payload.Content),
+		CreatedAt: createdAt,
+	}
+	if payload.User != nil {
+		row.AuthorUserID = pagerDutyCanonicalReferenceID(claim.OrgID, providerInstance, "operational_user", payload.User.ID)
+	}
+	if err := fillPagerDutyNoteOrdering(&row); err != nil {
+		return pagerDutyNoteRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func pagerDutyStringPointer(value string) *string {
+	return &value
+}
+
+func pagerDutyFirstPresent(values ...*string) *string {
+	for _, value := range values {
+		if value != nil && *value != "" {
+			copy := *value
+			return &copy
+		}
+	}
+	for _, value := range values {
+		if value != nil {
+			copy := *value
+			return &copy
+		}
+	}
+	return nil
+}
+
+func pagerDutyIncidentFamilyMaxRowsOption(value any, fallback int) (int, error) {
+	if value == nil {
+		return fallback, nil
+	}
+	var parsed int64
+	switch typed := value.(type) {
+	case int:
+		parsed = int64(typed)
+	case int64:
+		parsed = typed
+	case float64:
+		if math.IsNaN(typed) || math.IsInf(typed, 0) || math.Trunc(typed) != typed || typed < 0 || typed > float64(math.MaxInt) {
+			return 0, ErrInvalidConfiguration
+		}
+		parsed = int64(typed)
+	case json.Number:
+		value, err := strconv.ParseInt(string(typed), 10, 64)
+		if err != nil {
+			return 0, ErrInvalidConfiguration
+		}
+		parsed = value
+	default:
+		return 0, ErrInvalidConfiguration
+	}
+	if parsed < 0 || uint64(parsed) > uint64(math.MaxInt) {
+		return 0, ErrInvalidConfiguration
+	}
+	return int(parsed), nil
+}
+
+var _ CompleteRouteHandler = PagerDutyIncidentFamilyRouteHandler{}

--- a/internal/providersync/pagerduty_incidents_route_test.go
+++ b/internal/providersync/pagerduty_incidents_route_test.go
@@ -1,0 +1,256 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyIncidentFamilyResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutyIncidentFamilyDoer struct {
+	t         *testing.T
+	responses []pagerDutyIncidentFamilyResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyIncidentFamilyDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[{"id":"PI1","type":"incident","incident_number":42,"title":"Database outage","status":"resolved","urgency":"high","created_at":"2026-07-17T12:00:00.123456Z","updated_at":"2026-07-18T10:00:00.654321Z","resolved_at":"2026-07-18T09:00:00Z","service":{"id":"PSVC1"},"priority":{"id":"P1","summary":"P1"},"html_url":"https://acme.pagerduty.com/incidents/PI1"}],"more":false}`,
+	}}}
+	client := pagerDutyIncidentFamilyTestClient(t, doer)
+	claim := nativeTestClaim("pagerduty", "incidents")
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "}}
+	normalizedAt := time.Date(2026, 7, 19, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_incidents" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 1 || batch.Evidence.Pages != 1 || batch.Evidence.Records != 1 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(time.Date(2026, 7, 17, 12, 0, 0, 123456000, time.UTC)) {
+		t.Fatalf("batch=%+v", batch)
+	}
+	query := doer.requests[0].URL.Query()
+	if query.Get("since") != claim.SinceAt.Format(time.RFC3339Nano) || query.Get("until") != claim.BeforeAt.Format(time.RFC3339Nano) ||
+		query.Get("limit") != "100" || query.Get("offset") != "0" {
+		t.Fatalf("query=%v", query)
+	}
+	if doer.requests[0].URL.Path != "/incidents" {
+		t.Fatalf("parent path=%q", doer.requests[0].URL.Path)
+	}
+	row := mustPagerDutyIncidentRow(t, batch.Effects[0].Rows[0])
+	if row.ProviderInstanceID != "acme" || row.ExternalID != "PI1" || row.Title != "Database outage" ||
+		row.SourceEventID == nil || *row.SourceEventID != "42" || row.RawStatus == nil || *row.RawStatus != "resolved" ||
+		row.NormalizedStatus == nil || *row.NormalizedStatus != "resolved" || row.NormalizedSeverity == nil || *row.NormalizedSeverity != "high" ||
+		row.NormalizedPriority == nil || *row.NormalizedPriority != "high" || row.ServiceID == nil || row.ServiceExternalID == nil ||
+		*row.ServiceExternalID != "PSVC1" || row.SourceURL == nil || *row.SourceURL != "https://acme.pagerduty.com/incidents/PI1" ||
+		row.SourceEventAt == nil || !row.SourceEventAt.Equal(time.Date(2026, 7, 17, 12, 0, 0, 123456000, time.UTC)) ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 7, 18, 10, 0, 0, 654321000, time.UTC)) || row.SourceRevision == nil || row.IngestRevision == nil {
+		t.Fatalf("row=%+v", row)
+	}
+	if expected := pagerDutyCanonicalReferenceID(claim.OrgID, "acme", "operational_service", "PSVC1"); row.ServiceID == nil || *row.ServiceID != *expected {
+		t.Fatalf("service id=%v expected=%v", row.ServiceID, expected)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteCapsChildrenAndClampsToEarliestUndrainedIncident(t *testing.T) {
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{
+		{body: `{"incidents":[
+			{"id":"PI-OLD","created_at":"2026-07-10T12:00:00Z","updated_at":"2026-07-10T12:00:00Z"},
+			{"id":"PI-NEW","created_at":"2026-07-11T12:00:00Z","updated_at":"2026-07-11T12:00:00Z"}],"more":false}`},
+		{body: `{"alerts":[{"id":"A-OLD-1","status":"triggered","created_at":"2026-07-10T12:00:00Z"},{"id":"A-OLD-2","status":"triggered","created_at":"2026-07-10T12:01:00Z"}],"more":true}`},
+		{body: `{"alerts":[],"more":false}`},
+	}}
+	client := pagerDutyIncidentFamilyTestClient(t, doer)
+	claim := nativeTestClaim("pagerduty", "incident-alerts")
+	claim.DatasetOptions = map[string]any{"enrichment_cap": 1}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Evidence.Requests != 3 || batch.Evidence.Pages != 3 || batch.Evidence.Records != 1 || len(batch.Effects[0].Rows) != 1 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[1].URL.Path; got != "/incidents/PI-OLD/alerts" {
+		t.Fatalf("first child path=%q", got)
+	}
+	if len(doer.requests) != 3 {
+		t.Fatalf("requests=%d", len(doer.requests))
+	}
+	row := mustPagerDutyAlertRow(t, batch.Effects[0].Rows[0])
+	if row.IncidentID == nil || row.Title != "A-OLD-1" || row.NormalizedStatus == nil || *row.NormalizedStatus != "open" {
+		t.Fatalf("alert=%+v", row)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteKeepsSinceBoundaryInclusive(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	boundary := claim.SinceAt.UTC().Format(time.RFC3339)
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[
+			{"id":"PI-BEFORE","created_at":"2026-06-30T23:59:59Z","updated_at":"2026-06-30T23:59:59Z"},
+			{"id":"PI-BOUNDARY","created_at":"` + boundary + `","updated_at":"` + boundary + `"}],"more":false}`,
+	}}}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	row := mustPagerDutyIncidentRow(t, batch.Effects[0].Rows[0])
+	if row.ExternalID != "PI-BOUNDARY" || batch.Watermark == nil || !batch.Watermark.Equal(claim.SinceAt.UTC()) {
+		t.Fatalf("row=%+v watermark=%v", row, batch.Watermark)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteDoesNotPaginateNotes(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{
+		{body: `{"incidents":[{"id":"PI1","created_at":"2026-07-10T12:00:00Z","updated_at":"2026-07-10T12:00:00Z"}],"more":false}`},
+		{body: `{"notes":[{"id":"N1","content":"first note","created_at":"2026-07-10T12:01:00Z"}]}`},
+	}}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 2 || doer.requests[1].URL.Path != "/incidents/PI1/notes" || doer.requests[1].URL.RawQuery != "" {
+		t.Fatalf("requests=%d child=%s", len(doer.requests), doer.requests[1].URL.RequestURI())
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 1 || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("batch=%+v", batch)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteDisabledEnrichmentMakesNoProviderCall(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	claim.DatasetOptions = map[string]any{"enabled": false}
+	doer := &pagerDutyIncidentFamilyDoer{t: t}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 0 || batch.Evidence.Requests != 0 || batch.Evidence.Pages != 0 || len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 {
+		t.Fatalf("requests=%d batch=%+v", len(doer.requests), batch)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteZeroCapReadsParentsWithoutChildRequests(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	claim.DatasetOptions = map[string]any{"enrichment_cap": 0}
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[{"id":"PI1","created_at":"2026-07-10T12:00:00Z","updated_at":"2026-07-10T12:00:00Z"}],"more":false}`,
+	}}}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 1 || batch.Evidence.Requests != 1 || batch.Evidence.Records != 0 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("requests=%d batch=%+v", len(doer.requests), batch)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteRejectsPaginationCap(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[{"id":"PI1","created_at":"2026-07-10T12:00:00Z"}],"more":true}`,
+	}}}
+	_, err := (PagerDutyIncidentFamilyRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func pagerDutyIncidentFamilyTestClient(t *testing.T, doer providerfoundation.HTTPDoer) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyIncidentRow(t *testing.T, raw []byte) pagerDutyIncidentRow {
+	t.Helper()
+	var row pagerDutyIncidentRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func mustPagerDutyAlertRow(t *testing.T, raw []byte) pagerDutyAlertRow {
+	t.Helper()
+	var row pagerDutyAlertRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/pagerduty_oncalls_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_oncalls_effects_clickhouse.go
@@ -1,0 +1,252 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// This is the exact column order of migration 066's
+// operational_on_call_assignments table. The table intentionally has no
+// tombstone columns: Python's on-call branch is an upsert stream, not a
+// complete snapshot reconciliation.
+const pagerDutyOnCallsColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,schedule_id,user_id,escalation_policy_id,escalation_level,starts_at,ends_at"
+
+// PagerDutyOnCallsClickHouseEffects persists typed assignment rows and
+// performs tenant/provider-instance-fenced readback. Ordering values are not
+// columns in the migrated table, so they are reconstructed from the exact
+// persisted fields before comparison.
+type PagerDutyOnCallsClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pagerDutyOnCallRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validatePagerDutyOnCallRows(claim, rows); err != nil {
+		return err
+	}
+	if _, err := sink.providerInstance(rows); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(
+		ctx, "INSERT INTO operational_on_call_assignments ("+pagerDutyOnCallsColumns+")",
+	)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyOnCallValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pagerDutyOnCallRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validatePagerDutyOnCallRows(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	if _, err := sink.providerInstance(expected); err != nil {
+		return EffectConflict, err
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		actual, found, loadErr := sink.loadOnCall(ctx, claim, row.ProviderInstanceID, row.ID)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyOnCallVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "on-calls" ||
+		effect.Destination != "operational_on_call_assignments" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) providerInstance(
+	rows []pagerDutyOnCallRow,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, row := range rows {
+		rowInstance := strings.ToLower(strings.TrimSpace(row.ProviderInstanceID))
+		if rowInstance == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = rowInstance
+		}
+		if instance != rowInstance {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func validatePagerDutyOnCallRows(
+	claim Claim, rows []pagerDutyOnCallRow,
+) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "oncall" || row.ExternalID == "" || row.ID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.ScheduleID != nil && *row.ScheduleID == "") ||
+			(row.UserID != nil && *row.UserID == "") ||
+			(row.EscalationPolicyID != nil && *row.EscalationPolicyID == "") {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyOnCallOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyOnCallValues(row pagerDutyOnCallRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence, row.ScheduleID, row.UserID,
+		row.EscalationPolicyID, row.EscalationLevel, row.StartsAt, row.EndsAt,
+	}
+}
+
+func pagerDutyOnCallScanValues(row *pagerDutyOnCallRow) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.ScheduleID, &row.UserID,
+		&row.EscalationPolicyID, &row.EscalationLevel, &row.StartsAt, &row.EndsAt,
+	}
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) loadOnCall(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyOnCallRow, bool, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutyOnCallsColumns+
+			" FROM operational_on_call_assignments FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "oncall", id,
+	)
+	if err != nil {
+		return pagerDutyOnCallRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyOnCallRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyOnCallScanValues(&actual)...); err != nil {
+			return pagerDutyOnCallRow{}, false, err
+		}
+		if err := fillPagerDutyOnCallOrdering(&actual); err != nil {
+			return pagerDutyOnCallRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyOnCallRow{}, false, err
+	}
+	return actual, found, nil
+}
+
+func comparePagerDutyOnCallVersion(
+	expected, actual pagerDutyOnCallRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = PagerDutyOnCallsClickHouseEffects{}
+var _ EffectReadback = PagerDutyOnCallsClickHouseEffects{}

--- a/internal/providersync/pagerduty_oncalls_effects_integration_test.go
+++ b/internal/providersync/pagerduty_oncalls_effects_integration_test.go
@@ -1,0 +1,152 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyOnCallsEffectUsesMigratedClickHouseUpsertsAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Use the production migration chain so nullable Int32/DateTime64 values
+	// and the exact assignment table shape are exercised, not a test-only DDL.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	levelOne := int32(1)
+	rowA, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			ID: "OC1", Start: "2026-08-01T10:00:00.123456Z", End: "2026-08-01T18:00:00.123456Z",
+			EscalationLevel: &levelOne, User: &pagerDutyOnCallReference{ID: "PU1"},
+			Schedule: &pagerDutyOnCallReference{ID: "PS1"}, EscalationPolicy: &pagerDutyOnCallReference{ID: "PE1"},
+		}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowB, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			Start: "2026-08-02T10:00:00Z", End: "2026-08-02T18:00:00Z",
+			EscalationLevel: int32Pointer(2), User: &pagerDutyOnCallReference{ID: "PU2"},
+			Schedule: &pagerDutyOnCallReference{ID: "PS2"}, EscalationPolicy: &pagerDutyOnCallReference{ID: "PE2"},
+		}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialEffect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired,
+		[]pagerDutyOnCallRow{rowA, rowB},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutyOnCallsClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "Acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, initialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after initial write inspection=%s error=%v", inspection, err)
+	}
+
+	// The Python on-calls branch is an upsert stream. A later payload for OC1
+	// must update that assignment without treating omitted OC2 as a deletion.
+	updatedAt := initialAt.Add(time.Hour)
+	levelTwo := int32(2)
+	rowAUpdated, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			ID: "OC1", Start: "2026-08-01T11:00:00.123456Z", End: "2026-08-01T19:00:00.123456Z",
+			EscalationLevel: &levelTwo, User: &pagerDutyOnCallReference{ID: "PU1"},
+			Schedule: &pagerDutyOnCallReference{ID: "PS1"}, EscalationPolicy: &pagerDutyOnCallReference{ID: "PE1"},
+			UpdatedAt: updatedAt.Format(time.RFC3339Nano),
+		}, updatedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedEffect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired,
+		[]pagerDutyOnCallRow{rowAUpdated},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, updatedEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after update inspection=%s error=%v", inspection, err)
+	}
+	var retained uint64
+	if err := conn.QueryRow(ctx, `
+SELECT count()
+FROM operational_on_call_assignments FINAL
+WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ?`,
+		claim.OrgID, "pagerduty", "acme", "oncall", rowB.ID,
+	).Scan(&retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained != 1 {
+		t.Fatalf("upsert stream removed omitted OC2: count=%d", retained)
+	}
+	if err := sink.WriteEffect(ctx, claim, updatedEffect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+	}
+
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	otherRow := rowAUpdated
+	otherRow.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyOnCallOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	otherEffect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired,
+		[]pagerDutyOnCallRow{otherRow},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, otherEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign tenant changed readback inspection=%s error=%v", inspection, err)
+	}
+}
+
+func int32Pointer(value int32) *int32 { return &value }

--- a/internal/providersync/pagerduty_oncalls_effects_test.go
+++ b/internal/providersync/pagerduty_oncalls_effects_test.go
@@ -1,0 +1,95 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyOnCallsEffectRejectsForeignScopeOrderingTamperAndDuplicates(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	level := int32(1)
+	row, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			ID: "OC1", EscalationLevel: &level,
+			User:             &pagerDutyOnCallReference{ID: "PU1"},
+			Schedule:         &pagerDutyOnCallReference{ID: "PS1"},
+			EscalationPolicy: &pagerDutyOnCallReference{ID: "PE1"},
+		}, time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := row
+	foreign.OrgID = "org-other"
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := row
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyOnCallOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutyOnCallsClickHouseEffects{}).providerInstance(
+		[]pagerDutyOnCallRow{row, foreignInstance},
+	); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := row
+	levelTwo := int32(2)
+	tampered.EscalationLevel = &levelTwo
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	conflictTampered := row
+	conflictTampered.SourceConflictKey = "00"
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{conflictTampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("source conflict tamper error=%v", err)
+	}
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{row, row}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate row error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsEffectKeepsUpsertRowsWithoutTombstoneState(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	row, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{ID: "OC1"},
+		time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.SourceEntityType != "oncall" || row.ScheduleID != nil || row.UserID != nil ||
+		row.EscalationPolicyID != nil || row.EscalationLevel != nil || row.StartsAt != nil || row.EndsAt != nil {
+		t.Fatalf("unexpected on-call row=%+v", row)
+	}
+	if len(pagerDutyOnCallValues(row)) != 27 || pagerDutyOnCallsColumns == "" {
+		t.Fatalf("assignment schema projection changed unexpectedly: values=%d columns=%q", len(pagerDutyOnCallValues(row)), pagerDutyOnCallsColumns)
+	}
+}
+
+func TestPagerDutyOnCallsEffectRejectsUnsafeEmptySnapshotWithoutInstance(t *testing.T) {
+	if _, err := (PagerDutyOnCallsClickHouseEffects{}).providerInstance(nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsEffectRejectsWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	sink := PagerDutyOnCallsClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_on_call_assignments"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid request error=%v", err)
+	}
+	if err := sink.WriteEffect(
+		context.Background(), claim, EffectBatch{Destination: "other"},
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_oncalls_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_oncalls_generic_oracle_test.go
@@ -1,0 +1,86 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyOnCallRowForOracle(
+	t *testing.T, input map[string]any,
+) pagerDutyOnCallRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutyOnCallPayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyOnCall(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload,
+		observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyOnCallCases() []oracleCase {
+	return []oracleCase{
+		{ID: "explicit_id_updated_html_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "OC1", "type": "oncall",
+				"start": "2026-08-01T10:00:00.123456Z",
+				"end":   "2026-08-01T18:00:00.123456Z", "escalation_level": 1,
+				"user":              map[string]any{"id": "PU1"},
+				"schedule":          map[string]any{"id": "PS1"},
+				"escalation_policy": map[string]any{"id": "PE1"},
+				"updated_at":        "2026-08-01T10:00:00.123456Z",
+				"html_url":          "https://acme.pagerduty.com/oncalls/OC1", "self": "/oncalls/OC1",
+			},
+		}},
+		{ID: "composite_id_created_self_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"type": "oncall", "start": "2026-08-02T10:00:00Z",
+				"end": "2026-08-02T18:00:00Z", "escalation_level": 2,
+				"user":              map[string]any{"id": "PU2"},
+				"schedule":          map[string]any{"id": "PS2"},
+				"escalation_policy": map[string]any{"id": "PE2"},
+				"created_at":        "2026-07-31T09:00:00Z", "self": "/oncalls/composite",
+			},
+		}},
+		{ID: "permanent_composite_observed_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"type": "oncall", "escalation_level": 3,
+				"user":              map[string]any{"id": "PU3"},
+				"escalation_policy": map[string]any{"id": "PE3"},
+			},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/on-calls/row", oraclePagerDutyOnCallCases(),
+		buildPagerDutyOnCallRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_oncalls_route.go
+++ b/internal/providersync/pagerduty_oncalls_route.go
@@ -1,0 +1,383 @@
+package providersync
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyOnCallsMaxPages = 10_000
+	pagerDutyOnCallsMaxRows  = 100_000
+	pagerDutyOnCallsPerPage  = 100
+)
+
+// pagerDutyOnCallReference is the only nested provider data consumed by the
+// canonical on-call normalizer. Keeping the references typed prevents a
+// provider response from smuggling arbitrary values into the effect row.
+type pagerDutyOnCallReference struct {
+	ID string `json:"id"`
+}
+
+type pagerDutyOnCallPayload struct {
+	ID               string                    `json:"id"`
+	Type             string                    `json:"type"`
+	Start            string                    `json:"start"`
+	End              string                    `json:"end"`
+	EscalationLevel  *int32                    `json:"escalation_level"`
+	User             *pagerDutyOnCallReference `json:"user"`
+	Schedule         *pagerDutyOnCallReference `json:"schedule"`
+	EscalationPolicy *pagerDutyOnCallReference `json:"escalation_policy"`
+	SelfURL          string                    `json:"self"`
+	HTMLURL          string                    `json:"html_url"`
+	CreatedAt        string                    `json:"created_at"`
+	UpdatedAt        string                    `json:"updated_at"`
+}
+
+// pagerDutyOnCallRow mirrors every field on Python's OnCallAssignment
+// dataclass, including ordering values. The assignment table itself does not
+// persist the derived ordering columns; effects reconstruct and verify them
+// on readback before declaring a write exact.
+type pagerDutyOnCallRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ScheduleID             *string    `json:"schedule_id"`
+	UserID                 *string    `json:"user_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	EscalationLevel        *int32     `json:"escalation_level"`
+	StartsAt               *time.Time `json:"starts_at"`
+	EndsAt                 *time.Time `json:"ends_at"`
+}
+
+// PagerDutyOnCallsRouteHandler owns only source collection and canonical
+// normalization. Registration, matrix/config, and worker wiring stay in the
+// integration lane.
+type PagerDutyOnCallsRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutyOnCallsCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyOnCallsCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutyOnCallsRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutyOnCallsMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutyOnCallsMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyOnCallsPerPage
+	}
+	if pages < 1 || pages > pagerDutyOnCallsMaxPages || rows < 1 ||
+		rows > pagerDutyOnCallsMaxRows || perPage < 1 || perPage > pagerDutyOnCallsPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutyOnCallsRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "on-calls" || client == nil ||
+		client.Provider != "pagerduty" || client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyOnCallsCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/oncalls", DataKey: "oncalls", PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	rows := make([]pagerDutyOnCallRow, 0, len(pages.Items))
+	for _, raw := range pages.Items {
+		var payload pagerDutyOnCallPayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, err := normalizePagerDutyOnCall(
+			claim, providerInstance, payload, normalizedAt,
+		)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutyOnCall(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyOnCallPayload,
+	normalizedAt time.Time,
+) (pagerDutyOnCallRow, error) {
+	externalID, err := pagerDutyOnCallExternalID(payload)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	sourceVersionAt, err := pagerDutyOnCallSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	start, err := pagerDutyOnCallTime(payload.Start)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	end, err := pagerDutyOnCallTime(payload.End)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	sourceURL := pagerDutyOnCallURL(payload)
+	row := pagerDutyOnCallRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "oncall", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt,
+		ScheduleID: pagerDutyOnCallReferenceID(
+			claim.OrgID, providerInstance, payload.Schedule, "operational_on_call_schedule",
+		),
+		UserID: pagerDutyOnCallReferenceID(
+			claim.OrgID, providerInstance, payload.User, "operational_user",
+		),
+		EscalationPolicyID: pagerDutyOnCallReferenceID(
+			claim.OrgID, providerInstance, payload.EscalationPolicy, "operational_escalation_policy",
+		),
+		EscalationLevel: payload.EscalationLevel,
+		StartsAt:        start, EndsAt: end,
+	}
+	if (payload.User != nil && strings.TrimSpace(payload.User.ID) == "") ||
+		(payload.Schedule != nil && strings.TrimSpace(payload.Schedule.ID) == "") ||
+		(payload.EscalationPolicy != nil && strings.TrimSpace(payload.EscalationPolicy.ID) == "") {
+		return pagerDutyOnCallRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	if err := fillPagerDutyOnCallOrdering(&row); err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyOnCallExternalID(payload pagerDutyOnCallPayload) (string, error) {
+	if externalID := strings.TrimSpace(payload.ID); externalID != "" {
+		return externalID, nil
+	}
+	if payload.EscalationPolicy == nil || payload.User == nil ||
+		strings.TrimSpace(payload.EscalationPolicy.ID) == "" ||
+		strings.TrimSpace(payload.User.ID) == "" || payload.EscalationLevel == nil {
+		return "", providerfoundation.ErrNormalizationInvalid
+	}
+	scheduleID := "<permanent>"
+	if payload.Schedule != nil && payload.Schedule.ID != "" {
+		scheduleID = payload.Schedule.ID
+	}
+	start := "<permanent>"
+	if payload.Start != "" {
+		parsed, err := pagerDutyOnCallTime(payload.Start)
+		if err != nil {
+			return "", err
+		}
+		start = pagerDutyPythonISOTime(*parsed)
+	}
+	end := "<permanent>"
+	if payload.End != "" {
+		parsed, err := pagerDutyOnCallTime(payload.End)
+		if err != nil {
+			return "", err
+		}
+		end = pagerDutyPythonISOTime(*parsed)
+	}
+	return strings.Join([]string{
+		payload.EscalationPolicy.ID, scheduleID, payload.User.ID,
+		strconv.FormatInt(int64(*payload.EscalationLevel), 10), start, end,
+	}, "|"), nil
+}
+
+func pagerDutyOnCallSourceTime(
+	payload pagerDutyOnCallPayload, observedAt time.Time,
+) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	return pagerDutyOnCallParsedTime(value)
+}
+
+func pagerDutyOnCallTime(value string) (*time.Time, error) {
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := pagerDutyOnCallParsedTime(value)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
+func pagerDutyOnCallParsedTime(value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func pagerDutyPythonISOTime(value time.Time) string {
+	value = value.UTC().Truncate(time.Microsecond)
+	if value.Nanosecond() == 0 {
+		return value.Format("2006-01-02T15:04:05-07:00")
+	}
+	return value.Format("2006-01-02T15:04:05.000000-07:00")
+}
+
+func pagerDutyOnCallURL(payload pagerDutyOnCallPayload) *string {
+	value := payload.HTMLURL
+	if value == "" {
+		value = payload.SelfURL
+	}
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func pagerDutyOnCallReferenceID(
+	orgID, providerInstance string,
+	reference *pagerDutyOnCallReference, family string,
+) *string {
+	if reference == nil {
+		return nil
+	}
+	id := canonicalPagerDutyOperationalID(
+		orgID, "pagerduty", providerInstance, family, strings.TrimSpace(reference.ID),
+	)
+	return &id
+}
+
+func canonicalPagerDutyOperationalID(
+	orgID, provider, providerInstance, family, externalID string,
+) string {
+	parts := []string{orgID, provider, providerInstance, family, externalID}
+	quoted := make([]string, len(parts))
+	for index, part := range parts {
+		quoted[index] = strconv.QuoteToASCII(part)
+	}
+	digest := sha256Bytes([]byte("[" + strings.Join(quoted, ",") + "]"))
+	return hex.EncodeToString(digest)
+}
+
+func fillPagerDutyOnCallOrdering(row *pagerDutyOnCallRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	var escalationLevel any
+	if row.EscalationLevel != nil {
+		escalationLevel = *row.EscalationLevel
+	}
+	fields = append(fields,
+		jiraOperationalField{"schedule_id", jiraStringValue(row.ScheduleID)},
+		jiraOperationalField{"user_id", jiraStringValue(row.UserID)},
+		jiraOperationalField{"escalation_policy_id", jiraStringValue(row.EscalationPolicyID)},
+		jiraOperationalField{"escalation_level", escalationLevel},
+		jiraOperationalField{"starts_at", jiraTimeValue(row.StartsAt)},
+		jiraOperationalField{"ends_at", jiraTimeValue(row.EndsAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_on_call_assignment", row.OrgID, row.Provider,
+		row.ProviderInstanceID, row.ExternalID, row.SourceVersionAt,
+		row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+var _ CompleteRouteHandler = PagerDutyOnCallsRouteHandler{}

--- a/internal/providersync/pagerduty_oncalls_route_test.go
+++ b/internal/providersync/pagerduty_oncalls_route_test.go
@@ -1,0 +1,243 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyOnCallsResponse struct {
+	status int
+	body   string
+}
+
+type pagerDutyOnCallsDoer struct {
+	t         *testing.T
+	responses []pagerDutyOnCallsResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyOnCallsDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{body: `{"oncalls":[
+			{"id":"OC1","type":"oncall","start":"2026-08-01T10:00:00.123456Z","end":"2026-08-01T18:00:00.123456Z","escalation_level":1,"user":{"id":"PU1"},"schedule":{"id":"PS1"},"escalation_policy":{"id":"PE1"},"updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/oncalls/OC1","self":"/oncalls/OC1"},
+			{"type":"oncall","start":"2026-08-02T10:00:00Z","end":"2026-08-02T18:00:00Z","escalation_level":2,"user":{"id":"PU2"},"schedule":{"id":"PS2"},"escalation_policy":{"id":"PE2"},"created_at":"2026-07-31T09:00:00Z","self":"/oncalls/composite"}],"more":true}`},
+		{body: `{"oncalls":[],"more":false}`},
+	}}
+	client := pagerDutyOnCallsTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "},
+	}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyOnCallsRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_on_call_assignments" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 2 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 2 ||
+		batch.Evidence.CapReached || batch.Watermark != nil || batch.Result != nil {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[0].URL.Path; got != "/oncalls" {
+		t.Fatalf("first path=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+	row := mustPagerDutyOnCallRow(t, batch.Effects[0].Rows[0])
+	if row.Provider != "pagerduty" || row.ProviderInstanceID != "acme" ||
+		row.SourceEntityType != "oncall" || row.ExternalID != "OC1" ||
+		row.SourceURL == nil || *row.SourceURL != "https://acme.pagerduty.com/oncalls/OC1" ||
+		row.ScheduleID == nil || row.UserID == nil || row.EscalationPolicyID == nil ||
+		row.EscalationLevel == nil || *row.EscalationLevel != 1 ||
+		row.StartsAt == nil || row.EndsAt == nil || row.OrderingContract != 2 ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!row.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) {
+		t.Fatalf("row=%+v", row)
+	}
+	second := mustPagerDutyOnCallRow(t, batch.Effects[0].Rows[1])
+	if !strings.Contains(second.ExternalID, "PE2|PS2|PU2|2|2026-08-02T10:00:00+00:00|2026-08-02T18:00:00+00:00") ||
+		second.SourceURL == nil || *second.SourceURL != "/oncalls/composite" ||
+		second.ScheduleID == nil || second.UserID == nil || second.EscalationPolicyID == nil {
+		t.Fatalf("composite row=%+v", second)
+	}
+}
+
+func TestPagerDutyOnCallsRouteRejectsAnotherPagerDutyDataset(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	client := pagerDutyOnCallsTestClient(t, &pagerDutyOnCallsDoer{
+		t: t, responses: []pagerDutyOnCallsResponse{{body: `{"oncalls":[],"more":false}`}},
+	}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	if _, err := (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong dataset error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsRoutePreservesRetryAndPermanentErrorSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	retryDoer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{status: http.StatusTooManyRequests, body: `{"message":"slow down"}`},
+		{body: `{"oncalls":[],"more":false}`},
+	}}
+	retryClient := pagerDutyOnCallsTestClient(t, retryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, retryClient,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil || len(retryDoer.requests) != 2 || len(batch.Effects) != 1 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(retryDoer.requests))
+	}
+
+	authDoer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{status: http.StatusUnauthorized, body: `{"message":"bad token"}`},
+	}}
+	authClient := pagerDutyOnCallsTestClient(t, authDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	_, err = (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, authClient,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication ||
+		len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+}
+
+func TestPagerDutyOnCallsRouteFailsClosedOnPaginationCapAndInvalidAssignment(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	client := pagerDutyOnCallsTestClient(t, &pagerDutyOnCallsDoer{
+		t: t, responses: []pagerDutyOnCallsResponse{{body: `{"oncalls":[{"type":"oncall","user":{"id":"PU1"}}],"more":true}`}},
+	}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err := (PagerDutyOnCallsRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, credential, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+
+	invalidClient := pagerDutyOnCallsTestClient(t, &pagerDutyOnCallsDoer{
+		t: t, responses: []pagerDutyOnCallsResponse{{body: `{"oncalls":[{"type":"oncall","user":{"id":"PU1"}}],"more":false}`}},
+	}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err = (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, invalidClient,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("invalid assignment error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsRouteStopsWhenLeaseExpiresBetweenPages(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	doer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{body: `{"oncalls":[{"id":"OC1","type":"oncall"}],"more":true}`},
+		{body: `{"oncalls":[],"more":false}`},
+	}}
+	asserts := 0
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(doer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(doer.requests), asserts)
+	}
+}
+
+func pagerDutyOnCallsTestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyOnCallRow(t *testing.T, raw []byte) pagerDutyOnCallRow {
+	t.Helper()
+	var row pagerDutyOnCallRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/pagerduty_schedules_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_schedules_effects_clickhouse.go
@@ -1,0 +1,329 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// The migrated operational_on_call_schedules table predates durable ordering
+// columns. Keep the typed effect row complete for parity/readback validation,
+// but insert the exact columns provided by the production migration.
+const pagerDutySchedulesColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,name,description,timezone,is_deleted,deleted_at"
+
+// PagerDutySchedulesClickHouseEffects persists a complete schedules snapshot
+// and fences omitted active rows with typed tombstones. Tenant and provider
+// instance predicates keep one PagerDuty account from mutating another.
+type PagerDutySchedulesClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+	Now                func() time.Time
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pagerDutyScheduleRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validatePagerDutyScheduleRows(claim, rows); err != nil {
+		return err
+	}
+	providerInstance, err := sink.providerInstance(rows)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveSchedules(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.snapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyScheduleRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyScheduleTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(
+		ctx, "INSERT INTO operational_on_call_schedules ("+pagerDutySchedulesColumns+")",
+	)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyScheduleValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pagerDutyScheduleRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validatePagerDutyScheduleRows(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	providerInstance, err := sink.providerInstance(expected)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveSchedules(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	exact, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadSchedule(
+			ctx, claim, providerInstance, row.ID,
+		)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyScheduleVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	// A complete source snapshot is exact only when every active source row is
+	// represented by the returned identity set or has been tombstoned.
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected) && absent == 0:
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "schedules" ||
+		effect.Destination != "operational_on_call_schedules" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func validatePagerDutyScheduleRows(claim Claim, rows []pagerDutyScheduleRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "schedule" || row.ExternalID == "" || row.Name == "" ||
+			row.ID == "" || row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyScheduleOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) providerInstance(
+	rows []pagerDutyScheduleRow,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, row := range rows {
+		rowInstance := strings.ToLower(strings.TrimSpace(row.ProviderInstanceID))
+		if rowInstance == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = rowInstance
+		}
+		if instance != rowInstance {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func pagerDutyScheduleValues(row pagerDutyScheduleRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence, row.Name, row.Description, row.Timezone,
+		row.IsDeleted, row.DeletedAt,
+	}
+}
+
+func pagerDutyScheduleScanValues(row *pagerDutyScheduleRow) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.Name, &row.Description, &row.Timezone,
+		&row.IsDeleted, &row.DeletedAt,
+	}
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) loadActiveSchedules(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyScheduleRow, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutySchedulesColumns+
+			" FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+		claim.OrgID, claim.Provider, providerInstance, "schedule",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	active := make([]pagerDutyScheduleRow, 0)
+	for rows.Next() {
+		var row pagerDutyScheduleRow
+		if err := rows.Scan(pagerDutyScheduleScanValues(&row)...); err != nil {
+			return nil, err
+		}
+		if err := fillPagerDutyScheduleOrdering(&row); err != nil {
+			return nil, err
+		}
+		active = append(active, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return active, nil
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) loadSchedule(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyScheduleRow, bool, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutySchedulesColumns+
+			" FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "schedule", id,
+	)
+	if err != nil {
+		return pagerDutyScheduleRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyScheduleRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyScheduleScanValues(&actual)...); err != nil {
+			return pagerDutyScheduleRow{}, false, err
+		}
+		if err := fillPagerDutyScheduleOrdering(&actual); err != nil {
+			return pagerDutyScheduleRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyScheduleRow{}, false, err
+	}
+	return actual, found, nil
+}
+
+func comparePagerDutyScheduleVersion(
+	expected, actual pagerDutyScheduleRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) snapshotObservedAt(
+	rows []pagerDutyScheduleRow, claim Claim,
+) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	if sink.Now != nil {
+		return sink.Now().UTC().Truncate(time.Microsecond)
+	}
+	if claim.BeforeAt != nil && !claim.BeforeAt.IsZero() {
+		return claim.BeforeAt.UTC().Truncate(time.Microsecond)
+	}
+	return time.Now().UTC().Truncate(time.Microsecond)
+}
+
+var _ EffectSink = PagerDutySchedulesClickHouseEffects{}
+var _ EffectReadback = PagerDutySchedulesClickHouseEffects{}

--- a/internal/providersync/pagerduty_schedules_effects_integration_test.go
+++ b/internal/providersync/pagerduty_schedules_effects_integration_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Apply the production migration chain, including the canonical schedules
+	// table, rather than creating a test-only relaxed schema.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "schedules")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	rowA, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{
+			ID: "PS1", Name: "Primary", TimeZone: stringPtr("America/Los_Angeles"),
+		}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowB, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{ID: "PS2", Name: "Support"}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialEffect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired,
+		[]pagerDutyScheduleRow{rowA, rowB},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutySchedulesClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "Acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+		Now:   func() time.Time { return initialAt },
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, initialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after initial write inspection=%s error=%v", inspection, err)
+	}
+
+	// A later complete snapshot omits PS2. The sink must fence that omission
+	// with a strictly newer tombstone while retaining active PS1.
+	updatedAt := initialAt.Add(time.Hour)
+	rowAUpdated, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{
+			ID: "PS1", Name: "Primary updated", UpdatedAt: updatedAt.Format(time.RFC3339Nano),
+			TimeZone: stringPtr("America/Los_Angeles"),
+		}, updatedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partialEffect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired,
+		[]pagerDutyScheduleRow{rowAUpdated},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink.Now = func() time.Time { return updatedAt }
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("tombstone write inspection=%s error=%v", inspection, err)
+	}
+	var deleted bool
+	var deletedAt time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_deleted, deleted_at
+FROM operational_on_call_schedules FINAL
+WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND external_id = ?`,
+		claim.OrgID, "pagerduty", "acme", "schedule", "PS2",
+	).Scan(&deleted, &deletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted || !deletedAt.Equal(updatedAt) {
+		t.Fatalf("missing-schedule tombstone deleted=%v deleted_at=%s want %s", deleted, deletedAt, updatedAt)
+	}
+
+	// The durable effect payload can be replayed after the write. Exact
+	// readback must remain stable and must not create a second logical row.
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+	}
+
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	otherRow := rowAUpdated
+	otherRow.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyScheduleOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	otherEffect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired,
+		[]pagerDutyScheduleRow{otherRow},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, otherEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign row changed readback inspection=%s error=%v", inspection, err)
+	}
+}

--- a/internal/providersync/pagerduty_schedules_effects_test.go
+++ b/internal/providersync/pagerduty_schedules_effects_test.go
@@ -1,0 +1,102 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutySchedulesEffectRejectsForeignScopeOrderingTamperAndMixedInstances(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "schedules")
+	row, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{
+			ID: "PS1", Name: "Primary", TimeZone: stringPtr("UTC"),
+		}, time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := row
+	foreign.OrgID = "org-other"
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := row
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyScheduleOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutySchedulesClickHouseEffects{}).providerInstance(
+		[]pagerDutyScheduleRow{row, foreignInstance},
+	); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := row
+	tampered.Timezone = stringPtr("America/New_York")
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	inconsistent := row
+	inconsistent.IsDeleted = true
+	if err := fillPagerDutyScheduleOrdering(&inconsistent); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{inconsistent}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("deleted flag consistency error=%v", err)
+	}
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{row, row}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate row error=%v", err)
+	}
+}
+
+func TestPagerDutySchedulesTombstoneBumpsSourceVersionAndPreservesIdentity(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "schedules")
+	row, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{ID: "PS1", Name: "Primary"},
+		time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tombstone, err := pagerDutyScheduleTombstone(row, row.SourceVersionAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tombstone.ID != row.ID || tombstone.ExternalID != row.ExternalID ||
+		!tombstone.SourceVersionAt.Equal(row.SourceVersionAt.Add(time.Microsecond)) ||
+		!tombstone.ObservedAt.Equal(tombstone.SourceVersionAt) ||
+		!tombstone.LastSynced.Equal(tombstone.SourceVersionAt) || !tombstone.IsDeleted ||
+		tombstone.DeletedAt == nil || !tombstone.DeletedAt.Equal(tombstone.SourceVersionAt) ||
+		tombstone.SourceRevision == nil || tombstone.IngestRevision == nil ||
+		tombstone.OrderingContract != 2 {
+		t.Fatalf("tombstone=%+v", tombstone)
+	}
+	if tombstone.SourceRevision.Cmp(row.SourceRevision) <= 0 {
+		t.Fatalf("tombstone source revision did not advance: old=%s new=%s", row.SourceRevision, tombstone.SourceRevision)
+	}
+}
+
+func TestPagerDutySchedulesEffectRejectsUnsafeEmptySnapshotWithoutInstance(t *testing.T) {
+	if _, err := (PagerDutySchedulesClickHouseEffects{}).providerInstance(nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+}
+
+func TestPagerDutySchedulesEffectRejectsWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "schedules")
+	sink := PagerDutySchedulesClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_on_call_schedules"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid request error=%v", err)
+	}
+	if err := sink.WriteEffect(
+		context.Background(), claim, EffectBatch{Destination: "other"},
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_schedules_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_schedules_generic_oracle_test.go
@@ -1,0 +1,76 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyScheduleRowForOracle(
+	t *testing.T, input map[string]any,
+) pagerDutyScheduleRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutySchedulePayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "schedules")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutySchedule(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload,
+		observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyScheduleCases() []oracleCase {
+	return []oracleCase{
+		{ID: "updated_html_url_timezone", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS1", "type": "schedule", "name": "Primary",
+				"summary": "Ignored summary", "time_zone": "America/Los_Angeles",
+				"updated_at": "2026-08-01T10:00:00.123456Z",
+				"html_url":   "https://acme.pagerduty.com/schedules/PS1",
+			},
+		}},
+		{ID: "created_self_url_summary", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS2", "type": "schedule", "summary": "Support",
+				"created_at": "2026-07-31T09:00:00Z", "self": "/schedules/PS2",
+			},
+		}},
+		{ID: "observed_time_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS3", "type": "schedule", "name": "Operations",
+			},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyScheduleRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/schedules/row", oraclePagerDutyScheduleCases(),
+		buildPagerDutyScheduleRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_schedules_route.go
+++ b/internal/providersync/pagerduty_schedules_route.go
@@ -1,0 +1,286 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutySchedulesMaxPages = 10_000
+	pagerDutySchedulesMaxRows  = 100_000
+	pagerDutySchedulesPerPage  = 100
+)
+
+// pagerDutySchedulePayload is the provider-owned subset consumed by Python's
+// PagerDutyNormalizer.schedule. The schedules unit deliberately does not own
+// on-call assignment payloads; those are a separate source unit and table.
+type pagerDutySchedulePayload struct {
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	Summary   string  `json:"summary"`
+	SelfURL   string  `json:"self"`
+	HTMLURL   string  `json:"html_url"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
+	TimeZone  *string `json:"time_zone"`
+}
+
+// pagerDutyScheduleRow mirrors every field on Python's canonical
+// OnCallSchedule dataclass, including the persisted ordering fields.
+type pagerDutyScheduleRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	Name                   string     `json:"name"`
+	Description            *string    `json:"description"`
+	Timezone               *string    `json:"timezone"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+// PagerDutySchedulesRouteHandler owns source collection and canonical
+// normalization only. Registry, capability, and worker wiring stay outside
+// this provider slice.
+type PagerDutySchedulesRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutySchedulesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutySchedulesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutySchedulesRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutySchedulesMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutySchedulesMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutySchedulesPerPage
+	}
+	if pages < 1 || pages > pagerDutySchedulesMaxPages || rows < 1 ||
+		rows > pagerDutySchedulesMaxRows || perPage < 1 || perPage > pagerDutySchedulesPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutySchedulesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "schedules" || client == nil ||
+		client.Provider != "pagerduty" || client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutySchedulesCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/schedules", DataKey: "schedules", PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	rows := make([]pagerDutyScheduleRow, 0, len(pages.Items))
+	for _, raw := range pages.Items {
+		var payload pagerDutySchedulePayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, err := normalizePagerDutySchedule(claim, providerInstance, payload, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  map[string]any{"schedules_synced": len(rows)},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutySchedule(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutySchedulePayload,
+	normalizedAt time.Time,
+) (pagerDutyScheduleRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyScheduleRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyScheduleSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyScheduleRow{}, err
+	}
+	var sourceURL *string
+	if payload.HTMLURL != "" {
+		value := payload.HTMLURL
+		sourceURL = &value
+	} else if payload.SelfURL != "" {
+		value := payload.SelfURL
+		sourceURL = &value
+	}
+	name := payload.Name
+	if name == "" {
+		name = payload.Summary
+	}
+	if name == "" {
+		name = payload.ID
+	}
+	row := pagerDutyScheduleRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "schedule", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt, Name: name,
+		Timezone: payload.TimeZone,
+	}
+	if err := fillPagerDutyScheduleOrdering(&row); err != nil {
+		return pagerDutyScheduleRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyScheduleSourceTime(
+	payload pagerDutySchedulePayload, observedAt time.Time,
+) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func fillPagerDutyScheduleOrdering(row *pagerDutyScheduleRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"name", row.Name},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"timezone", jiraStringValue(row.Timezone)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_on_call_schedule", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func pagerDutyScheduleTombstone(
+	row pagerDutyScheduleRow, observedAt time.Time,
+) (pagerDutyScheduleRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyScheduleRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)
+	if version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt = version
+	row.ObservedAt = version
+	row.LastSynced = version
+	row.IsDeleted = true
+	row.DeletedAt = &version
+	row.SourceRevision = nil
+	row.SourceConflictKey = ""
+	row.IngestRevision = nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyScheduleOrdering(&row); err != nil {
+		return pagerDutyScheduleRow{}, err
+	}
+	return row, nil
+}
+
+var _ CompleteRouteHandler = PagerDutySchedulesRouteHandler{}

--- a/internal/providersync/pagerduty_schedules_route_test.go
+++ b/internal/providersync/pagerduty_schedules_route_test.go
@@ -1,0 +1,220 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutySchedulesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutySchedulesDoer struct {
+	t         *testing.T
+	responses []pagerDutySchedulesResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutySchedulesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{
+		{body: `{"schedules":[
+			{"id":"PS1","type":"schedule","name":"Primary","time_zone":"America/Los_Angeles","updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/schedules/PS1"},
+			{"id":"PS2","type":"schedule","summary":"Support","created_at":"2026-07-31T09:00:00Z","self":"/schedules/PS2"}],"more":true}`},
+		{body: `{"schedules":[{"id":"PS3","type":"schedule","name":"Operations"}],"more":false}`},
+	}}
+	client := pagerDutySchedulesTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "schedules")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "},
+	}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutySchedulesRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_on_call_schedules" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 ||
+		batch.Evidence.CapReached || batch.Watermark != nil {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[0].URL.Path; got != "/schedules" {
+		t.Fatalf("first path=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+	row := mustPagerDutyScheduleRow(t, batch.Effects[0].Rows[0])
+	if row.Provider != "pagerduty" || row.ProviderInstanceID != "acme" ||
+		row.SourceEntityType != "schedule" || row.ExternalID != "PS1" ||
+		row.Name != "Primary" || row.Timezone == nil || *row.Timezone != "America/Los_Angeles" ||
+		row.SourceURL == nil || *row.SourceURL != "https://acme.pagerduty.com/schedules/PS1" ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!row.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) ||
+		row.SourceRevision == nil || row.IngestRevision == nil || row.OrderingContract != 2 {
+		t.Fatalf("row=%+v", row)
+	}
+	secondary := mustPagerDutyScheduleRow(t, batch.Effects[0].Rows[1])
+	if secondary.Name != "Support" || secondary.Timezone != nil || secondary.SourceURL == nil ||
+		*secondary.SourceURL != "/schedules/PS2" {
+		t.Fatalf("secondary=%+v", secondary)
+	}
+	tertiary := mustPagerDutyScheduleRow(t, batch.Effects[0].Rows[2])
+	if tertiary.Name != "Operations" || !tertiary.SourceVersionAt.Equal(row.ObservedAt) {
+		t.Fatalf("tertiary=%+v", tertiary)
+	}
+}
+
+func TestPagerDutySchedulesRoutePreservesRetryAndPermanentErrorSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	retryDoer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{
+		{status: http.StatusTooManyRequests, headers: http.Header{"Retry-After": {"0"}}, body: `{"message":"slow down"}`},
+		{body: `{"schedules":[],"more":false}`},
+	}}
+	retryClient := pagerDutySchedulesTestClient(t, retryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim, credential, retryClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil || len(retryDoer.requests) != 2 || len(batch.Effects) != 1 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(retryDoer.requests))
+	}
+
+	authDoer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{{
+		status: http.StatusUnauthorized, body: `{"message":"bad token"}`,
+	}}}
+	authClient := pagerDutySchedulesTestClient(t, authDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	_, err = (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim, credential, authClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication ||
+		len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+}
+
+func TestPagerDutySchedulesRouteFailsClosedOnPaginationCapAndMissingInstance(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	client := pagerDutySchedulesTestClient(t, &pagerDutySchedulesDoer{
+		t: t, responses: []pagerDutySchedulesResponse{{
+			body: `{"schedules":[{"id":"one"}],"more":true}`,
+		}}}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	_, err := (PagerDutySchedulesRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, credential, client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	_, err = (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{Provider: "pagerduty"}, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("missing instance error=%v", err)
+	}
+}
+
+func TestPagerDutySchedulesRouteStopsWhenLeaseExpiresBetweenPages(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	doer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{
+		{body: `{"schedules":[{"id":"one"}],"more":true}`},
+		{body: `{"schedules":[],"more":false}`},
+	}}
+	asserts := 0
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(doer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(doer.requests), asserts)
+	}
+}
+
+func pagerDutySchedulesTestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyScheduleRow(t *testing.T, raw []byte) pagerDutyScheduleRow {
+	t.Helper()
+	var row pagerDutyScheduleRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/pagerduty_services_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_services_effects_clickhouse.go
@@ -1,0 +1,718 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+// These columns are the current migrated v2 operational schema. Keeping the
+// ordering columns in the INSERT/readback contract is important: source
+// revisions are the durable replay identity, not an in-memory annotation.
+const (
+	pagerDutyServicesOperationalServiceColumns = gitLabOperationalServiceColumns
+	pagerDutyServicesMappingColumns            = gitLabServiceMappingColumns
+)
+
+// PagerDutyServicesClickHouseEffects owns only the two destinations produced
+// by the services provider path. The repository mapping destination remains a
+// separate typed effect so its source/provenance contract cannot be silently
+// absorbed into OperationalService rows.
+type PagerDutyServicesClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+	Now                func() time.Time
+}
+
+func (sink PagerDutyServicesClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	switch effect.Destination {
+	case "operational_services":
+		rows, err := decodeEffectRows[pagerDutyServiceRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyServiceRows(claim, rows); err != nil {
+			return err
+		}
+		return sink.writeServicesSnapshot(ctx, claim, rows)
+	case "operational_service_repository_mappings":
+		rows, err := decodeEffectRows[pagerDutyServiceRepositoryMappingRow](effect)
+		if err != nil {
+			return err
+		}
+		rows, err = sink.resolvePagerDutyServiceMappings(ctx, claim, rows)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyServiceMappingRows(claim, rows); err != nil {
+			return err
+		}
+		return sink.writeMappingsSnapshot(ctx, claim, rows)
+	default:
+		return ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyServicesClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	switch effect.Destination {
+	case "operational_services":
+		expected, err := decodeEffectRows[pagerDutyServiceRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyServiceRows(claim, expected); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectServices(ctx, claim, expected)
+	case "operational_service_repository_mappings":
+		expected, err := decodeEffectRows[pagerDutyServiceRepositoryMappingRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		expected, err = sink.resolvePagerDutyServiceMappings(ctx, claim, expected)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyServiceMappingRows(claim, expected); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectMappings(ctx, claim, expected)
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyServicesClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "services" {
+		return ErrInvalidConfiguration
+	}
+	switch effect.Destination {
+	case "operational_services", "operational_service_repository_mappings":
+	default:
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) providerInstance(
+	instances ...string,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, value := range instances {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = value
+		}
+		if instance != value {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func validatePagerDutyServiceRows(claim Claim, rows []pagerDutyServiceRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "service" || row.ExternalID == "" || row.Name == "" ||
+			row.ServiceType == nil || *row.ServiceType != "technical" || row.OwningTeamID != nil ||
+			row.ID == "" || row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyServiceOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyServiceMappingRows(
+	claim Claim, rows []pagerDutyServiceRepositoryMappingRow,
+) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if !pagerDutyMappingSourceValid(row.SourceEntityType) ||
+			row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.ExternalID == "" || row.ServiceID == "" || row.ID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil || row.SourceConflictKey == "" ||
+			row.OrderingContract != 2 || row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() ||
+			row.LastSynced.IsZero() || row.RelationshipProvenance == nil ||
+			*row.RelationshipProvenance != row.SourceEntityType || row.RelationshipConfidence == nil ||
+			*row.RelationshipConfidence < 0 || *row.RelationshipConfidence > 1 ||
+			row.RepoProvider == nil || *row.RepoProvider == "" || row.RepoFullName == nil ||
+			*row.RepoFullName == "" || row.MappingKind == nil || *row.MappingKind == "" ||
+			row.RuleID == nil || *row.RuleID == "" || row.ValidFrom == nil ||
+			row.ValidTo != nil && row.IsActive || (!row.IsActive && row.ValidTo == nil) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyServiceMappingOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyMappingSourceValid(value string) bool {
+	switch pagerDutyServiceMappingSource(value) {
+	case pagerDutyMappingAdmin, pagerDutyMappingMetadata, pagerDutyMappingCompass, pagerDutyMappingHeuristic:
+		return true
+	default:
+		return false
+	}
+}
+
+func (sink PagerDutyServicesClickHouseEffects) writeServicesSnapshot(
+	ctx context.Context, claim Claim, rows []pagerDutyServiceRow,
+) error {
+	providerInstance, err := sink.providerInstance(pagerDutyServiceInstances(rows)...)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveServices(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.snapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyServiceRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyServiceTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_services ("+pagerDutyServicesOperationalServiceColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyServiceValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) writeMappingsSnapshot(
+	ctx context.Context, claim Claim, rows []pagerDutyServiceRepositoryMappingRow,
+) error {
+	instances := make([]string, 0, len(rows))
+	for _, row := range rows {
+		instances = append(instances, row.ProviderInstanceID)
+	}
+	providerInstance, err := sink.providerInstance(instances...)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveMappings(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.mappingSnapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyServiceRepositoryMappingRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyServiceMappingTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_service_repository_mappings ("+pagerDutyServicesMappingColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyServiceMappingValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+// resolvePagerDutyServiceMappings mirrors Python's
+// resolve_repository_mappings: repository identity is looked up only in the
+// org-scoped ClickHouse catalog, while unmatched evidence remains unresolved
+// with its provider/full-name pair intact. The effect payload stays a typed
+// evidence row; this sink-side enrichment is deterministic and is repeated on
+// readback/recovery before comparing the durable row.
+func (sink PagerDutyServicesClickHouseEffects) resolvePagerDutyServiceMappings(
+	ctx context.Context, claim Claim, rows []pagerDutyServiceRepositoryMappingRow,
+) ([]pagerDutyServiceRepositoryMappingRow, error) {
+	if len(rows) == 0 {
+		return rows, nil
+	}
+	needsCatalog := false
+	for _, row := range rows {
+		if row.RepoID == nil && row.RepoProvider != nil && row.RepoFullName != nil {
+			needsCatalog = true
+			break
+		}
+	}
+	if !needsCatalog {
+		return rows, nil
+	}
+	catalogRows, err := sink.Conn.Query(
+		ctx, "SELECT id, provider, repo FROM repos FINAL WHERE org_id = ?", claim.OrgID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer catalogRows.Close()
+	catalog := make(map[string]uuid.UUID)
+	for catalogRows.Next() {
+		var repoID uuid.UUID
+		var provider, fullName string
+		if err := catalogRows.Scan(&repoID, &provider, &fullName); err != nil {
+			return nil, err
+		}
+		catalog[provider+"\x00"+fullName] = repoID
+	}
+	if err := catalogRows.Err(); err != nil {
+		return nil, err
+	}
+	resolved := make([]pagerDutyServiceRepositoryMappingRow, len(rows))
+	copy(resolved, rows)
+	for index, row := range resolved {
+		if row.RepoID != nil || row.RepoProvider == nil || row.RepoFullName == nil {
+			continue
+		}
+		repoID, found := catalog[*row.RepoProvider+"\x00"+*row.RepoFullName]
+		if !found {
+			continue
+		}
+		row.RepoID = &repoID
+		row.ID, row.SourceConflictKey = "", ""
+		row.SourceRevision, row.IngestRevision = nil, nil
+		row.OrderingContract = 0
+		if err := fillPagerDutyServiceMappingOrdering(&row); err != nil {
+			return nil, err
+		}
+		resolved[index] = row
+	}
+	return resolved, nil
+}
+
+func pagerDutyServiceInstances(rows []pagerDutyServiceRow) []string {
+	instances := make([]string, 0, len(rows))
+	for _, row := range rows {
+		instances = append(instances, row.ProviderInstanceID)
+	}
+	return instances
+}
+
+func (sink PagerDutyServicesClickHouseEffects) snapshotObservedAt(rows []pagerDutyServiceRow, claim Claim) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	return sink.snapshotNow(claim)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) mappingSnapshotObservedAt(rows []pagerDutyServiceRepositoryMappingRow, claim Claim) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	return sink.snapshotNow(claim)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) snapshotNow(claim Claim) time.Time {
+	if sink.Now != nil {
+		return sink.Now().UTC().Truncate(time.Microsecond)
+	}
+	if claim.BeforeAt != nil && !claim.BeforeAt.IsZero() {
+		return claim.BeforeAt.UTC().Truncate(time.Microsecond)
+	}
+	return time.Now().UTC().Truncate(time.Microsecond)
+}
+
+func pagerDutyServiceValues(row pagerDutyServiceRow) []any {
+	values := gitLabOperationalBaseValues(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceRevision, row.SourceConflictKey,
+		row.IngestRevision, row.OrderingContract, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence,
+	)
+	return append(values, row.Name, row.Description, row.ServiceType, row.OwningTeamID,
+		row.EscalationPolicyID, row.IsDeleted, row.DeletedAt)
+}
+
+func pagerDutyServiceMappingValues(row pagerDutyServiceRepositoryMappingRow) []any {
+	values := gitLabOperationalBaseValues(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceRevision, row.SourceConflictKey,
+		row.IngestRevision, row.OrderingContract, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence,
+	)
+	return append(values, row.ServiceID, row.RepoID, row.RepoFullName, row.RepoProvider,
+		row.MappingKind, row.RuleID, row.ValidFrom, row.ValidTo, row.IsActive)
+}
+
+func pagerDutyServiceScanValues(row *pagerDutyServiceRow, sourceRevision, ingestRevision *big.Int) []any {
+	values := gitLabOperationalBaseScanValues(
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, sourceRevision, &row.SourceConflictKey,
+		ingestRevision, &row.OrderingContract, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence,
+	)
+	return append(values, &row.Name, &row.Description, &row.ServiceType, &row.OwningTeamID,
+		&row.EscalationPolicyID, &row.IsDeleted, &row.DeletedAt)
+}
+
+func pagerDutyServiceMappingScanValues(row *pagerDutyServiceRepositoryMappingRow, sourceRevision, ingestRevision *big.Int) []any {
+	values := gitLabOperationalBaseScanValues(
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, sourceRevision, &row.SourceConflictKey,
+		ingestRevision, &row.OrderingContract, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence,
+	)
+	return append(values, &row.ServiceID, &row.RepoID, &row.RepoFullName, &row.RepoProvider,
+		&row.MappingKind, &row.RuleID, &row.ValidFrom, &row.ValidTo, &row.IsActive)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadActiveServices(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyServiceRow, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesOperationalServiceColumns+
+		" FROM (SELECT "+pagerDutyServicesOperationalServiceColumns+
+		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? "+
+		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) "+
+		"WHERE is_deleted = 0",
+		claim.OrgID, claim.Provider, providerInstance, "service")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]pagerDutyServiceRow, 0)
+	for rows.Next() {
+		var row pagerDutyServiceRow
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceScanValues(&row, &sourceRevision, &ingestRevision)...); err != nil {
+			return nil, err
+		}
+		row.SourceRevision, row.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadActiveMappings(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyServiceRepositoryMappingRow, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesMappingColumns+
+		" FROM (SELECT "+pagerDutyServicesMappingColumns+
+		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? "+
+		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) "+
+		"WHERE is_active = 1",
+		claim.OrgID, claim.Provider, providerInstance)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]pagerDutyServiceRepositoryMappingRow, 0)
+	for rows.Next() {
+		var row pagerDutyServiceRepositoryMappingRow
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceMappingScanValues(&row, &sourceRevision, &ingestRevision)...); err != nil {
+			return nil, err
+		}
+		row.SourceRevision, row.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) inspectServices(
+	ctx context.Context, claim Claim, expected []pagerDutyServiceRow,
+) (EffectInspection, error) {
+	providerInstance, err := sink.providerInstance(pagerDutyServiceInstances(expected)...)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveServices(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	exact, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadService(ctx, claim, providerInstance, row.ID)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyServiceVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) && absent == 0 {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyServicesClickHouseEffects) inspectMappings(
+	ctx context.Context, claim Claim, expected []pagerDutyServiceRepositoryMappingRow,
+) (EffectInspection, error) {
+	instances := make([]string, 0, len(expected))
+	for _, row := range expected {
+		instances = append(instances, row.ProviderInstanceID)
+	}
+	providerInstance, err := sink.providerInstance(instances...)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveMappings(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	exact, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadMapping(ctx, claim, providerInstance, row.ID)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyServiceMappingVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) && absent == 0 {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadService(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyServiceRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesOperationalServiceColumns+
+		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? "+
+		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "service", id)
+	if err != nil {
+		return pagerDutyServiceRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyServiceRow
+	found := false
+	for rows.Next() {
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceScanValues(&actual, &sourceRevision, &ingestRevision)...); err != nil {
+			return pagerDutyServiceRow{}, false, err
+		}
+		actual.SourceRevision, actual.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		found = true
+	}
+	return actual, found, rows.Err()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadMapping(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyServiceRepositoryMappingRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesMappingColumns+
+		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND id = ? "+
+		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, id)
+	if err != nil {
+		return pagerDutyServiceRepositoryMappingRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyServiceRepositoryMappingRow
+	found := false
+	for rows.Next() {
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceMappingScanValues(&actual, &sourceRevision, &ingestRevision)...); err != nil {
+			return pagerDutyServiceRepositoryMappingRow{}, false, err
+		}
+		actual.SourceRevision, actual.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		found = true
+	}
+	return actual, found, rows.Err()
+}
+
+func comparePagerDutyServiceVersion(expected, actual pagerDutyServiceRow, found bool) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func comparePagerDutyServiceMappingVersion(expected, actual pagerDutyServiceRepositoryMappingRow, found bool) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func pagerDutyServiceMappingTombstone(
+	row pagerDutyServiceRepositoryMappingRow, observedAt time.Time,
+) (pagerDutyServiceRepositoryMappingRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyServiceRepositoryMappingRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	if previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond); version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt = version
+	observed := observedAt.UTC().Truncate(time.Microsecond)
+	row.ObservedAt, row.LastSynced = observed, observed
+	row.ValidTo, row.IsActive = &observed, false
+	row.SourceRevision, row.SourceConflictKey, row.IngestRevision = nil, "", nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyServiceMappingOrdering(&row); err != nil {
+		return pagerDutyServiceRepositoryMappingRow{}, err
+	}
+	return row, nil
+}
+
+var _ EffectSink = PagerDutyServicesClickHouseEffects{}
+var _ EffectReadback = PagerDutyServicesClickHouseEffects{}

--- a/internal/providersync/pagerduty_services_effects_integration_test.go
+++ b/internal/providersync/pagerduty_services_effects_integration_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	// The current production writer contract is v2; make the migration runner
+	// inherit that explicit admission instead of silently materializing its
+	// legacy default.
+	t.Setenv("OPERATIONAL_ORDERING_CONTRACT", "2")
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// This is the production migration chain, including the v2 ordering
+	// contract, rather than a test-only table that could omit readback fields.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "services")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	serviceA, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS1", Name: "Payments"}, initialAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceB, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS2", Name: "Support"}, initialAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingA, err := pagerDutyServiceMappingFromReference(serviceA, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"}, pagerDutyMappingMetadata, initialAt, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingB, err := pagerDutyServiceMappingFromReference(serviceB, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/support"}, pagerDutyMappingMetadata, initialAt, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceEffect, err := effectBatchFromValues("operational_services", EffectReadbackRequired, []pagerDutyServiceRow{serviceA, serviceB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingEffect, err := effectBatchFromValues("operational_service_repository_mappings", EffectReadbackRequired, []pagerDutyServiceRepositoryMappingRow{mappingA, mappingB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutyServicesClickHouseEffects{
+		Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+		ProviderInstanceID: "Acme", Now: func() time.Time { return initialAt },
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, serviceEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("services before write inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, mappingEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("mappings before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, serviceEffect); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, mappingEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, serviceEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("services after write inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, mappingEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("mappings after write inspection=%s error=%v", inspection, err)
+	}
+	// Replaying the durable effect is the recovery path: no new source fetch or
+	// generated identity is involved, and both destinations must read back exact.
+	if err := sink.WriteEffect(ctx, claim, serviceEffect); err != nil {
+		t.Fatalf("service replay: %v", err)
+	}
+	if err := sink.WriteEffect(ctx, claim, mappingEffect); err != nil {
+		t.Fatalf("mapping replay: %v", err)
+	}
+
+	updatedAt := initialAt.Add(time.Hour)
+	serviceAUpdated, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS1", Name: "Payments updated", UpdatedAt: updatedAt.Format(time.RFC3339Nano)}, updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedServiceEffect, err := effectBatchFromValues("operational_services", EffectReadbackRequired, []pagerDutyServiceRow{serviceAUpdated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingAUpdated, err := pagerDutyServiceMappingFromReference(serviceAUpdated, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"}, pagerDutyMappingMetadata, updatedAt, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedMappingEffect, err := effectBatchFromValues("operational_service_repository_mappings", EffectReadbackRequired, []pagerDutyServiceRepositoryMappingRow{mappingAUpdated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink.Now = func() time.Time { return updatedAt }
+	if err := sink.WriteEffect(ctx, claim, updatedServiceEffect); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, updatedMappingEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedServiceEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("updated services inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedMappingEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("updated mappings inspection=%s error=%v", inspection, err)
+	}
+	var deleted bool
+	var deletedAt time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_deleted, deleted_at
+FROM (
+  SELECT org_id, id, external_id, is_deleted, deleted_at, source_revision, source_conflict_key, ingest_revision
+  FROM operational_services
+  WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ?
+  ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC
+  LIMIT 1 BY org_id, id
+)
+WHERE external_id = ?`,
+		claim.OrgID, "pagerduty", "acme", "service", "PS2").Scan(&deleted, &deletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted || !deletedAt.Equal(updatedAt) {
+		t.Fatalf("service tombstone deleted=%v deleted_at=%s want %s", deleted, deletedAt, updatedAt)
+	}
+	var active bool
+	var validTo time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_active, valid_to
+FROM (
+  SELECT org_id, id, is_active, valid_to, source_revision, source_conflict_key, ingest_revision
+  FROM operational_service_repository_mappings
+  WHERE org_id = ? AND provider = ? AND provider_instance_id = ?
+  ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC
+  LIMIT 1 BY org_id, id
+)
+WHERE id = ?`,
+		claim.OrgID, "pagerduty", "acme", mappingB.ID).Scan(&active, &validTo); err != nil {
+		t.Fatal(err)
+	}
+	if active || !validTo.Equal(updatedAt) {
+		t.Fatalf("mapping tombstone active=%v valid_to=%s want %s", active, validTo, updatedAt)
+	}
+
+	// A foreign tenant may write its own identity, but it cannot alter this
+	// tenant's readback because every sink query includes org/provider/instance.
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	foreign := serviceAUpdated
+	foreign.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyServiceOrdering(&foreign); err != nil {
+		t.Fatal(err)
+	}
+	foreignEffect, err := effectBatchFromValues("operational_services", EffectReadbackRequired, []pagerDutyServiceRow{foreign})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, foreignEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedServiceEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign tenant changed service inspection=%s error=%v", inspection, err)
+	}
+
+	// A lease loss at the durable write boundary must fail closed; the batch is
+	// prepared but never acknowledged as written.
+	leaseSink := PagerDutyServicesClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return providerfoundation.ErrLeaseLost }),
+	}
+	if err := leaseSink.WriteEffect(ctx, claim, updatedServiceEffect); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("lease failure=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_services_effects_test.go
+++ b/internal/providersync/pagerduty_services_effects_test.go
@@ -1,0 +1,138 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "services")
+	now := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	service, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{
+		ID: "PS1", Name: "Payments", EscalationPolicy: &pagerDutyServiceReference{ID: "PE1"},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := service
+	foreign.OrgID = "org-other"
+	if err := fillPagerDutyServiceOrdering(&foreign); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := service
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyServiceOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutyServicesClickHouseEffects{}).providerInstance(service.ProviderInstanceID, foreignInstance.ProviderInstanceID); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := service
+	tampered.Name = "forged"
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{service, service}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate service error=%v", err)
+	}
+
+	mapping, err := pagerDutyServiceMappingFromReference(
+		service, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"},
+		pagerDutyMappingMetadata, now, "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreignMapping := mapping
+	foreignMapping.OrgID = "org-other"
+	if err := validatePagerDutyServiceMappingRows(claim, []pagerDutyServiceRepositoryMappingRow{foreignMapping}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign mapping tenant error=%v", err)
+	}
+	foreignMapping = mapping
+	foreignMapping.ProviderInstanceID = "other"
+	if err := fillPagerDutyServiceMappingOrdering(&foreignMapping); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceMappingRows(claim, []pagerDutyServiceRepositoryMappingRow{foreignMapping}); err != nil {
+		t.Fatalf("mapping instance structural validation: %v", err)
+	}
+	badMapping := mapping
+	badMapping.RelationshipProvenance = stringPtr("admin_configuration")
+	if err := fillPagerDutyServiceMappingOrdering(&badMapping); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceMappingRows(claim, []pagerDutyServiceRepositoryMappingRow{badMapping}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mapping provenance tamper error=%v", err)
+	}
+}
+
+func TestPagerDutyServicesTombstonesAdvanceVersionsAndPreserveMappingOwnership(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "services")
+	now := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	service, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS1", Name: "Payments"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceTombstone, err := pagerDutyServiceTombstone(service, service.SourceVersionAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if serviceTombstone.ID != service.ID || serviceTombstone.ExternalID != service.ExternalID ||
+		!serviceTombstone.SourceVersionAt.Equal(service.SourceVersionAt.Add(time.Microsecond)) ||
+		!serviceTombstone.ObservedAt.Equal(serviceTombstone.SourceVersionAt) ||
+		!serviceTombstone.LastSynced.Equal(serviceTombstone.SourceVersionAt) || !serviceTombstone.IsDeleted ||
+		serviceTombstone.DeletedAt == nil || !serviceTombstone.DeletedAt.Equal(serviceTombstone.SourceVersionAt) ||
+		serviceTombstone.SourceRevision == nil || serviceTombstone.SourceRevision.Cmp(service.SourceRevision) <= 0 {
+		t.Fatalf("service tombstone=%+v", serviceTombstone)
+	}
+	if got := new(big.Int).And(new(big.Int).Rsh(new(big.Int).Set(serviceTombstone.SourceRevision), 56), big.NewInt(255)); got.Cmp(big.NewInt(2)) != 0 {
+		t.Fatalf("service tombstone operation rank=%s want 2", got)
+	}
+	mapping, err := pagerDutyServiceMappingFromReference(
+		service, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"},
+		pagerDutyMappingMetadata, now, "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingTombstone, err := pagerDutyServiceMappingTombstone(mapping, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mappingTombstone.ID != mapping.ID || mappingTombstone.IsActive || mappingTombstone.ValidTo == nil ||
+		!mappingTombstone.ValidTo.Equal(now) || !mappingTombstone.ObservedAt.Equal(now) ||
+		!mappingTombstone.LastSynced.Equal(now) ||
+		!mappingTombstone.SourceVersionAt.Equal(mapping.SourceVersionAt.Add(time.Microsecond)) ||
+		mappingTombstone.SourceRevision == nil || mappingTombstone.SourceRevision.Cmp(mapping.SourceRevision) <= 0 ||
+		mappingTombstone.SourceEntityType != string(pagerDutyMappingMetadata) {
+		t.Fatalf("mapping tombstone=%+v", mappingTombstone)
+	}
+	if got := new(big.Int).And(new(big.Int).Rsh(new(big.Int).Set(mappingTombstone.SourceRevision), 56), big.NewInt(255)); got.Cmp(big.NewInt(2)) != 0 {
+		t.Fatalf("mapping tombstone operation rank=%s want 2", got)
+	}
+}
+
+func TestPagerDutyServicesEffectsRejectUnsafeEmptySnapshotAndWrongDestination(t *testing.T) {
+	if _, err := (PagerDutyServicesClickHouseEffects{}).providerInstance(); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+	claim := nativeTestClaim("pagerduty", "services")
+	sink := PagerDutyServicesClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_services"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("nil context error=%v", err)
+	}
+	if err := sink.WriteEffect(context.Background(), claim, EffectBatch{Destination: "other"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_services_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_services_generic_oracle_test.go
@@ -1,0 +1,71 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyServiceRowForOracle(t *testing.T, input map[string]any) pagerDutyServiceRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutyServicePayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "services")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyService(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload, observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyServiceCases() []oracleCase {
+	return []oracleCase{
+		{ID: "updated_html_url_policy", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS1", "type": "service", "name": "Payments", "summary": "Ignored",
+				"updated_at":        "2026-08-01T10:00:00.123456Z",
+				"html_url":          "https://acme.pagerduty.com/services/PS1",
+				"escalation_policy": map[string]any{"id": "PE1", "type": "escalation_policy"},
+			},
+		}},
+		{ID: "created_self_url_summary", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS2", "type": "service", "summary": "Support",
+				"created_at": "2026-07-31T09:00:00Z", "self": "/services/PS2",
+			},
+		}},
+		{ID: "observed_time_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload":     map[string]any{"id": "PS3", "type": "service", "name": "Operations"},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyServiceRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/services/row", oraclePagerDutyServiceCases(),
+		buildPagerDutyServiceRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_services_route.go
+++ b/internal/providersync/pagerduty_services_route.go
@@ -1,0 +1,684 @@
+package providersync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyServicesMaxPages = 10_000
+	pagerDutyServicesMaxRows  = 100_000
+	pagerDutyServicesPerPage  = 100
+)
+
+// pagerDutyServicePayload is the provider-owned subset consumed by
+// PagerDutyNormalizer.service. Raw is retained only for the separate,
+// evidence-preserving repository-mapping producer below; it is never emitted
+// as a generic provider result or effect row.
+type pagerDutyServicePayload struct {
+	ID               string                     `json:"id"`
+	Name             string                     `json:"name"`
+	Summary          string                     `json:"summary"`
+	SelfURL          string                     `json:"self"`
+	HTMLURL          string                     `json:"html_url"`
+	CreatedAt        string                     `json:"created_at"`
+	UpdatedAt        string                     `json:"updated_at"`
+	EscalationPolicy *pagerDutyServiceReference `json:"escalation_policy"`
+}
+
+type pagerDutyServiceReference struct {
+	ID string `json:"id"`
+}
+
+// pagerDutyServiceRow mirrors every field on Python's OperationalService
+// dataclass. Service rows and repository-mapping rows are deliberately
+// separate typed effects: service_repository_mapping.py owns mapping
+// provenance and this producer does not fold that evidence into service rows.
+type pagerDutyServiceRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	Name                   string     `json:"name"`
+	Description            *string    `json:"description"`
+	ServiceType            *string    `json:"service_type"`
+	OwningTeamID           *string    `json:"owning_team_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+// pagerDutyServiceRepositoryMappingRow is the typed counterpart of
+// ServiceRepositoryMapping. Its SourceEntityType is the mapping source enum
+// value (admin_configuration, pagerduty_service_metadata,
+// compass_service_catalog, or bounded_service_repository_heuristic), not the
+// service source type. This preserves the Python producer's provenance
+// ownership and lets the sink reconcile each source independently.
+type pagerDutyServiceRepositoryMappingRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ServiceID              string     `json:"service_id"`
+	RepoID                 *uuid.UUID `json:"repo_id"`
+	RepoFullName           *string    `json:"repo_full_name"`
+	RepoProvider           *string    `json:"repo_provider"`
+	MappingKind            *string    `json:"mapping_kind"`
+	RuleID                 *string    `json:"rule_id"`
+	ValidFrom              *time.Time `json:"valid_from"`
+	ValidTo                *time.Time `json:"valid_to"`
+	IsActive               bool       `json:"is_active"`
+}
+
+type PagerDutyServicesRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutyServicesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyServicesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutyServicesRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutyServicesMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutyServicesMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyServicesPerPage
+	}
+	if pages < 1 || pages > pagerDutyServicesMaxPages || rows < 1 ||
+		rows > pagerDutyServicesMaxRows || perPage < 1 || perPage > pagerDutyServicesPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutyServicesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "services" ||
+		client == nil || client.Provider != "pagerduty" || client.BaseURL == nil ||
+		normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyServicesCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/services", DataKey: "services", PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	services := make([]pagerDutyServiceRow, 0, len(pages.Items))
+	mappings := make([]pagerDutyServiceRepositoryMappingRow, 0)
+	inputs := pagerDutyServiceRepositoryMappingInputsFromOptions(claim.DatasetOptions)
+	for _, raw := range pages.Items {
+		var payload pagerDutyServicePayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		service, err := normalizePagerDutyService(claim, providerInstance, payload, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		services = append(services, service)
+		var metadata map[string]any
+		if err := json.Unmarshal(raw, &metadata); err != nil || metadata == nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		serviceMappings, err := pagerDutyServiceMappings(
+			service, metadata, normalizedAt, inputs,
+		)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		mappings = append(mappings, serviceMappings...)
+	}
+	mappings = selectPagerDutyPreferredMappings(mappings)
+	serviceEffect, err := effectBatchFromValues(
+		"operational_services", EffectReadbackRequired, services,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	mappingEffect, err := effectBatchFromValues(
+		"operational_service_repository_mappings", EffectReadbackRequired, mappings,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{serviceEffect, mappingEffect},
+		Result: map[string]any{
+			"services_synced": len(services), "service_repository_mappings_synced": len(mappings),
+		},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(services), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutyService(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyServicePayload,
+	normalizedAt time.Time,
+) (pagerDutyServiceRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyServiceRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyServiceSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyServiceRow{}, err
+	}
+	var sourceURL *string
+	if payload.HTMLURL != "" {
+		value := payload.HTMLURL
+		sourceURL = &value
+	} else if payload.SelfURL != "" {
+		value := payload.SelfURL
+		sourceURL = &value
+	}
+	name := payload.Name
+	if name == "" {
+		name = payload.Summary
+	}
+	if name == "" {
+		name = payload.ID
+	}
+	serviceType := "technical"
+	var escalationPolicyID *string
+	if payload.EscalationPolicy != nil && strings.TrimSpace(payload.EscalationPolicy.ID) != "" {
+		value := pagerDutyCanonicalOperationalID(
+			claim.OrgID, "pagerduty", providerInstance,
+			"operational_escalation_policy", strings.TrimSpace(payload.EscalationPolicy.ID),
+		)
+		escalationPolicyID = &value
+	}
+	row := pagerDutyServiceRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "service", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt, Name: name,
+		ServiceType: &serviceType, EscalationPolicyID: escalationPolicyID,
+	}
+	if err := fillPagerDutyServiceOrdering(&row); err != nil {
+		return pagerDutyServiceRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyServiceSourceTime(payload pagerDutyServicePayload, observedAt time.Time) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func fillPagerDutyServiceOrdering(row *pagerDutyServiceRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"name", row.Name},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"service_type", jiraStringValue(row.ServiceType)},
+		jiraOperationalField{"owning_team_id", jiraStringValue(row.OwningTeamID)},
+		jiraOperationalField{"escalation_policy_id", jiraStringValue(row.EscalationPolicyID)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_service", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	if row.IsDeleted {
+		row.SourceRevision, err = pagerDutyOperationalTombstoneRevision(sourceRevision, conflict)
+		if err != nil {
+			return err
+		}
+	}
+	row.OrderingContract = 2
+	return nil
+}
+
+func pagerDutyOperationalTombstoneRevision(sourceRevision *big.Int, conflict string) (*big.Int, error) {
+	if sourceRevision == nil || conflict == "" {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	conflictBytes, err := hex.DecodeString(conflict)
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	revisionDigest := sha256.Sum256(append([]byte("operational-source-revision-v1"), conflictBytes...))
+	timestamp := new(big.Int).Rsh(new(big.Int).Set(sourceRevision), 64)
+	rank := new(big.Int).Lsh(big.NewInt(2), 56)
+	revision := new(big.Int).Lsh(timestamp, 64)
+	revision.Or(revision, rank)
+	revision.Or(revision, new(big.Int).SetBytes(revisionDigest[:7]))
+	return revision, nil
+}
+
+func pagerDutyServiceTombstone(row pagerDutyServiceRow, observedAt time.Time) (pagerDutyServiceRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyServiceRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	if previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond); version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt, row.ObservedAt, row.LastSynced = version, version, version
+	row.IsDeleted = true
+	row.DeletedAt = &version
+	row.SourceRevision, row.SourceConflictKey, row.IngestRevision = nil, "", nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyServiceOrdering(&row); err != nil {
+		return pagerDutyServiceRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyCanonicalOperationalID(orgID, provider, instance, family, externalID string) string {
+	quoted := []string{
+		strconv.QuoteToASCII(orgID), strconv.QuoteToASCII(provider),
+		strconv.QuoteToASCII(instance), strconv.QuoteToASCII(family),
+		strconv.QuoteToASCII(externalID),
+	}
+	digest := sha256.Sum256([]byte("[" + strings.Join(quoted, ",") + "]"))
+	return hex.EncodeToString(digest[:])
+}
+
+type pagerDutyServiceMappingSource string
+
+const (
+	pagerDutyMappingAdmin     pagerDutyServiceMappingSource = "admin_configuration"
+	pagerDutyMappingMetadata  pagerDutyServiceMappingSource = "pagerduty_service_metadata"
+	pagerDutyMappingCompass   pagerDutyServiceMappingSource = "compass_service_catalog"
+	pagerDutyMappingHeuristic pagerDutyServiceMappingSource = "bounded_service_repository_heuristic"
+)
+
+func (source pagerDutyServiceMappingSource) confidence() float64 {
+	switch source {
+	case pagerDutyMappingAdmin:
+		return 1
+	case pagerDutyMappingMetadata:
+		return 0.95
+	case pagerDutyMappingCompass:
+		return 0.9
+	default:
+		return 0.4
+	}
+}
+
+func (source pagerDutyServiceMappingSource) mappingKind() string {
+	if source == pagerDutyMappingHeuristic {
+		return string(source)
+	}
+	return string(source) + "_exact"
+}
+
+func (source pagerDutyServiceMappingSource) ruleID() string {
+	switch source {
+	case pagerDutyMappingAdmin:
+		return "service_repository_mapping.admin.v1"
+	case pagerDutyMappingMetadata:
+		return "pagerduty.service_metadata.repository_url_or_key.v1"
+	case pagerDutyMappingCompass:
+		return "compass.service_repository_relationship.v1"
+	default:
+		return "pagerduty.service_repository.bounded_name_match.v1"
+	}
+}
+
+type pagerDutyServiceRepositoryReference struct {
+	Provider string
+	FullName string
+}
+
+type pagerDutyServiceMappingInputs struct {
+	Admin   map[string][]pagerDutyServiceRepositoryReference
+	Compass map[string][]pagerDutyServiceRepositoryReference
+}
+
+func pagerDutyServiceRepositoryMappingInputsFromOptions(options map[string]any) pagerDutyServiceMappingInputs {
+	inputs := pagerDutyServiceMappingInputs{
+		Admin:   map[string][]pagerDutyServiceRepositoryReference{},
+		Compass: map[string][]pagerDutyServiceRepositoryReference{},
+	}
+	config, ok := options["service_repository_mappings"].(map[string]any)
+	if !ok {
+		return inputs
+	}
+	inputs.Admin = pagerDutyParseServiceRepositoryReferences(config["admin"])
+	inputs.Compass = pagerDutyParseServiceRepositoryReferences(config["compass"])
+	return inputs
+}
+
+func pagerDutyParseServiceRepositoryReferences(value any) map[string][]pagerDutyServiceRepositoryReference {
+	result := map[string][]pagerDutyServiceRepositoryReference{}
+	services, ok := value.(map[string]any)
+	if !ok {
+		return result
+	}
+	for serviceID, rawReferences := range services {
+		entries, ok := rawReferences.([]any)
+		if !ok {
+			continue
+		}
+		for _, rawEntry := range entries {
+			entry, ok := rawEntry.(map[string]any)
+			if !ok {
+				continue
+			}
+			provider, providerOK := entry["provider"].(string)
+			fullName, fullNameOK := entry["full_name"].(string)
+			if providerOK && fullNameOK && provider != "" && fullName != "" {
+				result[serviceID] = append(result[serviceID], pagerDutyServiceRepositoryReference{Provider: provider, FullName: fullName})
+			}
+		}
+	}
+	return result
+}
+
+var (
+	pagerDutyGitHubRepositoryURL = regexp.MustCompile(`https?://(?:www\.)?github\.com/([^/\s]+)/([^/#?\s]+)`)
+	pagerDutyGitLabRepositoryURL = regexp.MustCompile(`https?://(?:www\.)?gitlab\.com/([^\s]+)/?$`)
+)
+
+func pagerDutyServiceMappings(
+	service pagerDutyServiceRow,
+	metadata map[string]any,
+	observedAt time.Time,
+	inputs pagerDutyServiceMappingInputs,
+) ([]pagerDutyServiceRepositoryMappingRow, error) {
+	references := pagerDutyMetadataRepositoryReferences(metadata)
+	values := make([]pagerDutyServiceRepositoryMappingRow, 0, len(references))
+	for _, reference := range references {
+		row, err := pagerDutyServiceMappingFromReference(service, reference, pagerDutyMappingMetadata, observedAt, "")
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, row)
+	}
+	for _, reference := range inputs.Admin[service.ExternalID] {
+		row, err := pagerDutyServiceMappingFromReference(service, reference, pagerDutyMappingAdmin, observedAt, "")
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, row)
+	}
+	for _, reference := range inputs.Compass[service.ExternalID] {
+		row, err := pagerDutyServiceMappingFromReference(service, reference, pagerDutyMappingCompass, observedAt, "")
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, row)
+	}
+	return values, nil
+}
+
+func pagerDutyMetadataRepositoryReferences(metadata map[string]any) []pagerDutyServiceRepositoryReference {
+	seen := map[pagerDutyServiceRepositoryReference]struct{}{}
+	var walk func(any, string)
+	walk = func(value any, key string) {
+		switch typed := value.(type) {
+		case string:
+			if match := pagerDutyGitHubRepositoryURL.FindStringSubmatch(typed); len(match) == 3 {
+				seen[pagerDutyServiceRepositoryReference{Provider: "github", FullName: strings.TrimSuffix(match[1]+"/"+match[2], ".git")}] = struct{}{}
+			}
+			if match := pagerDutyGitLabRepositoryURL.FindStringSubmatch(typed); len(match) == 2 {
+				seen[pagerDutyServiceRepositoryReference{Provider: "gitlab", FullName: strings.TrimSuffix(match[1], ".git")}] = struct{}{}
+			}
+			if (key == "repo" || key == "repository" || key == "repository_slug" || key == "repo_slug") && strings.Count(typed, "/") == 1 {
+				seen[pagerDutyServiceRepositoryReference{Provider: "github", FullName: strings.TrimSuffix(typed, ".git")}] = struct{}{}
+			}
+		case map[string]any:
+			for nestedKey, nestedValue := range typed {
+				walk(nestedValue, strings.ToLower(nestedKey))
+			}
+		case []any:
+			for _, nestedValue := range typed {
+				walk(nestedValue, key)
+			}
+		}
+	}
+	walk(metadata, "")
+	values := make([]pagerDutyServiceRepositoryReference, 0, len(seen))
+	for reference := range seen {
+		values = append(values, reference)
+	}
+	slicesSortPagerDutyReferences(values)
+	return values
+}
+
+func slicesSortPagerDutyReferences(values []pagerDutyServiceRepositoryReference) {
+	for index := 1; index < len(values); index++ {
+		current := values[index]
+		position := index
+		for position > 0 && (values[position-1].Provider > current.Provider ||
+			(values[position-1].Provider == current.Provider && values[position-1].FullName > current.FullName)) {
+			values[position] = values[position-1]
+			position--
+		}
+		values[position] = current
+	}
+}
+
+func pagerDutyServiceMappingFromReference(
+	service pagerDutyServiceRow,
+	reference pagerDutyServiceRepositoryReference,
+	source pagerDutyServiceMappingSource,
+	observedAt time.Time,
+	ruleIDOverride string,
+) (pagerDutyServiceRepositoryMappingRow, error) {
+	ruleID := source.ruleID()
+	if ruleIDOverride != "" {
+		ruleID = ruleIDOverride
+	}
+	fullName, provider := reference.FullName, reference.Provider
+	mappingKind, provenance, confidence := source.mappingKind(), string(source), source.confidence()
+	sourceEventID := "pagerduty_sync"
+	row := pagerDutyServiceRepositoryMappingRow{
+		OrgID: service.OrgID, Provider: service.Provider, ProviderInstanceID: service.ProviderInstanceID,
+		SourceEntityType: string(source),
+		ExternalID:       service.ExternalID + ":" + provider + ":" + fullName + ":" + ruleID,
+		SourceVersionAt:  observedAt, SourceURL: service.SourceURL, SourceEventID: &sourceEventID,
+		ObservedAt: observedAt, LastSynced: observedAt, RelationshipProvenance: &provenance,
+		RelationshipConfidence: &confidence, ServiceID: service.ID,
+		RepoFullName: &fullName, RepoProvider: &provider, MappingKind: &mappingKind,
+		RuleID: &ruleID, ValidFrom: &observedAt, IsActive: true,
+	}
+	if err := fillPagerDutyServiceMappingOrdering(&row); err != nil {
+		return pagerDutyServiceRepositoryMappingRow{}, err
+	}
+	return row, nil
+}
+
+func selectPagerDutyPreferredMappings(values []pagerDutyServiceRepositoryMappingRow) []pagerDutyServiceRepositoryMappingRow {
+	preferred := map[string]pagerDutyServiceRepositoryMappingRow{}
+	for _, value := range values {
+		key := value.ServiceID + "\x00" + pointerString(value.RepoProvider) + "\x00" + pointerString(value.RepoFullName)
+		current, exists := preferred[key]
+		if !exists || (value.RelationshipConfidence != nil && current.RelationshipConfidence != nil && *value.RelationshipConfidence > *current.RelationshipConfidence) {
+			preferred[key] = value
+		}
+	}
+	result := make([]pagerDutyServiceRepositoryMappingRow, 0, len(preferred))
+	for _, value := range preferred {
+		result = append(result, value)
+	}
+	for index := 1; index < len(result); index++ {
+		current := result[index]
+		position := index
+		for position > 0 && pagerDutyMappingSortKey(result[position-1]) > pagerDutyMappingSortKey(current) {
+			result[position] = result[position-1]
+			position--
+		}
+		result[position] = current
+	}
+	return result
+}
+
+func pagerDutyMappingSortKey(row pagerDutyServiceRepositoryMappingRow) string {
+	return row.ServiceID + "\x00" + pointerString(row.RepoProvider) + "\x00" + pointerString(row.RepoFullName)
+}
+
+func pointerString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func fillPagerDutyServiceMappingOrdering(row *pagerDutyServiceRepositoryMappingRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	var repoID any
+	if row.RepoID != nil {
+		repoID = *row.RepoID
+	}
+	fields = append(fields,
+		jiraOperationalField{"service_id", row.ServiceID}, jiraOperationalField{"repo_id", repoID},
+		jiraOperationalField{"repo_full_name", jiraStringValue(row.RepoFullName)},
+		jiraOperationalField{"repo_provider", jiraStringValue(row.RepoProvider)},
+		jiraOperationalField{"mapping_kind", jiraStringValue(row.MappingKind)},
+		jiraOperationalField{"rule_id", jiraStringValue(row.RuleID)},
+		jiraOperationalField{"valid_from", jiraTimeValue(row.ValidFrom)},
+		jiraOperationalField{"valid_to", jiraTimeValue(row.ValidTo)},
+		jiraOperationalField{"is_active", row.IsActive},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_service_repository_mapping", row.OrgID, row.Provider,
+		row.ProviderInstanceID, row.ExternalID, row.SourceVersionAt,
+		row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	if !row.IsActive {
+		row.SourceRevision, err = pagerDutyOperationalTombstoneRevision(sourceRevision, conflict)
+		if err != nil {
+			return err
+		}
+	}
+	row.OrderingContract = 2
+	return nil
+}
+
+var _ CompleteRouteHandler = PagerDutyServicesRouteHandler{}

--- a/internal/providersync/pagerduty_services_route_test.go
+++ b/internal/providersync/pagerduty_services_route_test.go
@@ -1,0 +1,206 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyServicesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutyServicesDoer struct {
+	t         *testing.T
+	responses []pagerDutyServicesResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyServicesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutyServicesRouteBuildsTypedServicesAndSeparateMappingEffects(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{
+		{body: `{"services":[
+			{"id":"PS1","type":"service","name":"Payments","summary":"Ignored","updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/services/PS1","escalation_policy":{"id":"PE1"},"metadata":{"repository":"https://github.com/full-chaos/payments"}},
+			{"id":"PS2","type":"service","summary":"Support","created_at":"2026-07-31T09:00:00Z","self":"/services/PS2"}],"more":true}`},
+		{body: `{"services":[{"id":"PS3","type":"service","name":"Operations","repo":"full-chaos/operations"}],"more":false}`},
+	}}
+	client := pagerDutyServicesTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "services")
+	claim.DatasetOptions = map[string]any{
+		"service_repository_mappings": map[string]any{
+			"admin": map[string]any{
+				"PS1": []any{map[string]any{"provider": "github", "full_name": "full-chaos/payments"}},
+			},
+			"compass": map[string]any{
+				"PS2": []any{map[string]any{"provider": "gitlab", "full_name": "full-chaos/support"}},
+			},
+		},
+	}
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "}}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyServicesRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 2 || batch.Effects[0].Destination != "operational_services" ||
+		batch.Effects[1].Destination != "operational_service_repository_mappings" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || batch.Effects[1].Recovery != EffectReadbackRequired ||
+		len(batch.Effects[0].Rows) != 3 || len(batch.Effects[1].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 || batch.Evidence.CapReached {
+		t.Fatalf("evidence=%+v", batch.Evidence)
+	}
+	if doer.requests[0].URL.Path != "/services" || doer.requests[0].URL.RawQuery != "limit=100&offset=0" ||
+		doer.requests[1].URL.RawQuery != "limit=100&offset=2" {
+		t.Fatalf("requests=%v", doer.requests)
+	}
+	var service pagerDutyServiceRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &service); err != nil {
+		t.Fatal(err)
+	}
+	if service.Provider != "pagerduty" || service.ProviderInstanceID != "acme" ||
+		service.SourceEntityType != "service" || service.ExternalID != "PS1" || service.Name != "Payments" ||
+		service.ServiceType == nil || *service.ServiceType != "technical" || service.EscalationPolicyID == nil ||
+		*service.EscalationPolicyID != pagerDutyCanonicalOperationalID(claim.OrgID, "pagerduty", "acme", "operational_escalation_policy", "PE1") ||
+		service.SourceURL == nil || *service.SourceURL != "https://acme.pagerduty.com/services/PS1" ||
+		!service.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!service.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) {
+		t.Fatalf("service=%+v", service)
+	}
+	var mapping pagerDutyServiceRepositoryMappingRow
+	if err := json.Unmarshal(batch.Effects[1].Rows[0], &mapping); err != nil {
+		t.Fatal(err)
+	}
+	if mapping.SourceEntityType != string(pagerDutyMappingAdmin) || mapping.RelationshipConfidence == nil ||
+		*mapping.RelationshipConfidence != 1 || mapping.RepoProvider == nil || *mapping.RepoProvider != "github" ||
+		mapping.RepoFullName == nil || *mapping.RepoFullName != "full-chaos/payments" ||
+		mapping.ServiceID != service.ID || mapping.ValidFrom == nil || !mapping.IsActive ||
+		mapping.SourceEventID == nil || *mapping.SourceEventID != "pagerduty_sync" {
+		t.Fatalf("mapping=%+v", mapping)
+	}
+}
+
+func TestPagerDutyServicesRouteRejectsAnotherPagerDutyDataset(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "teams")
+	client := pagerDutyServicesTestClient(t, &pagerDutyServicesDoer{t: t}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err := (PagerDutyServicesRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong dataset error=%v", err)
+	}
+}
+
+func TestPagerDutyServicesRouteUsesProviderIDWhenNamesAreAbsent(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "services")
+	row, err := normalizePagerDutyService(
+		claim, "acme", pagerDutyServicePayload{ID: "PS-fallback"},
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Name != "PS-fallback" {
+		t.Fatalf("name=%q", row.Name)
+	}
+}
+
+func TestPagerDutyServicesRoutePreservesRetryAuthCapAndLeaseSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "services")
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	clientRetryDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{
+		{status: http.StatusTooManyRequests, headers: http.Header{"Retry-After": {"0"}}, body: `{"message":"slow down"}`},
+		{body: `{"services":[],"more":false}`},
+	}}
+	retryClient := pagerDutyServicesTestClient(t, clientRetryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutyServicesRouteHandler{}).Collect(context.Background(), claim, credential, retryClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	if err != nil || len(clientRetryDoer.requests) != 2 || len(batch.Effects) != 2 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(clientRetryDoer.requests))
+	}
+	authDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{{status: http.StatusUnauthorized, body: `{"message":"bad token"}`}}}
+	authClient := pagerDutyServicesTestClient(t, authDoer, providerfoundation.RetryPolicy{MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err = (PagerDutyServicesRouteHandler{}).Collect(context.Background(), claim, credential, authClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication || len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+	capDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{{body: `{"services":[{"id":"one"}],"more":true}`}}}
+	capClient := pagerDutyServicesTestClient(t, capDoer, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err = (PagerDutyServicesRouteHandler{MaxPages: 1}).Collect(context.Background(), claim, credential, capClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	leaseDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{
+		{body: `{"services":[{"id":"one"}],"more":true}`}, {body: `{"services":[],"more":false}`},
+	}}
+	asserts := 0
+	leaseClient, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", leaseDoer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutyServicesRouteHandler{}).Collect(context.Background(), claim, credential, leaseClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(leaseDoer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(leaseDoer.requests), asserts)
+	}
+}
+
+func pagerDutyServicesTestClient(t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}

--- a/internal/providersync/testdata/mutation-plans/pagerduty_on-calls.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_on-calls.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty on-call assignment route, typed normalization, upsert effects, and readback fencing",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "This provider-only plan covers PagerDuty on-calls source selection, stable composite identities, complete typed row normalization, migrated assignment writes, upsert replay, and account fencing. It does not cover schedules, registry, matrix, config, deployment, cutover, or activation wiring. The ClickHouse entries require Docker and run against migration 066 through the real integration test.",
+  "mutations": [
+    {
+      "id": "OC1-route-rejects-other-dataset",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "claim.Dataset != \"on-calls\"",
+      "replace": "false",
+      "rationale": "The on-calls handler must not consume a schedules claim; removing this clause would send the wrong dataset to /oncalls and emit assignment effects under the wrong contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteRejectsAnotherPagerDutyDataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC2-route-uses-oncalls-path",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "Path: \"/oncalls\"",
+      "replace": "Path: \"/schedules\"",
+      "rationale": "PagerDuty on-call assignments are selected from the /oncalls endpoint; a sibling resource endpoint would silently collect the wrong provider resource family.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC3-route-uses-oncalls-response-key",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "DataKey: \"oncalls\"",
+      "replace": "DataKey: \"schedules\"",
+      "rationale": "The response collection key is part of the PagerDuty REST contract; reading a sibling key must fail closed instead of returning an empty successful assignment batch.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC4-composite-external-id-keeps-all-dimensions",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "payload.EscalationPolicy.ID, scheduleID, payload.User.ID,",
+      "replace": "payload.User.ID, scheduleID, payload.User.ID,",
+      "rationale": "The live Python normalizer's no-provider-id fallback is keyed by policy, schedule, user, level, and window. Dropping the policy dimension makes distinct assignments collide and diverges from the producer.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC5-composite-external-id-preserves-python-time-format",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "return value.Format(\"2006-01-02T15:04:05-07:00\")",
+      "replace": "return value.Format(\"2006-01-02T15:04:05Z07:00\")",
+      "rationale": "Python datetime.isoformat emits +00:00 for UTC permanent-window dimensions. Replacing it with a Z-formatted value changes the stable external identity and must be caught by the live oracle.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC6-reference-id-uses-schedule-family",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "\"operational_on_call_schedule\"",
+      "replace": "\"operational_on_call_assignment\"",
+      "rationale": "Nested schedule references use the canonical operational_on_call_schedule entity family. Reusing the assignment family produces a different ID and breaks cross-provider relationship parity.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC7-source-url-prefers-html-url",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "value := payload.HTMLURL\n\tif value == \"\" {\n\t\tvalue = payload.SelfURL\n\t}",
+      "replace": "value := payload.SelfURL\n\tif value == \"\" {\n\t\tvalue = payload.HTMLURL\n\t}",
+      "rationale": "The Python producer emits html_url before self. Reversing the precedence changes persisted source evidence whenever both provider URLs are present.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC8-effect-fences-mixed-provider-instances",
+      "file": "internal/providersync/pagerduty_oncalls_effects_clickhouse.go",
+      "find": "if instance != rowInstance {",
+      "replace": "if false {",
+      "rationale": "One effect batch must belong to one PagerDuty account. Accepting rows from mixed instances would make the sink's account fence arbitrary and unsafe.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsEffectRejectsForeignScopeOrderingTamperAndDuplicates$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC9-effect-rejects-source-conflict-tamper",
+      "file": "internal/providersync/pagerduty_oncalls_effects_clickhouse.go",
+      "find": "canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||",
+      "replace": "canonical.ID != row.ID || false ||",
+      "rationale": "The durable effect must reject forged source conflict keys even when the semantic row fields and derived revision otherwise look unchanged; otherwise readback identity can be falsified.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsEffectRejectsForeignScopeOrderingTamperAndDuplicates$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC10-effect-writes-migrated-assignment-table",
+      "file": "internal/providersync/pagerduty_oncalls_effects_clickhouse.go",
+      "find": "INSERT INTO operational_on_call_assignments (",
+      "replace": "INSERT INTO operational_on_call_schedules (",
+      "rationale": "The effect must write the migrated operational_on_call_assignments schema, not the separate schedules table. A table-family mutation must fail the real migration-backed write before any success claim.",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyOnCallsEffectUsesMigratedClickHouseUpsertsAndExactReplay$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/pagerduty_services.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_services.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty services typed parity, repository-mapping ownership, and complete snapshots",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "This plan covers the dormant PagerDuty services provider route, its separate service-repository mapping effect, live Python row oracles, tenant/account fences, ordering, and migrated ClickHouse integration proof. Registry, route-switch, matrix, config, deployment, and activation wiring remain intentionally outside this provider-only slice.",
+  "mutations": [
+    {
+      "id": "S1-services-route-dataset-fence",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "claim.Dataset != \"services\"",
+      "replace": "false",
+      "rationale": "The services handler must reject every other PagerDuty dataset; otherwise a teams or users claim could be fetched from /services and committed under the wrong source entity type.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteRejectsAnotherPagerDutyDataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2-service-name-id-fallback",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "if name == \"\" {\n\t\tname = payload.ID\n\t}",
+      "replace": "if false {\n\t\tname = payload.ID\n\t}",
+      "rationale": "Python falls back from name and summary to the provider id. Removing that clause emits an empty canonical service name and diverges from the live normalizer.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteUsesProviderIDWhenNamesAreAbsent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S3-service-escalation-policy-reference",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "if payload.EscalationPolicy != nil && strings.TrimSpace(payload.EscalationPolicy.ID) != \"\" {",
+      "replace": "if false && strings.TrimSpace(payload.EscalationPolicy.ID) != \"\" {",
+      "rationale": "The service normalizer must preserve the canonical operational escalation-policy reference when PagerDuty includes one; dropping this clause loses a typed relationship field.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteBuildsTypedServicesAndSeparateMappingEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S4-mapping-precedence-admin-over-metadata",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "*value.RelationshipConfidence > *current.RelationshipConfidence",
+      "replace": "*value.RelationshipConfidence < *current.RelationshipConfidence",
+      "rationale": "Python retains the highest-confidence evidence for each service/repository pair. Reversing this clause would let metadata or Compass evidence override explicit admin ownership.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteBuildsTypedServicesAndSeparateMappingEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S5-service-tombstone-version-bump",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)",
+      "replace": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(0)",
+      "rationale": "A complete snapshot with an observation time equal to the prior version must still produce a strictly newer ReplacingMergeTree tombstone.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesTombstonesAdvanceVersionsAndPreserveMappingOwnership$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S6-mapping-tombstone-version-bump",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)",
+      "replace": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(0)",
+      "rationale": "Mapping evidence has its own active/inactive lifecycle; its deactivation must win the source-version race independently of service tombstones.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesTombstonesAdvanceVersionsAndPreserveMappingOwnership$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S7-service-tenant-fence",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "if row.OrgID != claim.OrgID || row.Provider != \"pagerduty\" ||\n\t\t\trow.ProviderInstanceID == \"\" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||\n\t\t\trow.SourceEntityType != \"service\"",
+      "replace": "if false || row.Provider != \"pagerduty\" ||\n\t\t\trow.ProviderInstanceID == \"\" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||\n\t\t\trow.SourceEntityType != \"service\"",
+      "rationale": "Every service effect row must remain inside the claimed organization; accepting a foreign org row would cross the analytics tenant boundary.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S8-pagerduty-account-fence",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "if instance != value {",
+      "replace": "if false {",
+      "rationale": "One effect payload must contain one credential-derived PagerDuty account. Allowing mixed subdomains makes active-row queries and tombstones ambiguous across accounts.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S9-mapping-provenance-ownership",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "row.RelationshipProvenance == nil ||\n\t\t\t*row.RelationshipProvenance != row.SourceEntityType",
+      "replace": "row.RelationshipProvenance == nil ||\n\t\t\tfalse",
+      "rationale": "Repository-mapping evidence must retain the source enum as relationship provenance; accepting a different value would erase the ownership boundary between service rows and mapping producers.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S10-service-omitted-row-tombstone",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "allRows := append([]pagerDutyServiceRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; present {\n\t\t\tcontinue\n\t\t}",
+      "replace": "allRows := append([]pagerDutyServiceRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; !present {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "A complete successful services snapshot must tombstone every previously active service omitted by the provider, not leave stale rows active.",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S11-mapping-omitted-row-tombstone",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "allRows := append([]pagerDutyServiceRepositoryMappingRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; present {\n\t\t\tcontinue\n\t\t}",
+      "replace": "allRows := append([]pagerDutyServiceRepositoryMappingRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; !present {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "Mapping reconciliation is an independent complete snapshot. An omitted source mapping must become inactive with valid_to evidence, even when its service row remains present.",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_business-services_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_business-services_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OperationalService))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.BusinessService.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.business_service(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/business-services/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incident-alerts_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incident-alerts_row.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    normalizer = _normalizer(case)
+    parent = normalizer.incident(module.Incident.model_validate(case["incident"]))
+    return asdict(
+        normalizer.alert(module.Alert.model_validate(case["payload"]), parent.id)
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incident-alerts/row",
+        build_row=_build_row,
+        reflected_fields=lambda: frozenset(
+            field.name for field in fields(_module().OperationalAlert)
+        ),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incident-log-entries_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incident-log-entries_row.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    normalizer = _normalizer(case)
+    parent = normalizer.incident(module.Incident.model_validate(case["incident"]))
+    return asdict(
+        normalizer.log_entry(module.LogEntry.model_validate(case["payload"]), parent.id)
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incident-log-entries/row",
+        build_row=_build_row,
+        reflected_fields=lambda: frozenset(
+            field.name for field in fields(_module().IncidentTimelineEvent)
+        ),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incident-notes_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incident-notes_row.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    normalizer = _normalizer(case)
+    parent = normalizer.incident(module.Incident.model_validate(case["incident"]))
+    return asdict(
+        normalizer.note(module.Note.model_validate(case["payload"]), parent.id)
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incident-notes/row",
+        build_row=_build_row,
+        reflected_fields=lambda: frozenset(
+            field.name for field in fields(_module().IncidentNote)
+        ),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incidents_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incidents_row.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _reflected(entity: Any) -> frozenset[str]:
+    return frozenset(field.name for field in fields(entity))
+
+
+def _incident(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).incident(module.Incident.model_validate(case["payload"]))
+    )
+
+
+def _parent_id(case: dict[str, Any]) -> str:
+    module = _module()
+    return (
+        _normalizer(case).incident(module.Incident.model_validate(case["incident"])).id
+    )
+
+
+def _alert(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).alert(
+            module.Alert.model_validate(case["payload"]), _parent_id(case)
+        )
+    )
+
+
+def _log_entry(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).log_entry(
+            module.LogEntry.model_validate(case["payload"]), _parent_id(case)
+        )
+    )
+
+
+def _note(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).note(
+            module.Note.model_validate(case["payload"]), _parent_id(case)
+        )
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incidents/row",
+        build_row=_incident,
+        reflected_fields=lambda: _reflected(_module().OperationalIncident),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_on-calls_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_on-calls_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OnCallAssignment))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.Oncall.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.oncall(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/on-calls/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_schedules_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_schedules_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OnCallSchedule))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.Schedule.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.schedule(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/schedules/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_services_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_services_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OperationalService))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.Service.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.service(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/services/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/tests/tooling/mutation-plans/pagerduty_business_services.json
+++ b/tests/tooling/mutation-plans/pagerduty_business_services.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty business-services typed route and complete-snapshot effects",
+  "$limitation": "This plan covers the provider-owned business-services collection, typed normalization, canonical identity, and ClickHouse complete-snapshot tombstone/readback fences. Executor registration, capability/matrix wiring, route activation, and deployment remain intentionally outside this provider-only slice.",
+  "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+  "mutations": [
+    {
+      "id": "B1-dataset-identity-guard",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "claim.Provider != \"pagerduty\" || claim.Dataset != \"business-services\" ||",
+      "replace": "claim.Provider != \"pagerduty\" || claim.Dataset != \"business-service\" ||",
+      "rationale": "The route must accept exactly the checked-in business-services dataset identity; a singular alias must fail closed rather than collecting under the wrong contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyBusinessServicesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B2-business-services-path",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "Path: \"/business_services\", DataKey: \"business_services\",",
+      "replace": "Path: \"/services\", DataKey: \"business_services\",",
+      "rationale": "PagerDuty business services are collected from the dedicated /business_services endpoint; routing to /services would silently collect a different resource family.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyBusinessServicesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B3-business-services-response-key",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "Path: \"/business_services\", DataKey: \"business_services\",",
+      "replace": "Path: \"/business_services\", DataKey: \"services\",",
+      "rationale": "The response key is part of PagerDuty's typed page contract; accepting the wrong key would turn a non-empty source response into an unproven empty snapshot.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyBusinessServicesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B4-description-preserved",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "Description: payload.Description, ServiceType: &serviceType,",
+      "replace": "Description: nil, ServiceType: &serviceType,",
+      "rationale": "Python's business-service normalizer persists the typed source description; dropping it is a row-level parity defect.",
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "B5-business-service-type",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "serviceType := \"business\"",
+      "replace": "serviceType := \"technical\"",
+      "rationale": "Business services share operational_services with technical services but must retain the canonical service_type discriminator.",
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "B6-business-source-family",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "SourceEntityType: \"business_service\", ExternalID: externalID,",
+      "replace": "SourceEntityType: \"service\", ExternalID: externalID,",
+      "rationale": "The source_entity_type separates business-service rows from PagerDuty technical services in the shared ClickHouse table and in complete-snapshot reconciliation.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyBusinessServicesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B7-active-row-filter",
+      "file": "internal/providersync/pagerduty_business_services_effects_clickhouse.go",
+      "find": "FROM operational_services FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "replace": "FROM operational_services FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 1",
+      "rationale": "Complete snapshots must load active business-service rows before writing so omitted rows receive tombstones; selecting deleted rows loses the reconciliation set.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyBusinessServicesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B8-tenant-fence",
+      "file": "internal/providersync/pagerduty_business_services_effects_clickhouse.go",
+      "find": "FROM operational_services FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "replace": "FROM operational_services FINAL WHERE org_id != ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "rationale": "The complete-snapshot active-row read must stay tenant-scoped; weakening org_id equality allows one organization’s PagerDuty snapshot to mutate another’s services.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyBusinessServicesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B9-tombstone-version-bump",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "Add(time.Microsecond)",
+      "replace": "Add(0)",
+      "rationale": "A tombstone observed at the same timestamp as its active row must win ReplacingMergeTree deterministically, so its source version is strictly advanced by one microsecond.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyBusinessServicesTombstoneBumpsSourceVersionAndPreservesIdentity$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B10-instance-scope-fence",
+      "file": "internal/providersync/pagerduty_business_services_effects_clickhouse.go",
+      "find": "if instance != rowInstance {",
+      "replace": "if false && instance != rowInstance {",
+      "rationale": "A batch may not mix PagerDuty account identities; disabling the instance equality fence can merge canonical service rows across accounts.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyBusinessServicesEffectRejectsForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B11-omitted-row-readback-fence",
+      "file": "internal/providersync/pagerduty_business_services_effects_clickhouse.go",
+      "find": "if _, present := seen[row.ID]; !present {",
+      "replace": "if _, present := seen[row.ID]; present {",
+      "rationale": "Readback must reject a snapshot when an active business service remains outside the returned source set; otherwise a partial write can report exact.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyBusinessServicesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "B12-tombstone-state",
+      "file": "internal/providersync/pagerduty_business_services_route.go",
+      "find": "row.IsDeleted = true",
+      "replace": "row.IsDeleted = false",
+      "rationale": "An omitted source row must be persisted as a deleted typed OperationalService tombstone; leaving it active defeats complete-snapshot reconciliation.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyBusinessServicesTombstoneBumpsSourceVersionAndPreservesIdentity$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/pagerduty_incidents.json
+++ b/tests/tooling/mutation-plans/pagerduty_incidents.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty incident family typed route and readback effects",
+  "$limitation": "This plan covers the incidents parent stream, the three typed incident enrichment streams, their window/cap/pagination semantics, and tenant-scoped ClickHouse effects. Services, schedules, on-calls, registry/matrix/config, deployment, and cutover wiring remain outside this provider-only slice.",
+  "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+  "mutations": [
+    {
+      "id": "PI1-dataset-contract",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if claim.Dataset != \"incidents\" && claim.Dataset != \"incident-alerts\" &&",
+      "replace": "if claim.Dataset != \"incident\" && claim.Dataset != \"incident-alerts\" &&",
+      "expect_occurrences": 1,
+      "rationale": "The family route must accept the exact plural incidents dataset contract and fail closed on a singular alias.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI2-parent-path",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "path: \"/incidents\", decode: decodePagerDutyIncidents, paginated: true,",
+      "replace": "path: \"/services\", decode: decodePagerDutyIncidents, paginated: true,",
+      "expect_occurrences": 1,
+      "rationale": "The parent producer owns PagerDuty's /incidents endpoint; requesting another resource family cannot be normalized as an incident inventory.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI3-parent-response-key",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "return envelope.Incidents, *envelope.More, nil",
+      "replace": "return nil, *envelope.More, nil",
+      "expect_occurrences": 1,
+      "rationale": "A non-empty PagerDuty incidents response must remain non-empty after decoding; dropping the typed response slice would report a false empty batch.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI4-parent-pagination-cap",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if result.Pages >= maxPages {",
+      "replace": "if result.Pages > maxPages {",
+      "expect_occurrences": 1,
+      "rationale": "A parent response that advertises another page must fail at the configured page cap rather than issuing an unbounded follow-up request.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteRejectsPaginationCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI5-inclusive-since-cursor",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if claim.SinceAt != nil && createdAt.Before(claim.SinceAt.UTC()) {",
+      "replace": "if claim.SinceAt != nil && !createdAt.Before(claim.SinceAt.UTC()) {",
+      "expect_occurrences": 1,
+      "rationale": "The Python incremental window is inclusive at since; excluding the exact boundary drops a source incident and advances the cursor incorrectly.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteKeepsSinceBoundaryInclusive$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI6-before-window-clause",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "return claim.BeforeAt != nil && createdAt.After(claim.BeforeAt.UTC())",
+      "replace": "return claim.BeforeAt != nil && !createdAt.After(claim.BeforeAt.UTC())",
+      "expect_occurrences": 1,
+      "rationale": "The upper source window is inclusive; treating in-window incidents as outside the window makes a normal non-empty source batch disappear.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI7-child-cap-take",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if take > remaining {\n\t\t\t\ttake = remaining\n\t\t\t}",
+      "replace": "if take > remaining {\n\t\t\t\ttake = 0\n\t\t\t}",
+      "expect_occurrences": 1,
+      "rationale": "An enrichment cap must retain exactly the allowed prefix and clamp the watermark when the child source remains undrained.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteCapsChildrenAndClampsToEarliestUndrainedIncident$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI8-zero-enrichment-cap",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if cap == 0 {\n\t\t\tcontinue\n\t\t}",
+      "replace": "if cap != 0 {\n\t\t\tcontinue\n\t\t}",
+      "expect_occurrences": 1,
+      "rationale": "A zero enrichment cap is a valid bounded mode that reads the parent cursor without making child requests.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteZeroCapReadsParentsWithoutChildRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI9-disabled-enrichment",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if !enabled {\n\t\t\t\treturn handler.emptyPagerDutyIncidentFamilyBatch(claim, 0, 0)",
+      "replace": "if enabled {\n\t\t\t\treturn handler.emptyPagerDutyIncidentFamilyBatch(claim, 0, 0)",
+      "expect_occurrences": 1,
+      "rationale": "A disabled enrichment dataset must short-circuit before any provider request; enabling the branch reverses the source contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteDisabledEnrichmentMakesNoProviderCall$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI10-watermark-clamp-clause",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if earliestUndrained != nil && (watermark == nil || earliestUndrained.Before(*watermark)) {",
+      "replace": "if earliestUndrained != nil && (watermark == nil || earliestUndrained.After(*watermark)) {",
+      "expect_occurrences": 1,
+      "rationale": "When a child cap leaves work behind, the parent watermark must clamp to the earliest undrained incident, never a later one.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteCapsChildrenAndClampsToEarliestUndrainedIncident$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI11-notes-are-not-paginated",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "return pagerDutyIncidentFamilyEndpoint{path: base + \"/notes\", decode: decodePagerDutyNotes, paginated: false}, nil",
+      "replace": "return pagerDutyIncidentFamilyEndpoint{path: base + \"/notes\", decode: decodePagerDutyNotes, paginated: true}, nil",
+      "expect_occurrences": 1,
+      "rationale": "PagerDuty notes use the non-paginated source response contract; adding limit/offset changes the request and can make the source reject or reshape it.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteDoesNotPaginateNotes$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI12-html-url-priority",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if htmlURL != nil && *htmlURL != \"\" {",
+      "replace": "if false && htmlURL != nil && *htmlURL != \"\" {",
+      "expect_occurrences": 1,
+      "rationale": "The common Python normalizer prefers html_url over self; removing that priority changes the canonical source URL for incidents and every child row.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI13-incident-source-event-time",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "SourceEventAt:      createdAt, StartedAt: createdAt, ResolvedAt: resolvedAt,",
+      "replace": "SourceEventAt:      nil, StartedAt: createdAt, ResolvedAt: resolvedAt,",
+      "expect_occurrences": 1,
+      "rationale": "The incident producer's source event time is the created_at timestamp; omitting it changes canonical ordering and loses source evidence.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI14-tenant-scope-fence",
+      "file": "internal/providersync/pagerduty_incidents_effects_clickhouse.go",
+      "find": "if row.OrgID != claim.OrgID || row.Provider != \"pagerduty\" ||\n\t\t\t!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||\n\t\t\trow.SourceEntityType != \"incident\" ||",
+      "replace": "if row.OrgID == claim.OrgID || row.Provider != \"pagerduty\" ||\n\t\t\t!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||\n\t\t\trow.SourceEntityType != \"incident\" ||",
+      "expect_occurrences": 1,
+      "rationale": "Every ClickHouse effect must remain organization-scoped; a correctly ordered row from another tenant must be rejected before any write.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyEffectsValidateEachTypedDestinationAndScope$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/pagerduty_schedules.json
+++ b/tests/tooling/mutation-plans/pagerduty_schedules.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty schedules typed route and complete-snapshot effects",
+  "$limitation": "This plan covers provider-owned schedules collection, typed normalization, canonical identity, complete ClickHouse snapshot tombstones, and readback fences. On-call assignments remain a separate unit. Executor registration, capability/matrix wiring, route activation, and deployment remain outside this provider-only slice.",
+  "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+  "mutations": [
+    {
+      "id": "S1-dataset-identity-guard",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "claim.Provider != \"pagerduty\" || claim.Dataset != \"schedules\" || client == nil ||",
+      "replace": "claim.Provider != \"pagerduty\" || claim.Dataset != \"schedule\" || client == nil ||",
+      "rationale": "The route must accept exactly the schedules dataset identity; a singular alias must fail closed rather than collecting under the wrong contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2-schedules-path",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Path: \"/schedules\", DataKey: \"schedules\",",
+      "replace": "Path: \"/services\", DataKey: \"schedules\",",
+      "rationale": "PagerDuty schedules are collected from the dedicated /schedules endpoint; a different path silently collects a different resource family.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S3-schedules-response-key",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Path: \"/schedules\", DataKey: \"schedules\",",
+      "replace": "Path: \"/schedules\", DataKey: \"services\",",
+      "rationale": "The response key is part of PagerDuty's typed page contract; using the wrong key must not turn non-empty source data into an empty snapshot.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S4-timezone-preserved",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Timezone: payload.TimeZone,",
+      "replace": "Timezone: nil,",
+      "rationale": "Python's schedule normalizer persists the typed time_zone field; dropping it is a row-level parity defect.",
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "S5-schedule-source-family",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "SourceEntityType: \"schedule\", ExternalID: externalID,",
+      "replace": "SourceEntityType: \"service\", ExternalID: externalID,",
+      "rationale": "The source_entity_type distinguishes schedule rows from services and on-call assignments in the canonical source identity.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S6-active-row-filter",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "replace": "FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 1",
+      "rationale": "Complete snapshots must load active schedules before tombstoning omissions; selecting deleted rows loses the reconciliation set.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S7-tenant-fence",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "replace": "FROM operational_on_call_schedules FINAL WHERE org_id != ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "rationale": "Active-row reconciliation must remain organization-scoped; weakening org_id equality allows one tenant's snapshot to mutate another tenant's schedules.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S8-tombstone-version-bump",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Add(time.Microsecond)",
+      "replace": "Add(0)",
+      "rationale": "A tombstone observed at the same timestamp as its active row must win ReplacingMergeTree deterministically by advancing source_version_at.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesTombstoneBumpsSourceVersionAndPreservesIdentity$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S9-instance-scope-fence",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "if instance != rowInstance {",
+      "replace": "if false && instance != rowInstance {",
+      "rationale": "A batch may not mix PagerDuty account identities; disabling this fence can merge canonical schedules across accounts.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesEffectRejectsForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S10-omitted-row-readback-fence",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "if _, present := seen[row.ID]; !present {",
+      "replace": "if _, present := seen[row.ID]; present {",
+      "rationale": "Readback must reject a snapshot when an active schedule remains outside the returned source set; otherwise a partial write can report exact.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S11-tombstone-state",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "row.IsDeleted = true",
+      "replace": "row.IsDeleted = false",
+      "rationale": "An omitted source schedule must be persisted as a deleted typed tombstone; leaving it active defeats complete-snapshot reconciliation.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesTombstoneBumpsSourceVersionAndPreservesIdentity$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S12-source-url-priority",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "if payload.HTMLURL != \"\" {",
+      "replace": "if false && payload.HTMLURL != \"\" {",
+      "rationale": "Python's canonical common normalization prefers html_url and falls back to self; changing that priority produces a field-level parity mismatch.",
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Port PagerDuty business-services using concrete typed `OperationalService` rows, pagination/retry/auth/cap guards, complete-snapshot tombstones, and exact readback/replay.

## Evidence

- Live Python differential oracle
- Real migrated ClickHouse integration
- Shared mutation harness: 12/12 killed with clean restore
- Full providersync, vet, build, Ruff, and mypy green

## Boundaries

- PagerDuty `services` remains separate because it also owns repository-mapping evidence
- No registry, matrix, config, deployment, or cutover wiring

Linear: CHAOS-3726

SCREENSHOT-WAIVER: Backend-only provider implementation; no rendered UI changes.
