### PR TITLE
CHAOS-3731: port PagerDuty schedules provider parity

### DIFF
--- a/internal/providersync/pagerduty_incidents_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_incidents_effects_clickhouse.go
@@ -1,0 +1,559 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/big"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const pagerDutyIncidentColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,service_id,service_external_id,escalation_policy_id,title,description,started_at,resolved_at,is_deleted,deleted_at"
+const pagerDutyAlertColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,service_id,incident_id,title,description,triggered_at,acknowledged_at,resolved_at,is_deleted,deleted_at"
+const pagerDutyLogEntryColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,incident_id,event_type,body,actor_type,actor_id,occurred_at"
+const pagerDutyNoteColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,incident_id,body,author_user_id,created_at"
+
+// PagerDutyIncidentFamilyClickHouseEffects is the sink for the four atomic
+// Python incident-family destinations. It deliberately does not reconcile
+// omitted rows: these datasets are windowed incident streams, not complete
+// catalog snapshots. Every write and readback is tenant/provider-instance
+// scoped and lease fenced.
+type PagerDutyIncidentFamilyClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	switch effect.Destination {
+	case "operational_incidents":
+		rows, err := decodeEffectRows[pagerDutyIncidentRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyIncidentRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeIncidentRows(ctx, rows)
+	case "operational_alerts":
+		rows, err := decodeEffectRows[pagerDutyAlertRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyAlertRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeAlertRows(ctx, rows)
+	case "operational_incident_timeline_events":
+		rows, err := decodeEffectRows[pagerDutyLogEntryRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyLogEntryRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeLogEntryRows(ctx, rows)
+	case "operational_incident_notes":
+		rows, err := decodeEffectRows[pagerDutyNoteRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyNoteRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return err
+		}
+		return sink.writeNoteRows(ctx, rows)
+	default:
+		return ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	switch effect.Destination {
+	case "operational_incidents":
+		rows, err := decodeEffectRows[pagerDutyIncidentRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyIncidentRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectIncidentRows(ctx, claim, rows)
+	case "operational_alerts":
+		rows, err := decodeEffectRows[pagerDutyAlertRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyAlertRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectAlertRows(ctx, claim, rows)
+	case "operational_incident_timeline_events":
+		rows, err := decodeEffectRows[pagerDutyLogEntryRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyLogEntryRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectLogEntryRows(ctx, claim, rows)
+	case "operational_incident_notes":
+		rows, err := decodeEffectRows[pagerDutyNoteRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyNoteRows(claim, sink.ProviderInstanceID, rows); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectNoteRows(ctx, claim, rows)
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || strings.TrimSpace(sink.ProviderInstanceID) == "" {
+		return ErrInvalidConfiguration
+	}
+	validDataset := (claim.Dataset == "incidents" && effect.Destination == "operational_incidents") ||
+		(claim.Dataset == "incident-alerts" && effect.Destination == "operational_alerts") ||
+		(claim.Dataset == "incident-log-entries" && effect.Destination == "operational_incident_timeline_events") ||
+		(claim.Dataset == "incident-notes" && effect.Destination == "operational_incident_notes")
+	if !validDataset {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeIncidentRows(
+	ctx context.Context, rows []pagerDutyIncidentRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incidents ("+pagerDutyIncidentColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyIncidentValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeAlertRows(
+	ctx context.Context, rows []pagerDutyAlertRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_alerts ("+pagerDutyAlertColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyAlertValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeLogEntryRows(
+	ctx context.Context, rows []pagerDutyLogEntryRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incident_timeline_events ("+pagerDutyLogEntryColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyLogEntryValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) writeNoteRows(
+	ctx context.Context, rows []pagerDutyNoteRow,
+) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_incident_notes ("+pagerDutyNoteColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyNoteValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func validatePagerDutyIncidentRows(claim Claim, providerInstance string, rows []pagerDutyIncidentRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||
+			row.SourceEntityType != "incident" || row.ExternalID == "" || row.ID == "" ||
+			row.Title == "" || row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 || row.SourceVersionAt.IsZero() ||
+			row.ObservedAt.IsZero() || row.LastSynced.IsZero() || (row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyIncidentOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 || canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyAlertRows(claim Claim, providerInstance string, rows []pagerDutyAlertRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||
+			row.SourceEntityType != "alert" || row.ExternalID == "" || row.ID == "" ||
+			row.Title == "" || row.IncidentID == nil || *row.IncidentID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil || row.SourceConflictKey == "" ||
+			row.OrderingContract != 2 || row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyAlertOrdering(&canonical); err != nil || canonical.ID != row.ID ||
+			canonical.SourceConflictKey != row.SourceConflictKey || canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 || canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyLogEntryRows(claim Claim, providerInstance string, rows []pagerDutyLogEntryRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) || row.SourceEntityType != "log_entry" ||
+			row.ExternalID == "" || row.ID == "" || row.IncidentID == "" || row.EventType == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil || row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyLogEntryOrdering(&canonical); err != nil || canonical.ID != row.ID ||
+			canonical.SourceConflictKey != row.SourceConflictKey || canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 || canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyNoteRows(claim Claim, providerInstance string, rows []pagerDutyNoteRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) || row.SourceEntityType != "note" ||
+			row.ExternalID == "" || row.ID == "" || row.IncidentID == "" || row.SourceRevision == nil ||
+			row.IngestRevision == nil || row.SourceConflictKey == "" || row.OrderingContract != 2 || row.SourceVersionAt.IsZero() ||
+			row.ObservedAt.IsZero() || row.LastSynced.IsZero() {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyNoteOrdering(&canonical); err != nil || canonical.ID != row.ID ||
+			canonical.SourceConflictKey != row.SourceConflictKey || canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 || canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyProviderInstanceMatches(row, expected string) bool {
+	return row != "" && row == strings.ToLower(row) && strings.ToLower(strings.TrimSpace(expected)) == row
+}
+
+func pagerDutyIncidentValues(row pagerDutyIncidentRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.ServiceID, row.ServiceExternalID, row.EscalationPolicyID, row.Title, row.Description, row.StartedAt, row.ResolvedAt, row.IsDeleted, row.DeletedAt}
+}
+
+func pagerDutyAlertValues(row pagerDutyAlertRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.ServiceID, row.IncidentID, row.Title, row.Description, row.TriggeredAt, row.AcknowledgedAt, row.ResolvedAt, row.IsDeleted, row.DeletedAt}
+}
+
+func pagerDutyLogEntryValues(row pagerDutyLogEntryRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.IncidentID, row.EventType, row.Body, row.ActorType, row.ActorID, row.OccurredAt}
+}
+
+func pagerDutyNoteValues(row pagerDutyNoteRow) []any {
+	return []any{row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType, row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL, row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced, row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence, row.IncidentID, row.Body, row.AuthorUserID, row.CreatedAt}
+}
+
+func pagerDutyIncidentScanValues(row *pagerDutyIncidentRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.ServiceID, &row.ServiceExternalID, &row.EscalationPolicyID, &row.Title, &row.Description, &row.StartedAt, &row.ResolvedAt, &row.IsDeleted, &row.DeletedAt}
+}
+
+func pagerDutyAlertScanValues(row *pagerDutyAlertRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.ServiceID, &row.IncidentID, &row.Title, &row.Description, &row.TriggeredAt, &row.AcknowledgedAt, &row.ResolvedAt, &row.IsDeleted, &row.DeletedAt}
+}
+
+func pagerDutyLogEntryScanValues(row *pagerDutyLogEntryRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.IncidentID, &row.EventType, &row.Body, &row.ActorType, &row.ActorID, &row.OccurredAt}
+}
+
+func pagerDutyNoteScanValues(row *pagerDutyNoteRow) []any {
+	return []any{&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType, &row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL, &row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced, &row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus, &row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance, &row.RelationshipConfidence, &row.IncidentID, &row.Body, &row.AuthorUserID, &row.CreatedAt}
+}
+
+func equalPagerDutyRow(expected, actual any) bool {
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	return expectedErr == nil && actualErr == nil && bytes.Equal(expectedJSON, actualJSON)
+}
+
+func inspectPagerDutyRows[T any](
+	rows []T,
+	id func(T) string,
+	sourceRevision func(T) *big.Int,
+	load func(string) (T, bool, error),
+) (EffectInspection, error) {
+	if len(rows) == 0 {
+		return EffectAbsent, nil
+	}
+	exact, absent := 0, 0
+	for _, expected := range rows {
+		actual, found, err := load(id(expected))
+		if err != nil {
+			return EffectConflict, err
+		}
+		if !found || sourceRevision(actual) == nil {
+			absent++
+			continue
+		}
+		comparison := sourceRevision(actual).Cmp(sourceRevision(expected))
+		switch {
+		case comparison < 0:
+			absent++
+		case comparison > 0:
+			return EffectConflict, nil
+		case !equalPagerDutyRow(expected, actual):
+			return EffectConflict, nil
+		default:
+			exact++
+		}
+	}
+	switch {
+	case exact == len(rows):
+		return EffectExact, nil
+	case absent == len(rows):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectIncidentRows(
+	ctx context.Context, claim Claim, rows []pagerDutyIncidentRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyIncidentRow) string { return row.ID }, func(row pagerDutyIncidentRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyIncidentRow, bool, error) {
+		return sink.loadIncidentRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectAlertRows(
+	ctx context.Context, claim Claim, rows []pagerDutyAlertRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyAlertRow) string { return row.ID }, func(row pagerDutyAlertRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyAlertRow, bool, error) {
+		return sink.loadAlertRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectLogEntryRows(
+	ctx context.Context, claim Claim, rows []pagerDutyLogEntryRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyLogEntryRow) string { return row.ID }, func(row pagerDutyLogEntryRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyLogEntryRow, bool, error) {
+		return sink.loadLogEntryRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) inspectNoteRows(
+	ctx context.Context, claim Claim, rows []pagerDutyNoteRow,
+) (EffectInspection, error) {
+	return inspectPagerDutyRows(rows, func(row pagerDutyNoteRow) string { return row.ID }, func(row pagerDutyNoteRow) *big.Int { return row.SourceRevision }, func(id string) (pagerDutyNoteRow, bool, error) {
+		return sink.loadNoteRow(ctx, claim, id)
+	})
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadIncidentRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyIncidentRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyIncidentColumns+" FROM operational_incidents FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "incident", id)
+	if err != nil {
+		return pagerDutyIncidentRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyIncidentRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyIncidentScanValues(&row)...); err != nil {
+			return pagerDutyIncidentRow{}, false, err
+		}
+		if err := fillPagerDutyIncidentOrdering(&row); err != nil {
+			return pagerDutyIncidentRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyIncidentRow{}, false, err
+	}
+	return row, found, nil
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadAlertRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyAlertRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyAlertColumns+" FROM operational_alerts FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "alert", id)
+	if err != nil {
+		return pagerDutyAlertRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyAlertRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyAlertScanValues(&row)...); err != nil {
+			return pagerDutyAlertRow{}, false, err
+		}
+		if err := fillPagerDutyAlertOrdering(&row); err != nil {
+			return pagerDutyAlertRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyAlertRow{}, false, err
+	}
+	return row, found, nil
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadLogEntryRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyLogEntryRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyLogEntryColumns+" FROM operational_incident_timeline_events FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "log_entry", id)
+	if err != nil {
+		return pagerDutyLogEntryRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyLogEntryRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyLogEntryScanValues(&row)...); err != nil {
+			return pagerDutyLogEntryRow{}, false, err
+		}
+		if err := fillPagerDutyLogEntryOrdering(&row); err != nil {
+			return pagerDutyLogEntryRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyLogEntryRow{}, false, err
+	}
+	return row, found, nil
+}
+
+func (sink PagerDutyIncidentFamilyClickHouseEffects) loadNoteRow(
+	ctx context.Context, claim Claim, id string,
+) (pagerDutyNoteRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyNoteColumns+" FROM operational_incident_notes FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1", claim.OrgID, claim.Provider, strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID)), "note", id)
+	if err != nil {
+		return pagerDutyNoteRow{}, false, err
+	}
+	defer rows.Close()
+	var row pagerDutyNoteRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyNoteScanValues(&row)...); err != nil {
+			return pagerDutyNoteRow{}, false, err
+		}
+		if err := fillPagerDutyNoteOrdering(&row); err != nil {
+			return pagerDutyNoteRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyNoteRow{}, false, err
+	}
+	return row, found, nil
+}
+
+var _ EffectSink = PagerDutyIncidentFamilyClickHouseEffects{}
+var _ EffectReadback = PagerDutyIncidentFamilyClickHouseEffects{}

--- a/internal/providersync/pagerduty_incidents_effects_integration_test.go
+++ b/internal/providersync/pagerduty_incidents_effects_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyIncidentFamilyEffectsUseMigratedClickHouseAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Apply the production migration chain. This test must exercise the exact
+	// canonical tables, not a relaxed test-only schema.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	normalizedAt := time.Date(2026, 7, 19, 19, 0, 0, 123456000, time.UTC)
+	claim := nativeTestClaim("pagerduty", "incidents")
+	incident, err := normalizePagerDutyIncident(claim, "acme", pagerDutyIncidentPayload{
+		ID: "PI1", Title: stringPtr("Database outage"), Status: stringPtr("triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:00:00Z"), UpdatedAt: stringPtr("2026-07-17T12:01:00Z"),
+	}, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alertClaim := nativeTestClaim("pagerduty", "incident-alerts")
+	alert, err := normalizePagerDutyAlert(alertClaim, "acme", pagerDutyAlertPayload{
+		ID: "PA1", Summary: stringPtr("Disk alert"), Status: stringPtr("triggered"), Severity: stringPtr("critical"),
+		CreatedAt: stringPtr("2026-07-17T12:02:00Z"), UpdatedAt: stringPtr("2026-07-17T12:03:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logClaim := nativeTestClaim("pagerduty", "incident-log-entries")
+	entry, err := normalizePagerDutyLogEntry(logClaim, "acme", pagerDutyLogEntryPayload{
+		ID: "PL1", Type: stringPtr("status_change"), Summary: stringPtr("Triggered"), CreatedAt: stringPtr("2026-07-17T12:04:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noteClaim := nativeTestClaim("pagerduty", "incident-notes")
+	note, err := normalizePagerDutyNote(noteClaim, "acme", pagerDutyNotePayload{
+		ID: "PN1", Content: stringPtr("Investigating"), CreatedAt: stringPtr("2026-07-17T12:05:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sink := PagerDutyIncidentFamilyClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "Acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	cases := []struct {
+		name   string
+		claim  Claim
+		effect EffectBatch
+		table  string
+	}{
+		{name: "incidents", claim: claim, effect: mustPagerDutyIncidentEffect(t, incident), table: "operational_incidents"},
+		{name: "alerts", claim: alertClaim, effect: mustPagerDutyAlertEffect(t, alert), table: "operational_alerts"},
+		{name: "log_entries", claim: logClaim, effect: mustPagerDutyLogEntryEffect(t, entry), table: "operational_incident_timeline_events"},
+		{name: "notes", claim: noteClaim, effect: mustPagerDutyNoteEffect(t, note), table: "operational_incident_notes"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if inspection, err := sink.InspectEffect(ctx, testCase.claim, testCase.effect); err != nil || inspection != EffectAbsent {
+				t.Fatalf("before write inspection=%s error=%v", inspection, err)
+			}
+			if err := sink.WriteEffect(ctx, testCase.claim, testCase.effect); err != nil {
+				t.Fatal(err)
+			}
+			if inspection, err := sink.InspectEffect(ctx, testCase.claim, testCase.effect); err != nil || inspection != EffectExact {
+				t.Fatalf("after write inspection=%s error=%v", inspection, err)
+			}
+			if err := sink.WriteEffect(ctx, testCase.claim, testCase.effect); err != nil {
+				t.Fatalf("replay write: %v", err)
+			}
+			if inspection, err := sink.InspectEffect(ctx, testCase.claim, testCase.effect); err != nil || inspection != EffectExact {
+				t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+			}
+			var count uint64
+			if err := conn.QueryRow(ctx, "SELECT count() FROM "+testCase.table+" FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ?", testCase.claim.OrgID, "pagerduty", "acme").Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 {
+				t.Fatalf("rows=%d", count)
+			}
+		})
+	}
+
+	foreign := claim
+	foreign.OrgID = "org-other"
+	foreignEffect := mustPagerDutyIncidentEffect(t, incident)
+	if err := sink.WriteEffect(ctx, foreign, foreignEffect); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		// The row itself still carries org-acme, so the scope fence must reject it
+		// before ClickHouse can mutate the other tenant.
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+}
+
+func mustPagerDutyIncidentEffect(t *testing.T, row pagerDutyIncidentRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_incidents", EffectReadbackRequired, []pagerDutyIncidentRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func mustPagerDutyAlertEffect(t *testing.T, row pagerDutyAlertRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_alerts", EffectReadbackRequired, []pagerDutyAlertRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func mustPagerDutyLogEntryEffect(t *testing.T, row pagerDutyLogEntryRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_incident_timeline_events", EffectReadbackRequired, []pagerDutyLogEntryRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func mustPagerDutyNoteEffect(t *testing.T, row pagerDutyNoteRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("operational_incident_notes", EffectReadbackRequired, []pagerDutyNoteRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/pagerduty_incidents_effects_test.go
+++ b/internal/providersync/pagerduty_incidents_effects_test.go
@@ -1,0 +1,104 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyIncidentFamilyEffectsValidateEachTypedDestinationAndScope(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	normalizedAt := time.Date(2026, 7, 19, 19, 0, 0, 0, time.UTC)
+	incident, err := normalizePagerDutyIncident(claim, "acme", pagerDutyIncidentPayload{
+		ID: "PI1", Title: stringPtr("Incident"), Status: stringPtr("triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:00:00Z"), UpdatedAt: stringPtr("2026-07-17T12:01:00Z"),
+	}, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{incident}); err != nil {
+		t.Fatal(err)
+	}
+	alertClaim := claim
+	alertClaim.Dataset = "incident-alerts"
+	alert, err := normalizePagerDutyAlert(alertClaim, "acme", pagerDutyAlertPayload{
+		ID: "PA1", Summary: stringPtr("Alert"), Status: stringPtr("triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:02:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyAlertRows(alertClaim, "acme", []pagerDutyAlertRow{alert}); err != nil {
+		t.Fatal(err)
+	}
+	logClaim := claim
+	logClaim.Dataset = "incident-log-entries"
+	entry, err := normalizePagerDutyLogEntry(logClaim, "acme", pagerDutyLogEntryPayload{
+		ID: "PL1", Type: stringPtr("status_change"), Summary: stringPtr("Triggered"),
+		CreatedAt: stringPtr("2026-07-17T12:03:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyLogEntryRows(logClaim, "acme", []pagerDutyLogEntryRow{entry}); err != nil {
+		t.Fatal(err)
+	}
+	noteClaim := claim
+	noteClaim.Dataset = "incident-notes"
+	note, err := normalizePagerDutyNote(noteClaim, "acme", pagerDutyNotePayload{
+		ID: "PN1", Content: stringPtr("Investigating"), CreatedAt: stringPtr("2026-07-17T12:04:00Z"),
+	}, incident.ID, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyNoteRows(noteClaim, "acme", []pagerDutyNoteRow{note}); err != nil {
+		t.Fatal(err)
+	}
+
+	foreign := incident
+	foreign.OrgID = "org-other"
+	if err := fillPagerDutyIncidentOrdering(&foreign); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	mixed := incident
+	mixed.ProviderInstanceID = "other"
+	if err := fillPagerDutyIncidentOrdering(&mixed); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{mixed}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign instance error=%v", err)
+	}
+	tampered := incident
+	tampered.Title = "tampered"
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	contractTampered := incident
+	contractTampered.OrderingContract = 3
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{contractTampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering contract tamper error=%v", err)
+	}
+	if err := validatePagerDutyIncidentRows(claim, "acme", []pagerDutyIncidentRow{incident, incident}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate error=%v", err)
+	}
+}
+
+func TestPagerDutyIncidentFamilyEffectsRejectWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	sink := PagerDutyIncidentFamilyClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_incidents"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("nil context error=%v", err)
+	}
+	if err := sink.WriteEffect(context.Background(), claim, EffectBatch{Destination: "wrong"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+	if _, err := sink.InspectEffect(context.Background(), claim, EffectBatch{Destination: "operational_incidents"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid readback error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_incidents_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_incidents_generic_oracle_test.go
@@ -1,0 +1,225 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyIncidentRowForOracle(t *testing.T, input map[string]any) pagerDutyIncidentRow {
+	t.Helper()
+	var payload pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incidents")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyIncident(claim, strings.ToLower(input["provider_instance_id"].(string)), payload, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func buildPagerDutyAlertRowForOracle(t *testing.T, input map[string]any) pagerDutyAlertRow {
+	t.Helper()
+	var payload pagerDutyAlertPayload
+	var incident pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = json.Marshal(input["incident"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &incident); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incident-alerts")
+	claim.OrgID = input["org_id"].(string)
+	providerInstance := strings.ToLower(input["provider_instance_id"].(string))
+	parent, err := normalizePagerDutyIncident(claim, providerInstance, incident, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizePagerDutyAlert(claim, providerInstance, payload, parent.ID, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func buildPagerDutyLogEntryRowForOracle(t *testing.T, input map[string]any) pagerDutyLogEntryRow {
+	t.Helper()
+	var payload pagerDutyLogEntryPayload
+	var incident pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = json.Marshal(input["incident"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &incident); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incident-log-entries")
+	claim.OrgID = input["org_id"].(string)
+	providerInstance := strings.ToLower(input["provider_instance_id"].(string))
+	parent, err := normalizePagerDutyIncident(claim, providerInstance, incident, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizePagerDutyLogEntry(claim, providerInstance, payload, parent.ID, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func buildPagerDutyNoteRowForOracle(t *testing.T, input map[string]any) pagerDutyNoteRow {
+	t.Helper()
+	var payload pagerDutyNotePayload
+	var incident pagerDutyIncidentPayload
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = json.Marshal(input["incident"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &incident); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	claim.OrgID = input["org_id"].(string)
+	providerInstance := strings.ToLower(input["provider_instance_id"].(string))
+	parent, err := normalizePagerDutyIncident(claim, providerInstance, incident, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := normalizePagerDutyNote(claim, providerInstance, payload, parent.ID, observedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func pagerDutyIncidentOracleBase() map[string]any {
+	return map[string]any{
+		"org_id": "org-acme", "provider_instance_id": "Acme",
+		"observed_at": "2026-07-19T19:00:00.987654Z",
+	}
+}
+
+func pagerDutyIncidentOracleParent() map[string]any {
+	return map[string]any{
+		"id": "PI-PARENT", "type": "incident", "incident_number": 7,
+		"title": "Parent", "status": "triggered", "urgency": "high",
+		"created_at": "2026-07-17T12:00:00.123456Z", "updated_at": "2026-07-17T12:01:00.654321Z",
+		"service": map[string]any{"id": "PSVC1"}, "priority": map[string]any{"id": "P1", "summary": "P1"},
+		"html_url": "https://acme.pagerduty.com/incidents/PI-PARENT",
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyIncidentRows(t *testing.T) {
+	base := pagerDutyIncidentOracleBase()
+	cases := []oracleCase{
+		{ID: "resolved_full", Input: map[string]any{
+			"org_id": base["org_id"], "provider_instance_id": base["provider_instance_id"], "observed_at": base["observed_at"],
+			"payload": map[string]any{
+				"id": "PI1", "type": "incident", "incident_number": 42, "title": "Database outage", "status": "resolved", "urgency": "high",
+				"created_at": "2026-07-17T12:00:00.123456Z", "updated_at": "2026-07-18T10:00:00.654321Z", "resolved_at": "2026-07-18T09:00:00Z",
+				"last_status_change_at": "2026-07-18T09:01:00Z", "service": map[string]any{"id": "PSVC1"}, "priority": map[string]any{"id": "P1", "summary": "P1"},
+				"html_url": "https://acme.pagerduty.com/incidents/PI1",
+			},
+		}},
+		{ID: "acknowledged_created_self", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME", "observed_at": base["observed_at"],
+			"payload": map[string]any{"id": "PI2", "type": "incident", "summary": "Support", "status": "acknowledged", "urgency": "low", "created_at": "2026-07-17T13:00:00Z", "self": "/incidents/PI2"},
+		}},
+		{ID: "observed_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": base["observed_at"],
+			"payload": map[string]any{"id": "PI3", "type": "incident", "title": "Fallback", "status": "triggered", "urgency": "unknown", "priority": map[string]any{"id": "P9"}},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incidents/row", cases, buildPagerDutyIncidentRowForOracle, nil)
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyAlertRows(t *testing.T) {
+	cases := []oracleCase{
+		{ID: "resolved_critical", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PA1", "type": "alert", "summary": "Disk alert", "status": "resolved", "severity": "critical", "created_at": "2026-07-17T12:02:00Z", "updated_at": "2026-07-17T12:04:00Z", "self": "/incidents/PI-PARENT/alerts/PA1"},
+		}},
+		{ID: "triggered_warning", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PA2", "summary": "Warning", "status": "triggered", "severity": "warning", "created_at": "2026-07-17T12:05:00Z"},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incident-alerts/row", cases, buildPagerDutyAlertRowForOracle, nil)
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyLogEntryRows(t *testing.T) {
+	cases := []oracleCase{
+		{ID: "typed_summary", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PL1", "type": "status_change", "summary": "Triggered", "created_at": "2026-07-17T12:03:00Z", "updated_at": "2026-07-17T12:04:00Z", "html_url": "https://acme.pagerduty.com/log_entries/PL1"},
+		}},
+		{ID: "message_default_type", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PL2", "message": "Fallback message", "created_at": "2026-07-17T12:05:00Z"},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incident-log-entries/row", cases, buildPagerDutyLogEntryRowForOracle, nil)
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyNoteRows(t *testing.T) {
+	cases := []oracleCase{
+		{ID: "content_with_user", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PN1", "content": "Investigating", "created_at": "2026-07-17T12:06:00Z", "updated_at": "2026-07-17T12:07:00Z", "user": map[string]any{"id": "PU1"}},
+		}},
+		{ID: "empty_content", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme", "observed_at": "2026-07-19T19:00:00.987654Z", "incident": pagerDutyIncidentOracleParent(),
+			"payload": map[string]any{"id": "PN2", "content": nil, "created_at": "2026-07-17T12:08:00Z"},
+		}},
+	}
+	compareRowsAgainstPythonOracle(t, "pagerduty/incident-notes/row", cases, buildPagerDutyNoteRowForOracle, nil)
+}

--- a/internal/providersync/pagerduty_incidents_ordering.go
+++ b/internal/providersync/pagerduty_incidents_ordering.go
@@ -1,0 +1,136 @@
+package providersync
+
+import "github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+
+func fillPagerDutyIncidentOrdering(row *pagerDutyIncidentRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"service_id", jiraStringValue(row.ServiceID)},
+		jiraOperationalField{"service_external_id", jiraStringValue(row.ServiceExternalID)},
+		jiraOperationalField{"escalation_policy_id", jiraStringValue(row.EscalationPolicyID)},
+		jiraOperationalField{"title", row.Title},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"started_at", jiraTimeValue(row.StartedAt)},
+		jiraOperationalField{"resolved_at", jiraTimeValue(row.ResolvedAt)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_incident", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func fillPagerDutyAlertOrdering(row *pagerDutyAlertRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"service_id", jiraStringValue(row.ServiceID)},
+		jiraOperationalField{"incident_id", jiraStringValue(row.IncidentID)},
+		jiraOperationalField{"title", row.Title},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"triggered_at", jiraTimeValue(row.TriggeredAt)},
+		jiraOperationalField{"acknowledged_at", jiraTimeValue(row.AcknowledgedAt)},
+		jiraOperationalField{"resolved_at", jiraTimeValue(row.ResolvedAt)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_alert", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func fillPagerDutyLogEntryOrdering(row *pagerDutyLogEntryRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"incident_id", row.IncidentID},
+		jiraOperationalField{"event_type", row.EventType},
+		jiraOperationalField{"body", jiraStringValue(row.Body)},
+		jiraOperationalField{"actor_type", jiraStringValue(row.ActorType)},
+		jiraOperationalField{"actor_id", jiraStringValue(row.ActorID)},
+		jiraOperationalField{"occurred_at", jiraTimeValue(row.OccurredAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_incident_timeline_event", row.OrgID, row.Provider,
+		row.ProviderInstanceID, row.ExternalID, row.SourceVersionAt,
+		row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func fillPagerDutyNoteOrdering(row *pagerDutyNoteRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"incident_id", row.IncidentID},
+		jiraOperationalField{"body", row.Body},
+		jiraOperationalField{"author_user_id", jiraStringValue(row.AuthorUserID)},
+		jiraOperationalField{"created_at", jiraTimeValue(row.CreatedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_incident_note", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}

--- a/internal/providersync/pagerduty_incidents_route.go
+++ b/internal/providersync/pagerduty_incidents_route.go
@@ -1,0 +1,1192 @@
+package providersync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"math"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyIncidentFamilyMaxPages      = 10_000
+	pagerDutyIncidentFamilyMaxRows       = 100_000
+	pagerDutyIncidentFamilyPerPage       = 100
+	pagerDutyIncidentFamilyEnrichmentCap = 100
+)
+
+// PagerDuty's incident family has one parent stream and three independently
+// persisted child streams. The family handler owns the shared parent cursor,
+// cap, and completion rules while keeping one typed effect per Python sink
+// boundary. It intentionally does not register or activate a worker route.
+type PagerDutyIncidentFamilyRouteHandler struct {
+	MaxPages      int
+	MaxRows       int
+	PerPage       int
+	EnrichmentCap int
+}
+
+type pagerDutyIncidentReferencePayload struct {
+	ID      string  `json:"id"`
+	Summary *string `json:"summary"`
+}
+
+type pagerDutyIncidentPayload struct {
+	ID                 string                             `json:"id"`
+	Type               *string                            `json:"type"`
+	Summary            *string                            `json:"summary"`
+	SelfURL            *string                            `json:"self"`
+	HTMLURL            *string                            `json:"html_url"`
+	CreatedAt          *string                            `json:"created_at"`
+	UpdatedAt          *string                            `json:"updated_at"`
+	IncidentNumber     *int                               `json:"incident_number"`
+	Title              *string                            `json:"title"`
+	Status             *string                            `json:"status"`
+	Urgency            *string                            `json:"urgency"`
+	ResolvedAt         *string                            `json:"resolved_at"`
+	LastStatusChangeAt *string                            `json:"last_status_change_at"`
+	Service            *pagerDutyIncidentReferencePayload `json:"service"`
+	Priority           *pagerDutyIncidentReferencePayload `json:"priority"`
+}
+
+type pagerDutyAlertPayload struct {
+	ID        string  `json:"id"`
+	Type      *string `json:"type"`
+	Summary   *string `json:"summary"`
+	SelfURL   *string `json:"self"`
+	HTMLURL   *string `json:"html_url"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+	Status    *string `json:"status"`
+	Severity  *string `json:"severity"`
+}
+
+type pagerDutyLogEntryPayload struct {
+	ID        string  `json:"id"`
+	Type      *string `json:"type"`
+	Summary   *string `json:"summary"`
+	Message   *string `json:"message"`
+	SelfURL   *string `json:"self"`
+	HTMLURL   *string `json:"html_url"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+}
+
+type pagerDutyNotePayload struct {
+	ID        string                             `json:"id"`
+	Type      *string                            `json:"type"`
+	SelfURL   *string                            `json:"self"`
+	HTMLURL   *string                            `json:"html_url"`
+	CreatedAt *string                            `json:"created_at"`
+	UpdatedAt *string                            `json:"updated_at"`
+	Content   *string                            `json:"content"`
+	User      *pagerDutyIncidentReferencePayload `json:"user"`
+}
+
+// Each row mirrors the complete Python canonical dataclass field set. The
+// ordering fields are included in the durable effect payload even though the
+// migrated ClickHouse tables intentionally store only their production
+// projection.
+type pagerDutyIncidentRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ServiceID              *string    `json:"service_id"`
+	ServiceExternalID      *string    `json:"service_external_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	Title                  string     `json:"title"`
+	Description            *string    `json:"description"`
+	StartedAt              *time.Time `json:"started_at"`
+	ResolvedAt             *time.Time `json:"resolved_at"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+type pagerDutyAlertRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ServiceID              *string    `json:"service_id"`
+	IncidentID             *string    `json:"incident_id"`
+	Title                  string     `json:"title"`
+	Description            *string    `json:"description"`
+	TriggeredAt            *time.Time `json:"triggered_at"`
+	AcknowledgedAt         *time.Time `json:"acknowledged_at"`
+	ResolvedAt             *time.Time `json:"resolved_at"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+type pagerDutyLogEntryRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	IncidentID             string     `json:"incident_id"`
+	EventType              string     `json:"event_type"`
+	Body                   *string    `json:"body"`
+	ActorType              *string    `json:"actor_type"`
+	ActorID                *string    `json:"actor_id"`
+	OccurredAt             *time.Time `json:"occurred_at"`
+}
+
+type pagerDutyNoteRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	IncidentID             string     `json:"incident_id"`
+	Body                   string     `json:"body"`
+	AuthorUserID           *string    `json:"author_user_id"`
+	CreatedAt              *time.Time `json:"created_at"`
+}
+
+type pagerDutyIncidentFamilyCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyIncidentFamilyCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+type pagerDutyIncidentFamilyEndpoint struct {
+	path      string
+	decode    func([]byte) ([]json.RawMessage, bool, error)
+	paginated bool
+}
+
+type pagerDutyIncidentsEnvelope struct {
+	Incidents []json.RawMessage `json:"incidents"`
+	More      *bool             `json:"more"`
+}
+
+type pagerDutyAlertsEnvelope struct {
+	Alerts []json.RawMessage `json:"alerts"`
+	More   *bool             `json:"more"`
+}
+
+type pagerDutyLogEntriesEnvelope struct {
+	LogEntries []json.RawMessage `json:"log_entries"`
+	More       *bool             `json:"more"`
+}
+
+type pagerDutyNotesEnvelope struct {
+	Notes []json.RawMessage `json:"notes"`
+}
+
+func decodePagerDutyIncidents(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyIncidentsEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Incidents == nil || envelope.More == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.Incidents, *envelope.More, nil
+}
+
+func decodePagerDutyAlerts(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyAlertsEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Alerts == nil || envelope.More == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.Alerts, *envelope.More, nil
+}
+
+func decodePagerDutyLogEntries(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyLogEntriesEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.LogEntries == nil || envelope.More == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.LogEntries, *envelope.More, nil
+}
+
+func decodePagerDutyNotes(body []byte) ([]json.RawMessage, bool, error) {
+	var envelope pagerDutyNotesEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Notes == nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return envelope.Notes, false, nil
+}
+
+func pagerDutyIncidentChildEndpoint(client *providerfoundation.HTTPClient, incidentID, dataset string) (pagerDutyIncidentFamilyEndpoint, error) {
+	if client == nil || strings.TrimSpace(incidentID) == "" {
+		return pagerDutyIncidentFamilyEndpoint{}, providerfoundation.ErrNormalizationInvalid
+	}
+	base := providerRelativePath(client, "incidents", incidentID)
+	switch dataset {
+	case "incident-alerts":
+		return pagerDutyIncidentFamilyEndpoint{path: base + "/alerts", decode: decodePagerDutyAlerts, paginated: true}, nil
+	case "incident-log-entries":
+		return pagerDutyIncidentFamilyEndpoint{path: base + "/log_entries", decode: decodePagerDutyLogEntries, paginated: true}, nil
+	case "incident-notes":
+		return pagerDutyIncidentFamilyEndpoint{path: base + "/notes", decode: decodePagerDutyNotes, paginated: false}, nil
+	default:
+		return pagerDutyIncidentFamilyEndpoint{}, ErrInvalidConfiguration
+	}
+}
+
+type pagerDutyIncidentPageCollection struct {
+	Items      []json.RawMessage
+	Pages      int
+	CapReached bool
+}
+
+func pagerDutyIncidentFamilyLimits(handler PagerDutyIncidentFamilyRouteHandler) (int, int, int, int, error) {
+	maxPages, maxRows, perPage, cap := handler.MaxPages, handler.MaxRows, handler.PerPage, handler.EnrichmentCap
+	if maxPages == 0 {
+		maxPages = pagerDutyIncidentFamilyMaxPages
+	}
+	if maxRows == 0 {
+		maxRows = pagerDutyIncidentFamilyMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyIncidentFamilyPerPage
+	}
+	if cap == 0 {
+		cap = pagerDutyIncidentFamilyEnrichmentCap
+	}
+	if maxPages < 1 || maxPages > pagerDutyIncidentFamilyMaxPages || maxRows < 1 ||
+		maxRows > pagerDutyIncidentFamilyMaxRows || perPage < 1 || perPage > pagerDutyIncidentFamilyPerPage ||
+		cap < 0 || cap > pagerDutyIncidentFamilyMaxRows {
+		return 0, 0, 0, 0, ErrInvalidConfiguration
+	}
+	return maxPages, maxRows, perPage, cap, nil
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || client == nil || client.Provider != "pagerduty" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	if claim.Dataset != "incidents" && claim.Dataset != "incident-alerts" &&
+		claim.Dataset != "incident-log-entries" && claim.Dataset != "incident-notes" {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, cap, err := pagerDutyIncidentFamilyLimits(handler)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	if claim.Dataset != "incidents" {
+		if value, present := claim.DatasetOptions["enabled"]; present {
+			enabled, ok := value.(bool)
+			if !ok {
+				return CompleteRouteBatch{}, ErrInvalidConfiguration
+			}
+			if !enabled {
+				return handler.emptyPagerDutyIncidentFamilyBatch(claim, 0, 0)
+			}
+		}
+	}
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyIncidentFamilyCountingDoer{delegate: client.Doer, attempts: &requests}
+	parentEndpoint := pagerDutyIncidentFamilyEndpoint{
+		path: "/incidents", decode: decodePagerDutyIncidents, paginated: true,
+	}
+	query := url.Values{}
+	if claim.SinceAt != nil {
+		query.Set("since", claim.SinceAt.UTC().Format(time.RFC3339Nano))
+	}
+	if claim.BeforeAt != nil {
+		query.Set("until", claim.BeforeAt.UTC().Format(time.RFC3339Nano))
+	}
+	parents, err := collectPagerDutyIncidentFamilyPages(
+		ctx, &counted, parentEndpoint, query, perPage, maxPages, maxRows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if parents.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	if claim.Dataset == "incidents" {
+		return handler.collectPagerDutyIncidents(claim, providerInstance, normalizedAt, parents, requests)
+	}
+	if value, present := claim.DatasetOptions["enrichment_cap"]; present {
+		cap, err = pagerDutyIncidentFamilyMaxRowsOption(value, cap)
+		if err != nil || cap > pagerDutyIncidentFamilyMaxRows {
+			return CompleteRouteBatch{}, ErrInvalidConfiguration
+		}
+	}
+	return handler.collectPagerDutyEnrichment(
+		ctx, claim, providerInstance, &counted, normalizedAt, parents, &requests,
+		perPage, maxPages, maxRows, cap,
+	)
+}
+
+func collectPagerDutyIncidentFamilyPages(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	endpoint pagerDutyIncidentFamilyEndpoint,
+	baseQuery url.Values,
+	perPage, maxPages, maxRows int,
+) (pagerDutyIncidentPageCollection, error) {
+	if ctx == nil || client == nil || endpoint.decode == nil || strings.TrimSpace(endpoint.path) == "" ||
+		perPage < 1 || maxPages < 1 || maxRows < 1 {
+		return pagerDutyIncidentPageCollection{}, providerfoundation.ErrPaginationInvalid
+	}
+	result := pagerDutyIncidentPageCollection{Items: make([]json.RawMessage, 0)}
+	offset := 0
+	for {
+		if result.Pages >= maxPages {
+			result.CapReached = true
+			return result, nil
+		}
+		items, more, err := requestPagerDutyIncidentFamilyPage(
+			ctx, client, endpoint, baseQuery, offset, perPage,
+		)
+		if err != nil {
+			return result, err
+		}
+		result.Pages++
+		if len(items) > maxRows-len(result.Items) {
+			return result, ErrPaginationCapExceeded
+		}
+		result.Items = append(result.Items, items...)
+		if !more {
+			return result, nil
+		}
+		if len(result.Items) == maxRows {
+			return result, ErrPaginationCapExceeded
+		}
+		if len(items) == 0 {
+			return result, providerfoundation.ErrPaginationInvalid
+		}
+		offset += len(items)
+	}
+}
+
+func requestPagerDutyIncidentFamilyPage(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	endpoint pagerDutyIncidentFamilyEndpoint,
+	baseQuery url.Values,
+	offset, perPage int,
+) ([]json.RawMessage, bool, error) {
+	query := make(url.Values, len(baseQuery)+2)
+	for key, values := range baseQuery {
+		query[key] = append([]string(nil), values...)
+	}
+	if endpoint.paginated {
+		query.Set("limit", strconv.Itoa(perPage))
+		query.Set("offset", strconv.Itoa(offset))
+	}
+	target := endpoint.path
+	if encoded := query.Encode(); encoded != "" {
+		target += "?" + encoded
+	}
+	response, err := client.Do(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, false, providerfoundation.ErrPaginationInvalid
+	}
+	return endpoint.decode(body)
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) collectPagerDutyIncidents(
+	claim Claim,
+	providerInstance string,
+	normalizedAt time.Time,
+	parents pagerDutyIncidentPageCollection,
+	requests int,
+) (CompleteRouteBatch, error) {
+	rows := make([]pagerDutyIncidentRow, 0, len(parents.Items))
+	var watermark *time.Time
+	for _, raw := range parents.Items {
+		payload, err := decodePagerDutyIncidentPayload(raw)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		createdAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		if pagerDutyIncidentOutsideWindow(createdAt, claim) {
+			continue
+		}
+		row, err := normalizePagerDutyIncident(claim, providerInstance, payload, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+		watermark = pagerDutyMaxTime(watermark, createdAt)
+	}
+	effect, err := effectBatchFromValues("operational_incidents", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Result:    map[string]any{"incidents_synced": len(rows)},
+		Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: parents.Pages, Records: len(rows), CapReached: parents.CapReached,
+		},
+	}, nil
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) emptyPagerDutyIncidentFamilyBatch(
+	claim Claim, requests, pages int,
+) (CompleteRouteBatch, error) {
+	destination, resultKey := pagerDutyIncidentFamilyDestination(claim.Dataset)
+	var (
+		effect EffectBatch
+		err    error
+	)
+	switch claim.Dataset {
+	case "incident-alerts":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, []pagerDutyAlertRow{})
+	case "incident-log-entries":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, []pagerDutyLogEntryRow{})
+	case "incident-notes":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, []pagerDutyNoteRow{})
+	default:
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  map[string]any{resultKey: 0},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: requests, Pages: pages,
+		},
+	}, nil
+}
+
+func (handler PagerDutyIncidentFamilyRouteHandler) collectPagerDutyEnrichment(
+	ctx context.Context,
+	claim Claim,
+	providerInstance string,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+	parents pagerDutyIncidentPageCollection,
+	requests *int,
+	perPage, maxPages, maxRows, cap int,
+) (CompleteRouteBatch, error) {
+	destination, resultKey := pagerDutyIncidentFamilyDestination(claim.Dataset)
+	if destination == "" {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	alertRows := make([]pagerDutyAlertRow, 0)
+	logEntryRows := make([]pagerDutyLogEntryRow, 0)
+	noteRows := make([]pagerDutyNoteRow, 0)
+	watermark := pagerDutyTimePointer(claim.SinceAt)
+	var earliestUndrained *time.Time
+	childPages := 0
+	childRecords := 0
+	for _, raw := range parents.Items {
+		incident, err := decodePagerDutyIncidentPayload(raw)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		createdAt, err := pagerDutyOptionalTime(incident.CreatedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		if pagerDutyIncidentOutsideWindow(createdAt, claim) {
+			continue
+		}
+		incidentRow, err := normalizePagerDutyIncident(claim, providerInstance, incident, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		watermark = pagerDutyMaxTime(watermark, createdAt)
+		if cap == 0 {
+			continue
+		}
+		endpoint, err := pagerDutyIncidentChildEndpoint(client, incident.ID, claim.Dataset)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		childCount := 0
+		undrained := false
+		offset := 0
+		for {
+			if childPages >= maxPages {
+				return CompleteRouteBatch{}, ErrPaginationCapExceeded
+			}
+			items, more, requestErr := requestPagerDutyIncidentFamilyPage(
+				ctx, client, endpoint, nil, offset, perPage,
+			)
+			if requestErr != nil {
+				return CompleteRouteBatch{}, requestErr
+			}
+			childPages++
+			remaining := cap - childCount
+			take := len(items)
+			if take > remaining {
+				take = remaining
+			}
+			if take > 0 {
+				if childRecords > maxRows-take {
+					return CompleteRouteBatch{}, ErrPaginationCapExceeded
+				}
+				for _, childRaw := range items[:take] {
+					switch claim.Dataset {
+					case "incident-alerts":
+						payload, decodeErr := decodePagerDutyAlertPayload(childRaw)
+						if decodeErr != nil {
+							return CompleteRouteBatch{}, decodeErr
+						}
+						row, normalizeErr := normalizePagerDutyAlert(claim, providerInstance, payload, incidentRow.ID, normalizedAt)
+						if normalizeErr != nil {
+							return CompleteRouteBatch{}, normalizeErr
+						}
+						alertRows = append(alertRows, row)
+					case "incident-log-entries":
+						payload, decodeErr := decodePagerDutyLogEntryPayload(childRaw)
+						if decodeErr != nil {
+							return CompleteRouteBatch{}, decodeErr
+						}
+						row, normalizeErr := normalizePagerDutyLogEntry(claim, providerInstance, payload, incidentRow.ID, normalizedAt)
+						if normalizeErr != nil {
+							return CompleteRouteBatch{}, normalizeErr
+						}
+						logEntryRows = append(logEntryRows, row)
+					case "incident-notes":
+						payload, decodeErr := decodePagerDutyNotePayload(childRaw)
+						if decodeErr != nil {
+							return CompleteRouteBatch{}, decodeErr
+						}
+						row, normalizeErr := normalizePagerDutyNote(claim, providerInstance, payload, incidentRow.ID, normalizedAt)
+						if normalizeErr != nil {
+							return CompleteRouteBatch{}, normalizeErr
+						}
+						noteRows = append(noteRows, row)
+					}
+				}
+				childCount += take
+				childRecords += take
+			}
+			if childCount == cap {
+				undrained = more || len(items) > remaining
+				break
+			}
+			if !more {
+				break
+			}
+			if len(items) == 0 {
+				return CompleteRouteBatch{}, providerfoundation.ErrPaginationInvalid
+			}
+			offset += len(items)
+		}
+		if undrained {
+			earliestUndrained = pagerDutyMinTime(earliestUndrained, createdAt)
+		}
+	}
+	if earliestUndrained != nil && (watermark == nil || earliestUndrained.Before(*watermark)) {
+		watermark = earliestUndrained
+	}
+	var effect EffectBatch
+	var err error
+	switch claim.Dataset {
+	case "incident-alerts":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, alertRows)
+	case "incident-log-entries":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, logEntryRows)
+	case "incident-notes":
+		effect, err = effectBatchFromValues(destination, EffectReadbackRequired, noteRows)
+	default:
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Result:    map[string]any{resultKey: childRecords},
+		Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: valueOrZero(requests),
+			Pages: parents.Pages + childPages, Records: childRecords,
+		},
+	}, nil
+}
+
+func valueOrZero(value *int) int {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func pagerDutyIncidentFamilyDestination(dataset string) (string, string) {
+	switch dataset {
+	case "incidents":
+		return "operational_incidents", "incidents_synced"
+	case "incident-alerts":
+		return "operational_alerts", "alerts_synced"
+	case "incident-log-entries":
+		return "operational_incident_timeline_events", "log_entries_synced"
+	case "incident-notes":
+		return "operational_incident_notes", "notes_synced"
+	default:
+		return "", ""
+	}
+}
+
+func pagerDutyIncidentOutsideWindow(createdAt *time.Time, claim Claim) bool {
+	if createdAt == nil {
+		return false
+	}
+	if claim.SinceAt != nil && createdAt.Before(claim.SinceAt.UTC()) {
+		return true
+	}
+	return claim.BeforeAt != nil && createdAt.After(claim.BeforeAt.UTC())
+}
+
+func pagerDutyMaxTime(current, candidate *time.Time) *time.Time {
+	if candidate == nil {
+		return current
+	}
+	if current == nil || candidate.After(*current) {
+		copy := candidate.UTC().Truncate(time.Microsecond)
+		return &copy
+	}
+	return current
+}
+
+func pagerDutyMinTime(current, candidate *time.Time) *time.Time {
+	if candidate == nil {
+		return current
+	}
+	if current == nil || candidate.Before(*current) {
+		copy := candidate.UTC().Truncate(time.Microsecond)
+		return &copy
+	}
+	return current
+}
+
+func pagerDutyTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := value.UTC().Truncate(time.Microsecond)
+	return &copy
+}
+
+func decodePagerDutyIncidentPayload(raw json.RawMessage) (pagerDutyIncidentPayload, error) {
+	var payload pagerDutyIncidentPayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyIncidentPayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func decodePagerDutyAlertPayload(raw json.RawMessage) (pagerDutyAlertPayload, error) {
+	var payload pagerDutyAlertPayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyAlertPayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func decodePagerDutyLogEntryPayload(raw json.RawMessage) (pagerDutyLogEntryPayload, error) {
+	var payload pagerDutyLogEntryPayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyLogEntryPayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func decodePagerDutyNotePayload(raw json.RawMessage) (pagerDutyNotePayload, error) {
+	var payload pagerDutyNotePayload
+	if err := json.Unmarshal(raw, &payload); err != nil || strings.TrimSpace(payload.ID) == "" {
+		return pagerDutyNotePayload{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return payload, nil
+}
+
+func pagerDutyOptionalTime(value *string) (*time.Time, error) {
+	if value == nil || *value == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, *value)
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	result := parsed.UTC().Truncate(time.Microsecond)
+	return &result, nil
+}
+
+func pagerDutyIncidentSourceTime(updatedAt, createdAt *string, observedAt time.Time) (time.Time, error) {
+	value := updatedAt
+	if value == nil || *value == "" {
+		value = createdAt
+	}
+	if parsed, err := pagerDutyOptionalTime(value); err != nil {
+		return time.Time{}, err
+	} else if parsed != nil {
+		return *parsed, nil
+	}
+	return observedAt.UTC().Truncate(time.Microsecond), nil
+}
+
+func pagerDutyStringOrFallback(values ...*string) string {
+	for _, value := range values {
+		if value != nil && *value != "" {
+			return *value
+		}
+	}
+	return ""
+}
+
+func pagerDutyURL(htmlURL, selfURL *string) *string {
+	if htmlURL != nil && *htmlURL != "" {
+		value := *htmlURL
+		return &value
+	}
+	if selfURL != nil {
+		value := *selfURL
+		return &value
+	}
+	return nil
+}
+
+func pagerDutyReferenceValue(reference *pagerDutyIncidentReferencePayload) *string {
+	if reference == nil {
+		return nil
+	}
+	if reference.Summary != nil && *reference.Summary != "" {
+		value := *reference.Summary
+		return &value
+	}
+	value := reference.ID
+	return &value
+}
+
+func pagerDutyNormalizeStatus(raw *string) *string {
+	if raw == nil {
+		return nil
+	}
+	var value string
+	switch *raw {
+	case "triggered":
+		value = "open"
+	case "acknowledged":
+		value = "acknowledged"
+	case "resolved":
+		value = "resolved"
+	default:
+		return nil
+	}
+	return &value
+}
+
+func pagerDutyNormalizeIncidentSeverity(raw *string) *string {
+	if raw == nil {
+		return nil
+	}
+	if *raw != "high" && *raw != "low" {
+		return nil
+	}
+	value := *raw
+	return &value
+}
+
+func pagerDutyNormalizeAlertSeverity(raw *string) *string {
+	values := map[string]string{"critical": "critical", "error": "high", "warning": "medium", "info": "info"}
+	if raw == nil {
+		return nil
+	}
+	value, ok := values[*raw]
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func pagerDutyNormalizeIncidentPriority(reference *pagerDutyIncidentReferencePayload) *string {
+	value := pagerDutyReferenceValue(reference)
+	if value == nil {
+		return nil
+	}
+	var normalized string
+	switch *value {
+	case "P1":
+		normalized = "high"
+	case "P2":
+		normalized = "medium"
+	case "P3", "P4":
+		normalized = "low"
+	default:
+		return nil
+	}
+	return &normalized
+}
+
+func pagerDutyCanonicalReferenceID(orgID, providerInstance, family, externalID string) *string {
+	if strings.TrimSpace(externalID) == "" {
+		return nil
+	}
+	parts := []string{orgID, "pagerduty", providerInstance, family, strings.TrimSpace(externalID)}
+	for _, part := range parts {
+		if part == "" {
+			return nil
+		}
+	}
+	quoted := make([]string, len(parts))
+	for index, part := range parts {
+		quoted[index] = strconv.QuoteToASCII(part)
+	}
+	digest := sha256.Sum256([]byte("[" + strings.Join(quoted, ",") + "]"))
+	value := hex.EncodeToString(digest[:])
+	return &value
+}
+
+func normalizePagerDutyIncident(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyIncidentPayload,
+	normalizedAt time.Time,
+) (pagerDutyIncidentRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyIncidentRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	createdAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	resolvedAt, err := pagerDutyOptionalTime(payload.ResolvedAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	lastStatusChangeAt, err := pagerDutyOptionalTime(payload.LastStatusChangeAt)
+	if err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	if payload.Status == nil || *payload.Status != "resolved" {
+		resolvedAt = nil
+	} else if resolvedAt == nil {
+		resolvedAt = lastStatusChangeAt
+	}
+	row := pagerDutyIncidentRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "incident", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, RawStatus: payload.Status, RawSeverity: payload.Urgency,
+		RawPriority:        pagerDutyReferenceValue(payload.Priority),
+		NormalizedStatus:   pagerDutyNormalizeStatus(payload.Status),
+		NormalizedSeverity: pagerDutyNormalizeIncidentSeverity(payload.Urgency),
+		NormalizedPriority: pagerDutyNormalizeIncidentPriority(payload.Priority),
+		Title:              pagerDutyStringOrFallback(payload.Title, payload.Summary, &payload.ID),
+		SourceEventAt:      createdAt, StartedAt: createdAt, ResolvedAt: resolvedAt,
+	}
+	if payload.IncidentNumber != nil && *payload.IncidentNumber != 0 {
+		sourceEventID := strconv.Itoa(*payload.IncidentNumber)
+		row.SourceEventID = &sourceEventID
+	}
+	if payload.Service != nil {
+		serviceExternalID := payload.Service.ID
+		row.ServiceExternalID = &serviceExternalID
+		row.ServiceID = pagerDutyCanonicalReferenceID(claim.OrgID, providerInstance, "operational_service", serviceExternalID)
+	}
+	if err := fillPagerDutyIncidentOrdering(&row); err != nil {
+		return pagerDutyIncidentRow{}, err
+	}
+	return row, nil
+}
+
+func normalizePagerDutyAlert(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyAlertPayload,
+	incidentID string,
+	normalizedAt time.Time,
+) (pagerDutyAlertRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" || incidentID == "" {
+		return pagerDutyAlertRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyAlertRow{}, err
+	}
+	triggeredAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyAlertRow{}, err
+	}
+	resolvedAt := (*time.Time)(nil)
+	if payload.Status != nil && *payload.Status == "resolved" {
+		resolvedAt, err = pagerDutyOptionalTime(payload.UpdatedAt)
+		if err != nil {
+			return pagerDutyAlertRow{}, err
+		}
+		if resolvedAt == nil {
+			resolvedAt, err = pagerDutyOptionalTime(payload.CreatedAt)
+			if err != nil {
+				return pagerDutyAlertRow{}, err
+			}
+			if resolvedAt == nil {
+				copy := sourceVersionAt
+				resolvedAt = &copy
+			}
+		}
+	}
+	row := pagerDutyAlertRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "alert", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, RawStatus: payload.Status, RawSeverity: payload.Severity,
+		NormalizedStatus:   pagerDutyNormalizeStatus(payload.Status),
+		NormalizedSeverity: pagerDutyNormalizeAlertSeverity(payload.Severity),
+		IncidentID:         &incidentID, Title: pagerDutyStringOrFallback(payload.Summary, &payload.ID),
+		TriggeredAt: triggeredAt, ResolvedAt: resolvedAt,
+	}
+	if err := fillPagerDutyAlertOrdering(&row); err != nil {
+		return pagerDutyAlertRow{}, err
+	}
+	return row, nil
+}
+
+func normalizePagerDutyLogEntry(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyLogEntryPayload,
+	incidentID string,
+	normalizedAt time.Time,
+) (pagerDutyLogEntryRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" || incidentID == "" {
+		return pagerDutyLogEntryRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyLogEntryRow{}, err
+	}
+	occurredAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyLogEntryRow{}, err
+	}
+	eventType := "pagerduty_log_entry"
+	if payload.Type != nil && *payload.Type != "" {
+		eventType = *payload.Type
+	}
+	row := pagerDutyLogEntryRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "log_entry", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, IncidentID: incidentID, EventType: eventType,
+		Body:      pagerDutyFirstPresent(payload.Summary, payload.Message),
+		ActorType: pagerDutyStringPointer("pagerduty"), OccurredAt: occurredAt,
+	}
+	if err := fillPagerDutyLogEntryOrdering(&row); err != nil {
+		return pagerDutyLogEntryRow{}, err
+	}
+	return row, nil
+}
+
+func normalizePagerDutyNote(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyNotePayload,
+	incidentID string,
+	normalizedAt time.Time,
+) (pagerDutyNoteRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" || incidentID == "" {
+		return pagerDutyNoteRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyIncidentSourceTime(payload.UpdatedAt, payload.CreatedAt, normalizedAt)
+	if err != nil {
+		return pagerDutyNoteRow{}, err
+	}
+	createdAt, err := pagerDutyOptionalTime(payload.CreatedAt)
+	if err != nil {
+		return pagerDutyNoteRow{}, err
+	}
+	row := pagerDutyNoteRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "note", ExternalID: externalID, SourceVersionAt: sourceVersionAt,
+		SourceURL: pagerDutyURL(payload.HTMLURL, payload.SelfURL), ObservedAt: normalizedAt,
+		LastSynced: normalizedAt, IncidentID: incidentID, Body: pagerDutyStringValue(payload.Content),
+		CreatedAt: createdAt,
+	}
+	if payload.User != nil {
+		row.AuthorUserID = pagerDutyCanonicalReferenceID(claim.OrgID, providerInstance, "operational_user", payload.User.ID)
+	}
+	if err := fillPagerDutyNoteOrdering(&row); err != nil {
+		return pagerDutyNoteRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func pagerDutyStringPointer(value string) *string {
+	return &value
+}
+
+func pagerDutyFirstPresent(values ...*string) *string {
+	for _, value := range values {
+		if value != nil && *value != "" {
+			copy := *value
+			return &copy
+		}
+	}
+	for _, value := range values {
+		if value != nil {
+			copy := *value
+			return &copy
+		}
+	}
+	return nil
+}
+
+func pagerDutyIncidentFamilyMaxRowsOption(value any, fallback int) (int, error) {
+	if value == nil {
+		return fallback, nil
+	}
+	var parsed int64
+	switch typed := value.(type) {
+	case int:
+		parsed = int64(typed)
+	case int64:
+		parsed = typed
+	case float64:
+		if math.IsNaN(typed) || math.IsInf(typed, 0) || math.Trunc(typed) != typed || typed < 0 || typed > float64(math.MaxInt) {
+			return 0, ErrInvalidConfiguration
+		}
+		parsed = int64(typed)
+	case json.Number:
+		value, err := strconv.ParseInt(string(typed), 10, 64)
+		if err != nil {
+			return 0, ErrInvalidConfiguration
+		}
+		parsed = value
+	default:
+		return 0, ErrInvalidConfiguration
+	}
+	if parsed < 0 || uint64(parsed) > uint64(math.MaxInt) {
+		return 0, ErrInvalidConfiguration
+	}
+	return int(parsed), nil
+}
+
+var _ CompleteRouteHandler = PagerDutyIncidentFamilyRouteHandler{}

--- a/internal/providersync/pagerduty_incidents_route_test.go
+++ b/internal/providersync/pagerduty_incidents_route_test.go
@@ -1,0 +1,256 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyIncidentFamilyResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutyIncidentFamilyDoer struct {
+	t         *testing.T
+	responses []pagerDutyIncidentFamilyResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyIncidentFamilyDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[{"id":"PI1","type":"incident","incident_number":42,"title":"Database outage","status":"resolved","urgency":"high","created_at":"2026-07-17T12:00:00.123456Z","updated_at":"2026-07-18T10:00:00.654321Z","resolved_at":"2026-07-18T09:00:00Z","service":{"id":"PSVC1"},"priority":{"id":"P1","summary":"P1"},"html_url":"https://acme.pagerduty.com/incidents/PI1"}],"more":false}`,
+	}}}
+	client := pagerDutyIncidentFamilyTestClient(t, doer)
+	claim := nativeTestClaim("pagerduty", "incidents")
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "}}
+	normalizedAt := time.Date(2026, 7, 19, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_incidents" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 1 || batch.Evidence.Pages != 1 || batch.Evidence.Records != 1 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(time.Date(2026, 7, 17, 12, 0, 0, 123456000, time.UTC)) {
+		t.Fatalf("batch=%+v", batch)
+	}
+	query := doer.requests[0].URL.Query()
+	if query.Get("since") != claim.SinceAt.Format(time.RFC3339Nano) || query.Get("until") != claim.BeforeAt.Format(time.RFC3339Nano) ||
+		query.Get("limit") != "100" || query.Get("offset") != "0" {
+		t.Fatalf("query=%v", query)
+	}
+	if doer.requests[0].URL.Path != "/incidents" {
+		t.Fatalf("parent path=%q", doer.requests[0].URL.Path)
+	}
+	row := mustPagerDutyIncidentRow(t, batch.Effects[0].Rows[0])
+	if row.ProviderInstanceID != "acme" || row.ExternalID != "PI1" || row.Title != "Database outage" ||
+		row.SourceEventID == nil || *row.SourceEventID != "42" || row.RawStatus == nil || *row.RawStatus != "resolved" ||
+		row.NormalizedStatus == nil || *row.NormalizedStatus != "resolved" || row.NormalizedSeverity == nil || *row.NormalizedSeverity != "high" ||
+		row.NormalizedPriority == nil || *row.NormalizedPriority != "high" || row.ServiceID == nil || row.ServiceExternalID == nil ||
+		*row.ServiceExternalID != "PSVC1" || row.SourceURL == nil || *row.SourceURL != "https://acme.pagerduty.com/incidents/PI1" ||
+		row.SourceEventAt == nil || !row.SourceEventAt.Equal(time.Date(2026, 7, 17, 12, 0, 0, 123456000, time.UTC)) ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 7, 18, 10, 0, 0, 654321000, time.UTC)) || row.SourceRevision == nil || row.IngestRevision == nil {
+		t.Fatalf("row=%+v", row)
+	}
+	if expected := pagerDutyCanonicalReferenceID(claim.OrgID, "acme", "operational_service", "PSVC1"); row.ServiceID == nil || *row.ServiceID != *expected {
+		t.Fatalf("service id=%v expected=%v", row.ServiceID, expected)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteCapsChildrenAndClampsToEarliestUndrainedIncident(t *testing.T) {
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{
+		{body: `{"incidents":[
+			{"id":"PI-OLD","created_at":"2026-07-10T12:00:00Z","updated_at":"2026-07-10T12:00:00Z"},
+			{"id":"PI-NEW","created_at":"2026-07-11T12:00:00Z","updated_at":"2026-07-11T12:00:00Z"}],"more":false}`},
+		{body: `{"alerts":[{"id":"A-OLD-1","status":"triggered","created_at":"2026-07-10T12:00:00Z"},{"id":"A-OLD-2","status":"triggered","created_at":"2026-07-10T12:01:00Z"}],"more":true}`},
+		{body: `{"alerts":[],"more":false}`},
+	}}
+	client := pagerDutyIncidentFamilyTestClient(t, doer)
+	claim := nativeTestClaim("pagerduty", "incident-alerts")
+	claim.DatasetOptions = map[string]any{"enrichment_cap": 1}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Evidence.Requests != 3 || batch.Evidence.Pages != 3 || batch.Evidence.Records != 1 || len(batch.Effects[0].Rows) != 1 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[1].URL.Path; got != "/incidents/PI-OLD/alerts" {
+		t.Fatalf("first child path=%q", got)
+	}
+	if len(doer.requests) != 3 {
+		t.Fatalf("requests=%d", len(doer.requests))
+	}
+	row := mustPagerDutyAlertRow(t, batch.Effects[0].Rows[0])
+	if row.IncidentID == nil || row.Title != "A-OLD-1" || row.NormalizedStatus == nil || *row.NormalizedStatus != "open" {
+		t.Fatalf("alert=%+v", row)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteKeepsSinceBoundaryInclusive(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	boundary := claim.SinceAt.UTC().Format(time.RFC3339)
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[
+			{"id":"PI-BEFORE","created_at":"2026-06-30T23:59:59Z","updated_at":"2026-06-30T23:59:59Z"},
+			{"id":"PI-BOUNDARY","created_at":"` + boundary + `","updated_at":"` + boundary + `"}],"more":false}`,
+	}}}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	row := mustPagerDutyIncidentRow(t, batch.Effects[0].Rows[0])
+	if row.ExternalID != "PI-BOUNDARY" || batch.Watermark == nil || !batch.Watermark.Equal(claim.SinceAt.UTC()) {
+		t.Fatalf("row=%+v watermark=%v", row, batch.Watermark)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteDoesNotPaginateNotes(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{
+		{body: `{"incidents":[{"id":"PI1","created_at":"2026-07-10T12:00:00Z","updated_at":"2026-07-10T12:00:00Z"}],"more":false}`},
+		{body: `{"notes":[{"id":"N1","content":"first note","created_at":"2026-07-10T12:01:00Z"}]}`},
+	}}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 2 || doer.requests[1].URL.Path != "/incidents/PI1/notes" || doer.requests[1].URL.RawQuery != "" {
+		t.Fatalf("requests=%d child=%s", len(doer.requests), doer.requests[1].URL.RequestURI())
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 1 || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("batch=%+v", batch)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteDisabledEnrichmentMakesNoProviderCall(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	claim.DatasetOptions = map[string]any{"enabled": false}
+	doer := &pagerDutyIncidentFamilyDoer{t: t}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 0 || batch.Evidence.Requests != 0 || batch.Evidence.Pages != 0 || len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 {
+		t.Fatalf("requests=%d batch=%+v", len(doer.requests), batch)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteZeroCapReadsParentsWithoutChildRequests(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incident-notes")
+	claim.DatasetOptions = map[string]any{"enrichment_cap": 0}
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[{"id":"PI1","created_at":"2026-07-10T12:00:00Z","updated_at":"2026-07-10T12:00:00Z"}],"more":false}`,
+	}}}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 1 || batch.Evidence.Requests != 1 || batch.Evidence.Records != 0 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("requests=%d batch=%+v", len(doer.requests), batch)
+	}
+}
+
+func TestPagerDutyIncidentFamilyRouteRejectsPaginationCap(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "incidents")
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[{"id":"PI1","created_at":"2026-07-10T12:00:00Z"}],"more":true}`,
+	}}}
+	_, err := (PagerDutyIncidentFamilyRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		pagerDutyIncidentFamilyTestClient(t, doer), time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func pagerDutyIncidentFamilyTestClient(t *testing.T, doer providerfoundation.HTTPDoer) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyIncidentRow(t *testing.T, raw []byte) pagerDutyIncidentRow {
+	t.Helper()
+	var row pagerDutyIncidentRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func mustPagerDutyAlertRow(t *testing.T, raw []byte) pagerDutyAlertRow {
+	t.Helper()
+	var row pagerDutyAlertRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/pagerduty_schedules_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_schedules_effects_clickhouse.go
@@ -1,0 +1,329 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// The migrated operational_on_call_schedules table predates durable ordering
+// columns. Keep the typed effect row complete for parity/readback validation,
+// but insert the exact columns provided by the production migration.
+const pagerDutySchedulesColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,name,description,timezone,is_deleted,deleted_at"
+
+// PagerDutySchedulesClickHouseEffects persists a complete schedules snapshot
+// and fences omitted active rows with typed tombstones. Tenant and provider
+// instance predicates keep one PagerDuty account from mutating another.
+type PagerDutySchedulesClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+	Now                func() time.Time
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pagerDutyScheduleRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validatePagerDutyScheduleRows(claim, rows); err != nil {
+		return err
+	}
+	providerInstance, err := sink.providerInstance(rows)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveSchedules(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.snapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyScheduleRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyScheduleTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(
+		ctx, "INSERT INTO operational_on_call_schedules ("+pagerDutySchedulesColumns+")",
+	)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyScheduleValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pagerDutyScheduleRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validatePagerDutyScheduleRows(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	providerInstance, err := sink.providerInstance(expected)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveSchedules(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	exact, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadSchedule(
+			ctx, claim, providerInstance, row.ID,
+		)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyScheduleVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	// A complete source snapshot is exact only when every active source row is
+	// represented by the returned identity set or has been tombstoned.
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected) && absent == 0:
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "schedules" ||
+		effect.Destination != "operational_on_call_schedules" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func validatePagerDutyScheduleRows(claim Claim, rows []pagerDutyScheduleRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "schedule" || row.ExternalID == "" || row.Name == "" ||
+			row.ID == "" || row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyScheduleOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) providerInstance(
+	rows []pagerDutyScheduleRow,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, row := range rows {
+		rowInstance := strings.ToLower(strings.TrimSpace(row.ProviderInstanceID))
+		if rowInstance == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = rowInstance
+		}
+		if instance != rowInstance {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func pagerDutyScheduleValues(row pagerDutyScheduleRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence, row.Name, row.Description, row.Timezone,
+		row.IsDeleted, row.DeletedAt,
+	}
+}
+
+func pagerDutyScheduleScanValues(row *pagerDutyScheduleRow) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.Name, &row.Description, &row.Timezone,
+		&row.IsDeleted, &row.DeletedAt,
+	}
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) loadActiveSchedules(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyScheduleRow, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutySchedulesColumns+
+			" FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+		claim.OrgID, claim.Provider, providerInstance, "schedule",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	active := make([]pagerDutyScheduleRow, 0)
+	for rows.Next() {
+		var row pagerDutyScheduleRow
+		if err := rows.Scan(pagerDutyScheduleScanValues(&row)...); err != nil {
+			return nil, err
+		}
+		if err := fillPagerDutyScheduleOrdering(&row); err != nil {
+			return nil, err
+		}
+		active = append(active, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return active, nil
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) loadSchedule(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyScheduleRow, bool, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutySchedulesColumns+
+			" FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "schedule", id,
+	)
+	if err != nil {
+		return pagerDutyScheduleRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyScheduleRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyScheduleScanValues(&actual)...); err != nil {
+			return pagerDutyScheduleRow{}, false, err
+		}
+		if err := fillPagerDutyScheduleOrdering(&actual); err != nil {
+			return pagerDutyScheduleRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyScheduleRow{}, false, err
+	}
+	return actual, found, nil
+}
+
+func comparePagerDutyScheduleVersion(
+	expected, actual pagerDutyScheduleRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func (sink PagerDutySchedulesClickHouseEffects) snapshotObservedAt(
+	rows []pagerDutyScheduleRow, claim Claim,
+) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	if sink.Now != nil {
+		return sink.Now().UTC().Truncate(time.Microsecond)
+	}
+	if claim.BeforeAt != nil && !claim.BeforeAt.IsZero() {
+		return claim.BeforeAt.UTC().Truncate(time.Microsecond)
+	}
+	return time.Now().UTC().Truncate(time.Microsecond)
+}
+
+var _ EffectSink = PagerDutySchedulesClickHouseEffects{}
+var _ EffectReadback = PagerDutySchedulesClickHouseEffects{}

--- a/internal/providersync/pagerduty_schedules_effects_integration_test.go
+++ b/internal/providersync/pagerduty_schedules_effects_integration_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Apply the production migration chain, including the canonical schedules
+	// table, rather than creating a test-only relaxed schema.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "schedules")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	rowA, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{
+			ID: "PS1", Name: "Primary", TimeZone: stringPtr("America/Los_Angeles"),
+		}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowB, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{ID: "PS2", Name: "Support"}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialEffect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired,
+		[]pagerDutyScheduleRow{rowA, rowB},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutySchedulesClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "Acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+		Now:   func() time.Time { return initialAt },
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, initialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after initial write inspection=%s error=%v", inspection, err)
+	}
+
+	// A later complete snapshot omits PS2. The sink must fence that omission
+	// with a strictly newer tombstone while retaining active PS1.
+	updatedAt := initialAt.Add(time.Hour)
+	rowAUpdated, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{
+			ID: "PS1", Name: "Primary updated", UpdatedAt: updatedAt.Format(time.RFC3339Nano),
+			TimeZone: stringPtr("America/Los_Angeles"),
+		}, updatedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partialEffect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired,
+		[]pagerDutyScheduleRow{rowAUpdated},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink.Now = func() time.Time { return updatedAt }
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("tombstone write inspection=%s error=%v", inspection, err)
+	}
+	var deleted bool
+	var deletedAt time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_deleted, deleted_at
+FROM operational_on_call_schedules FINAL
+WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND external_id = ?`,
+		claim.OrgID, "pagerduty", "acme", "schedule", "PS2",
+	).Scan(&deleted, &deletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted || !deletedAt.Equal(updatedAt) {
+		t.Fatalf("missing-schedule tombstone deleted=%v deleted_at=%s want %s", deleted, deletedAt, updatedAt)
+	}
+
+	// The durable effect payload can be replayed after the write. Exact
+	// readback must remain stable and must not create a second logical row.
+	if err := sink.WriteEffect(ctx, claim, partialEffect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+	}
+
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	otherRow := rowAUpdated
+	otherRow.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyScheduleOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	otherEffect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired,
+		[]pagerDutyScheduleRow{otherRow},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, otherEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, partialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign row changed readback inspection=%s error=%v", inspection, err)
+	}
+}

--- a/internal/providersync/pagerduty_schedules_effects_test.go
+++ b/internal/providersync/pagerduty_schedules_effects_test.go
@@ -1,0 +1,102 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutySchedulesEffectRejectsForeignScopeOrderingTamperAndMixedInstances(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "schedules")
+	row, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{
+			ID: "PS1", Name: "Primary", TimeZone: stringPtr("UTC"),
+		}, time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := row
+	foreign.OrgID = "org-other"
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := row
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyScheduleOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutySchedulesClickHouseEffects{}).providerInstance(
+		[]pagerDutyScheduleRow{row, foreignInstance},
+	); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := row
+	tampered.Timezone = stringPtr("America/New_York")
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	inconsistent := row
+	inconsistent.IsDeleted = true
+	if err := fillPagerDutyScheduleOrdering(&inconsistent); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{inconsistent}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("deleted flag consistency error=%v", err)
+	}
+	if err := validatePagerDutyScheduleRows(claim, []pagerDutyScheduleRow{row, row}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate row error=%v", err)
+	}
+}
+
+func TestPagerDutySchedulesTombstoneBumpsSourceVersionAndPreservesIdentity(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "schedules")
+	row, err := normalizePagerDutySchedule(
+		claim, "acme", pagerDutySchedulePayload{ID: "PS1", Name: "Primary"},
+		time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tombstone, err := pagerDutyScheduleTombstone(row, row.SourceVersionAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tombstone.ID != row.ID || tombstone.ExternalID != row.ExternalID ||
+		!tombstone.SourceVersionAt.Equal(row.SourceVersionAt.Add(time.Microsecond)) ||
+		!tombstone.ObservedAt.Equal(tombstone.SourceVersionAt) ||
+		!tombstone.LastSynced.Equal(tombstone.SourceVersionAt) || !tombstone.IsDeleted ||
+		tombstone.DeletedAt == nil || !tombstone.DeletedAt.Equal(tombstone.SourceVersionAt) ||
+		tombstone.SourceRevision == nil || tombstone.IngestRevision == nil ||
+		tombstone.OrderingContract != 2 {
+		t.Fatalf("tombstone=%+v", tombstone)
+	}
+	if tombstone.SourceRevision.Cmp(row.SourceRevision) <= 0 {
+		t.Fatalf("tombstone source revision did not advance: old=%s new=%s", row.SourceRevision, tombstone.SourceRevision)
+	}
+}
+
+func TestPagerDutySchedulesEffectRejectsUnsafeEmptySnapshotWithoutInstance(t *testing.T) {
+	if _, err := (PagerDutySchedulesClickHouseEffects{}).providerInstance(nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+}
+
+func TestPagerDutySchedulesEffectRejectsWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "schedules")
+	sink := PagerDutySchedulesClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_on_call_schedules"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid request error=%v", err)
+	}
+	if err := sink.WriteEffect(
+		context.Background(), claim, EffectBatch{Destination: "other"},
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_schedules_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_schedules_generic_oracle_test.go
@@ -1,0 +1,76 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyScheduleRowForOracle(
+	t *testing.T, input map[string]any,
+) pagerDutyScheduleRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutySchedulePayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "schedules")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutySchedule(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload,
+		observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyScheduleCases() []oracleCase {
+	return []oracleCase{
+		{ID: "updated_html_url_timezone", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS1", "type": "schedule", "name": "Primary",
+				"summary": "Ignored summary", "time_zone": "America/Los_Angeles",
+				"updated_at": "2026-08-01T10:00:00.123456Z",
+				"html_url":   "https://acme.pagerduty.com/schedules/PS1",
+			},
+		}},
+		{ID: "created_self_url_summary", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS2", "type": "schedule", "summary": "Support",
+				"created_at": "2026-07-31T09:00:00Z", "self": "/schedules/PS2",
+			},
+		}},
+		{ID: "observed_time_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS3", "type": "schedule", "name": "Operations",
+			},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyScheduleRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/schedules/row", oraclePagerDutyScheduleCases(),
+		buildPagerDutyScheduleRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_schedules_route.go
+++ b/internal/providersync/pagerduty_schedules_route.go
@@ -1,0 +1,286 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutySchedulesMaxPages = 10_000
+	pagerDutySchedulesMaxRows  = 100_000
+	pagerDutySchedulesPerPage  = 100
+)
+
+// pagerDutySchedulePayload is the provider-owned subset consumed by Python's
+// PagerDutyNormalizer.schedule. The schedules unit deliberately does not own
+// on-call assignment payloads; those are a separate source unit and table.
+type pagerDutySchedulePayload struct {
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	Summary   string  `json:"summary"`
+	SelfURL   string  `json:"self"`
+	HTMLURL   string  `json:"html_url"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
+	TimeZone  *string `json:"time_zone"`
+}
+
+// pagerDutyScheduleRow mirrors every field on Python's canonical
+// OnCallSchedule dataclass, including the persisted ordering fields.
+type pagerDutyScheduleRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	Name                   string     `json:"name"`
+	Description            *string    `json:"description"`
+	Timezone               *string    `json:"timezone"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+// PagerDutySchedulesRouteHandler owns source collection and canonical
+// normalization only. Registry, capability, and worker wiring stay outside
+// this provider slice.
+type PagerDutySchedulesRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutySchedulesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutySchedulesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutySchedulesRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutySchedulesMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutySchedulesMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutySchedulesPerPage
+	}
+	if pages < 1 || pages > pagerDutySchedulesMaxPages || rows < 1 ||
+		rows > pagerDutySchedulesMaxRows || perPage < 1 || perPage > pagerDutySchedulesPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutySchedulesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "schedules" || client == nil ||
+		client.Provider != "pagerduty" || client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutySchedulesCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/schedules", DataKey: "schedules", PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	rows := make([]pagerDutyScheduleRow, 0, len(pages.Items))
+	for _, raw := range pages.Items {
+		var payload pagerDutySchedulePayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, err := normalizePagerDutySchedule(claim, providerInstance, payload, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues(
+		"operational_on_call_schedules", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  map[string]any{"schedules_synced": len(rows)},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutySchedule(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutySchedulePayload,
+	normalizedAt time.Time,
+) (pagerDutyScheduleRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyScheduleRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyScheduleSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyScheduleRow{}, err
+	}
+	var sourceURL *string
+	if payload.HTMLURL != "" {
+		value := payload.HTMLURL
+		sourceURL = &value
+	} else if payload.SelfURL != "" {
+		value := payload.SelfURL
+		sourceURL = &value
+	}
+	name := payload.Name
+	if name == "" {
+		name = payload.Summary
+	}
+	if name == "" {
+		name = payload.ID
+	}
+	row := pagerDutyScheduleRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "schedule", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt, Name: name,
+		Timezone: payload.TimeZone,
+	}
+	if err := fillPagerDutyScheduleOrdering(&row); err != nil {
+		return pagerDutyScheduleRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyScheduleSourceTime(
+	payload pagerDutySchedulePayload, observedAt time.Time,
+) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func fillPagerDutyScheduleOrdering(row *pagerDutyScheduleRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"name", row.Name},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"timezone", jiraStringValue(row.Timezone)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_on_call_schedule", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+func pagerDutyScheduleTombstone(
+	row pagerDutyScheduleRow, observedAt time.Time,
+) (pagerDutyScheduleRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyScheduleRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)
+	if version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt = version
+	row.ObservedAt = version
+	row.LastSynced = version
+	row.IsDeleted = true
+	row.DeletedAt = &version
+	row.SourceRevision = nil
+	row.SourceConflictKey = ""
+	row.IngestRevision = nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyScheduleOrdering(&row); err != nil {
+		return pagerDutyScheduleRow{}, err
+	}
+	return row, nil
+}
+
+var _ CompleteRouteHandler = PagerDutySchedulesRouteHandler{}

--- a/internal/providersync/pagerduty_schedules_route_test.go
+++ b/internal/providersync/pagerduty_schedules_route_test.go
@@ -1,0 +1,220 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutySchedulesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutySchedulesDoer struct {
+	t         *testing.T
+	responses []pagerDutySchedulesResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutySchedulesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{
+		{body: `{"schedules":[
+			{"id":"PS1","type":"schedule","name":"Primary","time_zone":"America/Los_Angeles","updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/schedules/PS1"},
+			{"id":"PS2","type":"schedule","summary":"Support","created_at":"2026-07-31T09:00:00Z","self":"/schedules/PS2"}],"more":true}`},
+		{body: `{"schedules":[{"id":"PS3","type":"schedule","name":"Operations"}],"more":false}`},
+	}}
+	client := pagerDutySchedulesTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "schedules")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "},
+	}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutySchedulesRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_on_call_schedules" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 ||
+		batch.Evidence.CapReached || batch.Watermark != nil {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[0].URL.Path; got != "/schedules" {
+		t.Fatalf("first path=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+	row := mustPagerDutyScheduleRow(t, batch.Effects[0].Rows[0])
+	if row.Provider != "pagerduty" || row.ProviderInstanceID != "acme" ||
+		row.SourceEntityType != "schedule" || row.ExternalID != "PS1" ||
+		row.Name != "Primary" || row.Timezone == nil || *row.Timezone != "America/Los_Angeles" ||
+		row.SourceURL == nil || *row.SourceURL != "https://acme.pagerduty.com/schedules/PS1" ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!row.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) ||
+		row.SourceRevision == nil || row.IngestRevision == nil || row.OrderingContract != 2 {
+		t.Fatalf("row=%+v", row)
+	}
+	secondary := mustPagerDutyScheduleRow(t, batch.Effects[0].Rows[1])
+	if secondary.Name != "Support" || secondary.Timezone != nil || secondary.SourceURL == nil ||
+		*secondary.SourceURL != "/schedules/PS2" {
+		t.Fatalf("secondary=%+v", secondary)
+	}
+	tertiary := mustPagerDutyScheduleRow(t, batch.Effects[0].Rows[2])
+	if tertiary.Name != "Operations" || !tertiary.SourceVersionAt.Equal(row.ObservedAt) {
+		t.Fatalf("tertiary=%+v", tertiary)
+	}
+}
+
+func TestPagerDutySchedulesRoutePreservesRetryAndPermanentErrorSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	retryDoer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{
+		{status: http.StatusTooManyRequests, headers: http.Header{"Retry-After": {"0"}}, body: `{"message":"slow down"}`},
+		{body: `{"schedules":[],"more":false}`},
+	}}
+	retryClient := pagerDutySchedulesTestClient(t, retryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim, credential, retryClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil || len(retryDoer.requests) != 2 || len(batch.Effects) != 1 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(retryDoer.requests))
+	}
+
+	authDoer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{{
+		status: http.StatusUnauthorized, body: `{"message":"bad token"}`,
+	}}}
+	authClient := pagerDutySchedulesTestClient(t, authDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	_, err = (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim, credential, authClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication ||
+		len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+}
+
+func TestPagerDutySchedulesRouteFailsClosedOnPaginationCapAndMissingInstance(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	client := pagerDutySchedulesTestClient(t, &pagerDutySchedulesDoer{
+		t: t, responses: []pagerDutySchedulesResponse{{
+			body: `{"schedules":[{"id":"one"}],"more":true}`,
+		}}}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	_, err := (PagerDutySchedulesRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, credential, client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	_, err = (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{Provider: "pagerduty"}, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("missing instance error=%v", err)
+	}
+}
+
+func TestPagerDutySchedulesRouteStopsWhenLeaseExpiresBetweenPages(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	doer := &pagerDutySchedulesDoer{t: t, responses: []pagerDutySchedulesResponse{
+		{body: `{"schedules":[{"id":"one"}],"more":true}`},
+		{body: `{"schedules":[],"more":false}`},
+	}}
+	asserts := 0
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutySchedulesRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(doer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(doer.requests), asserts)
+	}
+}
+
+func pagerDutySchedulesTestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyScheduleRow(t *testing.T, raw []byte) pagerDutyScheduleRow {
+	t.Helper()
+	var row pagerDutyScheduleRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incident-alerts_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incident-alerts_row.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    normalizer = _normalizer(case)
+    parent = normalizer.incident(module.Incident.model_validate(case["incident"]))
+    return asdict(
+        normalizer.alert(module.Alert.model_validate(case["payload"]), parent.id)
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incident-alerts/row",
+        build_row=_build_row,
+        reflected_fields=lambda: frozenset(
+            field.name for field in fields(_module().OperationalAlert)
+        ),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incident-log-entries_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incident-log-entries_row.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    normalizer = _normalizer(case)
+    parent = normalizer.incident(module.Incident.model_validate(case["incident"]))
+    return asdict(
+        normalizer.log_entry(module.LogEntry.model_validate(case["payload"]), parent.id)
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incident-log-entries/row",
+        build_row=_build_row,
+        reflected_fields=lambda: frozenset(
+            field.name for field in fields(_module().IncidentTimelineEvent)
+        ),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incident-notes_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incident-notes_row.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    normalizer = _normalizer(case)
+    parent = normalizer.incident(module.Incident.model_validate(case["incident"]))
+    return asdict(
+        normalizer.note(module.Note.model_validate(case["payload"]), parent.id)
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incident-notes/row",
+        build_row=_build_row,
+        reflected_fields=lambda: frozenset(
+            field.name for field in fields(_module().IncidentNote)
+        ),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_incidents_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_incidents_row.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _normalizer(case: dict[str, Any]) -> Any:
+    return _module().PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00")),
+    )
+
+
+def _reflected(entity: Any) -> frozenset[str]:
+    return frozenset(field.name for field in fields(entity))
+
+
+def _incident(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).incident(module.Incident.model_validate(case["payload"]))
+    )
+
+
+def _parent_id(case: dict[str, Any]) -> str:
+    module = _module()
+    return (
+        _normalizer(case).incident(module.Incident.model_validate(case["incident"])).id
+    )
+
+
+def _alert(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).alert(
+            module.Alert.model_validate(case["payload"]), _parent_id(case)
+        )
+    )
+
+
+def _log_entry(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).log_entry(
+            module.LogEntry.model_validate(case["payload"]), _parent_id(case)
+        )
+    )
+
+
+def _note(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    return asdict(
+        _normalizer(case).note(
+            module.Note.model_validate(case["payload"]), _parent_id(case)
+        )
+    )
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/incidents/row",
+        build_row=_incident,
+        reflected_fields=lambda: _reflected(_module().OperationalIncident),
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_schedules_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_schedules_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OnCallSchedule))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.Schedule.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.schedule(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/schedules/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/tests/tooling/mutation-plans/pagerduty_incidents.json
+++ b/tests/tooling/mutation-plans/pagerduty_incidents.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty incident family typed route and readback effects",
+  "$limitation": "This plan covers the incidents parent stream, the three typed incident enrichment streams, their window/cap/pagination semantics, and tenant-scoped ClickHouse effects. Services, schedules, on-calls, registry/matrix/config, deployment, and cutover wiring remain outside this provider-only slice.",
+  "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+  "mutations": [
+    {
+      "id": "PI1-dataset-contract",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if claim.Dataset != \"incidents\" && claim.Dataset != \"incident-alerts\" &&",
+      "replace": "if claim.Dataset != \"incident\" && claim.Dataset != \"incident-alerts\" &&",
+      "expect_occurrences": 1,
+      "rationale": "The family route must accept the exact plural incidents dataset contract and fail closed on a singular alias.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI2-parent-path",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "path: \"/incidents\", decode: decodePagerDutyIncidents, paginated: true,",
+      "replace": "path: \"/services\", decode: decodePagerDutyIncidents, paginated: true,",
+      "expect_occurrences": 1,
+      "rationale": "The parent producer owns PagerDuty's /incidents endpoint; requesting another resource family cannot be normalized as an incident inventory.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI3-parent-response-key",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "return envelope.Incidents, *envelope.More, nil",
+      "replace": "return nil, *envelope.More, nil",
+      "expect_occurrences": 1,
+      "rationale": "A non-empty PagerDuty incidents response must remain non-empty after decoding; dropping the typed response slice would report a false empty batch.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI4-parent-pagination-cap",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if result.Pages >= maxPages {",
+      "replace": "if result.Pages > maxPages {",
+      "expect_occurrences": 1,
+      "rationale": "A parent response that advertises another page must fail at the configured page cap rather than issuing an unbounded follow-up request.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteRejectsPaginationCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI5-inclusive-since-cursor",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if claim.SinceAt != nil && createdAt.Before(claim.SinceAt.UTC()) {",
+      "replace": "if claim.SinceAt != nil && !createdAt.Before(claim.SinceAt.UTC()) {",
+      "expect_occurrences": 1,
+      "rationale": "The Python incremental window is inclusive at since; excluding the exact boundary drops a source incident and advances the cursor incorrectly.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteKeepsSinceBoundaryInclusive$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI6-before-window-clause",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "return claim.BeforeAt != nil && createdAt.After(claim.BeforeAt.UTC())",
+      "replace": "return claim.BeforeAt != nil && !createdAt.After(claim.BeforeAt.UTC())",
+      "expect_occurrences": 1,
+      "rationale": "The upper source window is inclusive; treating in-window incidents as outside the window makes a normal non-empty source batch disappear.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI7-child-cap-take",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if take > remaining {\n\t\t\t\ttake = remaining\n\t\t\t}",
+      "replace": "if take > remaining {\n\t\t\t\ttake = 0\n\t\t\t}",
+      "expect_occurrences": 1,
+      "rationale": "An enrichment cap must retain exactly the allowed prefix and clamp the watermark when the child source remains undrained.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteCapsChildrenAndClampsToEarliestUndrainedIncident$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI8-zero-enrichment-cap",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if cap == 0 {\n\t\t\tcontinue\n\t\t}",
+      "replace": "if cap != 0 {\n\t\t\tcontinue\n\t\t}",
+      "expect_occurrences": 1,
+      "rationale": "A zero enrichment cap is a valid bounded mode that reads the parent cursor without making child requests.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteZeroCapReadsParentsWithoutChildRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI9-disabled-enrichment",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if !enabled {\n\t\t\t\treturn handler.emptyPagerDutyIncidentFamilyBatch(claim, 0, 0)",
+      "replace": "if enabled {\n\t\t\t\treturn handler.emptyPagerDutyIncidentFamilyBatch(claim, 0, 0)",
+      "expect_occurrences": 1,
+      "rationale": "A disabled enrichment dataset must short-circuit before any provider request; enabling the branch reverses the source contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteDisabledEnrichmentMakesNoProviderCall$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI10-watermark-clamp-clause",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if earliestUndrained != nil && (watermark == nil || earliestUndrained.Before(*watermark)) {",
+      "replace": "if earliestUndrained != nil && (watermark == nil || earliestUndrained.After(*watermark)) {",
+      "expect_occurrences": 1,
+      "rationale": "When a child cap leaves work behind, the parent watermark must clamp to the earliest undrained incident, never a later one.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteCapsChildrenAndClampsToEarliestUndrainedIncident$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI11-notes-are-not-paginated",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "return pagerDutyIncidentFamilyEndpoint{path: base + \"/notes\", decode: decodePagerDutyNotes, paginated: false}, nil",
+      "replace": "return pagerDutyIncidentFamilyEndpoint{path: base + \"/notes\", decode: decodePagerDutyNotes, paginated: true}, nil",
+      "expect_occurrences": 1,
+      "rationale": "PagerDuty notes use the non-paginated source response contract; adding limit/offset changes the request and can make the source reject or reshape it.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteDoesNotPaginateNotes$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI12-html-url-priority",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "if htmlURL != nil && *htmlURL != \"\" {",
+      "replace": "if false && htmlURL != nil && *htmlURL != \"\" {",
+      "expect_occurrences": 1,
+      "rationale": "The common Python normalizer prefers html_url over self; removing that priority changes the canonical source URL for incidents and every child row.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI13-incident-source-event-time",
+      "file": "internal/providersync/pagerduty_incidents_route.go",
+      "find": "SourceEventAt:      createdAt, StartedAt: createdAt, ResolvedAt: resolvedAt,",
+      "replace": "SourceEventAt:      nil, StartedAt: createdAt, ResolvedAt: resolvedAt,",
+      "expect_occurrences": 1,
+      "rationale": "The incident producer's source event time is the created_at timestamp; omitting it changes canonical ordering and loses source evidence.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyRouteNormalizesIncidentAndPreservesCreatedCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "PI14-tenant-scope-fence",
+      "file": "internal/providersync/pagerduty_incidents_effects_clickhouse.go",
+      "find": "if row.OrgID != claim.OrgID || row.Provider != \"pagerduty\" ||\n\t\t\t!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||\n\t\t\trow.SourceEntityType != \"incident\" ||",
+      "replace": "if row.OrgID == claim.OrgID || row.Provider != \"pagerduty\" ||\n\t\t\t!pagerDutyProviderInstanceMatches(row.ProviderInstanceID, providerInstance) ||\n\t\t\trow.SourceEntityType != \"incident\" ||",
+      "expect_occurrences": 1,
+      "rationale": "Every ClickHouse effect must remain organization-scoped; a correctly ordered row from another tenant must be rejected before any write.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyIncidentFamilyEffectsValidateEachTypedDestinationAndScope$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/pagerduty_schedules.json
+++ b/tests/tooling/mutation-plans/pagerduty_schedules.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty schedules typed route and complete-snapshot effects",
+  "$limitation": "This plan covers provider-owned schedules collection, typed normalization, canonical identity, complete ClickHouse snapshot tombstones, and readback fences. On-call assignments remain a separate unit. Executor registration, capability/matrix wiring, route activation, and deployment remain outside this provider-only slice.",
+  "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+  "mutations": [
+    {
+      "id": "S1-dataset-identity-guard",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "claim.Provider != \"pagerduty\" || claim.Dataset != \"schedules\" || client == nil ||",
+      "replace": "claim.Provider != \"pagerduty\" || claim.Dataset != \"schedule\" || client == nil ||",
+      "rationale": "The route must accept exactly the schedules dataset identity; a singular alias must fail closed rather than collecting under the wrong contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2-schedules-path",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Path: \"/schedules\", DataKey: \"schedules\",",
+      "replace": "Path: \"/services\", DataKey: \"schedules\",",
+      "rationale": "PagerDuty schedules are collected from the dedicated /schedules endpoint; a different path silently collects a different resource family.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S3-schedules-response-key",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Path: \"/schedules\", DataKey: \"schedules\",",
+      "replace": "Path: \"/schedules\", DataKey: \"services\",",
+      "rationale": "The response key is part of PagerDuty's typed page contract; using the wrong key must not turn non-empty source data into an empty snapshot.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S4-timezone-preserved",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Timezone: payload.TimeZone,",
+      "replace": "Timezone: nil,",
+      "rationale": "Python's schedule normalizer persists the typed time_zone field; dropping it is a row-level parity defect.",
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "S5-schedule-source-family",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "SourceEntityType: \"schedule\", ExternalID: externalID,",
+      "replace": "SourceEntityType: \"service\", ExternalID: externalID,",
+      "rationale": "The source_entity_type distinguishes schedule rows from services and on-call assignments in the canonical source identity.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesRouteUsesOffsetPaginationAndCanonicalRow$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S6-active-row-filter",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "replace": "FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 1",
+      "rationale": "Complete snapshots must load active schedules before tombstoning omissions; selecting deleted rows loses the reconciliation set.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S7-tenant-fence",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "FROM operational_on_call_schedules FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "replace": "FROM operational_on_call_schedules FINAL WHERE org_id != ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0",
+      "rationale": "Active-row reconciliation must remain organization-scoped; weakening org_id equality allows one tenant's snapshot to mutate another tenant's schedules.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S8-tombstone-version-bump",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "Add(time.Microsecond)",
+      "replace": "Add(0)",
+      "rationale": "A tombstone observed at the same timestamp as its active row must win ReplacingMergeTree deterministically by advancing source_version_at.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesTombstoneBumpsSourceVersionAndPreservesIdentity$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S9-instance-scope-fence",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "if instance != rowInstance {",
+      "replace": "if false && instance != rowInstance {",
+      "rationale": "A batch may not mix PagerDuty account identities; disabling this fence can merge canonical schedules across accounts.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesEffectRejectsForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S10-omitted-row-readback-fence",
+      "file": "internal/providersync/pagerduty_schedules_effects_clickhouse.go",
+      "find": "if _, present := seen[row.ID]; !present {",
+      "replace": "if _, present := seen[row.ID]; present {",
+      "rationale": "Readback must reject a snapshot when an active schedule remains outside the returned source set; otherwise a partial write can report exact.",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutySchedulesEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S11-tombstone-state",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "row.IsDeleted = true",
+      "replace": "row.IsDeleted = false",
+      "rationale": "An omitted source schedule must be persisted as a deleted typed tombstone; leaving it active defeats complete-snapshot reconciliation.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutySchedulesTombstoneBumpsSourceVersionAndPreservesIdentity$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S12-source-url-priority",
+      "file": "internal/providersync/pagerduty_schedules_route.go",
+      "find": "if payload.HTMLURL != \"\" {",
+      "replace": "if false && payload.HTMLURL != \"\" {",
+      "rationale": "Python's canonical common normalization prefers html_url and falls back to self; changing that priority produces a field-level parity mismatch.",
+      "proof": [["bash", "ci/check_go.sh", "live-python-oracles"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Port PagerDuty schedules with concrete typed collection/normalization/effects, bounded pagination and error handling, complete-snapshot tombstones, lease recovery, and exact ClickHouse readback.

## Evidence

- Live Python differential oracle
- Real migrated ClickHouse integration
- Shared mutation harness: 12/12 killed with clean restore
- Full providersync, vet, build, Ruff, and mypy green

## Boundaries

- On-calls remain a separate provider unit
- No registry, matrix, config, deployment, activation, or cutover wiring

Linear: CHAOS-3731

SCREENSHOT-WAIVER: Backend-only provider implementation; no rendered UI changes.
