### PR TITLE
CHAOS-3729: port PagerDuty teams provider parity

### DIFF
--- a/internal/providersync/pagerduty_teams_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_teams_effects_clickhouse.go
@@ -1,0 +1,325 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const pagerDutyTeamsColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,name,description,is_deleted,deleted_at"
+
+// PagerDutyTeamsClickHouseEffects persists a complete teams snapshot and
+// reconciles active rows omitted from that successful snapshot into Python-
+// compatible tombstones. Every read is fenced by organization, provider
+// instance, and source family.
+type PagerDutyTeamsClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+	Now                func() time.Time
+}
+
+func (sink PagerDutyTeamsClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pagerDutyTeamRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validatePagerDutyTeamRows(claim, rows); err != nil {
+		return err
+	}
+	providerInstance, err := sink.providerInstance(rows)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveTeams(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.snapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyTeamRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyTeamTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(
+		ctx, "INSERT INTO operational_teams ("+pagerDutyTeamsColumns+")",
+	)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyTeamValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyTeamsClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pagerDutyTeamRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validatePagerDutyTeamRows(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	providerInstance, err := sink.providerInstance(expected)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveTeams(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	matched, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadTeam(ctx, claim, providerInstance, row.ID)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		inspection := comparePagerDutyTeamVersion(row, actual, found)
+		switch inspection {
+		case EffectExact:
+			matched++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	if matched == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyTeamsClickHouseEffects) providerInstance(
+	rows []pagerDutyTeamRow,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, row := range rows {
+		rowInstance := strings.ToLower(strings.TrimSpace(row.ProviderInstanceID))
+		if rowInstance == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = rowInstance
+		}
+		if instance != rowInstance {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func (sink PagerDutyTeamsClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "teams" ||
+		effect.Destination != "operational_teams" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func validatePagerDutyTeamRows(claim Claim, rows []pagerDutyTeamRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "team" || row.ExternalID == "" || row.Name == "" ||
+			row.ID == "" || row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyTeamOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyTeamValues(row pagerDutyTeamRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence, row.Name, row.Description, row.IsDeleted,
+		row.DeletedAt,
+	}
+}
+
+func pagerDutyTeamScanValues(row *pagerDutyTeamRow) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.Name, &row.Description, &row.IsDeleted,
+		&row.DeletedAt,
+	}
+}
+
+func (sink PagerDutyTeamsClickHouseEffects) loadActiveTeams(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyTeamRow, error) {
+	rows, err := sink.Conn.Query(
+		ctx,
+		"SELECT "+pagerDutyTeamsColumns+
+			" FROM operational_teams FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+		claim.OrgID, claim.Provider, providerInstance, "team",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	active := make([]pagerDutyTeamRow, 0)
+	for rows.Next() {
+		var row pagerDutyTeamRow
+		if err := rows.Scan(pagerDutyTeamScanValues(&row)...); err != nil {
+			return nil, err
+		}
+		if err := fillPagerDutyTeamOrdering(&row); err != nil {
+			return nil, err
+		}
+		active = append(active, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return active, nil
+}
+
+func (sink PagerDutyTeamsClickHouseEffects) loadTeam(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyTeamRow, bool, error) {
+	rows, err := sink.Conn.Query(
+		ctx,
+		"SELECT "+pagerDutyTeamsColumns+
+			" FROM operational_teams FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "team", id,
+	)
+	if err != nil {
+		return pagerDutyTeamRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyTeamRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyTeamScanValues(&actual)...); err != nil {
+			return pagerDutyTeamRow{}, false, err
+		}
+		if err := fillPagerDutyTeamOrdering(&actual); err != nil {
+			return pagerDutyTeamRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyTeamRow{}, false, err
+	}
+	return actual, found, nil
+}
+
+func comparePagerDutyTeamVersion(
+	expected, actual pagerDutyTeamRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func (sink PagerDutyTeamsClickHouseEffects) snapshotObservedAt(
+	rows []pagerDutyTeamRow, claim Claim,
+) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	if sink.Now != nil {
+		return sink.Now().UTC().Truncate(time.Microsecond)
+	}
+	if claim.BeforeAt != nil && !claim.BeforeAt.IsZero() {
+		return claim.BeforeAt.UTC().Truncate(time.Microsecond)
+	}
+	return time.Now().UTC().Truncate(time.Microsecond)
+}
+
+var _ EffectSink = PagerDutyTeamsClickHouseEffects{}
+var _ EffectReadback = PagerDutyTeamsClickHouseEffects{}

--- a/internal/providersync/pagerduty_teams_effects_integration_test.go
+++ b/internal/providersync/pagerduty_teams_effects_integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyTeamsEffectUsesMigratedClickHouseTombstonesAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "teams")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	rowA, err := normalizePagerDutyTeam(
+		claim, "acme", pagerDutyTeamPayload{ID: "PT1", Name: "Platform"}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowB, err := normalizePagerDutyTeam(
+		claim, "acme", pagerDutyTeamPayload{ID: "PT2", Name: "Support"}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialEffect, err := effectBatchFromValues(
+		"operational_teams", EffectReadbackRequired, []pagerDutyTeamRow{rowA, rowB},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutyTeamsClickHouseEffects{
+		Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+		ProviderInstanceID: "Acme",
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, initialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after initial write inspection=%s error=%v", inspection, err)
+	}
+
+	updatedAt := initialAt.Add(time.Hour)
+	rowAUpdated, err := normalizePagerDutyTeam(
+		claim, "acme", pagerDutyTeamPayload{ID: "PT1", Name: "Platform updated", UpdatedAt: updatedAt.Format(time.RFC3339Nano)}, updatedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partialEffect, err := effectBatchFromValues(
+		"operational_teams", EffectReadbackRequired, []pagerDutyTeamRow{rowAUpdated},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("tombstone write inspection=%s error=%v", inspection, err)
+	}
+	var deleted bool
+	var deletedAt time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_deleted, deleted_at
+FROM operational_teams FINAL
+WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND external_id = ?`,
+		claim.OrgID, "pagerduty", "acme", "team", "PT2",
+	).Scan(&deleted, &deletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted || !deletedAt.Equal(updatedAt) {
+		t.Fatalf("missing-team tombstone deleted=%v deleted_at=%s want %s", deleted, deletedAt, updatedAt)
+	}
+
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+	}
+
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	otherRow := rowAUpdated
+	otherRow.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyTeamOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	otherEffect, err := effectBatchFromValues(
+		"operational_teams", EffectReadbackRequired, []pagerDutyTeamRow{otherRow},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, otherEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign tenant changed readback inspection=%s error=%v", inspection, err)
+	}
+}

--- a/internal/providersync/pagerduty_teams_effects_test.go
+++ b/internal/providersync/pagerduty_teams_effects_test.go
@@ -1,0 +1,101 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyTeamsEffectRejectsForeignScopeOrderingTamperAndMixedInstances(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "teams")
+	row, err := normalizePagerDutyTeam(
+		claim, "acme", pagerDutyTeamPayload{ID: "PT1", Name: "Platform", Description: teamStringPtr("response")},
+		time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := row
+	foreign.OrgID = "org-other"
+	if err := validatePagerDutyTeamRows(claim, []pagerDutyTeamRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := row
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyTeamOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyTeamRows(claim, []pagerDutyTeamRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutyTeamsClickHouseEffects{}).providerInstance([]pagerDutyTeamRow{row, foreignInstance}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := row
+	tampered.Name = "forged"
+	if err := validatePagerDutyTeamRows(claim, []pagerDutyTeamRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	inconsistent := row
+	inconsistent.IsDeleted = true
+	if err := fillPagerDutyTeamOrdering(&inconsistent); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyTeamRows(claim, []pagerDutyTeamRow{inconsistent}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("deleted flag consistency error=%v", err)
+	}
+	if err := validatePagerDutyTeamRows(claim, []pagerDutyTeamRow{row, row}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate row error=%v", err)
+	}
+}
+
+func TestPagerDutyTeamsTombstoneBumpsSourceVersionAndPreservesIdentity(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "teams")
+	row, err := normalizePagerDutyTeam(
+		claim, "acme", pagerDutyTeamPayload{ID: "PT1", Name: "Platform"},
+		time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tombstone, err := pagerDutyTeamTombstone(row, row.SourceVersionAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tombstone.ID != row.ID || tombstone.ExternalID != row.ExternalID ||
+		!tombstone.SourceVersionAt.Equal(row.SourceVersionAt.Add(time.Microsecond)) ||
+		!tombstone.ObservedAt.Equal(tombstone.SourceVersionAt) ||
+		!tombstone.LastSynced.Equal(tombstone.SourceVersionAt) || !tombstone.IsDeleted ||
+		tombstone.DeletedAt == nil || !tombstone.DeletedAt.Equal(tombstone.SourceVersionAt) ||
+		tombstone.SourceRevision == nil || tombstone.IngestRevision == nil ||
+		tombstone.OrderingContract != 2 {
+		t.Fatalf("tombstone=%+v", tombstone)
+	}
+	if tombstone.SourceRevision.Cmp(row.SourceRevision) <= 0 {
+		t.Fatalf("tombstone source revision did not advance: old=%s new=%s", row.SourceRevision, tombstone.SourceRevision)
+	}
+}
+
+func TestPagerDutyTeamsEffectRejectsUnsafeEmptySnapshotWithoutInstance(t *testing.T) {
+	if _, err := (PagerDutyTeamsClickHouseEffects{}).providerInstance(nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+}
+
+func TestPagerDutyTeamsEffectRejectsWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "teams")
+	sink := PagerDutyTeamsClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_teams"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid request error=%v", err)
+	}
+	if err := sink.WriteEffect(
+		context.Background(), claim, EffectBatch{Destination: "other"},
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}
+
+func teamStringPtr(value string) *string { return &value }

--- a/internal/providersync/pagerduty_teams_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_teams_generic_oracle_test.go
@@ -1,0 +1,76 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyTeamRowForOracle(
+	t *testing.T, input map[string]any,
+) pagerDutyTeamRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutyTeamPayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "teams")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyTeam(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload,
+		observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyTeamCases() []oracleCase {
+	return []oracleCase{
+		{ID: "updated_html_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PT1", "type": "team", "name": "Platform",
+				"description": "Platform response", "summary": "Ignored summary",
+				"updated_at": "2026-08-01T10:00:00.123456Z",
+				"html_url":   "https://acme.pagerduty.com/teams/PT1",
+			},
+		}},
+		{ID: "created_self_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PT2", "type": "team", "summary": "Support",
+				"created_at": "2026-07-31T09:00:00Z", "self": "/teams/PT2",
+			},
+		}},
+		{ID: "observed_time_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PT3", "type": "team", "name": "Tertiary",
+			},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyTeamRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/teams/row", oraclePagerDutyTeamCases(),
+		buildPagerDutyTeamRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_teams_route.go
+++ b/internal/providersync/pagerduty_teams_route.go
@@ -1,0 +1,286 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyTeamsMaxPages = 10_000
+	pagerDutyTeamsMaxRows  = 100_000
+	pagerDutyTeamsPerPage  = 100
+)
+
+// pagerDutyTeamPayload is the provider-owned subset consumed by Python's
+// PagerDutyNormalizer.team. Unknown PagerDuty fields are deliberately
+// ignored; they are not part of the persisted OperationalTeam contract.
+type pagerDutyTeamPayload struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Summary     string  `json:"summary"`
+	Description *string `json:"description"`
+	SelfURL     string  `json:"self"`
+	HTMLURL     string  `json:"html_url"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+// pagerDutyTeamRow mirrors every field on Python's canonical
+// operational.OperationalTeam dataclass, including the persisted ordering
+// fields. The live Python oracle compares this complete row rather than a
+// hand-picked projection.
+type pagerDutyTeamRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	Name                   string     `json:"name"`
+	Description            *string    `json:"description"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+// PagerDutyTeamsRouteHandler owns source collection and canonical
+// normalization. Executor registration, route switches, and matrix/config
+// wiring belong to the integration lane and intentionally do not live here.
+type PagerDutyTeamsRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutyTeamsCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyTeamsCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutyTeamsRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutyTeamsMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutyTeamsMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyTeamsPerPage
+	}
+	if pages < 1 || pages > pagerDutyTeamsMaxPages || rows < 1 ||
+		rows > pagerDutyTeamsMaxRows || perPage < 1 || perPage > pagerDutyTeamsPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutyTeamsRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "teams" || client == nil ||
+		client.Provider != "pagerduty" || client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyTeamsCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/teams", DataKey: "teams", PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	rows := make([]pagerDutyTeamRow, 0, len(pages.Items))
+	for _, raw := range pages.Items {
+		var payload pagerDutyTeamPayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, err := normalizePagerDutyTeam(claim, providerInstance, payload, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues("operational_teams", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutyTeam(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyTeamPayload,
+	normalizedAt time.Time,
+) (pagerDutyTeamRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyTeamRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyTeamSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyTeamRow{}, err
+	}
+	var sourceURL *string
+	if payload.HTMLURL != "" {
+		value := payload.HTMLURL
+		sourceURL = &value
+	} else if payload.SelfURL != "" {
+		value := payload.SelfURL
+		sourceURL = &value
+	}
+	name := payload.Name
+	if name == "" {
+		name = payload.Summary
+	}
+	if name == "" {
+		name = payload.ID
+	}
+	row := pagerDutyTeamRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "team", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: sourceURL, ObservedAt: normalizedAt, LastSynced: normalizedAt,
+		Name: name, Description: payload.Description,
+	}
+	if err := fillPagerDutyTeamOrdering(&row); err != nil {
+		return pagerDutyTeamRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyTeamSourceTime(
+	payload pagerDutyTeamPayload, observedAt time.Time,
+) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+// pagerDutyTeamTombstone mirrors Python's _reference_tombstone. A complete
+// source snapshot may omit a previously active team; the tombstone must win
+// the ReplacingMergeTree version race even when the snapshot timestamp equals
+// the prior row's source version.
+func pagerDutyTeamTombstone(
+	row pagerDutyTeamRow, observedAt time.Time,
+) (pagerDutyTeamRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyTeamRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)
+	if version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt = version
+	row.ObservedAt = version
+	row.LastSynced = version
+	row.IsDeleted = true
+	row.DeletedAt = &version
+	row.SourceRevision = nil
+	row.SourceConflictKey = ""
+	row.IngestRevision = nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyTeamOrdering(&row); err != nil {
+		return pagerDutyTeamRow{}, err
+	}
+	return row, nil
+}
+
+func fillPagerDutyTeamOrdering(row *pagerDutyTeamRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"name", row.Name},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_team", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey, row.SourceRevision, row.IngestRevision =
+		id, conflict, sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+var _ CompleteRouteHandler = PagerDutyTeamsRouteHandler{}

--- a/internal/providersync/pagerduty_teams_route_test.go
+++ b/internal/providersync/pagerduty_teams_route_test.go
@@ -1,0 +1,215 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyTeamsResponse struct {
+	status int
+	body   string
+}
+
+type pagerDutyTeamsDoer struct {
+	t         *testing.T
+	responses []pagerDutyTeamsResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyTeamsDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func TestPagerDutyTeamsRouteUsesOffsetPaginationAndCanonicalRow(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyTeamsDoer{t: t, responses: []pagerDutyTeamsResponse{
+		{body: `{"teams":[
+			{"id":"PT1","type":"team","name":"Platform","description":"Platform response","updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/teams/PT1"},
+			{"id":"PT2","type":"team","summary":"Support","created_at":"2026-07-31T09:00:00Z","self":"/teams/PT2"}],"more":true}`},
+		{body: `{"teams":[{"id":"PT3","type":"team"}],"more":false}`},
+	}}
+	client := pagerDutyTeamsTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "teams")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "},
+	}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyTeamsRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_teams" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 ||
+		batch.Evidence.CapReached || batch.Watermark != nil {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+	row := mustPagerDutyTeamRow(t, batch.Effects[0].Rows[0])
+	if row.Provider != "pagerduty" || row.ProviderInstanceID != "acme" ||
+		row.SourceEntityType != "team" || row.ExternalID != "PT1" ||
+		row.Name != "Platform" || row.Description == nil || *row.Description != "Platform response" ||
+		row.SourceURL == nil || *row.SourceURL != "https://acme.pagerduty.com/teams/PT1" ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!row.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) ||
+		row.SourceRevision == nil || row.IngestRevision == nil || row.OrderingContract != 2 {
+		t.Fatalf("row=%+v", row)
+	}
+	if second := mustPagerDutyTeamRow(t, batch.Effects[0].Rows[1]); second.Name != "Support" ||
+		second.Description != nil || second.SourceURL == nil || *second.SourceURL != "/teams/PT2" {
+		t.Fatalf("second=%+v", second)
+	}
+	if third := mustPagerDutyTeamRow(t, batch.Effects[0].Rows[2]); third.Name != "PT3" ||
+		!third.SourceVersionAt.Equal(row.ObservedAt) {
+		t.Fatalf("third=%+v", third)
+	}
+}
+
+func TestPagerDutyTeamsRoutePreservesRetryAndPermanentErrorSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "teams")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	clientRetryDoer := &pagerDutyTeamsDoer{t: t, responses: []pagerDutyTeamsResponse{
+		{status: http.StatusTooManyRequests, body: `{"message":"slow down"}`},
+		{body: `{"teams":[],"more":false}`},
+	}}
+	retryClient := pagerDutyTeamsTestClient(t, clientRetryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutyTeamsRouteHandler{}).Collect(
+		context.Background(), claim, credential, retryClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil || len(clientRetryDoer.requests) != 2 || len(batch.Effects) != 1 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(clientRetryDoer.requests))
+	}
+
+	authDoer := &pagerDutyTeamsDoer{t: t, responses: []pagerDutyTeamsResponse{
+		{status: http.StatusUnauthorized, body: `{"message":"bad token"}`},
+	}}
+	authClient := pagerDutyTeamsTestClient(t, authDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	_, err = (PagerDutyTeamsRouteHandler{}).Collect(
+		context.Background(), claim, credential, authClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication ||
+		len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+}
+
+func TestPagerDutyTeamsRouteFailsClosedOnPaginationCapAndWrongDataset(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "teams")
+	client := pagerDutyTeamsTestClient(t, &pagerDutyTeamsDoer{
+		t: t, responses: []pagerDutyTeamsResponse{{body: `{"teams":[{"id":"one"}],"more":true}`}},
+	}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	_, err := (PagerDutyTeamsRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, credential, client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	wrongClaim := nativeTestClaim("pagerduty", "users")
+	_, err = (PagerDutyTeamsRouteHandler{}).Collect(
+		context.Background(), wrongClaim, credential, client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong dataset error=%v", err)
+	}
+}
+
+func TestPagerDutyTeamsRouteStopsWhenLeaseExpiresBetweenPages(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "teams")
+	doer := &pagerDutyTeamsDoer{t: t, responses: []pagerDutyTeamsResponse{
+		{body: `{"teams":[{"id":"one"}],"more":true}`},
+		{body: `{"teams":[],"more":false}`},
+	}}
+	asserts := 0
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutyTeamsRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(doer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(doer.requests), asserts)
+	}
+}
+
+func pagerDutyTeamsTestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyTeamRow(t *testing.T, raw []byte) pagerDutyTeamRow {
+	t.Helper()
+	var row pagerDutyTeamRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/testdata/mutation-plans/pagerduty_teams.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_teams.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty teams route, complete-snapshot tombstones, and account fencing",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "This plan covers the teams provider route, full-row normalization, tenant/account fencing, and complete-snapshot tombstone reconciliation. Registry, matrix, config, deployment, stream/webhook, and activation wiring remain intentionally outside this provider-only slice. The migrated ClickHouse proof is integration-tagged and requires Docker.",
+  "mutations": [
+    {
+      "id": "T1-teams-route-rejects-other-dataset",
+      "file": "internal/providersync/pagerduty_teams_route.go",
+      "find": "claim.Dataset != \"teams\"",
+      "replace": "false",
+      "rationale": "The teams handler must not consume another PagerDuty dataset's claim; otherwise a users unit could be sent to /teams and committed as operational teams.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsRouteFailsClosedOnPaginationCapAndWrongDataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T2-team-source-url-precedence",
+      "file": "internal/providersync/pagerduty_teams_route.go",
+      "find": "if payload.HTMLURL != \"\" {",
+      "replace": "if false {",
+      "rationale": "Python's canonical source_url prefers html_url and falls back to self; dropping the html_url branch changes the persisted canonical URL when both provider links exist.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T3-team-name-provider-id-fallback",
+      "file": "internal/providersync/pagerduty_teams_route.go",
+      "find": "if name == \"\" {\n\t\tname = payload.ID\n\t}",
+      "replace": "if false {\n\t\tname = payload.ID\n\t}",
+      "rationale": "Python chooses the provider id when both name and summary are absent; dropping this fallback would emit an invalid empty canonical team name and diverge from the live normalizer.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T4-tombstone-version-must-advance",
+      "file": "internal/providersync/pagerduty_teams_route.go",
+      "find": "previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)",
+      "replace": "previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(0)",
+      "rationale": "A complete snapshot observed at the same time as the prior source version still needs a strictly newer ReplacingMergeTree version; otherwise the deletion can lose the version race and remain active.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsTombstoneBumpsSourceVersionAndPreservesIdentity$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T5-account-instance-fence",
+      "file": "internal/providersync/pagerduty_teams_effects_clickhouse.go",
+      "find": "if instance != rowInstance {",
+      "replace": "if false {",
+      "rationale": "One effect payload must contain one canonical PagerDuty account. Accepting mixed provider instances would make the sink query and tombstone rows under an arbitrary account fence.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsEffectRejectsForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T6-empty-snapshot-requires-instance-fence",
+      "file": "internal/providersync/pagerduty_teams_effects_clickhouse.go",
+      "find": "if instance == \"\" {\n\t\treturn \"\", ErrInvalidConfiguration\n\t}",
+      "replace": "if false {\n\t\treturn \"\", ErrInvalidConfiguration\n\t}",
+      "rationale": "An empty successful snapshot has no row from which to infer the PagerDuty account. It must fail closed unless the sink carries the credential-derived instance, rather than risking cross-account tombstones.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsEffectRejectsUnsafeEmptySnapshotWithoutInstance$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T7-deleted-fields-must-agree",
+      "file": "internal/providersync/pagerduty_teams_effects_clickhouse.go",
+      "find": "row.IsDeleted != (row.DeletedAt != nil)",
+      "replace": "false",
+      "rationale": "The canonical tombstone contract requires is_deleted and deleted_at to describe the same state; allowing a contradictory payload would make readback and analytics disagree.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsEffectRejectsForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T8-omitted-active-teams-must-be-tombstoned",
+      "file": "internal/providersync/pagerduty_teams_effects_clickhouse.go",
+      "find": "if _, present := seen[existing.ID]; present {\n\t\t\tcontinue\n\t\t}",
+      "replace": "if _, present := seen[existing.ID]; !present {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "A complete successful teams snapshot must reconcile every previously active row omitted by the source into a tombstone; skipping omitted rows leaves stale teams active and readback must reject the partial write.",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyTeamsEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_teams_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_teams_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OperationalTeam))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.Team.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.team(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/teams/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)


### PR DESCRIPTION
## Scope

Port PagerDuty teams with concrete typed normalization/effects, bounded pagination, tenant/account fencing, complete-snapshot tombstones, lease recovery, and exact ClickHouse readback.

## Evidence

- Live Python differential oracle
- Real migrated ClickHouse tombstone/replay/tenant proof
- Shared mutation harness: 8/8 killed with clean restore
- Vet, gofmt, Ruff, and mypy green

## Boundaries

- No registry, matrix, config, deployment, activation, or stream wiring

Linear: CHAOS-3729

SCREENSHOT-WAIVER: Backend-only provider implementation; no rendered UI changes.
