### PR TITLE
feat(providersync): add PagerDuty on-call route

### DIFF
--- a/internal/providersync/jira_incidents_route.go
+++ b/internal/providersync/jira_incidents_route.go
@@ -592,6 +592,26 @@ func encodeJiraOperationalValue(value any) (string, byte, []byte, error) {
 		return "datetime", 1, []byte(typed.UTC().Format("2006-01-02T15:04:05.000000Z")), nil
 	case uuid.UUID:
 		return "uuid", 1, []byte(strings.ToLower(typed.String())), nil
+	case int:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int8:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int16:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int32:
+		return "integer", 1, []byte(strconv.FormatInt(int64(typed), 10)), nil
+	case int64:
+		return "integer", 1, []byte(strconv.FormatInt(typed, 10)), nil
+	case uint:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint8:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint16:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint32:
+		return "integer", 1, []byte(strconv.FormatUint(uint64(typed), 10)), nil
+	case uint64:
+		return "integer", 1, []byte(strconv.FormatUint(typed, 10)), nil
 	case float64:
 		encoded := make([]byte, 8)
 		binary.BigEndian.PutUint64(encoded, math.Float64bits(typed))

--- a/internal/providersync/pagerduty_oncalls_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_oncalls_effects_clickhouse.go
@@ -1,0 +1,252 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// This is the exact column order of migration 066's
+// operational_on_call_assignments table. The table intentionally has no
+// tombstone columns: Python's on-call branch is an upsert stream, not a
+// complete snapshot reconciliation.
+const pagerDutyOnCallsColumns = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence,schedule_id,user_id,escalation_policy_id,escalation_level,starts_at,ends_at"
+
+// PagerDutyOnCallsClickHouseEffects persists typed assignment rows and
+// performs tenant/provider-instance-fenced readback. Ordering values are not
+// columns in the migrated table, so they are reconstructed from the exact
+// persisted fields before comparison.
+type PagerDutyOnCallsClickHouseEffects struct {
+	Conn               driver.Conn
+	Lease              providerfoundation.LeaseGuard
+	ProviderInstanceID string
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) WriteEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pagerDutyOnCallRow](effect)
+	if err != nil {
+		return err
+	}
+	if err := validatePagerDutyOnCallRows(claim, rows); err != nil {
+		return err
+	}
+	if _, err := sink.providerInstance(rows); err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	batch, err := sink.Conn.PrepareBatch(
+		ctx, "INSERT INTO operational_on_call_assignments ("+pagerDutyOnCallsColumns+")",
+	)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(pagerDutyOnCallValues(row)...); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) InspectEffect(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) (EffectInspection, error) {
+	if err := sink.validateRequest(ctx, claim, effect); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pagerDutyOnCallRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validatePagerDutyOnCallRows(claim, expected); err != nil {
+		return EffectConflict, err
+	}
+	if _, err := sink.providerInstance(expected); err != nil {
+		return EffectConflict, err
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		actual, found, loadErr := sink.loadOnCall(ctx, claim, row.ProviderInstanceID, row.ID)
+		if loadErr != nil {
+			return EffectConflict, loadErr
+		}
+		switch comparePagerDutyOnCallVersion(row, actual, found) {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) validateRequest(
+	ctx context.Context, claim Claim, effect EffectBatch,
+) error {
+	if ctx == nil || sink.Conn == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "pagerduty" || claim.Dataset != "on-calls" ||
+		effect.Destination != "operational_on_call_assignments" {
+		return ErrInvalidConfiguration
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) providerInstance(
+	rows []pagerDutyOnCallRow,
+) (string, error) {
+	instance := strings.ToLower(strings.TrimSpace(sink.ProviderInstanceID))
+	for _, row := range rows {
+		rowInstance := strings.ToLower(strings.TrimSpace(row.ProviderInstanceID))
+		if rowInstance == "" {
+			return "", providerfoundation.ErrInvalidScope
+		}
+		if instance == "" {
+			instance = rowInstance
+		}
+		if instance != rowInstance {
+			return "", providerfoundation.ErrInvalidScope
+		}
+	}
+	if instance == "" {
+		return "", ErrInvalidConfiguration
+	}
+	return instance, nil
+}
+
+func validatePagerDutyOnCallRows(
+	claim Claim, rows []pagerDutyOnCallRow,
+) error {
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if _, duplicate := seen[row.ID]; duplicate {
+			return ErrInvalidConfiguration
+		}
+		seen[row.ID] = struct{}{}
+		if row.OrgID != claim.OrgID || row.Provider != "pagerduty" ||
+			row.ProviderInstanceID == "" || row.ProviderInstanceID != strings.ToLower(row.ProviderInstanceID) ||
+			row.SourceEntityType != "oncall" || row.ExternalID == "" || row.ID == "" ||
+			row.SourceRevision == nil || row.IngestRevision == nil ||
+			row.SourceConflictKey == "" || row.OrderingContract != 2 ||
+			row.SourceVersionAt.IsZero() || row.ObservedAt.IsZero() || row.LastSynced.IsZero() ||
+			(row.ScheduleID != nil && *row.ScheduleID == "") ||
+			(row.UserID != nil && *row.UserID == "") ||
+			(row.EscalationPolicyID != nil && *row.EscalationPolicyID == "") {
+			return providerfoundation.ErrInvalidScope
+		}
+		canonical := row
+		canonical.ID, canonical.SourceConflictKey = "", ""
+		canonical.SourceRevision, canonical.IngestRevision = nil, nil
+		canonical.OrderingContract = 0
+		if err := fillPagerDutyOnCallOrdering(&canonical); err != nil ||
+			canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||
+			canonical.SourceRevision.Cmp(row.SourceRevision) != 0 ||
+			canonical.IngestRevision.Cmp(row.IngestRevision) != 0 ||
+			canonical.OrderingContract != row.OrderingContract {
+			return providerfoundation.ErrInvalidScope
+		}
+	}
+	return nil
+}
+
+func pagerDutyOnCallValues(row pagerDutyOnCallRow) []any {
+	return []any{
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.ID, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.ObservedAt, row.LastSynced,
+		row.RawStatus, row.RawSeverity, row.RawPriority, row.NormalizedStatus,
+		row.NormalizedSeverity, row.NormalizedPriority, row.RelationshipProvenance,
+		row.RelationshipConfidence, row.ScheduleID, row.UserID,
+		row.EscalationPolicyID, row.EscalationLevel, row.StartsAt, row.EndsAt,
+	}
+}
+
+func pagerDutyOnCallScanValues(row *pagerDutyOnCallRow) []any {
+	return []any{
+		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
+		&row.ExternalID, &row.SourceVersionAt, &row.ID, &row.SourceID, &row.SourceURL,
+		&row.SourceEventAt, &row.SourceEventID, &row.ObservedAt, &row.LastSynced,
+		&row.RawStatus, &row.RawSeverity, &row.RawPriority, &row.NormalizedStatus,
+		&row.NormalizedSeverity, &row.NormalizedPriority, &row.RelationshipProvenance,
+		&row.RelationshipConfidence, &row.ScheduleID, &row.UserID,
+		&row.EscalationPolicyID, &row.EscalationLevel, &row.StartsAt, &row.EndsAt,
+	}
+}
+
+func (sink PagerDutyOnCallsClickHouseEffects) loadOnCall(
+	ctx context.Context, claim Claim, providerInstance, id string,
+) (pagerDutyOnCallRow, bool, error) {
+	rows, err := sink.Conn.Query(
+		ctx, "SELECT "+pagerDutyOnCallsColumns+
+			" FROM operational_on_call_assignments FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1",
+		claim.OrgID, claim.Provider, providerInstance, "oncall", id,
+	)
+	if err != nil {
+		return pagerDutyOnCallRow{}, false, err
+	}
+	defer rows.Close()
+	var actual pagerDutyOnCallRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(pagerDutyOnCallScanValues(&actual)...); err != nil {
+			return pagerDutyOnCallRow{}, false, err
+		}
+		if err := fillPagerDutyOnCallOrdering(&actual); err != nil {
+			return pagerDutyOnCallRow{}, false, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return pagerDutyOnCallRow{}, false, err
+	}
+	return actual, found, nil
+}
+
+func comparePagerDutyOnCallVersion(
+	expected, actual pagerDutyOnCallRow, found bool,
+) EffectInspection {
+	if !found || actual.SourceRevision == nil {
+		return EffectAbsent
+	}
+	comparison := actual.SourceRevision.Cmp(expected.SourceRevision)
+	if comparison < 0 {
+		return EffectAbsent
+	}
+	if comparison > 0 {
+		return EffectConflict
+	}
+	expectedJSON, expectedErr := json.Marshal(expected)
+	actualJSON, actualErr := json.Marshal(actual)
+	if expectedErr != nil || actualErr != nil || !bytes.Equal(expectedJSON, actualJSON) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = PagerDutyOnCallsClickHouseEffects{}
+var _ EffectReadback = PagerDutyOnCallsClickHouseEffects{}

--- a/internal/providersync/pagerduty_oncalls_effects_integration_test.go
+++ b/internal/providersync/pagerduty_oncalls_effects_integration_test.go
@@ -1,0 +1,152 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestPagerDutyOnCallsEffectUsesMigratedClickHouseUpsertsAndExactReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	// Use the production migration chain so nullable Int32/DateTime64 values
+	// and the exact assignment table shape are exercised, not a test-only DDL.
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	initialAt := time.Date(2026, 8, 9, 19, 0, 0, 123456000, time.UTC)
+	levelOne := int32(1)
+	rowA, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			ID: "OC1", Start: "2026-08-01T10:00:00.123456Z", End: "2026-08-01T18:00:00.123456Z",
+			EscalationLevel: &levelOne, User: &pagerDutyOnCallReference{ID: "PU1"},
+			Schedule: &pagerDutyOnCallReference{ID: "PS1"}, EscalationPolicy: &pagerDutyOnCallReference{ID: "PE1"},
+		}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowB, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			Start: "2026-08-02T10:00:00Z", End: "2026-08-02T18:00:00Z",
+			EscalationLevel: int32Pointer(2), User: &pagerDutyOnCallReference{ID: "PU2"},
+			Schedule: &pagerDutyOnCallReference{ID: "PS2"}, EscalationPolicy: &pagerDutyOnCallReference{ID: "PE2"},
+		}, initialAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialEffect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired,
+		[]pagerDutyOnCallRow{rowA, rowB},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := PagerDutyOnCallsClickHouseEffects{
+		Conn: conn, ProviderInstanceID: "Acme",
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectAbsent {
+		t.Fatalf("before write inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, initialEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, initialEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after initial write inspection=%s error=%v", inspection, err)
+	}
+
+	// The Python on-calls branch is an upsert stream. A later payload for OC1
+	// must update that assignment without treating omitted OC2 as a deletion.
+	updatedAt := initialAt.Add(time.Hour)
+	levelTwo := int32(2)
+	rowAUpdated, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			ID: "OC1", Start: "2026-08-01T11:00:00.123456Z", End: "2026-08-01T19:00:00.123456Z",
+			EscalationLevel: &levelTwo, User: &pagerDutyOnCallReference{ID: "PU1"},
+			Schedule: &pagerDutyOnCallReference{ID: "PS1"}, EscalationPolicy: &pagerDutyOnCallReference{ID: "PE1"},
+			UpdatedAt: updatedAt.Format(time.RFC3339Nano),
+		}, updatedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedEffect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired,
+		[]pagerDutyOnCallRow{rowAUpdated},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, updatedEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after update inspection=%s error=%v", inspection, err)
+	}
+	var retained uint64
+	if err := conn.QueryRow(ctx, `
+SELECT count()
+FROM operational_on_call_assignments FINAL
+WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ?`,
+		claim.OrgID, "pagerduty", "acme", "oncall", rowB.ID,
+	).Scan(&retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained != 1 {
+		t.Fatalf("upsert stream removed omitted OC2: count=%d", retained)
+	}
+	if err := sink.WriteEffect(ctx, claim, updatedEffect); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("after replay inspection=%s error=%v", inspection, err)
+	}
+
+	otherClaim := claim
+	otherClaim.OrgID = "org-other"
+	otherRow := rowAUpdated
+	otherRow.OrgID = otherClaim.OrgID
+	if err := fillPagerDutyOnCallOrdering(&otherRow); err != nil {
+		t.Fatal(err)
+	}
+	otherEffect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired,
+		[]pagerDutyOnCallRow{otherRow},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, otherClaim, otherEffect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, updatedEffect); err != nil || inspection != EffectExact {
+		t.Fatalf("foreign tenant changed readback inspection=%s error=%v", inspection, err)
+	}
+}
+
+func int32Pointer(value int32) *int32 { return &value }

