### PR TITLE
feat(providersync): port PagerDuty services parity

### DIFF
--- a/internal/providersync/pagerduty_services_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_services_effects_clickhouse.go
@@ -1,0 +1,718 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+// These columns are the current migrated v2 operational schema. Keeping the
+// ordering columns in the INSERT/readback contract is important: source
+// revisions are the durable replay identity, not an in-memory annotation.
+const (
+	pagerDutyServicesOperationalServiceColumns = gitLabOperationalServiceColumns
+	pagerDutyServicesMappingColumns            = gitLabServiceMappingColumns
+)
+
+// PagerDutyServicesClickHouseEffects owns only the two destinations produced
+// by the services provider path. The repository mapping destination remains a
+// separate typed effect so its source/provenance contract cannot be silently
+// absorbed into OperationalService rows.
+type PagerDutyServicesClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+	Now                func() time.Time
+}
+
+func (sink PagerDutyServicesClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	switch effect.Destination {
+	case "operational_services":
+		rows, err := decodeEffectRows[pagerDutyServiceRow](effect)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyServiceRows(claim, rows); err != nil {
+			return err
+		}
+		return sink.writeServicesSnapshot(ctx, claim, rows)
+	case "operational_service_repository_mappings":
+		rows, err := decodeEffectRows[pagerDutyServiceRepositoryMappingRow](effect)
+		if err != nil {
+			return err
+		}
+		rows, err = sink.resolvePagerDutyServiceMappings(ctx, claim, rows)
+		if err != nil {
+			return err
+		}
+		if err := validatePagerDutyServiceMappingRows(claim, rows); err != nil {
+			return err
+		}
+		return sink.writeMappingsSnapshot(ctx, claim, rows)
+	default:
+		return ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyServicesClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	switch effect.Destination {
+	case "operational_services":
+		expected, err := decodeEffectRows[pagerDutyServiceRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyServiceRows(claim, expected); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectServices(ctx, claim, expected)
+	case "operational_service_repository_mappings":
+		expected, err := decodeEffectRows[pagerDutyServiceRepositoryMappingRow](effect)
+		if err != nil {
+			return EffectConflict, err
+		}
+		expected, err = sink.resolvePagerDutyServiceMappings(ctx, claim, expected)
+		if err != nil {
+			return EffectConflict, err
+		}
+		if err := validatePagerDutyServiceMappingRows(claim, expected); err != nil {
+			return EffectConflict, err
+		}
+		return sink.inspectMappings(ctx, claim, expected)
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+func (sink PagerDutyServicesClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "services" {
+		return ErrInvalidConfiguration
+	}
+	switch effect.Destination {
+	case "operational_services", "operational_service_repository_mappings":
+	default:
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) providerInstance(
+	instances ...string,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, value := range instances {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = value
+		}
+		if instance != value {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func validatePagerDutyServiceRows(claim Claim, rows []pagerDutyServiceRow) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "service" || row.ExternalID == "" || row.Name == "" ||
+			row.ServiceType == nil || *row.ServiceType != "technical" || row.OwningTeamID != nil ||
+			row.ID == "" || row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.IsDeleted != (row.DeletedAt != nil)) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyServiceOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func validatePagerDutyServiceMappingRows(
+	claim Claim, rows []pagerDutyServiceRepositoryMappingRow,
+) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if !pagerDutyMappingSourceValid(row.SourceEntityType) ||
+			row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.ExternalID == "" || row.ServiceID == "" || row.ID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil || row.SourceConflictKey == "" ||
+			row.OrderingContract != 2 || row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() ||
+			row.LastSynced.IsZero() || row.RelationshipProvenance == nil ||
+			*row.RelationshipProvenance != row.SourceEntityType || row.RelationshipConfidence == nil ||
+			*row.RelationshipConfidence < 0 || *row.RelationshipConfidence > 1 ||
+			row.RepoProvider == nil || *row.RepoProvider == "" || row.RepoFullName == nil ||
+			*row.RepoFullName == "" || row.MappingKind == nil || *row.MappingKind == "" ||
+			row.RuleID == nil || *row.RuleID == "" || row.ValidFrom == nil ||
+			row.ValidTo != nil && row.IsActive || (!row.IsActive && row.ValidTo == nil) {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyServiceMappingOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyMappingSourceValid(value string) bool {
+	switch pagerDutyServiceMappingSource(value) {
+	case pagerDutyMappingAdmin, pagerDutyMappingMetadata, pagerDutyMappingCompass, pagerDutyMappingHeuristic:
+		return true
+	default:
+		return false
+	}
+}
+
+func (sink PagerDutyServicesClickHouseEffects) writeServicesSnapshot(
+	ctx context.Context, claim Claim, rows []pagerDutyServiceRow,
+) error {
+	providerInstance, err := sink.providerInstance(pagerDutyServiceInstances(rows)...)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveServices(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.snapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyServiceRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyServiceTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_services ("+pagerDutyServicesOperationalServiceColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyServiceValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) writeMappingsSnapshot(
+	ctx context.Context, claim Claim, rows []pagerDutyServiceRepositoryMappingRow,
+) error {
+	instances := make([]string, 0, len(rows))
+	for _, row := range rows {
+		instances = append(instances, row.ProviderInstanceID)
+	}
+	providerInstance, err := sink.providerInstance(instances...)
+	if err != nil {
+		return err
+	}
+	active, err := sink.loadActiveMappings(ctx, claim, providerInstance)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		seen[row.ID] = struct{}{}
+	}
+	observedAt := sink.mappingSnapshotObservedAt(rows, claim)
+	allRows := append([]pagerDutyServiceRepositoryMappingRow(nil), rows...)
+	for _, existing := range active {
+		if _, present := seen[existing.ID]; present {
+			continue
+		}
+		tombstone, tombstoneErr := pagerDutyServiceMappingTombstone(existing, observedAt)
+		if tombstoneErr != nil {
+			return tombstoneErr
+		}
+		allRows = append(allRows, tombstone)
+	}
+	if len(allRows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_service_repository_mappings ("+pagerDutyServicesMappingColumns+")")
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range allRows {
+		if err := batch.Append(pagerDutyServiceMappingValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+// resolvePagerDutyServiceMappings mirrors Python's
+// resolve_repository_mappings: repository identity is looked up only in the
+// org-scoped ClickHouse catalog, while unmatched evidence remains unresolved
+// with its provider/full-name pair intact. The effect payload stays a typed
+// evidence row; this sink-side enrichment is deterministic and is repeated on
+// readback/recovery before comparing the durable row.
+func (sink PagerDutyServicesClickHouseEffects) resolvePagerDutyServiceMappings(
+	ctx context.Context, claim Claim, rows []pagerDutyServiceRepositoryMappingRow,
+) ([]pagerDutyServiceRepositoryMappingRow, error) {
+	if len(rows) == 0 {
+		return rows, nil
+	}
+	needsCatalog := false
+	for _, row := range rows {
+		if row.RepoID == nil && row.RepoProvider != nil && row.RepoFullName != nil {
+			needsCatalog = true
+			break
+		}
+	}
+	if !needsCatalog {
+		return rows, nil
+	}
+	catalogRows, err := sink.Conn.Query(
+		ctx, "SELECT id, provider, repo FROM repos FINAL WHERE org_id = ?", claim.OrgID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer catalogRows.Close()
+	catalog := make(map[string]uuid.UUID)
+	for catalogRows.Next() {
+		var repoID uuid.UUID
+		var provider, fullName string
+		if err := catalogRows.Scan(&repoID, &provider, &fullName); err != nil {
+			return nil, err
+		}
+		catalog[provider+"\x00"+fullName] = repoID
+	}
+	if err := catalogRows.Err(); err != nil {
+		return nil, err
+	}
+	resolved := make([]pagerDutyServiceRepositoryMappingRow, len(rows))
+	copy(resolved, rows)
+	for index, row := range resolved {
+		if row.RepoID != nil || row.RepoProvider == nil || row.RepoFullName == nil {
+			continue
+		}
+		repoID, found := catalog[*row.RepoProvider+"\x00"+*row.RepoFullName]
+		if !found {
+			continue
+		}
+		row.RepoID = &repoID
+		row.ID, row.SourceConflictKey = "", ""
+		row.SourceRevision, row.IngestRevision = nil, nil
+		row.OrderingContract = 0
+		if err := fillPagerDutyServiceMappingOrdering(&row); err != nil {
+			return nil, err
+		}
+		resolved[index] = row
+	}
+	return resolved, nil
+}
+
+func pagerDutyServiceInstances(rows []pagerDutyServiceRow) []string {
+	instances := make([]string, 0, len(rows))
+	for _, row := range rows {
+		instances = append(instances, row.ProviderInstanceID)
+	}
+	return instances
+}
+
+func (sink PagerDutyServicesClickHouseEffects) snapshotObservedAt(rows []pagerDutyServiceRow, claim Claim) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	return sink.snapshotNow(claim)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) mappingSnapshotObservedAt(rows []pagerDutyServiceRepositoryMappingRow, claim Claim) time.Time {
+	for _, row := range rows {
+		if !row.ObservedAt.IsZero() {
+			return row.ObservedAt.UTC().Truncate(time.Microsecond)
+		}
+	}
+	return sink.snapshotNow(claim)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) snapshotNow(claim Claim) time.Time {
+	if sink.Now != nil {
+		return sink.Now().UTC().Truncate(time.Microsecond)
+	}
+	if claim.BeforeAt != nil && !claim.BeforeAt.IsZero() {
+		return claim.BeforeAt.UTC().Truncate(time.Microsecond)
+	}
+	return time.Now().UTC().Truncate(time.Microsecond)
+}
+
+func pagerDutyServiceValues(row pagerDutyServiceRow) []any {
+	values := gitLabOperationalBaseValues(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceRevision, row.SourceConflictKey,
+		row.IngestRevision, row.OrderingContract, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence,
+	)
+	return append(values, row.Name, row.Description, row.ServiceType, row.OwningTeamID,
+		row.EscalationPolicyID, row.IsDeleted, row.DeletedAt)
+}
+
+func pagerDutyServiceMappingValues(row pagerDutyServiceRepositoryMappingRow) []any {
+	values := gitLabOperationalBaseValues(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceRevision, row.SourceConflictKey,
+		row.IngestRevision, row.OrderingContract, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence,
+	)
+	return append(values, row.ServiceID, row.RepoID, row.RepoFullName, row.RepoProvider,
+		row.MappingKind, row.RuleID, row.ValidFrom, row.ValidTo, row.IsActive)
+}
+
+func pagerDutyServiceScanValues(row *pagerDutyServiceRow, sourceRevision, ingestRevision *big.Int) []any {
+	values := gitLabOperationalBaseScanValues(
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, sourceRevision, &row.SourceConflictKey,
+		ingestRevision, &row.OrderingContract, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence,
+	)
+	return append(values, &row.Name, &row.Description, &row.ServiceType, &row.OwningTeamID,
+		&row.EscalationPolicyID, &row.IsDeleted, &row.DeletedAt)
+}
+
+func pagerDutyServiceMappingScanValues(row *pagerDutyServiceRepositoryMappingRow, sourceRevision, ingestRevision *big.Int) []any {
+	values := gitLabOperationalBaseScanValues(
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, sourceRevision, &row.SourceConflictKey,
+		ingestRevision, &row.OrderingContract, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence,
+	)
+	return append(values, &row.ServiceID, &row.RepoID, &row.RepoFullName, &row.RepoProvider,
+		&row.MappingKind, &row.RuleID, &row.ValidFrom, &row.ValidTo, &row.IsActive)
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadActiveServices(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyServiceRow, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesOperationalServiceColumns+
+		" FROM (SELECT "+pagerDutyServicesOperationalServiceColumns+
+		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? "+
+		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) "+
+		"WHERE is_deleted = 0",
+		claim.OrgID, claim.Provider, providerInstance, "service")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]pagerDutyServiceRow, 0)
+	for rows.Next() {
+		var row pagerDutyServiceRow
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceScanValues(&row, &sourceRevision, &ingestRevision)...); err != nil {
+			return nil, err
+		}
+		row.SourceRevision, row.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadActiveMappings(
+	ctx context.Context, claim Claim, providerInstance string,
+) ([]pagerDutyServiceRepositoryMappingRow, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesMappingColumns+
+		" FROM (SELECT "+pagerDutyServicesMappingColumns+
+		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? "+
+		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) "+
+		"WHERE is_active = 1",
+		claim.OrgID, claim.Provider, providerInstance)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]pagerDutyServiceRepositoryMappingRow, 0)
+	for rows.Next() {
+		var row pagerDutyServiceRepositoryMappingRow
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceMappingScanValues(&row, &sourceRevision, &ingestRevision)...); err != nil {
+			return nil, err
+		}
+		row.SourceRevision, row.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) inspectServices(
+	ctx context.Context, claim Claim, expected []pagerDutyServiceRow,
+) (EffectInspection, error) {
+	providerInstance, err := sink.providerInstance(pagerDutyServiceInstances(expected)...)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveServices(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	exact, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadService(ctx, claim, providerInstance, row.ID)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyServiceVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) && absent == 0 {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyServicesClickHouseEffects) inspectMappings(
+	ctx context.Context, claim Claim, expected []pagerDutyServiceRepositoryMappingRow,
+) (EffectInspection, error) {
+	instances := make([]string, 0, len(expected))
+	for _, row := range expected {
+		instances = append(instances, row.ProviderInstanceID)
+	}
+	providerInstance, err := sink.providerInstance(instances...)
+	if err != nil {
+		return EffectConflict, err
+	}
+	active, err := sink.loadActiveMappings(ctx, claim, providerInstance)
+	if err != nil {
+		return EffectConflict, err
+	}
+	seen := make(map[string]struct{}, len(expected))
+	exact, absent := 0, 0
+	for _, row := range expected {
+		seen[row.ID] = struct{}{}
+		actual, found, loadErr := sink.loadMapping(ctx, claim, providerInstance, row.ID)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyServiceMappingVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	for _, row := range active {
+		if _, present := seen[row.ID]; !present {
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) && absent == 0 {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadService(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyServiceRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesOperationalServiceColumns+
+		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? "+
+		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "service", id)
+	if err != nil {
+		return pagerDutyServiceRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyServiceRow
+	found := false
+	for rows.Next() {
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceScanValues(&actual, &sourceRevision, &ingestRevision)...); err != nil {
+			return pagerDutyServiceRow{}, false, err
+		}
+		actual.SourceRevision, actual.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		found = true
+	}
+	return actual, found, rows.Err()
+}
+
+func (sink PagerDutyServicesClickHouseEffects) loadMapping(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyServiceRepositoryMappingRow, bool, error) {
+	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesMappingColumns+
+		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND id = ? "+
+		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, id)
+	if err != nil {
+		return pagerDutyServiceRepositoryMappingRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyServiceRepositoryMappingRow
+	found := false
+	for rows.Next() {
+		var sourceRevision, ingestRevision big.Int
+		if err := rows.Scan(pagerDutyServiceMappingScanValues(&actual, &sourceRevision, &ingestRevision)...); err != nil {
+			return pagerDutyServiceRepositoryMappingRow{}, false, err
+		}
+		actual.SourceRevision, actual.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		found = true
+	}
+	return actual, found, rows.Err()
+}
+
+func comparePagerDutyServiceVersion(expected, actual pagerDutyServiceRow, found bool) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func comparePagerDutyServiceMappingVersion(expected, actual pagerDutyServiceRepositoryMappingRow, found bool) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func pagerDutyServiceMappingTombstone(
+	row pagerDutyServiceRepositoryMappingRow, observedAt time.Time,
+) (pagerDutyServiceRepositoryMappingRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyServiceRepositoryMappingRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	if previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond); version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt = version
+	observed := observedAt.UTC().Truncate(time.Microsecond)
+	row.ObservedAt, row.LastSynced = observed, observed
+	row.ValidTo, row.IsActive = &observed, false
+	row.SourceRevision, row.SourceConflictKey, row.IngestRevision = nil, "", nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyServiceMappingOrdering(&row); err != nil {
+		return pagerDutyServiceRepositoryMappingRow{}, err
+	}
+	return row, nil
+}
+
+var _ EffectSink = PagerDutyServicesClickHouseEffects{}
+var _ EffectReadback = PagerDutyServicesClickHouseEffects{}

--- a/internal/providersync/pagerduty_services_effects_integration_test.go
+++ b/internal/providersync/pagerduty_services_effects_integration_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	// The current production writer contract is v2; make the migration runner
+	// inherit that explicit admission instead of silently materializing its
+	// legacy default.
+	t.Setenv("OPERATIONAL_ORDERING_CONTRACT", "2")
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// This is the production migration chain, including the v2 ordering
+	// contract, rather than a test-only table that could omit readback fields.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "services")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	serviceA, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS1", Name: "Payments"}, initialAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceB, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS2", Name: "Support"}, initialAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingA, err := pagerDutyServiceMappingFromReference(serviceA, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"}, pagerDutyMappingMetadata, initialAt, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingB, err := pagerDutyServiceMappingFromReference(serviceB, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/support"}, pagerDutyMappingMetadata, initialAt, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceEffect, err := effectBatchFromValues("operational_services", EffectReadbackRequired, []pagerDutyServiceRow{serviceA, serviceB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingEffect, err := effectBatchFromValues("operational_service_repository_mappings", EffectReadbackRequired, []pagerDutyServiceRepositoryMappingRow{mappingA, mappingB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutyServicesClickHouseEffects{
+		Conn: conn, Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+		ProviderInstanceID: "Acme", Now: func() time.Time { return initialAt },
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, serviceEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("services before write inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, mappingEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("mappings before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, serviceEffect); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, mappingEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, serviceEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("services after write inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, mappingEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("mappings after write inspection=%s error=%v", inspection, err)
+	}
+	// Replaying the durable effect is the recovery path: no new source fetch or
+	// generated identity is involved, and both destinations must read back exact.
+	if err := sink.WriteEffect(ctx, claim, serviceEffect); err != nil {
+		t.Fatalf("service replay: %v", err)
+	}
+	if err := sink.WriteEffect(ctx, claim, mappingEffect); err != nil {
+		t.Fatalf("mapping replay: %v", err)
+	}
+
+	updatedAt := initialAt.Add(time.Hour)
+	serviceAUpdated, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS1", Name: "Payments updated", UpdatedAt: updatedAt.Format(time.RFC3339Nano)}, updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedServiceEffect, err := effectBatchFromValues("operational_services", EffectReadbackRequired, []pagerDutyServiceRow{serviceAUpdated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingAUpdated, err := pagerDutyServiceMappingFromReference(serviceAUpdated, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"}, pagerDutyMappingMetadata, updatedAt, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedMappingEffect, err := effectBatchFromValues("operational_service_repository_mappings", EffectReadbackRequired, []pagerDutyServiceRepositoryMappingRow{mappingAUpdated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink.Now = func() time.Time { return updatedAt }
+	if err := sink.WriteEffect(ctx, claim, updatedServiceEffect); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, updatedMappingEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedServiceEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("updated services inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedMappingEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("updated mappings inspection=%s error=%v", inspection, err)
+	}
+	var deleted bool
+	var deletedAt time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_deleted, deleted_at
+FROM (
+  SELECT org_id, id, external_id, is_deleted, deleted_at, source_revision, source_conflict_key, ingest_revision
+  FROM operational_services
+  WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ?
+  ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC
+  LIMIT 1 BY org_id, id
+)
+WHERE external_id = ?`,
+		claim.OrgID, "pagerduty", "acme", "service", "PS2").Scan(&deleted, &deletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted || !deletedAt.Equal(updatedAt) {
+		t.Fatalf("service tombstone deleted=%v deleted_at=%s want %s", deleted, deletedAt, updatedAt)
+	}
+	var active bool
+	var validTo time.Time
+	if err := conn.QueryRow(ctx, `
+SELECT is_active, valid_to
+FROM (
+  SELECT org_id, id, is_active, valid_to, source_revision, source_conflict_key, ingest_revision
+  FROM operational_service_repository_mappings
+  WHERE org_id = ? AND provider = ? AND provider_instance_id = ?
+  ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC
+  LIMIT 1 BY org_id, id
+)
+WHERE id = ?`,
+		claim.OrgID, "pagerduty", "acme", mappingB.ID).Scan(&active, &validTo); err != nil {
+		t.Fatal(err)
+	}
+	if active || !validTo.Equal(updatedAt) {
+		t.Fatalf("mapping tombstone active=%v valid_to=%s want %s", active, validTo, updatedAt)
+	}
+
+	// A foreign tenant may write its own identity, but it cannot alter this
+	// tenant's readback because every sink query includes org/provider/instance.
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	foreign := serviceAUpdated
+	foreign.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyServiceOrdering(&foreign); err != nil {
+		t.Fatal(err)
+	}
+	foreignEffect, err := effectBatchFromValues("operational_services", EffectReadbackRequired, []pagerDutyServiceRow{foreign})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, foreignEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedServiceEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign tenant changed service inspection=%s error=%v", inspection, err)
+	}
+
+	// A lease loss at the durable write boundary must fail closed; the batch is
+	// prepared but never acknowledged as written.
+	leaseSink := PagerDutyServicesClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return providerfoundation.ErrLeaseLost }),
+	}
+	if err := leaseSink.WriteEffect(ctx, claim, updatedServiceEffect); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("lease failure=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_services_effects_test.go
+++ b/internal/providersync/pagerduty_services_effects_test.go
@@ -1,0 +1,138 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "services")
+	now := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	service, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{
+		ID: "PS1", Name: "Payments", EscalationPolicy: &pagerDutyServiceReference{ID: "PE1"},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := service
+	foreign.OrgID = "org-other"
+	if err := fillPagerDutyServiceOrdering(&foreign); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := service
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyServiceOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutyServicesClickHouseEffects{}).providerInstance(service.ProviderInstanceID, foreignInstance.ProviderInstanceID); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := service
+	tampered.Name = "forged"
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	if err := validatePagerDutyServiceRows(claim, []pagerDutyServiceRow{service, service}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate service error=%v", err)
+	}
+
+	mapping, err := pagerDutyServiceMappingFromReference(
+		service, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"},
+		pagerDutyMappingMetadata, now, "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreignMapping := mapping
+	foreignMapping.OrgID = "org-other"
+	if err := validatePagerDutyServiceMappingRows(claim, []pagerDutyServiceRepositoryMappingRow{foreignMapping}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign mapping tenant error=%v", err)
+	}
+	foreignMapping = mapping
+	foreignMapping.ProviderInstanceID = "other"
+	if err := fillPagerDutyServiceMappingOrdering(&foreignMapping); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceMappingRows(claim, []pagerDutyServiceRepositoryMappingRow{foreignMapping}); err != nil {
+		t.Fatalf("mapping instance structural validation: %v", err)
+	}
+	badMapping := mapping
+	badMapping.RelationshipProvenance = stringPtr("admin_configuration")
+	if err := fillPagerDutyServiceMappingOrdering(&badMapping); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyServiceMappingRows(claim, []pagerDutyServiceRepositoryMappingRow{badMapping}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mapping provenance tamper error=%v", err)
+	}
+}
+
+func TestPagerDutyServicesTombstonesAdvanceVersionsAndPreserveMappingOwnership(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "services")
+	now := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	service, err := normalizePagerDutyService(claim, "acme", pagerDutyServicePayload{ID: "PS1", Name: "Payments"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceTombstone, err := pagerDutyServiceTombstone(service, service.SourceVersionAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if serviceTombstone.ID != service.ID || serviceTombstone.ExternalID != service.ExternalID ||
+		!serviceTombstone.SourceVersionAt.Equal(service.SourceVersionAt.Add(time.Microsecond)) ||
+		!serviceTombstone.ObservedAt.Equal(serviceTombstone.SourceVersionAt) ||
+		!serviceTombstone.LastSynced.Equal(serviceTombstone.SourceVersionAt) || !serviceTombstone.IsDeleted ||
+		serviceTombstone.DeletedAt == nil || !serviceTombstone.DeletedAt.Equal(serviceTombstone.SourceVersionAt) ||
+		serviceTombstone.SourceRevision == nil || serviceTombstone.SourceRevision.Cmp(service.SourceRevision) <= 0 {
+		t.Fatalf("service tombstone=%+v", serviceTombstone)
+	}
+	if got := new(big.Int).And(new(big.Int).Rsh(new(big.Int).Set(serviceTombstone.SourceRevision), 56), big.NewInt(255)); got.Cmp(big.NewInt(2)) != 0 {
+		t.Fatalf("service tombstone operation rank=%s want 2", got)
+	}
+	mapping, err := pagerDutyServiceMappingFromReference(
+		service, pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"},
+		pagerDutyMappingMetadata, now, "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingTombstone, err := pagerDutyServiceMappingTombstone(mapping, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mappingTombstone.ID != mapping.ID || mappingTombstone.IsActive || mappingTombstone.ValidTo == nil ||
+		!mappingTombstone.ValidTo.Equal(now) || !mappingTombstone.ObservedAt.Equal(now) ||
+		!mappingTombstone.LastSynced.Equal(now) ||
+		!mappingTombstone.SourceVersionAt.Equal(mapping.SourceVersionAt.Add(time.Microsecond)) ||
+		mappingTombstone.SourceRevision == nil || mappingTombstone.SourceRevision.Cmp(mapping.SourceRevision) <= 0 ||
+		mappingTombstone.SourceEntityType != string(pagerDutyMappingMetadata) {
+		t.Fatalf("mapping tombstone=%+v", mappingTombstone)
+	}
+	if got := new(big.Int).And(new(big.Int).Rsh(new(big.Int).Set(mappingTombstone.SourceRevision), 56), big.NewInt(255)); got.Cmp(big.NewInt(2)) != 0 {
+		t.Fatalf("mapping tombstone operation rank=%s want 2", got)
+	}
+}
+
+func TestPagerDutyServicesEffectsRejectUnsafeEmptySnapshotAndWrongDestination(t *testing.T) {
+	if _, err := (PagerDutyServicesClickHouseEffects{}).providerInstance(); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+	claim := nativeTestClaim("pagerduty", "services")
+	sink := PagerDutyServicesClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_services"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("nil context error=%v", err)
+	}
+	if err := sink.WriteEffect(context.Background(), claim, EffectBatch{Destination: "other"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_services_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_services_generic_oracle_test.go
@@ -1,0 +1,71 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyServiceRowForOracle(t *testing.T, input map[string]any) pagerDutyServiceRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutyServicePayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "services")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyService(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload, observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyServiceCases() []oracleCase {
+	return []oracleCase{
+		{ID: "updated_html_url_policy", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS1", "type": "service", "name": "Payments", "summary": "Ignored",
+				"updated_at":        "2026-08-01T10:00:00.123456Z",
+				"html_url":          "https://acme.pagerduty.com/services/PS1",
+				"escalation_policy": map[string]any{"id": "PE1", "type": "escalation_policy"},
+			},
+		}},
+		{ID: "created_self_url_summary", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "PS2", "type": "service", "summary": "Support",
+				"created_at": "2026-07-31T09:00:00Z", "self": "/services/PS2",
+			},
+		}},
+		{ID: "observed_time_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload":     map[string]any{"id": "PS3", "type": "service", "name": "Operations"},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyServiceRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/services/row", oraclePagerDutyServiceCases(),
+		buildPagerDutyServiceRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_services_route.go
+++ b/internal/providersync/pagerduty_services_route.go
@@ -1,0 +1,684 @@
+package providersync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyServicesMaxPages = 10_000
+	pagerDutyServicesMaxRows  = 100_000
+	pagerDutyServicesPerPage  = 100
+)
+
+// pagerDutyServicePayload is the provider-owned subset consumed by
+// PagerDutyNormalizer.service. Raw is retained only for the separate,
+// evidence-preserving repository-mapping producer below; it is never emitted
+// as a generic provider result or effect row.
+type pagerDutyServicePayload struct {
+	ID               string                     `json:"id"`
+	Name             string                     `json:"name"`
+	Summary          string                     `json:"summary"`
+	SelfURL          string                     `json:"self"`
+	HTMLURL          string                     `json:"html_url"`
+	CreatedAt        string                     `json:"created_at"`
+	UpdatedAt        string                     `json:"updated_at"`
+	EscalationPolicy *pagerDutyServiceReference `json:"escalation_policy"`
+}
+
+type pagerDutyServiceReference struct {
+	ID string `json:"id"`
+}
+
+// pagerDutyServiceRow mirrors every field on Python's OperationalService
+// dataclass. Service rows and repository-mapping rows are deliberately
+// separate typed effects: service_repository_mapping.py owns mapping
+// provenance and this producer does not fold that evidence into service rows.
+type pagerDutyServiceRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	Name                   string     `json:"name"`
+	Description            *string    `json:"description"`
+	ServiceType            *string    `json:"service_type"`
+	OwningTeamID           *string    `json:"owning_team_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	IsDeleted              bool       `json:"is_deleted"`
+	DeletedAt              *time.Time `json:"deleted_at"`
+}
+
+// pagerDutyServiceRepositoryMappingRow is the typed counterpart of
+// ServiceRepositoryMapping. Its SourceEntityType is the mapping source enum
+// value (admin_configuration, pagerduty_service_metadata,
+// compass_service_catalog, or bounded_service_repository_heuristic), not the
+// service source type. This preserves the Python producer's provenance
+// ownership and lets the sink reconcile each source independently.
+type pagerDutyServiceRepositoryMappingRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ServiceID              string     `json:"service_id"`
+	RepoID                 *uuid.UUID `json:"repo_id"`
+	RepoFullName           *string    `json:"repo_full_name"`
+	RepoProvider           *string    `json:"repo_provider"`
+	MappingKind            *string    `json:"mapping_kind"`
+	RuleID                 *string    `json:"rule_id"`
+	ValidFrom              *time.Time `json:"valid_from"`
+	ValidTo                *time.Time `json:"valid_to"`
+	IsActive               bool       `json:"is_active"`
+}
+
+type PagerDutyServicesRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutyServicesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyServicesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutyServicesRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutyServicesMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutyServicesMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyServicesPerPage
+	}
+	if pages < 1 || pages > pagerDutyServicesMaxPages || rows < 1 ||
+		rows > pagerDutyServicesMaxRows || perPage < 1 || perPage > pagerDutyServicesPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutyServicesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "services" ||
+		client == nil || client.Provider != "pagerduty" || client.BaseURL == nil ||
+		normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyServicesCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/services", DataKey: "services", PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	services := make([]pagerDutyServiceRow, 0, len(pages.Items))
+	mappings := make([]pagerDutyServiceRepositoryMappingRow, 0)
+	inputs := pagerDutyServiceRepositoryMappingInputsFromOptions(claim.DatasetOptions)
+	for _, raw := range pages.Items {
+		var payload pagerDutyServicePayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		service, err := normalizePagerDutyService(claim, providerInstance, payload, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		services = append(services, service)
+		var metadata map[string]any
+		if err := json.Unmarshal(raw, &metadata); err != nil || metadata == nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		serviceMappings, err := pagerDutyServiceMappings(
+			service, metadata, normalizedAt, inputs,
+		)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		mappings = append(mappings, serviceMappings...)
+	}
+	mappings = selectPagerDutyPreferredMappings(mappings)
+	serviceEffect, err := effectBatchFromValues(
+		"operational_services", EffectReadbackRequired, services,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	mappingEffect, err := effectBatchFromValues(
+		"operational_service_repository_mappings", EffectReadbackRequired, mappings,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{serviceEffect, mappingEffect},
+		Result: map[string]any{
+			"services_synced": len(services), "service_repository_mappings_synced": len(mappings),
+		},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(services), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutyService(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyServicePayload,
+	normalizedAt time.Time,
+) (pagerDutyServiceRow, error) {
+	externalID := strings.TrimSpace(payload.ID)
+	if externalID == "" {
+		return pagerDutyServiceRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	sourceVersionAt, err := pagerDutyServiceSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyServiceRow{}, err
+	}
+	var sourceURL *string
+	if payload.HTMLURL != "" {
+		value := payload.HTMLURL
+		sourceURL = &value
+	} else if payload.SelfURL != "" {
+		value := payload.SelfURL
+		sourceURL = &value
+	}
+	name := payload.Name
+	if name == "" {
+		name = payload.Summary
+	}
+	if name == "" {
+		name = payload.ID
+	}
+	serviceType := "technical"
+	var escalationPolicyID *string
+	if payload.EscalationPolicy != nil && strings.TrimSpace(payload.EscalationPolicy.ID) != "" {
+		value := pagerDutyCanonicalOperationalID(
+			claim.OrgID, "pagerduty", providerInstance,
+			"operational_escalation_policy", strings.TrimSpace(payload.EscalationPolicy.ID),
+		)
+		escalationPolicyID = &value
+	}
+	row := pagerDutyServiceRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "service", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt, Name: name,
+		ServiceType: &serviceType, EscalationPolicyID: escalationPolicyID,
+	}
+	if err := fillPagerDutyServiceOrdering(&row); err != nil {
+		return pagerDutyServiceRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyServiceSourceTime(payload pagerDutyServicePayload, observedAt time.Time) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func fillPagerDutyServiceOrdering(row *pagerDutyServiceRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	fields = append(fields,
+		jiraOperationalField{"name", row.Name},
+		jiraOperationalField{"description", jiraStringValue(row.Description)},
+		jiraOperationalField{"service_type", jiraStringValue(row.ServiceType)},
+		jiraOperationalField{"owning_team_id", jiraStringValue(row.OwningTeamID)},
+		jiraOperationalField{"escalation_policy_id", jiraStringValue(row.EscalationPolicyID)},
+		jiraOperationalField{"is_deleted", row.IsDeleted},
+		jiraOperationalField{"deleted_at", jiraTimeValue(row.DeletedAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_service", row.OrgID, row.Provider, row.ProviderInstanceID,
+		row.ExternalID, row.SourceVersionAt, row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	if row.IsDeleted {
+		row.SourceRevision, err = pagerDutyOperationalTombstoneRevision(sourceRevision, conflict)
+		if err != nil {
+			return err
+		}
+	}
+	row.OrderingContract = 2
+	return nil
+}
+
+func pagerDutyOperationalTombstoneRevision(sourceRevision *big.Int, conflict string) (*big.Int, error) {
+	if sourceRevision == nil || conflict == "" {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	conflictBytes, err := hex.DecodeString(conflict)
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	revisionDigest := sha256.Sum256(append([]byte("operational-source-revision-v1"), conflictBytes...))
+	timestamp := new(big.Int).Rsh(new(big.Int).Set(sourceRevision), 64)
+	rank := new(big.Int).Lsh(big.NewInt(2), 56)
+	revision := new(big.Int).Lsh(timestamp, 64)
+	revision.Or(revision, rank)
+	revision.Or(revision, new(big.Int).SetBytes(revisionDigest[:7]))
+	return revision, nil
+}
+
+func pagerDutyServiceTombstone(row pagerDutyServiceRow, observedAt time.Time) (pagerDutyServiceRow, error) {
+	if row.ID == "" || row.SourceVersionAt.IsZero() || observedAt.IsZero() {
+		return pagerDutyServiceRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	version := observedAt.UTC().Truncate(time.Microsecond)
+	if previousNext := row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond); version.Before(previousNext) {
+		version = previousNext
+	}
+	row.SourceVersionAt, row.ObservedAt, row.LastSynced = version, version, version
+	row.IsDeleted = true
+	row.DeletedAt = &version
+	row.SourceRevision, row.SourceConflictKey, row.IngestRevision = nil, "", nil
+	row.OrderingContract = 0
+	if err := fillPagerDutyServiceOrdering(&row); err != nil {
+		return pagerDutyServiceRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyCanonicalOperationalID(orgID, provider, instance, family, externalID string) string {
+	quoted := []string{
+		strconv.QuoteToASCII(orgID), strconv.QuoteToASCII(provider),
+		strconv.QuoteToASCII(instance), strconv.QuoteToASCII(family),
+		strconv.QuoteToASCII(externalID),
+	}
+	digest := sha256.Sum256([]byte("[" + strings.Join(quoted, ",") + "]"))
+	return hex.EncodeToString(digest[:])
+}
+
+type pagerDutyServiceMappingSource string
+
+const (
+	pagerDutyMappingAdmin     pagerDutyServiceMappingSource = "admin_configuration"
+	pagerDutyMappingMetadata  pagerDutyServiceMappingSource = "pagerduty_service_metadata"
+	pagerDutyMappingCompass   pagerDutyServiceMappingSource = "compass_service_catalog"
+	pagerDutyMappingHeuristic pagerDutyServiceMappingSource = "bounded_service_repository_heuristic"
+)
+
+func (source pagerDutyServiceMappingSource) confidence() float64 {
+	switch source {
+	case pagerDutyMappingAdmin:
+		return 1
+	case pagerDutyMappingMetadata:
+		return 0.95
+	case pagerDutyMappingCompass:
+		return 0.9
+	default:
+		return 0.4
+	}
+}
+
+func (source pagerDutyServiceMappingSource) mappingKind() string {
+	if source == pagerDutyMappingHeuristic {
+		return string(source)
+	}
+	return string(source) + "_exact"
+}
+
+func (source pagerDutyServiceMappingSource) ruleID() string {
+	switch source {
+	case pagerDutyMappingAdmin:
+		return "service_repository_mapping.admin.v1"
+	case pagerDutyMappingMetadata:
+		return "pagerduty.service_metadata.repository_url_or_key.v1"
+	case pagerDutyMappingCompass:
+		return "compass.service_repository_relationship.v1"
+	default:
+		return "pagerduty.service_repository.bounded_name_match.v1"
+	}
+}
+
+type pagerDutyServiceRepositoryReference struct {
+	Provider string
+	FullName string
+}
+
+type pagerDutyServiceMappingInputs struct {
+	Admin   map[string][]pagerDutyServiceRepositoryReference
+	Compass map[string][]pagerDutyServiceRepositoryReference
+}
+
+func pagerDutyServiceRepositoryMappingInputsFromOptions(options map[string]any) pagerDutyServiceMappingInputs {
+	inputs := pagerDutyServiceMappingInputs{
+		Admin:   map[string][]pagerDutyServiceRepositoryReference{},
+		Compass: map[string][]pagerDutyServiceRepositoryReference{},
+	}
+	config, ok := options["service_repository_mappings"].(map[string]any)
+	if !ok {
+		return inputs
+	}
+	inputs.Admin = pagerDutyParseServiceRepositoryReferences(config["admin"])
+	inputs.Compass = pagerDutyParseServiceRepositoryReferences(config["compass"])
+	return inputs
+}
+
+func pagerDutyParseServiceRepositoryReferences(value any) map[string][]pagerDutyServiceRepositoryReference {
+	result := map[string][]pagerDutyServiceRepositoryReference{}
+	services, ok := value.(map[string]any)
+	if !ok {
+		return result
+	}
+	for serviceID, rawReferences := range services {
+		entries, ok := rawReferences.([]any)
+		if !ok {
+			continue
+		}
+		for _, rawEntry := range entries {
+			entry, ok := rawEntry.(map[string]any)
+			if !ok {
+				continue
+			}
+			provider, providerOK := entry["provider"].(string)
+			fullName, fullNameOK := entry["full_name"].(string)
+			if providerOK && fullNameOK && provider != "" && fullName != "" {
+				result[serviceID] = append(result[serviceID], pagerDutyServiceRepositoryReference{Provider: provider, FullName: fullName})
+			}
+		}
+	}
+	return result
+}
+
+var (
+	pagerDutyGitHubRepositoryURL = regexp.MustCompile(`https?://(?:www\.)?github\.com/([^/\s]+)/([^/#?\s]+)`)
+	pagerDutyGitLabRepositoryURL = regexp.MustCompile(`https?://(?:www\.)?gitlab\.com/([^\s]+)/?$`)
+)
+
+func pagerDutyServiceMappings(
+	service pagerDutyServiceRow,
+	metadata map[string]any,
+	observedAt time.Time,
+	inputs pagerDutyServiceMappingInputs,
+) ([]pagerDutyServiceRepositoryMappingRow, error) {
+	references := pagerDutyMetadataRepositoryReferences(metadata)
+	values := make([]pagerDutyServiceRepositoryMappingRow, 0, len(references))
+	for _, reference := range references {
+		row, err := pagerDutyServiceMappingFromReference(service, reference, pagerDutyMappingMetadata, observedAt, "")
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, row)
+	}
+	for _, reference := range inputs.Admin[service.ExternalID] {
+		row, err := pagerDutyServiceMappingFromReference(service, reference, pagerDutyMappingAdmin, observedAt, "")
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, row)
+	}
+	for _, reference := range inputs.Compass[service.ExternalID] {
+		row, err := pagerDutyServiceMappingFromReference(service, reference, pagerDutyMappingCompass, observedAt, "")
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, row)
+	}
+	return values, nil
+}
+
+func pagerDutyMetadataRepositoryReferences(metadata map[string]any) []pagerDutyServiceRepositoryReference {
+	seen := map[pagerDutyServiceRepositoryReference]struct{}{}
+	var walk func(any, string)
+	walk = func(value any, key string) {
+		switch typed := value.(type) {
+		case string:
+			if match := pagerDutyGitHubRepositoryURL.FindStringSubmatch(typed); len(match) == 3 {
+				seen[pagerDutyServiceRepositoryReference{Provider: "github", FullName: strings.TrimSuffix(match[1]+"/"+match[2], ".git")}] = struct{}{}
+			}
+			if match := pagerDutyGitLabRepositoryURL.FindStringSubmatch(typed); len(match) == 2 {
+				seen[pagerDutyServiceRepositoryReference{Provider: "gitlab", FullName: strings.TrimSuffix(match[1], ".git")}] = struct{}{}
+			}
+			if (key == "repo" || key == "repository" || key == "repository_slug" || key == "repo_slug") && strings.Count(typed, "/") == 1 {
+				seen[pagerDutyServiceRepositoryReference{Provider: "github", FullName: strings.TrimSuffix(typed, ".git")}] = struct{}{}
+			}
+		case map[string]any:
+			for nestedKey, nestedValue := range typed {
+				walk(nestedValue, strings.ToLower(nestedKey))
+			}
+		case []any:
+			for _, nestedValue := range typed {
+				walk(nestedValue, key)
+			}
+		}
+	}
+	walk(metadata, "")
+	values := make([]pagerDutyServiceRepositoryReference, 0, len(seen))
+	for reference := range seen {
+		values = append(values, reference)
+	}
+	slicesSortPagerDutyReferences(values)
+	return values
+}
+
+func slicesSortPagerDutyReferences(values []pagerDutyServiceRepositoryReference) {
+	for index := 1; index < len(values); index++ {
+		current := values[index]
+		position := index
+		for position > 0 && (values[position-1].Provider > current.Provider ||
+			(values[position-1].Provider == current.Provider && values[position-1].FullName > current.FullName)) {
+			values[position] = values[position-1]
+			position--
+		}
+		values[position] = current
+	}
+}
+
+func pagerDutyServiceMappingFromReference(
+	service pagerDutyServiceRow,
+	reference pagerDutyServiceRepositoryReference,
+	source pagerDutyServiceMappingSource,
+	observedAt time.Time,
+	ruleIDOverride string,
+) (pagerDutyServiceRepositoryMappingRow, error) {
+	ruleID := source.ruleID()
+	if ruleIDOverride != "" {
+		ruleID = ruleIDOverride
+	}
+	fullName, provider := reference.FullName, reference.Provider
+	mappingKind, provenance, confidence := source.mappingKind(), string(source), source.confidence()
+	sourceEventID := "pagerduty_sync"
+	row := pagerDutyServiceRepositoryMappingRow{
+		OrgID: service.OrgID, Provider: service.Provider, ProviderInstanceID: service.ProviderInstanceID,
+		SourceEntityType: string(source),
+		ExternalID:       service.ExternalID + ":" + provider + ":" + fullName + ":" + ruleID,
+		SourceVersionAt:  observedAt, SourceURL: service.SourceURL, SourceEventID: &sourceEventID,
+		ObservedAt: observedAt, LastSynced: observedAt, RelationshipProvenance: &provenance,
+		RelationshipConfidence: &confidence, ServiceID: service.ID,
+		RepoFullName: &fullName, RepoProvider: &provider, MappingKind: &mappingKind,
+		RuleID: &ruleID, ValidFrom: &observedAt, IsActive: true,
+	}
+	if err := fillPagerDutyServiceMappingOrdering(&row); err != nil {
+		return pagerDutyServiceRepositoryMappingRow{}, err
+	}
+	return row, nil
+}
+
+func selectPagerDutyPreferredMappings(values []pagerDutyServiceRepositoryMappingRow) []pagerDutyServiceRepositoryMappingRow {
+	preferred := map[string]pagerDutyServiceRepositoryMappingRow{}
+	for _, value := range values {
+		key := value.ServiceID + "\x00" + pointerString(value.RepoProvider) + "\x00" + pointerString(value.RepoFullName)
+		current, exists := preferred[key]
+		if !exists || (value.RelationshipConfidence != nil && current.RelationshipConfidence != nil && *value.RelationshipConfidence > *current.RelationshipConfidence) {
+			preferred[key] = value
+		}
+	}
+	result := make([]pagerDutyServiceRepositoryMappingRow, 0, len(preferred))
+	for _, value := range preferred {
+		result = append(result, value)
+	}
+	for index := 1; index < len(result); index++ {
+		current := result[index]
+		position := index
+		for position > 0 && pagerDutyMappingSortKey(result[position-1]) > pagerDutyMappingSortKey(current) {
+			result[position] = result[position-1]
+			position--
+		}
+		result[position] = current
+	}
+	return result
+}
+
+func pagerDutyMappingSortKey(row pagerDutyServiceRepositoryMappingRow) string {
+	return row.ServiceID + "\x00" + pointerString(row.RepoProvider) + "\x00" + pointerString(row.RepoFullName)
+}
+
+func pointerString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func fillPagerDutyServiceMappingOrdering(row *pagerDutyServiceRepositoryMappingRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	var repoID any
+	if row.RepoID != nil {
+		repoID = *row.RepoID
+	}
+	fields = append(fields,
+		jiraOperationalField{"service_id", row.ServiceID}, jiraOperationalField{"repo_id", repoID},
+		jiraOperationalField{"repo_full_name", jiraStringValue(row.RepoFullName)},
+		jiraOperationalField{"repo_provider", jiraStringValue(row.RepoProvider)},
+		jiraOperationalField{"mapping_kind", jiraStringValue(row.MappingKind)},
+		jiraOperationalField{"rule_id", jiraStringValue(row.RuleID)},
+		jiraOperationalField{"valid_from", jiraTimeValue(row.ValidFrom)},
+		jiraOperationalField{"valid_to", jiraTimeValue(row.ValidTo)},
+		jiraOperationalField{"is_active", row.IsActive},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_service_repository_mapping", row.OrgID, row.Provider,
+		row.ProviderInstanceID, row.ExternalID, row.SourceVersionAt,
+		row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	if !row.IsActive {
+		row.SourceRevision, err = pagerDutyOperationalTombstoneRevision(sourceRevision, conflict)
+		if err != nil {
+			return err
+		}
+	}
+	row.OrderingContract = 2
+	return nil
+}
+
+var _ CompleteRouteHandler = PagerDutyServicesRouteHandler{}

--- a/internal/providersync/pagerduty_services_route_test.go
+++ b/internal/providersync/pagerduty_services_route_test.go
@@ -1,0 +1,206 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyServicesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type pagerDutyServicesDoer struct {
+	t         *testing.T
+	responses []pagerDutyServicesResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyServicesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status, Header: response.headers,
+		Body: io.NopCloser(strings.NewReader(response.body)), Request: request,
+	}, nil
+}
+
+func TestPagerDutyServicesRouteBuildsTypedServicesAndSeparateMappingEffects(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{
+		{body: `{"services":[
+			{"id":"PS1","type":"service","name":"Payments","summary":"Ignored","updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/services/PS1","escalation_policy":{"id":"PE1"},"metadata":{"repository":"https://github.com/full-chaos/payments"}},
+			{"id":"PS2","type":"service","summary":"Support","created_at":"2026-07-31T09:00:00Z","self":"/services/PS2"}],"more":true}`},
+		{body: `{"services":[{"id":"PS3","type":"service","name":"Operations","repo":"full-chaos/operations"}],"more":false}`},
+	}}
+	client := pagerDutyServicesTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "services")
+	claim.DatasetOptions = map[string]any{
+		"service_repository_mappings": map[string]any{
+			"admin": map[string]any{
+				"PS1": []any{map[string]any{"provider": "github", "full_name": "full-chaos/payments"}},
+			},
+			"compass": map[string]any{
+				"PS2": []any{map[string]any{"provider": "gitlab", "full_name": "full-chaos/support"}},
+			},
+		},
+	}
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "}}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyServicesRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 2 || batch.Effects[0].Destination != "operational_services" ||
+		batch.Effects[1].Destination != "operational_service_repository_mappings" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || batch.Effects[1].Recovery != EffectReadbackRequired ||
+		len(batch.Effects[0].Rows) != 3 || len(batch.Effects[1].Rows) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 3 || batch.Evidence.CapReached {
+		t.Fatalf("evidence=%+v", batch.Evidence)
+	}
+	if doer.requests[0].URL.Path != "/services" || doer.requests[0].URL.RawQuery != "limit=100&offset=0" ||
+		doer.requests[1].URL.RawQuery != "limit=100&offset=2" {
+		t.Fatalf("requests=%v", doer.requests)
+	}
+	var service pagerDutyServiceRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &service); err != nil {
+		t.Fatal(err)
+	}
+	if service.Provider != "pagerduty" || service.ProviderInstanceID != "acme" ||
+		service.SourceEntityType != "service" || service.ExternalID != "PS1" || service.Name != "Payments" ||
+		service.ServiceType == nil || *service.ServiceType != "technical" || service.EscalationPolicyID == nil ||
+		*service.EscalationPolicyID != pagerDutyCanonicalOperationalID(claim.OrgID, "pagerduty", "acme", "operational_escalation_policy", "PE1") ||
+		service.SourceURL == nil || *service.SourceURL != "https://acme.pagerduty.com/services/PS1" ||
+		!service.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!service.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) {
+		t.Fatalf("service=%+v", service)
+	}
+	var mapping pagerDutyServiceRepositoryMappingRow
+	if err := json.Unmarshal(batch.Effects[1].Rows[0], &mapping); err != nil {
+		t.Fatal(err)
+	}
+	if mapping.SourceEntityType != string(pagerDutyMappingAdmin) || mapping.RelationshipConfidence == nil ||
+		*mapping.RelationshipConfidence != 1 || mapping.RepoProvider == nil || *mapping.RepoProvider != "github" ||
+		mapping.RepoFullName == nil || *mapping.RepoFullName != "full-chaos/payments" ||
+		mapping.ServiceID != service.ID || mapping.ValidFrom == nil || !mapping.IsActive ||
+		mapping.SourceEventID == nil || *mapping.SourceEventID != "pagerduty_sync" {
+		t.Fatalf("mapping=%+v", mapping)
+	}
+}
+
+func TestPagerDutyServicesRouteRejectsAnotherPagerDutyDataset(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "teams")
+	client := pagerDutyServicesTestClient(t, &pagerDutyServicesDoer{t: t}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err := (PagerDutyServicesRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong dataset error=%v", err)
+	}
+}
+
+func TestPagerDutyServicesRouteUsesProviderIDWhenNamesAreAbsent(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "services")
+	row, err := normalizePagerDutyService(
+		claim, "acme", pagerDutyServicePayload{ID: "PS-fallback"},
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Name != "PS-fallback" {
+		t.Fatalf("name=%q", row.Name)
+	}
+}
+
+func TestPagerDutyServicesRoutePreservesRetryAuthCapAndLeaseSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "services")
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	clientRetryDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{
+		{status: http.StatusTooManyRequests, headers: http.Header{"Retry-After": {"0"}}, body: `{"message":"slow down"}`},
+		{body: `{"services":[],"more":false}`},
+	}}
+	retryClient := pagerDutyServicesTestClient(t, clientRetryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutyServicesRouteHandler{}).Collect(context.Background(), claim, credential, retryClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	if err != nil || len(clientRetryDoer.requests) != 2 || len(batch.Effects) != 2 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(clientRetryDoer.requests))
+	}
+	authDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{{status: http.StatusUnauthorized, body: `{"message":"bad token"}`}}}
+	authClient := pagerDutyServicesTestClient(t, authDoer, providerfoundation.RetryPolicy{MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err = (PagerDutyServicesRouteHandler{}).Collect(context.Background(), claim, credential, authClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication || len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+	capDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{{body: `{"services":[{"id":"one"}],"more":true}`}}}
+	capClient := pagerDutyServicesTestClient(t, capDoer, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err = (PagerDutyServicesRouteHandler{MaxPages: 1}).Collect(context.Background(), claim, credential, capClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	leaseDoer := &pagerDutyServicesDoer{t: t, responses: []pagerDutyServicesResponse{
+		{body: `{"services":[{"id":"one"}],"more":true}`}, {body: `{"services":[],"more":false}`},
+	}}
+	asserts := 0
+	leaseClient, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", leaseDoer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutyServicesRouteHandler{}).Collect(context.Background(), claim, credential, leaseClient, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(leaseDoer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(leaseDoer.requests), asserts)
+	}
+}
+
+func pagerDutyServicesTestClient(t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}

--- a/internal/providersync/testdata/mutation-plans/pagerduty_services.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_services.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty services typed parity, repository-mapping ownership, and complete snapshots",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "This plan covers the dormant PagerDuty services provider route, its separate service-repository mapping effect, live Python row oracles, tenant/account fences, ordering, and migrated ClickHouse integration proof. Registry, route-switch, matrix, config, deployment, and activation wiring remain intentionally outside this provider-only slice.",
+  "mutations": [
+    {
+      "id": "S1-services-route-dataset-fence",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "claim.Dataset != \"services\"",
+      "replace": "false",
+      "rationale": "The services handler must reject every other PagerDuty dataset; otherwise a teams or users claim could be fetched from /services and committed under the wrong source entity type.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteRejectsAnotherPagerDutyDataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S2-service-name-id-fallback",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "if name == \"\" {\n\t\tname = payload.ID\n\t}",
+      "replace": "if false {\n\t\tname = payload.ID\n\t}",
+      "rationale": "Python falls back from name and summary to the provider id. Removing that clause emits an empty canonical service name and diverges from the live normalizer.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteUsesProviderIDWhenNamesAreAbsent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S3-service-escalation-policy-reference",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "if payload.EscalationPolicy != nil && strings.TrimSpace(payload.EscalationPolicy.ID) != \"\" {",
+      "replace": "if false && strings.TrimSpace(payload.EscalationPolicy.ID) != \"\" {",
+      "rationale": "The service normalizer must preserve the canonical operational escalation-policy reference when PagerDuty includes one; dropping this clause loses a typed relationship field.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteBuildsTypedServicesAndSeparateMappingEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S4-mapping-precedence-admin-over-metadata",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "*value.RelationshipConfidence > *current.RelationshipConfidence",
+      "replace": "*value.RelationshipConfidence < *current.RelationshipConfidence",
+      "rationale": "Python retains the highest-confidence evidence for each service/repository pair. Reversing this clause would let metadata or Compass evidence override explicit admin ownership.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesRouteBuildsTypedServicesAndSeparateMappingEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S5-service-tombstone-version-bump",
+      "file": "internal/providersync/pagerduty_services_route.go",
+      "find": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)",
+      "replace": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(0)",
+      "rationale": "A complete snapshot with an observation time equal to the prior version must still produce a strictly newer ReplacingMergeTree tombstone.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesTombstonesAdvanceVersionsAndPreserveMappingOwnership$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S6-mapping-tombstone-version-bump",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(time.Microsecond)",
+      "replace": "row.SourceVersionAt.UTC().Truncate(time.Microsecond).Add(0)",
+      "rationale": "Mapping evidence has its own active/inactive lifecycle; its deactivation must win the source-version race independently of service tombstones.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesTombstonesAdvanceVersionsAndPreserveMappingOwnership$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S7-service-tenant-fence",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "if row.OrgID != claim.OrgID || row.Provider != \"pagerduty\" ||\n\t\t\trow.ProviderInstanceID == \"\" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||\n\t\t\trow.SourceEntityType != \"service\"",
+      "replace": "if false || row.Provider != \"pagerduty\" ||\n\t\t\trow.ProviderInstanceID == \"\" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||\n\t\t\trow.SourceEntityType != \"service\"",
+      "rationale": "Every service effect row must remain inside the claimed organization; accepting a foreign org row would cross the analytics tenant boundary.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S8-pagerduty-account-fence",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "if instance != value {",
+      "replace": "if false {",
+      "rationale": "One effect payload must contain one credential-derived PagerDuty account. Allowing mixed subdomains makes active-row queries and tombstones ambiguous across accounts.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S9-mapping-provenance-ownership",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "row.RelationshipProvenance == nil ||\n\t\t\t*row.RelationshipProvenance != row.SourceEntityType",
+      "replace": "row.RelationshipProvenance == nil ||\n\t\t\tfalse",
+      "rationale": "Repository-mapping evidence must retain the source enum as relationship provenance; accepting a different value would erase the ownership boundary between service rows and mapping producers.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServicesEffectsRejectForeignScopeOrderingTamperAndMixedInstances$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S10-service-omitted-row-tombstone",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "allRows := append([]pagerDutyServiceRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; present {\n\t\t\tcontinue\n\t\t}",
+      "replace": "allRows := append([]pagerDutyServiceRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; !present {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "A complete successful services snapshot must tombstone every previously active service omitted by the provider, not leave stale rows active.",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S11-mapping-omitted-row-tombstone",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "allRows := append([]pagerDutyServiceRepositoryMappingRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; present {\n\t\t\tcontinue\n\t\t}",
+      "replace": "allRows := append([]pagerDutyServiceRepositoryMappingRow(nil), rows...)\n\tfor _, existing := range active {\n\t\tif _, present := seen[existing.ID]; !present {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "Mapping reconciliation is an independent complete snapshot. An omitted source mapping must become inactive with valid_to evidence, even when its service row remains present.",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_services_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_services_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OperationalService))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.Service.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.service(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/services/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)


### PR DESCRIPTION
## Summary

- Port the dormant PagerDuty `services` sync route with concrete typed provider payloads, normalized service rows, and separate repository-mapping evidence rows.
- Persist `operational_services` and `operational_service_repository_mappings` through migrated v2 ClickHouse columns, including org-scoped repository resolution, complete-snapshot tombstones, replay/readback, tenant/account fences, and lease checks.
- Add a live Python services-row differential oracle and a shared clause-level mutation plan covering route guards, precedence, ordering, provenance, fences, and omitted-row tombstones.
- No registry, route-switch, matrix, config, deployment, or other production wiring changes.

## Verification

- `GOCACHE=/tmp/pagerduty-services-go-cache go test ./internal/providersync -run 'TestPagerDutyServices|TestGenericOracleMatchesLivePythonForPagerDutyService' -count=1` — PASS.
- Live oracle enabled with `DEV_HEALTH_LIVE_PYTHON_ORACLES=1` and proof marker output — PASS; the oracle executes the checked-in production PagerDuty normalizer.
- `GOCACHE=/tmp/pagerduty-services-go-cache go test -tags integration ./internal/providersync -run '^TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease$' -count=1` — PASS against real Docker ClickHouse and migrated v2 schema.
- `GOCACHE=/tmp/pagerduty-services-go-cache go vet ./internal/providersync` — PASS.
- `GOCACHE=/tmp/pagerduty-services-go-cache go test -tags integration ./internal/providersync -run '^$' -count=1` — PASS (integration compile).
- Shared `scripts/mutation_harness.py`: S1–S11 all KILLED and restored, including real ClickHouse omitted-row mutants.
- Commit and push hooks — PASS (`ruff-format`, `ruff`, and `mypy`).

The package-wide `go test ./internal/providersync -count=1` remains limited by an unrelated existing environment failure: `gitlab_tests_route_test.go:364` cannot bind the IPv6 loopback listener under the sandbox (`operation not permitted`).

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI surface.

Refs CHAOS-3732 (parent CHAOS-3125).
