### PR TITLE
CHAOS-3718: prove Linear lifecycle and atomic alias recovery

### DIFF
--- a/internal/providerfoundation/pagination.go
+++ b/internal/providerfoundation/pagination.go
@@ -196,6 +196,9 @@ type LinearPageOptions struct {
 	ConnectionPath []string
 	PerPage        int
 	MaxPages       int
+	// InitialCursor resumes a connection after a cursor already embedded in a
+	// parent object. A zero value preserves the ordinary first-page request.
+	InitialCursor string
 }
 
 // CollectLinearGraphQLPages mirrors Linear's first/after connection contract.
@@ -212,7 +215,7 @@ func CollectLinearGraphQLPages(
 		return PageCollection{}, ErrPaginationInvalid
 	}
 	result := PageCollection{}
-	cursor := ""
+	cursor := strings.TrimSpace(options.InitialCursor)
 	for {
 		if result.Pages >= options.MaxPages {
 			result.CapReached = true

--- a/internal/providersync/linear_work_items_lifecycle.go
+++ b/internal/providersync/linear_work_items_lifecycle.go
@@ -1,0 +1,458 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/full-chaos/dev-health-ops/internal/workitemcontract"
+)
+
+// Exported aliases keep the provider's normalized rows concrete at the
+// lifecycle boundary without introducing a second row definition. The
+// underlying types are the same structs used by the ClickHouse adapters.
+type LinearWorkItemRow = linearWorkItemRow
+type LinearWorkItemTransitionRow = linearWorkItemTransitionRow
+type LinearWorkItemDependencyRow = linearWorkItemDependencyRow
+type LinearWorkItemReopenRow = linearWorkItemReopenRow
+type LinearWorkItemInteractionRow = linearWorkItemInteractionRow
+type LinearSprintRow = linearSprintRow
+
+// LinearWorkItemsRows is the complete normalized producer output. Each field
+// maps to one of the six migrated ClickHouse destination projections.
+type LinearWorkItemsRows struct {
+	WorkItems         []LinearWorkItemRow
+	StatusTransitions []LinearWorkItemTransitionRow
+	Dependencies      []LinearWorkItemDependencyRow
+	ReopenEvents      []LinearWorkItemReopenRow
+	Interactions      []LinearWorkItemInteractionRow
+	Sprints           []LinearSprintRow
+}
+
+type LinearWorkItemCounts struct {
+	WorkItems         int `json:"work_items"`
+	StatusTransitions int `json:"status_transitions"`
+	Dependencies      int `json:"dependencies"`
+	ReopenEvents      int `json:"reopen_events"`
+	Interactions      int `json:"interactions"`
+	Sprints           int `json:"sprints"`
+}
+
+func (rows LinearWorkItemsRows) Counts() LinearWorkItemCounts {
+	return LinearWorkItemCounts{
+		WorkItems: len(rows.WorkItems), StatusTransitions: len(rows.StatusTransitions),
+		Dependencies: len(rows.Dependencies), ReopenEvents: len(rows.ReopenEvents),
+		Interactions: len(rows.Interactions), Sprints: len(rows.Sprints),
+	}
+}
+
+func (rows LinearWorkItemsRows) NonEmpty() bool {
+	counts := rows.Counts()
+	return counts.WorkItems > 0 || counts.StatusTransitions > 0 ||
+		counts.Dependencies > 0 || counts.ReopenEvents > 0 ||
+		counts.Interactions > 0 || counts.Sprints > 0
+}
+
+type LinearWorkItemsFailureStage string
+
+const (
+	LinearWorkItemsFailureNone      LinearWorkItemsFailureStage = ""
+	LinearWorkItemsFailureFetch     LinearWorkItemsFailureStage = "fetch"
+	LinearWorkItemsFailureNormalize LinearWorkItemsFailureStage = "normalize"
+	LinearWorkItemsFailureEffects   LinearWorkItemsFailureStage = "effects"
+	LinearWorkItemsFailureReadback  LinearWorkItemsFailureStage = "readback"
+	LinearWorkItemsFailureComplete  LinearWorkItemsFailureStage = "complete"
+)
+
+type LinearWorkItemsFailureState struct {
+	Stage     LinearWorkItemsFailureStage `json:"stage"`
+	Code      string                      `json:"code"`
+	Retryable bool                        `json:"retryable"`
+	Cause     string                      `json:"cause"`
+}
+
+// LinearWorkItemsRouteResult is the typed counterpart to the legacy generic
+// CompleteRouteBatch.Result map. New lifecycle callers consume this value;
+// the map remains populated only for compatibility with the pre-existing
+// CompleteRouteHandler interface.
+type LinearWorkItemsRouteResult struct {
+	Rows     LinearWorkItemsRows
+	Counts   LinearWorkItemCounts
+	NonEmpty bool
+	Evidence FetchEvidence
+	Failure  LinearWorkItemsFailureState
+}
+
+type LinearWorkItemsRouteBatch struct {
+	Effects   []EffectBatch
+	Watermark *time.Time
+	Evidence  FetchEvidence
+	Result    LinearWorkItemsRouteResult
+}
+
+func linearWorkItemsFailure(stage LinearWorkItemsFailureStage, err error) LinearWorkItemsFailureState {
+	if err == nil {
+		return LinearWorkItemsFailureState{}
+	}
+	failure := LinearWorkItemsFailureState{
+		Stage: stage, Code: "provider_error", Cause: err.Error(),
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) {
+		failure.Code = string(providerErr.Class)
+		failure.Retryable = providerErr.Retryable()
+	}
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		failure.Code, failure.Retryable = "canceled", true
+	case errors.Is(err, providerfoundation.ErrLeaseLost), errors.Is(err, ErrLeaseLost):
+		failure.Code, failure.Retryable = "lease_lost", true
+	case errors.Is(err, ErrPaginationCapExceeded):
+		failure.Code = "pagination_cap"
+	case errors.Is(err, providerfoundation.ErrPaginationInvalid):
+		failure.Code = "pagination_invalid"
+	case errors.Is(err, providerfoundation.ErrGraphQLComplexity):
+		failure.Code = "graphql_complexity"
+	case errors.Is(err, providerfoundation.ErrGraphQLResponse):
+		failure.Code = "graphql_response"
+	case errors.Is(err, providerfoundation.ErrNormalizationInvalid):
+		failure.Stage, failure.Code = LinearWorkItemsFailureNormalize, "normalization_invalid"
+	case errors.Is(err, ErrEffectRecoveryAmbiguous), errors.Is(err, ErrEffectLedgerConflict):
+		failure.Code = "effect_recovery_ambiguous"
+	}
+	return failure
+}
+
+func decodeLinearWorkItemsRouteBatch(
+	batch CompleteRouteBatch,
+) (LinearWorkItemsRows, error) {
+	var rows LinearWorkItemsRows
+	seen := make(map[string]struct{}, len(batch.Effects))
+	for _, effect := range batch.Effects {
+		if _, duplicate := seen[effect.Destination]; duplicate {
+			return LinearWorkItemsRows{}, ErrInvalidConfiguration
+		}
+		seen[effect.Destination] = struct{}{}
+		switch effect.Destination {
+		case "work_items":
+			decoded, err := decodeEffectRows[LinearWorkItemRow](effect)
+			if err != nil {
+				return LinearWorkItemsRows{}, err
+			}
+			rows.WorkItems = decoded
+		case "work_item_transitions":
+			decoded, err := decodeEffectRows[LinearWorkItemTransitionRow](effect)
+			if err != nil {
+				return LinearWorkItemsRows{}, err
+			}
+			rows.StatusTransitions = decoded
+		case "work_item_dependencies":
+			decoded, err := decodeEffectRows[LinearWorkItemDependencyRow](effect)
+			if err != nil {
+				return LinearWorkItemsRows{}, err
+			}
+			rows.Dependencies = decoded
+		case "work_item_reopen_events":
+			decoded, err := decodeEffectRows[LinearWorkItemReopenRow](effect)
+			if err != nil {
+				return LinearWorkItemsRows{}, err
+			}
+			rows.ReopenEvents = decoded
+		case "work_item_interactions":
+			decoded, err := decodeEffectRows[LinearWorkItemInteractionRow](effect)
+			if err != nil {
+				return LinearWorkItemsRows{}, err
+			}
+			rows.Interactions = decoded
+		case "sprints":
+			decoded, err := decodeEffectRows[LinearSprintRow](effect)
+			if err != nil {
+				return LinearWorkItemsRows{}, err
+			}
+			rows.Sprints = decoded
+		default:
+			return LinearWorkItemsRows{}, ErrInvalidConfiguration
+		}
+	}
+	if len(seen) != len(linearWorkItemEffectDestinations) {
+		return LinearWorkItemsRows{}, ErrInvalidConfiguration
+	}
+	return rows, nil
+}
+
+// CollectTyped executes the same real provider route as Collect and exposes
+// only concrete normalized rows/evidence/failure state to lifecycle callers.
+func (handler LinearWorkItemsRouteHandler) CollectTyped(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (LinearWorkItemsRouteBatch, error) {
+	batch, err := handler.Collect(ctx, claim, credential, client, normalizedAt)
+	if err != nil {
+		return LinearWorkItemsRouteBatch{
+			Result: LinearWorkItemsRouteResult{
+				Failure: linearWorkItemsFailure(LinearWorkItemsFailureFetch, err),
+			},
+		}, err
+	}
+	rows, err := decodeLinearWorkItemsRouteBatch(batch)
+	if err != nil {
+		return LinearWorkItemsRouteBatch{
+			Effects: batch.Effects, Watermark: batch.Watermark, Evidence: batch.Evidence,
+			Result: LinearWorkItemsRouteResult{
+				Failure: linearWorkItemsFailure(LinearWorkItemsFailureNormalize, err),
+			},
+		}, err
+	}
+	return LinearWorkItemsRouteBatch{
+		Effects: batch.Effects, Watermark: batch.Watermark, Evidence: batch.Evidence,
+		Result: LinearWorkItemsRouteResult{
+			Rows: rows, Counts: rows.Counts(), NonEmpty: rows.NonEmpty(),
+			Evidence: batch.Evidence,
+		},
+	}, nil
+}
+
+type LinearWorkItemAliasReadbackState string
+
+const (
+	LinearAliasReadbackExact    LinearWorkItemAliasReadbackState = "exact"
+	LinearAliasReadbackEmpty    LinearWorkItemAliasReadbackState = "empty"
+	LinearAliasReadbackConflict LinearWorkItemAliasReadbackState = "conflict"
+)
+
+type LinearWorkItemEffectAudit struct {
+	Destination   string                           `json:"destination"`
+	Rows          int                              `json:"rows"`
+	ContentDigest string                           `json:"content_digest"`
+	Readback      LinearWorkItemAliasReadbackState `json:"readback"`
+}
+
+type LinearWorkItemAliasAudit struct {
+	Dataset            string                           `json:"dataset"`
+	Enabled            bool                             `json:"enabled"`
+	Rows               int                              `json:"rows"`
+	EffectDestinations []string                         `json:"effect_destinations"`
+	Readback           LinearWorkItemAliasReadbackState `json:"readback"`
+	Complete           bool                             `json:"complete"`
+}
+
+type LinearWorkItemsCompletionResult struct {
+	Provider   string                      `json:"provider"`
+	Dataset    string                      `json:"dataset"`
+	Generation string                      `json:"generation"`
+	Status     string                      `json:"status"`
+	NonEmpty   bool                        `json:"non_empty"`
+	Counts     LinearWorkItemCounts        `json:"counts"`
+	Effects    []LinearWorkItemEffectAudit `json:"effects"`
+	Aliases    [5]LinearWorkItemAliasAudit `json:"aliases"`
+	Evidence   FetchEvidence               `json:"evidence"`
+	Watermark  time.Time                   `json:"watermark"`
+	Failure    LinearWorkItemsFailureState `json:"failure"`
+}
+
+func linearAliasDestinations(dataset string) []string {
+	switch dataset {
+	case "work-items":
+		return []string{"work_items"}
+	case "work-item-labels":
+		return []string{"work_items"}
+	case "work-item-projects":
+		return []string{"work_items", "sprints"}
+	case "work-item-history":
+		return []string{"work_item_transitions", "work_item_reopen_events"}
+	case "work-item-comments":
+		return []string{"work_item_interactions"}
+	default:
+		return nil
+	}
+}
+
+func linearAliasRows(dataset string, counts LinearWorkItemCounts) int {
+	switch dataset {
+	case "work-items", "work-item-labels":
+		return counts.WorkItems
+	case "work-item-projects":
+		return counts.WorkItems + counts.Sprints
+	case "work-item-history":
+		return counts.StatusTransitions + counts.ReopenEvents
+	case "work-item-comments":
+		return counts.Interactions
+	default:
+		return 0
+	}
+}
+
+func linearEffectReadbackState(inspection EffectInspection, rows int) LinearWorkItemAliasReadbackState {
+	if inspection == EffectExact {
+		return LinearAliasReadbackExact
+	}
+	if inspection == EffectAbsent && rows == 0 {
+		return LinearAliasReadbackEmpty
+	}
+	return LinearAliasReadbackConflict
+}
+
+func buildLinearWorkItemsCompletionResult(
+	claim Claim,
+	route LinearWorkItemsRouteBatch,
+	audits []LinearWorkItemEffectAudit,
+	watermark time.Time,
+) (LinearWorkItemsCompletionResult, error) {
+	if claim.Validate() != nil || claim.Provider != "linear" || claim.Dataset != "work-items" ||
+		route.Result.Failure.Stage != LinearWorkItemsFailureNone || !route.Result.NonEmpty || watermark.IsZero() {
+		return LinearWorkItemsCompletionResult{}, ErrInvalidConfiguration
+	}
+	result := LinearWorkItemsCompletionResult{
+		Provider: claim.Provider, Dataset: claim.Dataset, Generation: claim.GenerationKey(),
+		Status: "success", NonEmpty: route.Result.NonEmpty, Counts: route.Result.Counts,
+		Effects: audits, Evidence: route.Result.Evidence, Watermark: watermark.UTC(),
+	}
+	datasets := workitemcontract.FamilyDatasets()
+	if len(datasets) != len(result.Aliases) {
+		return LinearWorkItemsCompletionResult{}, ErrInvalidConfiguration
+	}
+	for index, dataset := range datasets {
+		destinations := linearAliasDestinations(dataset)
+		readback := LinearAliasReadbackExact
+		for _, destination := range destinations {
+			found := false
+			for _, audit := range audits {
+				if audit.Destination == destination {
+					found = true
+					if audit.Readback != LinearAliasReadbackExact && audit.Readback != LinearAliasReadbackEmpty {
+						readback = LinearAliasReadbackConflict
+					}
+					break
+				}
+			}
+			if !found {
+				return LinearWorkItemsCompletionResult{}, ErrInvalidConfiguration
+			}
+		}
+		result.Aliases[index] = LinearWorkItemAliasAudit{
+			Dataset: dataset, Enabled: true, Rows: linearAliasRows(dataset, route.Result.Counts),
+			EffectDestinations: destinations, Readback: readback,
+			Complete: readback == LinearAliasReadbackExact || readback == LinearAliasReadbackEmpty,
+		}
+	}
+	if err := ValidateLinearWorkItemsCompletion(claim, result); err != nil {
+		return LinearWorkItemsCompletionResult{}, err
+	}
+	return result, nil
+}
+
+func ValidateLinearWorkItemsCompletion(
+	claim Claim,
+	result LinearWorkItemsCompletionResult,
+) error {
+	if claim.Validate() != nil || claim.Provider != "linear" || claim.Dataset != "work-items" ||
+		result.Provider != claim.Provider || result.Dataset != claim.Dataset ||
+		result.Generation != claim.GenerationKey() || result.Status != "success" ||
+		!result.NonEmpty || result.Watermark.IsZero() || result.Failure.Stage != LinearWorkItemsFailureNone {
+		return ErrInvalidConfiguration
+	}
+	datasets := workitemcontract.FamilyDatasets()
+	if len(datasets) != len(result.Aliases) {
+		return ErrInvalidConfiguration
+	}
+	knownFlags := make(map[string]struct{}, len(datasets))
+	for _, dataset := range datasets {
+		knownFlags[workItemFamilyFlagForDataset(dataset)] = struct{}{}
+	}
+	for flag := range claim.ProcessorFlags {
+		if strings.HasPrefix(flag, workItemFamilyFlagPrefix) {
+			if _, known := knownFlags[flag]; !known {
+				return ErrInvalidConfiguration
+			}
+		}
+	}
+	for index, dataset := range datasets {
+		alias := result.Aliases[index]
+		expectedDestinations := linearAliasDestinations(dataset)
+		if alias.Dataset != dataset || !alias.Enabled || !alias.Complete ||
+			(alias.Readback != LinearAliasReadbackExact && alias.Readback != LinearAliasReadbackEmpty) ||
+			!slices.Equal(alias.EffectDestinations, expectedDestinations) {
+			return ErrInvalidConfiguration
+		}
+		if !strings.EqualFold(workItemFamilyFlagForDataset(dataset), workItemFamilyFlagForDataset(alias.Dataset)) ||
+			!claim.ProcessorFlags[workItemFamilyFlagForDataset(dataset)] {
+			return ErrInvalidConfiguration
+		}
+	}
+	if len(result.Effects) != len(linearWorkItemEffectDestinations) {
+		return ErrInvalidConfiguration
+	}
+	seenDestinations := make(map[string]struct{}, len(result.Effects))
+	for _, audit := range result.Effects {
+		if !linearWorkItemDestination(audit.Destination) || audit.ContentDigest == "" ||
+			(audit.Readback != LinearAliasReadbackExact && audit.Readback != LinearAliasReadbackEmpty) {
+			return ErrInvalidConfiguration
+		}
+		if _, duplicate := seenDestinations[audit.Destination]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seenDestinations[audit.Destination] = struct{}{}
+	}
+	if len(seenDestinations) != len(linearWorkItemEffectDestinations) {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
+// LinearWorkItemsLifecycle commits the typed route manifest through the
+// existing lease-fenced effect ledger/sink and performs exact readback for
+// every migrated destination before producing a completion result.
+type LinearWorkItemsLifecycle struct {
+	Committer EffectCommitter
+}
+
+func (lifecycle LinearWorkItemsLifecycle) Commit(
+	ctx context.Context,
+	claim Claim,
+	route LinearWorkItemsRouteBatch,
+	normalizedAt time.Time,
+) (LinearWorkItemsCompletionResult, EffectCommitResult, error) {
+	if ctx == nil || lifecycle.Committer.Readback == nil || !route.Result.NonEmpty ||
+		route.Result.Failure.Stage != LinearWorkItemsFailureNone {
+		return LinearWorkItemsCompletionResult{}, EffectCommitResult{}, ErrInvalidConfiguration
+	}
+	commitResult, err := lifecycle.Committer.Commit(ctx, claim, route.Effects, normalizedAt)
+	if err != nil {
+		return LinearWorkItemsCompletionResult{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Generation: claim.GenerationKey(), Status: "failed",
+			Failure: linearWorkItemsFailure(LinearWorkItemsFailureEffects, err),
+		}, commitResult, err
+	}
+	audits := make([]LinearWorkItemEffectAudit, 0, len(route.Effects))
+	for _, effect := range route.Effects {
+		inspection, inspectErr := lifecycle.Committer.Readback.InspectEffect(ctx, claim, effect)
+		if inspectErr != nil {
+			return LinearWorkItemsCompletionResult{
+				Provider: claim.Provider, Dataset: claim.Dataset,
+				Generation: claim.GenerationKey(), Status: "failed",
+				Failure: linearWorkItemsFailure(LinearWorkItemsFailureReadback, inspectErr),
+			}, commitResult, inspectErr
+		}
+		audits = append(audits, LinearWorkItemEffectAudit{
+			Destination: effect.Destination, Rows: len(effect.Rows),
+			ContentDigest: effect.ContentDigest,
+			Readback:      linearEffectReadbackState(inspection, len(effect.Rows)),
+		})
+	}
+	watermark := route.Watermark
+	if watermark == nil {
+		return LinearWorkItemsCompletionResult{}, commitResult, ErrInvalidConfiguration
+	}
+	result, err := buildLinearWorkItemsCompletionResult(claim, route, audits, *watermark)
+	if err != nil {
+		return LinearWorkItemsCompletionResult{}, commitResult, err
+	}
+	return result, commitResult, nil
+}

--- a/internal/providersync/linear_work_items_lifecycle_integration_test.go
+++ b/internal/providersync/linear_work_items_lifecycle_integration_test.go
@@ -1,0 +1,256 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/full-chaos/dev-health-ops/internal/workitemcontract"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestLinearTypedCompletionAtomicallyAuditsFiveAliasesAndWatermarks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	unitID := uuid.NewString()
+	linearFlags, err := json.Marshal(allLinearFamilyFlags(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+INSERT INTO public.integration_datasets
+  (id, org_id, integration_id, dataset_key, options)
+VALUES ($1, 'org-acme', $2, 'work-items', '{}'::jsonb)`, uuid.NewString(), firstIntegrationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+INSERT INTO public.sync_run_units (
+    id, org_id, sync_run_id, integration_id, source_id, provider,
+    dataset_key, cost_class, mode, since_at, before_at, status,
+    processor_flags, updated_at
+) VALUES (
+    $1, 'org-acme', $2, $3, $4, 'linear', 'work-items', 'medium',
+    'incremental', '2026-08-09T12:00:00Z', '2026-08-10T12:00:00Z',
+    'dispatching', $5::jsonb, $6)`,
+		unitID, firstRunID, firstIntegrationID, firstSourceID, string(linearFlags), now); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: unitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Provider != "linear" || claim.Dataset != "work-items" ||
+		len(claim.ProcessorFlags) != len(allLinearFamilyFlags(true)) {
+		t.Fatalf("linear claim=%+v", claim)
+	}
+
+	_, route := linearTypedLifecycleFixture(t)
+	route.Watermark = claim.BeforeAt
+	route.Result.Evidence = route.Evidence
+	audits := make([]LinearWorkItemEffectAudit, 0, len(route.Effects))
+	for _, effect := range route.Effects {
+		audits = append(audits, LinearWorkItemEffectAudit{
+			Destination: effect.Destination, Rows: len(effect.Rows),
+			ContentDigest: effect.ContentDigest, Readback: LinearAliasReadbackExact,
+		})
+	}
+	result, err := buildLinearWorkItemsCompletionResult(claim, route, audits, *claim.BeforeAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	completedAt := now.Add(30 * time.Second)
+	if err := repository.CompleteLinearWorkItemFamily(ctx, claim, result, now, completedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	var status string
+	var persistedResult []byte
+	if err := pool.QueryRow(ctx, `
+SELECT status, result::jsonb
+FROM public.sync_run_units WHERE id = $1`, unitID).Scan(&status, &persistedResult); err != nil {
+		t.Fatal(err)
+	}
+	var persisted LinearWorkItemsCompletionResult
+	if err := json.Unmarshal(persistedResult, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if status != "success" || len(persisted.Aliases) != len(workitemcontract.FamilyDatasets()) ||
+		persisted.Generation != claim.GenerationKey() {
+		t.Fatalf("status=%q persisted=%+v", status, persisted)
+	}
+	var watermarkCount int
+	var watermarkKeys string
+	if err := pool.QueryRow(ctx, `
+SELECT count(*), string_agg(dataset_key, ',' ORDER BY dataset_key)
+FROM public.sync_watermarks
+WHERE org_id = 'org-acme' AND source_id = 'acme/api'
+  AND dataset_key IN (
+    'work-items', 'work-item-labels', 'work-item-projects',
+    'work-item-history', 'work-item-comments'
+  ) AND last_synced_at = $1`, *claim.BeforeAt).Scan(&watermarkCount, &watermarkKeys); err != nil {
+		t.Fatal(err)
+	}
+	wantKeys := "work-item-comments,work-item-history,work-item-labels,work-item-projects,work-items"
+	if watermarkCount != 5 || watermarkKeys != wantKeys {
+		t.Fatalf("alias watermark count=%d keys=%q", watermarkCount, watermarkKeys)
+	}
+
+	// The validator runs before the transaction. An unsupported alias flag must
+	// leave both the unit and every watermark untouched, proving the five writes
+	// cannot be partially committed from an invalid audit.
+	badUnitID := uuid.NewString()
+	badFlags := `{"family_dataset_work_items":true,"family_dataset_future_alias":true}`
+	if _, err := pool.Exec(ctx, `
+INSERT INTO public.sync_run_units (
+    id, org_id, sync_run_id, integration_id, source_id, provider,
+    dataset_key, cost_class, mode, since_at, before_at, status,
+    processor_flags, updated_at
+) VALUES (
+    $1, 'org-acme', $2, $3, $4, 'linear', 'work-items', 'medium',
+    'incremental', '2026-08-09T12:00:00Z', '2026-08-10T12:00:00Z',
+    'dispatching', $5::jsonb, $6)`,
+		badUnitID, firstRunID, firstIntegrationID, firstSourceID, badFlags, now); err != nil {
+		t.Fatal(err)
+	}
+	badClaim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: badUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.CompleteLinearWorkItemFamily(ctx, badClaim, result, now, completedAt); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid alias completion error=%v", err)
+	}
+	var badStatus string
+	if err := pool.QueryRow(ctx, `SELECT status FROM public.sync_run_units WHERE id = $1`, badUnitID).Scan(&badStatus); err != nil {
+		t.Fatal(err)
+	}
+	if badStatus != "running" {
+		t.Fatalf("invalid alias status=%q", badStatus)
+	}
+}
+
+func TestLinearTypedLifecycleUsesMigratedClickHouseAndRecoversExactWrite(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t)
+	claim := nativeTestClaim("linear", "work-items")
+	claim.SourceExternalID = "ENG"
+	claim.ProcessorFlags = allLinearFamilyFlags(true)
+	now := time.Date(2026, 8, 10, 12, 0, 0, 123000000, time.UTC)
+	row := LinearWorkItemRow{
+		WorkItemID: "linear:ENG-3718", Provider: "linear", Title: "Linear lifecycle proof",
+		Type: "task", Status: "in_progress", StatusRaw: stringPtr("In Progress"),
+		NativeTeamKey: stringPtr("ENG"), Assignees: []string{"linear@example.com"},
+		CreatedAt: now.Add(-time.Hour), UpdatedAt: now, StartedAt: &now,
+		Labels: []string{"lifecycle"}, OrgID: claim.OrgID, LastSynced: now,
+	}
+	rowRaw, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effects, err := BuildLinearWorkItemEffects(LinearWorkItemEffectRows{
+		WorkItems: []json.RawMessage{rowRaw},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	route := LinearWorkItemsRouteBatch{
+		Effects: effects, Watermark: claim.BeforeAt,
+		Evidence: FetchEvidence{Provider: "linear", Dataset: "work-items", Requests: 3, Pages: 3, Records: 1},
+		Result: LinearWorkItemsRouteResult{
+			Rows:   LinearWorkItemsRows{WorkItems: []LinearWorkItemRow{row}},
+			Counts: LinearWorkItemCounts{WorkItems: 1}, NonEmpty: true,
+			Evidence: FetchEvidence{Provider: "linear", Dataset: "work-items", Requests: 3, Pages: 3, Records: 1},
+		},
+	}
+	lease := &linearLifecycleCountingLease{failAt: 12}
+	sink := linearMigratedClickHouseSink(conn, lease)
+	ledger := &memoryEffectLedger{}
+	lifecycle := LinearWorkItemsLifecycle{Committer: EffectCommitter{
+		Ledger: ledger, Sink: sink, Readback: sink, Now: func() time.Time { return now },
+	}}
+	if _, _, err := lifecycle.Commit(ctx, claim, route, now); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("first lease-fenced commit error=%v", err)
+	}
+	recoveredSink := linearMigratedClickHouseSink(conn, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	result, commit, err := (LinearWorkItemsLifecycle{Committer: EffectCommitter{
+		Ledger: ledger, Sink: recoveredSink, Readback: recoveredSink, Now: func() time.Time { return now.Add(time.Minute) },
+	}}).Commit(ctx, claim, route, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commit.MarkedCommitted != 1 || commit.Skipped != 5 {
+		t.Fatalf("recovery commit=%+v", commit)
+	}
+	if err := ValidateLinearWorkItemsCompletion(claim, result); err != nil {
+		t.Fatalf("completion validation=%v", err)
+	}
+}
+
+func linearMigratedClickHouseSink(conn driver.Conn, lease providerfoundation.LeaseGuard) LinearWorkItemClickHouseEffects {
+	return LinearWorkItemClickHouseEffects{
+		Lease:             lease,
+		WorkItems:         LinearWorkItemsClickHouseAdapter{Conn: conn},
+		StatusTransitions: LinearWorkItemTransitionsClickHouseAdapter{Conn: conn},
+		Dependencies: LinearWorkItemDependenciesClickHouseAdapter{
+			Delegate: GitHubWorkItemDependenciesClickHouseAdapter{Conn: conn},
+		},
+		ReopenEvents: LinearWorkItemReopenEventsClickHouseAdapter{
+			Delegate: GitHubWorkItemReopenEventsClickHouseAdapter{Conn: conn},
+		},
+		Interactions: LinearWorkItemInteractionsClickHouseAdapter{
+			Delegate: GitHubWorkItemInteractionsClickHouseAdapter{Conn: conn},
+		},
+		Sprints: LinearSprintsClickHouseAdapter{
+			Delegate: GitHubSprintsClickHouseAdapter{Conn: conn},
+		},
+	}
+}
+
+type linearLifecycleCountingLease struct {
+	calls  int
+	failAt int
+}
+
+func (lease *linearLifecycleCountingLease) Assert(context.Context) error {
+	lease.calls++
+	if lease.failAt > 0 && lease.calls >= lease.failAt {
+		return providerfoundation.ErrLeaseLost
+	}
+	return nil
+}

--- a/internal/providersync/linear_work_items_lifecycle_test.go
+++ b/internal/providersync/linear_work_items_lifecycle_test.go
@@ -1,0 +1,306 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/full-chaos/dev-health-ops/internal/workitemcontract"
+)
+
+func linearLifecycleIssueResponse(identifier, teamKey string) string {
+	return `{"data":{"issues":{"nodes":[{"id":"` + identifier + `","identifier":"` + identifier + `","title":"typed Linear issue","createdAt":"2026-07-25T09:00:00Z","updatedAt":"2026-07-28T16:30:00Z","state":{"name":"Todo","type":"unstarted"},"labels":{"nodes":[]},"team":{"id":"team-` + strings.ToLower(teamKey) + `","key":"` + teamKey + `","name":"` + teamKey + `"},"history":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"attachments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"relations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}`
+}
+
+func TestLinearRouteGlobalDiscoveryCrawlsEveryDiscoveredTeam(t *testing.T) {
+	doer := &linearWorkItemsDoer{responses: []string{
+		`{"data":{"teams":{"nodes":[{"id":"team-eng","key":"ENG","name":"Engineering"},{"id":"team-ops","key":"OPS","name":"Operations"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}`,
+		linearLifecycleIssueResponse("ENG-1", "ENG"),
+		linearLifecycleIssueResponse("OPS-1", "OPS"),
+	}}
+	claim := nativeTestClaim("linear", "work-items")
+	claim.SourceExternalID = "global-discovery"
+	noCycles := false
+	batch, err := (LinearWorkItemsRouteHandler{GlobalDiscovery: true, FetchCycles: &noCycles}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "linear", ID: claim.CredentialID},
+		linearWorkItemsClient(t, doer), time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 3 || batch.Evidence.Pages != 3 || len(batch.Effects[0].Rows) != 2 {
+		t.Fatalf("requests=%d evidence=%+v effects=%+v", len(doer.requests), batch.Evidence, batch.Effects)
+	}
+	for index, wantTeam := range []string{"ENG", "OPS"} {
+		var requestBody struct {
+			Variables struct {
+				Filter struct {
+					Team struct {
+						Key struct {
+							In []string `json:"in"`
+						} `json:"key"`
+					} `json:"team"`
+				} `json:"filter"`
+			} `json:"variables"`
+		}
+		if err := json.NewDecoder(doer.requests[index+1].Body).Decode(&requestBody); err != nil {
+			t.Fatal(err)
+		}
+		if len(requestBody.Variables.Filter.Team.Key.In) != 1 || requestBody.Variables.Filter.Team.Key.In[0] != wantTeam {
+			t.Fatalf("team request=%+v", requestBody)
+		}
+	}
+}
+
+func TestLinearRequestPlanBoundsCanonicalRouteFamilies(t *testing.T) {
+	want := []RequestEstimate{
+		{Dimension: BudgetGraphQLCost, Units: 3, Confidence: "low", RouteFamily: "attachments"},
+		{Dimension: BudgetGraphQLCost, Units: 6, Confidence: "low", RouteFamily: "comments"},
+		{Dimension: BudgetGraphQLCost, Units: 2, Confidence: "low", RouteFamily: "cycles"},
+		{Dimension: BudgetGraphQLCost, Units: 6, Confidence: "low", RouteFamily: "history"},
+		{Dimension: BudgetGraphQLCost, Units: 30, Confidence: "low", RouteFamily: "issues"},
+		{Dimension: BudgetGraphQLCost, Units: 6, Confidence: "low", RouteFamily: "relations"},
+		{Dimension: BudgetGraphQLCost, Units: 1, Confidence: "medium", RouteFamily: "teams"},
+	}
+	if got := ProviderRequestPlan("linear", "work-items", 3, nil); !reflect.DeepEqual(got, want) {
+		t.Fatalf("linear request plan=%+v want=%+v", got, want)
+	}
+	for _, dataset := range workitemcontract.FamilyDatasets() {
+		if plan := ProviderRequestPlan("linear", dataset, 1, nil); len(plan) == 0 {
+			t.Fatalf("linear alias %q has no bounded request estimate", dataset)
+		}
+	}
+}
+
+func TestLinearRoutePaginatesInlineHistoryFromTheParentCursor(t *testing.T) {
+	doer := &linearWorkItemsDoer{responses: []string{
+		linearTeamResponse(),
+		`{"data":{"issues":{"nodes":[{"id":"lin-history","identifier":"ENG-1","title":"history","createdAt":"2026-07-25T09:00:00Z","updatedAt":"2026-07-28T16:30:00Z","state":{"name":"Todo","type":"unstarted"},"labels":{"nodes":[]},"team":{"id":"team-eng","key":"ENG","name":"Engineering"},"history":{"nodes":[{"createdAt":"2026-07-26T10:00:00Z","fromState":{"name":"Todo","type":"unstarted"},"toState":{"name":"In Progress","type":"started"},"actor":null}],"pageInfo":{"hasNextPage":true,"endCursor":"history-cursor-1"}},"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"attachments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"relations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}},"inverseRelations":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}`,
+		`{"data":{"issue":{"history":{"nodes":[{"createdAt":"2026-07-27T10:00:00Z","fromState":{"name":"In Progress","type":"started"},"toState":{"name":"Done","type":"completed"},"actor":null}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`,
+	}}
+	claim := nativeTestClaim("linear", "work-items")
+	claim.SourceExternalID = "ENG"
+	noCycles := false
+	batch, err := (LinearWorkItemsRouteHandler{FetchCycles: &noCycles}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "linear", ID: claim.CredentialID},
+		linearWorkItemsClient(t, doer), time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 3 || len(batch.Effects[1].Rows) != 2 {
+		t.Fatalf("requests=%d transitions=%d", len(doer.requests), len(batch.Effects[1].Rows))
+	}
+	var historyRequest struct {
+		Variables map[string]any `json:"variables"`
+	}
+	if err := json.NewDecoder(doer.requests[2].Body).Decode(&historyRequest); err != nil {
+		t.Fatal(err)
+	}
+	if historyRequest.Variables["after"] != "history-cursor-1" {
+		t.Fatalf("history variables=%+v", historyRequest.Variables)
+	}
+}
+
+func TestLinearRouteRejectsMalformedNestedConnectionBeforeWatermark(t *testing.T) {
+	doer := &linearWorkItemsDoer{responses: []string{
+		linearTeamResponse(),
+		`{"data":{"issues":{"nodes":[{"id":"lin-malformed","identifier":"ENG-1","title":"malformed","createdAt":"2026-07-25T09:00:00Z","updatedAt":"2026-07-28T16:30:00Z","state":{"name":"Todo","type":"unstarted"},"labels":{"nodes":[]},"team":{"id":"team-eng","key":"ENG","name":"Engineering"},"attachments":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}`,
+	}}
+	claim := nativeTestClaim("linear", "work-items")
+	claim.SourceExternalID = "ENG"
+	noCycles := false
+	batch, err := (LinearWorkItemsRouteHandler{FetchCycles: &noCycles}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "linear", ID: claim.CredentialID},
+		linearWorkItemsClient(t, doer), time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrPaginationInvalid) || batch.Watermark != nil {
+		t.Fatalf("batch=%+v error=%v", batch, err)
+	}
+}
+
+func TestLinearRoutePropagatesCancellationBeforeIssuingAnotherPage(t *testing.T) {
+	claim := nativeTestClaim("linear", "work-items")
+	claim.SourceExternalID = "ENG"
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client, err := providerfoundation.NewHTTPClient(
+		"linear", "https://api.linear.app", &linearWorkItemsDoer{},
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(ctx context.Context) error { return ctx.Err() }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (LinearWorkItemsRouteHandler{}).Collect(
+		ctx, claim, providerfoundation.Credential{Provider: "linear", ID: claim.CredentialID},
+		client, time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation error=%v", err)
+	}
+}
+
+func allLinearFamilyFlags(enabled bool) map[string]bool {
+	flags := make(map[string]bool, len(workitemcontract.FamilyDatasets()))
+	for _, dataset := range workitemcontract.FamilyDatasets() {
+		flags[workItemFamilyFlagForDataset(dataset)] = enabled
+	}
+	return flags
+}
+
+func linearTypedLifecycleFixture(t *testing.T) (Claim, LinearWorkItemsRouteBatch) {
+	t.Helper()
+	claim := nativeTestClaim("linear", "work-items")
+	claim.SourceExternalID = "ENG"
+	claim.ProcessorFlags = allLinearFamilyFlags(true)
+	effects, err := BuildLinearWorkItemEffects(LinearWorkItemEffectRows{
+		WorkItems: []json.RawMessage{json.RawMessage(`{"org_id":"org-acme","provider":"linear","work_item_id":"linear:ENG-1"}`)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	watermark := *claim.BeforeAt
+	return claim, LinearWorkItemsRouteBatch{
+		Effects: effects, Watermark: &watermark,
+		Evidence: FetchEvidence{Provider: "linear", Dataset: "work-items", Pages: 1, Requests: 1, Records: 1},
+		Result: LinearWorkItemsRouteResult{
+			Rows:   LinearWorkItemsRows{WorkItems: []LinearWorkItemRow{{WorkItemID: "linear:ENG-1"}}},
+			Counts: LinearWorkItemCounts{WorkItems: 1}, NonEmpty: true,
+			Evidence: FetchEvidence{Provider: "linear", Dataset: "work-items", Pages: 1, Requests: 1, Records: 1},
+		},
+	}
+}
+
+func TestLinearTypedLifecycleProducesFiveAliasReadbackAudit(t *testing.T) {
+	claim, route := linearTypedLifecycleFixture(t)
+	backend := newLinearSemanticEffectBackend()
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink := linearWorkItemEffectsFixture(backend, lease)
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	result, commit, err := (LinearWorkItemsLifecycle{
+		Committer: EffectCommitter{
+			Ledger: &memoryEffectLedger{}, Sink: sink, Readback: sink,
+			Now: func() time.Time { return now },
+		},
+	}).Commit(context.Background(), claim, route, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commit.Written != 6 || len(result.Effects) != 6 || len(result.Aliases) != 5 {
+		t.Fatalf("commit=%+v result=%+v", commit, result)
+	}
+	if err := ValidateLinearWorkItemsCompletion(claim, result); err != nil {
+		t.Fatalf("typed completion validation: %v", err)
+	}
+	for index, alias := range result.Aliases {
+		if !alias.Complete || alias.Readback != LinearAliasReadbackExact && alias.Readback != LinearAliasReadbackEmpty {
+			t.Fatalf("alias[%d]=%+v", index, alias)
+		}
+	}
+}
+
+func TestLinearTypedLifecycleRejectsEmptyProducerBatch(t *testing.T) {
+	claim, route := linearTypedLifecycleFixture(t)
+	route.Result.NonEmpty = false
+	_, _, err := (LinearWorkItemsLifecycle{}).Commit(
+		context.Background(), claim, route, time.Now().UTC(),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty lifecycle error=%v", err)
+	}
+}
+
+func TestLinearTypedLifecycleRejectsMissingWatermark(t *testing.T) {
+	claim, route := linearTypedLifecycleFixture(t)
+	route.Watermark = nil
+	backend := newLinearSemanticEffectBackend()
+	sink := linearWorkItemEffectsFixture(backend, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	_, _, err := (LinearWorkItemsLifecycle{
+		Committer: EffectCommitter{Ledger: &memoryEffectLedger{}, Sink: sink, Readback: sink, Now: func() time.Time { return now }},
+	}).Commit(context.Background(), claim, route, now)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("missing watermark error=%v", err)
+	}
+}
+
+func TestLinearTypedCompletionRejectsMissingOrUnknownAliasFlags(t *testing.T) {
+	claim, route := linearTypedLifecycleFixture(t)
+	backend := newLinearSemanticEffectBackend()
+	sink := linearWorkItemEffectsFixture(backend, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	result, _, err := (LinearWorkItemsLifecycle{
+		Committer: EffectCommitter{Ledger: &memoryEffectLedger{}, Sink: sink, Readback: sink, Now: func() time.Time { return now }},
+	}).Commit(context.Background(), claim, route, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*Claim)
+	}{
+		{name: "missing alias", mutate: func(c *Claim) { delete(c.ProcessorFlags, workItemFamilyFlagForDataset("work-item-comments")) }},
+		{name: "unknown alias", mutate: func(c *Claim) { c.ProcessorFlags["family_dataset_future_alias"] = true }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mutated := claim
+			mutated.ProcessorFlags = cloneBoolMap(claim.ProcessorFlags)
+			test.mutate(&mutated)
+			if err := ValidateLinearWorkItemsCompletion(mutated, result); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("validation error=%v", err)
+			}
+		})
+	}
+}
+
+func TestLinearTypedCompletionRejectsAliasEffectMismatches(t *testing.T) {
+	claim, route := linearTypedLifecycleFixture(t)
+	backend := newLinearSemanticEffectBackend()
+	sink := linearWorkItemEffectsFixture(backend, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	result, _, err := (LinearWorkItemsLifecycle{
+		Committer: EffectCommitter{Ledger: &memoryEffectLedger{}, Sink: sink, Readback: sink, Now: func() time.Time { return now }},
+	}).Commit(context.Background(), claim, route, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated := result
+	mutated.Aliases[0].EffectDestinations = []string{"work_items", "sprints"}
+	if err := ValidateLinearWorkItemsCompletion(claim, mutated); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("mismatched alias destinations error=%v", err)
+	}
+	mutated = result
+	mutated.Aliases[2].EffectDestinations = []string{"sprints", "work_items"}
+	if err := ValidateLinearWorkItemsCompletion(claim, mutated); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("reordered alias destinations error=%v", err)
+	}
+	mutated = result
+	mutated.NonEmpty = false
+	if err := ValidateLinearWorkItemsCompletion(claim, mutated); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty completion result error=%v", err)
+	}
+	mutated = result
+	mutated.Effects = mutated.Effects[:1]
+	if err := ValidateLinearWorkItemsCompletion(claim, mutated); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("incomplete effect audit error=%v", err)
+	}
+}
+
+func cloneBoolMap(input map[string]bool) map[string]bool {
+	clone := make(map[string]bool, len(input))
+	for key, value := range input {
+		clone[key] = value
+	}
+	return clone
+}

--- a/internal/providersync/linear_work_items_provider_oracle_test.go
+++ b/internal/providersync/linear_work_items_provider_oracle_test.go
@@ -1,0 +1,17 @@
+package providersync
+
+import "testing"
+
+// This pair executes LinearProvider.iter_ingest with an injected typed client
+// and compares the resulting WorkItem dataclass against the same Go-normalized
+// production row. It is opt-in through the shared live-oracle gate; ordinary
+// package tests never claim Python execution evidence.
+func TestLinearProviderIterIngestMatchesLivePythonProducer(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"linear/work-items/provider",
+		linearWorkItemOracleCases(),
+		buildLinearWorkItemOracleRow,
+		linearWorkItemWriteStampGoOnly,
+	)
+}

--- a/internal/providersync/linear_work_items_route.go
+++ b/internal/providersync/linear_work_items_route.go
@@ -22,6 +22,7 @@ const (
 	// a second page or issuing an unbounded nested crawl.
 	linearWorkItemsCommentsPerPage  = 50
 	linearWorkItemsCommentsMaxPages = 2
+	linearWorkItemsHistoryPerPage   = 50
 )
 
 // linearWorkItemsQuery deliberately follows the fields selected by
@@ -47,6 +48,7 @@ query LinearWorkItems($first: Int!, $after: String, $filter: IssueFilter) {
           toState { name type }
           actor { name email }
         }
+        pageInfo { hasNextPage endCursor }
       }
       comments(first: 50) {
         nodes {
@@ -128,6 +130,21 @@ query LinearWorkItemsComments($first: Int!, $after: String, $issueId: String!) {
         body
         createdAt
         user { name email }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`
+
+const linearWorkItemsHistoryQuery = `
+query LinearWorkItemsHistory($first: Int!, $after: String, $issueId: String!) {
+  issue(id: $issueId) {
+    history(first: $first, after: $after) {
+      nodes {
+        createdAt
+        fromState { name type }
+        toState { name type }
+        actor { name email }
       }
       pageInfo { hasNextPage endCursor }
     }
@@ -227,7 +244,8 @@ type linearCyclesPayload struct {
 }
 
 type linearHistoryPayload struct {
-	Nodes []linearHistoryEntry `json:"nodes"`
+	Nodes    []linearHistoryEntry  `json:"nodes"`
+	PageInfo linearPageInfoPayload `json:"pageInfo"`
 }
 
 type linearPageInfoPayload struct {
@@ -355,6 +373,11 @@ type LinearWorkItemsRouteHandler struct {
 	FetchComments *bool
 	FetchHistory  *bool
 	FetchCycles   *bool
+	// GlobalDiscovery mirrors Python's repo=None mode. The claim still carries
+	// a non-empty source identity for lease/watermark fencing, but the route
+	// discovers every Linear team and applies the same bounded issue crawl to
+	// each team. It is provider-local and intentionally not a registry switch.
+	GlobalDiscovery bool
 	// ReferenceTeams and ReferenceSprints model the reference dimensions that
 	// Python receives through IngestionContext.  They are deliberately inputs
 	// to this provider-owned route only; no registry, planner, or sink wiring is
@@ -383,6 +406,42 @@ type LinearReferenceTeam struct {
 
 func linearWorkItemsFlag(value *bool) bool {
 	return value == nil || *value
+}
+
+func linearConnectionCursor(pageInfo linearPageInfoPayload) (string, error) {
+	if !pageInfo.HasNextPage {
+		return "", nil
+	}
+	cursor := strings.TrimSpace(pageInfo.EndCursor)
+	if cursor == "" {
+		return "", providerfoundation.ErrPaginationInvalid
+	}
+	return cursor, nil
+}
+
+func appendLinearUnique[T any](existing []T, extra ...[]T) []T {
+	seen := make(map[string]struct{}, len(existing))
+	key := func(value T) string {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return ""
+		}
+		return string(encoded)
+	}
+	for _, value := range existing {
+		seen[key(value)] = struct{}{}
+	}
+	for _, values := range extra {
+		for _, value := range values {
+			valueKey := key(value)
+			if _, duplicate := seen[valueKey]; duplicate {
+				continue
+			}
+			seen[valueKey] = struct{}{}
+			existing = append(existing, value)
+		}
+	}
+	return existing
 }
 
 func linearNestedPageLimit() int { return 5 } // 5 * 100 == Python's 500-row bound
@@ -447,6 +506,80 @@ func (handler LinearWorkItemsRouteHandler) resolveLinearTeam(
 		return team, 0, nil
 	}
 	return collectLinearTeam(ctx, client, teamKey)
+}
+
+func linearReferenceTeamPayloads(rows []LinearReferenceTeam) []linearTeamPayload {
+	teams := make([]linearTeamPayload, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		provider := strings.TrimSpace(row.Provider)
+		if provider != "" && provider != "linear" {
+			continue
+		}
+		id := strings.TrimSpace(row.ID)
+		key := strings.TrimSpace(row.NativeTeamKey)
+		name := strings.TrimSpace(row.Name)
+		if key == "" {
+			for _, candidate := range row.ProjectKeys {
+				if candidate = strings.TrimSpace(candidate); candidate != "" {
+					key = candidate
+					break
+				}
+			}
+		}
+		if key == "" {
+			continue
+		}
+		if id == "" {
+			id = key
+		}
+		if name == "" {
+			name = key
+		}
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		teams = append(teams, linearTeamPayload{ID: id, Key: key, Name: name})
+	}
+	return teams
+}
+
+func collectLinearTeams(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	maxPages int,
+) ([]linearTeamPayload, int, error) {
+	page, err := providerfoundation.CollectLinearGraphQLPages(
+		ctx, client, providerfoundation.LinearPageOptions{
+			Query:          linearWorkItemsTeamQuery,
+			Variables:      map[string]any{},
+			ConnectionPath: []string{"teams"},
+			PerPage:        linearWorkItemsMaxPerPage,
+			MaxPages:       maxPages,
+		},
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	if page.CapReached {
+		return nil, page.Pages, ErrPaginationCapExceeded
+	}
+	teams := make([]linearTeamPayload, 0, len(page.Items))
+	seen := make(map[string]struct{}, len(page.Items))
+	for _, raw := range page.Items {
+		var team linearTeamPayload
+		if err := json.Unmarshal(raw, &team); err != nil ||
+			strings.TrimSpace(team.ID) == "" || strings.TrimSpace(team.Key) == "" {
+			return nil, page.Pages, providerfoundation.ErrNormalizationInvalid
+		}
+		if _, duplicate := seen[team.Key]; duplicate {
+			continue
+		}
+		seen[team.Key] = struct{}{}
+		teams = append(teams, team)
+	}
+	return teams, page.Pages, nil
 }
 
 func linearReferenceSprints(
@@ -536,6 +669,7 @@ func collectLinearIssueAttachments(
 	ctx context.Context,
 	client *providerfoundation.HTTPClient,
 	issueID string,
+	after string,
 ) ([]linearAttachmentPayload, int, error) {
 	page, err := providerfoundation.CollectLinearGraphQLPages(
 		ctx, client, providerfoundation.LinearPageOptions{
@@ -543,10 +677,14 @@ func collectLinearIssueAttachments(
 			Variables:      map[string]any{"issueId": issueID},
 			ConnectionPath: []string{"issue", "attachments"},
 			PerPage:        100, MaxPages: linearNestedPageLimit(),
+			InitialCursor: after,
 		},
 	)
 	if err != nil {
 		return nil, 0, err
+	}
+	if page.CapReached {
+		return nil, page.Pages, ErrPaginationCapExceeded
 	}
 	items := make([]linearAttachmentPayload, 0, len(page.Items))
 	for _, raw := range page.Items {
@@ -556,11 +694,38 @@ func collectLinearIssueAttachments(
 		}
 		items = append(items, item)
 	}
-	// Python's attachment helper stops at its 500-row bound and keeps that
-	// prefix. It does not claim the omitted tail is present, so preserve that
-	// bounded behavior while still failing malformed pagination.
-	if len(items) > 500 {
-		items = items[:500]
+	return items, page.Pages, nil
+}
+
+func collectLinearIssueHistory(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	issueID string,
+	after string,
+) ([]linearHistoryEntry, int, error) {
+	page, err := providerfoundation.CollectLinearGraphQLPages(
+		ctx, client, providerfoundation.LinearPageOptions{
+			Query:          linearWorkItemsHistoryQuery,
+			Variables:      map[string]any{"issueId": issueID},
+			ConnectionPath: []string{"issue", "history"},
+			PerPage:        linearWorkItemsHistoryPerPage,
+			MaxPages:       linearNestedPageLimit(),
+			InitialCursor:  after,
+		},
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	if page.CapReached {
+		return nil, page.Pages, ErrPaginationCapExceeded
+	}
+	items := make([]linearHistoryEntry, 0, len(page.Items))
+	for _, raw := range page.Items {
+		var item linearHistoryEntry
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return nil, page.Pages, providerfoundation.ErrNormalizationInvalid
+		}
+		items = append(items, item)
 	}
 	return items, page.Pages, nil
 }
@@ -569,6 +734,7 @@ func collectLinearIssueComments(
 	ctx context.Context,
 	client *providerfoundation.HTTPClient,
 	issueID string,
+	after string,
 ) ([]linearCommentPayload, int, error) {
 	page, err := providerfoundation.CollectLinearGraphQLPages(
 		ctx, client, providerfoundation.LinearPageOptions{
@@ -577,6 +743,7 @@ func collectLinearIssueComments(
 			ConnectionPath: []string{"issue", "comments"},
 			PerPage:        linearWorkItemsCommentsPerPage,
 			MaxPages:       linearWorkItemsCommentsMaxPages,
+			InitialCursor:  after,
 		},
 	)
 	if err != nil {
@@ -601,6 +768,7 @@ func collectLinearIssueRelations(
 	client *providerfoundation.HTTPClient,
 	issueID string,
 	inverse bool,
+	after string,
 ) ([]linearRelationPayload, int, error) {
 	query := linearWorkItemsRelationsQuery
 	connection := "relations"
@@ -614,6 +782,7 @@ func collectLinearIssueRelations(
 			Variables:      map[string]any{"issueId": issueID},
 			ConnectionPath: []string{"issue", connection},
 			PerPage:        100, MaxPages: linearNestedPageLimit(),
+			InitialCursor: after,
 		},
 	)
 	if err != nil {
@@ -878,22 +1047,6 @@ func (handler LinearWorkItemsRouteHandler) Collect(
 		return CompleteRouteBatch{}, err
 	}
 	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
-	filter := map[string]any{
-		"team": map[string]any{"key": map[string]any{
-			"in": []string{claim.SourceExternalID},
-		}},
-		"archivedAt": map[string]any{"null": true},
-	}
-	updatedAt := map[string]any{}
-	if claim.SinceAt != nil {
-		updatedAt["gte"] = claim.SinceAt.UTC().Format(time.RFC3339Nano)
-	}
-	if claim.BeforeAt != nil {
-		updatedAt["lte"] = claim.BeforeAt.UTC().Format(time.RFC3339Nano)
-	}
-	if len(updatedAt) > 0 {
-		filter["updatedAt"] = updatedAt
-	}
 	fetchComments := linearWorkItemsFlag(handler.FetchComments)
 	fetchHistory := linearWorkItemsFlag(handler.FetchHistory)
 	fetchCycles := linearWorkItemsFlag(handler.FetchCycles)
@@ -906,127 +1059,217 @@ func (handler LinearWorkItemsRouteHandler) Collect(
 		Interactions:      make([]linearWorkItemInteractionRow, 0),
 		Sprints:           make([]linearSprintRow, 0),
 	}
-	// Python resolves the scoped team before it starts the issue crawl even
-	// when cycles are disabled.  That check prevents a malformed or stale
-	// source external id from producing a clean-looking empty work-item batch.
-	team, teamPages, teamErr := handler.resolveLinearTeam(ctx, claim, client, claim.SourceExternalID)
-	pagesSeen += teamPages
-	if teamErr != nil {
-		return CompleteRouteBatch{}, teamErr
+	var teams []linearTeamPayload
+	if handler.GlobalDiscovery {
+		teams = linearReferenceTeamPayloads(handler.ReferenceTeams)
+		if len(teams) == 0 {
+			var teamErr error
+			var teamPages int
+			teams, teamPages, teamErr = collectLinearTeams(ctx, client, maxPages)
+			pagesSeen += teamPages
+			if teamErr != nil {
+				return CompleteRouteBatch{}, teamErr
+			}
+		}
+	} else {
+		// Python resolves the scoped team before it starts the issue crawl even
+		// when cycles are disabled. That check prevents a malformed or stale
+		// source external id from producing a clean-looking empty batch.
+		team, teamPages, teamErr := handler.resolveLinearTeam(ctx, claim, client, claim.SourceExternalID)
+		pagesSeen += teamPages
+		if teamErr != nil {
+			return CompleteRouteBatch{}, teamErr
+		}
+		teams = []linearTeamPayload{team}
 	}
-	if strings.TrimSpace(team.ID) == "" {
+	if len(teams) == 0 && !handler.GlobalDiscovery {
 		return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
 	}
-	if fetchCycles {
-		referenceSprints, referenceErr := linearReferenceSprints(claim, handler.ReferenceSprints)
-		if referenceErr != nil {
-			return CompleteRouteBatch{}, referenceErr
-		}
-		if len(referenceSprints) > 0 {
-			rows.Sprints = append(rows.Sprints, referenceSprints...)
-		} else {
-			cycles, cyclePages, cycleErr := collectLinearCycles(ctx, client, team.ID)
-			pagesSeen += cyclePages
-			if cycleErr != nil {
-				return CompleteRouteBatch{}, cycleErr
-			}
-			for _, cycle := range cycles {
-				sprint, sprintErr := normalizeLinearSprint(claim, cycle, normalizedAt)
-				if sprintErr != nil {
-					return CompleteRouteBatch{}, sprintErr
-				}
-				rows.Sprints = append(rows.Sprints, sprint)
-			}
-		}
-	}
-	page, err := providerfoundation.CollectLinearGraphQLPages(
-		ctx, client, providerfoundation.LinearPageOptions{
-			Query:          linearWorkItemsQuery,
-			Variables:      map[string]any{"filter": filter},
-			ConnectionPath: []string{"issues"}, PerPage: perPage, MaxPages: maxPages,
-		},
-	)
-	if err != nil {
-		return CompleteRouteBatch{}, err
-	}
-	if page.CapReached {
-		return CompleteRouteBatch{}, ErrPaginationCapExceeded
-	}
-	pagesSeen += page.Pages
-	for _, raw := range page.Items {
-		var payload linearWorkItemPayload
-		decoder := json.Unmarshal(raw, &payload)
-		if decoder != nil {
+	sprintSeen := make(map[string]struct{})
+	for _, team := range teams {
+		teamKey := strings.TrimSpace(team.Key)
+		if strings.TrimSpace(team.ID) == "" || teamKey == "" {
 			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
 		}
-		if payload.ArchivedAt != nil {
-			continue
+		teamClaim := claim
+		teamClaim.SourceExternalID = teamKey
+		filter := map[string]any{
+			"team": map[string]any{"key": map[string]any{
+				"in": []string{teamKey},
+			}},
+			"archivedAt": map[string]any{"null": true},
 		}
-		if payload.Attachments.PageInfo.HasNextPage && payload.ID != "" {
-			attachments, attachmentPages, attachmentErr := collectLinearIssueAttachments(
-				ctx, client, payload.ID,
-			)
-			pagesSeen += attachmentPages
-			if attachmentErr == nil {
-				payload.Attachments.Nodes = attachments
+		updatedAt := map[string]any{}
+		if claim.SinceAt != nil {
+			updatedAt["gte"] = claim.SinceAt.UTC().Format(time.RFC3339Nano)
+		}
+		if claim.BeforeAt != nil {
+			updatedAt["lte"] = claim.BeforeAt.UTC().Format(time.RFC3339Nano)
+		}
+		if len(updatedAt) > 0 {
+			filter["updatedAt"] = updatedAt
+		}
+		if fetchCycles {
+			var referenceSprints []linearSprintRow
+			var referenceErr error
+			if !handler.GlobalDiscovery {
+				referenceSprints, referenceErr = linearReferenceSprints(teamClaim, handler.ReferenceSprints)
+			}
+			if referenceErr != nil {
+				return CompleteRouteBatch{}, referenceErr
+			}
+			if len(referenceSprints) > 0 {
+				for _, sprint := range referenceSprints {
+					if _, duplicate := sprintSeen[sprint.SprintID]; !duplicate {
+						rows.Sprints = append(rows.Sprints, sprint)
+						sprintSeen[sprint.SprintID] = struct{}{}
+					}
+				}
+			} else {
+				cycles, cyclePages, cycleErr := collectLinearCycles(ctx, client, team.ID)
+				pagesSeen += cyclePages
+				if cycleErr != nil {
+					return CompleteRouteBatch{}, cycleErr
+				}
+				for _, cycle := range cycles {
+					sprint, sprintErr := normalizeLinearSprint(teamClaim, cycle, normalizedAt)
+					if sprintErr != nil {
+						return CompleteRouteBatch{}, sprintErr
+					}
+					if _, duplicate := sprintSeen[sprint.SprintID]; !duplicate {
+						rows.Sprints = append(rows.Sprints, sprint)
+						sprintSeen[sprint.SprintID] = struct{}{}
+					}
+				}
 			}
 		}
-		if fetchComments && payload.Comments.PageInfo.HasNextPage && payload.ID != "" {
-			comments, commentPages, commentErr := collectLinearIssueComments(
-				ctx, client, payload.ID,
-			)
-			pagesSeen += commentPages
-			if commentErr != nil {
-				return CompleteRouteBatch{}, commentErr
-			}
-			payload.Comments.Nodes = comments
-		}
-		if payload.Relations.PageInfo.HasNextPage && payload.ID != "" {
-			relations, relationPages, relationErr := collectLinearIssueRelations(
-				ctx, client, payload.ID, false,
-			)
-			pagesSeen += relationPages
-			if relationErr != nil {
-				return CompleteRouteBatch{}, relationErr
-			}
-			payload.Relations.Nodes = relations
-		}
-		if payload.InverseRelations.PageInfo.HasNextPage && payload.ID != "" {
-			relations, relationPages, relationErr := collectLinearIssueRelations(
-				ctx, client, payload.ID, true,
-			)
-			pagesSeen += relationPages
-			if relationErr != nil {
-				return CompleteRouteBatch{}, relationErr
-			}
-			payload.InverseRelations.Nodes = relations
-		}
-		if !fetchHistory {
-			payload.History.Nodes = nil
-		}
-		if !fetchComments {
-			payload.Comments.Nodes = nil
-		}
-		item, transitions, normalizeErr := normalizeLinearWorkItem(
-			claim, payload, normalizedAt,
+		page, pageErr := providerfoundation.CollectLinearGraphQLPages(
+			ctx, client, providerfoundation.LinearPageOptions{
+				Query:          linearWorkItemsQuery,
+				Variables:      map[string]any{"filter": filter},
+				ConnectionPath: []string{"issues"}, PerPage: perPage, MaxPages: maxPages,
+			},
 		)
-		if normalizeErr != nil {
-			return CompleteRouteBatch{}, normalizeErr
+		if pageErr != nil {
+			return CompleteRouteBatch{}, pageErr
 		}
-		rows.WorkItems = append(rows.WorkItems, item)
-		rows.StatusTransitions = append(rows.StatusTransitions, transitions...)
-		rows.Dependencies = append(rows.Dependencies, normalizeLinearDependencies(
-			claim, payload, item.WorkItemID, normalizedAt,
-		)...)
-		if fetchHistory {
-			rows.ReopenEvents = append(rows.ReopenEvents, normalizeLinearReopens(
-				claim, item.WorkItemID, payload.History.Nodes, normalizedAt,
-			)...)
+		if page.CapReached {
+			return CompleteRouteBatch{}, ErrPaginationCapExceeded
 		}
-		if fetchComments {
-			rows.Interactions = append(rows.Interactions, normalizeLinearInteractions(
-				claim, item.WorkItemID, payload.Comments.Nodes, normalizedAt,
+		pagesSeen += page.Pages
+		for _, raw := range page.Items {
+			var payload linearWorkItemPayload
+			if decoderErr := json.Unmarshal(raw, &payload); decoderErr != nil {
+				return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+			}
+			if payload.ArchivedAt != nil {
+				continue
+			}
+			if payload.ID == "" {
+				return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+			}
+			if payload.Attachments.PageInfo.HasNextPage {
+				cursor, cursorErr := linearConnectionCursor(payload.Attachments.PageInfo)
+				if cursorErr != nil {
+					return CompleteRouteBatch{}, cursorErr
+				}
+				attachments, attachmentPages, attachmentErr := collectLinearIssueAttachments(
+					ctx, client, payload.ID, cursor,
+				)
+				pagesSeen += attachmentPages
+				if attachmentErr != nil {
+					return CompleteRouteBatch{}, attachmentErr
+				}
+				payload.Attachments.Nodes = appendLinearUnique(payload.Attachments.Nodes, attachments)
+				payload.Attachments.PageInfo = linearPageInfoPayload{}
+			}
+			if fetchHistory && payload.History.PageInfo.HasNextPage {
+				cursor, cursorErr := linearConnectionCursor(payload.History.PageInfo)
+				if cursorErr != nil {
+					return CompleteRouteBatch{}, cursorErr
+				}
+				history, historyPages, historyErr := collectLinearIssueHistory(
+					ctx, client, payload.ID, cursor,
+				)
+				pagesSeen += historyPages
+				if historyErr != nil {
+					return CompleteRouteBatch{}, historyErr
+				}
+				payload.History.Nodes = appendLinearUnique(payload.History.Nodes, history)
+				payload.History.PageInfo = linearPageInfoPayload{}
+			}
+			if fetchComments && payload.Comments.PageInfo.HasNextPage {
+				cursor, cursorErr := linearConnectionCursor(payload.Comments.PageInfo)
+				if cursorErr != nil {
+					return CompleteRouteBatch{}, cursorErr
+				}
+				comments, commentPages, commentErr := collectLinearIssueComments(
+					ctx, client, payload.ID, cursor,
+				)
+				pagesSeen += commentPages
+				if commentErr != nil {
+					return CompleteRouteBatch{}, commentErr
+				}
+				payload.Comments.Nodes = appendLinearUnique(payload.Comments.Nodes, comments)
+				payload.Comments.PageInfo = linearPageInfoPayload{}
+			}
+			if payload.Relations.PageInfo.HasNextPage {
+				cursor, cursorErr := linearConnectionCursor(payload.Relations.PageInfo)
+				if cursorErr != nil {
+					return CompleteRouteBatch{}, cursorErr
+				}
+				relations, relationPages, relationErr := collectLinearIssueRelations(
+					ctx, client, payload.ID, false, cursor,
+				)
+				pagesSeen += relationPages
+				if relationErr != nil {
+					return CompleteRouteBatch{}, relationErr
+				}
+				payload.Relations.Nodes = appendLinearUnique(payload.Relations.Nodes, relations)
+				payload.Relations.PageInfo = linearPageInfoPayload{}
+			}
+			if payload.InverseRelations.PageInfo.HasNextPage {
+				cursor, cursorErr := linearConnectionCursor(payload.InverseRelations.PageInfo)
+				if cursorErr != nil {
+					return CompleteRouteBatch{}, cursorErr
+				}
+				relations, relationPages, relationErr := collectLinearIssueRelations(
+					ctx, client, payload.ID, true, cursor,
+				)
+				pagesSeen += relationPages
+				if relationErr != nil {
+					return CompleteRouteBatch{}, relationErr
+				}
+				payload.InverseRelations.Nodes = appendLinearUnique(payload.InverseRelations.Nodes, relations)
+				payload.InverseRelations.PageInfo = linearPageInfoPayload{}
+			}
+			if !fetchHistory {
+				payload.History.Nodes = nil
+			}
+			if !fetchComments {
+				payload.Comments.Nodes = nil
+			}
+			item, transitions, normalizeErr := normalizeLinearWorkItem(
+				teamClaim, payload, normalizedAt,
+			)
+			if normalizeErr != nil {
+				return CompleteRouteBatch{}, normalizeErr
+			}
+			rows.WorkItems = append(rows.WorkItems, item)
+			rows.StatusTransitions = append(rows.StatusTransitions, transitions...)
+			rows.Dependencies = append(rows.Dependencies, normalizeLinearDependencies(
+				teamClaim, payload, item.WorkItemID, normalizedAt,
 			)...)
+			if fetchHistory {
+				rows.ReopenEvents = append(rows.ReopenEvents, normalizeLinearReopens(
+					teamClaim, item.WorkItemID, payload.History.Nodes, normalizedAt,
+				)...)
+			}
+			if fetchComments {
+				rows.Interactions = append(rows.Interactions, normalizeLinearInteractions(
+					teamClaim, item.WorkItemID, payload.Comments.Nodes, normalizedAt,
+				)...)
+			}
 		}
 	}
 	effects, err := buildLinearWorkItemEffectsFromRows(rows)

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/full-chaos/dev-health-ops/internal/workitemcontract"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -159,6 +160,68 @@ func (repository *PostgresRepository) Complete(
 			); err != nil {
 				return ErrInvalidConfiguration
 			}
+		}
+	}
+	if _, err := tx.Exec(ctx, upsertFinalizeSQL,
+		uuid.New(), claim.OrgID, claim.SyncRunID, completedAt.UTC(),
+	); err != nil {
+		return ErrInvalidConfiguration
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
+// CompleteLinearWorkItemFamily is the typed completion boundary for the
+// Linear five-alias family. It writes the canonical unit audit and all five
+// alias watermarks in one PostgreSQL transaction; callers cannot accidentally
+// complete one alias while leaving the others unadvanced. The generic
+// Complete method remains for legacy providers and is intentionally not used
+// by this proof path.
+func (repository *PostgresRepository) CompleteLinearWorkItemFamily(
+	ctx context.Context,
+	claim Claim,
+	result LinearWorkItemsCompletionResult,
+	startedAt time.Time,
+	completedAt time.Time,
+) error {
+	if repository == nil || repository.Pool == nil || ctx == nil ||
+		claim.Validate() != nil || startedAt.IsZero() || completedAt.Before(startedAt) ||
+		ValidateLinearWorkItemsCompletion(claim, result) != nil {
+		return ErrInvalidConfiguration
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return ErrInvalidConfiguration
+	}
+	tx, err := repository.Pool.Begin(ctx)
+	if err != nil {
+		return ErrInvalidConfiguration
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	command, err := tx.Exec(ctx, completeUnitSQL,
+		claim.ID, claim.Owner, completedAt.UTC(),
+		int(completedAt.Sub(startedAt).Seconds()), encoded,
+	)
+	if err != nil || command.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	if _, err := tx.Exec(ctx, deletePreparedRouteSnapshotSQL,
+		claim.OrgID, claim.ID, claim.GenerationKey(),
+	); err != nil {
+		return ErrInvalidConfiguration
+	}
+	for _, datasetKey := range workitemcontract.FamilyDatasets() {
+		normalized := normalizeWatermarkWrite(
+			result.Watermark, claim.BeforeAt, completedAt,
+			claim.OrgID, claim.SourceExternalID, datasetKey,
+		)
+		if _, err := tx.Exec(ctx, upsertWatermarkSQL,
+			uuid.New(), claim.OrgID, claim.SourceExternalID, datasetKey,
+			normalized, completedAt.UTC(),
+		); err != nil {
+			return ErrInvalidConfiguration
 		}
 	}
 	if _, err := tx.Exec(ctx, upsertFinalizeSQL,

--- a/internal/providersync/testdata/mutation-plans/linear_work_items.json
+++ b/internal/providersync/testdata/mutation-plans/linear_work_items.json
@@ -28,8 +28,8 @@
     {
       "id": "L3-pagination-cap-fails-closed",
       "file": "internal/providersync/linear_work_items_route.go",
-      "find": "if page.CapReached {\n\t\treturn CompleteRouteBatch{}, ErrPaginationCapExceeded\n\t}",
-      "replace": "if false {\n\t\treturn CompleteRouteBatch{}, ErrPaginationCapExceeded\n\t}",
+      "find": "\t\tif page.CapReached {\n\t\t\treturn CompleteRouteBatch{}, ErrPaginationCapExceeded\n\t\t}",
+      "replace": "\t\tif false {\n\t\t\treturn CompleteRouteBatch{}, ErrPaginationCapExceeded\n\t\t}",
       "rationale": "a capped GraphQL collection cannot advance the watermark as if the provider result were complete",
       "proof": [["go", "test", "-count=1", "-run", "^TestLinearWorkItemsRouteFailsClosedOnGraphQLErrorsAndCaps$", "./internal/providersync/"]]
     },

--- a/internal/providersync/testdata/mutation-plans/linear_work_items_lifecycle.json
+++ b/internal/providersync/testdata/mutation-plans/linear_work_items_lifecycle.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "name": "Linear bounded lifecycle, typed alias audit, and atomic completion",
+  "build": [
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "./internal/providersync/"
+  ],
+  "mutations": [
+    {
+      "id": "LL1-connection-cursor-fails-closed",
+      "file": "internal/providersync/linear_work_items_route.go",
+      "find": "if cursor == \"\" {",
+      "replace": "if false {",
+      "rationale": "a nested connection that advertises another page without an end cursor must fail before the route can produce a watermark",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLinearRouteRejectsMalformedNestedConnectionBeforeWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "LL2-pagination-honors-initial-cursor",
+      "file": "internal/providerfoundation/pagination.go",
+      "find": "cursor := strings.TrimSpace(options.InitialCursor)",
+      "replace": "cursor := \"\"",
+      "rationale": "continuation requests must start at the parent connection cursor rather than replaying the first page",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLinearRoutePaginatesInlineHistoryFromTheParentCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "LL3-history-carries-parent-cursor",
+      "file": "internal/providersync/linear_work_items_route.go",
+      "find": "ConnectionPath: []string{\"issue\", \"history\"},\n\t\t\tPerPage:        linearWorkItemsHistoryPerPage,\n\t\t\tMaxPages:       linearNestedPageLimit(),\n\t\t\tInitialCursor:  after,",
+      "replace": "ConnectionPath: []string{\"issue\", \"history\"},\n\t\t\tPerPage:        linearWorkItemsHistoryPerPage,\n\t\t\tMaxPages:       linearNestedPageLimit(),\n\t\t\tInitialCursor:  \"\",",
+      "rationale": "the history continuation must pass the exact parent end cursor into the bounded collector",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLinearRoutePaginatesInlineHistoryFromTheParentCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "LL4-history-pages-are-merged",
+      "file": "internal/providersync/linear_work_items_route.go",
+      "find": "payload.History.Nodes = appendLinearUnique(payload.History.Nodes, history)",
+      "replace": "payload.History.Nodes = history",
+      "rationale": "the canonical normalized history must retain both the inline first page and every bounded continuation page",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLinearRoutePaginatesInlineHistoryFromTheParentCursor$", "./internal/providersync/"]]
+    },
+    {
+      "id": "LL5-alias-effects-match-destinations",
+      "file": "internal/providersync/linear_work_items_lifecycle.go",
+      "find": "!slices.Equal(alias.EffectDestinations, expectedDestinations)",
+      "replace": "!slices.Equal(alias.EffectDestinations, alias.EffectDestinations) || len(expectedDestinations) < 0",
+      "rationale": "each of the five aliases must audit the exact migrated effect destinations and cannot claim another alias's rows",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLinearTypedCompletionRejectsAliasEffectMismatches$", "./internal/providersync/"]]
+    },
+    {
+      "id": "LL6-empty-result-fails-closed",
+      "file": "internal/providersync/linear_work_items_lifecycle.go",
+      "find": "!result.NonEmpty || result.Watermark.IsZero()",
+      "replace": "false || result.Watermark.IsZero()",
+      "rationale": "a lifecycle completion with no normalized work must not be accepted as a successful provider run",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLinearTypedCompletionRejectsAliasEffectMismatches$", "./internal/providersync/"]]
+    },
+    {
+      "id": "LL7-missing-watermark-fails-closed",
+      "file": "internal/providersync/linear_work_items_lifecycle.go",
+      "find": "if watermark == nil {",
+      "replace": "if false {",
+      "rationale": "a typed route without a bounded watermark cannot produce a truthful completion record",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLinearTypedLifecycleRejectsMissingWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "LL8-atomic-completion-fans-out-five-watermarks",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "for _, datasetKey := range workitemcontract.FamilyDatasets() {",
+      "replace": "for _, datasetKey := range workitemcontract.FamilyDatasets()[:1] {",
+      "rationale": "the typed PostgreSQL completion transaction must write every alias watermark or roll back the unit audit rather than partially advancing the family",
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestLinearTypedCompletionAtomicallyAuditsFiveAliasesAndWatermarks$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/linear_work-items_provider.py
+++ b/internal/providersync/testdata/oracle_pairs/linear_work-items_provider.py
@@ -1,0 +1,85 @@
+"""Execute the real LinearProvider.iter_ingest producer for parity cases."""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/work_items.py"
+_PROVIDER_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/linear/provider.py"
+
+
+class _InjectedLinearClient:
+    def __init__(self, issue: dict[str, Any], team_key: str) -> None:
+        self._issue = issue
+        self._team_key = team_key
+
+    def get_team_by_key(self, team_key: str) -> dict[str, Any] | None:
+        if team_key != self._team_key:
+            return None
+        return {"id": "team-" + team_key.lower(), "key": team_key, "name": team_key}
+
+    def iter_cycles(self, *, team_id: str | None = None) -> list[dict[str, Any]]:
+        return []
+
+    def iter_issues_pages(self, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+        return [[self._issue]]
+
+    def iter_issues(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    provider_module = load_live_module(_PROVIDER_SOURCE)
+    from dev_health_ops.providers.base import IngestionContext, IngestionWindow
+    from dev_health_ops.providers.identity import IdentityResolver
+    from dev_health_ops.providers.status_mapping import StatusMapping
+
+    team_key = str(case.get("team_key", "ENG"))
+    issue = dict(case["raw_issue"])
+    issue["history"] = {"nodes": list(case.get("history", []))}
+    issue.setdefault("attachments", {"nodes": [], "pageInfo": {"hasNextPage": False}})
+    issue.setdefault("relations", {"nodes": [], "pageInfo": {"hasNextPage": False}})
+    issue.setdefault(
+        "inverseRelations", {"nodes": [], "pageInfo": {"hasNextPage": False}}
+    )
+    issue.setdefault("comments", {"nodes": [], "pageInfo": {"hasNextPage": False}})
+
+    provider = provider_module.LinearProvider(
+        status_mapping=StatusMapping({}, {}, {}, {}),
+        identity=IdentityResolver({}),
+        client=_InjectedLinearClient(issue, team_key),
+    )
+    context = IngestionContext(
+        window=IngestionWindow(
+            updated_since=datetime(2026, 7, 1, tzinfo=timezone.utc),
+            active_until=datetime(2026, 7, 31, 23, 59, 59, tzinfo=timezone.utc),
+        ),
+        repo=team_key,
+    )
+    batches = list(provider.iter_ingest(context))
+    work_items = [item for batch in batches for item in batch.work_items]
+    if len(work_items) != 1 or not dataclasses.is_dataclass(work_items[0]):
+        raise AssertionError(
+            f"real LinearProvider returned {len(work_items)} work items of "
+            f"type {type(work_items[0]) if work_items else None!r}"
+        )
+    return dataclasses.asdict(dataclasses.replace(work_items[0], org_id=case["org_id"]))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="linear/work-items/provider",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "WorkItem"
+        ),
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/linear_work-items_provider.py
+++ b/internal/providersync/testdata/oracle_pairs/linear_work-items_provider.py
@@ -66,12 +66,17 @@ def _build_row(case: dict[str, Any]) -> dict[str, Any]:
     )
     batches = list(provider.iter_ingest(context))
     work_items = [item for batch in batches for item in batch.work_items]
-    if len(work_items) != 1 or not dataclasses.is_dataclass(work_items[0]):
+    work_item = work_items[0] if len(work_items) == 1 else None
+    if (
+        work_item is None
+        or not dataclasses.is_dataclass(work_item)
+        or isinstance(work_item, type)
+    ):
         raise AssertionError(
             f"real LinearProvider returned {len(work_items)} work items of "
             f"type {type(work_items[0]) if work_items else None!r}"
         )
-    return dataclasses.asdict(dataclasses.replace(work_items[0], org_id=case["org_id"]))
+    return dataclasses.asdict(dataclasses.replace(work_item, org_id=case["org_id"]))
 
 
 oracle_registry.register(

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -937,13 +937,16 @@ def _target_linear_normalize() -> None:
 
 
 def _target_linear_provider() -> None:
-    """Load the live Linear provider wrapper for provider-only helpers.
+    """Load the live Linear provider for an injected-client producer oracle.
 
-    The reference-dimension resolver lives in ``provider.py`` rather than the
-    pure normalizer.  Keep the provider module itself live while loading only
-    the dependency-free contracts needed to define its class; the oracle never
-    enters the HTTP client or ingestion method.
+    The oracle supplies a typed in-memory client, so no HTTP transport or
+    credential stack is needed. The provider's actual ``iter_ingest`` method,
+    its batch boundaries, and the real Linear normalizer still execute.
     """
+    _target_linear_normalize()
+    _load_source_module(
+        "dev_health_ops.providers.linear.normalize", _LINEAR_NORMALIZE_SOURCE
+    )
     _load_source_module("dev_health_ops.models.work_items", _WORK_ITEMS_MODEL_SOURCE)
     _load_source_module("dev_health_ops.providers.base", _PROVIDERS_BASE_SOURCE)
     _load_source_module("dev_health_ops.providers.utils", _PROVIDERS_UTILS_SOURCE)


### PR DESCRIPTION
## Scope

Close Linear's bounded lifecycle and atomic five-alias proof with concrete typed route state, pagination/budget behavior, audit/watermark atomicity, lease recovery, and exact readback.

## Evidence

- Live Python `LinearProvider.iter_ingest` oracle with non-empty execution proof
- PostgreSQL atomic five-alias audit/watermark proof
- Real migrated ClickHouse lease-loss/recovery/readback proof
- Shared mutation harness: 8/8 clause mutations killed with clean restore
- Focused Linear/providerfoundation tests and commit hooks green

## Boundaries and limits

- Stacked on Linear provider parity PR #1703
- No registry, matrix, config, deployment, or cutover wiring
- Broader package failure is pre-existing GitHub mutation-plan anchor drift

Linear: CHAOS-3718

SCREENSHOT-WAIVER: Backend-only provider implementation; no rendered UI changes.