--- a/internal/providersync/pagerduty_oncalls_effects_test.go
+++ b/internal/providersync/pagerduty_oncalls_effects_test.go
@@ -1,0 +1,95 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestPagerDutyOnCallsEffectRejectsForeignScopeOrderingTamperAndDuplicates(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	level := int32(1)
+	row, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{
+			ID: "OC1", EscalationLevel: &level,
+			User:             &pagerDutyOnCallReference{ID: "PU1"},
+			Schedule:         &pagerDutyOnCallReference{ID: "PS1"},
+			EscalationPolicy: &pagerDutyOnCallReference{ID: "PE1"},
+		}, time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := row
+	foreign.OrgID = "org-other"
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{foreign}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v", err)
+	}
+	foreignInstance := row
+	foreignInstance.ProviderInstanceID = "other"
+	if err := fillPagerDutyOnCallOrdering(&foreignInstance); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{foreignInstance}); err != nil {
+		t.Fatalf("row instance should be structurally valid before sink fence: %v", err)
+	}
+	if _, err := (PagerDutyOnCallsClickHouseEffects{}).providerInstance(
+		[]pagerDutyOnCallRow{row, foreignInstance},
+	); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("mixed instance error=%v", err)
+	}
+	tampered := row
+	levelTwo := int32(2)
+	tampered.EscalationLevel = &levelTwo
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{tampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("ordering tamper error=%v", err)
+	}
+	conflictTampered := row
+	conflictTampered.SourceConflictKey = "00"
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{conflictTampered}); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("source conflict tamper error=%v", err)
+	}
+	if err := validatePagerDutyOnCallRows(claim, []pagerDutyOnCallRow{row, row}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("duplicate row error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsEffectKeepsUpsertRowsWithoutTombstoneState(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	row, err := normalizePagerDutyOnCall(
+		claim, "acme", pagerDutyOnCallPayload{ID: "OC1"},
+		time.Date(2026, 8, 9, 19, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.SourceEntityType != "oncall" || row.ScheduleID != nil || row.UserID != nil ||
+		row.EscalationPolicyID != nil || row.EscalationLevel != nil || row.StartsAt != nil || row.EndsAt != nil {
+		t.Fatalf("unexpected on-call row=%+v", row)
+	}
+	if len(pagerDutyOnCallValues(row)) != 27 || pagerDutyOnCallsColumns == "" {
+		t.Fatalf("assignment schema projection changed unexpectedly: values=%d columns=%q", len(pagerDutyOnCallValues(row)), pagerDutyOnCallsColumns)
+	}
+}
+
+func TestPagerDutyOnCallsEffectRejectsUnsafeEmptySnapshotWithoutInstance(t *testing.T) {
+	if _, err := (PagerDutyOnCallsClickHouseEffects{}).providerInstance(nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("empty snapshot provider instance error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsEffectRejectsWrongRequestBeforeSinkAccess(t *testing.T) {
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	sink := PagerDutyOnCallsClickHouseEffects{}
+	if err := sink.WriteEffect(nil, claim, EffectBatch{Destination: "operational_on_call_assignments"}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid request error=%v", err)
+	}
+	if err := sink.WriteEffect(
+		context.Background(), claim, EffectBatch{Destination: "other"},
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong destination error=%v", err)
+	}
+}

--- a/internal/providersync/pagerduty_oncalls_generic_oracle_test.go
+++ b/internal/providersync/pagerduty_oncalls_generic_oracle_test.go
@@ -1,0 +1,86 @@
+package providersync
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildPagerDutyOnCallRowForOracle(
+	t *testing.T, input map[string]any,
+) pagerDutyOnCallRow {
+	t.Helper()
+	encoded, err := json.Marshal(input["payload"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var payload pagerDutyOnCallPayload
+	if err := decoder.Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	observedAt, err := time.Parse(time.RFC3339Nano, input["observed_at"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	claim.OrgID = input["org_id"].(string)
+	row, err := normalizePagerDutyOnCall(
+		claim, strings.ToLower(input["provider_instance_id"].(string)), payload,
+		observedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func oraclePagerDutyOnCallCases() []oracleCase {
+	return []oracleCase{
+		{ID: "explicit_id_updated_html_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "Acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"id": "OC1", "type": "oncall",
+				"start": "2026-08-01T10:00:00.123456Z",
+				"end":   "2026-08-01T18:00:00.123456Z", "escalation_level": 1,
+				"user":              map[string]any{"id": "PU1"},
+				"schedule":          map[string]any{"id": "PS1"},
+				"escalation_policy": map[string]any{"id": "PE1"},
+				"updated_at":        "2026-08-01T10:00:00.123456Z",
+				"html_url":          "https://acme.pagerduty.com/oncalls/OC1", "self": "/oncalls/OC1",
+			},
+		}},
+		{ID: "composite_id_created_self_url", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "ACME",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"type": "oncall", "start": "2026-08-02T10:00:00Z",
+				"end": "2026-08-02T18:00:00Z", "escalation_level": 2,
+				"user":              map[string]any{"id": "PU2"},
+				"schedule":          map[string]any{"id": "PS2"},
+				"escalation_policy": map[string]any{"id": "PE2"},
+				"created_at":        "2026-07-31T09:00:00Z", "self": "/oncalls/composite",
+			},
+		}},
+		{ID: "permanent_composite_observed_fallback", Input: map[string]any{
+			"org_id": "org-acme", "provider_instance_id": "acme",
+			"observed_at": "2026-08-09T19:00:00.987654Z",
+			"payload": map[string]any{
+				"type": "oncall", "escalation_level": 3,
+				"user":              map[string]any{"id": "PU3"},
+				"escalation_policy": map[string]any{"id": "PE3"},
+			},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "pagerduty/on-calls/row", oraclePagerDutyOnCallCases(),
+		buildPagerDutyOnCallRowForOracle, nil,
+	)
+}

--- a/internal/providersync/pagerduty_oncalls_route.go
+++ b/internal/providersync/pagerduty_oncalls_route.go
@@ -1,0 +1,383 @@
+package providersync
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	pagerDutyOnCallsMaxPages = 10_000
+	pagerDutyOnCallsMaxRows  = 100_000
+	pagerDutyOnCallsPerPage  = 100
+)
+
+// pagerDutyOnCallReference is the only nested provider data consumed by the
+// canonical on-call normalizer. Keeping the references typed prevents a
+// provider response from smuggling arbitrary values into the effect row.
+type pagerDutyOnCallReference struct {
+	ID string `json:"id"`
+}
+
+type pagerDutyOnCallPayload struct {
+	ID               string                    `json:"id"`
+	Type             string                    `json:"type"`
+	Start            string                    `json:"start"`
+	End              string                    `json:"end"`
+	EscalationLevel  *int32                    `json:"escalation_level"`
+	User             *pagerDutyOnCallReference `json:"user"`
+	Schedule         *pagerDutyOnCallReference `json:"schedule"`
+	EscalationPolicy *pagerDutyOnCallReference `json:"escalation_policy"`
+	SelfURL          string                    `json:"self"`
+	HTMLURL          string                    `json:"html_url"`
+	CreatedAt        string                    `json:"created_at"`
+	UpdatedAt        string                    `json:"updated_at"`
+}
+
+// pagerDutyOnCallRow mirrors every field on Python's OnCallAssignment
+// dataclass, including ordering values. The assignment table itself does not
+// persist the derived ordering columns; effects reconstruct and verify them
+// on readback before declaring a write exact.
+type pagerDutyOnCallRow struct {
+	OrgID                  string     `json:"org_id"`
+	Provider               string     `json:"provider"`
+	ProviderInstanceID     string     `json:"provider_instance_id"`
+	SourceEntityType       string     `json:"source_entity_type"`
+	ExternalID             string     `json:"external_id"`
+	SourceVersionAt        time.Time  `json:"source_version_at"`
+	SourceRevision         *big.Int   `json:"source_revision"`
+	SourceConflictKey      string     `json:"source_conflict_key"`
+	IngestRevision         *big.Int   `json:"ingest_revision"`
+	OrderingContract       uint8      `json:"ordering_contract"`
+	ID                     string     `json:"id"`
+	SourceID               *uuid.UUID `json:"source_id"`
+	SourceURL              *string    `json:"source_url"`
+	SourceEventAt          *time.Time `json:"source_event_at"`
+	SourceEventID          *string    `json:"source_event_id"`
+	ObservedAt             time.Time  `json:"observed_at"`
+	LastSynced             time.Time  `json:"last_synced"`
+	RawStatus              *string    `json:"raw_status"`
+	RawSeverity            *string    `json:"raw_severity"`
+	RawPriority            *string    `json:"raw_priority"`
+	NormalizedStatus       *string    `json:"normalized_status"`
+	NormalizedSeverity     *string    `json:"normalized_severity"`
+	NormalizedPriority     *string    `json:"normalized_priority"`
+	RelationshipProvenance *string    `json:"relationship_provenance"`
+	RelationshipConfidence *float64   `json:"relationship_confidence"`
+	ScheduleID             *string    `json:"schedule_id"`
+	UserID                 *string    `json:"user_id"`
+	EscalationPolicyID     *string    `json:"escalation_policy_id"`
+	EscalationLevel        *int32     `json:"escalation_level"`
+	StartsAt               *time.Time `json:"starts_at"`
+	EndsAt                 *time.Time `json:"ends_at"`
+}
+
+// PagerDutyOnCallsRouteHandler owns only source collection and canonical
+// normalization. Registration, matrix/config, and worker wiring stay in the
+// integration lane.
+type PagerDutyOnCallsRouteHandler struct {
+	MaxPages int
+	MaxRows  int
+	PerPage  int
+}
+
+type pagerDutyOnCallsCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer pagerDutyOnCallsCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+func (handler PagerDutyOnCallsRouteHandler) limits() (int, int, int, error) {
+	pages, rows, perPage := handler.MaxPages, handler.MaxRows, handler.PerPage
+	if pages == 0 {
+		pages = pagerDutyOnCallsMaxPages
+	}
+	if rows == 0 {
+		rows = pagerDutyOnCallsMaxRows
+	}
+	if perPage == 0 {
+		perPage = pagerDutyOnCallsPerPage
+	}
+	if pages < 1 || pages > pagerDutyOnCallsMaxPages || rows < 1 ||
+		rows > pagerDutyOnCallsMaxRows || perPage < 1 || perPage > pagerDutyOnCallsPerPage {
+		return 0, 0, 0, ErrInvalidConfiguration
+	}
+	return pages, rows, perPage, nil
+}
+
+func (handler PagerDutyOnCallsRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	credential providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || credential.Provider != "pagerduty" ||
+		claim.Provider != "pagerduty" || claim.Dataset != "on-calls" || client == nil ||
+		client.Provider != "pagerduty" || client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, maxRows, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	providerInstance, err := pagerDutyProviderInstance(credential)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Microsecond)
+	requests := 0
+	counted := *client
+	counted.Doer = pagerDutyOnCallsCountingDoer{delegate: client.Doer, attempts: &requests}
+	pages, err := providerfoundation.CollectPagerDutyOffsetPages(
+		ctx, &counted, providerfoundation.PagerDutyOffsetOptions{
+			Path: "/oncalls", DataKey: "oncalls", PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if len(pages.Items) > maxRows || pages.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	rows := make([]pagerDutyOnCallRow, 0, len(pages.Items))
+	for _, raw := range pages.Items {
+		var payload pagerDutyOnCallPayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+		}
+		row, err := normalizePagerDutyOnCall(
+			claim, providerInstance, payload, normalizedAt,
+		)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+	effect, err := effectBatchFromValues(
+		"operational_on_call_assignments", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
+			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,
+		},
+	}, nil
+}
+
+func normalizePagerDutyOnCall(
+	claim Claim,
+	providerInstance string,
+	payload pagerDutyOnCallPayload,
+	normalizedAt time.Time,
+) (pagerDutyOnCallRow, error) {
+	externalID, err := pagerDutyOnCallExternalID(payload)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	sourceVersionAt, err := pagerDutyOnCallSourceTime(payload, normalizedAt)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	start, err := pagerDutyOnCallTime(payload.Start)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	end, err := pagerDutyOnCallTime(payload.End)
+	if err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	sourceURL := pagerDutyOnCallURL(payload)
+	row := pagerDutyOnCallRow{
+		OrgID: claim.OrgID, Provider: "pagerduty", ProviderInstanceID: providerInstance,
+		SourceEntityType: "oncall", ExternalID: externalID,
+		SourceVersionAt: sourceVersionAt, SourceURL: sourceURL,
+		ObservedAt: normalizedAt, LastSynced: normalizedAt,
+		ScheduleID: pagerDutyOnCallReferenceID(
+			claim.OrgID, providerInstance, payload.Schedule, "operational_on_call_schedule",
+		),
+		UserID: pagerDutyOnCallReferenceID(
+			claim.OrgID, providerInstance, payload.User, "operational_user",
+		),
+		EscalationPolicyID: pagerDutyOnCallReferenceID(
+			claim.OrgID, providerInstance, payload.EscalationPolicy, "operational_escalation_policy",
+		),
+		EscalationLevel: payload.EscalationLevel,
+		StartsAt:        start, EndsAt: end,
+	}
+	if (payload.User != nil && strings.TrimSpace(payload.User.ID) == "") ||
+		(payload.Schedule != nil && strings.TrimSpace(payload.Schedule.ID) == "") ||
+		(payload.EscalationPolicy != nil && strings.TrimSpace(payload.EscalationPolicy.ID) == "") {
+		return pagerDutyOnCallRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	if err := fillPagerDutyOnCallOrdering(&row); err != nil {
+		return pagerDutyOnCallRow{}, err
+	}
+	return row, nil
+}
+
+func pagerDutyOnCallExternalID(payload pagerDutyOnCallPayload) (string, error) {
+	if externalID := strings.TrimSpace(payload.ID); externalID != "" {
+		return externalID, nil
+	}
+	if payload.EscalationPolicy == nil || payload.User == nil ||
+		strings.TrimSpace(payload.EscalationPolicy.ID) == "" ||
+		strings.TrimSpace(payload.User.ID) == "" || payload.EscalationLevel == nil {
+		return "", providerfoundation.ErrNormalizationInvalid
+	}
+	scheduleID := "<permanent>"
+	if payload.Schedule != nil && payload.Schedule.ID != "" {
+		scheduleID = payload.Schedule.ID
+	}
+	start := "<permanent>"
+	if payload.Start != "" {
+		parsed, err := pagerDutyOnCallTime(payload.Start)
+		if err != nil {
+			return "", err
+		}
+		start = pagerDutyPythonISOTime(*parsed)
+	}
+	end := "<permanent>"
+	if payload.End != "" {
+		parsed, err := pagerDutyOnCallTime(payload.End)
+		if err != nil {
+			return "", err
+		}
+		end = pagerDutyPythonISOTime(*parsed)
+	}
+	return strings.Join([]string{
+		payload.EscalationPolicy.ID, scheduleID, payload.User.ID,
+		strconv.FormatInt(int64(*payload.EscalationLevel), 10), start, end,
+	}, "|"), nil
+}
+
+func pagerDutyOnCallSourceTime(
+	payload pagerDutyOnCallPayload, observedAt time.Time,
+) (time.Time, error) {
+	value := payload.UpdatedAt
+	if value == "" {
+		value = payload.CreatedAt
+	}
+	if value == "" {
+		return observedAt, nil
+	}
+	return pagerDutyOnCallParsedTime(value)
+}
+
+func pagerDutyOnCallTime(value string) (*time.Time, error) {
+	if value == "" {
+		return nil, nil
+	}
+	parsed, err := pagerDutyOnCallParsedTime(value)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
+func pagerDutyOnCallParsedTime(value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	}
+	return parsed.UTC().Truncate(time.Microsecond), nil
+}
+
+func pagerDutyPythonISOTime(value time.Time) string {
+	value = value.UTC().Truncate(time.Microsecond)
+	if value.Nanosecond() == 0 {
+		return value.Format("2006-01-02T15:04:05-07:00")
+	}
+	return value.Format("2006-01-02T15:04:05.000000-07:00")
+}
+
+func pagerDutyOnCallURL(payload pagerDutyOnCallPayload) *string {
+	value := payload.HTMLURL
+	if value == "" {
+		value = payload.SelfURL
+	}
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func pagerDutyOnCallReferenceID(
+	orgID, providerInstance string,
+	reference *pagerDutyOnCallReference, family string,
+) *string {
+	if reference == nil {
+		return nil
+	}
+	id := canonicalPagerDutyOperationalID(
+		orgID, "pagerduty", providerInstance, family, strings.TrimSpace(reference.ID),
+	)
+	return &id
+}
+
+func canonicalPagerDutyOperationalID(
+	orgID, provider, providerInstance, family, externalID string,
+) string {
+	parts := []string{orgID, provider, providerInstance, family, externalID}
+	quoted := make([]string, len(parts))
+	for index, part := range parts {
+		quoted[index] = strconv.QuoteToASCII(part)
+	}
+	digest := sha256Bytes([]byte("[" + strings.Join(quoted, ",") + "]"))
+	return hex.EncodeToString(digest)
+}
+
+func fillPagerDutyOnCallOrdering(row *pagerDutyOnCallRow) error {
+	if row == nil {
+		return providerfoundation.ErrNormalizationInvalid
+	}
+	fields := gitLabOperationalBaseFields(
+		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
+		row.ExternalID, row.SourceVersionAt, row.SourceID, row.SourceURL,
+		row.SourceEventAt, row.SourceEventID, row.RawStatus, row.RawSeverity,
+		row.RawPriority, row.NormalizedStatus, row.NormalizedSeverity,
+		row.NormalizedPriority, row.RelationshipProvenance, row.RelationshipConfidence,
+	)
+	var escalationLevel any
+	if row.EscalationLevel != nil {
+		escalationLevel = *row.EscalationLevel
+	}
+	fields = append(fields,
+		jiraOperationalField{"schedule_id", jiraStringValue(row.ScheduleID)},
+		jiraOperationalField{"user_id", jiraStringValue(row.UserID)},
+		jiraOperationalField{"escalation_policy_id", jiraStringValue(row.EscalationPolicyID)},
+		jiraOperationalField{"escalation_level", escalationLevel},
+		jiraOperationalField{"starts_at", jiraTimeValue(row.StartsAt)},
+		jiraOperationalField{"ends_at", jiraTimeValue(row.EndsAt)},
+	)
+	id, conflict, sourceRevision, ingestRevision, err := deriveGitLabOperationalOrdering(
+		"operational_on_call_assignment", row.OrgID, row.Provider,
+		row.ProviderInstanceID, row.ExternalID, row.SourceVersionAt,
+		row.ObservedAt, row.LastSynced, fields,
+	)
+	if err != nil {
+		return err
+	}
+	row.ID, row.SourceConflictKey = id, conflict
+	row.SourceRevision, row.IngestRevision = sourceRevision, ingestRevision
+	row.OrderingContract = 2
+	return nil
+}
+
+var _ CompleteRouteHandler = PagerDutyOnCallsRouteHandler{}

--- a/internal/providersync/pagerduty_oncalls_route_test.go
+++ b/internal/providersync/pagerduty_oncalls_route_test.go
@@ -1,0 +1,243 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type pagerDutyOnCallsResponse struct {
+	status int
+	body   string
+}
+
+type pagerDutyOnCallsDoer struct {
+	t         *testing.T
+	responses []pagerDutyOnCallsResponse
+	requests  []*http.Request
+}
+
+func (doer *pagerDutyOnCallsDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected PagerDuty request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{body: `{"oncalls":[
+			{"id":"OC1","type":"oncall","start":"2026-08-01T10:00:00.123456Z","end":"2026-08-01T18:00:00.123456Z","escalation_level":1,"user":{"id":"PU1"},"schedule":{"id":"PS1"},"escalation_policy":{"id":"PE1"},"updated_at":"2026-08-01T10:00:00.123456Z","html_url":"https://acme.pagerduty.com/oncalls/OC1","self":"/oncalls/OC1"},
+			{"type":"oncall","start":"2026-08-02T10:00:00Z","end":"2026-08-02T18:00:00Z","escalation_level":2,"user":{"id":"PU2"},"schedule":{"id":"PS2"},"escalation_policy":{"id":"PE2"},"created_at":"2026-07-31T09:00:00Z","self":"/oncalls/composite"}],"more":true}`},
+		{body: `{"oncalls":[],"more":false}`},
+	}}
+	client := pagerDutyOnCallsTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": " Acme "},
+	}
+	normalizedAt := time.Date(2026, 8, 9, 12, 0, 0, 987654321, time.FixedZone("PDT", -7*60*60))
+	batch, err := (PagerDutyOnCallsRouteHandler{MaxPages: 10}).Collect(
+		context.Background(), claim, credential, client, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_on_call_assignments" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 2 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 2 ||
+		batch.Evidence.CapReached || batch.Watermark != nil || batch.Result != nil {
+		t.Fatalf("batch=%+v", batch)
+	}
+	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {
+		t.Fatalf("first query=%q", got)
+	}
+	if got := doer.requests[0].URL.Path; got != "/oncalls" {
+		t.Fatalf("first path=%q", got)
+	}
+	if got := doer.requests[1].URL.RawQuery; got != "limit=100&offset=2" {
+		t.Fatalf("second query=%q", got)
+	}
+	row := mustPagerDutyOnCallRow(t, batch.Effects[0].Rows[0])
+	if row.Provider != "pagerduty" || row.ProviderInstanceID != "acme" ||
+		row.SourceEntityType != "oncall" || row.ExternalID != "OC1" ||
+		row.SourceURL == nil || *row.SourceURL != "https://acme.pagerduty.com/oncalls/OC1" ||
+		row.ScheduleID == nil || row.UserID == nil || row.EscalationPolicyID == nil ||
+		row.EscalationLevel == nil || *row.EscalationLevel != 1 ||
+		row.StartsAt == nil || row.EndsAt == nil || row.OrderingContract != 2 ||
+		!row.SourceVersionAt.Equal(time.Date(2026, 8, 1, 10, 0, 0, 123456000, time.UTC)) ||
+		!row.ObservedAt.Equal(time.Date(2026, 8, 9, 19, 0, 0, 987654000, time.UTC)) {
+		t.Fatalf("row=%+v", row)
+	}
+	second := mustPagerDutyOnCallRow(t, batch.Effects[0].Rows[1])
+	if !strings.Contains(second.ExternalID, "PE2|PS2|PU2|2|2026-08-02T10:00:00+00:00|2026-08-02T18:00:00+00:00") ||
+		second.SourceURL == nil || *second.SourceURL != "/oncalls/composite" ||
+		second.ScheduleID == nil || second.UserID == nil || second.EscalationPolicyID == nil {
+		t.Fatalf("composite row=%+v", second)
+	}
+}
+
+func TestPagerDutyOnCallsRouteRejectsAnotherPagerDutyDataset(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "schedules")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	client := pagerDutyOnCallsTestClient(t, &pagerDutyOnCallsDoer{
+		t: t, responses: []pagerDutyOnCallsResponse{{body: `{"oncalls":[],"more":false}`}},
+	}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	if _, err := (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong dataset error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsRoutePreservesRetryAndPermanentErrorSemantics(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	retryDoer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{status: http.StatusTooManyRequests, body: `{"message":"slow down"}`},
+		{body: `{"oncalls":[],"more":false}`},
+	}}
+	retryClient := pagerDutyOnCallsTestClient(t, retryDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	batch, err := (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, retryClient,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil || len(retryDoer.requests) != 2 || len(batch.Effects) != 1 {
+		t.Fatalf("retry batch=%+v error=%v requests=%d", batch, err, len(retryDoer.requests))
+	}
+
+	authDoer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{status: http.StatusUnauthorized, body: `{"message":"bad token"}`},
+	}}
+	authClient := pagerDutyOnCallsTestClient(t, authDoer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	_, err = (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, authClient,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication ||
+		len(authDoer.requests) != 1 {
+		t.Fatalf("auth error=%v requests=%d", err, len(authDoer.requests))
+	}
+}
+
+func TestPagerDutyOnCallsRouteFailsClosedOnPaginationCapAndInvalidAssignment(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	client := pagerDutyOnCallsTestClient(t, &pagerDutyOnCallsDoer{
+		t: t, responses: []pagerDutyOnCallsResponse{{body: `{"oncalls":[{"type":"oncall","user":{"id":"PU1"}}],"more":true}`}},
+	}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err := (PagerDutyOnCallsRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, credential, client,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+
+	invalidClient := pagerDutyOnCallsTestClient(t, &pagerDutyOnCallsDoer{
+		t: t, responses: []pagerDutyOnCallsResponse{{body: `{"oncalls":[{"type":"oncall","user":{"id":"PU1"}}],"more":false}`}},
+	}, providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond})
+	_, err = (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim, credential, invalidClient,
+		time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("invalid assignment error=%v", err)
+	}
+}
+
+func TestPagerDutyOnCallsRouteStopsWhenLeaseExpiresBetweenPages(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "on-calls")
+	doer := &pagerDutyOnCallsDoer{t: t, responses: []pagerDutyOnCallsResponse{
+		{body: `{"oncalls":[{"id":"OC1","type":"oncall"}],"more":true}`},
+		{body: `{"oncalls":[],"more":false}`},
+	}}
+	asserts := 0
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			asserts++
+			if asserts > 2 {
+				return providerfoundation.ErrLeaseLost
+			}
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (PagerDutyOnCallsRouteHandler{}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}},
+		client, time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || len(doer.requests) != 1 {
+		t.Fatalf("lease error=%v requests=%d asserts=%d", err, len(doer.requests), asserts)
+	}
+}
+
+func pagerDutyOnCallsTestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"pagerduty", "https://api.pagerduty.com", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func mustPagerDutyOnCallRow(t *testing.T, raw []byte) pagerDutyOnCallRow {
+	t.Helper()
+	var row pagerDutyOnCallRow
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	return row
+}

--- a/internal/providersync/testdata/mutation-plans/pagerduty_on-calls.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_on-calls.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty on-call assignment route, typed normalization, upsert effects, and readback fencing",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "This provider-only plan covers PagerDuty on-calls source selection, stable composite identities, complete typed row normalization, migrated assignment writes, upsert replay, and account fencing. It does not cover schedules, registry, matrix, config, deployment, cutover, or activation wiring. The ClickHouse entries require Docker and run against migration 066 through the real integration test.",
+  "mutations": [
+    {
+      "id": "OC1-route-rejects-other-dataset",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "claim.Dataset != \"on-calls\"",
+      "replace": "false",
+      "rationale": "The on-calls handler must not consume a schedules claim; removing this clause would send the wrong dataset to /oncalls and emit assignment effects under the wrong contract.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteRejectsAnotherPagerDutyDataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC2-route-uses-oncalls-path",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "Path: \"/oncalls\"",
+      "replace": "Path: \"/schedules\"",
+      "rationale": "PagerDuty on-call assignments are selected from the /oncalls endpoint; a sibling resource endpoint would silently collect the wrong provider resource family.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC3-route-uses-oncalls-response-key",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "DataKey: \"oncalls\"",
+      "replace": "DataKey: \"schedules\"",
+      "rationale": "The response collection key is part of the PagerDuty REST contract; reading a sibling key must fail closed instead of returning an empty successful assignment batch.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC4-composite-external-id-keeps-all-dimensions",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "payload.EscalationPolicy.ID, scheduleID, payload.User.ID,",
+      "replace": "payload.User.ID, scheduleID, payload.User.ID,",
+      "rationale": "The live Python normalizer's no-provider-id fallback is keyed by policy, schedule, user, level, and window. Dropping the policy dimension makes distinct assignments collide and diverges from the producer.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC5-composite-external-id-preserves-python-time-format",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "return value.Format(\"2006-01-02T15:04:05-07:00\")",
+      "replace": "return value.Format(\"2006-01-02T15:04:05Z07:00\")",
+      "rationale": "Python datetime.isoformat emits +00:00 for UTC permanent-window dimensions. Replacing it with a Z-formatted value changes the stable external identity and must be caught by the live oracle.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC6-reference-id-uses-schedule-family",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "\"operational_on_call_schedule\"",
+      "replace": "\"operational_on_call_assignment\"",
+      "rationale": "Nested schedule references use the canonical operational_on_call_schedule entity family. Reusing the assignment family produces a different ID and breaks cross-provider relationship parity.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC7-source-url-prefers-html-url",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "value := payload.HTMLURL\n\tif value == \"\" {\n\t\tvalue = payload.SelfURL\n\t}",
+      "replace": "value := payload.SelfURL\n\tif value == \"\" {\n\t\tvalue = payload.HTMLURL\n\t}",
+      "rationale": "The Python producer emits html_url before self. Reversing the precedence changes persisted source evidence whenever both provider URLs are present.",
+      "proof": [["bash", "-c", "set -euo pipefail; root=\"$(pwd -P)\"; proof_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-python.XXXXXX\")\"; cache_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/pagerduty-oncalls-go.XXXXXX\")\"; trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT; PYTHON=\"$(command -v python3)\" PYTHONPATH=\"$root/src${PYTHONPATH:+:$PYTHONPATH}\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" GOCACHE=\"$cache_dir\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForPagerDutyOnCallRow$' ./internal/providersync/; test \"$(cat \"$proof_dir/pagerduty_on-calls_row.py\")\" = executed"]]
+    },
+    {
+      "id": "OC8-effect-fences-mixed-provider-instances",
+      "file": "internal/providersync/pagerduty_oncalls_effects_clickhouse.go",
+      "find": "if instance != rowInstance {",
+      "replace": "if false {",
+      "rationale": "One effect batch must belong to one PagerDuty account. Accepting rows from mixed instances would make the sink's account fence arbitrary and unsafe.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsEffectRejectsForeignScopeOrderingTamperAndDuplicates$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC9-effect-rejects-source-conflict-tamper",
+      "file": "internal/providersync/pagerduty_oncalls_effects_clickhouse.go",
+      "find": "canonical.ID != row.ID || canonical.SourceConflictKey != row.SourceConflictKey ||",
+      "replace": "canonical.ID != row.ID || false ||",
+      "rationale": "The durable effect must reject forged source conflict keys even when the semantic row fields and derived revision otherwise look unchanged; otherwise readback identity can be falsified.",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsEffectRejectsForeignScopeOrderingTamperAndDuplicates$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC10-effect-writes-migrated-assignment-table",
+      "file": "internal/providersync/pagerduty_oncalls_effects_clickhouse.go",
+      "find": "INSERT INTO operational_on_call_assignments (",
+      "replace": "INSERT INTO operational_on_call_schedules (",
+      "rationale": "The effect must write the migrated operational_on_call_assignments schema, not the separate schedules table. A table-family mutation must fail the real migration-backed write before any success claim.",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyOnCallsEffectUsesMigratedClickHouseUpsertsAndExactReplay$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/pagerduty_on-calls_row.py
+++ b/internal/providersync/testdata/oracle_pairs/pagerduty_on-calls_row.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, fields
+from datetime import datetime
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pagerduty/normalize.py"
+_NORMALIZE = load_live_module(_SOURCE)
+
+
+def _module() -> Any:
+    if pathlib.Path(_NORMALIZE.__file__).resolve(strict=True) != _SOURCE.resolve(
+        strict=True
+    ):
+        raise RuntimeError("PagerDuty oracle did not import the live normalizer")
+    return _NORMALIZE
+
+
+def _reflected_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(_module().OnCallAssignment))
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = _module()
+    observed_at = datetime.fromisoformat(case["observed_at"].replace("Z", "+00:00"))
+    source = module.Oncall.model_validate(case["payload"])
+    normalizer = module.PagerDutyNormalizer(
+        org_id=case["org_id"],
+        provider_instance_id=case["provider_instance_id"],
+        observed_at=observed_at,
+    )
+    return asdict(normalizer.oncall(source))
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="pagerduty/on-calls/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)


### PR DESCRIPTION
## Scope

- Port the PagerDuty on-calls provider-code slice as a stacked PR on `feat/go-worker-pagerduty-business-services`.
- Add typed payloads, bounded pagination, normalization, stable composite external IDs/reference IDs, exact `operational_on_call_assignments` ClickHouse effects/readback/replay, fencing, and recovery behavior.
- Include the live Python differential oracle, migrated ClickHouse integration proof, and shared clause-level mutation plan.

## Verification

- Live Python differential oracle: PASS with non-empty execution proof marker.
- Real migrated ClickHouse integration: PASS for assignment upsert/readback/replay and tenant/provider-instance/lease fencing.
- Shared mutation harness: PASS; OC1–OC10 all KILLED with clean restore verification.
- Focused route/effects/oracle tests, Go integration compile, `go vet`, Ruff, mypy, and commit hooks: PASS.
- Full `internal/providersync` package remains limited by the unrelated pre-existing GitLab IPv6 loopback bind restriction in the sandbox (`operation not permitted`).

## Boundaries

- Provider code only; no registry, provider matrix, config, deployment, route activation, cutover, schedules, or webhooks.

Refs CHAOS-3734 (parent CHAOS-3125).

SCREENSHOT-WAIVER: Backend/provider-only change; no rendered UI surface.