### PR TITLE
feat(ask-dev): expose graph assistance state

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -78,7 +78,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "85639619c9935096ca2b58920f3152a390b94f93ee9241810d40ec1d8b67e844"
+        "sha256": "46aefa2ab1f8df406cffc7435c11fdc4a650de0f782d820f46d4111d3fcf5ab6"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -167,7 +167,7 @@
       ],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "08979fa641ca71a903cc78be67e8dd813bed02233a5ba5b66d82ee5b4f9e9895"
+        "sha256": "c5f3c184200010e3fea4b970250e56a988d5a88232dae55fb74c4c3531847916"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -186,7 +186,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer_graph_assistance.v1.schema.json",
-        "sha256": "1cebaf80e272fdbbe5983d6a1bab5f094be9e4791f0c90fd03c87d552562cefa"
+        "sha256": "05c125b85d08b6e86cb1b51f0a68ca85f4d5ec483fac50946e619c3cdf6c5609"
       },
       "schema_version": "dev_answer_graph_assistance.v1"
     },
@@ -440,7 +440,7 @@
       ],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "7cec5b786ce14b4b0f18b248b3a10ec44a5479108b4c0dbbd0351d0e767ac849"
+        "sha256": "001622125e3259dc34de825a1cf55a63ba583b3581a5ad8b18b597e165129365"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
@@ -155,7 +155,7 @@
     },
     "DevAnswerGraphAssistance": {
       "additionalProperties": false,
-      "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. Schema-only on ``main`` today -- see\n``DevAnswer.graph_assisted``'s own docstring.",
+      "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. The orchestrator owns the runtime\nprojection of the route attempt; packet/backend details never cross this\ncontract boundary.",
       "properties": {
         "as_of": {
           "format": "date-time",

--- a/contracts/ask-dev/v1/schemas/dev_answer_graph_assistance.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_answer_graph_assistance.v1.schema.json
@@ -174,7 +174,7 @@
   "$id": "https://api.fullchaos.dev/contracts/ask-dev/v1/dev_answer_graph_assistance.v1.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. Schema-only on ``main`` today -- see\n``DevAnswer.graph_assisted``'s own docstring.",
+  "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. The orchestrator owns the runtime\nprojection of the route attempt; packet/backend details never cross this\ncontract boundary.",
   "properties": {
     "as_of": {
       "format": "date-time",

--- a/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
@@ -288,7 +288,7 @@
     },
     "DevAnswerGraphAssistance": {
       "additionalProperties": false,
-      "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. Schema-only on ``main`` today -- see\n``DevAnswer.graph_assisted``'s own docstring.",
+      "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. The orchestrator owns the runtime\nprojection of the route attempt; packet/backend details never cross this\ncontract boundary.",
       "properties": {
         "as_of": {
           "format": "date-time",

--- a/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
@@ -288,7 +288,7 @@
     },
     "DevAnswerGraphAssistance": {
       "additionalProperties": false,
-      "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. Schema-only on ``main`` today -- see\n``DevAnswer.graph_assisted``'s own docstring.",
+      "description": "CHAOS-3660 \u00a78(b)/(c)/(d). Everything the graph route (CHAOS-3502\nwave) contributed to an answer, in one namespace. ``cohort``,\n``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are\npopulated only when ``state`` reflects a completed, cohort-shaped\nanswer; ``None``/empty otherwise. The orchestrator owns the runtime\nprojection of the route attempt; packet/backend details never cross this\ncontract boundary.",
       "properties": {
         "as_of": {
           "format": "date-time",

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -909,8 +909,9 @@ class DevAnswerGraphAssistance(ContractModel):
     wave) contributed to an answer, in one namespace. ``cohort``,
     ``ranked_drivers``, ``evidence_lineage``, and ``limitations`` are
     populated only when ``state`` reflects a completed, cohort-shaped
-    answer; ``None``/empty otherwise. Schema-only on ``main`` today -- see
-    ``DevAnswer.graph_assisted``'s own docstring.
+    answer; ``None``/empty otherwise. The orchestrator owns the runtime
+    projection of the route attempt; packet/backend details never cross this
+    contract boundary.
     """
 
     schema_version: Literal["dev_answer_graph_assistance.v1"]
@@ -950,11 +951,9 @@ class DevAnswer(ContractModel):
     #: route at all (mirrors the feature branch's
     #: ``describe_availability``'s own ``result is None`` branch); present
     #: with ``state=unavailable`` when attempted but the route
-    #: declined/failed. Schema-only on ``main`` today: the graph-routing
-    #: wave (CHAOS-3502) that computes a real value here has not landed on
-    #: `main` yet, so no runtime path constructs a ``DevAnswer`` with this
-    #: set -- every existing answer (and every already-persisted
-    #: ``dev_answer.v1``) is unaffected.
+    #: declined/failed. The field remains absent when routing was never
+    #: attempted, so existing non-graph answers and persisted v1 payloads are
+    #: unaffected.
     graph_assisted: DevAnswerGraphAssistance | None = None
 
     @model_validator(mode="after")
@@ -1528,9 +1527,8 @@ class DevStreamEvent(ContractModel):
     #: CHAOS-3660 §8(c). Carries only the `{state, as_of}` pair (via
     #: `DevAnswerGraphAssistance`, reused rather than a slimmer duplicate)
     #: -- the same object `DevAnswer.graph_assisted` carries once, in full,
-    #: on the terminal event. Schema-only on `main` today: see
-    #: `DevAnswer.graph_assisted`'s own docstring for why nothing here
-    #: emits a populated value yet.
+    #: on the terminal event. The streaming projection emits it only after a
+    #: graph query has actually returned, and carries no backend identifiers.
     graph_state: DevAnswerGraphAssistance | None = None
     delta: Annotated[str, StringConstraints(min_length=1, max_length=8_192)] | None = (
         None

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -71,6 +71,7 @@ from .contracts import (
     V1_SCOPE_LIST_LIMIT,
     AnswerStatus,
     DevAnswer,
+    DevAnswerGraphAssistance,
     DevClaim,
     DevContractVersions,
     DevCoverage,
@@ -88,10 +89,14 @@ from .contracts import (
     EntityType,
     FreshnessState,
     MetricID,
+    PacketLimitationKind,
     QuestionClass,
     ScopeResolutionOutcome,
     ToolID,
     dev_error_remediation,
+)
+from .contracts import (
+    GraphAssistedAvailability as ContractGraphAssistedAvailability,
 )
 from .contracts_v2 import (
     NO_ANSWER_OUTCOMES,
@@ -117,10 +122,14 @@ from .graph_investigation_query import (
     GraphInvestigationQuery,
     GraphInvestigationRequest,
     GraphQueryOutcome,
+    GraphQueryResult,
 )
 from .graph_routing_policy import (
+    GraphAssistedAvailability,
     GraphRoutingEntitlementAuthorizer,
     GraphRoutingPolicyDeniedError,
+    describe_availability,
+    limitation_kinds_of,
 )
 from .investigation_contract import AskDevInvestigationPacket, InvestigationOutcome
 from .investigation_plans import PlanExecutor, StepContext
@@ -564,6 +573,47 @@ class DevRunLimits:
 class OrchestratorEvent:
     state: RunState
     safe_code: str | None = None
+    #: A public-safe graph routing state. The orchestrator emits this as an
+    #: interior event only after the graph seam was actually called; a run
+    #: that never attempted graph routing leaves it ``None``.
+    graph_state: DevAnswerGraphAssistance | None = None
+
+
+def _graph_assistance_for_result(
+    result: GraphQueryResult,
+    *,
+    graph_answered: bool,
+) -> DevAnswerGraphAssistance:
+    """Project one graph attempt into the public answer/event contract.
+
+    ``GraphQueryResult.diagnostic`` and packet internals deliberately never
+    cross this boundary. The optional packet details stay empty in this
+    narrow state slice; only limitations already disclosed by the validated
+    packet are copied for a graph-grounded answer.
+
+    A completed query that did not produce a graph answer is not advertised
+    as ``enabled`` merely because transport succeeded: the user received the
+    native arm, so graph assistance was unavailable for that answer.
+    """
+
+    availability = describe_availability(entitled=True, result=result)
+    if not graph_answered and availability is GraphAssistedAvailability.ENABLED:
+        availability = GraphAssistedAvailability.UNAVAILABLE
+    packet = result.packet
+    limitations: list[PacketLimitationKind] = []
+    if graph_answered and packet is not None:
+        # Map by the existing closed vocabulary. Do not expose packet details
+        # such as graph node names/IDs or backend-specific diagnostics.
+        limitations = [
+            PacketLimitationKind(kind.value)
+            for kind in sorted(limitation_kinds_of(packet), key=lambda item: item.value)
+        ]
+    return DevAnswerGraphAssistance(
+        schema_version="dev_answer_graph_assistance.v1",
+        state=ContractGraphAssistedAvailability(availability.value),
+        as_of=(packet.produced_at if packet is not None else datetime.now(UTC)),
+        limitations=limitations,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1441,6 +1491,9 @@ class DevOrchestrator:
         # it, without threading a new parameter through every one of
         # `finish()`'s ~35 call sites.
         investigation_result: DevInvestigationResult | None = None
+        # The public graph-assistance state is set only after the graph seam
+        # returns. A route that was gated off therefore remains ``None``.
+        graph_assistance: DevAnswerGraphAssistance | None = None
         # CHAOS-3393: mirrors investigation_result's own free-variable
         # posture -- set below when a PLURAL_COHORT/ORGANIZATION_WIDE
         # status.portfolio.v1 run actually executes against a committed
@@ -1504,6 +1557,17 @@ class DevOrchestrator:
             event = OrchestratorEvent(state=state, safe_code=safe_code)
             events.append(event)
             await self._recorder.transition(state)
+            if selected_event_sink is not None:
+                await selected_event_sink(event)
+
+        async def emit_graph_state(state: DevAnswerGraphAssistance) -> None:
+            """Publish a graph state without exposing internal graph data."""
+
+            event = OrchestratorEvent(
+                state=RunState.TOOL_EXECUTION,
+                graph_state=state,
+            )
+            events.append(event)
             if selected_event_sink is not None:
                 await selected_event_sink(event)
 
@@ -1575,6 +1639,11 @@ class DevOrchestrator:
                 answer = disclose_subject_match(
                     answer, span=matched_span, label=matched_label
                 )
+            if answer is not None and graph_assistance is not None:
+                # Attach the same object that was emitted on the interior
+                # event. This keeps live, persisted, and replayed answer
+                # projections on one server-owned state value.
+                answer = answer.model_copy(update={"graph_assisted": graph_assistance})
             # CHAOS-3367: the one place every terminal in this module passes
             # through, and therefore the only place a user-visible-copy rule
             # can be enforced structurally rather than by asking ~35 call
@@ -3264,6 +3333,10 @@ class DevOrchestrator:
                     # The RUN is cancelled, not just this one call -- unlike
                     # every other outcome below, this does not fall through
                     # to the legacy loop (see the CHAOS-3660 fallback table).
+                    graph_assistance = _graph_assistance_for_result(
+                        graph_result, graph_answered=False
+                    )
+                    await emit_graph_state(graph_assistance)
                     return await finish(
                         RunState.CANCELLED,
                         error=error("cancelled", "The request was cancelled."),
@@ -3303,6 +3376,10 @@ class DevOrchestrator:
                         packet=graph_result.packet,
                     )
                     if graph_answer is not None:
+                        graph_assistance = _graph_assistance_for_result(
+                            graph_result, graph_answered=True
+                        )
+                        await emit_graph_state(graph_assistance)
                         return await finish(
                             RunState.COMPLETED,
                             answer=graph_answer,
@@ -3323,6 +3400,14 @@ class DevOrchestrator:
                 # §4: graph outage, lag, or unavailability must never break
                 # existing Ask Dev behavior, and this question's legacy
                 # answer is a real, already-working path, not a regression.
+
+                # The graph route was attempted, but any answer below comes
+                # from the native arm. Derive only the public state; no
+                # backend diagnostics, names, or IDs are user-facing.
+                graph_assistance = _graph_assistance_for_result(
+                    graph_result, graph_answered=False
+                )
+                await emit_graph_state(graph_assistance)
 
             for round_index in range(self._limits.model_rounds):
                 del round_index

--- a/src/dev_health_ops/api/dev/streaming.py
+++ b/src/dev_health_ops/api/dev/streaming.py
@@ -120,6 +120,11 @@ async def stream_orchestrator(
             return
         while not queue.empty():
             internal = queue.get_nowait()
+            if internal.graph_state is not None:
+                await public_event(
+                    StreamEventType.GRAPH_STATE,
+                    graph_state=internal.graph_state,
+                )
             progress = _PROGRESS_BY_STATE.get(internal.state)
             if progress is not None and progress is not last_progress:
                 last_progress = progress
@@ -148,6 +153,11 @@ async def stream_orchestrator(
             done, _ = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
             if next_internal in done:
                 internal = next_internal.result()
+                if internal.graph_state is not None:
+                    yield await public_event(
+                        StreamEventType.GRAPH_STATE,
+                        graph_state=internal.graph_state,
+                    )
                 progress = _PROGRESS_BY_STATE.get(internal.state)
                 if progress is not None and progress is not last_progress:
                     last_progress = progress
@@ -160,6 +170,11 @@ async def stream_orchestrator(
 
         while not queue.empty():
             internal = queue.get_nowait()
+            if internal.graph_state is not None:
+                yield await public_event(
+                    StreamEventType.GRAPH_STATE,
+                    graph_state=internal.graph_state,
+                )
             progress = _PROGRESS_BY_STATE.get(internal.state)
             if progress is not None and progress is not last_progress:
                 last_progress = progress

--- a/tests/api/dev/test_chaos_3502_graph_routing_branch.py
+++ b/tests/api/dev/test_chaos_3502_graph_routing_branch.py
@@ -30,6 +30,7 @@ import logging
 
 import pytest
 
+from dev_health_ops.api.dev.contracts import GraphAssistedAvailability
 from dev_health_ops.api.dev.evidence_service import (
     EvidenceReferenceSigner,
     EvidenceService,
@@ -137,7 +138,21 @@ async def test_every_fallthrough_outcome_is_observed_and_still_answers(
     # working answer.
     assert output.result.state is not RunState.CANCELLED
     assert output.result.state is not RunState.FAILED
-    assert output.result.answer is not None
+    answer = output.result.answer
+    assert answer is not None
+    assert answer.graph_assisted is not None
+    assert answer.graph_assisted.state is (
+        GraphAssistedAvailability.STALE
+        if outcome is GraphQueryOutcome.STALE
+        else GraphAssistedAvailability.LAGGING
+        if outcome is GraphQueryOutcome.COMPLETED
+        else GraphAssistedAvailability.UNAVAILABLE
+    )
+    graph_events = [
+        event for event in output.result.events if event.graph_state is not None
+    ]
+    assert len(graph_events) == 1
+    assert graph_events[0].graph_state == answer.graph_assisted
 
     assert any(
         record.levelno == logging.INFO
@@ -186,6 +201,13 @@ async def test_cancelled_outcome_terminates_the_run_directly(
     assert output.result.error is not None
     assert output.result.error.code == "cancelled"
     assert output.result.answer is None
+    graph_events = [
+        event for event in output.result.events if event.graph_state is not None
+    ]
+    assert len(graph_events) == 1
+    graph_state = graph_events[0].graph_state
+    assert graph_state is not None
+    assert graph_state.state is GraphAssistedAvailability.UNAVAILABLE
     assert output.calls == [], (
         "a CANCELLED graph outcome must terminate the run before the "
         "legacy model-tool-choice loop ever executes a tool"
@@ -242,6 +264,16 @@ async def test_flag_off_is_byte_identical_to_collaborators_never_wired(
     )
 
     assert with_collaborators.outcome_tuple() == without_collaborators.outcome_tuple()
+    assert with_collaborators.result.answer is not None
+    assert with_collaborators.result.answer.graph_assisted is None
+    assert not any(
+        event.graph_state is not None for event in with_collaborators.result.events
+    )
+    assert without_collaborators.result.answer is not None
+    assert without_collaborators.result.answer.graph_assisted is None
+    assert not any(
+        event.graph_state is not None for event in without_collaborators.result.events
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
+++ b/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
@@ -36,7 +36,13 @@ from dev_health_ops.api.dev.canonical_enrichment import CanonicalEnrichmentAcces
 from dev_health_ops.api.dev.contract_fixtures import (
     positive_fixtures as v1_positive_fixtures,
 )
-from dev_health_ops.api.dev.contracts import AnswerStatus, DevMetricRef, FreshnessState
+from dev_health_ops.api.dev.contracts import (
+    AnswerStatus,
+    DevMetricRef,
+    FreshnessState,
+    GraphAssistedAvailability,
+    PacketLimitationKind,
+)
 from dev_health_ops.api.dev.evidence_service import (
     EvidenceRecord,
     EvidenceReferenceSigner,
@@ -314,12 +320,50 @@ async def test_completed_with_admissible_evidence_produces_a_graph_grounded_answ
     answer = output.result.answer
     assert answer is not None
     assert answer.status is AnswerStatus.PARTIAL
+    assert answer.graph_assisted is not None
+    assert answer.graph_assisted.state is GraphAssistedAvailability.LAGGING
+    assert answer.graph_assisted.cohort is None
+    assert answer.graph_assisted.ranked_drivers == []
+    assert answer.graph_assisted.evidence_lineage == []
+    assert answer.graph_assisted.limitations == [
+        PacketLimitationKind.MISSING_SOURCE,
+        PacketLimitationKind.STALE_SOURCE,
+    ]
+    assert "graphiti" not in answer.model_dump_json().casefold()
     assert len(answer.evidence) == 1
     assert answer.warnings == []
     assert recorder.grounding_validation_statuses[-1] == GRAPH_ASSISTED_GROUNDING_STATUS
     # The legacy model-tool-choice loop must never even start: the graph
     # path returned directly through finish().
     assert output.calls == []
+
+
+@pytest.mark.asyncio
+async def test_clean_graph_answer_exposes_enabled_state_without_backend_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    packet = _graph_arm_packet([_ADMIT_LOCATOR])
+    clean_coverage = packet.evidence_coverage.model_copy(update={"limitations": ()})
+    packet = packet.model_copy(update={"evidence_coverage": clean_coverage})
+
+    output = await run_preflight_orchestrator(
+        question=_DISCOVERED_COHORT_QUESTION,
+        entities=[],
+        org_id=ORG_ID,
+        script_id="chaos-w3-clean-state",
+        graph_investigation_query=FakeGraphInvestigationQuery(packet=packet),
+        evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
+        canonical_enrichment=_canonical_enrichment(),
+    )
+
+    assert output.result.answer is not None
+    graph_assistance = output.result.answer.graph_assisted
+    assert graph_assistance is not None
+    assert graph_assistance.state is GraphAssistedAvailability.ENABLED
+    assert graph_assistance.limitations == []
+    assert "graphiti" not in output.result.answer.model_dump_json().casefold()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/dev/test_streaming.py
+++ b/tests/api/dev/test_streaming.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
 
 from dev_health_ops.api.dev.contract_fixtures import positive_fixtures
-from dev_health_ops.api.dev.contracts import DevAnswer, DevError, StreamEventType
+from dev_health_ops.api.dev.contracts import (
+    DevAnswer,
+    DevAnswerGraphAssistance,
+    DevError,
+    GraphAssistedAvailability,
+    StreamEventType,
+)
 from dev_health_ops.api.dev.orchestrator import (
     OrchestratorEvent,
     OrchestratorResult,
@@ -56,6 +63,16 @@ def _error_result() -> OrchestratorResult:
         tool_call_count=0,
         provider_fingerprint=None,
         model_fingerprint=None,
+    )
+
+
+def _graph_state(
+    state: GraphAssistedAvailability = GraphAssistedAvailability.UNAVAILABLE,
+) -> DevAnswerGraphAssistance:
+    return DevAnswerGraphAssistance(
+        schema_version="dev_answer_graph_assistance.v1",
+        state=state,
+        as_of=datetime(2026, 8, 10, tzinfo=UTC),
     )
 
 
@@ -108,6 +125,30 @@ async def test_error_stream_has_one_error_then_done() -> None:
         StreamEventType.ERROR,
         StreamEventType.DONE,
     ]
+
+
+@pytest.mark.asyncio
+async def test_graph_state_is_projected_as_a_safe_interior_event() -> None:
+    graph_state = _graph_state()
+
+    async def run(sink):
+        await sink(OrchestratorEvent(RunState.TOOL_EXECUTION, graph_state=graph_state))
+        return _answer_result()
+
+    events = [
+        event
+        async for event in stream_orchestrator(
+            run_id="run_01", run_with_events=run, cancellation=asyncio.Event()
+        )
+    ]
+
+    validate_completed_stream(events)
+    graph_events = [
+        event for event in events if event.event is StreamEventType.GRAPH_STATE
+    ]
+    assert len(graph_events) == 1
+    assert graph_events[0].graph_state == graph_state
+    assert b"Graphiti" not in encode_sse(graph_events[0])
 
 
 @pytest.mark.asyncio
@@ -200,6 +241,73 @@ async def test_disconnect_persists_completion_once_before_generator_close(
         else StreamEventType.ERROR,
         StreamEventType.DONE,
     ]
+
+
+@pytest.mark.asyncio
+async def test_graph_state_persists_and_replays_once_after_cursor() -> None:
+    graph_state = _graph_state()
+    answer = _answer_result().answer
+    assert answer is not None
+    result = OrchestratorResult(
+        run_id="run_01",
+        state=RunState.COMPLETED,
+        answer=answer.model_copy(update={"graph_assisted": graph_state}),
+        error=None,
+        events=(OrchestratorEvent(RunState.COMPLETED),),
+        usage=AgentUsage(),
+        tool_call_count=1,
+        provider_fingerprint="provider_01",
+        model_fingerprint="model_01",
+    )
+    persisted: list[Mapping[str, Any]] = []
+
+    async def run(sink):
+        await sink(
+            OrchestratorEvent(
+                RunState.TOOL_EXECUTION,
+                graph_state=graph_state,
+            )
+        )
+        return result
+
+    async def persist(event: Mapping[str, Any]) -> None:
+        persisted.append(event)
+
+    events = [
+        event
+        async for event in stream_orchestrator(
+            run_id="run_01",
+            run_with_events=run,
+            cancellation=asyncio.Event(),
+            persist_event=persist,
+        )
+    ]
+    validate_completed_stream(events)
+    persisted_graph = [
+        event
+        for event in persisted
+        if event["event"] == StreamEventType.GRAPH_STATE.value
+    ]
+    assert len(persisted_graph) == 1
+
+    replayed = validate_persisted_resume_events(
+        run_id="run_01",
+        after_sequence=0,
+        persisted_events=persisted[1:],
+    )
+    replayed_graph = [
+        event for event in replayed if event.event is StreamEventType.GRAPH_STATE
+    ]
+    assert len(replayed_graph) == 1
+    assert replayed_graph[0].graph_state == graph_state
+
+    graph_sequence = persisted_graph[0]["sequence"]
+    suffix = validate_persisted_resume_events(
+        run_id="run_01",
+        after_sequence=graph_sequence,
+        persisted_events=persisted[graph_sequence + 1 :],
+    )
+    assert not any(event.event is StreamEventType.GRAPH_STATE for event in suffix)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- project graph-assistance state onto completed Ask Dev answers
- emit a safe graph.state SSE frame after a real graph attempt
- preserve durable sequencing and strict cursor replay semantics
- regenerate governed v1 contract artifacts

## Verification
- independent review: approved, no blocking defect reproduced
- focused graph/streaming, policy/persistence, router/replay, and contract suites passed
- Ruff, format, diff hygiene, and pinned project mypy passed

## Evidence boundary
No live PostgreSQL process-kill or concurrency stress proof is claimed by this PR.