### PR TITLE
CHAOS-3735: Integrate GitLab provider parity stack

### DIFF
--- a/ci/requirements-live-python-oracles.txt
+++ b/ci/requirements-live-python-oracles.txt
@@ -5,6 +5,7 @@ annotated-types==0.7.0
 anyio==4.13.0
 atlassian-gen-client==0.1.0b3
 certifi==2026.4.22
+colorama==0.4.6
 defusedxml==0.7.1
 gitdb==4.0.12
 GitPython==3.1.54
@@ -15,6 +16,7 @@ httpcore==1.0.9
 httpx==0.28.1
 idna==3.15
 iniconfig==2.3.0
+mando==0.7.1
 packaging==26.2
 pluggy==1.6.0
 pydantic==2.13.4
@@ -22,6 +24,8 @@ pydantic-core==2.46.4
 pygments==2.20.0
 pytest==9.0.3
 PyYAML==6.0.3
+radon==6.0.1
+six==1.17.0
 smmap==5.0.3
 SQLAlchemy==2.0.49
 typing-extensions==4.15.0

--- a/internal/providerfoundation/foundation_test.go
+++ b/internal/providerfoundation/foundation_test.go
@@ -140,6 +140,38 @@ func TestHTTPClassificationAndPaginationFixtures(t *testing.T) {
 	}
 }
 
+func TestGitLabForbiddenRateLimitQualification(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		headers http.Header
+		want    ErrorClass
+	}{
+		{
+			name:    "retry-after",
+			headers: http.Header{"Retry-After": []string{"2"}},
+			want:    ErrorRateLimited,
+		},
+		{
+			name:    "remaining-zero",
+			headers: http.Header{"RateLimit-Remaining": []string{"0"}},
+			want:    ErrorRateLimited,
+		},
+		{
+			name:    "plain-forbidden",
+			headers: http.Header{},
+			want:    ErrorAuthentication,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ClassifyHTTP("gitlab", http.StatusForbidden, test.headers); got == nil || got.Class != test.want {
+				t.Fatalf("classification=%v, want %s", got, test.want)
+			}
+		})
+	}
+}
+
 func TestProviderParityFixture(t *testing.T) {
 	t.Parallel()
 	content, err := os.ReadFile("testdata/provider_parity.json")

--- a/internal/providerfoundation/http.go
+++ b/internal/providerfoundation/http.go
@@ -335,8 +335,8 @@ func (c *HTTPClient) observe(class ErrorClass) {
 }
 
 // ClassifyHTTP mirrors the current Python provider taxonomy without retaining
-// response bodies or headers. GitHub's 403 rate-limit vocabulary is special;
-// all other 403s remain authentication/permission failures.
+// response bodies or headers. GitHub's and GitLab's 403 rate-limit vocabularies
+// are special; all other 403s remain authentication/permission failures.
 func ClassifyHTTP(provider string, status int, headers http.Header) *ProviderError {
 	return ClassifyHTTPWithMessage(provider, status, headers, "")
 }
@@ -344,7 +344,7 @@ func ClassifyHTTP(provider string, status int, headers http.Header) *ProviderErr
 func ClassifyHTTPWithMessage(provider string, status int, headers http.Header, message string) *ProviderError {
 	retryAfter := ParseRetryAfter(headerValue(headers, "retry-after"), time.Now())
 	message = strings.ToLower(message)
-	if provider == "github" && status == http.StatusForbidden && (headerValue(headers, "x-ratelimit-remaining") == "0" || headerValue(headers, "retry-after") != "" || strings.Contains(message, "rate limit") || strings.Contains(message, "abuse") || strings.Contains(message, "secondary")) {
+	if isRateLimitedForbidden(provider, status, headers, message) {
 		return &ProviderError{Class: ErrorRateLimited, StatusCode: status, RetryAfter: retryAfter}
 	}
 	switch status {
@@ -368,6 +368,22 @@ func ClassifyHTTPWithMessage(provider string, status int, headers http.Header, m
 	return nil
 }
 
+func isRateLimitedForbidden(provider string, status int, headers http.Header, message string) bool {
+	if status != http.StatusForbidden {
+		return false
+	}
+	if provider == "gitlab" &&
+		(hasHeader(headers, "retry-after") || headerValue(headers, "ratelimit-remaining") == "0") {
+		return true
+	}
+	return provider == "github" &&
+		(headerValue(headers, "x-ratelimit-remaining") == "0" ||
+			headerValue(headers, "retry-after") != "" ||
+			strings.Contains(message, "rate limit") ||
+			strings.Contains(message, "abuse") ||
+			strings.Contains(message, "secondary"))
+}
+
 func headerValue(headers http.Header, wanted string) string {
 	for key, values := range headers {
 		if strings.EqualFold(key, wanted) && len(values) > 0 {
@@ -375,6 +391,15 @@ func headerValue(headers http.Header, wanted string) string {
 		}
 	}
 	return ""
+}
+
+func hasHeader(headers http.Header, wanted string) bool {
+	for key := range headers {
+		if strings.EqualFold(key, wanted) {
+			return true
+		}
+	}
+	return false
 }
 
 func ParseRetryAfter(raw string, now time.Time) time.Duration {

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -81,9 +81,40 @@ func validateGitHubWorkItemDerivedEffect[T any](
 		if err := json.Unmarshal(raw, &row); err != nil {
 			return nil, ErrInvalidConfiguration
 		}
+		if !validGitHubWorkItemDerivedRowTenancy(row, identity) {
+			return nil, ErrInvalidConfiguration
+		}
 		rows = append(rows, row)
 	}
 	return rows, nil
+}
+
+// validGitHubWorkItemDerivedRowTenancy is shared by the GitHub and GitLab
+// adapters. The JSON effect ledger is not allowed to become a bypass around
+// the provider and tenant fences that the typed compute rows already carry.
+func validGitHubWorkItemDerivedRowTenancy[T any](
+	row T,
+	identity GitHubWorkItemEffectIdentity,
+) bool {
+	switch value := any(row).(type) {
+	case githubEstimateCoverageMetricsDailyRow:
+		return value.OrgID == identity.OrgID && value.Provider == identity.Provider
+	case githubWorkItemTeamAttributionRow:
+		return value.OrgID == identity.OrgID && value.Provider == identity.Provider
+	case githubWorkItemStateDurationDailyRow:
+		return value.OrgID == identity.OrgID && value.Provider == identity.Provider
+	case githubIssueTypeMetricsDailyRow:
+		return value.OrgID == identity.OrgID && value.Provider == identity.Provider
+	case githubInvestmentClassificationDailyRow:
+		return value.OrgID == identity.OrgID && value.Provider == identity.Provider
+	case githubInvestmentMetricsDailyRow:
+		// investment_metrics_daily's production schema has no provider column;
+		// its natural key is tenant/repo/day/team/investment tuple. The provider
+		// is already fenced at the typed compute claim and effect identity.
+		return value.OrgID == identity.OrgID
+	default:
+		return true
+	}
 }
 
 // inspectGitHubWorkItemDerivedRows returns the WEAKEST verdict across rows:

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -60,11 +60,10 @@ type GitHubWorkItemStateDurationsClickHouseEffects struct {
 	Lease providerfoundation.LeaseGuard
 }
 
-// validateGitHubWorkItemDerivedEffect re-derives the typed rows from the
-// frozen effect and refuses anything whose destination, tenancy or recovery
-// posture does not match the identity. Decoding from effect.Rows rather than
-// from a builder result is deliberate: recovery replays a persisted manifest
-// that no builder run produced.
+// validateGitHubWorkItemDerivedEffect decodes the typed rows from the frozen
+// effect and validates its destination and recovery posture. Readback callers
+// must allow a row from another tenant through to the SQL fence so it can
+// return EffectAbsent; write callers apply row-tenancy validation separately.
 func validateGitHubWorkItemDerivedEffect[T any](
 	identity GitHubWorkItemEffectIdentity,
 	effect EffectBatch,
@@ -81,12 +80,21 @@ func validateGitHubWorkItemDerivedEffect[T any](
 		if err := json.Unmarshal(raw, &row); err != nil {
 			return nil, ErrInvalidConfiguration
 		}
-		if !validGitHubWorkItemDerivedRowTenancy(row, identity) {
-			return nil, ErrInvalidConfiguration
-		}
 		rows = append(rows, row)
 	}
 	return rows, nil
+}
+
+func validGitHubWorkItemDerivedWriteRows[T any](
+	rows []T,
+	identity GitHubWorkItemEffectIdentity,
+) bool {
+	for _, row := range rows {
+		if !validGitHubWorkItemDerivedRowTenancy(row, identity) {
+			return false
+		}
+	}
+	return true
 }
 
 // validGitHubWorkItemDerivedRowTenancy is shared by the GitHub and GitLab
@@ -269,7 +277,8 @@ func (sink GitHubEstimateCoverageClickHouseEffects) WriteGitHubWorkItemEffect(
 	rows, err := validateGitHubWorkItemDerivedEffect[githubEstimateCoverageMetricsDailyRow](
 		identity, effect, githubEstimateCoverageDestination,
 	)
-	if err != nil || ctx == nil || sink.Lease == nil || sink.Conn == nil {
+	if err != nil || !validGitHubWorkItemDerivedWriteRows(rows, identity) ||
+		ctx == nil || sink.Lease == nil || sink.Conn == nil {
 		return ErrInvalidConfiguration
 	}
 	if err := sink.Lease.Assert(ctx); err != nil {
@@ -395,7 +404,8 @@ func (sink GitHubWorkItemTeamAttributionsClickHouseEffects) WriteGitHubWorkItemE
 	rows, err := validateGitHubWorkItemDerivedEffect[githubWorkItemTeamAttributionRow](
 		identity, effect, githubTeamAttributionsDestination,
 	)
-	if err != nil || ctx == nil || sink.Lease == nil || sink.Conn == nil {
+	if err != nil || !validGitHubWorkItemDerivedWriteRows(rows, identity) ||
+		ctx == nil || sink.Lease == nil || sink.Conn == nil {
 		return ErrInvalidConfiguration
 	}
 	if err := sink.Lease.Assert(ctx); err != nil {
@@ -514,7 +524,8 @@ func (sink GitHubWorkItemStateDurationsClickHouseEffects) WriteGitHubWorkItemEff
 	rows, err := validateGitHubWorkItemDerivedEffect[githubWorkItemStateDurationDailyRow](
 		identity, effect, githubStateDurationsDestination,
 	)
-	if err != nil || ctx == nil || sink.Lease == nil || sink.Conn == nil {
+	if err != nil || !validGitHubWorkItemDerivedWriteRows(rows, identity) ||
+		ctx == nil || sink.Lease == nil || sink.Conn == nil {
 		return ErrInvalidConfiguration
 	}
 	if err := sink.Lease.Assert(ctx); err != nil {

--- a/internal/providersync/github_work_item_derived_effects_test.go
+++ b/internal/providersync/github_work_item_derived_effects_test.go
@@ -1,11 +1,107 @@
 package providersync
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
+
+type inertGitHubDerivedConn struct{ driver.Conn }
+
+func TestGitHubEstimateCoverageWrite_rejectsForeignTenantBeforeLease(t *testing.T) {
+	// Given: a foreign-tenant effect and a connection/lease that would expose a
+	// write if row tenancy validation were bypassed.
+	row := githubDerivedEffectCoverageRow()
+	row.OrgID = "org-other"
+	raw, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effect, err := BuildEffectBatch(
+		githubEstimateCoverageDestination, EffectReadbackRequired,
+		[]json.RawMessage{raw},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := GitHubWorkItemEffectIdentity{
+		OrgID: "org-acme", Provider: "github", Destination: githubEstimateCoverageDestination,
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}
+	leaseCalls := 0
+	sink := GitHubEstimateCoverageClickHouseEffects{
+		Conn: &inertGitHubDerivedConn{},
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			leaseCalls++
+			return errors.New("lease reached")
+		}),
+	}
+
+	// When: the public write entrypoint receives the effect.
+	err = sink.WriteGitHubWorkItemEffect(context.Background(), identity, effect)
+
+	// Then: it rejects the payload before using the lease or connection.
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("write error = %v, want ErrInvalidConfiguration", err)
+	}
+	if leaseCalls != 0 {
+		t.Fatalf("lease assertions = %d, want 0", leaseCalls)
+	}
+}
+
+func TestValidateGitHubWorkItemDerivedEffect_allowsForeignTenantForReadback(t *testing.T) {
+	// Given: a persisted effect row from another tenant and an identity for the
+	// tenant whose ClickHouse fence will be queried.
+	row := githubDerivedEffectCoverageRow()
+	row.OrgID = "org-other"
+	raw, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effect, err := BuildEffectBatch(
+		githubEstimateCoverageDestination, EffectReadbackRequired,
+		[]json.RawMessage{raw},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := GitHubWorkItemEffectIdentity{
+		OrgID: "org-acme", Provider: "github", Destination: githubEstimateCoverageDestination,
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}
+
+	// When: the effect is decoded for a readback.
+	_, err = validateGitHubWorkItemDerivedEffect[githubEstimateCoverageMetricsDailyRow](
+		identity, effect, githubEstimateCoverageDestination,
+	)
+
+	// Then: the SQL tenant fence gets the chance to return EffectAbsent.
+	if err != nil {
+		t.Fatalf("readback validation rejected a foreign tenant row: %v", err)
+	}
+}
+
+func TestGitHubWorkItemDerivedWriteRows_rejectsForeignTenant(t *testing.T) {
+	// Given: a decoded effect row whose tenant does not match the write identity.
+	row := githubDerivedEffectCoverageRow()
+	row.OrgID = "org-other"
+	identity := GitHubWorkItemEffectIdentity{OrgID: "org-acme", Provider: "github"}
+
+	// When: rows are checked before a write.
+	valid := validGitHubWorkItemDerivedWriteRows([]githubEstimateCoverageMetricsDailyRow{row}, identity)
+
+	// Then: the write path rejects the cross-tenant payload.
+	if valid {
+		t.Fatal("foreign tenant row passed write validation")
+	}
+}
 
 // These are fast, synthetic-data unit tests of the three comparators' own
 // logic. Each clause gets a case that exercises ONLY that clause, so a

--- a/internal/providersync/github_work_item_derived_surfaces.go
+++ b/internal/providersync/github_work_item_derived_surfaces.go
@@ -151,7 +151,24 @@ func buildGitHubWorkItemDerivedSurfaces(
 	computedAt time.Time,
 	derived githubWorkItemDerivationContext,
 ) (githubWorkItemDerivedSurfaces, error) {
-	if claim.Validate() != nil || claim.Provider != "github" ||
+	return buildWorkItemDerivedSurfacesForProvider(
+		"github", claim, rows, day, computedAt, derived,
+	)
+}
+
+// buildWorkItemDerivedSurfacesForProvider is the provider-neutral implementation
+// for the three resolver-backed daily surfaces. It deliberately leaves the
+// row's provider untouched; the source provider is a tenancy boundary, not a
+// cosmetic label that may be rewritten for code reuse.
+func buildWorkItemDerivedSurfacesForProvider(
+	provider string,
+	claim Claim,
+	rows githubWorkItemRows,
+	day time.Time,
+	computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) (githubWorkItemDerivedSurfaces, error) {
+	if claim.Validate() != nil || claim.Provider != provider ||
 		!isWorkItemFamilyDataset(claim.Dataset) || day.IsZero() || computedAt.IsZero() {
 		return githubWorkItemDerivedSurfaces{}, ErrInvalidConfiguration
 	}

--- a/internal/providersync/github_work_item_engine_destinations.go
+++ b/internal/providersync/github_work_item_engine_destinations.go
@@ -125,24 +125,27 @@ func (engine *GitHubWorkItemEngineDeriver) Derive(
 		return nil, err
 	}
 
-	result := make(map[string][]json.RawMessage, len(githubWorkItemDerivedEngineDestinations))
+	var issueTypeMetrics, investmentClassifications, metrics []json.RawMessage
 	for _, destination := range githubWorkItemDerivedEngineDestinations {
-		var encoded []json.RawMessage
 		var err error
 		switch destination {
 		case githubIssueTypeMetricsDestination:
-			encoded, err = marshalGitHubWorkItemDerivedRows(engineRows.IssueTypes)
+			issueTypeMetrics, err = marshalGitHubWorkItemDerivedRows(engineRows.IssueTypes)
 		case githubInvestmentClassificationsDestination:
-			encoded, err = marshalGitHubWorkItemDerivedRows(engineRows.Classifications)
+			investmentClassifications, err = marshalGitHubWorkItemDerivedRows(engineRows.Classifications)
 		case githubInvestmentMetricsDestination:
-			encoded, err = marshalGitHubWorkItemDerivedRows(engineRows.InvestmentMetrics)
+			metrics, err = marshalGitHubWorkItemDerivedRows(engineRows.InvestmentMetrics)
 		default:
 			return nil, ErrInvalidConfiguration
 		}
 		if err != nil {
 			return nil, err
 		}
-		result[destination] = encoded
+	}
+	result := map[string][]json.RawMessage{
+		githubIssueTypeMetricsDestination:          issueTypeMetrics,
+		githubInvestmentClassificationsDestination: investmentClassifications,
+		githubInvestmentMetricsDestination:         metrics,
 	}
 	if len(result) != len(githubWorkItemDerivedEngineDestinations) {
 		return nil, ErrInvalidConfiguration

--- a/internal/providersync/github_work_item_engine_destinations.go
+++ b/internal/providersync/github_work_item_engine_destinations.go
@@ -84,6 +84,16 @@ type GitHubWorkItemEngineDeriver struct {
 	investmentClassifier *InvestmentClassifier
 }
 
+// githubWorkItemEngineRows is the concrete, schema-aligned result of one
+// engine invocation. The legacy GitHub deriver still projects it onto its
+// historical JSON seam, while the GitLab port consumes these typed fields
+// directly so no provider result needs a generic destination map.
+type githubWorkItemEngineRows struct {
+	IssueTypes        []githubIssueTypeMetricsDailyRow
+	Classifications   []githubInvestmentClassificationDailyRow
+	InvestmentMetrics []githubInvestmentMetricsDailyRow
+}
+
 func NewGitHubWorkItemEngineDeriver(
 	statusMapping *StatusMapping,
 	investmentClassifier *InvestmentClassifier,
@@ -108,17 +118,58 @@ func (engine *GitHubWorkItemEngineDeriver) Derive(
 	computedAt time.Time,
 	derived githubWorkItemDerivationContext,
 ) (map[string][]json.RawMessage, error) {
+	engineRows, err := engine.deriveRowsForProvider(
+		ctx, "github", claim, rows, day, computedAt, derived,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]json.RawMessage, len(githubWorkItemDerivedEngineDestinations))
+	for _, destination := range githubWorkItemDerivedEngineDestinations {
+		var encoded []json.RawMessage
+		var err error
+		switch destination {
+		case githubIssueTypeMetricsDestination:
+			encoded, err = marshalGitHubWorkItemDerivedRows(engineRows.IssueTypes)
+		case githubInvestmentClassificationsDestination:
+			encoded, err = marshalGitHubWorkItemDerivedRows(engineRows.Classifications)
+		case githubInvestmentMetricsDestination:
+			encoded, err = marshalGitHubWorkItemDerivedRows(engineRows.InvestmentMetrics)
+		default:
+			return nil, ErrInvalidConfiguration
+		}
+		if err != nil {
+			return nil, err
+		}
+		result[destination] = encoded
+	}
+	if len(result) != len(githubWorkItemDerivedEngineDestinations) {
+		return nil, ErrInvalidConfiguration
+	}
+	return result, nil
+}
+
+func (engine *GitHubWorkItemEngineDeriver) deriveRowsForProvider(
+	ctx context.Context,
+	provider string,
+	claim Claim,
+	rows githubWorkItemRows,
+	day time.Time,
+	computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) (githubWorkItemEngineRows, error) {
 	if ctx == nil || engine == nil || engine.statusMapping == nil ||
 		engine.investmentClassifier == nil || claim.Validate() != nil ||
-		claim.Provider != "github" || !isWorkItemFamilyDataset(claim.Dataset) ||
+		claim.Provider != provider || !isWorkItemFamilyDataset(claim.Dataset) ||
 		day.IsZero() || computedAt.IsZero() {
-		return nil, ErrInvalidConfiguration
+		return githubWorkItemEngineRows{}, ErrInvalidConfiguration
 	}
 	for _, item := range rows.WorkItems {
 		// Validate before every time-window skip. A foreign future row is still a
 		// foreign row and must not become harmless merely because it is inactive.
 		if err := assertGitHubWorkItemDerivedTenancy(claim, item); err != nil {
-			return nil, err
+			return githubWorkItemEngineRows{}, err
 		}
 	}
 
@@ -134,30 +185,12 @@ func (engine *GitHubWorkItemEngineDeriver) Derive(
 		claim, rows, dayUTC, end, stamp, derived, engine.investmentClassifier,
 	)
 	if err != nil {
-		return nil, err
+		return githubWorkItemEngineRows{}, err
 	}
-
-	values := map[string]any{
-		githubIssueTypeMetricsDestination:          issueTypes,
-		githubInvestmentClassificationsDestination: classifications,
-		githubInvestmentMetricsDestination:         metrics,
-	}
-	result := make(map[string][]json.RawMessage, len(values))
-	for _, destination := range githubWorkItemDerivedEngineDestinations {
-		value, owned := values[destination]
-		if !owned {
-			return nil, ErrInvalidConfiguration
-		}
-		encoded, err := marshalGitHubWorkItemDerivedRows(value)
-		if err != nil {
-			return nil, err
-		}
-		result[destination] = encoded
-	}
-	if len(result) != len(values) {
-		return nil, ErrInvalidConfiguration
-	}
-	return result, nil
+	return githubWorkItemEngineRows{
+		IssueTypes: issueTypes, Classifications: classifications,
+		InvestmentMetrics: metrics,
+	}, nil
 }
 
 type githubNullableUUIDKey struct {

--- a/internal/providersync/github_work_item_metric_triplet.go
+++ b/internal/providersync/github_work_item_metric_triplet.go
@@ -167,7 +167,24 @@ func buildGitHubWorkItemMetricTriplet(
 	computedAt time.Time,
 	derived githubWorkItemDerivationContext,
 ) (githubWorkItemMetricTriplet, error) {
-	if claim.Validate() != nil || claim.Provider != "github" ||
+	return buildWorkItemMetricTripletForProvider(
+		"github", claim, rows, day, computedAt, derived,
+	)
+}
+
+// buildWorkItemMetricTripletForProvider keeps the metric computation identical
+// across providers while retaining the provider value on every schema row.
+// GitLab uses the same canonical WorkItem fields and resolver, but must never
+// be made to look like GitHub merely to reuse this arithmetic.
+func buildWorkItemMetricTripletForProvider(
+	provider string,
+	claim Claim,
+	rows githubWorkItemRows,
+	day time.Time,
+	computedAt time.Time,
+	derived githubWorkItemDerivationContext,
+) (githubWorkItemMetricTriplet, error) {
+	if claim.Validate() != nil || claim.Provider != provider ||
 		!isWorkItemFamilyDataset(claim.Dataset) || day.IsZero() || computedAt.IsZero() {
 		return githubWorkItemMetricTriplet{}, ErrInvalidConfiguration
 	}

--- a/internal/providersync/github_work_item_metric_triplet_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_metric_triplet_effects_clickhouse.go
@@ -374,7 +374,8 @@ func validateGitHubWorkItemMetricEffect[T any](
 	effect EffectBatch,
 	destination string,
 ) ([]T, error) {
-	if strings.TrimSpace(identity.OrgID) == "" || identity.Provider != "github" ||
+	if strings.TrimSpace(identity.OrgID) == "" ||
+		(identity.Provider != "github" && identity.Provider != "gitlab") ||
 		!isWorkItemFamilyDataset(identity.Dataset) || strings.TrimSpace(identity.Generation) == "" ||
 		identity.Destination != destination || effect.Destination != destination ||
 		identity.ContentDigest != effect.ContentDigest || identity.RowCount != len(effect.Rows) ||

--- a/internal/providersync/github_work_items_derivation_context.go
+++ b/internal/providersync/github_work_items_derivation_context.go
@@ -146,8 +146,25 @@ func loadGitHubWorkItemDerivationContext(
 	source githubWorkItemDerivationContextSource,
 	asOf time.Time,
 ) (githubWorkItemDerivationContext, error) {
+	return loadWorkItemDerivationContextForProvider(
+		ctx, "github", claim, rows, source, asOf,
+	)
+}
+
+// loadWorkItemDerivationContextForProvider is the provider-neutral context
+// loader shared by the GitHub and GitLab work-item families. The source facts
+// are already provider-keyed, so the resolver can apply the same canonical
+// precedence without copying or weakening the team-attribution contract.
+func loadWorkItemDerivationContextForProvider(
+	ctx context.Context,
+	provider string,
+	claim Claim,
+	rows githubWorkItemRows,
+	source githubWorkItemDerivationContextSource,
+	asOf time.Time,
+) (githubWorkItemDerivationContext, error) {
 	if ctx == nil || source == nil || claim.Validate() != nil ||
-		claim.Provider != "github" || claim.Dataset != "work-items" || asOf.IsZero() {
+		claim.Provider != provider || claim.Dataset != "work-items" || asOf.IsZero() {
 		return githubWorkItemDerivationContext{}, ErrInvalidConfiguration
 	}
 	for _, row := range rows.WorkItems {
@@ -774,7 +791,8 @@ func (source githubWorkItemClickHouseDerivationContextSource) Load(
 	request githubWorkItemDerivationLoadRequest,
 ) (githubWorkItemDerivationFacts, error) {
 	if ctx == nil || source.Conn == nil || source.Lease == nil || claim.Validate() != nil ||
-		claim.Provider != "github" || claim.Dataset != "work-items" || request.AsOf.IsZero() {
+		(claim.Provider != "github" && claim.Provider != "gitlab") ||
+		claim.Dataset != "work-items" || request.AsOf.IsZero() {
 		return githubWorkItemDerivationFacts{}, ErrInvalidConfiguration
 	}
 	if err := source.Lease.Assert(ctx); err != nil {

--- a/internal/providersync/gitlab_feature_flags_effects_integration_test.go
+++ b/internal/providersync/gitlab_feature_flags_effects_integration_test.go
@@ -1,0 +1,250 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// This test authors no DDL. The feature-flag and work-graph tables come from
+// the real ClickHouse migration chain applied by chschema, so nullable UUID,
+// String, Date, and DateTime64 behavior is exercised against the deployed
+// schema rather than a second hand-written copy.
+func TestGitLabFeatureFlagsEffectsAgainstMigratedSchema(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink := GitLabFeatureFlagsClickHouseEffects{Conn: conn, Lease: lease}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	// Deliberately include sub-millisecond digits: DateTime64(3) quantizes
+	// these on insert, and readback must compare the stored representation.
+	now := time.Date(2026, 8, 10, 12, 0, 0, 123456789, time.UTC)
+
+	t.Run("feature flag exact readback and version conflict", func(t *testing.T) {
+		created := now.Add(-24 * time.Hour)
+		archived := now.Add(-time.Hour)
+		row := launchDarklyFlagRow{
+			OrgID: claim.OrgID, Provider: "gitlab", FlagKey: "checkout-integration",
+			ProjectKey: "group/project", RepoID: "", Environment: "production",
+			FlagType: "new_version_flag", CreatedAt: &created, ArchivedAt: &archived,
+			LastSynced: now,
+		}
+		effect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag", EffectReplaySafe, []launchDarklyFlagRow{row})
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectAbsent)
+		if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectExact)
+
+		newer := row
+		newer.FlagType = "new_version_flag_v2"
+		newer.LastSynced = now.Add(time.Minute)
+		newerEffect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag", EffectReplaySafe, []launchDarklyFlagRow{newer})
+		if err := sink.WriteEffect(ctx, claim, newerEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectConflict)
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, newerEffect, EffectExact)
+	})
+
+	t.Run("same flag identity across environments remains exact after FINAL", func(t *testing.T) {
+		created := now.Add(-24 * time.Hour)
+		production := launchDarklyFlagRow{
+			OrgID: claim.OrgID, Provider: "gitlab", FlagKey: "checkout-environments",
+			ProjectKey: "group/project", RepoID: "", Environment: "production",
+			FlagType: "new_version_flag", CreatedAt: &created, LastSynced: now,
+		}
+		stagingCreated := now.Add(-23 * time.Hour)
+		staging := production
+		staging.Environment = "staging"
+		staging.CreatedAt = &stagingCreated
+		staging.LastSynced = now.Add(time.Second)
+		effect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag", EffectReplaySafe, []launchDarklyFlagRow{production, staging})
+		if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+			t.Fatal(err)
+		}
+		var physical, final uint64
+		if err := conn.QueryRow(ctx, `
+SELECT count()
+		FROM feature_flag
+		WHERE org_id = ? AND provider = ? AND project_key = ? AND flag_key = ?`,
+			claim.OrgID, "gitlab", "group/project", "checkout-environments",
+		).Scan(&physical); err != nil {
+			t.Fatal(err)
+		}
+		if err := conn.QueryRow(ctx, `
+	SELECT count()
+		FROM feature_flag FINAL
+		WHERE org_id = ? AND provider = ? AND project_key = ? AND flag_key = ?`,
+			claim.OrgID, "gitlab", "group/project", "checkout-environments",
+		).Scan(&final); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("feature_flag same-identity rows physical=%d final=%d", physical, final)
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectExact)
+	})
+
+	t.Run("event exact readback and divergent conflict", func(t *testing.T) {
+		event := launchDarklyEventRow{
+			OrgID: claim.OrgID, EventType: "toggle", FlagKey: "checkout-event",
+			Environment: "production", RepoID: "", ActorType: "snapshot",
+			PrevState: "off", NextState: "on", EventAt: now,
+			IngestedAt: now, SourceEventID: "gitlab-event-1", DedupeKey: "gitlab-event-1",
+		}
+		effect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag_event", EffectReadbackRequired, []launchDarklyEventRow{event})
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectAbsent)
+		if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectExact)
+
+		divergent := event
+		divergent.NextState = "off"
+		divergentEffect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag_event", EffectReadbackRequired, []launchDarklyEventRow{divergent})
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, divergentEffect, EffectConflict)
+	})
+
+	t.Run("replayed exact event remains exact after MergeTree duplicate", func(t *testing.T) {
+		event := launchDarklyEventRow{
+			OrgID: claim.OrgID, EventType: "toggle", FlagKey: "checkout-replay",
+			Environment: "production", RepoID: "", ActorType: "snapshot",
+			PrevState: "off", NextState: "on", EventAt: now,
+			IngestedAt: now, SourceEventID: "gitlab-event-replay", DedupeKey: "gitlab-event-replay",
+		}
+		effect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag_event", EffectReadbackRequired, []launchDarklyEventRow{event})
+		if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectExact)
+		if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+			t.Fatal(err)
+		}
+		var rows uint64
+		if err := conn.QueryRow(ctx, `
+SELECT count()
+FROM feature_flag_event
+WHERE org_id = ? AND dedupe_key = ?`, claim.OrgID, "gitlab-event-replay").Scan(&rows); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("feature_flag_event replay rows=%d", rows)
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectExact)
+	})
+
+	t.Run("work graph edge nullable repo exact readback and version conflict", func(t *testing.T) {
+		edge := launchDarklyEdgeRow{
+			EdgeID: "gitlab-edge-integration", SourceType: "feature_flag", SourceID: "flag",
+			TargetType: "file", TargetID: "group/project:checkout.go", EdgeType: "guards",
+			RepoID: "", Provider: "gitlab", Provenance: "native", Confidence: 0.875,
+			Evidence: "flag", DiscoveredAt: now.Add(-time.Minute), LastSynced: now,
+			EventAt: now.Add(-time.Minute), Day: "2026-08-10", OrgID: claim.OrgID,
+		}
+		effect := gitlabFeatureFlagsIntegrationEffect(t, "work_graph_edges", EffectReplaySafe, []launchDarklyEdgeRow{edge})
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectAbsent)
+		if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectExact)
+
+		newer := edge
+		newer.Evidence = "flag-v2"
+		newer.LastSynced = now.Add(2 * time.Minute)
+		newerEffect := gitlabFeatureFlagsIntegrationEffect(t, "work_graph_edges", EffectReplaySafe, []launchDarklyEdgeRow{newer})
+		if err := sink.WriteEffect(ctx, claim, newerEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, effect, EffectConflict)
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, newerEffect, EffectExact)
+	})
+
+	t.Run("tenant fence remains independent", func(t *testing.T) {
+		foreignClaim := claim
+		foreignClaim.OrgID = "org-gitlab-foreign"
+		foreign := launchDarklyFlagRow{
+			OrgID: foreignClaim.OrgID, Provider: "gitlab", FlagKey: "tenant-integration",
+			ProjectKey: "group/project", Environment: "production", FlagType: "flag",
+			CreatedAt: &now, LastSynced: now,
+		}
+		foreignEffect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag", EffectReplaySafe, []launchDarklyFlagRow{foreign})
+		if err := sink.WriteEffect(ctx, foreignClaim, foreignEffect); err != nil {
+			t.Fatal(err)
+		}
+		local := foreign
+		local.OrgID = claim.OrgID
+		localEffect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag", EffectReplaySafe, []launchDarklyFlagRow{local})
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, localEffect, EffectAbsent)
+		if err := sink.WriteEffect(ctx, claim, localEffect); err != nil {
+			t.Fatal(err)
+		}
+		assertGitLabFeatureFlagsInspection(t, ctx, sink, claim, localEffect, EffectExact)
+	})
+
+	t.Run("forged row and forbidden link never reach ClickHouse", func(t *testing.T) {
+		forged := launchDarklyFlagRow{
+			OrgID: "org-forged", Provider: "gitlab", FlagKey: "forged",
+			ProjectKey: "group/project", Environment: "production", FlagType: "flag", CreatedAt: &now, LastSynced: now,
+		}
+		forgedEffect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag", EffectReplaySafe, []launchDarklyFlagRow{forged})
+		if err := sink.WriteEffect(ctx, claim, forgedEffect); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+			t.Fatalf("forged write error=%v", err)
+		}
+		linkEffect := gitlabFeatureFlagsIntegrationEffect(t, "feature_flag_link", EffectReplaySafe, []launchDarklyLinkRow{{OrgID: claim.OrgID, Provider: "gitlab"}})
+		if err := sink.WriteEffect(ctx, claim, linkEffect); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("forbidden link write error=%v", err)
+		}
+	})
+}
+
+func assertGitLabFeatureFlagsInspection(
+	t *testing.T,
+	ctx context.Context,
+	sink GitLabFeatureFlagsClickHouseEffects,
+	claim Claim,
+	effect EffectBatch,
+	want EffectInspection,
+) {
+	t.Helper()
+	got, err := sink.InspectEffect(ctx, claim, effect)
+	if err != nil || got != want {
+		t.Fatalf("inspection=%s error=%v want=%s", got, err, want)
+	}
+}
+
+func gitlabFeatureFlagsIntegrationEffect[T any](
+	t *testing.T,
+	destination string,
+	recovery EffectRecoveryPolicy,
+	rows []T,
+) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues(destination, recovery, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/gitlab_feature_flags_effects_test.go
+++ b/internal/providersync/gitlab_feature_flags_effects_test.go
@@ -1,0 +1,349 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects(t *testing.T) {
+	ctx := context.Background()
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink := GitLabFeatureFlagsClickHouseEffects{Lease: lease}
+
+	for _, test := range []struct {
+		destination string
+		recovery    EffectRecoveryPolicy
+	}{
+		{destination: "feature_flag", recovery: EffectReplaySafe},
+		{destination: "feature_flag_event", recovery: EffectReadbackRequired},
+		{destination: "work_graph_edges", recovery: EffectReplaySafe},
+	} {
+		t.Run(test.destination, func(t *testing.T) {
+			empty, err := effectBatchFromValues(test.destination, test.recovery, []any{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := sink.WriteEffect(ctx, claim, empty); err != nil {
+				t.Fatalf("empty write error=%v", err)
+			}
+			inspection, err := sink.InspectEffect(ctx, claim, empty)
+			if err != nil || inspection != EffectAbsent {
+				t.Fatalf("empty inspection=%s error=%v", inspection, err)
+			}
+		})
+	}
+
+	githubClaim := nativeTestClaim("github", "feature-flags")
+	empty, err := effectBatchFromValues("feature_flag", EffectReplaySafe, []any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, githubClaim, empty); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("GitLab sink accepted GitHub claim: %v", err)
+	}
+}
+
+func TestGitLabFeatureFlagsEffectsRejectProviderDatasetAndDestinationBeforeClickHouse(t *testing.T) {
+	ctx := context.Background()
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	valid, err := effectBatchFromValues(
+		"feature_flag",
+		EffectReplaySafe,
+		[]launchDarklyFlagRow{gitlabFeatureFlagsEffectFlag(claim, "scope")},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+
+	// Use another provider that legitimately supports the feature-flags
+	// dataset. A github claim would fail Claim.Validate before the sink's
+	// provider guard, so it cannot observe that guard's behavior.
+	wrongProvider := claim
+	wrongProvider.Provider = "launchdarkly"
+	tests := []struct {
+		name   string
+		claim  Claim
+		effect EffectBatch
+	}{
+		{name: "provider", claim: wrongProvider, effect: valid},
+		{name: "dataset", claim: nativeTestClaim("gitlab", "commits"), effect: valid},
+		{name: "destination", claim: claim, effect: func() EffectBatch {
+			wrong := valid
+			wrong.Destination = "feature_flag_link"
+			return wrong
+		}()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conn := &gitlabFeatureFlagsEffectsRecordingConn{}
+			sink := GitLabFeatureFlagsClickHouseEffects{Conn: conn, Lease: lease}
+			if err := sink.WriteEffect(ctx, test.claim, test.effect); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("write error=%v", err)
+			}
+			inspection, err := sink.InspectEffect(ctx, test.claim, test.effect)
+			if !errors.Is(err, ErrInvalidConfiguration) || inspection != EffectConflict {
+				t.Fatalf("inspection=%s error=%v", inspection, err)
+			}
+			if conn.prepares != 0 || conn.queries != 0 {
+				t.Fatalf("invalid request reached ClickHouse: prepares=%d queries=%d", conn.prepares, conn.queries)
+			}
+		})
+	}
+
+	linkEffect, err := effectBatchFromValues(
+		"feature_flag_link",
+		EffectReplaySafe,
+		[]launchDarklyLinkRow{{OrgID: claim.OrgID, Provider: "gitlab"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := (GitLabFeatureFlagsClickHouseEffects{Lease: lease}).WriteEffect(ctx, claim, linkEffect); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("GitLab sink accepted forbidden link destination: %v", err)
+	}
+}
+
+func TestGitLabFeatureFlagsEffectsFenceTenantAndLeaseBeforeClickHouse(t *testing.T) {
+	ctx := context.Background()
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	validEffect, err := effectBatchFromValues(
+		"feature_flag",
+		EffectReplaySafe,
+		[]launchDarklyFlagRow{gitlabFeatureFlagsEffectFlag(claim, "tenant")},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validLease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+
+	t.Run("forged org is rejected before ClickHouse", func(t *testing.T) {
+		forged := gitlabFeatureFlagsEffectFlag(claim, "forged")
+		forged.OrgID = "org-forged"
+		forgedEffect, err := effectBatchFromValues("feature_flag", EffectReplaySafe, []launchDarklyFlagRow{forged})
+		if err != nil {
+			t.Fatal(err)
+		}
+		conn := &gitlabFeatureFlagsEffectsRecordingConn{}
+		sink := GitLabFeatureFlagsClickHouseEffects{Conn: conn, Lease: validLease}
+
+		if err := sink.WriteEffect(ctx, claim, forgedEffect); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+			t.Fatalf("forged write error=%v", err)
+		}
+		inspection, err := sink.InspectEffect(ctx, claim, forgedEffect)
+		if !errors.Is(err, providerfoundation.ErrInvalidScope) || inspection != EffectConflict {
+			t.Fatalf("forged inspection=%s error=%v", inspection, err)
+		}
+		if conn.prepares != 0 || conn.queries != 0 {
+			t.Fatalf("forged tenant reached ClickHouse: prepares=%d queries=%d", conn.prepares, conn.queries)
+		}
+	})
+
+	t.Run("lost lease prevents prepare and query", func(t *testing.T) {
+		conn := &gitlabFeatureFlagsEffectsRecordingConn{}
+		lost := providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return providerfoundation.ErrLeaseLost
+		})
+		sink := GitLabFeatureFlagsClickHouseEffects{Conn: conn, Lease: lost}
+
+		if err := sink.WriteEffect(ctx, claim, validEffect); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+			t.Fatalf("pre-prepare lease error=%v", err)
+		}
+		inspection, err := sink.InspectEffect(ctx, claim, validEffect)
+		if !errors.Is(err, providerfoundation.ErrLeaseLost) || inspection != EffectConflict {
+			t.Fatalf("pre-query inspection=%s error=%v", inspection, err)
+		}
+		if conn.prepares != 0 || conn.queries != 0 {
+			t.Fatalf("lost lease reached ClickHouse: prepares=%d queries=%d", conn.prepares, conn.queries)
+		}
+	})
+
+	t.Run("second lease assertion prevents send", func(t *testing.T) {
+		conn := &gitlabFeatureFlagsEffectsRecordingConn{}
+		lostAfterAppend := &gitlabFeatureFlagsEffectsSecondAssertionLosesLease{}
+		sink := GitLabFeatureFlagsClickHouseEffects{Conn: conn, Lease: lostAfterAppend}
+
+		if err := sink.WriteEffect(ctx, claim, validEffect); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+			t.Fatalf("pre-send lease error=%v", err)
+		}
+		if lostAfterAppend.calls != 2 || conn.prepares != 1 || conn.batch == nil ||
+			conn.batch.appends != 1 || conn.batch.sends != 0 || conn.batch.aborts != 1 {
+			t.Fatalf(
+				"pre-send fence calls=%d prepares=%d batch=%+v",
+				lostAfterAppend.calls, conn.prepares, conn.batch,
+			)
+		}
+	})
+
+	t.Run("valid GitLab effect is written", func(t *testing.T) {
+		conn := &gitlabFeatureFlagsEffectsRecordingConn{}
+		sink := GitLabFeatureFlagsClickHouseEffects{Conn: conn, Lease: validLease}
+		if err := sink.WriteEffect(ctx, claim, validEffect); err != nil {
+			t.Fatalf("valid GitLab write error=%v", err)
+		}
+		if conn.prepares != 1 || conn.batch == nil || conn.batch.appends != 1 || conn.batch.sends != 1 {
+			t.Fatalf("GitLab write prepares=%d batch=%+v", conn.prepares, conn.batch)
+		}
+	})
+}
+
+func TestGitLabFeatureFlagsEffectsPreserveNullableStringAndTimeValues(t *testing.T) {
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	now := time.Date(2026, 8, 10, 1, 2, 3, 456000000, time.UTC)
+	archived := now.Add(-time.Hour)
+	flag := gitlabFeatureFlagsEffectFlag(claim, "nullable")
+	flag.RepoID = ""
+	flag.ArchivedAt = &archived
+	flag.CreatedAt = &now
+	flag.LastSynced = now
+	flagEffect, err := effectBatchFromValues("feature_flag", EffectReplaySafe, []launchDarklyFlagRow{flag})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	edge := launchDarklyEdgeRow{
+		EdgeID: "edge-nullable", SourceType: "feature_flag", SourceID: "flag", TargetType: "repo",
+		TargetID: "repo", EdgeType: "references", RepoID: "", Provider: "gitlab",
+		Provenance: "native", Confidence: 0.875, Evidence: "flag", DiscoveredAt: now,
+		LastSynced: now, EventAt: now, Day: "2026-08-10", OrgID: claim.OrgID,
+	}
+	edgeEffect, err := effectBatchFromValues("work_graph_edges", EffectReplaySafe, []launchDarklyEdgeRow{edge})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		effect EffectBatch
+		check  func(t *testing.T, values []any)
+	}{
+		{
+			name:   "feature flag nullable time",
+			effect: flagEffect,
+			check: func(t *testing.T, values []any) {
+				if len(values) != 10 {
+					t.Fatalf("append values=%d want 10: %#v", len(values), values)
+				}
+				if got, ok := values[8].(*time.Time); !ok || got == nil || !got.Equal(archived) {
+					t.Fatalf("archived_at=%T %#v", values[8], values[8])
+				}
+				if got, ok := values[9].(time.Time); !ok || !got.Equal(now) {
+					t.Fatalf("last_synced=%T %#v", values[9], values[9])
+				}
+			},
+		},
+		{
+			name:   "work graph nullable repo and times",
+			effect: edgeEffect,
+			check: func(t *testing.T, values []any) {
+				if len(values) != 16 {
+					t.Fatalf("append values=%d want 16: %#v", len(values), values)
+				}
+				if values[6] != nil {
+					t.Fatalf("empty nullable repo_id=%#v want nil", values[6])
+				}
+				if got, ok := values[11].(time.Time); !ok || !got.Equal(now) {
+					t.Fatalf("discovered_at=%T %#v", values[11], values[11])
+				}
+				if got, ok := values[13].(time.Time); !ok || !got.Equal(now) {
+					t.Fatalf("event_ts=%T %#v", values[13], values[13])
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			conn := &gitlabFeatureFlagsEffectsRecordingConn{}
+			sink := GitLabFeatureFlagsClickHouseEffects{
+				Conn:  conn,
+				Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+			}
+			if err := sink.WriteEffect(context.Background(), claim, test.effect); err != nil {
+				t.Fatal(err)
+			}
+			test.check(t, conn.batch.values[0])
+		})
+	}
+}
+
+func gitlabFeatureFlagsEffectFlag(claim Claim, suffix string) launchDarklyFlagRow {
+	now := time.Date(2026, 8, 10, 1, 2, 3, 0, time.UTC)
+	return launchDarklyFlagRow{
+		OrgID: claim.OrgID, Provider: "gitlab", FlagKey: "flag-" + suffix,
+		ProjectKey: "group/project", RepoID: "repo-" + suffix, Environment: "production",
+		FlagType: "new_version_flag", CreatedAt: &now, LastSynced: now,
+	}
+}
+
+type gitlabFeatureFlagsEffectsRecordingConn struct {
+	driver.Conn
+	prepares int
+	queries  int
+	batch    *gitlabFeatureFlagsEffectsRecordingBatch
+}
+
+func (conn *gitlabFeatureFlagsEffectsRecordingConn) PrepareBatch(
+	context.Context, string, ...driver.PrepareBatchOption,
+) (driver.Batch, error) {
+	conn.prepares++
+	conn.batch = &gitlabFeatureFlagsEffectsRecordingBatch{}
+	return conn.batch, nil
+}
+
+func (conn *gitlabFeatureFlagsEffectsRecordingConn) Query(
+	context.Context, string, ...any,
+) (driver.Rows, error) {
+	conn.queries++
+	return emptyGitLabFeatureFlagsEffectsRows{}, nil
+}
+
+type gitlabFeatureFlagsEffectsRecordingBatch struct {
+	driver.Batch
+	appends int
+	sends   int
+	aborts  int
+	values  [][]any
+}
+
+func (batch *gitlabFeatureFlagsEffectsRecordingBatch) Append(values ...any) error {
+	batch.appends++
+	batch.values = append(batch.values, append([]any(nil), values...))
+	return nil
+}
+
+func (batch *gitlabFeatureFlagsEffectsRecordingBatch) Send() error {
+	batch.sends++
+	return nil
+}
+
+func (batch *gitlabFeatureFlagsEffectsRecordingBatch) Abort() error {
+	batch.aborts++
+	return nil
+}
+
+type emptyGitLabFeatureFlagsEffectsRows struct{}
+
+func (emptyGitLabFeatureFlagsEffectsRows) Next() bool                       { return false }
+func (emptyGitLabFeatureFlagsEffectsRows) Scan(...any) error                { return nil }
+func (emptyGitLabFeatureFlagsEffectsRows) ScanStruct(any) error             { return nil }
+func (emptyGitLabFeatureFlagsEffectsRows) ColumnTypes() []driver.ColumnType { return nil }
+func (emptyGitLabFeatureFlagsEffectsRows) Totals(...any) error              { return nil }
+func (emptyGitLabFeatureFlagsEffectsRows) Columns() []string                { return nil }
+func (emptyGitLabFeatureFlagsEffectsRows) Close() error                     { return nil }
+func (emptyGitLabFeatureFlagsEffectsRows) Err() error                       { return nil }
+func (emptyGitLabFeatureFlagsEffectsRows) HasData() bool                    { return false }
+
+type gitlabFeatureFlagsEffectsSecondAssertionLosesLease struct{ calls int }
+
+func (guard *gitlabFeatureFlagsEffectsSecondAssertionLosesLease) Assert(context.Context) error {
+	guard.calls++
+	if guard.calls == 2 {
+		return providerfoundation.ErrLeaseLost
+	}
+	return nil
+}

--- a/internal/providersync/gitlab_feature_flags_generic_oracle_test.go
+++ b/internal/providersync/gitlab_feature_flags_generic_oracle_test.go
@@ -1,0 +1,356 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitLabFeatureFlagsOracleFlag struct {
+	OrgID       string     `json:"org_id"`
+	Provider    string     `json:"provider"`
+	FlagKey     string     `json:"flag_key"`
+	ProjectKey  string     `json:"project_key"`
+	RepoID      *string    `json:"repo_id"`
+	Environment string     `json:"environment"`
+	FlagType    string     `json:"flag_type"`
+	CreatedAt   *time.Time `json:"created_at"`
+	ArchivedAt  *time.Time `json:"archived_at"`
+	LastSynced  time.Time  `json:"last_synced"`
+}
+
+type gitLabFeatureFlagsOracleEvent struct {
+	OrgID         string    `json:"org_id"`
+	EventType     string    `json:"event_type"`
+	FlagKey       string    `json:"flag_key"`
+	Environment   string    `json:"environment"`
+	RepoID        *string   `json:"repo_id"`
+	ActorType     *string   `json:"actor_type"`
+	PrevState     *string   `json:"prev_state"`
+	NextState     *string   `json:"next_state"`
+	EventAt       time.Time `json:"event_ts"`
+	IngestedAt    time.Time `json:"ingested_at"`
+	SourceEventID *string   `json:"source_event_id"`
+	DedupeKey     string    `json:"dedupe_key"`
+}
+
+type gitLabFeatureFlagsOracleDate string
+
+func (value gitLabFeatureFlagsOracleDate) oracleDate() string { return string(value) }
+
+type gitLabFeatureFlagsOracleEdge struct {
+	EdgeID       string                       `json:"edge_id"`
+	SourceType   string                       `json:"source_type"`
+	SourceID     string                       `json:"source_id"`
+	TargetType   string                       `json:"target_type"`
+	TargetID     string                       `json:"target_id"`
+	EdgeType     string                       `json:"edge_type"`
+	RepoID       *string                      `json:"repo_id"`
+	Provider     *string                      `json:"provider"`
+	Provenance   string                       `json:"provenance"`
+	Confidence   float64                      `json:"confidence"`
+	Evidence     string                       `json:"evidence"`
+	DiscoveredAt time.Time                    `json:"discovered_at"`
+	LastSynced   time.Time                    `json:"last_synced"`
+	EventAt      time.Time                    `json:"event_ts"`
+	Day          gitLabFeatureFlagsOracleDate `json:"day"`
+	OrgID        string                       `json:"org_id"`
+}
+
+type gitLabFeatureFlagsOracleTrace struct {
+	Flags      []gitLabFeatureFlagsOracleFlag  `json:"flags"`
+	Events     []gitLabFeatureFlagsOracleEvent `json:"events"`
+	Edges      []gitLabFeatureFlagsOracleEdge  `json:"edges"`
+	ProjectKey string                          `json:"project_key"`
+	Requests   []string                        `json:"requests"`
+	Error      string                          `json:"error"`
+}
+
+type gitLabFeatureFlagsOracleDoer struct {
+	t         *testing.T
+	caseInput map[string]any
+	requests  []*http.Request
+}
+
+func (doer *gitLabFeatureFlagsOracleDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	path := request.URL.Path
+	query := request.URL.Query()
+	status := http.StatusOK
+	bodyValue := any([]any{})
+	headers := make(http.Header)
+	if stringsHasSuffix(path, "/feature_flags") {
+		status = oracleInt(doer.caseInput["flags_status"], http.StatusOK)
+		if configured, ok := doer.caseInput["flags_headers"].(map[string]any); ok {
+			for key, value := range configured {
+				headers.Set(key, oracleString(value))
+			}
+		}
+		page := oracleInt(query.Get("page"), 1)
+		pages, _ := doer.caseInput["flags_pages"].([]any)
+		if page-1 >= 0 && page-1 < len(pages) {
+			bodyValue = pages[page-1]
+		}
+		if nextPages, ok := doer.caseInput["next_pages"].([]any); ok && page-1 >= 0 && page-1 < len(nextPages) {
+			if next := oracleString(nextPages[page-1]); next != "" {
+				headers.Set("X-Next-Page", next)
+			}
+		}
+	} else {
+		status = oracleInt(doer.caseInput["project_status"], http.StatusOK)
+		bodyValue = doer.caseInput["project_payload"]
+	}
+	encoded, err := json.Marshal(bodyValue)
+	if err != nil {
+		doer.t.Fatal(err)
+	}
+	return &http.Response{
+		StatusCode: status, Header: headers, Body: ioNopCloser(bytes.NewReader(encoded)), Request: request,
+	}, nil
+}
+
+func stringsHasSuffix(value, suffix string) bool {
+	return len(value) >= len(suffix) && value[len(value)-len(suffix):] == suffix
+}
+
+func oracleInt(value any, fallback int) int {
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case float64:
+		return int(typed)
+	case string:
+		parsed, err := strconv.Atoi(typed)
+		if err == nil {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func oracleString(value any) string {
+	if value == nil {
+		return ""
+	}
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return strconv.FormatFloat(value.(float64), 'f', -1, 64)
+}
+
+func ioNopCloser(reader *bytes.Reader) *oracleReadCloser {
+	return &oracleReadCloser{Reader: reader}
+}
+
+type oracleReadCloser struct{ *bytes.Reader }
+
+func (oracleReadCloser) Close() error { return nil }
+
+func gitLabFeatureFlagsOracleGoError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) {
+		switch providerErr.Class {
+		case providerfoundation.ErrorRateLimited:
+			return "rate_limited"
+		case providerfoundation.ErrorAuthentication:
+			return "authentication"
+		default:
+			return "api"
+		}
+	}
+	if errors.Is(err, providerfoundation.ErrPaginationInvalid) ||
+		errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		return "api"
+	}
+	return "api"
+}
+
+func buildGitLabFeatureFlagsOracleTrace(t *testing.T, input map[string]any) gitLabFeatureFlagsOracleTrace {
+	t.Helper()
+	encodedNormalizedAt, ok := input["normalized_at"].(string)
+	if !ok {
+		t.Fatalf("normalized_at=%T", input["normalized_at"])
+	}
+	normalizedAt, err := time.Parse(time.RFC3339Nano, encodedNormalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doer := &gitLabFeatureFlagsOracleDoer{t: t, caseInput: input}
+	client := gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: oracleInt(input["max_retries"], 1),
+		InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	claim.OrgID = oracleString(input["org_id"])
+	claim.SourceExternalID = oracleString(input["project_id_or_path"])
+	claim.SourceName = claim.SourceExternalID
+	handler := GitLabFeatureFlagsRouteHandler{
+		MaxPages: oracleInt(input["max_pages"], 0),
+		PerPage:  oracleInt(input["per_page"], 0),
+	}
+	batch, collectErr := handler.Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt,
+	)
+	trace := gitLabFeatureFlagsOracleTrace{
+		Flags:      make([]gitLabFeatureFlagsOracleFlag, 0),
+		Events:     make([]gitLabFeatureFlagsOracleEvent, 0),
+		Edges:      make([]gitLabFeatureFlagsOracleEdge, 0),
+		Requests:   make([]string, 0, len(doer.requests)),
+		Error:      gitLabFeatureFlagsOracleGoError(collectErr),
+		ProjectKey: claim.SourceExternalID,
+	}
+	for _, request := range doer.requests {
+		trace.Requests = append(trace.Requests, request.URL.RequestURI())
+	}
+	for _, effect := range batch.Effects {
+		switch effect.Destination {
+		case "feature_flag":
+			for _, raw := range effect.Rows {
+				var row launchDarklyFlagRow
+				if err := json.Unmarshal(raw, &row); err != nil {
+					t.Fatal(err)
+				}
+				trace.Flags = append(trace.Flags, gitLabFeatureFlagsOracleFlag{
+					OrgID: row.OrgID, Provider: row.Provider, FlagKey: row.FlagKey,
+					ProjectKey: row.ProjectKey, RepoID: oracleOptionalString(row.RepoID), Environment: row.Environment,
+					FlagType: row.FlagType, CreatedAt: row.CreatedAt,
+					ArchivedAt: row.ArchivedAt, LastSynced: row.LastSynced,
+				})
+			}
+		case "feature_flag_event":
+			for _, raw := range effect.Rows {
+				var row launchDarklyEventRow
+				if err := json.Unmarshal(raw, &row); err != nil {
+					t.Fatal(err)
+				}
+				trace.Events = append(trace.Events, gitLabFeatureFlagsOracleEvent{
+					OrgID: row.OrgID, EventType: row.EventType, FlagKey: row.FlagKey,
+					Environment: row.Environment, RepoID: oracleOptionalString(row.RepoID),
+					ActorType: oracleOptionalString(row.ActorType), PrevState: oracleOptionalString(row.PrevState),
+					NextState: oracleOptionalString(row.NextState), EventAt: row.EventAt,
+					IngestedAt: row.IngestedAt, SourceEventID: oracleOptionalString(row.SourceEventID),
+					DedupeKey: row.DedupeKey,
+				})
+			}
+		case "work_graph_edges":
+			for _, raw := range effect.Rows {
+				var row launchDarklyEdgeRow
+				if err := json.Unmarshal(raw, &row); err != nil {
+					t.Fatal(err)
+				}
+				trace.Edges = append(trace.Edges, gitLabFeatureFlagsOracleEdge{
+					EdgeID: row.EdgeID, SourceType: row.SourceType, SourceID: row.SourceID,
+					TargetType: row.TargetType, TargetID: row.TargetID, EdgeType: row.EdgeType,
+					RepoID: oracleOptionalString(row.RepoID), Provider: oracleOptionalString(row.Provider),
+					Provenance: row.Provenance, Confidence: row.Confidence, Evidence: row.Evidence,
+					DiscoveredAt: row.DiscoveredAt, LastSynced: row.LastSynced, EventAt: row.EventAt,
+					Day: gitLabFeatureFlagsOracleDate(row.Day), OrgID: row.OrgID,
+				})
+			}
+		}
+	}
+	if project, ok := batch.Result["project_key"].(string); ok {
+		trace.ProjectKey = project
+	}
+	sort.Slice(trace.Edges, func(i, j int) bool {
+		if trace.Edges[i].EdgeID != trace.Edges[j].EdgeID {
+			return trace.Edges[i].EdgeID < trace.Edges[j].EdgeID
+		}
+		return trace.Edges[i].EdgeType < trace.Edges[j].EdgeType
+	})
+	return trace
+}
+
+func oracleOptionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func oracleGitLabFeatureFlagsCases() []oracleCase {
+	return []oracleCase{
+		{ID: "multi_scope_and_full_page_fallback", Input: map[string]any{
+			"org_id": "org-acme", "project_id_or_path": "group/project", "per_page": 2,
+			"normalized_at": "2026-08-10T12:00:00.123Z",
+			"flags_pages": []any{
+				[]any{
+					map[string]any{
+						"name": "checkout", "key": "checkout-key", "active": true, "version": "new_version_flag",
+						"created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-09T10:00:00Z",
+						"strategies": []any{map[string]any{
+							"scopes": []any{
+								map[string]any{"environment_scope": "production"},
+								map[string]any{"environment_scope": "production"},
+								map[string]any{"environment_scope": "staging"},
+							},
+						}},
+					},
+					map[string]any{
+						"name": "search", "active": false,
+						"created_at": "2026-08-02T10:00:00Z", "updated_at": "2026-08-09T11:00:00Z",
+						"strategies": []any{map[string]any{
+							"scopes": []any{map[string]any{"environment_scope": "*"}},
+						}},
+					},
+				},
+				[]any{map[string]any{
+					"key": "billing", "active": true, "updated_at": "2026-08-09T12:00:00Z",
+					"strategies": []any{},
+				}},
+			},
+			"project_payload": map[string]any{"path_with_namespace": "acme/api", "path": "acme/api-short"},
+		}},
+		{ID: "next_header_and_non_object_project_fallback", Input: map[string]any{
+			"org_id": "org-acme", "project_id_or_path": "123", "per_page": 2,
+			"normalized_at": "2026-08-10T12:00:00.123Z",
+			"flags_pages": []any{
+				[]any{map[string]any{
+					"name": "checkout", "active": true,
+					"created_at": "2026-08-01T10:00:00Z", "updated_at": "2026-08-09T10:00:00Z",
+					"strategies": []any{map[string]any{
+						"scopes": []any{map[string]any{"environment_scope": "production"}},
+					}},
+				}},
+				[]any{},
+			},
+			"next_pages": []any{"2", ""}, "project_payload": []any{},
+		}},
+		{ID: "non_list_flags_is_error", Input: map[string]any{
+			"org_id": "org-acme", "project_id_or_path": "123",
+			"normalized_at":   "2026-08-10T12:00:00.123Z",
+			"flags_pages":     []any{map[string]any{"items": []any{}}},
+			"project_payload": map[string]any{"path": "acme/api"},
+		}},
+		{ID: "plain_forbidden_is_authentication_error", Input: map[string]any{
+			"org_id": "org-acme", "project_id_or_path": "123",
+			"normalized_at": "2026-08-10T12:00:00.123Z", "flags_status": 403,
+			"flags_pages": []any{[]any{}}, "project_payload": map[string]any{},
+		}},
+		{ID: "qualified_forbidden_is_rate_limited", Input: map[string]any{
+			"org_id": "org-acme", "project_id_or_path": "123",
+			"normalized_at": "2026-08-10T12:00:00.123Z", "flags_status": 403,
+			"flags_headers": map[string]any{"Retry-After": "0"},
+			"flags_pages":   []any{[]any{}}, "project_payload": map[string]any{},
+		}},
+	}
+}
+
+func TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/feature/flags", oracleGitLabFeatureFlagsCases(),
+		buildGitLabFeatureFlagsOracleTrace, nil,
+	)
+}

--- a/internal/providersync/gitlab_feature_flags_route.go
+++ b/internal/providersync/gitlab_feature_flags_route.go
@@ -1,0 +1,510 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	// GitLabFeatureFlagsClient uses a 100-item page and a 1,000-page defensive
+	// bound. Unlike the Python client, the complete Go route refuses to advance
+	// the watermark when that bound is reached: a truncated inventory is not a
+	// complete unit.
+	gitLabFeatureFlagsDefaultPerPage = 100
+	gitLabFeatureFlagsMaxPages       = 1_000
+)
+
+// GitLabFeatureFlagsRouteHandler is the complete provider-local route for
+// gitlab/feature-flags. The request order deliberately follows
+// GitLabFeatureFlagsClient: feature-flag pages first, then the project GET
+// used to resolve the canonical path. No LaunchDarkly code-reference or link
+// behavior belongs on this provider route.
+type GitLabFeatureFlagsRouteHandler struct {
+	MaxPages int
+	PerPage  int
+}
+
+type gitLabFeatureFlagsCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer gitLabFeatureFlagsCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	*doer.attempts++
+	response, err := doer.delegate.Do(request)
+	if response != nil && gitLabFeatureFlagsQualified403(response) {
+		// providerfoundation's shared classifier intentionally gives GitLab's
+		// 403 the ordinary authentication meaning. GitLabFeatureFlagsClient has
+		// one provider-specific exception: a 403 carrying Retry-After or
+		// RateLimit-Remaining: 0 is a retryable throttle. Convert only that
+		// qualified shape to the shared 429 class at this provider boundary so
+		// the HTTP client's retry accounting remains physical and bounded.
+		response.StatusCode = http.StatusTooManyRequests
+	}
+	return response, err
+}
+
+func gitLabFeatureFlagsQualified403(response *http.Response) bool {
+	if response == nil || response.StatusCode != http.StatusForbidden {
+		return false
+	}
+	return strings.TrimSpace(gitLabFeatureFlagsHeaderValue(response.Header, "Retry-After")) != "" ||
+		strings.TrimSpace(gitLabFeatureFlagsHeaderValue(response.Header, "RateLimit-Remaining")) == "0"
+}
+
+func gitLabFeatureFlagsHeaderValue(headers http.Header, wanted string) string {
+	for key, values := range headers {
+		if strings.EqualFold(key, wanted) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func (handler GitLabFeatureFlagsRouteHandler) limits() (int, int, error) {
+	maxPages, perPage := handler.MaxPages, handler.PerPage
+	if maxPages == 0 {
+		maxPages = gitLabFeatureFlagsMaxPages
+	}
+	if perPage == 0 {
+		perPage = gitLabFeatureFlagsDefaultPerPage
+	}
+	if maxPages < 1 || maxPages > gitLabFeatureFlagsMaxPages || perPage < 1 || perPage > gitLabFeatureFlagsDefaultPerPage {
+		return 0, 0, ErrInvalidConfiguration
+	}
+	return maxPages, perPage, nil
+}
+
+func (handler GitLabFeatureFlagsRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "feature-flags" || client == nil ||
+		client.Provider != "gitlab" || client.BaseURL == nil || client.Doer == nil ||
+		normalizedAt.IsZero() || strings.TrimSpace(claim.SourceExternalID) == "" {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxPages, perPage, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	projectIDOrPath := strings.TrimSpace(claim.SourceExternalID)
+	requests := 0
+	counted := *client
+	counted.Doer = gitLabFeatureFlagsCountingDoer{
+		delegate: client.Doer, attempts: &requests,
+	}
+	flagsPath := providerRelativePath(
+		&counted, "api", "v4", "projects", projectIDOrPath, "feature_flags",
+	)
+	flagsPage, err := providerfoundation.CollectGitLabPageParamPages(
+		ctx, &counted, providerfoundation.GitLabPageOptions{
+			Path: flagsPath, PerPage: perPage, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	if flagsPage.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+
+	// The Python producer calls get_project_name only after the complete flag
+	// inventory. Keep this second physical request after all flag pages,
+	// including the empty terminating page.
+	projectPath := providerRelativePath(
+		&counted, "api", "v4", "projects", projectIDOrPath,
+	)
+	projectKey, err := fetchGitLabFeatureFlagProjectName(
+		ctx, &counted, projectPath, projectIDOrPath,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	flags, err := normalizeGitLabFeatureFlags(
+		flagsPage.Items, claim.OrgID, projectKey, normalizedAt,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	events, err := normalizeGitLabFeatureFlagEvents(
+		flagsPage.Items, claim.OrgID, projectKey, normalizedAt,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	edges := gitLabFeatureFlagEdges(flags, events, projectKey, normalizedAt)
+	flagEffect, err := effectBatchFromValues(
+		"feature_flag", EffectReplaySafe, flags,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	eventEffect, err := effectBatchFromValues(
+		"feature_flag_event", EffectReadbackRequired, events,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	edgeEffect, err := effectBatchFromValues(
+		"work_graph_edges", EffectReplaySafe, edges,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{flagEffect, eventEffect, edgeEffect},
+		Result: map[string]any{
+			"flags_synced": len(flags), "events_synced": len(events),
+			"project_key": projectKey, "project_id_or_path": projectIDOrPath,
+		},
+		Watermark: claim.BeforeAt,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: requests, Pages: flagsPage.Pages, Records: len(flags) + len(events) + len(edges),
+		},
+	}, nil
+}
+
+func fetchGitLabFeatureFlagProjectName(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	path string,
+	fallback string,
+) (string, error) {
+	response, err := client.Do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, nativeMaxObjectBytes+1))
+	if err != nil || len(body) > nativeMaxObjectBytes {
+		return "", providerfoundation.ErrNormalizationInvalid
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(body)))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", providerfoundation.ErrNormalizationInvalid
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return "", providerfoundation.ErrNormalizationInvalid
+	}
+	object, ok := value.(map[string]any)
+	if !ok || object == nil {
+		return fallback, nil
+	}
+	for _, key := range []string{"path_with_namespace", "path"} {
+		candidate, exists := object[key]
+		if !exists || !pythonTruthy(candidate) {
+			continue
+		}
+		if text := stringValue(candidate); text != "" {
+			return text, nil
+		}
+	}
+	return fallback, nil
+}
+
+func normalizeGitLabFeatureFlags(
+	items []json.RawMessage,
+	orgID string,
+	projectKey string,
+	normalizedAt time.Time,
+) ([]launchDarklyFlagRow, error) {
+	rows := make([]launchDarklyFlagRow, 0, len(items))
+	for _, raw := range items {
+		flag, err := decodeGitLabFeatureFlagObject(raw)
+		if err != nil {
+			return nil, err
+		}
+		scopes, err := gitLabFeatureFlagScopes(flag)
+		if err != nil {
+			return nil, err
+		}
+		createdAt := parseGitLabFeatureFlagTime(flag["created_at"])
+		if createdAt == nil {
+			fallback := normalizedAt.UTC()
+			createdAt = &fallback
+		}
+		flagKey := gitLabFeatureFlagFirstString(flag, "name", "key")
+		flagType := gitLabFeatureFlagFirstString(flag, "version")
+		if flagType == "" {
+			flagType = "new_version_flag"
+		}
+		for _, environment := range scopes {
+			rows = append(rows, launchDarklyFlagRow{
+				OrgID: orgID, Provider: "gitlab", FlagKey: flagKey,
+				ProjectKey: projectKey, Environment: environment,
+				FlagType: flagType, CreatedAt: createdAt,
+				LastSynced: normalizedAt.UTC(),
+			})
+		}
+	}
+	return rows, nil
+}
+
+func normalizeGitLabFeatureFlagEvents(
+	items []json.RawMessage,
+	orgID string,
+	projectKey string,
+	normalizedAt time.Time,
+) ([]launchDarklyEventRow, error) {
+	rows := make([]launchDarklyEventRow, 0, len(items))
+	for _, raw := range items {
+		flag, err := decodeGitLabFeatureFlagObject(raw)
+		if err != nil {
+			return nil, err
+		}
+		scopes, err := gitLabFeatureFlagScopes(flag)
+		if err != nil {
+			return nil, err
+		}
+		flagKey := gitLabFeatureFlagFirstString(flag, "name", "key")
+		state := "off"
+		if pythonTruthy(flag["active"]) {
+			state = "on"
+		}
+		eventAt := parseGitLabFeatureFlagTime(flag["updated_at"])
+		if eventAt == nil {
+			fallback := normalizedAt.UTC()
+			eventAt = &fallback
+		}
+		for _, environment := range scopes {
+			rows = append(rows, launchDarklyEventRow{
+				OrgID: orgID, EventType: "toggle", FlagKey: flagKey,
+				Environment: environment, ActorType: "snapshot",
+				NextState: state, EventAt: eventAt.UTC(),
+				IngestedAt: normalizedAt.UTC(), SourceEventID: flagKey,
+				DedupeKey: "gitlab:" + projectKey + ":" + flagKey + ":" + environment + ":" + state,
+			})
+		}
+	}
+	return rows, nil
+}
+
+func decodeGitLabFeatureFlagObject(raw json.RawMessage) (map[string]any, error) {
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	object, ok := value.(map[string]any)
+	if !ok || object == nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	return object, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return providerfoundation.ErrNormalizationInvalid
+		}
+		return err
+	}
+	return nil
+}
+
+func gitLabFeatureFlagScopes(flag map[string]any) ([]string, error) {
+	rawStrategies, exists := flag["strategies"]
+	if !exists || !pythonTruthy(rawStrategies) {
+		return []string{""}, nil
+	}
+	strategies, ok := rawStrategies.([]any)
+	if !ok {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	scopes := make([]string, 0)
+	for _, rawStrategy := range strategies {
+		strategy, ok := rawStrategy.(map[string]any)
+		if !ok || strategy == nil {
+			return nil, providerfoundation.ErrNormalizationInvalid
+		}
+		rawScopes, exists := strategy["scopes"]
+		if !exists || !pythonTruthy(rawScopes) {
+			continue
+		}
+		scopeValues, ok := rawScopes.([]any)
+		if !ok {
+			return nil, providerfoundation.ErrNormalizationInvalid
+		}
+		for _, rawScope := range scopeValues {
+			scope, ok := rawScope.(map[string]any)
+			if !ok || scope == nil {
+				return nil, providerfoundation.ErrNormalizationInvalid
+			}
+			environment := strings.TrimSpace(stringValue(scope["environment_scope"]))
+			if environment == "" {
+				continue
+			}
+			seen := false
+			for _, existing := range scopes {
+				if existing == environment {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				scopes = append(scopes, environment)
+			}
+		}
+	}
+	if len(scopes) == 0 {
+		return []string{""}, nil
+	}
+	return scopes, nil
+}
+
+func gitLabFeatureFlagFirstString(flag map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := flag[key]
+		if !ok || !pythonTruthy(value) {
+			continue
+		}
+		if text := stringValue(value); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func parseGitLabFeatureFlagTime(value any) *time.Time {
+	if !pythonTruthy(value) {
+		return nil
+	}
+	text := stringValue(value)
+	if text == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, text)
+	if err != nil {
+		for _, layout := range []string{
+			"2006-01-02T15:04:05.999999999", "2006-01-02 15:04:05.999999999",
+		} {
+			parsed, err = time.ParseInLocation(layout, text, time.UTC)
+			if err == nil {
+				break
+			}
+		}
+	}
+	if err != nil {
+		return nil
+	}
+	parsed = parsed.UTC()
+	return &parsed
+}
+
+func pythonTruthy(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return typed
+	case string:
+		return typed != ""
+	case json.Number:
+		if typed == "" {
+			return false
+		}
+		parsed, err := strconv.ParseFloat(typed.String(), 64)
+		return err != nil || parsed != 0
+	case float64:
+		return typed != 0
+	case []any:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return true
+	}
+}
+
+func gitLabFeatureFlagEdges(
+	flags []launchDarklyFlagRow,
+	events []launchDarklyEventRow,
+	fallbackProjectKey string,
+	normalizedAt time.Time,
+) []launchDarklyEdgeRow {
+	latest := map[string]launchDarklyEventRow{}
+	for _, event := range events {
+		current, ok := latest[event.FlagKey]
+		if !ok || event.EventAt.After(current.EventAt) {
+			latest[event.FlagKey] = event
+		}
+	}
+	edges := make([]launchDarklyEdgeRow, 0, len(flags)*2)
+	for _, flag := range flags {
+		projectKey := flag.ProjectKey
+		if projectKey == "" {
+			projectKey = fallbackProjectKey
+		}
+		flagID := launchDarklyFeatureFlagID(
+			flag.OrgID, flag.Provider, projectKey, flag.FlagKey,
+		)
+		eventAt := normalizedAt.UTC()
+		if flag.CreatedAt != nil {
+			eventAt = flag.CreatedAt.UTC()
+		}
+		edges = append(edges, newLaunchDarklyEdge(
+			flag.OrgID, flagID, "feature_flag", flagID, "feature_flag",
+			"relates", "", flag.Provider, 1.0,
+			"flag:"+flag.Provider+"/"+projectKey+"/"+flag.FlagKey,
+			eventAt, normalizedAt,
+		))
+		if event, ok := latest[flag.FlagKey]; ok {
+			evidence := gitLabFeatureFlagPythonISOTime(event.EventAt) + "|" +
+				event.EventType + "|" + event.NextState
+			edges = append(edges, newLaunchDarklyEdge(
+				flag.OrgID, flagID, "feature_flag", flagID, "feature_flag",
+				"config_changed_by", "", flag.Provider, 1.0,
+				evidence, event.EventAt, normalizedAt,
+			))
+		}
+	}
+	return edges
+}
+
+func gitLabFeatureFlagPythonISOTime(value time.Time) string {
+	text := value.UTC().Format(time.RFC3339Nano)
+	if strings.HasSuffix(text, "Z") {
+		text = strings.TrimSuffix(text, "Z") + "+00:00"
+	}
+	dot := strings.IndexByte(text, '.')
+	if dot < 0 {
+		return text
+	}
+	zone := strings.IndexAny(text[dot:], "+-")
+	if zone < 0 {
+		return text
+	}
+	zone += dot
+	frac := text[dot+1 : zone]
+	if len(frac) > 6 {
+		frac = frac[:6]
+	}
+	frac = strings.TrimRight(frac, "0")
+	if frac == "" {
+		return text[:dot] + text[zone:]
+	}
+	return text[:dot+1] + frac + text[zone:]
+}
+
+var _ CompleteRouteHandler = GitLabFeatureFlagsRouteHandler{}

--- a/internal/providersync/gitlab_feature_flags_route_test.go
+++ b/internal/providersync/gitlab_feature_flags_route_test.go
@@ -1,0 +1,321 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitLabFeatureFlagsResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type gitLabFeatureFlagsDoer struct {
+	t         *testing.T
+	responses []gitLabFeatureFlagsResponse
+	requests  []*http.Request
+}
+
+func (doer *gitLabFeatureFlagsDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	if len(doer.responses) == 0 {
+		doer.t.Fatalf("unexpected request %s", request.URL.RequestURI())
+	}
+	response := doer.responses[0]
+	doer.responses = doer.responses[1:]
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     response.headers,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func gitLabFeatureFlagsClient(
+	t *testing.T,
+	doer providerfoundation.HTTPDoer,
+	retry providerfoundation.RetryPolicy,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"gitlab", "https://gitlab.example", doer,
+		func(*http.Request) error { return nil }, retry,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests(t *testing.T) {
+	validAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	validRetry := providerfoundation.RetryPolicy{
+		MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	}
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		claim      func() Claim
+		client     func(t *testing.T, doer *gitLabFeatureFlagsDoer) *providerfoundation.HTTPClient
+		normalized time.Time
+		handler    GitLabFeatureFlagsRouteHandler
+	}{
+		{name: "nil context", ctx: nil},
+		{name: "invalid claim", claim: func() Claim {
+			claim := nativeTestClaim("gitlab", "feature-flags")
+			claim.OrgID = ""
+			return claim
+		}},
+		{name: "wrong claim provider", claim: func() Claim {
+			return nativeTestClaim("github", "feature-flags")
+		}},
+		{name: "wrong claim dataset", claim: func() Claim {
+			return nativeTestClaim("gitlab", "commits")
+		}},
+		{name: "nil client", client: func(*testing.T, *gitLabFeatureFlagsDoer) *providerfoundation.HTTPClient {
+			return nil
+		}},
+		{name: "wrong client provider", client: func(t *testing.T, doer *gitLabFeatureFlagsDoer) *providerfoundation.HTTPClient {
+			client := gitLabFeatureFlagsClient(t, doer, validRetry)
+			client.Provider = "github"
+			return client
+		}},
+		{name: "nil client base URL", client: func(t *testing.T, doer *gitLabFeatureFlagsDoer) *providerfoundation.HTTPClient {
+			client := gitLabFeatureFlagsClient(t, doer, validRetry)
+			client.BaseURL = nil
+			return client
+		}},
+		{name: "nil client doer", client: func(t *testing.T, doer *gitLabFeatureFlagsDoer) *providerfoundation.HTTPClient {
+			client := gitLabFeatureFlagsClient(t, doer, validRetry)
+			client.Doer = nil
+			return client
+		}},
+		{name: "zero normalized time", normalized: time.Time{}},
+		{name: "blank source id", claim: func() Claim {
+			claim := nativeTestClaim("gitlab", "feature-flags")
+			claim.SourceExternalID = "  "
+			return claim
+		}},
+		{name: "negative max pages", handler: GitLabFeatureFlagsRouteHandler{MaxPages: -1}},
+		{name: "excessive max pages", handler: GitLabFeatureFlagsRouteHandler{MaxPages: gitLabFeatureFlagsMaxPages + 1}},
+		{name: "negative page size", handler: GitLabFeatureFlagsRouteHandler{PerPage: -1}},
+		{name: "excessive page size", handler: GitLabFeatureFlagsRouteHandler{PerPage: gitLabFeatureFlagsDefaultPerPage + 1}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			doer := &gitLabFeatureFlagsDoer{t: t}
+			ctx := test.ctx
+			if test.name != "nil context" {
+				ctx = context.Background()
+			}
+			claim := nativeTestClaim("gitlab", "feature-flags")
+			if test.claim != nil {
+				claim = test.claim()
+			}
+			client := gitLabFeatureFlagsClient(t, doer, validRetry)
+			if test.client != nil {
+				client = test.client(t, doer)
+			}
+			normalizedAt := test.normalized
+			if test.name != "zero normalized time" {
+				normalizedAt = validAt
+			}
+
+			batch, err := test.handler.Collect(
+				ctx, claim, providerfoundation.Credential{}, client, normalizedAt,
+			)
+			if !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+			}
+			if len(doer.requests) != 0 || len(batch.Effects) != 0 || batch.Watermark != nil {
+				t.Fatalf("invalid configuration reached provider or effects: requests=%d batch=%+v", len(doer.requests), batch)
+			}
+		})
+	}
+}
+
+func TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects(t *testing.T) {
+	t.Parallel()
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 123456789, time.UTC)
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{body: `[
+			{"name":"checkout","active":true,"version":"new_version_flag","created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-09T10:00:00Z","strategies":[{"scopes":[{"environment_scope":"production"},{"environment_scope":"staging"}]}]},
+			{"name":"search","active":false,"created_at":"2026-08-02T10:00:00Z","updated_at":"2026-08-09T11:00:00Z","strategies":[{"scopes":[{"environment_scope":"*"}]}]}
+		]`, headers: http.Header{"X-Next-Page": {"2"}}},
+		{body: `[{"key":"billing","active":true,"updated_at":"2026-08-09T12:00:00Z","strategies":[]}]`},
+		{body: `{"path_with_namespace":"","path":"acme/api"}`},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	claim.SourceExternalID = "group/project"
+	claim.SourceName = "group/project"
+	batch, err := (GitLabFeatureFlagsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), normalizedAt,
+	)
+	if err != nil {
+		t.Fatalf("collect error=%v requests=%v", err, requestURLs(doer.requests))
+	}
+	if len(batch.Effects) != 3 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	byDestination := make(map[string]EffectBatch, len(batch.Effects))
+	for _, effect := range batch.Effects {
+		byDestination[effect.Destination] = effect
+	}
+	for _, destination := range []string{"feature_flag", "feature_flag_event", "work_graph_edges"} {
+		if _, ok := byDestination[destination]; !ok {
+			t.Fatalf("missing destination %q: %+v", destination, byDestination)
+		}
+	}
+	wantRecovery := map[string]EffectRecoveryPolicy{
+		"feature_flag":       EffectReplaySafe,
+		"feature_flag_event": EffectReadbackRequired,
+		"work_graph_edges":   EffectReplaySafe,
+	}
+	for destination, want := range wantRecovery {
+		if got := byDestination[destination].Recovery; got != want {
+			t.Fatalf("destination %q recovery=%q want=%q", destination, got, want)
+		}
+	}
+	if _, ok := byDestination["feature_flag_link"]; ok {
+		t.Fatal("GitLab route emitted LaunchDarkly-only feature_flag_link effect")
+	}
+	if len(byDestination["feature_flag"].Rows) != 4 ||
+		len(byDestination["feature_flag_event"].Rows) != 4 ||
+		len(byDestination["work_graph_edges"].Rows) != 8 {
+		t.Fatalf("row counts flags=%d events=%d edges=%d", len(byDestination["feature_flag"].Rows), len(byDestination["feature_flag_event"].Rows), len(byDestination["work_graph_edges"].Rows))
+	}
+	if batch.Evidence.Requests != 3 || batch.Evidence.Pages != 2 ||
+		batch.Evidence.Records != 16 || batch.Evidence.CapReached {
+		t.Fatalf("evidence=%+v", batch.Evidence)
+	}
+	if batch.Watermark == nil || claim.BeforeAt == nil ||
+		!batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark=%v claim_before=%v", batch.Watermark, claim.BeforeAt)
+	}
+	if got := batch.Result["project_key"]; got != "acme/api" {
+		t.Fatalf("project_key=%v", got)
+	}
+	if got := batch.Result["project_id_or_path"]; got != claim.SourceExternalID {
+		t.Fatalf("project_id_or_path=%v want=%q", got, claim.SourceExternalID)
+	}
+	if batch.Evidence.Provider != claim.Provider || batch.Evidence.Dataset != claim.Dataset {
+		t.Fatalf("evidence identity provider=%q dataset=%q want provider=%q dataset=%q", batch.Evidence.Provider, batch.Evidence.Dataset, claim.Provider, claim.Dataset)
+	}
+	wantRequests := []string{
+		"/api/v4/projects/group%2Fproject/feature_flags?page=1&per_page=100",
+		"/api/v4/projects/group%2Fproject/feature_flags?page=2&per_page=100",
+		"/api/v4/projects/group%2Fproject",
+	}
+	if len(doer.requests) != len(wantRequests) {
+		t.Fatalf("requests=%d want=%d paths=%v", len(doer.requests), len(wantRequests), requestURLs(doer.requests))
+	}
+	for index, want := range wantRequests {
+		if got := doer.requests[index].URL.RequestURI(); got != want {
+			t.Fatalf("request[%d]=%q want=%q", index, got, want)
+		}
+	}
+	var flag launchDarklyFlagRow
+	if err := json.Unmarshal(byDestination["feature_flag"].Rows[0], &flag); err != nil {
+		t.Fatal(err)
+	}
+	if flag.Provider != "gitlab" || flag.ProjectKey != "acme/api" ||
+		flag.OrgID != claim.OrgID || flag.LastSynced.IsZero() {
+		t.Fatalf("flag=%+v", flag)
+	}
+}
+
+func TestGitLabFeatureFlagsRouteFallsBackForNonObjectProject(t *testing.T) {
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{body: `[{"name":"checkout","active":true,"strategies":[]}]`},
+		{body: `[]`},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	batch, err := (GitLabFeatureFlagsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Result["project_key"] != claim.SourceExternalID || batch.Evidence.Requests != 2 {
+		t.Fatalf("batch=%+v", batch)
+	}
+}
+
+func TestGitLabFeatureFlagsRouteFailsClosedOnNonListFlags(t *testing.T) {
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{body: `{"items":[]}`},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	batch, err := (GitLabFeatureFlagsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, providerfoundation.ErrPaginationInvalid) &&
+		!errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("error=%v want invalid flags payload", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("failed collection returned effects/watermark: %+v", batch)
+	}
+}
+
+func TestGitLabFeatureFlagsRouteFailsClosedOnPaginationCap(t *testing.T) {
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{body: `[{"name":"checkout","strategies":[]}]`, headers: http.Header{"X-Next-Page": {"2"}}},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	batch, err := (GitLabFeatureFlagsRouteHandler{MaxPages: 1}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("error=%v want ErrPaginationCapExceeded", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil || len(doer.requests) != 1 {
+		t.Fatalf("failed capped collection batch=%+v requests=%d", batch, len(doer.requests))
+	}
+}
+
+func TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403(t *testing.T) {
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{status: http.StatusForbidden, body: `{}`, headers: http.Header{"ratelimit-remaining": {"0"}}},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	_, err := (GitLabFeatureFlagsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("error=%v want case-insensitive qualified rate limit", err)
+	}
+}

--- a/internal/providersync/gitlab_files_effects_clickhouse.go
+++ b/internal/providersync/gitlab_files_effects_clickhouse.go
@@ -1,0 +1,188 @@
+package providersync
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitLabFilesClickHouseEffects persists gitlab/files rows to the existing
+// tenant-qualified git_files ReplacingMergeTree. The schema and readback
+// comparison intentionally match GitHub files; the provider guard remains
+// local so a GitLab effect can never be accepted under the GitHub claim.
+type GitLabFilesClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "files" || effect.Destination != "git_files" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[gitFileRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.preserveExistingContents(ctx, claim, rows); err != nil {
+		return err
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `
+INSERT INTO git_files (repo_id, path, executable, contents, last_synced, org_id)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(row.RepoID, row.Path, row.Executable, row.Contents, row.LastSynced, row.OrgID); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+// preserveExistingContents mirrors base_git.backfill_file_records: a
+// paths-only rewrite must not replace known text with NULL in the shared
+// ReplacingMergeTree. Freshly fetched content remains authoritative; only
+// missing content is hydrated from the tenant-qualified winning row.
+func (sink GitLabFilesClickHouseEffects) preserveExistingContents(
+	ctx context.Context, claim Claim, rows []gitFileRow,
+) error {
+	for index := range rows {
+		if rows[index].Contents != nil {
+			continue
+		}
+		result, err := sink.Conn.Query(ctx, `
+SELECT contents FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`,
+			claim.OrgID, rows[index].RepoID, rows[index].Path)
+		if err != nil {
+			return err
+		}
+		var existing *string
+		found := false
+		for result.Next() {
+			if err := result.Scan(&existing); err != nil {
+				result.Close()
+				return err
+			}
+			found = true
+		}
+		if err := result.Err(); err != nil {
+			result.Close()
+			return err
+		}
+		result.Close()
+		if found && existing != nil {
+			rows[index].Contents = existing
+		}
+	}
+	return nil
+}
+
+func (sink GitLabFilesClickHouseEffects) InspectEffect(ctx context.Context, claim Claim, effect EffectBatch) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "files" || effect.Destination != "git_files" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[gitFileRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectGitLabFile(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT repo_id, path, executable, contents, last_synced, org_id
+FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`, expected.OrgID, expected.RepoID, expected.Path)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual gitFileVersion
+	for rows.Next() {
+		if err := rows.Scan(
+			&actual.Row.RepoID, &actual.Row.Path, &actual.Row.Executable, &actual.Row.Contents,
+			&actual.LastSynced, &actual.Row.OrgID,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.Found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareGitLabFileVersion(expected, actual), nil
+}
+
+func compareGitLabFileVersion(expected gitFileRow, actual gitFileVersion) EffectInspection {
+	if !actual.Found || actual.LastSynced.IsZero() || actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) || actual.Row.RepoID != expected.RepoID ||
+		actual.Row.Path != expected.Path || actual.Row.Executable != expected.Executable ||
+		actual.Row.OrgID != expected.OrgID ||
+		(expected.Contents != nil && !stringPointersEqual(actual.Row.Contents, expected.Contents)) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitLabFilesClickHouseEffects{}
+var _ EffectReadback = GitLabFilesClickHouseEffects{}

--- a/internal/providersync/gitlab_files_effects_integration_test.go
+++ b/internal/providersync/gitlab_files_effects_integration_test.go
@@ -1,0 +1,195 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+func TestGitLabFilesReadbackResolvesWinningReplacingMergeTreeVersion(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	claim := nativeTestClaim("gitlab", "files")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	current := gitFileRow{RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go", LastSynced: now, OrgID: claim.OrgID}
+	currentText := "package main\n"
+	current.Contents = &currentText
+	previous := current
+	previous.LastSynced = now.Add(-time.Hour)
+	previousText := "package old\n"
+	previous.Contents = &previousText
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, previous)); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale-only inspection=%s error=%v", inspection, err)
+	}
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil || inspection != EffectExact {
+		t.Fatalf("winning inspection=%s error=%v", inspection, err)
+	}
+	// Replaying the exact effect must converge on the same RMT winner rather
+	// than create a conflicting readback generation.
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, current)); err != nil || inspection != EffectExact {
+		t.Fatalf("replay inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabFilesReadbackScopesSameNaturalKeyByTenant(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	claim := nativeTestClaim("gitlab", "files")
+	claim.OrgID = "org-a"
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	row := gitFileRow{RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go", LastSynced: now, OrgID: claim.OrgID}
+	textA := "package orga\n"
+	row.Contents = &textA
+	otherClaim := claim
+	otherClaim.OrgID = "org-b"
+	otherRow := row
+	otherRow.OrgID = otherClaim.OrgID
+	textB := "package orgb\n"
+	otherRow.Contents = &textB
+	if err := sink.WriteEffect(ctx, otherClaim, gitLabFileEffect(t, otherRow)); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, row)); err != nil {
+		t.Fatal(err)
+	}
+	var count uint64
+	var minOrgID, maxOrgID, minContents, maxContents string
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT count(), min(org_id), max(org_id), min(ifNull(contents, '')), max(ifNull(contents, ''))
+FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`, row.OrgID, row.RepoID, row.Path).
+		Scan(&count, &minOrgID, &maxOrgID, &minContents, &maxContents); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || minOrgID != claim.OrgID || maxOrgID != claim.OrgID ||
+		minContents != textA || maxContents != textA {
+		t.Fatalf("tenant readback count=%d orgs=(%q,%q) contents=(%q,%q)", count, minOrgID, maxOrgID, minContents, maxContents)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, row)); err != nil || inspection != EffectExact {
+		t.Fatalf("claim inspection=%s error=%v", inspection, err)
+	}
+	if inspection, err := sink.InspectEffect(ctx, otherClaim, gitLabFileEffect(t, otherRow)); err != nil || inspection != EffectExact {
+		t.Fatalf("other tenant inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabFilesWritePreservesExistingContentsForPathsOnlyRewrite(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	claim := nativeTestClaim("gitlab", "files")
+	base := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	content := "package existing\n"
+	withContent := gitFileRow{
+		RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go",
+		Contents: &content, LastSynced: base, OrgID: claim.OrgID,
+	}
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, withContent)); err != nil {
+		t.Fatal(err)
+	}
+	pathsOnly := withContent
+	pathsOnly.Contents = nil
+	pathsOnly.LastSynced = base.Add(time.Hour)
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, pathsOnly)); err != nil {
+		t.Fatal(err)
+	}
+	var got *string
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT contents FROM git_files FINAL
+WHERE org_id = ? AND repo_id = ? AND path = ?`, claim.OrgID, withContent.RepoID, withContent.Path).
+		Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || *got != content {
+		t.Fatalf("paths-only rewrite lost existing content: %#v", got)
+	}
+	if inspection, err := sink.InspectEffect(ctx, claim, gitLabFileEffect(t, pathsOnly)); err != nil || inspection != EffectExact {
+		t.Fatalf("paths-only readback=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabFilesWriteRechecksLeaseBeforeClickHouseSend(t *testing.T) {
+	ctx, sink := newGitLabFilesIntegrationSink(t)
+	lease := &gitLabFilesLeaseAfterFirstAssert{}
+	sink.Lease = lease
+	claim := nativeTestClaim("gitlab", "files")
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	row := gitFileRow{
+		RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go",
+		LastSynced: now, OrgID: claim.OrgID,
+	}
+	text := "package main\n"
+	row.Contents = &text
+	if err := sink.WriteEffect(ctx, claim, gitLabFileEffect(t, row)); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("lease-before-send error=%v", err)
+	}
+	var count uint64
+	if err := sink.Conn.QueryRow(ctx, `
+SELECT count() FROM git_files FINAL WHERE org_id = ? AND repo_id = ? AND path = ?`,
+		row.OrgID, row.RepoID, row.Path).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("lease-lost write landed %d rows", count)
+	}
+}
+
+type gitLabFilesLeaseAfterFirstAssert struct{ calls int }
+
+func (lease *gitLabFilesLeaseAfterFirstAssert) Assert(context.Context) error {
+	lease.calls++
+	if lease.calls > 1 {
+		return providerfoundation.ErrLeaseLost
+	}
+	return nil
+}
+
+func newGitLabFilesIntegrationSink(t *testing.T) (context.Context, GitLabFilesClickHouseEffects) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, gitFilesDDL); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, GitLabFilesClickHouseEffects{
+		Conn:  conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+}
+
+func gitLabFileEffect(t *testing.T, row gitFileRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, []gitFileRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/gitlab_files_effects_test.go
+++ b/internal/providersync/gitlab_files_effects_test.go
@@ -1,0 +1,72 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func TestGitLabFilesEffectsValidateProviderAndEmptyBatches(t *testing.T) {
+	sink := GitLabFilesClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	empty := mustGitLabFileEffect(t, nil)
+	if err := sink.WriteEffect(context.Background(), claim, empty); err != nil {
+		t.Fatalf("empty write error=%v", err)
+	}
+	if inspection, err := sink.InspectEffect(context.Background(), claim, empty); err != nil || inspection != EffectAbsent {
+		t.Fatalf("empty inspect=%s error=%v", inspection, err)
+	}
+	wrongClaim := nativeTestClaim("github", "files")
+	if err := sink.WriteEffect(context.Background(), wrongClaim, empty); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong provider write error=%v", err)
+	}
+	if _, err := sink.InspectEffect(context.Background(), wrongClaim, empty); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong provider inspect error=%v", err)
+	}
+}
+
+func TestGitLabFilesEffectsAssertLeaseBeforeDecoding(t *testing.T) {
+	sink := GitLabFilesClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return errors.New("lease gone") }),
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	malformed := EffectBatch{Destination: "git_files", Rows: []json.RawMessage{{'n', 'o', 't', '-', 'j', 's', 'o', 'n'}}}
+	if err := sink.WriteEffect(context.Background(), claim, malformed); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("write lease error=%v", err)
+	}
+	if _, err := sink.InspectEffect(context.Background(), claim, malformed); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("inspect lease error=%v", err)
+	}
+}
+
+func TestGitLabFilesEffectsPathsOnlyReadbackAllowsExistingContent(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	expected := gitFileRow{
+		RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Path: "src/main.go",
+		LastSynced: now, OrgID: "org-a",
+	}
+	content := "package existing\n"
+	actual := expected
+	actual.Contents = &content
+	if got := compareGitLabFileVersion(expected, gitFileVersion{Row: actual, LastSynced: now, Found: true}); got != EffectExact {
+		t.Fatalf("paths-only readback=%s want exact", got)
+	}
+}
+
+func mustGitLabFileEffect(t *testing.T, rows []gitFileRow) EffectBatch {
+	t.Helper()
+	if rows == nil {
+		rows = []gitFileRow{}
+	}
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}

--- a/internal/providersync/gitlab_files_generic_oracle_test.go
+++ b/internal/providersync/gitlab_files_generic_oracle_test.go
@@ -116,16 +116,18 @@ type gitLabFilesTraceRow struct {
 }
 
 type gitLabFilesTraversalTrace struct {
-	ProducerRequests  []string                `json:"producer_requests"`
-	UsageRequestCount int                     `json:"usage_request_count"`
-	TreePaths         []string                `json:"tree_paths"`
-	Rows              []gitLabFilesTraceRow   `json:"rows"`
-	Incomplete        []GitLabFilesIncomplete `json:"incomplete"`
+	ProducerRequests      []string                `json:"producer_requests"`
+	RequestedContentPaths []string                `json:"requested_content_paths"`
+	UsageRequestCount     int                     `json:"usage_request_count"`
+	TreePaths             []string                `json:"tree_paths"`
+	Rows                  []gitLabFilesTraceRow   `json:"rows"`
+	Incomplete            []GitLabFilesIncomplete `json:"incomplete"`
 }
 
 type gitLabFilesTraceDoer struct {
 	t              *testing.T
 	requests       []*http.Request
+	contentPaths   []string
 	treePages      [][]map[string]any
 	nextPages      []string
 	commitRows     []map[string]any
@@ -165,6 +167,9 @@ func (doer *gitLabFilesTraceDoer) Do(request *http.Request) (*http.Response, err
 		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
 			t := doer.t
 			t.Fatal(err)
+		}
+		if strings.Contains(input.Query, "rawSize") || strings.Contains(input.Query, "rawTextBlob") {
+			doer.contentPaths = append(doer.contentPaths, input.Variables.Paths...)
 		}
 		if doer.contentFailure && strings.Contains(input.Query, "rawTextBlob") {
 			status = http.StatusInternalServerError
@@ -280,6 +285,27 @@ func TestGenericOracleMatchesLivePythonForGitLabFilesContentFailure(t *testing.T
 	)
 }
 
+func TestGenericOracleMatchesLivePythonForGitLabFilesCaseSensitiveExtensions(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/trace",
+		[]oracleCase{{ID: "case_sensitive_extensions", Input: map[string]any{
+			"repo_id":           "c7198fbc-1945-3717-05d8-eb78866b4e79",
+			"project_full_name": "Acme/API", "default_branch": "main",
+			"tree_pages": []any{[]any{
+				map[string]any{"path": "src/Main.GO", "type": "blob"},
+				map[string]any{"path": "src/mixed.Go", "type": "blob"},
+				map[string]any{"path": "src/main.go", "type": "blob"},
+			}},
+			"tree_next_pages": []any{},
+			"sizes":           map[string]any{"src/main.go": 15},
+			"contents":        map[string]any{"src/main.go": "package main\n"},
+		}}},
+		buildGitLabFilesTraversalTrace,
+		nil,
+	)
+}
+
 func buildGitLabFilesTraversalTrace(t *testing.T, input map[string]any) gitLabFilesTraversalTrace {
 	t.Helper()
 	treePages := make([][]map[string]any, 0)
@@ -321,11 +347,12 @@ func buildGitLabFilesTraversalTrace(t *testing.T, input map[string]any) gitLabFi
 		t.Fatalf("physical evidence=%+v requests=%d", batch.Evidence, len(doer.requests))
 	}
 	trace := gitLabFilesTraversalTrace{
-		ProducerRequests:  make([]string, 0, len(doer.requests)-1),
-		UsageRequestCount: batch.Evidence.Requests - 1,
-		TreePaths:         make([]string, 0),
-		Rows:              make([]gitLabFilesTraceRow, 0),
-		Incomplete:        make([]GitLabFilesIncomplete, 0),
+		ProducerRequests:      make([]string, 0, len(doer.requests)-1),
+		RequestedContentPaths: append([]string(nil), doer.contentPaths...),
+		UsageRequestCount:     batch.Evidence.Requests - 1,
+		TreePaths:             make([]string, 0),
+		Rows:                  make([]gitLabFilesTraceRow, 0),
+		Incomplete:            make([]GitLabFilesIncomplete, 0),
 	}
 	if raw, ok := batch.Result[gitLabFilesIncompleteResultKey]; ok {
 		var encoded []byte

--- a/internal/providersync/gitlab_files_generic_oracle_test.go
+++ b/internal/providersync/gitlab_files_generic_oracle_test.go
@@ -1,0 +1,386 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+var oracleGitLabFilesGoOnlyFields = map[string]string{
+	"last_synced": "stamped from the Go complete-route handler after Python backfill_file_records",
+	"org_id":      "carried from the Go claim to keep ClickHouse writes tenant-scoped",
+}
+
+type gitLabHTTPClassificationOracleRow struct {
+	IsRateLimit bool `json:"is_rate_limit"`
+}
+
+func buildGitLabHTTPClassificationOracleRow(t *testing.T, input map[string]any) gitLabHTTPClassificationOracleRow {
+	t.Helper()
+	headers := http.Header{}
+	for key, value := range input["headers"].(map[string]any) {
+		headers.Set(key, value.(string))
+	}
+	classified := providerfoundation.ClassifyHTTP(
+		"gitlab", int(input["status"].(int)), headers,
+	)
+	return gitLabHTTPClassificationOracleRow{
+		IsRateLimit: classified != nil && classified.Class == providerfoundation.ErrorRateLimited,
+	}
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesHTTPClassification(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/http-classification",
+		[]oracleCase{
+			{ID: "retry_after_qualified_403", Input: map[string]any{
+				"status": 403, "headers": map[string]any{"Retry-After": "2"},
+			}},
+			{ID: "remaining_zero_qualified_403", Input: map[string]any{
+				"status": 403, "headers": map[string]any{"RateLimit-Remaining": "0"},
+			}},
+			{ID: "plain_403_is_authentication", Input: map[string]any{
+				"status": 403, "headers": map[string]any{},
+			}},
+			{ID: "remaining_nonzero_is_authentication", Input: map[string]any{
+				"status": 403, "headers": map[string]any{"RateLimit-Remaining": "42"},
+			}},
+			{ID: "429_is_primary_rate_limit", Input: map[string]any{
+				"status": 429, "headers": map[string]any{"Retry-After": "2"},
+			}},
+		},
+		buildGitLabHTTPClassificationOracleRow,
+		nil,
+	)
+}
+
+func buildGitLabFileRowForOracle(t *testing.T, input map[string]any) gitFileRow {
+	t.Helper()
+	contents := make(map[string]string)
+	if existing, ok := input["existing_contents"].(map[string]any); ok {
+		for path, value := range existing {
+			contents[path] = value.(string)
+		}
+	}
+	for path, value := range input["contents_by_path"].(map[string]any) {
+		contents[path] = value.(string)
+	}
+	return newGitLabFileRow(
+		nativeTestClaim("gitlab", "files"),
+		input["repo_id"].(string), input["path"].(string), contents,
+		time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesWorkerRows(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/row",
+		[]oracleCase{
+			{ID: "scannable_content", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "src/main.go",
+				"contents_by_path": map[string]any{"src/main.go": "package main\n"},
+			}},
+			{ID: "path_only", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "README.md",
+				"contents_by_path": map[string]any{},
+			}},
+			{ID: "empty_text_is_distinct_from_missing", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "src/empty.go",
+				"contents_by_path": map[string]any{"src/empty.go": ""},
+			}},
+			{ID: "paths_only_preserves_existing_content", Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "path": "src/main.go",
+				"existing_contents": map[string]any{"src/main.go": "package existing\n"},
+				"contents_by_path":  map[string]any{},
+			}},
+		},
+		buildGitLabFileRowForOracle,
+		oracleGitLabFilesGoOnlyFields,
+	)
+}
+
+type gitLabFilesTraceRow struct {
+	Path       string  `json:"path"`
+	Executable bool    `json:"executable"`
+	Contents   *string `json:"contents"`
+}
+
+type gitLabFilesTraversalTrace struct {
+	ProducerRequests  []string                `json:"producer_requests"`
+	UsageRequestCount int                     `json:"usage_request_count"`
+	TreePaths         []string                `json:"tree_paths"`
+	Rows              []gitLabFilesTraceRow   `json:"rows"`
+	Incomplete        []GitLabFilesIncomplete `json:"incomplete"`
+}
+
+type gitLabFilesTraceDoer struct {
+	t              *testing.T
+	requests       []*http.Request
+	treePages      [][]map[string]any
+	nextPages      []string
+	commitRows     []map[string]any
+	sizes          map[string]int
+	contents       map[string]string
+	project        string
+	contentFailure bool
+}
+
+func (doer *gitLabFilesTraceDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	status := http.StatusOK
+	headers := http.Header{"Content-Type": []string{"application/json"}}
+	var body string
+	switch {
+	case request.URL.Path == "/api/v4/projects/123":
+		body = doer.project
+	case request.URL.Path == "/api/v4/projects/123/repository/commits":
+		body = marshalJSON(doer.t, doer.commitRows)
+	case request.URL.Path == "/api/v4/projects/123/repository/tree":
+		page := queryInt(request, "page")
+		if page < 1 || page > len(doer.treePages) {
+			doer.t.Fatalf("unexpected tree page=%d", page)
+		}
+		body = marshalJSON(doer.t, doer.treePages[page-1])
+		if page <= len(doer.nextPages) && doer.nextPages[page-1] != "" {
+			headers.Set("X-Next-Page", doer.nextPages[page-1])
+		}
+	case request.URL.Path == "/api/graphql":
+		var input struct {
+			Query     string `json:"query"`
+			Variables struct {
+				Paths []string `json:"paths"`
+			} `json:"variables"`
+		}
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t := doer.t
+			t.Fatal(err)
+		}
+		if doer.contentFailure && strings.Contains(input.Query, "rawTextBlob") {
+			status = http.StatusInternalServerError
+			body = `{}`
+			break
+		}
+		nodes := make([]map[string]any, 0, len(input.Variables.Paths))
+		for _, filePath := range input.Variables.Paths {
+			node := map[string]any{"path": filePath}
+			if strings.Contains(input.Query, "rawSize") {
+				node["rawSize"] = doer.sizes[filePath]
+			} else if content, ok := doer.contents[filePath]; ok {
+				node["rawTextBlob"] = content
+			} else {
+				node["rawTextBlob"] = nil
+			}
+			nodes = append(nodes, node)
+		}
+		body = marshalJSON(doer.t, map[string]any{
+			"data": map[string]any{"project": map[string]any{
+				"repository": map[string]any{"blobs": map[string]any{"nodes": nodes}},
+			}},
+		})
+	default:
+		doer.t.Fatalf("unexpected GitLab files trace request %s", request.URL)
+	}
+	return &http.Response{
+		StatusCode: status, Header: headers,
+		Body: io.NopCloser(strings.NewReader(body)), Request: request,
+	}, nil
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesTraversal(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/trace",
+		[]oracleCase{{ID: "paged_tree_and_content", Input: map[string]any{
+			"repo_id":           "c7198fbc-1945-3717-05d8-eb78866b4e79",
+			"project_full_name": "Acme/API", "default_branch": "main",
+			"tree_pages": []any{
+				[]any{
+					map[string]any{"path": "README.md", "type": "blob"},
+					map[string]any{"path": "src/main.go", "type": "blob"},
+				},
+				[]any{
+					map[string]any{"path": "tests/example.go", "type": "blob"},
+					map[string]any{"path": "src/oversized.go", "type": "blob"},
+				},
+			},
+			"tree_next_pages": []any{"2"},
+			"sizes":           map[string]any{"src/main.go": 15, "src/oversized.go": 1000001},
+			"contents":        map[string]any{"src/main.go": "package main\n"},
+		}}},
+		buildGitLabFilesTraversalTrace,
+		nil,
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesContentCap(t *testing.T) {
+	const count = 2_001
+	treePages := make([]any, 0, (count+99)/100)
+	treeNextPages := make([]any, 0, (count+99)/100-1)
+	sizes := make(map[string]any, count)
+	contents := map[string]any{"src/file0000.go": "package main\n"}
+	for index := 0; index < count; index++ {
+		filePath := fmt.Sprintf("src/file%04d.go", index)
+		pageIndex := index / 100
+		if pageIndex == len(treePages) {
+			treePages = append(treePages, []any{})
+			if pageIndex > 0 {
+				treeNextPages = append(treeNextPages, fmt.Sprintf("%d", pageIndex+1))
+			}
+		}
+		page := treePages[pageIndex].([]any)
+		page = append(page, map[string]any{"path": filePath, "type": "blob"})
+		treePages[pageIndex] = page
+		sizes[filePath] = 10
+	}
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/trace",
+		[]oracleCase{{ID: "content_cap", Input: map[string]any{
+			"repo_id":           "c7198fbc-1945-3717-05d8-eb78866b4e79",
+			"project_full_name": "Acme/API", "default_branch": "main",
+			"tree_pages":      treePages,
+			"tree_next_pages": treeNextPages,
+			"sizes":           sizes,
+			"contents":        contents,
+		}}},
+		buildGitLabFilesTraversalTrace,
+		nil,
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabFilesContentFailure(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t,
+		"gitlab/files/trace",
+		[]oracleCase{{ID: "ordinary_content_failure", Input: map[string]any{
+			"repo_id":           "c7198fbc-1945-3717-05d8-eb78866b4e79",
+			"project_full_name": "Acme/API", "default_branch": "main",
+			"tree_pages": []any{[]any{
+				map[string]any{"path": "README.md", "type": "blob"},
+				map[string]any{"path": "src/main.go", "type": "blob"},
+			}},
+			"tree_next_pages": []any{},
+			"sizes":           map[string]any{"src/main.go": 10},
+			"contents":        map[string]any{"src/main.go": "package main\n"},
+			"content_failure": true,
+		}}},
+		buildGitLabFilesTraversalTrace,
+		nil,
+	)
+}
+
+func buildGitLabFilesTraversalTrace(t *testing.T, input map[string]any) gitLabFilesTraversalTrace {
+	t.Helper()
+	treePages := make([][]map[string]any, 0)
+	for _, rawPage := range input["tree_pages"].([]any) {
+		page := make([]map[string]any, 0)
+		for _, rawItem := range rawPage.([]any) {
+			page = append(page, rawItem.(map[string]any))
+		}
+		treePages = append(treePages, page)
+	}
+	nextPages := make([]string, 0)
+	for _, value := range input["tree_next_pages"].([]any) {
+		nextPages = append(nextPages, value.(string))
+	}
+	sizes := make(map[string]int)
+	for path, value := range input["sizes"].(map[string]any) {
+		sizes[path] = int(value.(int))
+	}
+	contents := make(map[string]string)
+	for path, value := range input["contents"].(map[string]any) {
+		contents[path] = value.(string)
+	}
+	doer := &gitLabFilesTraceDoer{
+		t: t, project: gitLabRepositoryFixture, treePages: treePages,
+		nextPages: nextPages, sizes: sizes, contents: contents,
+		contentFailure: input["content_failure"] == true,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.test"), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) < 1 || batch.Evidence.Requests != len(doer.requests) {
+		t.Fatalf("physical evidence=%+v requests=%d", batch.Evidence, len(doer.requests))
+	}
+	trace := gitLabFilesTraversalTrace{
+		ProducerRequests:  make([]string, 0, len(doer.requests)-1),
+		UsageRequestCount: batch.Evidence.Requests - 1,
+		TreePaths:         make([]string, 0),
+		Rows:              make([]gitLabFilesTraceRow, 0),
+		Incomplete:        make([]GitLabFilesIncomplete, 0),
+	}
+	if raw, ok := batch.Result[gitLabFilesIncompleteResultKey]; ok {
+		var encoded []byte
+		encoded, err = json.Marshal(raw)
+		if err != nil || json.Unmarshal(encoded, &trace.Incomplete) != nil {
+			t.Fatalf("decode files incomplete evidence: %v", err)
+		}
+	}
+	for _, request := range doer.requests[1:] {
+		trace.ProducerRequests = append(trace.ProducerRequests, gitLabFilesTraceRequestURI(request))
+	}
+	for _, page := range treePages {
+		for _, item := range page {
+			if item["type"] == "blob" && item["path"] != nil {
+				trace.TreePaths = append(trace.TreePaths, item["path"].(string))
+			}
+		}
+	}
+	for _, effect := range batch.Effects {
+		if effect.Destination != "git_files" {
+			continue
+		}
+		for _, raw := range effect.Rows {
+			var row gitFileRow
+			if err := json.Unmarshal(raw, &row); err != nil {
+				t.Fatal(err)
+			}
+			trace.Rows = append(trace.Rows, gitLabFilesTraceRow{
+				Path: row.Path, Executable: row.Executable, Contents: row.Contents,
+			})
+		}
+	}
+	sort.Slice(trace.Rows, func(left, right int) bool { return trace.Rows[left].Path < trace.Rows[right].Path })
+	return trace
+}
+
+func gitLabFilesTraceRequestURI(request *http.Request) string {
+	uri := request.URL.RequestURI()
+	return strings.Replace(uri, "/api/v4/projects/123/", "/api/v4/projects/{project}/", 1)
+}
+
+func marshalJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(encoded)
+}
+
+func queryInt(request *http.Request, key string) int {
+	value := request.URL.Query().Get(key)
+	var parsed int
+	if _, err := fmt.Sscanf(value, "%d", &parsed); err != nil {
+		return 0
+	}
+	return parsed
+}

--- a/internal/providersync/gitlab_files_route.go
+++ b/internal/providersync/gitlab_files_route.go
@@ -1,0 +1,545 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const (
+	defaultGitLabFilesPerPage  = 100
+	defaultGitLabFilesMaxPages = 10_000
+	gitLabFileContentMaxBytes  = 1_000_000
+	gitLabFileContentMaxFiles  = 2_000
+	gitLabFileContentBatch     = 50
+	gitLabGraphQLResponseLimit = 64 << 20
+)
+
+// ErrGitLabFilesTraversalFailed marks a tree traversal that did not establish
+// a complete path inventory. Content traversal is deliberately softer: the
+// Python producer preserves available paths, records typed incompleteness, and
+// leaves the watermark nil so the content window is retried.
+var ErrGitLabFilesTraversalFailed = errors.New("gitlab files traversal failed")
+
+const gitLabFilesIncompleteResultKey = "gitlab_files_incomplete"
+
+// GitLabFilesIncomplete is durable evidence that the path inventory landed
+// but content coverage did not. It is intentionally JSON-safe because the
+// complete-route snapshot persists Result before effects are committed.
+type GitLabFilesIncomplete struct {
+	Cause    string `json:"cause"`
+	Subject  string `json:"subject"`
+	Limit    int    `json:"limit,omitempty"`
+	Observed int    `json:"observed,omitempty"`
+}
+
+type gitLabFilesContentStatus struct {
+	Incomplete []GitLabFilesIncomplete
+}
+
+func (status *gitLabFilesContentStatus) addIncomplete(cause string, limit, observed int) {
+	for _, existing := range status.Incomplete {
+		if existing.Cause == cause {
+			return
+		}
+	}
+	status.Incomplete = append(status.Incomplete, GitLabFilesIncomplete{
+		Cause: cause, Subject: "gitlab/files", Limit: limit, Observed: observed,
+	})
+}
+
+// GitLabFilesRouteHandler owns only the gitlab/files unit. GitLab's blame
+// dataset has a separate destination and remains outside this route.
+//
+// The handler follows the live Python producer's project -> bounded commit
+// ref -> recursive tree -> scanner-filtered GraphQL blob sequence. Tree
+// traversal errors fail closed so an incomplete path inventory cannot become
+// a successful empty effect. Ordinary content errors preserve paths, emit
+// typed incompleteness, and leave the watermark nil; rate limits still
+// propagate (D16 policy is recorded on CHAOS-3188).
+type GitLabFilesRouteHandler struct {
+	PerPage   int
+	MaxPages  int
+	MaxFiles  int
+	MaxBytes  int
+	BatchSize int
+}
+
+type gitLabFilesCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	attempts *int
+}
+
+func (doer gitLabFilesCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.attempts)++
+	return doer.delegate.Do(request)
+}
+
+type gitLabTreePayload struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+}
+
+type gitLabCommitRefPayload struct {
+	ID string `json:"id"`
+}
+
+type gitLabBlobNode struct {
+	Path        string          `json:"path"`
+	RawSize     json.RawMessage `json:"rawSize"`
+	RawTextBlob *string         `json:"rawTextBlob"`
+}
+
+func (handler GitLabFilesRouteHandler) limits() (int, int, int, int, int, error) {
+	perPage, maxPages, maxFiles, maxBytes, batchSize :=
+		handler.PerPage, handler.MaxPages, handler.MaxFiles, handler.MaxBytes, handler.BatchSize
+	if perPage == 0 {
+		perPage = defaultGitLabFilesPerPage
+	}
+	if maxPages == 0 {
+		maxPages = defaultGitLabFilesMaxPages
+	}
+	if maxFiles == 0 {
+		maxFiles = gitLabFileContentMaxFiles
+	}
+	if maxBytes == 0 {
+		maxBytes = gitLabFileContentMaxBytes
+	}
+	if batchSize == 0 {
+		batchSize = gitLabFileContentBatch
+	}
+	if perPage < 1 || perPage > defaultGitLabFilesPerPage || maxPages < 1 ||
+		maxPages > defaultGitLabFilesMaxPages || maxFiles < 1 ||
+		maxFiles > gitLabFileContentMaxFiles || maxBytes < 1 || batchSize < 1 ||
+		batchSize > gitLabFileContentBatch {
+		return 0, 0, 0, 0, 0, ErrInvalidConfiguration
+	}
+	return perPage, maxPages, maxFiles, maxBytes, batchSize, nil
+}
+
+func (handler GitLabFilesRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "files" || client == nil || client.Provider != "gitlab" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	perPage, maxPages, maxFiles, maxBytes, batchSize, err := handler.limits()
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	projectID, err := gitLabProjectID(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	requests := 0
+	counted := *client
+	counted.Doer = gitLabFilesCountingDoer{delegate: client.Doer, attempts: &requests}
+	root := providerRelativePath(&counted, "api", "v4", "projects", projectID)
+	var project repositoryPayload
+	if err := fetchObject(ctx, &counted, root, &project); err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	parsedProjectID, err := project.ID.Int64()
+	if err != nil || parsedProjectID < 1 || strconv.FormatInt(parsedProjectID, 10) != projectID {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(providerfoundation.ErrNormalizationInvalid)
+	}
+	fullName := gitLabProjectFullName(project)
+	repoID, err := repositoryIdentity(fullName)
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	branch := project.DefaultBranch
+	if branch == "" {
+		branch = "main"
+	}
+
+	treeRef, _, err := gitLabFilesTreeRef(
+		ctx, &counted, root, branch, claim.BeforeAt,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	if treeRef == "" {
+		return gitLabFilesBatch(claim, fullName, nil, nil, requests, 0)
+	}
+
+	tree, err := providerfoundation.CollectGitLabPageParamPages(ctx, &counted,
+		providerfoundation.GitLabPageOptions{
+			Path: root + "/repository/tree",
+			Query: url.Values{
+				"ref": {treeRef}, "recursive": {"true"},
+			},
+			PerPage: perPage, MaxPages: maxPages,
+		})
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	if tree.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	paths := make([]string, 0, len(tree.Items))
+	for _, raw := range tree.Items {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+			return CompleteRouteBatch{}, gitLabFilesTraversalError(providerfoundation.ErrNormalizationInvalid)
+		}
+		var item gitLabTreePayload
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return CompleteRouteBatch{}, gitLabFilesTraversalError(providerfoundation.ErrNormalizationInvalid)
+		}
+		if item.Type == "blob" && item.Path != "" {
+			paths = append(paths, item.Path)
+		}
+	}
+	contents, contentStatus, err := fetchGitLabFileContents(
+		ctx, &counted, fullName, treeRef, paths, maxFiles, maxBytes, batchSize,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+	}
+	rows := make([]gitFileRow, 0, len(paths))
+	for _, filePath := range paths {
+		row := newGitLabFileRow(claim, repoID, filePath, contents, normalizedAt)
+		if err := row.validate(claim); err != nil {
+			return CompleteRouteBatch{}, gitLabFilesTraversalError(err)
+		}
+		rows = append(rows, row)
+	}
+	return gitLabFilesBatch(
+		claim, fullName, rows, contentStatus.Incomplete, requests, tree.Pages,
+	)
+}
+
+func gitLabFilesTraversalError(err error) error {
+	if err == nil {
+		return ErrGitLabFilesTraversalFailed
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrGitLabFilesTraversalFailed, err)
+}
+
+func gitLabFilesTreeRef(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	root, branch string,
+	beforeAt *time.Time,
+) (string, int, error) {
+	if beforeAt == nil {
+		return branch, 0, nil
+	}
+	page, err := providerfoundation.CollectGitLabPageParamPages(ctx, client,
+		providerfoundation.GitLabPageOptions{
+			Path: root + "/repository/commits",
+			Query: url.Values{
+				"ref_name": {branch}, "until": {beforeAt.UTC().Format(time.RFC3339Nano)},
+			},
+			PerPage: 1, MaxPages: 1, SinglePage: true,
+		})
+	if err != nil {
+		return "", 0, err
+	}
+	if len(page.Items) == 0 {
+		return "", page.Pages, nil
+	}
+	var commit gitLabCommitRefPayload
+	if err := json.Unmarshal(page.Items[0], &commit); err != nil || strings.TrimSpace(commit.ID) == "" {
+		return "", page.Pages, providerfoundation.ErrNormalizationInvalid
+	}
+	return commit.ID, page.Pages, nil
+}
+
+func fetchGitLabFileContents(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	projectFullName, ref string,
+	paths []string,
+	maxFiles, maxBytes, batchSize int,
+) (map[string]string, gitLabFilesContentStatus, error) {
+	status := gitLabFilesContentStatus{}
+	allScannable := make([]string, 0, len(paths))
+	for _, filePath := range paths {
+		if !gitLabFileContentEligible(filePath) {
+			continue
+		}
+		allScannable = append(allScannable, filePath)
+	}
+	scannable := allScannable
+	if len(scannable) > maxFiles {
+		status.addIncomplete("content_cap", maxFiles, len(scannable))
+		scannable = scannable[:maxFiles]
+	}
+	if len(scannable) == 0 {
+		return map[string]string{}, status, nil
+	}
+
+	eligible := make([]string, 0, len(scannable))
+	requests := 0
+	for start := 0; start < len(scannable); start += batchSize {
+		end := min(start+batchSize, len(scannable))
+		nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, scannable[start:end], "path rawSize")
+		if err != nil {
+			if !gitLabFilesContentErrorDegradable(err) {
+				return nil, status, err
+			}
+			status.addIncomplete("content_size_fetch", 0, end-start)
+			eligible = append(eligible, scannable[start:end]...)
+			continue
+		}
+		requests++
+		for _, node := range nodes {
+			if node.Path == "" {
+				continue
+			}
+			size, err := gitLabRawSize(node.RawSize)
+			if err != nil {
+				status.addIncomplete("content_size_decode", 0, 1)
+				eligible = append(eligible, node.Path)
+				continue
+			}
+			if size == nil || *size <= maxBytes {
+				eligible = append(eligible, node.Path)
+			}
+		}
+	}
+
+	contents := make(map[string]string, len(eligible))
+	for start := 0; start < len(eligible); start += batchSize {
+		end := min(start+batchSize, len(eligible))
+		nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, eligible[start:end], "path rawTextBlob")
+		if err != nil {
+			if !gitLabFilesContentErrorDegradable(err) {
+				return nil, status, err
+			}
+			status.addIncomplete("content_fetch", 0, end-start)
+			continue
+		}
+		requests++
+		for _, node := range nodes {
+			if node.Path != "" && node.RawTextBlob != nil {
+				contents[node.Path] = *node.RawTextBlob
+			}
+		}
+	}
+	return contents, status, nil
+}
+
+func gitLabFilesContentErrorDegradable(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, providerfoundation.ErrLeaseLost) || errors.Is(err, providerfoundation.ErrBudgetUnavailable) {
+		return false
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) && providerErr.Class == providerfoundation.ErrorRateLimited {
+		return false
+	}
+	return true
+}
+
+func fetchGitLabGraphQLBlobs(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	projectFullName, ref string,
+	paths []string,
+	fields string,
+) ([]gitLabBlobNode, error) {
+	body, err := json.Marshal(map[string]any{
+		"query": gitLabBlobQuery(fields),
+		"variables": map[string]any{
+			"fullPath": projectFullName, "ref": ref, "paths": paths,
+		},
+	})
+	if err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	response, err := client.Do(ctx, http.MethodPost, gitLabGraphQLPath(client), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if response == nil || response.Body == nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	defer response.Body.Close()
+	payload, err := io.ReadAll(io.LimitReader(response.Body, gitLabGraphQLResponseLimit+1))
+	if err != nil || len(payload) > gitLabGraphQLResponseLimit {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	var envelope struct {
+		Data struct {
+			Project *struct {
+				Repository *struct {
+					Blobs *struct {
+						Nodes []gitLabBlobNode `json:"nodes"`
+					} `json:"blobs"`
+				} `json:"repository"`
+			} `json:"project"`
+		} `json:"data"`
+		Errors json.RawMessage `json:"errors"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	trimmedErrors := bytes.TrimSpace(envelope.Errors)
+	if len(trimmedErrors) > 0 && !bytes.Equal(trimmedErrors, []byte("null")) && !bytes.Equal(trimmedErrors, []byte("[]")) {
+		return nil, providerfoundation.ErrGraphQLResponse
+	}
+	if envelope.Data.Project == nil || envelope.Data.Project.Repository == nil ||
+		envelope.Data.Project.Repository.Blobs == nil {
+		return nil, providerfoundation.ErrGraphQLResponse
+	}
+	return envelope.Data.Project.Repository.Blobs.Nodes, nil
+}
+
+func gitLabRawSize(raw json.RawMessage) (*int, error) {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	var value int
+	if err := json.Unmarshal(raw, &value); err != nil || value < 0 {
+		return nil, providerfoundation.ErrNormalizationInvalid
+	}
+	return &value, nil
+}
+
+func gitLabBlobQuery(fields string) string {
+	return "query($fullPath: ID!, $ref: String!, $paths: [String!]!) {\n" +
+		"  project(fullPath: $fullPath) {\n" +
+		"    repository {\n" +
+		"      blobs(ref: $ref, paths: $paths) {\n" +
+		"        nodes { " + fields + " }\n" +
+		"      }\n" +
+		"    }\n" +
+		"  }\n" +
+		"}"
+}
+
+func gitLabGraphQLPath(client *providerfoundation.HTTPClient) string {
+	base := strings.TrimSuffix(client.BaseURL.EscapedPath(), "/")
+	if strings.HasSuffix(base, "/api/v4") {
+		return strings.TrimSuffix(base, "/api/v4") + "/api/graphql"
+	}
+	return base + "/api/graphql"
+}
+
+func gitLabFileContentEligible(filePath string) bool {
+	for _, segment := range strings.Split(filePath, "/") {
+		switch segment {
+		case "migrations":
+			return false
+		case "tests":
+			return false
+		case "venv":
+			return false
+		case ".venv":
+			return false
+		case "node_modules":
+			return false
+		case "dist":
+			return false
+		case "build":
+			return false
+		case ".next":
+			return false
+		case "vendor":
+			return false
+		}
+	}
+	base := path.Base(filePath)
+	if base == "__init__.py" {
+		return false
+	}
+	if strings.HasSuffix(base, ".min.js") {
+		return false
+	}
+	if strings.HasSuffix(base, ".d.ts") {
+		return false
+	}
+	if strings.HasSuffix(base, ".config.js") {
+		return false
+	}
+	if strings.HasSuffix(base, ".config.ts") {
+		return false
+	}
+	if strings.HasSuffix(base, ".config.mjs") {
+		return false
+	}
+	switch strings.ToLower(path.Ext(base)) {
+	case ".py", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".go", ".rs", ".java", ".kt", ".kts", ".rb", ".php", ".c", ".h", ".cpp", ".cc", ".hpp", ".cs", ".swift", ".scala", ".m", ".mm", ".lua", ".vue":
+		return true
+	default:
+		return false
+	}
+}
+
+func newGitLabFileRow(claim Claim, repoID, filePath string, contents map[string]string, normalizedAt time.Time) gitFileRow {
+	row := gitFileRow{RepoID: repoID, Path: filePath, LastSynced: normalizedAt.UTC().Truncate(time.Millisecond), OrgID: claim.OrgID}
+	if content, ok := contents[filePath]; ok {
+		row.Contents = &content
+	}
+	return row
+}
+
+func gitLabFilesBatch(
+	claim Claim,
+	fullName string,
+	rows []gitFileRow,
+	incomplete []GitLabFilesIncomplete,
+	requests, pages int,
+) (CompleteRouteBatch, error) {
+	effect, err := effectBatchFromValues("git_files", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	inventoryStatus := "complete"
+	if len(rows) == 0 {
+		inventoryStatus = "empty"
+		if pages == 0 && claim.BeforeAt != nil {
+			inventoryStatus = "no_commit_at_bound"
+		}
+	}
+	result := map[string]any{
+		"files_synced": len(rows), "inventory_status": inventoryStatus, "repo": fullName,
+	}
+	if len(incomplete) != 0 {
+		result[gitLabFilesIncompleteResultKey] = append([]GitLabFilesIncomplete(nil), incomplete...)
+	}
+	watermark := claim.BeforeAt
+	capReached := false
+	if len(incomplete) != 0 {
+		watermark = nil
+		for _, partial := range incomplete {
+			if partial.Cause == "content_cap" {
+				capReached = true
+				break
+			}
+		}
+	}
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result:  result, Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: requests, Pages: pages, Records: len(rows), CapReached: capReached,
+		},
+	}, nil
+}
+
+var _ CompleteRouteHandler = GitLabFilesRouteHandler{}

--- a/internal/providersync/gitlab_files_route.go
+++ b/internal/providersync/gitlab_files_route.go
@@ -481,7 +481,11 @@ func gitLabFileContentEligible(filePath string) bool {
 	if strings.HasSuffix(base, ".config.mjs") {
 		return false
 	}
-	switch strings.ToLower(path.Ext(base)) {
+	// The Python producer applies the lowercase include_globs through
+	// fnmatch.fnmatch, which is case-sensitive on the supported worker
+	// platform. Keep the extension's source spelling instead of normalizing it:
+	// Main.GO and mixed.Go must remain paths-only, just as Python emits them.
+	switch path.Ext(base) {
 	case ".py", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".go", ".rs", ".java", ".kt", ".kts", ".rb", ".php", ".c", ".h", ".cpp", ".cc", ".hpp", ".cs", ".swift", ".scala", ".m", ".mm", ".lua", ".vue":
 		return true
 	default:

--- a/internal/providersync/gitlab_files_route_test.go
+++ b/internal/providersync/gitlab_files_route_test.go
@@ -560,6 +560,8 @@ func TestGitLabFileContentEligibilityMatchesComplexityScannerConfig(t *testing.T
 		want bool
 	}{
 		{path: "src/main.go", want: true},
+		{path: "src/Main.GO", want: false},
+		{path: "src/mixed.Go", want: false},
 		{path: "README.md", want: false},
 		{path: "tests/example.go", want: false},
 		{path: "migrations/001.go", want: false},

--- a/internal/providersync/gitlab_files_route_test.go
+++ b/internal/providersync/gitlab_files_route_test.go
@@ -1,0 +1,609 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitLabFilesResponse struct {
+	status  int
+	body    string
+	headers http.Header
+}
+
+type gitLabFilesDoer struct {
+	t             *testing.T
+	requests      []*http.Request
+	treeResponses map[string]gitLabFilesResponse
+	graphQLSize   gitLabFilesResponse
+	graphQLText   gitLabFilesResponse
+	project       gitLabFilesResponse
+	commits       gitLabFilesResponse
+	contentCalls  int
+	treeCalls     int
+}
+
+func (doer *gitLabFilesDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request)
+	response := gitLabFilesResponse{body: `{}`}
+	switch {
+	case request.URL.Path == "/api/v4/projects/123":
+		response = doer.project
+	case request.URL.Path == "/api/v4/projects/123/repository/tree":
+		doer.treeCalls++
+		response = doer.treeResponses[request.URL.Query().Get("page")]
+	case request.URL.Path == "/api/v4/projects/123/repository/commits":
+		response = doer.commits
+	case request.URL.Path == "/api/graphql":
+		doer.contentCalls++
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			doer.t.Fatal(err)
+		}
+		if strings.Contains(string(body), "rawSize") {
+			response = doer.graphQLSize
+		} else if strings.Contains(string(body), "rawTextBlob") {
+			response = doer.graphQLText
+		} else {
+			doer.t.Fatalf("unexpected GitLab GraphQL query=%s", body)
+		}
+	default:
+		doer.t.Fatalf("unexpected GitLab files request %s", request.URL)
+	}
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	headers := response.headers
+	if headers == nil {
+		headers = http.Header{"Content-Type": []string{"application/json"}}
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func gitLabFilesFixtureDoer(t *testing.T) *gitLabFilesDoer {
+	t.Helper()
+	return &gitLabFilesDoer{
+		t:       t,
+		project: gitLabFilesResponse{body: gitLabRepositoryFixture},
+		treeResponses: map[string]gitLabFilesResponse{
+			"1": {
+				body: `[{
+					"path":"README.md","type":"blob","size":20
+				},{"path":"src/main.go","type":"blob","size":15}]`,
+				headers: http.Header{"X-Next-Page": []string{"2"}},
+			},
+			"2": {
+				body: `[{
+					"path":"tests/example.go","type":"blob","size":20
+				},{"path":"src/types.d.ts","type":"blob","size":20}]`,
+				headers: http.Header{"X-Next-Page": []string{"3"}},
+			},
+			"3": {
+				body: `[{"path":"src/data.bin","type":"blob","size":8}]`,
+			},
+		},
+		graphQLSize: gitLabFilesResponse{
+			body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/main.go","rawSize":15}]}}}}}`,
+		},
+		graphQLText: gitLabFilesResponse{
+			body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/main.go","rawTextBlob":"package main\n"}]}}}}}`,
+		},
+	}
+}
+
+func TestGitLabFilesRouteTraversesTreeAndWritesNonEmptyInventory(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 987654321, time.UTC)
+	batch, err := (GitLabFilesRouteHandler{PerPage: 2, MaxPages: 4}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 6 || doer.treeCalls != 3 || doer.contentCalls != 2 {
+		t.Fatalf("requests=%d tree=%d content=%d", len(doer.requests), doer.treeCalls, doer.contentCalls)
+	}
+	if got := doer.requests[1].URL.Query(); got.Get("ref") != "main" || got.Get("recursive") != "true" ||
+		got.Get("page") != "1" || got.Get("per_page") != "2" {
+		t.Fatalf("tree query=%s", got.Encode())
+	}
+	if got := doer.requests[2].URL.Query().Get("page"); got != "2" {
+		t.Fatalf("second tree page=%q", got)
+	}
+	if got := doer.requests[3].URL.Query().Get("page"); got != "3" {
+		t.Fatalf("third tree page=%q", got)
+	}
+	if batch.Evidence.Provider != "gitlab" || batch.Evidence.Dataset != "files" ||
+		batch.Evidence.Requests != 6 || batch.Evidence.Pages != 3 || batch.Evidence.Records != 5 ||
+		batch.Evidence.CapReached || batch.Watermark != nil {
+		t.Fatalf("evidence=%+v watermark=%v", batch.Evidence, batch.Watermark)
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "git_files" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 5 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	rows := make(map[string]gitFileRow)
+	for _, raw := range batch.Effects[0].Rows {
+		var row gitFileRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		rows[row.Path] = row
+	}
+	if len(rows) != 5 || rows["src/main.go"].Contents == nil ||
+		*rows["src/main.go"].Contents != "package main\n" || rows["README.md"].Contents != nil ||
+		rows["tests/example.go"].Contents != nil || rows["src/types.d.ts"].Contents != nil ||
+		rows["src/data.bin"].Contents != nil {
+		t.Fatalf("rows=%+v", rows)
+	}
+	for _, row := range rows {
+		if row.OrgID != claim.OrgID || !row.LastSynced.Equal(normalizedAt.UTC().Truncate(time.Millisecond)) {
+			t.Fatalf("row scope/timestamp=%+v", row)
+		}
+	}
+	if batch.Result["inventory_status"] != "complete" || batch.Result["files_synced"] != 5 {
+		t.Fatalf("result=%+v", batch.Result)
+	}
+}
+
+func TestGitLabFilesRouteUsesPythonBoundRefAndDistinguishesNoCommit(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.commits = gitLabFilesResponse{body: `[]`}
+	claim := nativeTestClaim("gitlab", "files")
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 2 || doer.requests[1].URL.Query().Get("ref_name") != "main" ||
+		doer.requests[1].URL.Query().Get("until") != "2026-07-31T23:59:59Z" {
+		t.Fatalf("bound requests=%v", doer.requests)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 || batch.Watermark == nil ||
+		!batch.Watermark.Equal(*claim.BeforeAt) || batch.Evidence.Pages != 0 ||
+		batch.Result["inventory_status"] != "no_commit_at_bound" {
+		t.Fatalf("batch=%+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteReportsLegitimateEmptyTree(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{"1": {body: `[]`}}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 || batch.Evidence.Pages != 1 ||
+		batch.Result["inventory_status"] != "empty" {
+		t.Fatalf("batch=%+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteFailsClosedOnTreePaginationCap(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{PerPage: 2, MaxPages: 1}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, ErrPaginationCapExceeded) {
+		t.Fatalf("cap error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("capped traversal returned effects/watermark: %+v", batch)
+	}
+	if len(doer.requests) != 2 || doer.contentCalls != 0 {
+		t.Fatalf("requests=%d content=%d", len(doer.requests), doer.contentCalls)
+	}
+}
+
+func TestGitLabFilesRouteRejectsMalformedTreeItem(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{"1": {body: `[null]`}}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("malformed tree error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("malformed tree returned effects/watermark: %+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteDegradesGraphQLPayloadErrorToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{
+		body: `{"errors":[{"message":"repository unavailable"}]}`,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("GraphQL payload batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" {
+		t.Fatalf("GraphQL payload incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteDegradesMissingGraphQLRepositoryToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{body: `{"data":{"project":null}}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("missing GraphQL repository batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" {
+		t.Fatalf("missing GraphQL repository incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRoutePreservesEmptyTextAsPresentContent(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{
+		"1": {body: `[{"path":"src/empty.go","type":"blob","size":0}]`},
+	}
+	doer.graphQLSize = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/empty.go","rawSize":0}]}}}}}`,
+	}
+	doer.graphQLText = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/empty.go","rawTextBlob":""}]}}}}}`,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row gitFileRow
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 1 ||
+		json.Unmarshal(batch.Effects[0].Rows[0], &row) != nil || row.Contents == nil || *row.Contents != "" {
+		t.Fatalf("empty content row=%+v", row)
+	}
+}
+
+func TestGitLabFilesRouteDegradesGraphQLContentErrorToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusInternalServerError, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("content failure batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" || incomplete[0].Subject != "gitlab/files" {
+		t.Fatalf("content failure incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRoutePreservesRateLimitPropagation(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusTooManyRequests, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("rate error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("rate failure returned effects/watermark: %+v", batch)
+	}
+}
+
+func TestGitLabFilesRoutePreservesQualifiedForbiddenRateLimitPropagation(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{
+		status:  http.StatusForbidden,
+		body:    `{}`,
+		headers: http.Header{"RateLimit-Remaining": []string{"0"}},
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("qualified forbidden error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("qualified forbidden returned effects/watermark: %+v", batch)
+	}
+}
+
+func TestGitLabFilesRouteDegradesUnqualifiedForbiddenToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusForbidden, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("plain forbidden batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_size_fetch" {
+		t.Fatalf("plain forbidden incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteDegradesGraphQLTextFailureToPathsOnly(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLText = gitLabFilesResponse{status: http.StatusInternalServerError, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 5 || batch.Watermark != nil {
+		t.Fatalf("text failure batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_fetch" {
+		t.Fatalf("text failure incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteMarksContentCapIncompleteWithoutWatermark(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{
+		"1": {body: `[{"path":"src/a.go","type":"blob"},{"path":"src/b.go","type":"blob"},{"path":"src/c.go","type":"blob"}]`},
+	}
+	doer.commits = gitLabFilesResponse{body: `[{"id":"commit-cap"}]`}
+	doer.graphQLSize = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/a.go","rawSize":10},{"path":"src/b.go","rawSize":10}]}}}}}`,
+	}
+	doer.graphQLText = gitLabFilesResponse{
+		body: `{"data":{"project":{"repository":{"blobs":{"nodes":[{"path":"src/a.go","rawTextBlob":"a"},{"path":"src/b.go","rawTextBlob":"b"}]}}}}}`,
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	bound := time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC)
+	claim.BeforeAt = &bound
+	batch, err := (GitLabFilesRouteHandler{MaxFiles: 2}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 3 || batch.Watermark != nil || !batch.Evidence.CapReached {
+		t.Fatalf("cap batch=%+v", batch)
+	}
+	incomplete, ok := batch.Result[gitLabFilesIncompleteResultKey].([]GitLabFilesIncomplete)
+	if !ok || len(incomplete) != 1 || incomplete[0].Cause != "content_cap" || incomplete[0].Limit != 2 || incomplete[0].Observed != 3 {
+		t.Fatalf("cap incomplete=%#v", batch.Result[gitLabFilesIncompleteResultKey])
+	}
+}
+
+func TestGitLabFilesRouteReraisesGraphQLRateLimit(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.graphQLSize = gitLabFilesResponse{status: http.StatusTooManyRequests, body: `{}`}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	_, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("rate error=%v", err)
+	}
+}
+
+func TestGitLabFilesRouteCountsPhysicalRetryAttempts(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	client, err := providerfoundation.NewHTTPClient(
+		"gitlab", "https://gitlab.example", &retryingGitLabFilesDoer{delegate: doer},
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{MaxAttempts: 2, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{PerPage: 2, MaxPages: 4}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, time.Now().UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Evidence.Requests != 7 || len(doer.requests) != 6 {
+		t.Fatalf("evidence=%+v requests=%d", batch.Evidence, len(doer.requests))
+	}
+}
+
+type retryingGitLabFilesDoer struct {
+	delegate *gitLabFilesDoer
+	used     bool
+}
+
+func (doer *retryingGitLabFilesDoer) Do(request *http.Request) (*http.Response, error) {
+	if request.URL.Path == "/api/v4/projects/123/repository/tree" && !doer.used {
+		doer.used = true
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Request:    request,
+		}, nil
+	}
+	return doer.delegate.Do(request)
+}
+
+func TestGitLabFilesRouteRejectsBlameClaim(t *testing.T) {
+	claim := nativeTestClaim("gitlab", "blame")
+	_, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, gitLabFilesFixtureDoer(t), "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong dataset error=%v", err)
+	}
+}
+
+type deniedGitLabFilesBudget struct{}
+
+func (deniedGitLabFilesBudget) Acquire(context.Context, providerfoundation.BudgetKey) (providerfoundation.Reservation, error) {
+	return nil, providerfoundation.ErrBudgetUnavailable
+}
+
+func TestGitLabFilesRoutePropagatesBudgetDenialBeforeProviderWork(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	client := gitLabRepositoryClient(t, doer, "https://gitlab.example")
+	client.Budget = deniedGitLabFilesBudget{}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	_, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client, time.Now().UTC(),
+	)
+	if !errors.Is(err, providerfoundation.ErrBudgetUnavailable) {
+		t.Fatalf("budget error=%v", err)
+	}
+	if len(doer.requests) != 0 {
+		t.Fatalf("budget denial still reached provider: requests=%d", len(doer.requests))
+	}
+}
+
+func TestGitLabFileContentEligibilityMatchesComplexityScannerConfig(t *testing.T) {
+	for _, test := range []struct {
+		path string
+		want bool
+	}{
+		{path: "src/main.go", want: true},
+		{path: "README.md", want: false},
+		{path: "tests/example.go", want: false},
+		{path: "migrations/001.go", want: false},
+		{path: "venv/lib.go", want: false},
+		{path: ".venv/lib.go", want: false},
+		{path: "node_modules/pkg/index.js", want: false},
+		{path: "dist/bundle.js", want: false},
+		{path: "build/generated.go", want: false},
+		{path: ".next/server.js", want: false},
+		{path: "vendor/module.go", want: false},
+		{path: "src/__init__.py", want: false},
+		{path: "src/types.d.ts", want: false},
+		{path: "src/app.min.js", want: false},
+		{path: "src/app.config.js", want: false},
+		{path: "src/app.config.ts", want: false},
+		{path: "src/app.config.mjs", want: false},
+		{path: "src/data.bin", want: false},
+	} {
+		if got := gitLabFileContentEligible(test.path); got != test.want {
+			t.Fatalf("eligible(%q)=%v want %v", test.path, got, test.want)
+		}
+	}
+}
+
+func TestGitLabFilesRouteSkipsTreeEntriesAndRejectsProjectMismatch(t *testing.T) {
+	t.Parallel()
+	doer := gitLabFilesFixtureDoer(t)
+	doer.treeResponses = map[string]gitLabFilesResponse{"1": {body: `[{"path":"src","type":"tree"}]`}}
+	claim := nativeTestClaim("gitlab", "files")
+	claim.BeforeAt = nil
+	batch, err := (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, doer, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if err != nil || len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 {
+		t.Fatalf("tree-only batch=%+v error=%v", batch, err)
+	}
+	mismatch := gitLabFilesFixtureDoer(t)
+	mismatch.project = gitLabFilesResponse{body: `{"id":999,"path_with_namespace":"Acme/API"}`}
+	_, err = (GitLabFilesRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabRepositoryClient(t, mismatch, "https://gitlab.example"), time.Now().UTC(),
+	)
+	if !errors.Is(err, providerfoundation.ErrNormalizationInvalid) {
+		t.Fatalf("project mismatch error=%v", err)
+	}
+}

--- a/internal/providersync/gitlab_security_effects_clickhouse.go
+++ b/internal/providersync/gitlab_security_effects_clickhouse.go
@@ -1,0 +1,208 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitLabSecurityClickHouseEffects is the tenant-fenced persistence boundary
+// for security_alerts. The schema is supplied by the real migrated
+// ClickHouse chain; this file intentionally contains no local DDL.
+type GitLabSecurityClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitLabSecurityClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "gitlab" || claim.Dataset != "security" ||
+		effect.Destination != "security_alerts" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeGitLabSecurityRows(effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, `INSERT INTO security_alerts (org_id, repo_id, alert_id, source, severity, state, package_name, cve_id, url, title, description, created_at, fixed_at, dismissed_at, last_synced)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(
+			row.OrgID, row.RepoID, row.AlertID, row.Source, row.Severity,
+			row.State, row.PackageName, row.CVEID, row.URL, row.Title,
+			row.Description, row.CreatedAt, row.FixedAt, row.DismissedAt,
+			row.LastSynced,
+		); err != nil {
+			return err
+		}
+	}
+	// A lease can expire while PrepareBatch is building a large effect. Do not
+	// send a batch after that boundary; the caller can retry the same frozen
+	// manifest under a fresh lease.
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+func (sink GitLabSecurityClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "gitlab" || claim.Dataset != "security" ||
+		effect.Destination != "security_alerts" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeGitLabSecurityRows(effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectGitLabSecurityAlert(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	if exact == len(expected) {
+		return EffectExact, nil
+	}
+	if absent == len(expected) {
+		return EffectAbsent, nil
+	}
+	return EffectConflict, nil
+}
+
+func decodeGitLabSecurityRows(effect EffectBatch) ([]gitLabSecurityAlertRow, error) {
+	rows, err := decodeEffectRows[gitLabSecurityAlertRow](effect)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		key := row.OrgID + "\x00" + row.RepoID + "\x00" + row.AlertID
+		if _, duplicate := seen[key]; duplicate {
+			return nil, errors.Join(providerfoundation.ErrSinkDuplicate, ErrEffectRecoveryUnsafe)
+		}
+		seen[key] = struct{}{}
+	}
+	return rows, nil
+}
+
+func (sink GitLabSecurityClickHouseEffects) inspectGitLabSecurityAlert(
+	ctx context.Context,
+	expected gitLabSecurityAlertRow,
+) (EffectInspection, error) {
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	rows, err := sink.Conn.Query(ctx, `SELECT org_id, repo_id, alert_id, source, severity, state, package_name, cve_id, url, title, description, created_at, fixed_at, dismissed_at, last_synced FROM security_alerts FINAL WHERE org_id = ? AND repo_id = ? AND alert_id = ?`, expected.OrgID, expected.RepoID, expected.AlertID)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual gitLabSecurityAlertRow
+	found := 0
+	for rows.Next() {
+		if err := rows.Scan(
+			&actual.OrgID, &actual.RepoID, &actual.AlertID, &actual.Source,
+			&actual.Severity, &actual.State, &actual.PackageName, &actual.CVEID,
+			&actual.URL, &actual.Title, &actual.Description, &actual.CreatedAt,
+			&actual.FixedAt, &actual.DismissedAt, &actual.LastSynced,
+		); err != nil {
+			return EffectConflict, err
+		}
+		found++
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return gitLabSecurityReadbackDecision(found, expected, actual), nil
+}
+
+func gitLabSecurityReadbackDecision(
+	found int,
+	expected, actual gitLabSecurityAlertRow,
+) EffectInspection {
+	if found > 1 {
+		return EffectConflict
+	}
+	return compareGitLabSecurityAlertVersion(expected, actual, found == 1)
+}
+
+func compareGitLabSecurityAlertVersion(
+	expected, actual gitLabSecurityAlertRow,
+	found bool,
+) EffectInspection {
+	if !found || actual.LastSynced.IsZero() || actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) {
+		return EffectConflict
+	}
+	if actual.OrgID != expected.OrgID || actual.RepoID != expected.RepoID ||
+		actual.AlertID != expected.AlertID || actual.Source != expected.Source ||
+		!stringPointersEqual(actual.Severity, expected.Severity) ||
+		!stringPointersEqual(actual.State, expected.State) ||
+		!stringPointersEqual(actual.PackageName, expected.PackageName) ||
+		!stringPointersEqual(actual.CVEID, expected.CVEID) ||
+		!stringPointersEqual(actual.URL, expected.URL) ||
+		!stringPointersEqual(actual.Title, expected.Title) ||
+		!stringPointersEqual(actual.Description, expected.Description) ||
+		!actual.CreatedAt.UTC().Equal(expected.CreatedAt.UTC()) ||
+		!timePointersEqual(actual.FixedAt, expected.FixedAt) ||
+		!timePointersEqual(actual.DismissedAt, expected.DismissedAt) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+var _ EffectSink = GitLabSecurityClickHouseEffects{}
+var _ EffectReadback = GitLabSecurityClickHouseEffects{}

--- a/internal/providersync/gitlab_security_effects_integration_test.go
+++ b/internal/providersync/gitlab_security_effects_integration_test.go
@@ -1,0 +1,214 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/chschema"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// This integration proof authors no DDL.  security_alerts is created by the
+// real 032/033 migrations and rebuilt by 042 so org_id is the first component
+// of the ReplacingMergeTree key.  A hand-written table here would only prove a
+// second schema and could never catch drift in the production migration chain.
+func TestGitLabSecurityEffectsAgainstMigratedSchema(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+	conn := gitLabSecurityMigratedConnection(t, ctx)
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink := GitLabSecurityClickHouseEffects{Conn: conn, Lease: lease}
+
+	t.Run("migration exposes concrete tenant key and payload columns", func(t *testing.T) {
+		rows, err := conn.Query(ctx, `
+SELECT name, type
+FROM system.columns
+WHERE database = currentDatabase() AND table = 'security_alerts'
+ORDER BY name`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		columns := make(map[string]string)
+		for rows.Next() {
+			var name, columnType string
+			if err := rows.Scan(&name, &columnType); err != nil {
+				t.Fatal(err)
+			}
+			columns[name] = columnType
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		want := map[string]string{
+			"org_id":       "String",
+			"repo_id":      "UUID",
+			"alert_id":     "String",
+			"source":       "String",
+			"severity":     "Nullable(String)",
+			"state":        "Nullable(String)",
+			"package_name": "Nullable(String)",
+			"cve_id":       "Nullable(String)",
+			"url":          "Nullable(String)",
+			"title":        "Nullable(String)",
+			"description":  "Nullable(String)",
+			"created_at":   "DateTime64(3, 'UTC')",
+			"fixed_at":     "Nullable(DateTime64(3, 'UTC'))",
+			"dismissed_at": "Nullable(DateTime64(3, 'UTC'))",
+			"last_synced":  "DateTime64(3, 'UTC')",
+		}
+		if len(columns) != len(want) {
+			t.Fatalf("migrated security_alerts columns=%v want exactly=%v", columns, want)
+		}
+		for name, expected := range want {
+			if got := strings.ReplaceAll(columns[name], " ", ""); got != strings.ReplaceAll(expected, " ", "") {
+				t.Fatalf("column %s type=%q want=%q (all=%v)", name, columns[name], expected, columns)
+			}
+		}
+
+		var engine, sortingKey string
+		if err := conn.QueryRow(ctx, `
+SELECT engine, sorting_key
+FROM system.tables
+WHERE database = currentDatabase() AND name = 'security_alerts'`).Scan(&engine, &sortingKey); err != nil {
+			t.Fatal(err)
+		}
+		if engine != "ReplacingMergeTree" {
+			t.Fatalf("security_alerts engine=%q want ReplacingMergeTree", engine)
+		}
+		if normalized := strings.ReplaceAll(sortingKey, " ", ""); normalized != "org_id,repo_id,alert_id" {
+			t.Fatalf("security_alerts sorting key=%q want org_id,repo_id,alert_id", sortingKey)
+		}
+	})
+
+	// Stop background merges so count() proves physical replay/version rows;
+	// InspectEffect still uses FINAL and must resolve the logical winner.
+	if err := conn.Exec(ctx, `SYSTEM STOP MERGES security_alerts`); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Exec(ctx, `SYSTEM START MERGES security_alerts`); err != nil {
+			t.Errorf("resume security_alerts merges: %v", err)
+		}
+	})
+
+	claim := nativeTestClaim("gitlab", "security")
+	foreignClaim := claim
+	foreignClaim.OrgID = "org-gitlab-foreign"
+	now := time.Date(2026, 8, 10, 12, 0, 0, 123000000, time.UTC)
+
+	t.Run("same natural key remains tenant fenced", func(t *testing.T) {
+		foreign := gitLabSecurityIntegrationRow(foreignClaim, "tenant-collision", now)
+		current := gitLabSecurityIntegrationRow(claim, "tenant-collision", now)
+		if err := sink.WriteEffect(ctx, foreignClaim, gitLabSecurityIntegrationEffect(t, foreign)); err != nil {
+			t.Fatal(err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, current)); err != nil || inspection != EffectAbsent {
+			t.Fatalf("foreign row inspection=%s error=%v", inspection, err)
+		}
+		if err := sink.WriteEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, current)); err != nil {
+			t.Fatal(err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, current)); err != nil || inspection != EffectExact {
+			t.Fatalf("current row inspection=%s error=%v", inspection, err)
+		}
+		assertGitLabSecurityPhysicalRows(t, ctx, conn, current, 2)
+	})
+
+	t.Run("FINAL selects newer replay version", func(t *testing.T) {
+		stale := gitLabSecurityIntegrationRow(claim, "versioned", now)
+		newer := stale
+		newer.LastSynced = now.Add(time.Minute)
+		newer.Title = gitLabSecurityStringPointer("newer")
+		if err := sink.WriteEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, stale)); err != nil {
+			t.Fatal(err)
+		}
+		if err := sink.WriteEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, newer)); err != nil {
+			t.Fatal(err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, stale)); err != nil || inspection != EffectConflict {
+			t.Fatalf("stale row inspection=%s error=%v", inspection, err)
+		}
+		if inspection, err := sink.InspectEffect(ctx, claim, gitLabSecurityIntegrationEffect(t, newer)); err != nil || inspection != EffectExact {
+			t.Fatalf("newer row inspection=%s error=%v", inspection, err)
+		}
+		assertGitLabSecurityPhysicalRows(t, ctx, conn, stale, 2)
+	})
+}
+
+func gitLabSecurityMigratedConnection(t *testing.T, ctx context.Context) driver.Conn {
+	t.Helper()
+	instance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	chschema.Apply(ctx, t, instance)
+	conn, err := clickhousestore.Open(ctx, clickhousestore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func gitLabSecurityIntegrationRow(claim Claim, alertID string, synced time.Time) gitLabSecurityAlertRow {
+	created := synced.Add(-time.Hour)
+	severity := "high"
+	state := "detected"
+	cve := "CVE-2026-3124"
+	url := "https://gitlab.example/acme/api/-/security/vulnerability/" + alertID
+	packageName := "example-package"
+	return gitLabSecurityAlertRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		AlertID: alertID, Source: "gitlab_vulnerability", Severity: &severity,
+		State: &state, PackageName: &packageName, CVEID: &cve, URL: &url,
+		Title: gitLabSecurityStringPointer("security finding"), CreatedAt: created,
+		LastSynced: synced,
+	}
+}
+
+func gitLabSecurityIntegrationEffect(t *testing.T, row gitLabSecurityAlertRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, []gitLabSecurityAlertRow{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func assertGitLabSecurityPhysicalRows(
+	t *testing.T,
+	ctx context.Context,
+	conn driver.Conn,
+	row gitLabSecurityAlertRow,
+	want uint64,
+) {
+	t.Helper()
+	var got uint64
+	if err := conn.QueryRow(ctx, `
+SELECT count()
+FROM security_alerts
+WHERE repo_id = ? AND alert_id = ?`, row.RepoID, row.AlertID).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("physical security_alerts rows=%d want=%d (%s)", got, want, fmt.Sprintf("%s/%s", row.OrgID, row.AlertID))
+	}
+}
+
+func gitLabSecurityStringPointer(value string) *string { return &value }

--- a/internal/providersync/gitlab_security_effects_test.go
+++ b/internal/providersync/gitlab_security_effects_test.go
@@ -1,0 +1,147 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func gitLabSecurityEffect(t *testing.T, rows ...gitLabSecurityAlertRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+func validGitLabSecurityRow(claim Claim) gitLabSecurityAlertRow {
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	fixedAt := now.Add(time.Minute)
+	dismissedAt := now.Add(2 * time.Minute)
+	return gitLabSecurityAlertRow{
+		OrgID: claim.OrgID, RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		AlertID: "gitlab_vuln:1", Source: "gitlab_vulnerability",
+		Severity: ptrString("high"), State: ptrString("detected"),
+		CVEID: ptrString("CVE-2026-0001"), URL: ptrString("https://example.invalid/1"),
+		Title: ptrString("finding"), Description: ptrString("description"),
+		CreatedAt: now, FixedAt: &fixedAt, DismissedAt: &dismissedAt, LastSynced: now,
+	}
+}
+
+func ptrString(value string) *string { return &value }
+
+func TestGitLabSecurityEffectsRejectCrossTenantAndDuplicateRowsBeforeClickHouse(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	sink := GitLabSecurityClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	foreign := validGitLabSecurityRow(claim)
+	foreign.OrgID = "other-org"
+	if err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t, foreign)); err == nil {
+		t.Fatal("foreign row passed sink validation")
+	}
+	row := validGitLabSecurityRow(claim)
+	err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t, row, row))
+	if !errors.Is(err, providerfoundation.ErrSinkDuplicate) {
+		t.Fatalf("duplicate error=%v", err)
+	}
+}
+
+func TestGitLabSecurityEffectsCheckLeaseBeforePrepareAndQuery(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	sink := GitLabSecurityClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return providerfoundation.ErrLeaseLost
+		}),
+	}
+	row := validGitLabSecurityRow(claim)
+	if err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t, row)); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("write error=%v", err)
+	}
+	inspection, err := sink.InspectEffect(context.Background(), claim, gitLabSecurityEffect(t, row))
+	if !errors.Is(err, providerfoundation.ErrLeaseLost) || inspection != EffectConflict {
+		t.Fatalf("inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabSecurityEffectsAllowLegitimateEmptyEffect(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	sink := GitLabSecurityClickHouseEffects{
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	}
+	if err := sink.WriteEffect(context.Background(), claim, gitLabSecurityEffect(t)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := sink.InspectEffect(context.Background(), claim, gitLabSecurityEffect(t))
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("inspection=%s error=%v", inspection, err)
+	}
+}
+
+func TestCompareGitLabSecurityAlertVersionChecksFullPayloadAndTimestamp(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	expected := validGitLabSecurityRow(claim)
+	if got := compareGitLabSecurityAlertVersion(expected, expected, true); got != EffectExact {
+		t.Fatalf("exact=%s", got)
+	}
+	if got := compareGitLabSecurityAlertVersion(expected, gitLabSecurityAlertRow{}, false); got != EffectAbsent {
+		t.Fatalf("absent=%s", got)
+	}
+	stale := expected
+	stale.LastSynced = stale.LastSynced.Add(-time.Second)
+	if got := compareGitLabSecurityAlertVersion(expected, stale, true); got != EffectAbsent {
+		t.Fatalf("stale=%s", got)
+	}
+	newer := expected
+	newer.LastSynced = newer.LastSynced.Add(time.Second)
+	if got := compareGitLabSecurityAlertVersion(expected, newer, true); got != EffectConflict {
+		t.Fatalf("newer=%s", got)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*gitLabSecurityAlertRow)
+	}{
+		{name: "org_id", mutate: func(row *gitLabSecurityAlertRow) { row.OrgID = "other-org" }},
+		{name: "repo_id", mutate: func(row *gitLabSecurityAlertRow) { row.RepoID = "2f2d6f7c-2f28-4d6b-a0b7-48ec4d77a4f0" }},
+		{name: "alert_id", mutate: func(row *gitLabSecurityAlertRow) { row.AlertID = "gitlab_vuln:changed" }},
+		{name: "source", mutate: func(row *gitLabSecurityAlertRow) { row.Source = "gitlab_dependency" }},
+		{name: "severity", mutate: func(row *gitLabSecurityAlertRow) { row.Severity = ptrString("low") }},
+		{name: "state", mutate: func(row *gitLabSecurityAlertRow) { row.State = ptrString("resolved") }},
+		{name: "package_name", mutate: func(row *gitLabSecurityAlertRow) { row.PackageName = ptrString("pkg") }},
+		{name: "cve_id", mutate: func(row *gitLabSecurityAlertRow) { row.CVEID = ptrString("CVE-2026-0002") }},
+		{name: "url", mutate: func(row *gitLabSecurityAlertRow) { row.URL = ptrString("https://example.invalid/changed") }},
+		{name: "title", mutate: func(row *gitLabSecurityAlertRow) { row.Title = ptrString("changed") }},
+		{name: "description", mutate: func(row *gitLabSecurityAlertRow) { row.Description = ptrString("changed") }},
+		{name: "created_at", mutate: func(row *gitLabSecurityAlertRow) { row.CreatedAt = row.CreatedAt.Add(time.Second) }},
+		{name: "fixed_at", mutate: func(row *gitLabSecurityAlertRow) { changed := row.FixedAt.Add(time.Second); row.FixedAt = &changed }},
+		{name: "dismissed_at", mutate: func(row *gitLabSecurityAlertRow) {
+			changed := row.DismissedAt.Add(time.Second)
+			row.DismissedAt = &changed
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := expected
+			test.mutate(&changed)
+			if got := compareGitLabSecurityAlertVersion(expected, changed, true); got != EffectConflict {
+				t.Fatalf("changed=%s", got)
+			}
+		})
+	}
+}
+
+func TestGitLabSecurityReadbackRejectsAmbiguousRows(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("gitlab", "security")
+	row := validGitLabSecurityRow(claim)
+	if got := gitLabSecurityReadbackDecision(2, row, row); got != EffectConflict {
+		t.Fatalf("ambiguous rows=%s", got)
+	}
+}

--- a/internal/providersync/gitlab_security_generic_oracle_test.go
+++ b/internal/providersync/gitlab_security_generic_oracle_test.go
@@ -1,0 +1,278 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+var oracleGitLabSecurityNormalizedAt = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+var oracleGitLabSecurityGoOnlyFields = map[string]string{
+	"org_id":      "stamped from the Go claim for tenant-scoped persistence",
+	"repo_id":     "provided by the Go route after repository identity resolution",
+	"last_synced": "stamped from normalizedAt by the Go route",
+}
+
+func decodeGitLabSecurityOracleMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var decoded map[string]any
+	if err := decoder.Decode(&decoded); err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+func buildGitLabSecurityVulnerabilityRowForOracle(t *testing.T, input map[string]any) gitLabSecurityAlertRow {
+	t.Helper()
+	claim := nativeTestClaim("gitlab", "security")
+	row, include, err := normalizeGitLabSecurityAlert(
+		claim, input["repo_id"].(string), "gitlab_vulnerability",
+		decodeGitLabSecurityOracleMap(t, input["raw_alert"]), oracleGitLabSecurityNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !include {
+		t.Fatal("vulnerability oracle item did not produce a row")
+	}
+	return row
+}
+
+func buildGitLabSecurityDependencyRowForOracle(t *testing.T, input map[string]any) gitLabSecurityAlertRow {
+	t.Helper()
+	claim := nativeTestClaim("gitlab", "security")
+	row, include, err := normalizeGitLabSecurityAlert(
+		claim, input["repo_id"].(string), "gitlab_dependency",
+		func() map[string]any {
+			payload := decodeGitLabSecurityOracleMap(t, input["raw_alert"])
+			payload["package_name"] = input["package_name"]
+			return payload
+		}(), oracleGitLabSecurityNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !include {
+		t.Fatal("dependency oracle item did not produce a row")
+	}
+	return row
+}
+
+func oracleGitLabSecurityVulnerabilityCases() []oracleCase {
+	return []oracleCase{
+		{
+			ID: "full_mapping",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_alert": map[string]any{
+					"id": 101, "severity": "high", "state": "detected", "name": "SQL Injection",
+					"created_at":  "2026-01-15T10:30:00.000Z",
+					"identifiers": []any{map[string]any{"type": "other", "name": "ignored"}, map[string]any{"type": "cve", "name": "CVE-2026-1234"}},
+					"links":       map[string]any{"url": "https://gitlab.example/vuln/101"},
+				},
+			},
+		},
+		{
+			ID: "optional_fields_missing",
+			Input: map[string]any{
+				"repo_id":   "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_alert": map[string]any{"id": 202, "severity": "low", "state": "resolved", "name": "XSS", "created_at": "2026-01-16T10:30:00Z"},
+			},
+		},
+	}
+}
+
+func oracleGitLabSecurityDependencyCases() []oracleCase {
+	return []oracleCase{{
+		ID: "dependency_mapping",
+		Input: map[string]any{
+			"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "package_name": "lodash",
+			"raw_alert": map[string]any{"id": 303, "severity": "critical", "url": "https://gitlab.example/vuln/303", "name": "Prototype Pollution"},
+		},
+	}}
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabSecurityVulnerabilityRows(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/security/vulnerability", oracleGitLabSecurityVulnerabilityCases(),
+		buildGitLabSecurityVulnerabilityRowForOracle, oracleGitLabSecurityGoOnlyFields,
+	)
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabSecurityDependencyRows(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/security/dependency", oracleGitLabSecurityDependencyCases(),
+		buildGitLabSecurityDependencyRowForOracle, oracleGitLabSecurityGoOnlyFields,
+	)
+}
+
+type gitLabSecurityTraversalTraceRow struct {
+	AlertID string `json:"alert_id"`
+	Source  string `json:"source"`
+}
+
+type gitLabSecurityTraversalTrace struct {
+	ProducerRequests  []string                          `json:"producer_requests"`
+	UsageRequestCount int                               `json:"usage_request_count"`
+	Rows              []gitLabSecurityTraversalTraceRow `json:"rows"`
+}
+
+func TestGenericOracleMatchesLivePythonForGitLabSecurityTraversal(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/security/trace", oracleGitLabSecurityTraversalCases(),
+		buildGitLabSecurityTraversalTrace, nil,
+	)
+}
+
+func oracleGitLabSecurityTraversalCases() []oracleCase {
+	return []oracleCase{
+		{
+			ID: "single_page_window",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "max_alerts": 1000,
+				"since": "2026-07-22T00:00:00Z", "until": "2026-07-23T12:00:00Z",
+				"findings": []any{
+					map[string]any{"id": 1, "created_at": "2026-07-21T10:00:00Z", "name": "old"},
+					map[string]any{"id": 2, "created_at": "2026-07-22T10:00:00Z", "name": "in"},
+					map[string]any{"id": 3, "created_at": "2026-07-23T13:00:00Z", "name": "after"},
+				},
+				"dependencies": []any{map[string]any{"name": "pkg", "vulnerabilities": []any{map[string]any{"id": 4, "name": "dependency"}}}},
+				"response_headers": map[string]any{
+					"findings": map[string]any{"X-Next-Page": "2"}, "dependencies": map[string]any{"X-Next-Page": "2"},
+				},
+			},
+		},
+		{
+			ID: "plain_forbidden_optional_endpoint",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "max_alerts": 1000,
+				"since": "2026-07-01T00:00:00Z", "until": "2026-12-31T00:00:00Z",
+				"findings_status": http.StatusForbidden, "findings": []any{},
+				"dependencies": []any{map[string]any{"name": "pkg", "vulnerabilities": []any{map[string]any{"id": 5, "name": "dependency"}}}},
+			},
+		},
+		{
+			ID: "core_failure_stops_second_endpoint",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79", "max_alerts": 1000,
+				"since": "2026-07-01T00:00:00Z", "until": "2026-12-31T00:00:00Z",
+				"findings_status": http.StatusBadRequest,
+				"dependencies":    []any{map[string]any{"name": "pkg", "vulnerabilities": []any{map[string]any{"id": 6, "name": "not fetched"}}}},
+			},
+		},
+	}
+}
+
+func buildGitLabSecurityTraversalTrace(t *testing.T, input map[string]any) gitLabSecurityTraversalTrace {
+	t.Helper()
+	responses := map[string]gitLabSecurityHTTPResponse{
+		"/api/v4/projects/123": {body: `{"id":123,"name":"api","path_with_namespace":"acme/api"}`},
+	}
+	for _, endpoint := range []struct {
+		path string
+		key  string
+	}{
+		{path: "/api/v4/projects/123/vulnerability_findings", key: "findings"},
+		{path: "/api/v4/projects/123/dependencies", key: "dependencies"},
+	} {
+		body, err := json.Marshal(input[endpoint.key])
+		if err != nil {
+			t.Fatal(err)
+		}
+		status := http.StatusOK
+		if value, ok := input[endpoint.key+"_status"].(int); ok {
+			status = value
+		}
+		headers := http.Header{}
+		if configured, ok := input["response_headers"].(map[string]any); ok {
+			if endpointHeaders, ok := configured[endpoint.key].(map[string]any); ok {
+				for key, value := range endpointHeaders {
+					headers.Set(key, stringValue(value))
+				}
+			}
+		}
+		responses[endpoint.path] = gitLabSecurityHTTPResponse{status: status, headers: headers, body: string(body)}
+	}
+	doer := &gitLabSecurityRouteDoer{responses: responses}
+	claim := nativeTestClaim("gitlab", "security")
+	claim.SinceAt = oracleGitLabSecurityTraceTime(t, input, "since")
+	claim.BeforeAt = oracleGitLabSecurityTraceTime(t, input, "until")
+	maxAlerts, ok := input["max_alerts"].(int)
+	if !ok {
+		t.Fatalf("max_alerts=%T", input["max_alerts"])
+	}
+	batch, err := (GitLabSecurityRouteHandler{MaxAlerts: maxAlerts}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), oracleGitLabSecurityNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trace := gitLabSecurityTraversalTrace{
+		ProducerRequests:  make([]string, 0, len(doer.requests)),
+		UsageRequestCount: batch.Evidence.Requests,
+		Rows:              make([]gitLabSecurityTraversalTraceRow, 0),
+	}
+	for _, request := range doer.requests {
+		trace.ProducerRequests = append(trace.ProducerRequests, oracleGitLabSecurityRequestPath(request))
+	}
+	if len(batch.Effects) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	for _, raw := range batch.Effects[0].Rows {
+		var row gitLabSecurityAlertRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		trace.Rows = append(trace.Rows, gitLabSecurityTraversalTraceRow{AlertID: row.AlertID, Source: row.Source})
+	}
+	return trace
+}
+
+func oracleGitLabSecurityTraceTime(t *testing.T, input map[string]any, key string) *time.Time {
+	t.Helper()
+	value, ok := input[key].(string)
+	if !ok || value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &parsed
+}
+
+func oracleGitLabSecurityRequestPath(request *http.Request) string {
+	query := request.URL.Query()
+	encoded := url.Values{}
+	keys := make([]string, 0, len(query))
+	for key := range query {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		values := append([]string(nil), query[key]...)
+		sort.Strings(values)
+		for _, value := range values {
+			encoded.Add(key, value)
+		}
+	}
+	if encoded.Encode() == "" {
+		return request.URL.Path
+	}
+	return request.URL.Path + "?" + encoded.Encode()
+}

--- a/internal/providersync/gitlab_security_route.go
+++ b/internal/providersync/gitlab_security_route.go
@@ -1,0 +1,424 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+const (
+	// The Python helper passes the processor batch size through to the code
+	// client. The code client itself requests exactly one 100-record page for
+	// each security endpoint; that frozen single-page boundary is intentional.
+	defaultGitLabSecurityMaxAlerts = 1_000
+	gitLabSecurityPerPage          = 100
+)
+
+// gitLabSecurityAlertRow is the sink-ready form of SecurityAlertData. The
+// provider's code client owns source mapping; the route adds tenant/repo
+// identity and the retry-stable last_synced value at this boundary.
+type gitLabSecurityAlertRow struct {
+	OrgID       string     `json:"org_id"`
+	RepoID      string     `json:"repo_id"`
+	AlertID     string     `json:"alert_id"`
+	Source      string     `json:"source"`
+	Severity    *string    `json:"severity"`
+	State       *string    `json:"state"`
+	PackageName *string    `json:"package_name"`
+	CVEID       *string    `json:"cve_id"`
+	URL         *string    `json:"url"`
+	Title       *string    `json:"title"`
+	Description *string    `json:"description"`
+	CreatedAt   time.Time  `json:"created_at"`
+	FixedAt     *time.Time `json:"fixed_at"`
+	DismissedAt *time.Time `json:"dismissed_at"`
+	LastSynced  time.Time  `json:"last_synced"`
+}
+
+// GitLabSecurityRouteHandler mirrors
+// processors.gitlab._fetch_gitlab_security_alerts_sync. It deliberately has
+// no switch/registry wiring in this slice; the parent lane owns activation.
+type GitLabSecurityRouteHandler struct{ MaxAlerts int }
+
+type gitLabSecurityResponseObserver struct {
+	attempts    *int
+	lastStatus  int
+	lastHeaders http.Header
+}
+
+type gitLabSecurityCountingDoer struct {
+	delegate providerfoundation.HTTPDoer
+	observe  *gitLabSecurityResponseObserver
+}
+
+func (doer gitLabSecurityCountingDoer) Do(request *http.Request) (*http.Response, error) {
+	(*doer.observe.attempts)++
+	response, err := doer.delegate.Do(request)
+	if response != nil {
+		doer.observe.lastStatus = response.StatusCode
+		doer.observe.lastHeaders = response.Header.Clone()
+	}
+	return response, err
+}
+
+func (handler GitLabSecurityRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "security" || client == nil || client.Provider != "gitlab" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	maxAlerts := handler.MaxAlerts
+	if maxAlerts == 0 {
+		maxAlerts = defaultGitLabSecurityMaxAlerts
+	}
+	if maxAlerts < 1 {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	projectID, err := gitLabProjectID(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+
+	requests := 0
+	observer := &gitLabSecurityResponseObserver{attempts: &requests}
+	counted := *client
+	counted.Doer = gitLabSecurityCountingDoer{delegate: client.Doer, observe: observer}
+	root := providerRelativePath(&counted, "api", "v4", "projects", projectID)
+	var project repositoryPayload
+	if err := fetchObject(ctx, &counted, root, &project); err != nil {
+		// Project resolution is not optional in the Python client: without its
+		// returned numeric id and full name no security row can be scoped.
+		return CompleteRouteBatch{}, err
+	}
+	parsedProjectID, err := project.ID.Int64()
+	if err != nil || parsedProjectID < 1 || strconv.FormatInt(parsedProjectID, 10) != projectID {
+		return CompleteRouteBatch{}, providerfoundation.ErrNormalizationInvalid
+	}
+	fullName := gitLabProjectFullName(project)
+	repoID, err := repositoryIdentity(fullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+
+	findings, findingPages, err := fetchGitLabSecurityObjects(
+		ctx, &counted, root+"/vulnerability_findings", observer,
+	)
+	findingsOptional, fatal := gitLabSecurityEndpointDecision(ctx, err, observer)
+	if fatal != nil {
+		return CompleteRouteBatch{}, fatal
+	}
+	if err != nil {
+		if !findingsOptional {
+			return gitLabSecurityBatch(claim, fullName, parsedProjectID, normalizedAt, nil, requests, findingPages)
+		}
+		// The Python processor catches any optional security fetch exception and
+		// continues with the alerts already accumulated by the helper. A failed
+		// endpoint therefore contributes no rows but does not block the other
+		// optional endpoint; control-plane cancellation/lease/rate-limit errors
+		// were returned above.
+		findings, findingPages = nil, 0
+	}
+
+	dependencies, dependencyPages, err := fetchGitLabSecurityObjects(
+		ctx, &counted, root+"/dependencies", observer,
+	)
+	dependenciesOptional, fatal := gitLabSecurityEndpointDecision(ctx, err, observer)
+	if fatal != nil {
+		return CompleteRouteBatch{}, fatal
+	}
+	if err != nil {
+		if !dependenciesOptional {
+			return gitLabSecurityBatch(claim, fullName, parsedProjectID, normalizedAt, nil, requests, findingPages+dependencyPages)
+		}
+		dependencies, dependencyPages = nil, 0
+	}
+
+	// GitLabCodeClient.get_security_alerts slices the combined source list,
+	// before processors.gitlab applies its since filter. Preserve that order.
+	combined := make([]gitLabSecurityObject, 0, len(findings)+len(dependencies))
+	combined = append(combined, findings...)
+	combined = append(combined, dependencies...)
+	if len(combined) > maxAlerts {
+		combined = combined[:maxAlerts]
+	}
+	rows := make([]gitLabSecurityAlertRow, 0, len(combined))
+	for _, object := range combined {
+		row, include, normalizeErr := normalizeGitLabSecurityAlert(
+			claim, repoID, object.Source, object.Payload, normalizedAt,
+		)
+		if normalizeErr != nil {
+			return CompleteRouteBatch{}, normalizeErr
+		}
+		if !include {
+			// The Python processor discards mapped alerts with a missing or
+			// malformed created_at before constructing the persisted model.
+			continue
+		}
+		if securityAlertOutsideWindow(row.CreatedAt, claim) {
+			continue
+		}
+		rows = append(rows, row)
+	}
+
+	return gitLabSecurityBatch(claim, fullName, parsedProjectID, normalizedAt, rows, requests, findingPages+dependencyPages)
+}
+
+type gitLabSecurityObject struct {
+	Source  string
+	Payload map[string]any
+}
+
+func fetchGitLabSecurityObjects(
+	ctx context.Context,
+	client *providerfoundation.HTTPClient,
+	path string,
+	observer *gitLabSecurityResponseObserver,
+) ([]gitLabSecurityObject, int, error) {
+	// GitLabCodeClient calls the security endpoints directly with only
+	// per_page; unlike the provider's generic paginator it does not add a
+	// page=1 parameter. Preserve that request shape as well as its deliberate
+	// one-page/no-X-Next-Page traversal boundary.
+	query := url.Values{"per_page": {strconv.Itoa(gitLabSecurityPerPage)}}
+	response, err := client.Do(ctx, http.MethodGet, path+"?"+query.Encode(), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if response == nil || response.Body == nil {
+		return nil, 0, providerfoundation.ErrNormalizationInvalid
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 2<<20))
+	if err != nil {
+		return nil, 0, err
+	}
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal(body, &rawItems); err != nil {
+		return nil, 0, providerfoundation.ErrNormalizationInvalid
+	}
+	objects := make([]gitLabSecurityObject, 0, len(rawItems))
+	source := "gitlab_vulnerability"
+	if strings.HasSuffix(path, "/dependencies") {
+		source = "gitlab_dependency"
+	}
+	for _, raw := range rawItems {
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.UseNumber()
+		var payload map[string]any
+		if err := decoder.Decode(&payload); err != nil || payload == nil {
+			return nil, 1, providerfoundation.ErrNormalizationInvalid
+		}
+		if source == "gitlab_dependency" {
+			for _, rawVulnerability := range gitLabSecurityList(payload["vulnerabilities"]) {
+				vulnerability, ok := rawVulnerability.(map[string]any)
+				if !ok {
+					return nil, 1, providerfoundation.ErrNormalizationInvalid
+				}
+				// _map_dependency_alert receives both the dependency package
+				// and its vulnerability. Flatten only at the Go normalization
+				// boundary; the raw request shape remains unchanged.
+				flattened := cloneGitLabSecurityMap(vulnerability)
+				flattened["package_name"] = payload["name"]
+				objects = append(objects, gitLabSecurityObject{Source: source, Payload: flattened})
+			}
+			continue
+		}
+		objects = append(objects, gitLabSecurityObject{Source: source, Payload: payload})
+	}
+	return objects, 1, nil
+}
+
+func gitLabSecurityEndpointDecision(
+	ctx context.Context,
+	err error,
+	observer *gitLabSecurityResponseObserver,
+) (optional bool, fatal error) {
+	if err == nil {
+		return true, nil
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, providerfoundation.ErrLeaseLost) || errors.Is(err, ErrLeaseLost) {
+		return false, err
+	}
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) {
+		if providerErr.Class == providerfoundation.ErrorRateLimited ||
+			(providerErr.StatusCode == http.StatusForbidden && gitLabSecurityRateLimited(observer.lastHeaders)) {
+			return false, err
+		}
+		if providerErr.StatusCode == http.StatusForbidden || providerErr.StatusCode == http.StatusNotFound {
+			return true, nil
+		}
+	}
+	// A non-optional exception aborts get_security_alerts before its second
+	// endpoint, and the processor catches the whole call as an empty result.
+	// Return false so the route emits the same empty successful batch without
+	// manufacturing partial rows from the endpoint fetched first.
+	return false, nil
+}
+
+func gitLabSecurityBatch(
+	claim Claim,
+	fullName string,
+	projectID int64,
+	normalizedAt time.Time,
+	rows []gitLabSecurityAlertRow,
+	requests int,
+	pages int,
+) (CompleteRouteBatch, error) {
+	effect, err := effectBatchFromValues("security_alerts", EffectReadbackRequired, rows)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	return CompleteRouteBatch{
+		Effects:   []EffectBatch{effect},
+		Result:    map[string]any{"security_alerts_synced": len(rows), "repo": fullName, "project_id": projectID},
+		Watermark: claim.BeforeAt,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: requests, Pages: pages, Records: len(rows),
+		},
+	}, nil
+}
+
+func gitLabSecurityRateLimited(headers http.Header) bool {
+	if headers == nil {
+		return false
+	}
+	return strings.TrimSpace(gitLabSecurityHeader(headers, "Retry-After")) != "" ||
+		strings.TrimSpace(gitLabSecurityHeader(headers, "RateLimit-Remaining")) == "0"
+}
+
+func gitLabSecurityHeader(headers http.Header, name string) string {
+	for key, values := range headers {
+		if strings.EqualFold(key, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
+func normalizeGitLabSecurityAlert(
+	claim Claim,
+	repoID string,
+	source string,
+	payload map[string]any,
+	normalizedAt time.Time,
+) (gitLabSecurityAlertRow, bool, error) {
+	row := gitLabSecurityAlertRow{
+		OrgID: claim.OrgID, RepoID: repoID, Source: source, LastSynced: normalizedAt,
+	}
+	switch source {
+	case "gitlab_vulnerability":
+		id := strings.TrimSpace(stringValue(payload["id"]))
+		if id == "" {
+			return gitLabSecurityAlertRow{}, false, providerfoundation.ErrNormalizationInvalid
+		}
+		row.AlertID = "gitlab_vuln:" + id
+		row.Severity = gitLabSecurityOptionalString(payload["severity"])
+		row.State = gitLabSecurityOptionalString(payload["state"])
+		row.Title = gitLabSecurityOptionalString(payload["name"])
+		if links, ok := payload["links"].(map[string]any); ok {
+			row.URL = gitLabSecurityOptionalString(links["url"])
+		}
+		for _, identifier := range gitLabSecurityList(payload["identifiers"]) {
+			item, ok := identifier.(map[string]any)
+			if ok && stringValue(item["type"]) == "cve" {
+				row.CVEID = gitLabSecurityOptionalString(item["name"])
+				break
+			}
+		}
+		createdAt := parseGitLabSecurityTime(payload["created_at"])
+		if createdAt == nil {
+			return row, false, nil
+		}
+		row.CreatedAt = createdAt.UTC().Truncate(time.Millisecond)
+	case "gitlab_dependency":
+		id := strings.TrimSpace(stringValue(payload["id"]))
+		if id == "" {
+			return gitLabSecurityAlertRow{}, false, providerfoundation.ErrNormalizationInvalid
+		}
+		row.AlertID = "gitlab_dep:" + id
+		row.Severity = gitLabSecurityOptionalString(payload["severity"])
+		row.PackageName = gitLabSecurityOptionalString(payload["package_name"])
+		row.URL = gitLabSecurityOptionalString(payload["url"])
+		row.Title = gitLabSecurityOptionalString(payload["name"])
+		// The dependency API has no vulnerability timestamp. Python uses
+		// datetime.now(timezone.utc); normalizedAt is the route's stable,
+		// executor-supplied equivalent so retries converge.
+		row.CreatedAt = normalizedAt
+	default:
+		return gitLabSecurityAlertRow{}, false, providerfoundation.ErrNormalizationInvalid
+	}
+	if err := row.validate(claim); err != nil {
+		return gitLabSecurityAlertRow{}, false, err
+	}
+	return row, true, nil
+}
+
+func gitLabSecurityList(value any) []any {
+	items, _ := value.([]any)
+	return items
+}
+
+func cloneGitLabSecurityMap(input map[string]any) map[string]any {
+	cloned := make(map[string]any, len(input)+1)
+	for key, value := range input {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func parseGitLabSecurityTime(value any) *time.Time {
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, strings.Replace(text, "Z", "+00:00", 1))
+	if err != nil {
+		return nil
+	}
+	parsed = parsed.UTC()
+	return &parsed
+}
+
+func gitLabSecurityOptionalString(value any) *string {
+	text := strings.TrimSpace(stringValue(value))
+	if text == "" {
+		return nil
+	}
+	return &text
+}
+
+func (row gitLabSecurityAlertRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || row.AlertID == "" ||
+		(row.Source != "gitlab_vulnerability" && row.Source != "gitlab_dependency") ||
+		row.CreatedAt.IsZero() || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	if _, err := uuid.Parse(row.RepoID); err != nil {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitLabSecurityRouteHandler{}

--- a/internal/providersync/gitlab_security_route_test.go
+++ b/internal/providersync/gitlab_security_route_test.go
@@ -1,0 +1,373 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+type gitLabSecurityRouteDoer struct {
+	responses map[string]gitLabSecurityHTTPResponse
+	requests  []*http.Request
+}
+
+type gitLabSecurityHTTPResponse struct {
+	status  int
+	headers http.Header
+	body    string
+}
+
+func (doer *gitLabSecurityRouteDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.requests = append(doer.requests, request)
+	response, ok := doer.responses[request.URL.Path]
+	if !ok {
+		return nil, errors.New("unexpected GitLab security request: " + request.URL.String())
+	}
+	status := response.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	headers := response.headers
+	if headers == nil {
+		headers = http.Header{"Content-Type": []string{"application/json"}}
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     headers,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+		Request:    request,
+	}, nil
+}
+
+func gitLabSecurityRouteClient(t *testing.T, doer providerfoundation.HTTPDoer) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"gitlab", "https://gitlab.example", doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func gitLabSecurityRouteFixtures() map[string]gitLabSecurityHTTPResponse {
+	return map[string]gitLabSecurityHTTPResponse{
+		"/api/v4/projects/123": {body: `{"id":123,"name":"api","path_with_namespace":"acme/api"}`},
+		"/api/v4/projects/123/vulnerability_findings": {headers: http.Header{"X-Next-Page": []string{"2"}}, body: `[
+            {"id":1,"severity":"low","state":"detected","name":"old","created_at":"2026-07-21T10:00:00Z"},
+            {"id":2,"severity":"high","state":"detected","name":"in-window","created_at":"2026-07-22T10:00:00Z","identifiers":[{"type":"other","name":"x"},{"type":"cve","name":"CVE-2026-0002"}],"links":{"url":"https://gitlab.example/a/2"}},
+            {"id":3,"severity":"critical","state":"detected","name":"after","created_at":"2026-07-23T13:00:00Z"}
+        ]`},
+		"/api/v4/projects/123/dependencies": {headers: http.Header{"X-Next-Page": []string{"2"}}, body: `[
+            {"name":"widget","vulnerabilities":[{"id":4,"severity":"medium","name":"dep","url":"https://gitlab.example/d/4"}]}
+        ]`},
+	}
+}
+
+func TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	claim := nativeTestClaim("gitlab", "security")
+	since := time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	claim.SinceAt, claim.BeforeAt = &since, &before
+	normalizedAt := time.Date(2026, 7, 23, 12, 30, 0, 987654321, time.UTC)
+
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(doer.requests) != 3 || batch.Evidence.Requests != 3 || batch.Evidence.Pages != 2 ||
+		batch.Evidence.Records != 1 || batch.Evidence.CapReached {
+		t.Fatalf("requests=%d evidence=%+v", len(doer.requests), batch.Evidence)
+	}
+	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark=%v", batch.Watermark)
+	}
+	for _, request := range doer.requests[1:] {
+		if request.URL.Query().Get("page") != "" || request.URL.Query().Get("per_page") != "100" {
+			t.Fatalf("single-page request=%s", request.URL.String())
+		}
+	}
+	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "security_alerts" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+	var row gitLabSecurityAlertRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &row); err != nil {
+		t.Fatal(err)
+	}
+	if row.AlertID != "gitlab_vuln:2" || row.Source != "gitlab_vulnerability" ||
+		row.OrgID != claim.OrgID || row.PackageName != nil || row.CVEID == nil ||
+		*row.CVEID != "CVE-2026-0002" || row.URL == nil ||
+		!row.CreatedAt.Equal(time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)) ||
+		!row.LastSynced.Equal(normalizedAt.UTC().Truncate(time.Millisecond)) {
+		t.Fatalf("row=%+v", row)
+	}
+}
+
+func TestGitLabSecurityRouteSlicesCombinedAlertsBeforeWindowFiltering(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	claim := nativeTestClaim("gitlab", "security")
+	since := time.Date(2026, 7, 22, 0, 0, 0, 0, time.UTC)
+	claim.SinceAt = &since
+	batch, err := (GitLabSecurityRouteHandler{MaxAlerts: 1}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 {
+		// The first vulnerability is before the claim window; Python applies
+		// max_alerts in the code client before processors applies `since`.
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+}
+
+func TestGitLabSecurityRouteDegradesPlainOptionalErrors(t *testing.T) {
+	t.Parallel()
+	for path, status := range map[string]int{
+		"/api/v4/projects/123/vulnerability_findings": http.StatusForbidden,
+		"/api/v4/projects/123/dependencies":           http.StatusNotFound,
+	} {
+		doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+		doer.responses[path] = gitLabSecurityHTTPResponse{status: status, body: `{"message":"unavailable"}`}
+		batch, err := (GitLabSecurityRouteHandler{}).Collect(
+			context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+			gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+		)
+		if err != nil {
+			t.Fatalf("path=%s error=%v", path, err)
+		}
+		if len(batch.Effects) != 1 || batch.Watermark == nil {
+			t.Fatalf("path=%s batch=%+v", path, batch)
+		}
+		if path == "/api/v4/projects/123/vulnerability_findings" &&
+			(len(batch.Effects[0].Rows) != 1 || !strings.Contains(string(batch.Effects[0].Rows[0]), "gitlab_dep:4")) {
+			t.Fatalf("path=%s rows=%s", path, batch.Effects[0].Rows)
+		}
+		if path == "/api/v4/projects/123/dependencies" && len(batch.Effects[0].Rows) != 3 {
+			t.Fatalf("path=%s rows=%d", path, len(batch.Effects[0].Rows))
+		}
+	}
+}
+
+func TestGitLabSecurityRoutePropagatesRateLimitWithoutWatermark(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	doer.responses["/api/v4/projects/123/dependencies"] = gitLabSecurityHTTPResponse{
+		status: http.StatusTooManyRequests, body: `{"message":"slow down"}`,
+	}
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		t.Fatalf("error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("rate-limited batch advanced state: %+v", batch)
+	}
+}
+
+func TestGitLabSecurityRoutePropagatesHeaderQualifiedForbiddenRateLimit(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	doer.responses["/api/v4/projects/123/dependencies"] = gitLabSecurityHTTPResponse{
+		status:  http.StatusForbidden,
+		headers: http.Header{"RateLimit-Remaining": []string{"0"}},
+		body:    `{"message":"throttled"}`,
+	}
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication {
+		t.Fatalf("error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil {
+		t.Fatalf("header-qualified forbidden batch advanced state: %+v", batch)
+	}
+}
+
+func TestGitLabSecurityRouteMirrorsCoreFailureAsEmptySuccess(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	doer.responses["/api/v4/projects/123/vulnerability_findings"] = gitLabSecurityHTTPResponse{
+		status: http.StatusBadRequest, body: `{"message":"invalid"}`,
+	}
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+	)
+	if err != nil || len(batch.Effects) != 1 || len(batch.Effects[0].Rows) != 0 ||
+		batch.Evidence.Requests != 2 || batch.Watermark == nil {
+		t.Fatalf("error=%v batch=%+v", err, batch)
+	}
+}
+
+func TestGitLabSecurityRouteRejectsProjectMismatchAndLeaseBeforeRequests(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name       string
+		project    string
+		leaseError error
+		want       error
+	}{
+		{name: "project mismatch", project: `{"id":999,"path_with_namespace":"acme/api"}`, want: providerfoundation.ErrNormalizationInvalid},
+		{name: "lease lost", project: `{"id":123,"path_with_namespace":"acme/api"}`, leaseError: providerfoundation.ErrLeaseLost, want: providerfoundation.ErrLeaseLost},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+			doer.responses["/api/v4/projects/123"] = gitLabSecurityHTTPResponse{body: test.project}
+			client := gitLabSecurityRouteClient(t, doer)
+			if test.leaseError != nil {
+				client.Lease = providerfoundation.LeaseGuardFunc(func(context.Context) error { return test.leaseError })
+			}
+			batch, err := (GitLabSecurityRouteHandler{}).Collect(
+				context.Background(), nativeTestClaim("gitlab", "security"), providerfoundation.Credential{},
+				client, time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
+			)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error=%v want=%v", err, test.want)
+			}
+			if len(batch.Effects) != 0 || batch.Watermark != nil {
+				t.Fatalf("incomplete batch=%+v", batch)
+			}
+			if test.leaseError != nil && len(doer.requests) != 0 {
+				t.Fatalf("lease made requests=%d", len(doer.requests))
+			}
+		})
+	}
+}
+
+func TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests(t *testing.T) {
+	t.Parallel()
+	normalizedAt := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name       string
+		claim      Claim
+		client     *providerfoundation.HTTPClient
+		normalized time.Time
+		maxAlerts  int
+	}{
+		{
+			name: "wrong_claim_provider",
+			claim: func() Claim {
+				claim := nativeTestClaim("gitlab", "security")
+				claim.Provider = "github"
+				return claim
+			}(),
+			client: gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+		},
+		{
+			name:   "wrong_claim_dataset",
+			claim:  nativeTestClaim("gitlab", "commits"),
+			client: gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+		},
+		{
+			name:   "nil_client",
+			claim:  nativeTestClaim("gitlab", "security"),
+			client: nil,
+		},
+		{
+			name:  "wrong_client_provider",
+			claim: nativeTestClaim("gitlab", "security"),
+			client: func() *providerfoundation.HTTPClient {
+				client := gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()})
+				client.Provider = "github"
+				return client
+			}(),
+		},
+		{
+			name:  "nil_client_base_URL",
+			claim: nativeTestClaim("gitlab", "security"),
+			client: func() *providerfoundation.HTTPClient {
+				client := gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()})
+				client.BaseURL = nil
+				return client
+			}(),
+		},
+		{
+			name:       "zero_normalized_at",
+			claim:      nativeTestClaim("gitlab", "security"),
+			client:     gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+			normalized: time.Time{},
+		},
+		{
+			name:      "negative_max_alerts",
+			claim:     nativeTestClaim("gitlab", "security"),
+			client:    gitLabSecurityRouteClient(t, &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}),
+			maxAlerts: -1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := test.normalized
+			if now.IsZero() && test.name != "zero_normalized_at" {
+				now = normalizedAt
+			}
+			batch, err := (GitLabSecurityRouteHandler{MaxAlerts: test.maxAlerts}).Collect(
+				context.Background(), test.claim, providerfoundation.Credential{}, test.client, now,
+			)
+			if !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("error=%v", err)
+			}
+			if len(batch.Effects) != 0 || len(batch.Evidence.Provider) != 0 {
+				t.Fatalf("invalid configuration returned batch=%+v", batch)
+			}
+			if test.client != nil {
+				if doer, ok := test.client.Doer.(*gitLabSecurityRouteDoer); ok && len(doer.requests) != 0 {
+					t.Fatalf("invalid configuration made %d requests", len(doer.requests))
+				}
+			}
+		})
+	}
+}
+
+func TestGitLabSecurityRouteNormalizesDependencyCreatedAtAndPackage(t *testing.T) {
+	t.Parallel()
+	doer := &gitLabSecurityRouteDoer{responses: gitLabSecurityRouteFixtures()}
+	claim := nativeTestClaim("gitlab", "security")
+	normalizedAt := time.Date(2026, 7, 23, 12, 30, 0, 987654321, time.UTC)
+	batch, err := (GitLabSecurityRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabSecurityRouteClient(t, doer), normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, raw := range batch.Effects[0].Rows {
+		var row gitLabSecurityAlertRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			t.Fatal(err)
+		}
+		if row.AlertID != "gitlab_dep:4" {
+			continue
+		}
+		if row.PackageName == nil || *row.PackageName != "widget" || row.State != nil ||
+			!row.CreatedAt.Equal(normalizedAt.UTC().Truncate(time.Millisecond)) {
+			t.Fatalf("dependency row=%+v", row)
+		}
+		return
+	}
+	t.Fatal("dependency row was not emitted")
+}

--- a/internal/providersync/gitlab_security_route_test.go
+++ b/internal/providersync/gitlab_security_route_test.go
@@ -201,7 +201,7 @@ func TestGitLabSecurityRoutePropagatesHeaderQualifiedForbiddenRateLimit(t *testi
 		gitLabSecurityRouteClient(t, doer), time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC),
 	)
 	var providerErr *providerfoundation.ProviderError
-	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorAuthentication {
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
 		t.Fatalf("error=%v", err)
 	}
 	if len(batch.Effects) != 0 || batch.Watermark != nil {

--- a/internal/providersync/gitlab_work_item_derived.go
+++ b/internal/providersync/gitlab_work_item_derived.go
@@ -1,0 +1,489 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// The GitLab derived family is the nine schema-backed projections that can be
+// computed from the six normalized work-item facts. ai_attribution is kept out
+// of this set intentionally: the authoritative producer consumes the original
+// merge-request payload (including source branch and bot/author signals), but
+// those fields are not part of the six raw ClickHouse projections. An empty
+// AI effect would falsely claim that producer ran.
+var gitlabWorkItemDerivedDestinations = []string{
+	"estimate_coverage_metrics_daily",
+	"investment_classifications_daily",
+	"investment_metrics_daily",
+	"issue_type_metrics_daily",
+	"work_item_cycle_times",
+	"work_item_metrics_daily",
+	"work_item_state_durations_daily",
+	"work_item_team_attributions",
+	"work_item_user_metrics_daily",
+}
+
+type gitlabEstimateCoverageMetricsDailyRow = githubEstimateCoverageMetricsDailyRow
+type gitlabWorkItemTeamAttributionRow = githubWorkItemTeamAttributionRow
+type gitlabWorkItemStateDurationDailyRow = githubWorkItemStateDurationDailyRow
+type gitlabWorkItemMetricsDailyRow = githubWorkItemMetricsDailyRow
+type gitlabWorkItemUserMetricsDailyRow = githubWorkItemUserMetricsDailyRow
+type gitlabWorkItemCycleTimeRecord = githubWorkItemCycleTimeRecord
+type gitlabWorkItemCycleTimePersistenceRow = githubWorkItemCycleTimePersistenceRow
+type gitlabIssueTypeMetricsDailyRow = githubIssueTypeMetricsDailyRow
+type gitlabInvestmentClassificationDailyRow = githubInvestmentClassificationDailyRow
+type gitlabInvestmentMetricsDailyRow = githubInvestmentMetricsDailyRow
+
+// GitLabWorkItemDerivedGap is a typed explanation of a destination that was
+// evaluated and deliberately withheld because its authoritative producer is
+// not reconstructible from the raw fact contract.
+type GitLabWorkItemDerivedGap struct {
+	Destination           string `json:"destination"`
+	AuthoritativeProducer string `json:"authoritative_producer"`
+	Reason                string `json:"reason"`
+}
+
+// GitLabWorkItemDerivedRows is the provider result at the compute boundary.
+// Every destination is a concrete ClickHouse row slice, so callers cannot
+// accidentally smuggle an untyped map or generic evidence envelope into the
+// effect ledger. AIAttribution is represented by the explicit typed gap below,
+// never by an empty slice.
+type GitLabWorkItemDerivedRows struct {
+	EstimateCoverageMetricsDaily   []gitlabEstimateCoverageMetricsDailyRow
+	InvestmentClassificationsDaily []gitlabInvestmentClassificationDailyRow
+	InvestmentMetricsDaily         []gitlabInvestmentMetricsDailyRow
+	IssueTypeMetricsDaily          []gitlabIssueTypeMetricsDailyRow
+	WorkItemCycleTimes             []gitlabWorkItemCycleTimePersistenceRow
+	WorkItemMetricsDaily           []gitlabWorkItemMetricsDailyRow
+	WorkItemStateDurationsDaily    []gitlabWorkItemStateDurationDailyRow
+	WorkItemTeamAttributions       []gitlabWorkItemTeamAttributionRow
+	WorkItemUserMetricsDaily       []gitlabWorkItemUserMetricsDailyRow
+	Gaps                           []GitLabWorkItemDerivedGap
+	Watermark                      *time.Time
+}
+
+func (rows GitLabWorkItemDerivedRows) producedDestinations() []string {
+	return append([]string(nil), gitlabWorkItemDerivedDestinations...)
+}
+
+func gitlabWorkItemRowsAsGitHub(rows gitlabWorkItemRows) githubWorkItemRows {
+	return githubWorkItemRows{
+		WorkItems:         rows.WorkItems,
+		StatusTransitions: rows.StatusTransitions,
+		Dependencies:      rows.Dependencies,
+		ReopenEvents:      rows.ReopenEvents,
+		Interactions:      rows.Interactions,
+		Sprints:           rows.Sprints,
+	}
+}
+
+// GitLabWorkItemDeriver owns only the compute boundary. It is intentionally
+// unregistered: the provider route/cutover wiring remains a separate slice.
+type GitLabWorkItemDeriver struct {
+	Source               githubWorkItemDerivationContextSource
+	statusMapping        *StatusMapping
+	investmentClassifier *InvestmentClassifier
+}
+
+// NewGitLabWorkItemDeriver loads the same governed status and investment
+// configuration used by Python's work-item job. Both paths are required so a
+// missing engine cannot be mistaken for an empty destination.
+func NewGitLabWorkItemDeriver(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+	statusMappingConfigPath string,
+	investmentConfigPath string,
+) (*GitLabWorkItemDeriver, error) {
+	if conn == nil || lease == nil || strings.TrimSpace(statusMappingConfigPath) == "" ||
+		strings.TrimSpace(investmentConfigPath) == "" {
+		return nil, ErrInvalidConfiguration
+	}
+	statusMapping, err := LoadStatusMapping(statusMappingConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	classifier, err := NewInvestmentClassifier(investmentConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return &GitLabWorkItemDeriver{
+		Source:        githubWorkItemClickHouseDerivationContextSource{Conn: conn, Lease: lease},
+		statusMapping: statusMapping, investmentClassifier: classifier,
+	}, nil
+}
+
+// Derive computes all nine available destinations for every UTC day in the
+// claim window. Context is loaded once, before the day loop, matching the
+// Python job's donor/ownership snapshot semantics. Since AI attribution is a
+// declared producer gap, Watermark remains nil and no AI effect is emitted.
+func (deriver GitLabWorkItemDeriver) Derive(
+	ctx context.Context,
+	claim Claim,
+	rows gitlabWorkItemRows,
+	normalizedAt time.Time,
+) (GitLabWorkItemDerivedRows, error) {
+	if ctx == nil || deriver.Source == nil || deriver.statusMapping == nil ||
+		deriver.investmentClassifier == nil || claim.Validate() != nil ||
+		claim.Provider != "gitlab" || claim.Dataset != "work-items" || normalizedAt.IsZero() {
+		return GitLabWorkItemDerivedRows{}, ErrInvalidConfiguration
+	}
+	days, err := githubWorkItemDerivedDays(claim, normalizedAt)
+	if err != nil {
+		return GitLabWorkItemDerivedRows{}, err
+	}
+	contextFacts, err := loadWorkItemDerivationContextForProvider(
+		ctx, "gitlab", claim, gitlabWorkItemRowsAsGitHub(rows), deriver.Source, normalizedAt,
+	)
+	if err != nil {
+		return GitLabWorkItemDerivedRows{}, err
+	}
+	result := GitLabWorkItemDerivedRows{
+		EstimateCoverageMetricsDaily:   []gitlabEstimateCoverageMetricsDailyRow{},
+		InvestmentClassificationsDaily: []gitlabInvestmentClassificationDailyRow{},
+		InvestmentMetricsDaily:         []gitlabInvestmentMetricsDailyRow{},
+		IssueTypeMetricsDaily:          []gitlabIssueTypeMetricsDailyRow{},
+		WorkItemCycleTimes:             []gitlabWorkItemCycleTimePersistenceRow{},
+		WorkItemMetricsDaily:           []gitlabWorkItemMetricsDailyRow{},
+		WorkItemStateDurationsDaily:    []gitlabWorkItemStateDurationDailyRow{},
+		WorkItemTeamAttributions:       []gitlabWorkItemTeamAttributionRow{},
+		WorkItemUserMetricsDaily:       []gitlabWorkItemUserMetricsDailyRow{},
+		Watermark:                      nil,
+		Gaps: []GitLabWorkItemDerivedGap{{
+			Destination:           "ai_attribution",
+			AuthoritativeProducer: "gitlab_mr_ai_attributions",
+			Reason: "the six raw work-item facts do not retain source_branch, bot-author, " +
+				"or the original merge-request signal payload required by the producer",
+		}},
+	}
+	for _, day := range days {
+		triplet, err := buildWorkItemMetricTripletForProvider(
+			"gitlab", claim, gitlabWorkItemRowsAsGitHub(rows), day, normalizedAt, contextFacts,
+		)
+		if err != nil {
+			return GitLabWorkItemDerivedRows{}, err
+		}
+		result.WorkItemMetricsDaily = append(result.WorkItemMetricsDaily, triplet.MetricsDaily...)
+		result.WorkItemUserMetricsDaily = append(result.WorkItemUserMetricsDaily, triplet.UserMetricsDaily...)
+		for _, cycle := range triplet.CycleTimes {
+			result.WorkItemCycleTimes = append(result.WorkItemCycleTimes, cycle.persistenceRow())
+		}
+
+		surfaces, err := buildWorkItemDerivedSurfacesForProvider(
+			"gitlab", claim, gitlabWorkItemRowsAsGitHub(rows), day, normalizedAt, contextFacts,
+		)
+		if err != nil {
+			return GitLabWorkItemDerivedRows{}, err
+		}
+		result.EstimateCoverageMetricsDaily = append(result.EstimateCoverageMetricsDaily, surfaces.EstimateCoverage...)
+		result.WorkItemTeamAttributions = append(result.WorkItemTeamAttributions, surfaces.TeamAttributions...)
+		result.WorkItemStateDurationsDaily = append(result.WorkItemStateDurationsDaily, surfaces.StateDurations...)
+
+		engine := GitHubWorkItemEngineDeriver{
+			statusMapping:        deriver.statusMapping,
+			investmentClassifier: deriver.investmentClassifier,
+		}
+		engineRows, err := engine.deriveRowsForProvider(
+			ctx, "gitlab", claim, gitlabWorkItemRowsAsGitHub(rows), day, normalizedAt, contextFacts,
+		)
+		if err != nil {
+			return GitLabWorkItemDerivedRows{}, err
+		}
+		result.IssueTypeMetricsDaily = append(result.IssueTypeMetricsDaily, engineRows.IssueTypes...)
+		result.InvestmentClassificationsDaily = append(result.InvestmentClassificationsDaily, engineRows.Classifications...)
+		result.InvestmentMetricsDaily = append(result.InvestmentMetricsDaily, engineRows.InvestmentMetrics...)
+	}
+	return result, nil
+}
+
+// GitLabWorkItemDerivedEffectRows is the explicit effect projection. It has
+// one field per landed destination and therefore cannot silently omit a row
+// family through a string-keyed map.
+type GitLabWorkItemDerivedEffectRows struct {
+	EstimateCoverageMetricsDaily   []gitlabEstimateCoverageMetricsDailyRow
+	InvestmentClassificationsDaily []gitlabInvestmentClassificationDailyRow
+	InvestmentMetricsDaily         []gitlabInvestmentMetricsDailyRow
+	IssueTypeMetricsDaily          []gitlabIssueTypeMetricsDailyRow
+	WorkItemCycleTimes             []gitlabWorkItemCycleTimePersistenceRow
+	WorkItemMetricsDaily           []gitlabWorkItemMetricsDailyRow
+	WorkItemStateDurationsDaily    []gitlabWorkItemStateDurationDailyRow
+	WorkItemTeamAttributions       []gitlabWorkItemTeamAttributionRow
+	WorkItemUserMetricsDaily       []gitlabWorkItemUserMetricsDailyRow
+}
+
+func (rows GitLabWorkItemDerivedRows) EffectRows() GitLabWorkItemDerivedEffectRows {
+	return GitLabWorkItemDerivedEffectRows{
+		EstimateCoverageMetricsDaily:   rows.EstimateCoverageMetricsDaily,
+		InvestmentClassificationsDaily: rows.InvestmentClassificationsDaily,
+		InvestmentMetricsDaily:         rows.InvestmentMetricsDaily,
+		IssueTypeMetricsDaily:          rows.IssueTypeMetricsDaily,
+		WorkItemCycleTimes:             rows.WorkItemCycleTimes,
+		WorkItemMetricsDaily:           rows.WorkItemMetricsDaily,
+		WorkItemStateDurationsDaily:    rows.WorkItemStateDurationsDaily,
+		WorkItemTeamAttributions:       rows.WorkItemTeamAttributions,
+		WorkItemUserMetricsDaily:       rows.WorkItemUserMetricsDaily,
+	}
+}
+
+// BuildGitLabWorkItemDerivedEffects serializes only concrete typed row slices,
+// in canonical destination order. The AI gap is not represented as an empty
+// effect and is therefore impossible to mistake for successful computation.
+func BuildGitLabWorkItemDerivedEffects(rows GitLabWorkItemDerivedEffectRows) ([]EffectBatch, error) {
+	effects := make([]EffectBatch, 0, len(gitlabWorkItemDerivedDestinations))
+	for _, destination := range gitlabWorkItemDerivedDestinations {
+		var effect EffectBatch
+		var err error
+		switch destination {
+		case "estimate_coverage_metrics_daily":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.EstimateCoverageMetricsDaily)
+		case "investment_classifications_daily":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.InvestmentClassificationsDaily)
+		case "investment_metrics_daily":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.InvestmentMetricsDaily)
+		case "issue_type_metrics_daily":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.IssueTypeMetricsDaily)
+		case "work_item_cycle_times":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemCycleTimes)
+		case "work_item_metrics_daily":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemMetricsDaily)
+		case "work_item_state_durations_daily":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemStateDurationsDaily)
+		case "work_item_team_attributions":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemTeamAttributions)
+		case "work_item_user_metrics_daily":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemUserMetricsDaily)
+		default:
+			return nil, ErrInvalidConfiguration
+		}
+		if err != nil {
+			return nil, err
+		}
+		effects = append(effects, effect)
+	}
+	return effects, nil
+}
+
+func buildGitLabTypedDerivedEffect[T any](
+	destination string,
+	rows []T,
+) (EffectBatch, error) {
+	encoded, err := json.Marshal(rows)
+	if err != nil {
+		return EffectBatch{}, err
+	}
+	var effectRows []json.RawMessage
+	if err := json.Unmarshal(encoded, &effectRows); err != nil {
+		return EffectBatch{}, ErrEffectRecoveryUnsafe
+	}
+	return BuildEffectBatch(destination, EffectReadbackRequired, effectRows)
+}
+
+func newGitLabWorkItemDerivedEffectIdentity(
+	claim Claim,
+	effect EffectBatch,
+) (GitLabWorkItemEffectIdentity, error) {
+	if claim.Validate() != nil || claim.Provider != "gitlab" || claim.Dataset != "work-items" ||
+		!gitlabWorkItemDerivedDestination(effect.Destination) ||
+		effect.Recovery != EffectReadbackRequired || !validDigest(effect.ContentDigest) ||
+		effect.PayloadBytes < 0 {
+		return GitLabWorkItemEffectIdentity{}, ErrInvalidConfiguration
+	}
+	rebuilt, err := BuildEffectBatch(effect.Destination, effect.Recovery, effect.Rows)
+	if err != nil || rebuilt.ContentDigest != effect.ContentDigest ||
+		rebuilt.PayloadBytes != effect.PayloadBytes {
+		return GitLabWorkItemEffectIdentity{}, ErrInvalidConfiguration
+	}
+	identity := GitLabWorkItemEffectIdentity{
+		OrgID: claim.OrgID, Provider: claim.Provider, Dataset: claim.Dataset,
+		Generation: claim.GenerationKey(), Destination: effect.Destination,
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}
+	if strings.TrimSpace(identity.OrgID) == "" || strings.TrimSpace(identity.Generation) == "" {
+		return GitLabWorkItemEffectIdentity{}, ErrInvalidConfiguration
+	}
+	return identity, nil
+}
+
+func gitlabWorkItemDerivedDestination(destination string) bool {
+	for _, candidate := range gitlabWorkItemDerivedDestinations {
+		if candidate == destination {
+			return true
+		}
+	}
+	return false
+}
+
+func gitlabDerivedGitHubIdentity(
+	identity GitLabWorkItemEffectIdentity,
+) GitHubWorkItemEffectIdentity {
+	return GitHubWorkItemEffectIdentity{
+		OrgID: identity.OrgID, Provider: identity.Provider, Dataset: identity.Dataset,
+		Generation: identity.Generation, Destination: identity.Destination,
+		ContentDigest: identity.ContentDigest, RowCount: identity.RowCount,
+	}
+}
+
+// GitLabWorkItemDerivedClickHouseEffects is the nine-destination provider
+// sink. Its fields are concrete adapter types and its dispatcher is an
+// explicit switch, so a destination cannot be accepted without a corresponding
+// schema-specific write/readback implementation.
+type GitLabWorkItemDerivedClickHouseEffects struct {
+	Lease                          providerfoundation.LeaseGuard
+	EstimateCoverageMetricsDaily   GitHubEstimateCoverageClickHouseEffects
+	InvestmentClassificationsDaily GitHubInvestmentClassificationsClickHouseEffects
+	InvestmentMetricsDaily         GitHubInvestmentMetricsClickHouseEffects
+	IssueTypeMetricsDaily          GitHubIssueTypeMetricsClickHouseEffects
+	WorkItemCycleTimes             GitHubWorkItemCycleTimesClickHouseEffects
+	WorkItemMetricsDaily           GitHubWorkItemMetricsDailyClickHouseEffects
+	WorkItemStateDurationsDaily    GitHubWorkItemStateDurationsClickHouseEffects
+	WorkItemTeamAttributions       GitHubWorkItemTeamAttributionsClickHouseEffects
+	WorkItemUserMetricsDaily       GitHubWorkItemUserMetricsDailyClickHouseEffects
+}
+
+func NewGitLabWorkItemDerivedClickHouseEffects(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+) (GitLabWorkItemDerivedClickHouseEffects, error) {
+	if conn == nil || lease == nil {
+		return GitLabWorkItemDerivedClickHouseEffects{}, ErrInvalidConfiguration
+	}
+	sink := GitLabWorkItemDerivedClickHouseEffects{
+		Lease:                          lease,
+		EstimateCoverageMetricsDaily:   GitHubEstimateCoverageClickHouseEffects{Conn: conn, Lease: lease},
+		InvestmentClassificationsDaily: GitHubInvestmentClassificationsClickHouseEffects{Conn: conn, Lease: lease},
+		InvestmentMetricsDaily:         GitHubInvestmentMetricsClickHouseEffects{Conn: conn, Lease: lease},
+		IssueTypeMetricsDaily:          GitHubIssueTypeMetricsClickHouseEffects{Conn: conn, Lease: lease},
+		WorkItemCycleTimes:             GitHubWorkItemCycleTimesClickHouseEffects{Conn: conn, Lease: lease},
+		WorkItemMetricsDaily:           GitHubWorkItemMetricsDailyClickHouseEffects{Conn: conn, Lease: lease},
+		WorkItemStateDurationsDaily:    GitHubWorkItemStateDurationsClickHouseEffects{Conn: conn, Lease: lease},
+		WorkItemTeamAttributions:       GitHubWorkItemTeamAttributionsClickHouseEffects{Conn: conn, Lease: lease},
+		WorkItemUserMetricsDaily:       GitHubWorkItemUserMetricsDailyClickHouseEffects{Conn: conn, Lease: lease},
+	}
+	if missing := sink.MissingDestinations(); len(missing) > 0 {
+		return sink, ErrInvalidConfiguration
+	}
+	return sink, nil
+}
+
+func (sink GitLabWorkItemDerivedClickHouseEffects) MissingDestinations() []string {
+	missing := make([]string, 0, len(gitlabWorkItemDerivedDestinations))
+	checks := []struct {
+		name  string
+		conn  driver.Conn
+		lease providerfoundation.LeaseGuard
+	}{
+		{"estimate_coverage_metrics_daily", sink.EstimateCoverageMetricsDaily.Conn, sink.EstimateCoverageMetricsDaily.Lease},
+		{"investment_classifications_daily", sink.InvestmentClassificationsDaily.Conn, sink.InvestmentClassificationsDaily.Lease},
+		{"investment_metrics_daily", sink.InvestmentMetricsDaily.Conn, sink.InvestmentMetricsDaily.Lease},
+		{"issue_type_metrics_daily", sink.IssueTypeMetricsDaily.Conn, sink.IssueTypeMetricsDaily.Lease},
+		{"work_item_cycle_times", sink.WorkItemCycleTimes.Conn, sink.WorkItemCycleTimes.Lease},
+		{"work_item_metrics_daily", sink.WorkItemMetricsDaily.Conn, sink.WorkItemMetricsDaily.Lease},
+		{"work_item_state_durations_daily", sink.WorkItemStateDurationsDaily.Conn, sink.WorkItemStateDurationsDaily.Lease},
+		{"work_item_team_attributions", sink.WorkItemTeamAttributions.Conn, sink.WorkItemTeamAttributions.Lease},
+		{"work_item_user_metrics_daily", sink.WorkItemUserMetricsDaily.Conn, sink.WorkItemUserMetricsDaily.Lease},
+	}
+	for _, check := range checks {
+		if check.conn == nil || check.lease == nil {
+			missing = append(missing, check.name)
+		}
+	}
+	return missing
+}
+
+func (sink GitLabWorkItemDerivedClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	identity, err := newGitLabWorkItemDerivedEffectIdentity(claim, effect)
+	if err != nil || ctx == nil || sink.Lease == nil || len(sink.MissingDestinations()) > 0 {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	gitHubIdentity := gitlabDerivedGitHubIdentity(identity)
+	switch effect.Destination {
+	case "estimate_coverage_metrics_daily":
+		err = sink.EstimateCoverageMetricsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "investment_classifications_daily":
+		err = sink.InvestmentClassificationsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "investment_metrics_daily":
+		err = sink.InvestmentMetricsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "issue_type_metrics_daily":
+		err = sink.IssueTypeMetricsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_cycle_times":
+		err = sink.WorkItemCycleTimes.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_metrics_daily":
+		err = sink.WorkItemMetricsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_state_durations_daily":
+		err = sink.WorkItemStateDurationsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_team_attributions":
+		err = sink.WorkItemTeamAttributions.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_user_metrics_daily":
+		err = sink.WorkItemUserMetricsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	default:
+		return ErrInvalidConfiguration
+	}
+	if err != nil {
+		return err
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink GitLabWorkItemDerivedClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	identity, err := newGitLabWorkItemDerivedEffectIdentity(claim, effect)
+	if err != nil || ctx == nil || sink.Lease == nil || len(sink.MissingDestinations()) > 0 {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	gitHubIdentity := gitlabDerivedGitHubIdentity(identity)
+	var inspection EffectInspection
+	switch effect.Destination {
+	case "estimate_coverage_metrics_daily":
+		inspection, err = sink.EstimateCoverageMetricsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "investment_classifications_daily":
+		inspection, err = sink.InvestmentClassificationsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "investment_metrics_daily":
+		inspection, err = sink.InvestmentMetricsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "issue_type_metrics_daily":
+		inspection, err = sink.IssueTypeMetricsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_cycle_times":
+		inspection, err = sink.WorkItemCycleTimes.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_metrics_daily":
+		inspection, err = sink.WorkItemMetricsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_state_durations_daily":
+		inspection, err = sink.WorkItemStateDurationsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_team_attributions":
+		inspection, err = sink.WorkItemTeamAttributions.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	case "work_item_user_metrics_daily":
+		inspection, err = sink.WorkItemUserMetricsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	switch inspection {
+	case EffectExact, EffectAbsent, EffectConflict:
+		return inspection, nil
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+var _ EffectSink = GitLabWorkItemDerivedClickHouseEffects{}
+var _ EffectReadback = GitLabWorkItemDerivedClickHouseEffects{}

--- a/internal/providersync/gitlab_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/gitlab_work_item_derived_effects_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// This suite deliberately uses githubDerivedIntegrationConn: it applies the
+// production ClickHouse migration chain and authors no local DDL. The GitLab
+// dispatcher is then exercised through the same nine schema-specific adapters
+// used by the provider route, with the provider identity kept as "gitlab".
+func TestGitLabWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink, err := NewGitLabWorkItemDerivedClickHouseEffects(conn, lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = githubDerivedIntegrationOrg
+	now := time.Date(2026, 8, 5, 0, 30, 0, 123000000, time.UTC)
+	day := newGitHubWorkItemDerivedDay(now)
+	metricDay := newGitHubWorkItemMetricDay(now)
+	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	teamID, teamName := "team-a", "Team A"
+	area, rule := "security", "sec_general"
+	assignee := "dev@example.com"
+	ratio := 0.5
+
+	estimate := gitlabEstimateCoverageMetricsDailyRow{
+		Day: day, Provider: "gitlab", WorkScopeID: "acme/api", TeamID: &teamID,
+		TeamName: &teamName, EstimatedCount: 1, UnestimatedCount: 1, BacklogSize: 2,
+		Ratio: &ratio, ComputedAt: now, OrgID: claim.OrgID,
+	}
+	classification := gitlabInvestmentClassificationDailyRow{
+		RepoID: &repoID, Day: day, ArtifactType: "work_item", ArtifactID: "acme/api#1",
+		Provider: "gitlab", InvestmentArea: &area, ProjectStream: "general", Confidence: 1,
+		RuleID: &rule, ComputedAt: now, OrgID: claim.OrgID,
+	}
+	investment := gitlabInvestmentMetricsDailyRow{
+		RepoID: &repoID, Day: day, TeamID: "payments", InvestmentArea: &area,
+		ProjectStream: "general", DeliveryUnits: 3, WorkItemsCompleted: 2, PRsMerged: 1,
+		ChurnLOC: 4, CycleP50Hours: 5, ComputedAt: now, OrgID: claim.OrgID,
+	}
+	issueType := gitlabIssueTypeMetricsDailyRow{
+		RepoID: &repoID, Day: day, Provider: "gitlab", TeamID: "payments",
+		IssueTypeNorm: "bug", CreatedCount: 1, CompletedCount: 2, ActiveCount: 3,
+		CycleP50Hours: 4, CycleP90Hours: 5, LeadP50Hours: 6, ComputedAt: now,
+		OrgID: claim.OrgID,
+	}
+	cycle := gitlabWorkItemCycleTimePersistenceRow{
+		WorkItemID: "gitlab:acme/api#1", Provider: "gitlab", Day: metricDay,
+		WorkScopeID: "acme/api", TeamID: teamID, TeamName: teamName, Assignee: &assignee,
+		Type: "feature", Status: "done", CreatedAt: now.Add(-72 * time.Hour),
+		CompletedAt: timePtr(now.Add(-2 * time.Hour)), CycleTimeHours: floatPtr(2),
+		LeadTimeHours: floatPtr(72), ComputedAt: now, OrgID: claim.OrgID,
+	}
+	metrics := githubWorkItemMetricTestGroupRow()
+	metrics.Provider, metrics.OrgID, metrics.Day = "gitlab", claim.OrgID, metricDay
+	users := githubWorkItemMetricTestUserRow()
+	users.Provider, users.OrgID, users.Day = "gitlab", claim.OrgID, metricDay
+	state := gitlabWorkItemStateDurationDailyRow{
+		Day: day, Provider: "gitlab", WorkScopeID: "acme/api", TeamID: teamID,
+		TeamName: teamName, Status: "in_progress", DurationHours: 6, ItemsTouched: 1,
+		ComputedAt: now, AvgWIP: 0.25, OrgID: claim.OrgID,
+	}
+	team := gitlabWorkItemTeamAttributionRow{
+		WorkItemID: "gitlab:acme/api#1", Provider: "gitlab", Source: "native_team",
+		IsPrimary: 1, Confidence: "high", Evidence: "native", ComputedAt: now,
+		RepoID: &repoID, TeamID: &teamID, TeamName: &teamName, OrgID: claim.OrgID,
+	}
+
+	effects, err := BuildGitLabWorkItemDerivedEffects(GitLabWorkItemDerivedEffectRows{
+		EstimateCoverageMetricsDaily:   []gitlabEstimateCoverageMetricsDailyRow{estimate},
+		InvestmentClassificationsDaily: []gitlabInvestmentClassificationDailyRow{classification},
+		InvestmentMetricsDaily:         []gitlabInvestmentMetricsDailyRow{investment},
+		IssueTypeMetricsDaily:          []gitlabIssueTypeMetricsDailyRow{issueType},
+		WorkItemCycleTimes:             []gitlabWorkItemCycleTimePersistenceRow{cycle},
+		WorkItemMetricsDaily:           []gitlabWorkItemMetricsDailyRow{metrics},
+		WorkItemStateDurationsDaily:    []gitlabWorkItemStateDurationDailyRow{state},
+		WorkItemTeamAttributions:       []gitlabWorkItemTeamAttributionRow{team},
+		WorkItemUserMetricsDaily:       []gitlabWorkItemUserMetricsDailyRow{users},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(effects) != len(gitlabWorkItemDerivedDestinations) {
+		t.Fatalf("effects=%d want=%d", len(effects), len(gitlabWorkItemDerivedDestinations))
+	}
+
+	for _, effect := range effects {
+		t.Run(effect.Destination, func(t *testing.T) {
+			if inspection, inspectErr := sink.InspectEffect(ctx, claim, effect); inspectErr != nil || inspection != EffectAbsent {
+				t.Fatalf("before write: inspection=%v error=%v", inspection, inspectErr)
+			}
+			if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+				t.Fatal(err)
+			}
+			if inspection, inspectErr := sink.InspectEffect(ctx, claim, effect); inspectErr != nil || inspection != EffectExact {
+				t.Fatalf("after write: inspection=%v error=%v", inspection, inspectErr)
+			}
+			if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+				t.Fatalf("replay write: %v", err)
+			}
+			if inspection, inspectErr := sink.InspectEffect(ctx, claim, effect); inspectErr != nil || inspection != EffectExact {
+				t.Fatalf("replay readback: inspection=%v error=%v", inspection, inspectErr)
+			}
+
+			foreign := claim
+			foreign.OrgID = "org-other"
+			if inspection, inspectErr := sink.InspectEffect(ctx, foreign, effect); inspectErr == nil || inspection == EffectExact {
+				t.Fatalf("foreign tenant was not rejected: inspection=%v error=%v", inspection, inspectErr)
+			}
+		})
+	}
+
+	// Simulate a worker dying after the durable write but before the adapter's
+	// post-write lease assertion. Recovery must find the exact row and avoid a
+	// duplicate write. Only the estimate adapter uses the expiring guard; the
+	// outer guard remains valid long enough to enter the adapter.
+	recoveryGuard := &secondAssertionLosesLease{}
+	recoverySink := sink
+	recoverySink.EstimateCoverageMetricsDaily.Lease = recoveryGuard
+	if err := recoverySink.WriteEffect(ctx, claim, effects[0]); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("post-write lease loss error=%v", err)
+	}
+	if inspection, inspectErr := sink.InspectEffect(ctx, claim, effects[0]); inspectErr != nil || inspection != EffectExact {
+		t.Fatalf("recovery readback: inspection=%v error=%v", inspection, inspectErr)
+	}
+}
+
+func timePtr(value time.Time) *time.Time { return &value }
+
+func floatPtr(value float64) *float64 { return &value }

--- a/internal/providersync/gitlab_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/gitlab_work_item_derived_effects_integration_test.go
@@ -119,8 +119,19 @@ func TestGitLabWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse(t *testi
 
 			foreign := claim
 			foreign.OrgID = "org-other"
-			if inspection, inspectErr := sink.InspectEffect(ctx, foreign, effect); inspectErr == nil || inspection == EffectExact {
-				t.Fatalf("foreign tenant was not rejected: inspection=%v error=%v", inspection, inspectErr)
+			inspection, inspectErr := sink.InspectEffect(ctx, foreign, effect)
+			switch effect.Destination {
+			case "estimate_coverage_metrics_daily", "work_item_state_durations_daily", "work_item_team_attributions":
+				if inspectErr != nil || inspection != EffectAbsent {
+					t.Fatalf("foreign tenant readback: inspection=%v error=%v", inspection, inspectErr)
+				}
+				if writeErr := sink.WriteEffect(ctx, foreign, effect); !errors.Is(writeErr, ErrInvalidConfiguration) {
+					t.Fatalf("foreign tenant write error=%v want=%v", writeErr, ErrInvalidConfiguration)
+				}
+			default:
+				if inspectErr == nil || inspection == EffectExact {
+					t.Fatalf("foreign tenant was not rejected: inspection=%v error=%v", inspection, inspectErr)
+				}
 			}
 		})
 	}

--- a/internal/providersync/gitlab_work_item_derived_oracle_test.go
+++ b/internal/providersync/gitlab_work_item_derived_oracle_test.go
@@ -1,0 +1,480 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// The GitLab cases reuse the same boundary-rich inputs as the already-landed
+// provider-neutral Python work-item producers, changing only provider leaves.
+// The Python side still executes the real production functions; this helper
+// only prevents nine hand-maintained fixture sets from drifting apart.
+func gitlabOracleCases(cases []oracleCase) []oracleCase {
+	result := make([]oracleCase, 0, len(cases))
+	for _, testCase := range cases {
+		result = append(result, oracleCase{ID: "gitlab_" + testCase.ID, Input: gitlabOracleValue(testCase.Input).(map[string]any)})
+	}
+	return result
+}
+
+func gitlabOracleValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			result[key] = gitlabOracleValue(nested)
+		}
+		return result
+	case []any:
+		result := make([]any, len(typed))
+		for index, nested := range typed {
+			result[index] = gitlabOracleValue(nested)
+		}
+		return result
+	case string:
+		if typed == "github" {
+			return "gitlab"
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func gitlabWorkItemOracleClaim(input map[string]any) Claim {
+	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = input["OrgID"].(string)
+	return claim
+}
+
+func gitlabWorkItemOracleRows(
+	t *testing.T,
+	input map[string]any,
+) (Claim, githubWorkItemRows, githubWorkItemDerivationContext) {
+	t.Helper()
+	claim := gitlabWorkItemOracleClaim(input)
+	rows := githubWorkItemRows{}
+	for _, raw := range githubDerivedOracleList(input, "WorkItems") {
+		rows.WorkItems = append(rows.WorkItems, gitlabWorkItemOracleGoItem(t, raw.(map[string]any)))
+	}
+	for _, raw := range githubDerivedOracleList(input, "Transitions") {
+		rows.StatusTransitions = append(rows.StatusTransitions, githubDerivedOracleGoTransition(t, raw.(map[string]any)))
+	}
+	for _, raw := range githubDerivedOracleList(input, "Dependencies") {
+		rows.Dependencies = append(rows.Dependencies, githubDerivedOracleGoDependency(t, raw.(map[string]any)))
+	}
+	encodedFacts, err := json.Marshal(input["Facts"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var facts githubWorkItemDerivationFacts
+	if err := json.Unmarshal(encodedFacts, &facts); err != nil {
+		t.Fatal(err)
+	}
+	derived := newGitHubWorkItemDerivationContext(facts)
+	subjects := make(map[string]githubWorkItemDerivationSubject)
+	for _, raw := range githubDerivedOracleList(input, "Donors") {
+		donor := githubWorkItemDerivationSubjectFromRow(gitlabWorkItemOracleGoItem(t, raw.(map[string]any)))
+		subjects[donor.WorkItemID] = donor
+	}
+	for _, row := range rows.WorkItems {
+		subject := githubWorkItemDerivationSubjectFromRow(row)
+		subjects[subject.WorkItemID] = subject
+	}
+	derived.linkedIssue = derived.buildLinkedIssueIndex(subjects, rows.Dependencies)
+	return claim, rows, derived
+}
+
+func gitlabWorkItemOracleGoItem(t *testing.T, raw map[string]any) githubWorkItemRow {
+	t.Helper()
+	item := githubDerivedOracleGoItem(t, raw)
+	if nativeTeamKey, ok := raw["native_team_key"].(string); ok {
+		item.NativeTeamKey = stringPointer(nativeTeamKey)
+	}
+	return item
+}
+
+func gitlabWorkItemOracleDay(t *testing.T, input map[string]any) time.Time {
+	t.Helper()
+	dayValue, ok := input["Day"].(string)
+	if !ok {
+		dayValue = input["SinceAt"].(string)[:len(time.DateOnly)]
+	}
+	day, err := time.Parse(time.DateOnly, dayValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return day
+}
+
+func gitlabWorkItemOracleComputedAt(t *testing.T, input map[string]any) time.Time {
+	t.Helper()
+	return githubDerivedOracleTime(t, input["ComputedAt"].(string))
+}
+
+func (columns githubWorkItemMetricsDailyOracleColumns) fromRows(
+	rows []githubWorkItemMetricsDailyRow,
+) githubWorkItemMetricsDailyOracleColumns {
+	for _, row := range rows {
+		columns.Day = append(columns.Day, row.Day)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.WorkScopeID = append(columns.WorkScopeID, row.WorkScopeID)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.TeamName = append(columns.TeamName, row.TeamName)
+		columns.ItemsStarted = append(columns.ItemsStarted, row.ItemsStarted)
+		columns.ItemsCompleted = append(columns.ItemsCompleted, row.ItemsCompleted)
+		columns.ItemsStartedUnassigned = append(columns.ItemsStartedUnassigned, row.ItemsStartedUnassigned)
+		columns.ItemsCompletedUnassigned = append(columns.ItemsCompletedUnassigned, row.ItemsCompletedUnassigned)
+		columns.WIPCountEndOfDay = append(columns.WIPCountEndOfDay, row.WIPCountEndOfDay)
+		columns.WIPUnassignedEndOfDay = append(columns.WIPUnassignedEndOfDay, row.WIPUnassignedEndOfDay)
+		columns.CycleTimeP50Hours = append(columns.CycleTimeP50Hours, row.CycleTimeP50Hours)
+		columns.CycleTimeP90Hours = append(columns.CycleTimeP90Hours, row.CycleTimeP90Hours)
+		columns.LeadTimeP50Hours = append(columns.LeadTimeP50Hours, row.LeadTimeP50Hours)
+		columns.LeadTimeP90Hours = append(columns.LeadTimeP90Hours, row.LeadTimeP90Hours)
+		columns.WIPAgeP50Hours = append(columns.WIPAgeP50Hours, row.WIPAgeP50Hours)
+		columns.WIPAgeP90Hours = append(columns.WIPAgeP90Hours, row.WIPAgeP90Hours)
+		columns.BugCompletedRatio = append(columns.BugCompletedRatio, row.BugCompletedRatio)
+		columns.StoryPointsCompleted = append(columns.StoryPointsCompleted, row.StoryPointsCompleted)
+		columns.NewBugsCount = append(columns.NewBugsCount, row.NewBugsCount)
+		columns.NewItemsCount = append(columns.NewItemsCount, row.NewItemsCount)
+		columns.DefectIntroRate = append(columns.DefectIntroRate, row.DefectIntroRate)
+		columns.WIPCongestionRatio = append(columns.WIPCongestionRatio, row.WIPCongestionRatio)
+		columns.PredictabilityScore = append(columns.PredictabilityScore, row.PredictabilityScore)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+func (columns githubWorkItemUserMetricsDailyOracleColumns) fromRows(
+	rows []githubWorkItemUserMetricsDailyRow,
+) githubWorkItemUserMetricsDailyOracleColumns {
+	for _, row := range rows {
+		columns.Day = append(columns.Day, row.Day)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.WorkScopeID = append(columns.WorkScopeID, row.WorkScopeID)
+		columns.UserIdentity = append(columns.UserIdentity, row.UserIdentity)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.TeamName = append(columns.TeamName, row.TeamName)
+		columns.ItemsStarted = append(columns.ItemsStarted, row.ItemsStarted)
+		columns.ItemsCompleted = append(columns.ItemsCompleted, row.ItemsCompleted)
+		columns.WIPCountEndOfDay = append(columns.WIPCountEndOfDay, row.WIPCountEndOfDay)
+		columns.CycleTimeP50Hours = append(columns.CycleTimeP50Hours, row.CycleTimeP50Hours)
+		columns.CycleTimeP90Hours = append(columns.CycleTimeP90Hours, row.CycleTimeP90Hours)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+func (columns githubWorkItemCycleTimeOracleColumns) fromRows(
+	rows []githubWorkItemCycleTimeRecord,
+) githubWorkItemCycleTimeOracleColumns {
+	for _, row := range rows {
+		columns.WorkItemID = append(columns.WorkItemID, row.WorkItemID)
+		columns.Provider = append(columns.Provider, row.Provider)
+		columns.Day = append(columns.Day, row.Day)
+		columns.WorkScopeID = append(columns.WorkScopeID, row.WorkScopeID)
+		columns.TeamID = append(columns.TeamID, row.TeamID)
+		columns.TeamName = append(columns.TeamName, row.TeamName)
+		columns.Assignee = append(columns.Assignee, row.Assignee)
+		columns.Type = append(columns.Type, row.Type)
+		columns.Status = append(columns.Status, row.Status)
+		columns.CreatedAt = append(columns.CreatedAt, row.CreatedAt)
+		columns.StartedAt = append(columns.StartedAt, row.StartedAt)
+		columns.CompletedAt = append(columns.CompletedAt, row.CompletedAt)
+		columns.CycleTimeHours = append(columns.CycleTimeHours, row.CycleTimeHours)
+		columns.LeadTimeHours = append(columns.LeadTimeHours, row.LeadTimeHours)
+		columns.ActiveTimeHours = append(columns.ActiveTimeHours, row.ActiveTimeHours)
+		columns.WaitTimeHours = append(columns.WaitTimeHours, row.WaitTimeHours)
+		columns.FlowEfficiency = append(columns.FlowEfficiency, row.FlowEfficiency)
+		columns.ComputedAt = append(columns.ComputedAt, row.ComputedAt)
+		columns.OrgID = append(columns.OrgID, row.OrgID)
+	}
+	return columns
+}
+
+func TestGitLabWorkItemMetricsDailyMatchesLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/metrics-daily", gitlabOracleCases(githubWorkItemMetricTripletOracleCases()), func(t *testing.T, input map[string]any) githubWorkItemMetricsDailyOracleColumns {
+		claim, rows, derived := gitlabWorkItemOracleRows(t, input)
+		triplet, err := buildWorkItemMetricTripletForProvider("gitlab", claim, rows, gitlabWorkItemOracleDay(t, input), gitlabWorkItemOracleComputedAt(t, input), derived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return newGitHubWorkItemMetricsDailyOracleColumns(len(triplet.MetricsDaily)).fromRows(triplet.MetricsDaily)
+	}, nil)
+}
+
+func TestGitLabWorkItemUserMetricsDailyMatchesLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/user-metrics-daily", gitlabOracleCases(githubWorkItemMetricTripletOracleCases()), func(t *testing.T, input map[string]any) githubWorkItemUserMetricsDailyOracleColumns {
+		claim, rows, derived := gitlabWorkItemOracleRows(t, input)
+		triplet, err := buildWorkItemMetricTripletForProvider("gitlab", claim, rows, gitlabWorkItemOracleDay(t, input), gitlabWorkItemOracleComputedAt(t, input), derived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return newGitHubWorkItemUserMetricsDailyOracleColumns(len(triplet.UserMetricsDaily)).fromRows(triplet.UserMetricsDaily)
+	}, nil)
+}
+
+func TestGitLabWorkItemCycleTimesMatchLivePythonProduction(t *testing.T) {
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/cycle-times", gitlabOracleCases(githubWorkItemMetricTripletOracleCases()), func(t *testing.T, input map[string]any) githubWorkItemCycleTimeOracleColumns {
+		claim, rows, derived := gitlabWorkItemOracleRows(t, input)
+		triplet, err := buildWorkItemMetricTripletForProvider("gitlab", claim, rows, gitlabWorkItemOracleDay(t, input), gitlabWorkItemOracleComputedAt(t, input), derived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return newGitHubWorkItemCycleTimeOracleColumns(len(triplet.CycleTimes)).fromRows(triplet.CycleTimes)
+	}, nil)
+}
+
+func TestGitLabDerivedSurfacesMatchLivePythonProduction(t *testing.T) {
+	cases := gitlabOracleCases(githubDerivedOracleCases())
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/estimate-coverage", cases, func(t *testing.T, input map[string]any) githubEstimateCoverageColumns {
+		claim, rows, derived := gitlabWorkItemOracleRows(t, input)
+		surfaces, err := buildWorkItemDerivedSurfacesForProvider("gitlab", claim, rows, gitlabWorkItemOracleDay(t, input), gitlabWorkItemOracleComputedAt(t, input), derived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return newGitHubEstimateCoverageColumns(surfaces.EstimateCoverage)
+	}, nil)
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/team-attributions", cases, func(t *testing.T, input map[string]any) githubTeamAttributionColumns {
+		claim, rows, derived := gitlabWorkItemOracleRows(t, input)
+		surfaces, err := buildWorkItemDerivedSurfacesForProvider("gitlab", claim, rows, gitlabWorkItemOracleDay(t, input), gitlabWorkItemOracleComputedAt(t, input), derived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return newGitHubTeamAttributionColumns(surfaces.TeamAttributions)
+	}, nil)
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/state-durations", cases, func(t *testing.T, input map[string]any) githubStateDurationColumns {
+		claim, rows, derived := gitlabWorkItemOracleRows(t, input)
+		surfaces, err := buildWorkItemDerivedSurfacesForProvider("gitlab", claim, rows, gitlabWorkItemOracleDay(t, input), gitlabWorkItemOracleComputedAt(t, input), derived)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return newGitHubStateDurationColumns(surfaces.StateDurations)
+	}, nil)
+}
+
+func TestGitLabEngineDestinationsMatchLivePythonProduction(t *testing.T) {
+	cases := gitlabOracleCases(githubWorkItemEngineOracleCases())
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/issue-type-metrics", cases,
+		func(t *testing.T, input map[string]any) githubIssueTypeMetricsColumns {
+			return newGitHubIssueTypeMetricsColumns(gitlabEngineOracleResult(t, input).IssueTypeMetricsDaily)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/investment-classifications", cases,
+		func(t *testing.T, input map[string]any) githubInvestmentClassificationColumns {
+			return newGitHubInvestmentClassificationColumns(gitlabEngineOracleResult(t, input).InvestmentClassificationsDaily)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "gitlab/work-items/investment-metrics", cases,
+		func(t *testing.T, input map[string]any) githubInvestmentMetricsColumns {
+			return newGitHubInvestmentMetricsColumns(gitlabEngineOracleResult(t, input).InvestmentMetricsDaily)
+		}, nil)
+}
+
+func gitlabEngineOracleResult(t *testing.T, input map[string]any) GitLabWorkItemDerivedRows {
+	t.Helper()
+	claim, rows, _ := gitlabWorkItemOracleRows(t, input)
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	facts := githubWorkItemDerivationFacts{}
+	encoded, err := json.Marshal(input["Facts"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &facts); err != nil {
+		t.Fatal(err)
+	}
+	source := &githubMultiDayOracleSource{facts: facts}
+	deriver := GitLabWorkItemDeriver{Source: source, statusMapping: statusMapping, investmentClassifier: classifier}
+	if sinceRaw, ok := input["SinceAt"].(string); ok {
+		since := githubDerivedOracleTime(t, sinceRaw)
+		before := githubDerivedOracleTime(t, input["BeforeAt"].(string))
+		claim.SinceAt, claim.BeforeAt = &since, &before
+	} else {
+		day := gitlabWorkItemOracleDay(t, input)
+		before := day.AddDate(0, 0, 1)
+		claim.SinceAt, claim.BeforeAt = &day, &before
+	}
+	result, err := deriver.Derive(context.Background(), claim, gitlabRowsFromGitHub(rows), gitlabWorkItemOracleComputedAt(t, input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Gaps) != 1 || result.Watermark != nil {
+		t.Fatalf("gap/watermark contract violated: gaps=%v watermark=%v", result.Gaps, result.Watermark)
+	}
+	return result
+}
+
+func gitlabRowsFromGitHub(rows githubWorkItemRows) gitlabWorkItemRows {
+	return gitlabWorkItemRows{
+		WorkItems: rows.WorkItems, StatusTransitions: rows.StatusTransitions,
+		Dependencies: rows.Dependencies, ReopenEvents: rows.ReopenEvents,
+		Interactions: rows.Interactions, Sprints: rows.Sprints,
+	}
+}
+
+func TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &githubMultiDayOracleSource{}
+	deriver := GitLabWorkItemDeriver{
+		Source: source, statusMapping: statusMapping, investmentClassifier: classifier,
+	}
+	counts := [9]int{}
+	cases := gitlabOracleCases(githubDerivedOracleCases())
+	cases = append(cases, gitlabOracleCases(githubWorkItemEngineOracleCases())...)
+	for _, testCase := range cases {
+		claim, rows, _ := gitlabWorkItemOracleRows(t, testCase.Input)
+		day := gitlabWorkItemOracleDay(t, testCase.Input)
+		before := day.AddDate(0, 0, 1)
+		claim.SinceAt, claim.BeforeAt = &day, &before
+		result, err := deriver.Derive(context.Background(), claim, gitlabRowsFromGitHub(rows), gitlabWorkItemOracleComputedAt(t, testCase.Input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		counts[0] += len(result.EstimateCoverageMetricsDaily)
+		counts[1] += len(result.InvestmentClassificationsDaily)
+		counts[2] += len(result.InvestmentMetricsDaily)
+		counts[3] += len(result.IssueTypeMetricsDaily)
+		counts[4] += len(result.WorkItemCycleTimes)
+		counts[5] += len(result.WorkItemMetricsDaily)
+		counts[6] += len(result.WorkItemStateDurationsDaily)
+		counts[7] += len(result.WorkItemTeamAttributions)
+		counts[8] += len(result.WorkItemUserMetricsDaily)
+		if len(result.Gaps) != 1 || result.Gaps[0].Destination != "ai_attribution" ||
+			result.Gaps[0].AuthoritativeProducer != "gitlab_mr_ai_attributions" {
+			t.Fatalf("unexpected typed gap: %+v", result.Gaps)
+		}
+		if result.Watermark != nil {
+			t.Fatalf("watermark advanced despite AI producer gap: %v", result.Watermark)
+		}
+	}
+	for index, count := range counts {
+		if count == 0 {
+			t.Fatalf("derived destination index %d produced no semantic rows across oracle cases", index)
+		}
+	}
+}
+
+func TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndExcludesAIGap(t *testing.T) {
+	metric := githubWorkItemMetricTestGroupRow()
+	metric.Provider = "gitlab"
+	metric.ItemsCompletedUnassigned = 7
+	rows := GitLabWorkItemDerivedEffectRows{
+		WorkItemMetricsDaily: []gitlabWorkItemMetricsDailyRow{metric},
+	}
+	effects, err := BuildGitLabWorkItemDerivedEffects(rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(effects) != len(gitlabWorkItemDerivedDestinations) {
+		t.Fatalf("effects=%d want=%d", len(effects), len(gitlabWorkItemDerivedDestinations))
+	}
+	for index, effect := range effects {
+		if effect.Destination != gitlabWorkItemDerivedDestinations[index] {
+			t.Fatalf("effect[%d]=%q want=%q", index, effect.Destination, gitlabWorkItemDerivedDestinations[index])
+		}
+		wantRows := 0
+		if index == 5 {
+			wantRows = 1
+		}
+		if effect.Recovery != EffectReadbackRequired || len(effect.Rows) != wantRows {
+			t.Fatalf("effect[%d] recovery/rows = %s/%d", index, effect.Recovery, len(effect.Rows))
+		}
+	}
+	for _, effect := range effects {
+		if effect.Destination == "ai_attribution" {
+			t.Fatal("AI producer gap was fabricated as an empty effect")
+		}
+	}
+	var metrics gitlabWorkItemMetricsDailyRow
+	if err := json.Unmarshal(effects[5].Rows[0], &metrics); err != nil {
+		t.Fatal(err)
+	}
+	if metrics.ItemsCompletedUnassigned != 7 {
+		t.Fatalf("metrics effect lost its typed row: %+v", metrics)
+	}
+}
+
+func TestGitLabWorkItemDerivedIdentityRejectsRawAndAIDestinations(t *testing.T) {
+	claim := nativeTestClaim("gitlab", "work-items")
+	effects, err := BuildGitLabWorkItemDerivedEffects(GitLabWorkItemDerivedEffectRows{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newGitLabWorkItemDerivedEffectIdentity(claim, effects[0]); err != nil {
+		t.Fatalf("first derived destination rejected: %v", err)
+	}
+	ai, err := BuildEffectBatch("ai_attribution", EffectReadbackRequired, []json.RawMessage{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newGitLabWorkItemDerivedEffectIdentity(claim, ai); err == nil {
+		t.Fatal("AI gap accepted as a derived effect")
+	}
+	raw, err := BuildEffectBatch("work_items", EffectReadbackRequired, []json.RawMessage{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newGitLabWorkItemDerivedEffectIdentity(claim, raw); err == nil {
+		t.Fatal("raw destination accepted by derived identity")
+	}
+}
+
+func TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap(t *testing.T) {
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deriver := GitLabWorkItemDeriver{
+		Source:               &githubMultiDayOracleSource{},
+		statusMapping:        statusMapping,
+		investmentClassifier: classifier,
+	}
+	doer := &gitLabWorkItemsDoer{responses: gitLabWorkItemResponses()}
+	claim := nativeTestClaim("gitlab", "work-items")
+	batch, err := (GitLabWorkItemsRouteHandler{
+		StatusMapping: loadRealStatusMapping(t), Derived: deriver,
+		PerPage: 2, MaxPages: 10, NestedMaxPages: 10,
+	}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "gitlab", ID: claim.CredentialID},
+		gitLabWorkItemsClient(t, doer), time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.Effects) != 15 {
+		t.Fatalf("effects=%d want 15 raw+nine-derived", len(batch.Effects))
+	}
+	for _, effect := range batch.Effects {
+		if effect.Destination == "ai_attribution" {
+			t.Fatal("AI gap was fabricated as an effect")
+		}
+	}
+	summary, ok := batch.Result["gitlab_work_items"].(GitLabWorkItemsResult)
+	if !ok {
+		t.Fatalf("summary type=%T", batch.Result["gitlab_work_items"])
+	}
+	if len(summary.DerivedDestinationsUnimplemented) != 1 ||
+		summary.DerivedDestinationsUnimplemented[0] != "ai_attribution" ||
+		len(summary.DerivedDestinationsImplemented) != 9 ||
+		!summary.WatermarkHeldForDerivedGap || batch.Watermark != nil {
+		t.Fatalf("derived summary/watermark=%+v/%v", summary, batch.Watermark)
+	}
+	implemented, ok := batch.Result["derived_destinations_implemented"].([]string)
+	if !ok || len(implemented) != 9 {
+		t.Fatalf("implemented destinations=%T/%v", batch.Result["derived_destinations_implemented"], batch.Result["derived_destinations_implemented"])
+	}
+}

--- a/internal/providersync/gitlab_work_items_route.go
+++ b/internal/providersync/gitlab_work_items_route.go
@@ -23,9 +23,9 @@ const (
 )
 
 // gitLabWorkItemRawDestinations are the six raw facts emitted by the Python
-// GitLabProvider batch. They are deliberately kept separate from the ten
-// canonical derived destinations; emitting empty derived rows would claim a
-// capability that this slice does not implement.
+// GitLabProvider batch. They are deliberately kept separate from the canonical
+// derived destinations; the unconfigured/raw-only route does not manufacture
+// empty effects for a destination whose producer is not active.
 var gitLabWorkItemRawDestinations = []string{
 	"work_items",
 	"work_item_transitions",
@@ -35,10 +35,11 @@ var gitLabWorkItemRawDestinations = []string{
 	"sprints",
 }
 
-// gitLabWorkItemDerivedGap is the honest remainder of the 16-destination
-// canonical work-item family. AI attribution is a direct Python destination,
-// but it is outside this six-fact slice; the other nine entries are computed
-// metric/attribution surfaces. No empty effect is manufactured for any entry.
+// gitLabWorkItemDerivedGap is the raw-only route's honest remainder of the
+// 16-destination canonical work-item family. Once the typed deriver is injected
+// at the processor boundary, its nine concrete destinations are removed and
+// only the AI producer gap remains. No empty effect is manufactured for that
+// missing producer.
 var gitLabWorkItemDerivedGap = []string{
 	"ai_attribution",
 	"estimate_coverage_metrics_daily",
@@ -73,8 +74,15 @@ type GitLabWorkItemsResult struct {
 	InteractionsSynced               int      `json:"interactions_synced"`
 	SprintsSynced                    int      `json:"sprints_synced"`
 	RawDestinations                  []string `json:"raw_destinations"`
+	DerivedDestinationsImplemented   []string `json:"derived_destinations_implemented"`
 	DerivedDestinationsUnimplemented []string `json:"derived_destinations_unimplemented"`
 	WatermarkHeldForDerivedGap       bool     `json:"watermark_held_for_derived_gap"`
+}
+
+// gitlabWorkItemsDeriver is injected at the processor boundary. It is not a
+// registry/configuration seam: activation remains outside this provider slice.
+type gitlabWorkItemsDeriver interface {
+	Derive(context.Context, Claim, gitlabWorkItemRows, time.Time) (GitLabWorkItemDerivedRows, error)
 }
 
 // GitLabWorkItemsRouteHandler is the canonical provider-only route. It mirrors
@@ -96,6 +104,7 @@ type GitLabWorkItemsRouteHandler struct {
 	FetchLinks      *bool
 	FetchMilestones *bool
 	IncludeMRs      *bool
+	Derived         gitlabWorkItemsDeriver
 }
 
 func gitLabWorkItemsFlag(value *bool) bool { return value == nil || *value }
@@ -351,12 +360,37 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 	if err != nil {
 		return CompleteRouteBatch{}, err
 	}
+	derivedUnimplemented := append([]string(nil), gitLabWorkItemDerivedGap...)
+	derivedImplemented := []string{}
+	derivedRecords := 0
+	if handler.Derived != nil {
+		derived, deriveErr := handler.Derived.Derive(ctx, claim, rows, normalizedAt)
+		if deriveErr != nil {
+			return CompleteRouteBatch{}, deriveErr
+		}
+		derivedEffects, effectErr := BuildGitLabWorkItemDerivedEffects(derived.EffectRows())
+		if effectErr != nil {
+			return CompleteRouteBatch{}, effectErr
+		}
+		effects = append(effects, derivedEffects...)
+		derivedImplemented = derived.producedDestinations()
+		derivedUnimplemented = make([]string, 0, len(derived.Gaps))
+		for _, gap := range derived.Gaps {
+			derivedUnimplemented = append(derivedUnimplemented, gap.Destination)
+		}
+		derivedRecords = len(derived.EstimateCoverageMetricsDaily) +
+			len(derived.InvestmentClassificationsDaily) + len(derived.InvestmentMetricsDaily) +
+			len(derived.IssueTypeMetricsDaily) + len(derived.WorkItemCycleTimes) +
+			len(derived.WorkItemMetricsDaily) + len(derived.WorkItemStateDurationsDaily) +
+			len(derived.WorkItemTeamAttributions) + len(derived.WorkItemUserMetricsDaily)
+	}
 	summary := GitLabWorkItemsResult{
 		WorkItemsSynced: len(rows.WorkItems), TransitionsSynced: len(rows.StatusTransitions),
 		DependenciesSynced: len(rows.Dependencies), ReopenEventsSynced: len(rows.ReopenEvents),
 		InteractionsSynced: len(rows.Interactions), SprintsSynced: len(rows.Sprints),
 		RawDestinations:                  append([]string(nil), gitLabWorkItemRawDestinations...),
-		DerivedDestinationsUnimplemented: append([]string(nil), gitLabWorkItemDerivedGap...),
+		DerivedDestinationsImplemented:   append([]string(nil), derivedImplemented...),
+		DerivedDestinationsUnimplemented: derivedUnimplemented,
 		WatermarkHeldForDerivedGap:       true,
 	}
 	result := map[string]any{
@@ -367,7 +401,8 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 		"interactions_synced":                len(rows.Interactions),
 		"sprints_synced":                     len(rows.Sprints),
 		"raw_destinations":                   append([]string(nil), gitLabWorkItemRawDestinations...),
-		"derived_destinations_unimplemented": append([]string(nil), gitLabWorkItemDerivedGap...),
+		"derived_destinations_implemented":   derivedImplemented,
+		"derived_destinations_unimplemented": derivedUnimplemented,
 		"watermark_held_for_derived_gap":     true,
 		"gitlab_work_items":                  summary,
 	}
@@ -376,7 +411,8 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 		Evidence: FetchEvidence{
 			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
 			Pages: pages, Records: len(rows.WorkItems) + len(rows.StatusTransitions) +
-				len(rows.Dependencies) + len(rows.ReopenEvents) + len(rows.Interactions) + len(rows.Sprints),
+				len(rows.Dependencies) + len(rows.ReopenEvents) + len(rows.Interactions) +
+				len(rows.Sprints) + derivedRecords,
 		},
 	}, nil
 }

--- a/internal/providersync/launchdarkly_effects_clickhouse.go
+++ b/internal/providersync/launchdarkly_effects_clickhouse.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
@@ -15,13 +16,91 @@ type LaunchDarklyClickHouseEffects struct {
 	Lease providerfoundation.LeaseGuard
 }
 
+// GitLabFeatureFlagsClickHouseEffects applies the feature-flag persistence
+// contract to GitLab rows. The provider is fixed by the wrapper so a caller
+// cannot use a compatible row shape to write a different provider's data.
+type GitLabFeatureFlagsClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+type featureFlagsClickHouseEffects struct {
+	Conn     driver.Conn
+	Lease    providerfoundation.LeaseGuard
+	Provider string
+}
+
 func (sink LaunchDarklyClickHouseEffects) WriteEffect(
 	ctx context.Context,
 	claim Claim,
 	effect EffectBatch,
 ) error {
-	if ctx == nil || sink.Lease == nil ||
-		claim.Validate() != nil || claim.Provider != "launchdarkly" {
+	return sink.shared().WriteEffect(ctx, claim, effect)
+}
+
+func (sink LaunchDarklyClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	return sink.shared().InspectEffect(ctx, claim, effect)
+}
+
+func (sink LaunchDarklyClickHouseEffects) shared() featureFlagsClickHouseEffects {
+	return featureFlagsClickHouseEffects{
+		Conn: sink.Conn, Lease: sink.Lease, Provider: "launchdarkly",
+	}
+}
+
+func (sink GitLabFeatureFlagsClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	return sink.shared().WriteEffect(ctx, claim, effect)
+}
+
+func (sink GitLabFeatureFlagsClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	return sink.shared().InspectEffect(ctx, claim, effect)
+}
+
+func (sink GitLabFeatureFlagsClickHouseEffects) shared() featureFlagsClickHouseEffects {
+	return featureFlagsClickHouseEffects{
+		Conn: sink.Conn, Lease: sink.Lease, Provider: "gitlab",
+	}
+}
+
+func (sink featureFlagsClickHouseEffects) acceptsDestination(destination string) bool {
+	switch destination {
+	case "feature_flag", "feature_flag_event", "work_graph_edges":
+		return true
+	case "feature_flag_link":
+		return sink.Provider == "launchdarkly"
+	default:
+		return false
+	}
+}
+
+func (sink featureFlagsClickHouseEffects) supportsReadback(destination string) bool {
+	if sink.Provider == "launchdarkly" {
+		return destination == "feature_flag_event"
+	}
+	return sink.Provider == "gitlab" && sink.acceptsDestination(destination)
+}
+
+func (sink featureFlagsClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		(sink.Provider != "launchdarkly" && sink.Provider != "gitlab") ||
+		claim.Provider != sink.Provider || claim.Dataset != "feature-flags" ||
+		!sink.acceptsDestination(effect.Destination) {
 		return ErrInvalidConfiguration
 	}
 	if err := sink.Lease.Assert(ctx); err != nil {
@@ -33,8 +112,11 @@ func (sink LaunchDarklyClickHouseEffects) WriteEffect(
 		if err != nil {
 			return err
 		}
-		if err := validateLaunchDarklyFlagScope(claim, rows); err != nil {
+		if err := validateFeatureFlagScope(claim, rows, sink.Provider); err != nil {
 			return err
+		}
+		if len(rows) == 0 && sink.Provider == "gitlab" {
+			return nil
 		}
 		if sink.Conn == nil {
 			return ErrInvalidConfiguration
@@ -45,8 +127,11 @@ func (sink LaunchDarklyClickHouseEffects) WriteEffect(
 		if err != nil {
 			return err
 		}
-		if err := validateLaunchDarklyEventScope(claim, rows); err != nil {
+		if err := validateFeatureFlagEventScope(claim, rows); err != nil {
 			return err
+		}
+		if len(rows) == 0 && sink.Provider == "gitlab" {
+			return nil
 		}
 		if sink.Conn == nil {
 			return ErrInvalidConfiguration
@@ -57,7 +142,7 @@ func (sink LaunchDarklyClickHouseEffects) WriteEffect(
 		if err != nil {
 			return err
 		}
-		if err := validateLaunchDarklyLinkScope(claim, rows); err != nil {
+		if err := validateFeatureFlagLinkScope(claim, rows, sink.Provider); err != nil {
 			return err
 		}
 		if sink.Conn == nil {
@@ -69,8 +154,11 @@ func (sink LaunchDarklyClickHouseEffects) WriteEffect(
 		if err != nil {
 			return err
 		}
-		if err := validateLaunchDarklyEdgeScope(claim, rows); err != nil {
+		if err := validateFeatureFlagEdgeScope(claim, rows, sink.Provider); err != nil {
 			return err
+		}
+		if len(rows) == 0 && sink.Provider == "gitlab" {
+			return nil
 		}
 		if sink.Conn == nil {
 			return ErrInvalidConfiguration
@@ -81,27 +169,56 @@ func (sink LaunchDarklyClickHouseEffects) WriteEffect(
 	}
 }
 
-func (sink LaunchDarklyClickHouseEffects) InspectEffect(
+func (sink featureFlagsClickHouseEffects) InspectEffect(
 	ctx context.Context,
 	claim Claim,
 	effect EffectBatch,
 ) (EffectInspection, error) {
-	if ctx == nil || sink.Lease == nil ||
-		claim.Validate() != nil || effect.Destination != "feature_flag_event" {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		(sink.Provider != "launchdarkly" && sink.Provider != "gitlab") ||
+		claim.Provider != sink.Provider || claim.Dataset != "feature-flags" ||
+		!sink.supportsReadback(effect.Destination) {
 		return EffectConflict, ErrInvalidConfiguration
 	}
 	if err := sink.Lease.Assert(ctx); err != nil {
 		return EffectConflict, err
 	}
+	switch effect.Destination {
+	case "feature_flag":
+		return sink.inspectFlags(ctx, claim, effect)
+	case "feature_flag_event":
+		return sink.inspectEvents(ctx, claim, effect)
+	case "work_graph_edges":
+		return sink.inspectEdges(ctx, claim, effect)
+	default:
+		// supportsReadback above makes this unreachable, but keep a defensive
+		// guard so a future destination cannot accidentally fall through.
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+func (sink featureFlagsClickHouseEffects) inspectEvents(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
 	expected, err := decodeEffectRows[launchDarklyEventRow](effect)
 	if err != nil {
 		return EffectConflict, err
 	}
-	if err := validateLaunchDarklyEventScope(claim, expected); err != nil {
+	if err := validateFeatureFlagEventScope(claim, expected); err != nil {
 		return EffectConflict, err
+	}
+	if len(expected) == 0 && sink.Provider == "gitlab" {
+		return EffectAbsent, nil
 	}
 	if sink.Conn == nil {
 		return EffectConflict, ErrInvalidConfiguration
+	}
+	if len(expected) == 0 {
+		// LaunchDarkly historically classified an empty event inspection as
+		// exact; retain that behavior for recovery compatibility.
+		return EffectExact, nil
 	}
 	exact, absent := 0, 0
 	for _, event := range expected {
@@ -128,19 +245,252 @@ func (sink LaunchDarklyClickHouseEffects) InspectEffect(
 	}
 }
 
-func validateLaunchDarklyFlagScope(
+func (sink featureFlagsClickHouseEffects) inspectFlags(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	expected, err := decodeEffectRows[launchDarklyFlagRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validateFeatureFlagScope(claim, expected, sink.Provider); err != nil {
+		return EffectConflict, err
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, flag := range expected {
+		inspection, err := sink.inspectFlag(ctx, flag)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink featureFlagsClickHouseEffects) inspectFlag(
+	ctx context.Context,
+	expected launchDarklyFlagRow,
+) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT org_id, provider, flag_key, project_key, repo_id, environment, flag_type,
+       created_at, archived_at, last_synced
+FROM feature_flag FINAL
+WHERE org_id = ? AND provider = ? AND project_key = ? AND flag_key = ? AND environment = ?`,
+		expected.OrgID, expected.Provider, expected.ProjectKey, expected.FlagKey,
+		expected.Environment,
+	)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual launchDarklyFlagRow
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(
+			&actual.OrgID, &actual.Provider, &actual.FlagKey, &actual.ProjectKey,
+			&actual.RepoID, &actual.Environment, &actual.FlagType, &actual.CreatedAt,
+			&actual.ArchivedAt, &actual.LastSynced,
+		); err != nil {
+			return EffectConflict, err
+		}
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareFeatureFlagVersion(expected, actual, found), nil
+}
+
+func compareFeatureFlagVersion(
+	expected, actual launchDarklyFlagRow,
+	found bool,
+) EffectInspection {
+	actualVersion := featureFlagsStoredTime(actual.LastSynced)
+	expectedVersion := featureFlagsStoredTime(expected.LastSynced)
+	if !found || actualVersion.IsZero() {
+		return EffectAbsent
+	}
+	if actualVersion.Before(expectedVersion) {
+		return EffectAbsent
+	}
+	if actualVersion.After(expectedVersion) {
+		return EffectConflict
+	}
+	if actual.OrgID != expected.OrgID || actual.Provider != expected.Provider ||
+		actual.FlagKey != expected.FlagKey || actual.ProjectKey != expected.ProjectKey ||
+		actual.RepoID != expected.RepoID || actual.Environment != expected.Environment ||
+		actual.FlagType != expected.FlagType ||
+		!featureFlagsStoredTimePointersEqual(actual.CreatedAt, expected.CreatedAt) ||
+		!featureFlagsStoredTimePointersEqual(actual.ArchivedAt, expected.ArchivedAt) {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func (sink featureFlagsClickHouseEffects) inspectEdges(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	expected, err := decodeEffectRows[launchDarklyEdgeRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := validateFeatureFlagEdgeScope(claim, expected, sink.Provider); err != nil {
+		return EffectConflict, err
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, edge := range expected {
+		inspection, err := sink.inspectEdge(ctx, edge)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+func (sink featureFlagsClickHouseEffects) inspectEdge(
+	ctx context.Context,
+	expected launchDarklyEdgeRow,
+) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT edge_id, source_type, source_id, target_type, target_id, edge_type,
+       ifNull(toString(repo_id), ''), provider, provenance, confidence, evidence,
+       discovered_at, last_synced, event_ts, toString(day), org_id
+FROM work_graph_edges FINAL
+WHERE org_id = ? AND source_type = ? AND source_id = ? AND edge_type = ?
+  AND target_type = ? AND target_id = ?`,
+		expected.OrgID, expected.SourceType, expected.SourceID, expected.EdgeType,
+		expected.TargetType, expected.TargetID,
+	)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var actual launchDarklyEdgeRow
+	var repoID string
+	var confidence float32
+	found := false
+	for rows.Next() {
+		if err := rows.Scan(
+			&actual.EdgeID, &actual.SourceType, &actual.SourceID, &actual.TargetType,
+			&actual.TargetID, &actual.EdgeType, &repoID, &actual.Provider,
+			&actual.Provenance, &confidence, &actual.Evidence, &actual.DiscoveredAt,
+			&actual.LastSynced, &actual.EventAt, &actual.Day, &actual.OrgID,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.RepoID = repoID
+		actual.Confidence = float64(confidence)
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return compareFeatureFlagEdgeVersion(expected, actual, found), nil
+}
+
+func compareFeatureFlagEdgeVersion(
+	expected, actual launchDarklyEdgeRow,
+	found bool,
+) EffectInspection {
+	actualVersion := featureFlagsStoredTime(actual.LastSynced)
+	expectedVersion := featureFlagsStoredTime(expected.LastSynced)
+	if !found || actualVersion.IsZero() {
+		return EffectAbsent
+	}
+	if actualVersion.Before(expectedVersion) {
+		return EffectAbsent
+	}
+	if actualVersion.After(expectedVersion) {
+		return EffectConflict
+	}
+	if actual.EdgeID != expected.EdgeID || actual.SourceType != expected.SourceType ||
+		actual.SourceID != expected.SourceID || actual.TargetType != expected.TargetType ||
+		actual.TargetID != expected.TargetID || actual.EdgeType != expected.EdgeType ||
+		actual.RepoID != expected.RepoID || actual.Provider != expected.Provider ||
+		actual.Provenance != expected.Provenance ||
+		float32(actual.Confidence) != float32(expected.Confidence) ||
+		actual.Evidence != expected.Evidence ||
+		!featureFlagsStoredTime(actual.DiscoveredAt).Equal(featureFlagsStoredTime(expected.DiscoveredAt)) ||
+		!featureFlagsStoredTime(actual.EventAt).Equal(featureFlagsStoredTime(expected.EventAt)) || actual.Day != expected.Day ||
+		actual.OrgID != expected.OrgID {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+// All feature-flag destinations use DateTime64(3). Compare the value as it
+// exists in ClickHouse, not as it appeared in a provider payload with finer
+// precision. Recovery receives the original effect snapshot, while the
+// server has already quantized the inserted timestamp to milliseconds.
+func featureFlagsStoredTime(value time.Time) time.Time {
+	return value.UTC().Truncate(time.Millisecond)
+}
+
+func featureFlagsStoredTimePointersEqual(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return featureFlagsStoredTime(*left).Equal(featureFlagsStoredTime(*right))
+}
+
+func validateFeatureFlagScope(
 	claim Claim,
 	rows []launchDarklyFlagRow,
+	provider string,
 ) error {
 	for _, row := range rows {
-		if row.OrgID != claim.OrgID || row.Provider != claim.Provider {
+		if row.OrgID != claim.OrgID || row.Provider != provider {
 			return providerfoundation.ErrInvalidScope
 		}
 	}
 	return nil
 }
 
-func validateLaunchDarklyEventScope(
+func validateFeatureFlagEventScope(
 	claim Claim,
 	rows []launchDarklyEventRow,
 ) error {
@@ -152,31 +502,87 @@ func validateLaunchDarklyEventScope(
 	return nil
 }
 
-func validateLaunchDarklyLinkScope(
+func validateFeatureFlagLinkScope(
 	claim Claim,
 	rows []launchDarklyLinkRow,
+	provider string,
 ) error {
 	for _, row := range rows {
-		if row.OrgID != claim.OrgID || row.Provider != claim.Provider {
+		if row.OrgID != claim.OrgID || row.Provider != provider {
 			return providerfoundation.ErrInvalidScope
 		}
 	}
 	return nil
 }
 
-func validateLaunchDarklyEdgeScope(
+func validateFeatureFlagEdgeScope(
 	claim Claim,
 	rows []launchDarklyEdgeRow,
+	provider string,
 ) error {
 	for _, row := range rows {
-		if row.OrgID != claim.OrgID || row.Provider != claim.Provider {
+		if row.OrgID != claim.OrgID || row.Provider != provider {
 			return providerfoundation.ErrInvalidScope
 		}
 	}
 	return nil
+}
+
+// Keep the original LaunchDarkly-scoped helpers as narrow compatibility
+// shims for package-local callers while the shared implementation serves both
+// fixed-provider wrappers.
+func validateLaunchDarklyFlagScope(claim Claim, rows []launchDarklyFlagRow) error {
+	return validateFeatureFlagScope(claim, rows, "launchdarkly")
+}
+
+func validateLaunchDarklyEventScope(claim Claim, rows []launchDarklyEventRow) error {
+	return validateFeatureFlagEventScope(claim, rows)
+}
+
+func validateLaunchDarklyLinkScope(claim Claim, rows []launchDarklyLinkRow) error {
+	return validateFeatureFlagLinkScope(claim, rows, "launchdarkly")
+}
+
+func validateLaunchDarklyEdgeScope(claim Claim, rows []launchDarklyEdgeRow) error {
+	return validateFeatureFlagEdgeScope(claim, rows, "launchdarkly")
 }
 
 func (sink LaunchDarklyClickHouseEffects) writeFlags(
+	ctx context.Context,
+	rows []launchDarklyFlagRow,
+) error {
+	return sink.shared().writeFlags(ctx, rows)
+}
+
+func (sink LaunchDarklyClickHouseEffects) writeEvents(
+	ctx context.Context,
+	rows []launchDarklyEventRow,
+) error {
+	return sink.shared().writeEvents(ctx, rows)
+}
+
+func (sink LaunchDarklyClickHouseEffects) writeLinks(
+	ctx context.Context,
+	rows []launchDarklyLinkRow,
+) error {
+	return sink.shared().writeLinks(ctx, rows)
+}
+
+func (sink LaunchDarklyClickHouseEffects) writeEdges(
+	ctx context.Context,
+	rows []launchDarklyEdgeRow,
+) error {
+	return sink.shared().writeEdges(ctx, rows)
+}
+
+func (sink LaunchDarklyClickHouseEffects) inspectEvent(
+	ctx context.Context,
+	expected launchDarklyEventRow,
+) (EffectInspection, error) {
+	return sink.shared().inspectEvent(ctx, expected)
+}
+
+func (sink featureFlagsClickHouseEffects) writeFlags(
 	ctx context.Context,
 	rows []launchDarklyFlagRow,
 ) error {
@@ -207,7 +613,7 @@ INSERT INTO feature_flag (
 	return batch.Send()
 }
 
-func (sink LaunchDarklyClickHouseEffects) writeEvents(
+func (sink featureFlagsClickHouseEffects) writeEvents(
 	ctx context.Context,
 	rows []launchDarklyEventRow,
 ) error {
@@ -238,7 +644,7 @@ INSERT INTO feature_flag_event (
 	return batch.Send()
 }
 
-func (sink LaunchDarklyClickHouseEffects) writeLinks(
+func (sink featureFlagsClickHouseEffects) writeLinks(
 	ctx context.Context,
 	rows []launchDarklyLinkRow,
 ) error {
@@ -269,7 +675,7 @@ INSERT INTO feature_flag_link (
 	return batch.Send()
 }
 
-func (sink LaunchDarklyClickHouseEffects) writeEdges(
+func (sink featureFlagsClickHouseEffects) writeEdges(
 	ctx context.Context,
 	rows []launchDarklyEdgeRow,
 ) error {
@@ -306,7 +712,7 @@ INSERT INTO work_graph_edges (
 	return batch.Send()
 }
 
-func (sink LaunchDarklyClickHouseEffects) inspectEvent(
+func (sink featureFlagsClickHouseEffects) inspectEvent(
 	ctx context.Context,
 	expected launchDarklyEventRow,
 ) (EffectInspection, error) {
@@ -322,6 +728,9 @@ WHERE org_id = ? AND dedupe_key = ?`,
 		return EffectConflict, err
 	}
 	defer rows.Close()
+	storedExpected := expected
+	storedExpected.EventAt = featureFlagsStoredTime(expected.EventAt)
+	storedExpected.IngestedAt = featureFlagsStoredTime(expected.IngestedAt)
 	found, matched := 0, 0
 	for rows.Next() {
 		var actual launchDarklyEventRow
@@ -334,11 +743,9 @@ WHERE org_id = ? AND dedupe_key = ?`,
 			return EffectConflict, err
 		}
 		found++
-		actual.EventAt = actual.EventAt.UTC()
-		actual.IngestedAt = actual.IngestedAt.UTC()
-		expected.EventAt = expected.EventAt.UTC()
-		expected.IngestedAt = expected.IngestedAt.UTC()
-		if actual == expected {
+		actual.EventAt = featureFlagsStoredTime(actual.EventAt)
+		actual.IngestedAt = featureFlagsStoredTime(actual.IngestedAt)
+		if actual == storedExpected {
 			matched++
 		}
 	}
@@ -348,7 +755,7 @@ WHERE org_id = ? AND dedupe_key = ?`,
 	switch {
 	case found == 0:
 		return EffectAbsent, nil
-	case found == 1 && matched == 1:
+	case found > 0 && matched == found:
 		return EffectExact, nil
 	default:
 		return EffectConflict, nil
@@ -376,3 +783,5 @@ func decodeEffectRows[T any](effect EffectBatch) ([]T, error) {
 
 var _ EffectSink = LaunchDarklyClickHouseEffects{}
 var _ EffectReadback = LaunchDarklyClickHouseEffects{}
+var _ EffectSink = GitLabFeatureFlagsClickHouseEffects{}
+var _ EffectReadback = GitLabFeatureFlagsClickHouseEffects{}

--- a/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_derived_surfaces.json
@@ -557,6 +557,23 @@
           "./internal/providersync/"
         ]
       ]
+    },
+    {
+      "id": "W1-derived-write-rejects-foreign-tenant-rows",
+      "file": "internal/providersync/github_work_item_derived_effects_clickhouse.go",
+      "find": "\t\tif !validGitHubWorkItemDerivedRowTenancy(row, identity) {",
+      "replace": "\t\tif !validGitHubWorkItemDerivedRowTenancy(row, identity) && false {",
+      "rationale": "readback must let the SQL org_id fence return EffectAbsent, but writes must reject a persisted row whose tenant or provider differs from the effect identity before acquiring the lease. The public write-entrypoint proof makes bypassing this guard observable.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubEstimateCoverageWrite_rejectsForeignTenantBeforeLease$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/github_work_item_metric_triplet.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_item_metric_triplet.json
@@ -612,8 +612,8 @@
     {
       "id": "M41-the-identity-tenant-is-non-blank",
       "file": "internal/providersync/github_work_item_metric_triplet_effects_clickhouse.go",
-      "find": "\tif strings.TrimSpace(identity.OrgID) == \"\" || identity.Provider != \"github\" ||",
-      "replace": "\tif identity.Provider != \"github\" ||",
+      "find": "\tif strings.TrimSpace(identity.OrgID) == \"\" ||\n\t\t(identity.Provider != \"github\" && identity.Provider != \"gitlab\") ||",
+      "replace": "\tif (identity.Provider != \"github\" && identity.Provider != \"gitlab\") ||",
       "rationale": "a blank tenant fences nothing; the readback would compare against every tenant's rows",
       "proof": [
         [

--- a/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_effects.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_effects.json
@@ -1,0 +1,338 @@
+{
+  "schema_version": 1,
+  "name": "GitLab feature-flags effects provider parity (CHAOS-3702)",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "Effects-only coverage for the fixed GitLab ClickHouse sink: provider/dataset/destination guards, tenant scope, empty effects, lease fences, projections/append values, readback/version decisions, and migrated-schema provider/tenant fences. The current proof suite has no observable forged-provider row for the GitLab feature_flag or work_graph_edges validators, so those duplicate provider-row clauses and the duplicate event/edge pre-send sites are intentionally not declared as measured mutations; adding entries without a failing trigger would create false coverage. Registry, route, oracle, matrix, scheduler, transport, wiring, migration, and harness execution remain outside this plan.",
+  "mutations": [
+    {
+      "id": "E1-gitlab-wrapper-provider",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func (sink GitLabFeatureFlagsClickHouseEffects) shared() featureFlagsClickHouseEffects {\n\treturn featureFlagsClickHouseEffects{\n\t\tConn: sink.Conn, Lease: sink.Lease, Provider: \"gitlab\",\n\t}\n}",
+      "replace": "func (sink GitLabFeatureFlagsClickHouseEffects) shared() featureFlagsClickHouseEffects {\n\treturn featureFlagsClickHouseEffects{\n\t\tConn: sink.Conn, Lease: sink.Lease, Provider: \"launchdarkly\",\n\t}\n}",
+      "rationale": "the exported GitLab wrapper must pin the shared sink to GitLab before claim validation or persistence",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E2-gitlab-forbidden-link",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "return sink.Provider == \"launchdarkly\"",
+      "replace": "return true",
+      "rationale": "feature_flag_link is a LaunchDarkly-only destination and a GitLab effect must never be allowed to write it",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E3-write-provider-guard",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "claim.Provider != sink.Provider || claim.Dataset != \"feature-flags\" ||\n\t\t!sink.acceptsDestination(effect.Destination) {",
+      "replace": "false || claim.Dataset != \"feature-flags\" ||\n\t\t!sink.acceptsDestination(effect.Destination) {",
+      "rationale": "WriteEffect must reject a claim from another provider before decoding rows or preparing a ClickHouse batch",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsRejectProviderDatasetAndDestinationBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E4-write-dataset-guard",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "claim.Dataset != \"feature-flags\" ||\n\t\t!sink.acceptsDestination(effect.Destination) {",
+      "replace": "false ||\n\t\t!sink.acceptsDestination(effect.Destination) {",
+      "rationale": "WriteEffect must reject a different dataset even when the provider claim is GitLab",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsRejectProviderDatasetAndDestinationBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E5-write-destination-guard",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "!sink.acceptsDestination(effect.Destination) {",
+      "replace": "false {",
+      "rationale": "WriteEffect must reject a destination outside the GitLab feature_flag, feature_flag_event, and work_graph_edges contract",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsRejectProviderDatasetAndDestinationBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E6-inspect-provider-guard",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "claim.Provider != sink.Provider || claim.Dataset != \"feature-flags\" ||\n\t\t!sink.supportsReadback(effect.Destination) {",
+      "replace": "false || claim.Dataset != \"feature-flags\" ||\n\t\t!sink.supportsReadback(effect.Destination) {",
+      "rationale": "InspectEffect must reject readback for another provider before issuing a query",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsRejectProviderDatasetAndDestinationBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E7-inspect-dataset-guard",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "claim.Dataset != \"feature-flags\" ||\n\t\t!sink.supportsReadback(effect.Destination) {",
+      "replace": "false ||\n\t\t!sink.supportsReadback(effect.Destination) {",
+      "rationale": "InspectEffect must reject readback for a different dataset before issuing a query",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsRejectProviderDatasetAndDestinationBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E8-inspect-destination-support",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "return sink.Provider == \"gitlab\" && sink.acceptsDestination(destination)",
+      "replace": "return sink.Provider == \"gitlab\" && false",
+      "rationale": "GitLab readback must support each allowed feature-flag destination while continuing to reject feature_flag_link",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E9-flag-org-scope",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func validateFeatureFlagScope(\n\tclaim Claim,\n\trows []launchDarklyFlagRow,\n\tprovider string,\n) error {\n\tfor _, row := range rows {\n\t\tif row.OrgID != claim.OrgID || row.Provider != provider {",
+      "replace": "func validateFeatureFlagScope(\n\tclaim Claim,\n\trows []launchDarklyFlagRow,\n\tprovider string,\n) error {\n\tfor _, row := range rows {\n\t\tif false || row.Provider != provider {",
+      "rationale": "feature-flag rows must remain tenant-bound before either writes or readback queries",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsFenceTenantAndLeaseBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E10-event-org-scope",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func validateFeatureFlagEventScope(\n\tclaim Claim,\n\trows []launchDarklyEventRow,\n) error {\n\tfor _, row := range rows {\n\t\tif row.OrgID != claim.OrgID {",
+      "replace": "func validateFeatureFlagEventScope(\n\tclaim Claim,\n\trows []launchDarklyEventRow,\n) error {\n\tfor _, row := range rows {\n\t\tif row.OrgID != row.OrgID {",
+      "rationale": "feature-flag event rows must remain tenant-bound before event persistence or LaunchDarkly readback",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLaunchDarklyClickHouseEffectsRejectCrossTenantRowsBeforeIO$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E11-link-provider-scope",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func validateFeatureFlagLinkScope(\n\tclaim Claim,\n\trows []launchDarklyLinkRow,\n\tprovider string,\n) error {\n\tfor _, row := range rows {\n\t\tif row.OrgID != claim.OrgID || row.Provider != provider {",
+      "replace": "func validateFeatureFlagLinkScope(\n\tclaim Claim,\n\trows []launchDarklyLinkRow,\n\tprovider string,\n) error {\n\tfor _, row := range rows {\n\t\tif row.OrgID != claim.OrgID || false {",
+      "rationale": "LaunchDarkly link rows still require the fixed provider even though links are forbidden for GitLab",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLaunchDarklyClickHouseEffectsRejectCrossTenantRowsBeforeIO$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E12-edge-org-scope",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func validateFeatureFlagEdgeScope(\n\tclaim Claim,\n\trows []launchDarklyEdgeRow,\n\tprovider string,\n) error {\n\tfor _, row := range rows {\n\t\tif row.OrgID != claim.OrgID || row.Provider != provider {",
+      "replace": "func validateFeatureFlagEdgeScope(\n\tclaim Claim,\n\trows []launchDarklyEdgeRow,\n\tprovider string,\n) error {\n\tfor _, row := range rows {\n\t\tif false || row.Provider != provider {",
+      "rationale": "work-graph edge rows must remain tenant-bound before edge persistence or readback",
+      "proof": [["go", "test", "-count=1", "-run", "^TestLaunchDarklyClickHouseEffectsRejectCrossTenantRowsBeforeIO$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E13-pre-prepare-lease",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\tswitch effect.Destination {",
+      "replace": "if err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn nil\n\t}\n\tswitch effect.Destination {",
+      "rationale": "the lease must be rechecked before decoding and preparing any destination batch",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsFenceTenantAndLeaseBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E14-pre-send-lease",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "\t\t\trow.LastSynced,\n\t\t); err != nil {\n\t\t\treturn err\n\t\t}\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()",
+      "replace": "\t\t\trow.LastSynced,\n\t\t); err != nil {\n\t\t\treturn err\n\t\t}\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn nil\n\t}\n\treturn batch.Send()",
+      "rationale": "the flag batch must not be sent after the lease is lost between append and send",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsFenceTenantAndLeaseBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E15-pre-query-lease",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tswitch effect.Destination {",
+      "replace": "if err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn EffectAbsent, nil\n\t}\n\tswitch effect.Destination {",
+      "rationale": "readback must stop at the lease fence before issuing a ClickHouse query",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsFenceTenantAndLeaseBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E16-write-empty-flag",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if err := validateFeatureFlagScope(claim, rows, sink.Provider); err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif len(rows) == 0 && sink.Provider == \"gitlab\" {",
+      "replace": "if err := validateFeatureFlagScope(claim, rows, sink.Provider); err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif false {",
+      "rationale": "a valid empty GitLab feature-flag effect is a successful no-op and must not require ClickHouse",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E17-write-empty-event",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if err := validateFeatureFlagEventScope(claim, rows); err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif len(rows) == 0 && sink.Provider == \"gitlab\" {",
+      "replace": "if err := validateFeatureFlagEventScope(claim, rows); err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif false {",
+      "rationale": "a valid empty GitLab feature-flag event effect is a successful no-op and must not require ClickHouse",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E18-write-empty-edge",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if err := validateFeatureFlagEdgeScope(claim, rows, sink.Provider); err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif len(rows) == 0 && sink.Provider == \"gitlab\" {",
+      "replace": "if err := validateFeatureFlagEdgeScope(claim, rows, sink.Provider); err != nil {\n\t\t\treturn err\n\t\t}\n\t\tif false {",
+      "rationale": "a valid empty GitLab work-graph edge effect is a successful no-op and must not require ClickHouse",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E19-inspect-empty-event",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if len(expected) == 0 && sink.Provider == \"gitlab\" {\n\t\treturn EffectAbsent, nil\n\t}",
+      "replace": "if false {\n\t\treturn EffectAbsent, nil\n\t}",
+      "rationale": "GitLab empty event readback is an absent effect without a query, unlike the preserved LaunchDarkly legacy classification",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E21-inspect-empty-flag-clause",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func (sink featureFlagsClickHouseEffects) inspectFlags(\n\tctx context.Context,\n\tclaim Claim,\n\teffect EffectBatch,\n) (EffectInspection, error) {\n\texpected, err := decodeEffectRows[launchDarklyFlagRow](effect)\n\tif err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif err := validateFeatureFlagScope(claim, expected, sink.Provider); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(expected) == 0 {",
+      "replace": "func (sink featureFlagsClickHouseEffects) inspectFlags(\n\tctx context.Context,\n\tclaim Claim,\n\teffect EffectBatch,\n) (EffectInspection, error) {\n\texpected, err := decodeEffectRows[launchDarklyFlagRow](effect)\n\tif err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif err := validateFeatureFlagScope(claim, expected, sink.Provider); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif false {",
+      "rationale": "a GitLab empty feature-flag inspection must return absent before the nil-connection guard",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E22-inspect-empty-edge",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func (sink featureFlagsClickHouseEffects) inspectEdges(\n\tctx context.Context,\n\tclaim Claim,\n\teffect EffectBatch,\n) (EffectInspection, error) {\n\texpected, err := decodeEffectRows[launchDarklyEdgeRow](effect)\n\tif err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif err := validateFeatureFlagEdgeScope(claim, expected, sink.Provider); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif len(expected) == 0 {",
+      "replace": "func (sink featureFlagsClickHouseEffects) inspectEdges(\n\tctx context.Context,\n\tclaim Claim,\n\teffect EffectBatch,\n) (EffectInspection, error) {\n\texpected, err := decodeEffectRows[launchDarklyEdgeRow](effect)\n\tif err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif err := validateFeatureFlagEdgeScope(claim, expected, sink.Provider); err != nil {\n\t\treturn EffectConflict, err\n\t}\n\tif false {",
+      "rationale": "a GitLab empty work-graph edge inspection must return absent before the nil-connection guard",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAcceptsLegitimateEmptyEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E23-flag-append-values",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "row.Environment, row.FlagType, row.CreatedAt, row.ArchivedAt,\n\t\t\trow.LastSynced,",
+      "replace": "row.Environment, row.FlagType, row.CreatedAt, row.CreatedAt,\n\t\t\trow.LastSynced,",
+      "rationale": "feature_flag append order must preserve nullable archived_at separately from created_at",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsPreserveNullableStringAndTimeValues$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E24-event-append-values",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "row.ActorType, row.PrevState, row.NextState, row.EventAt,\n\t\t\trow.IngestedAt, row.SourceEventID, row.DedupeKey,",
+      "replace": "row.ActorType, row.PrevState, row.PrevState, row.EventAt,\n\t\t\trow.IngestedAt, row.SourceEventID, row.DedupeKey,",
+      "rationale": "feature_flag_event append order must preserve the distinct previous and next states",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E25-edge-append-values",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "float32(row.Confidence), row.Evidence, row.DiscoveredAt,\n\t\t\trow.LastSynced, row.EventAt, row.Day, row.OrgID,",
+      "replace": "float32(row.Confidence), row.Provenance, row.DiscoveredAt,\n\t\t\trow.LastSynced, row.EventAt, row.Day, row.OrgID,",
+      "rationale": "work_graph_edges append order must preserve evidence independently from provenance",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E26-edge-nullable-repo-append",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if row.RepoID != \"\" {",
+      "replace": "if row.RepoID == \"\" {",
+      "rationale": "an empty GitLab repository identifier must be appended as nullable nil, not as a non-null empty string",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsPreserveNullableStringAndTimeValues$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E27-flag-readback-projection",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "&actual.RepoID, &actual.Environment, &actual.FlagType, &actual.CreatedAt,",
+      "replace": "&actual.RepoID, &actual.FlagType, &actual.FlagType, &actual.CreatedAt,",
+      "rationale": "feature_flag readback scan destinations must match the migrated-schema SELECT projection",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E28-event-readback-projection",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "&actual.RepoID, &actual.ActorType, &actual.PrevState,\n\t\t\t&actual.NextState, &actual.EventAt,",
+      "replace": "&actual.RepoID, &actual.ActorType, &actual.NextState,\n\t\t\t&actual.NextState, &actual.EventAt,",
+      "rationale": "feature_flag_event readback scan destinations must preserve both state columns in projection order",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E29-edge-readback-projection",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "&actual.Provenance, &confidence, &actual.Evidence, &actual.DiscoveredAt,",
+      "replace": "&actual.Provenance, &confidence, &actual.Provenance, &actual.DiscoveredAt,",
+      "rationale": "work_graph_edges readback scan destinations must preserve evidence independently from provenance",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E30-edge-nullable-repo-projection",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "ifNull(toString(repo_id), '')",
+      "replace": "ifNull(toString(repo_id), 'mutated')",
+      "rationale": "a migrated nullable repo_id must map NULL to the empty comparison value rather than a forged non-empty identifier",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E31-datetime64-millisecond-quantization",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "return value.UTC().Truncate(time.Millisecond)",
+      "replace": "return value.UTC()",
+      "rationale": "DateTime64(3) readback must compare the stored millisecond representation, not provider sub-millisecond input",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E32-nullable-time-comparison",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "return featureFlagsStoredTime(*left).Equal(featureFlagsStoredTime(*right))",
+      "replace": "return false",
+      "rationale": "nullable created_at and archived_at values must participate in exact flag readback",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E33-flag-tenant-readback-fence",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND provider = ? AND project_key = ? AND flag_key = ?",
+      "replace": "WHERE org_id != ? AND provider = ? AND project_key = ? AND flag_key = ?",
+      "rationale": "feature_flag readback must retain the organization predicate so a foreign tenant row cannot satisfy a local effect",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E34-event-dedupe-readback-key",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND dedupe_key = ?",
+      "replace": "WHERE org_id = ? AND dedupe_key != ?",
+      "rationale": "feature_flag_event exact readback must query the claimed dedupe key rather than its complement",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E34a-flag-environment-readback-key",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "AND environment = ?`,\n\t\texpected.OrgID, expected.Provider, expected.ProjectKey, expected.FlagKey,\n\t\texpected.Environment,",
+      "replace": "AND environment != ?`,\n\t\texpected.OrgID, expected.Provider, expected.ProjectKey, expected.FlagKey,\n\t\texpected.Environment,",
+      "rationale": "feature_flag readback must select the expected environment after environment becomes part of the deployed row identity",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E35-edge-readback-key",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "WHERE org_id = ? AND source_type = ? AND source_id = ? AND edge_type = ?",
+      "replace": "WHERE org_id = ? AND source_type = ? AND source_id = ? AND edge_type != ?",
+      "rationale": "work_graph_edges exact readback must select the claimed edge identity and type",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E36-flag-version-after-conflict",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func compareFeatureFlagVersion(\n\texpected, actual launchDarklyFlagRow,\n\tfound bool,\n) EffectInspection {\n\tactualVersion := featureFlagsStoredTime(actual.LastSynced)\n\texpectedVersion := featureFlagsStoredTime(expected.LastSynced)\n\tif !found || actualVersion.IsZero() {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.Before(expectedVersion) {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.After(expectedVersion) {\n\t\treturn EffectConflict",
+      "replace": "func compareFeatureFlagVersion(\n\texpected, actual launchDarklyFlagRow,\n\tfound bool,\n) EffectInspection {\n\tactualVersion := featureFlagsStoredTime(actual.LastSynced)\n\texpectedVersion := featureFlagsStoredTime(expected.LastSynced)\n\tif !found || actualVersion.IsZero() {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.Before(expectedVersion) {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.After(expectedVersion) {\n\t\treturn EffectAbsent",
+      "rationale": "a stored feature flag newer than the claimed version is a conflict, not an absent effect",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E37-edge-version-after-conflict",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "func compareFeatureFlagEdgeVersion(\n\texpected, actual launchDarklyEdgeRow,\n\tfound bool,\n) EffectInspection {\n\tactualVersion := featureFlagsStoredTime(actual.LastSynced)\n\texpectedVersion := featureFlagsStoredTime(expected.LastSynced)\n\tif !found || actualVersion.IsZero() {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.Before(expectedVersion) {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.After(expectedVersion) {\n\t\treturn EffectConflict",
+      "replace": "func compareFeatureFlagEdgeVersion(\n\texpected, actual launchDarklyEdgeRow,\n\tfound bool,\n) EffectInspection {\n\tactualVersion := featureFlagsStoredTime(actual.LastSynced)\n\texpectedVersion := featureFlagsStoredTime(expected.LastSynced)\n\tif !found || actualVersion.IsZero() {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.Before(expectedVersion) {\n\t\treturn EffectAbsent\n\t}\n\tif actualVersion.After(expectedVersion) {\n\t\treturn EffectAbsent",
+      "rationale": "a stored work-graph edge newer than the claimed version is a conflict, not an absent effect",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E38-event-exact-comparison",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "if actual == storedExpected {",
+      "replace": "if true {",
+      "rationale": "feature_flag_event readback must compare every projected nullable/string/time field rather than accepting a divergent row",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E39-event-duplicate-exact",
+      "file": "internal/providersync/launchdarkly_effects_clickhouse.go",
+      "find": "case found > 0 && matched == found:",
+      "replace": "case found == 1 && matched == 1:",
+      "rationale": "replaying an identical plain-MergeTree event may leave multiple matching rows; all matches must remain Exact while any divergent row remains Conflict",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitLabFeatureFlagsEffectsAgainstMigratedSchema$/replayed_exact_event_remains_exact_after_MergeTree_duplicate$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_route.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_route.json
@@ -1,0 +1,496 @@
+{
+  "schema_version": 1,
+  "name": "GitLab feature-flags provider-local route (CHAOS-3702)",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "Provider-local mutation coverage only. The focused route suite proves the valid multi-page request sequence, physical request accounting, scope rows, three destinations, cap/no-watermark, non-list fail-closed behavior, qualified 403 classification, invalid configuration guards, project fallback, recovery policies, result identity, and evidence identity. The fresh live proof executes the pinned Python client, normalizers, worker edge block, and real WorkGraphBuilder methods with a capturing sink. Frozen tests do not contain malformed nested scope shapes, project HTTP/decode failures, duplicate scopes with different timestamps, or sub-millisecond timestamp precision cases; those unmeasurable mutations are intentionally excluded rather than overstating coverage. This plan intentionally excludes registry, matrix, scheduler, transport wiring, ClickHouse implementation, and the mutation harness itself.",
+  "mutations": [
+    {
+      "id": "R1-context-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "ctx == nil || claim.Validate() != nil ||",
+      "replace": "false || claim.Validate() != nil ||",
+      "rationale": "a nil context must fail closed before the provider client or any effect is reached",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R2-claim-validate-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "ctx == nil || claim.Validate() != nil || claim.Provider != \"gitlab\" ||",
+      "replace": "ctx == nil || false || claim.Provider != \"gitlab\" ||",
+      "rationale": "invalid leased claims must be rejected before provider I/O",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R4-claim-dataset-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "claim.Provider != \"gitlab\" ||\n\t\tclaim.Dataset != \"feature-flags\" ||",
+      "replace": "claim.Provider != \"gitlab\" ||\n\t\tfalse ||",
+      "rationale": "a GitLab claim for another dataset must not be accepted by the feature-flags route",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R5-nil-client-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "claim.Dataset != \"feature-flags\" || client == nil ||",
+      "replace": "claim.Dataset != \"feature-flags\" || false ||",
+      "rationale": "a missing resolved HTTP client must fail before dereference",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R6-client-provider-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "client == nil ||\n\t\tclient.Provider != \"gitlab\" ||",
+      "replace": "client == nil ||\n\t\tfalse ||",
+      "rationale": "the resolved client provider must agree with the claimed GitLab route",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R7-client-base-url-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "client.Provider != \"gitlab\" || client.BaseURL == nil ||",
+      "replace": "client.Provider != \"gitlab\" || false ||",
+      "rationale": "path construction requires a resolved base URL",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R8-client-doer-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "client.BaseURL == nil || client.Doer == nil ||",
+      "replace": "client.BaseURL == nil || false ||",
+      "rationale": "a client without a request doer must fail closed before pagination",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R9-normalized-at-guard",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "client.Doer == nil ||\n\t\tnormalizedAt.IsZero() ||",
+      "replace": "client.Doer == nil ||\n\t\tfalse ||",
+      "rationale": "the route needs a nonzero observation instant for deterministic rows and watermark evidence",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R11-default-max-pages",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if maxPages == 0 {",
+      "replace": "if false {",
+      "rationale": "zero handler configuration must resolve to the production defensive page cap",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R12-default-per-page",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if perPage == 0 {",
+      "replace": "if false {",
+      "rationale": "zero handler configuration must resolve to the Python client's per-page default",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R13-positive-page-bound",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "maxPages < 1 || maxPages > gitLabFeatureFlagsMaxPages ||",
+      "replace": "false || maxPages > gitLabFeatureFlagsMaxPages ||",
+      "rationale": "nonpositive page caps must be rejected rather than silently disabling traversal limits",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R14-upper-page-bound",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "maxPages > gitLabFeatureFlagsMaxPages || perPage < 1 ||",
+      "replace": "false || perPage < 1 ||",
+      "rationale": "page traversal must reject a MaxPages value above the defensive bound",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R15-per-page-bound",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "perPage < 1 || perPage > gitLabFeatureFlagsDefaultPerPage",
+      "replace": "false || perPage > gitLabFeatureFlagsDefaultPerPage",
+      "rationale": "nonpositive per-page configuration must fail before a provider request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteRejectsInvalidConfigurationBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R16-physical-request-counter",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "func (doer gitLabFeatureFlagsCountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.attempts++",
+      "replace": "func (doer gitLabFeatureFlagsCountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.attempts = *doer.attempts",
+      "rationale": "accepted fetch evidence must count every physical page and project request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R17-qualified-403-conversion",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if response != nil && gitLabFeatureFlagsQualified403(response) {",
+      "replace": "if false {",
+      "rationale": "only GitLab's qualified 403 shape may enter shared retry accounting as a throttle",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R18-rate-limit-header-clause",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "strings.TrimSpace(gitLabFeatureFlagsHeaderValue(response.Header, \"RateLimit-Remaining\")) == \"0\"",
+      "replace": "false",
+      "rationale": "RateLimit-Remaining: 0 is an explicit GitLab throttle signal",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R19-case-insensitive-rate-header",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if strings.EqualFold(key, wanted) && len(values) > 0 {",
+      "replace": "if key == wanted && len(values) > 0 {",
+      "rationale": "HTTP header names are case-insensitive and the Python client accepts GitLab's casing variants",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R20-feature-flags-endpoint",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "flagsPath := providerRelativePath(\n\t\t&counted, \"api\", \"v4\", \"projects\", projectIDOrPath, \"feature_flags\",\n\t)",
+      "replace": "flagsPath := providerRelativePath(\n\t\t&counted, \"api\", \"v4\", \"projects\", projectIDOrPath, \"feature-flags\",\n\t)",
+      "rationale": "the first physical requests must target GitLab's feature_flags endpoint exactly",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R21-project-endpoint-order",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "projectPath := providerRelativePath(\n\t\t&counted, \"api\", \"v4\", \"projects\", projectIDOrPath,\n\t)",
+      "replace": "projectPath := providerRelativePath(\n\t\t&counted, \"api\", \"v4\", \"groups\", projectIDOrPath,\n\t)",
+      "rationale": "the project GET must remain the second endpoint after all flag pages and use the same project scope",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R22-per-page-query-accounting",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "PerPage: perPage, MaxPages: maxPages,",
+      "replace": "PerPage: perPage + 1, MaxPages: maxPages,",
+      "rationale": "the physical GitLab query must report the configured per_page value used by the Python client",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R23-page-cap-forwarding",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "MaxPages: maxPages,",
+      "replace": "MaxPages: maxPages / maxPages,",
+      "rationale": "the route's explicit page cap must reach the shared paginator",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R24-x-next-page-authority",
+      "file": "internal/providerfoundation/pagination.go",
+      "find": "if nextHeader != \"\" {",
+      "replace": "if false {",
+      "rationale": "a nonempty X-Next-Page header is authoritative for GitLab traversal",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R25-full-page-fallback",
+      "file": "internal/providerfoundation/pagination.go",
+      "find": "if len(items) < options.PerPage {",
+      "replace": "if false {",
+      "rationale": "without X-Next-Page, a short page must terminate traversal while a full page must advance",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R26-shared-pagination-cap",
+      "file": "internal/providerfoundation/pagination.go",
+      "find": "func CollectGitLabPageParamPages(\n\tctx context.Context,\n\tclient *HTTPClient,\n\toptions GitLabPageOptions,\n) (PageCollection, error) {\n\tif ctx == nil || client == nil || strings.TrimSpace(options.Path) == \"\" ||\n\t\toptions.PerPage < 1 || options.PerPage > maximumGitLabPerPage ||\n\t\toptions.MaxPages < 1 || options.MaxPages > maximumProviderPages {\n\t\treturn PageCollection{}, ErrPaginationInvalid\n\t}\n\tpage := 1\n\tresult := PageCollection{}\n\tfor page > 0 {\n\t\tif result.Pages >= options.MaxPages {",
+      "replace": "func CollectGitLabPageParamPages(\n\tctx context.Context,\n\tclient *HTTPClient,\n\toptions GitLabPageOptions,\n) (PageCollection, error) {\n\tif ctx == nil || client == nil || strings.TrimSpace(options.Path) == \"\" ||\n\t\toptions.PerPage < 1 || options.PerPage > maximumGitLabPerPage ||\n\t\toptions.MaxPages < 1 || options.MaxPages > maximumProviderPages {\n\t\treturn PageCollection{}, ErrPaginationInvalid\n\t}\n\tpage := 1\n\tresult := PageCollection{}\n\tfor page > 0 {\n\t\tif false {",
+      "rationale": "the shared paginator must stop before issuing a page beyond MaxPages and mark the collection capped",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteFailsClosedOnPaginationCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R27-route-cap-fail-closed",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if flagsPage.CapReached {",
+      "replace": "if false {",
+      "rationale": "a capped inventory must fail before the project request, effects, or watermark",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteFailsClosedOnPaginationCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R28-cap-error-no-watermark",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if flagsPage.CapReached {\n\t\treturn CompleteRouteBatch{}, ErrPaginationCapExceeded\n\t}",
+      "replace": "if flagsPage.CapReached {\n\t\treturn CompleteRouteBatch{}, nil\n\t}",
+      "rationale": "cap exhaustion is an error, not an empty successful batch that could advance a watermark",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteFailsClosedOnPaginationCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R29-non-list-page-error",
+      "file": "internal/providerfoundation/pagination.go",
+      "find": "items, decodeErr := decodePage(response, \"\")\n\t\tif decodeErr != nil {\n\t\t\treturn PageCollection{}, decodeErr\n\t\t}",
+      "replace": "items, decodeErr := decodePage(response, \"\")\n\t\tif false {\n\t\t\treturn PageCollection{}, decodeErr\n\t\t}",
+      "rationale": "a non-list feature-flags payload must fail closed instead of becoming an empty successful inventory",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteFailsClosedOnNonListFlags$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R32-project-key-precedence",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "[]string{\"path_with_namespace\", \"path\"}",
+      "replace": "[]string{\"path\", \"path_with_namespace\"}",
+      "rationale": "GitLab's canonical path_with_namespace must take precedence over the shorter path",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R35-default-scope-branch",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if !exists || !pythonTruthy(rawStrategies) {\n\t\treturn []string{\"\"}, nil\n\t}",
+      "replace": "if !exists || !pythonTruthy(rawStrategies) {\n\t\treturn []string{\"mutated\"}, nil\n\t}",
+      "rationale": "missing or false strategies must produce Python's default empty environment scope",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R40-scope-dedup",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if !seen {\n\t\t\t\tscopes = append(scopes, environment)\n\t\t\t}",
+      "replace": "if seen || true {\n\t\t\t\tscopes = append(scopes, environment)\n\t\t\t}",
+      "rationale": "repeated environment scopes must emit one row per flag/environment rather than duplicate facts",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R42-flag-name-key-precedence",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "flagKey := gitLabFeatureFlagFirstString(flag, \"name\", \"key\")\n\t\tflagType := gitLabFeatureFlagFirstString(flag, \"version\")",
+      "replace": "flagKey := gitLabFeatureFlagFirstString(flag, \"key\", \"name\")\n\t\tflagType := gitLabFeatureFlagFirstString(flag, \"version\")",
+      "rationale": "GitLab name must win over the key fallback when both are supplied",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R43-flag-type-fallback",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if flagType == \"\" {",
+      "replace": "if false {",
+      "rationale": "missing GitLab versions must normalize to new_version_flag like Python",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R44-created-at-fallback",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if createdAt == nil {",
+      "replace": "if false {",
+      "rationale": "missing or invalid created_at must use normalized_at for flag rows and identity-edge timestamps",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R46-active-state",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if pythonTruthy(flag[\"active\"]) {",
+      "replace": "if false {",
+      "rationale": "the event next state must reflect GitLab active=true as on and false/missing as off",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R48-event-dedupe-key",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "DedupeKey: \"gitlab:\" + projectKey + \":\" + flagKey + \":\" + environment + \":\" + state,",
+      "replace": "DedupeKey: \"mutated:\" + projectKey + \":\" + flagKey + \":\" + environment + \":\" + state,",
+      "rationale": "event snapshots must use the provider/project/flag/environment/state dedupe contract",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R50-latest-event-first-seen",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if !ok || event.EventAt.After(current.EventAt) {",
+      "replace": "if ok && event.EventAt.After(current.EventAt) && false {",
+      "rationale": "the edge builder must seed a latest-event entry for every flag key before comparing later snapshots",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R53-edge-flag-id-provider",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "flag.OrgID, flag.Provider, projectKey, flag.FlagKey,",
+      "replace": "flag.OrgID, \"launchdarkly\", projectKey, flag.FlagKey,",
+      "rationale": "feature-flag identity IDs must include the GitLab provider namespace",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R54-identity-edge-created-at",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "if flag.CreatedAt != nil {\n\t\t\teventAt = flag.CreatedAt.UTC()\n\t\t}",
+      "replace": "if false {\n\t\t\teventAt = flag.CreatedAt.UTC()\n\t\t}",
+      "rationale": "identity edges must use created_at when present and normalized_at only when it is absent",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R55-identity-edge-evidence",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "\"flag:\"+flag.Provider+\"/\"+projectKey+\"/\"+flag.FlagKey",
+      "replace": "\"mutated:\"+flag.Provider+\"/\"+projectKey+\"/\"+flag.FlagKey",
+      "rationale": "identity edge evidence must identify the GitLab provider, project, and flag key",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R56-config-edge-evidence",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "evidence := gitLabFeatureFlagPythonISOTime(event.EventAt) + \"|\" +",
+      "replace": "evidence := \"mutated\" + \"|\" +",
+      "rationale": "config_changed_by evidence must preserve the selected event timestamp, type, and next state",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R57-edge-id-input-separator",
+      "file": "internal/providersync/launchdarkly_route.go",
+      "find": "sourceType + \":\" + sourceID + \"|\" + edgeType + \"|\" +",
+      "replace": "sourceType + \":\" + sourceID + \"/\" + edgeType + \"|\" +",
+      "rationale": "work-graph edge IDs must use the canonical source|edge|target separator",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R58-feature-flag-id-prefix",
+      "file": "internal/providersync/launchdarkly_route.go",
+      "find": "\"flag:\" + orgID + \"/\" + provider + \"/\" + projectKey + \"/\" + flagKey",
+      "replace": "\"feature:\" + orgID + \"/\" + provider + \"/\" + projectKey + \"/\" + flagKey",
+      "rationale": "feature-flag node IDs must use the production flag namespace and all tenant/provider/project/key inputs",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R59-edge-provenance",
+      "file": "internal/providersync/launchdarkly_route.go",
+      "find": "RepoID: repoID, Provider: provider, Provenance: \"native\",",
+      "replace": "RepoID: repoID, Provider: provider, Provenance: \"heuristic\",",
+      "rationale": "provider-native feature-flag edges must retain native provenance",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R60-edge-discovered-last-synced",
+      "file": "internal/providersync/launchdarkly_route.go",
+      "find": "DiscoveredAt: normalizedAt.UTC(), LastSynced: normalizedAt.UTC(),",
+      "replace": "DiscoveredAt: eventAt.UTC(), LastSynced: eventAt.UTC(),",
+      "rationale": "edge discovery and last-synced timestamps must use the route observation instant, not the flag event instant",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R61-edge-event-timestamp",
+      "file": "internal/providersync/launchdarkly_route.go",
+      "find": "EventAt: eventAt.UTC(), Day: eventAt.UTC().Format(\"2006-01-02\"),",
+      "replace": "EventAt: normalizedAt.UTC(), Day: normalizedAt.UTC().Format(\"2006-01-02\"),",
+      "rationale": "edge event_ts and day must follow the selected flag/event timestamp, not always normalized_at",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R62-edge-org-id",
+      "file": "internal/providersync/launchdarkly_route.go",
+      "find": "EventAt: eventAt.UTC(), Day: eventAt.UTC().Format(\"2006-01-02\"),\n\t\tOrgID: orgID,",
+      "replace": "EventAt: eventAt.UTC(), Day: eventAt.UTC().Format(\"2006-01-02\"),\n\t\tOrgID: \"\",",
+      "rationale": "all edge rows must remain tenant-stamped with the claim organization",
+      "proof": [["bash", "-c", "proof_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX\") && cache_dir=$(mktemp -d \"${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX\") && trap 'rm -rf -- \"$proof_dir\" \"$cache_dir\"' EXIT && PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_PYTHON=\"$PWD/.venv/bin/python\" DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"$proof_dir\" PYTHONPATH=\"$PWD/src\" GOCACHE=\"$cache_dir\" go test -mod=readonly -count=1 -run '^TestGenericOracleMatchesLivePythonGitLabFeatureFlagsRoute$' ./internal/providersync/ && test \"$(cat \"$proof_dir/gitlab_feature_flags.py\")\" = executed"]]
+    },
+    {
+      "id": "R63-three-effect-list",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "Effects: []EffectBatch{flagEffect, eventEffect, edgeEffect},",
+      "replace": "Effects: []EffectBatch{flagEffect, eventEffect, edgeEffect, edgeEffect},",
+      "rationale": "the provider route must emit feature_flag, feature_flag_event, and work_graph_edges together",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R64-feature-flag-destination",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "\"feature_flag\", EffectReplaySafe, flags,",
+      "replace": "\"feature_flag_mutated\", EffectReplaySafe, flags,",
+      "rationale": "normalized flag rows must target the feature_flag destination exactly",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R65-event-destination",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "\"feature_flag_event\", EffectReadbackRequired, events,",
+      "replace": "\"feature_flag_event_mutated\", EffectReadbackRequired, events,",
+      "rationale": "snapshot events must target the feature_flag_event destination exactly",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R66-edge-destination",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "\"work_graph_edges\", EffectReplaySafe, edges,",
+      "replace": "\"work_graph_edges_mutated\", EffectReplaySafe, edges,",
+      "rationale": "captured identity/configuration edges must target work_graph_edges, with no LaunchDarkly link destination",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R67-feature-flag-recovery",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "EffectReplaySafe, flags,",
+      "replace": "EffectReadbackRequired, flags,",
+      "rationale": "feature_flag writes must retain their replay-safe recovery policy",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R68-event-recovery",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "EffectReadbackRequired, events,",
+      "replace": "EffectReplaySafe, events,",
+      "rationale": "feature_flag_event writes must require readback recovery",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R69-edge-recovery",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "EffectReplaySafe, edges,",
+      "replace": "EffectReadbackRequired, edges,",
+      "rationale": "work_graph_edges are replay-safe and must not be changed to readback recovery",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R70-watermark-candidate",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "Watermark: claim.BeforeAt,",
+      "replace": "Watermark: nil,",
+      "rationale": "a complete successful collection must return the leased upper-bound watermark candidate",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R73-result-project-key",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "\"project_key\": projectKey, \"project_id_or_path\": projectIDOrPath,",
+      "replace": "\"project_key\": projectIDOrPath, \"project_id_or_path\": projectIDOrPath,",
+      "rationale": "route result project_key must be the canonical project response/fallback, distinct from the claimed identifier when GitLab resolves a path",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R74-result-project-id",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "\"project_id_or_path\": projectIDOrPath,",
+      "replace": "\"project_id_or_path\": projectKey,",
+      "rationale": "route result must preserve the exact claimed project id/path separately from the resolved canonical project key",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R75-evidence-request-count",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "Requests: requests,",
+      "replace": "Requests: requests - 1,",
+      "rationale": "fetch evidence must account for every physical flag-page and project request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R76-evidence-page-count",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "Pages: flagsPage.Pages,",
+      "replace": "Pages: flagsPage.Pages - 1,",
+      "rationale": "fetch evidence must report all physical flag pages traversed",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R77-evidence-record-count",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "Records: len(flags) + len(events) + len(edges),",
+      "replace": "Records: len(flags) + len(events),",
+      "rationale": "accepted evidence must include all three canonical output row families, including work_graph_edges",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R78-evidence-provider",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "Provider: claim.Provider,",
+      "replace": "Provider: \"\",",
+      "rationale": "fetch evidence must retain the provider identity used by the route",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R79-evidence-dataset",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "Dataset: claim.Dataset,",
+      "replace": "Dataset: \"\",",
+      "rationale": "fetch evidence must retain the canonical feature-flags dataset identity",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_files.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_files.json
@@ -221,6 +221,17 @@
       "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
     },
     {
+      "id": "scanner-extension-case-sensitivity",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "switch path.Ext(base) {",
+      "replace": "switch strings.ToLower(path.Ext(base)) {",
+      "rationale": "Python's lowercase include_globs are applied by case-sensitive fnmatch on the worker platform; normalizing the source extension would fetch content for Main.GO and mixed.Go that Python leaves paths-only",
+      "proof": [
+        ["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 PYTHONPATH=\"$PWD/src\" DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"${DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR:?missing}\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForGitLabFilesCaseSensitiveExtensions$' ./internal/providersync/"],
+        ["go", "test", "-count=1", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]
+      ]
+    },
+    {
       "id": "normalized-at-is-clickhouse-precision",
       "file": "internal/providersync/gitlab_files_route.go",
       "find": "LastSynced: normalizedAt.UTC().Truncate(time.Millisecond)",

--- a/internal/providersync/testdata/mutation-plans/gitlab_files.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_files.json
@@ -1,0 +1,288 @@
+{
+  "schema_version": 1,
+  "name": "gitlab/files provider-local parity (CHAOS-3707)",
+  "build": ["go", "build", "./..."],
+  "$limitation": "Provider-only plan. Live ClickHouse proofs require the integration Docker service; if unavailable, those mutation verdicts remain unverified rather than being treated as skipped coverage.",
+  "mutations": [
+    {
+      "id": "gitlab-forbidden-retry-after-qualification",
+      "file": "internal/providerfoundation/http.go",
+      "find": "if provider == \"gitlab\" &&\n\t\t(hasHeader(headers, \"retry-after\") || headerValue(headers, \"ratelimit-remaining\") == \"0\") {",
+      "replace": "if provider == \"gitlab\" &&\n\t\t(false || headerValue(headers, \"ratelimit-remaining\") == \"0\") {",
+      "rationale": "GitLab's header-qualified 403 contract treats a present Retry-After as a rate limit even when the remaining counter is absent; this clause is shared by every native route using providerfoundation.ClassifyHTTP",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabForbiddenRateLimitQualification$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "gitlab-forbidden-remaining-zero-qualification",
+      "file": "internal/providerfoundation/http.go",
+      "find": "if provider == \"gitlab\" &&\n\t\t(hasHeader(headers, \"retry-after\") || headerValue(headers, \"ratelimit-remaining\") == \"0\") {",
+      "replace": "if provider == \"gitlab\" &&\n\t\t(hasHeader(headers, \"retry-after\") || false) {",
+      "rationale": "GitLab's RateLimit-Remaining: 0 is an independent qualified-403 signal and must propagate as rate limited through the GitLab files GraphQL route",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFilesRoutePreservesQualifiedForbiddenRateLimitPropagation$", "./internal/providersync/"]]
+    },
+    {
+      "id": "tree-cap-fails-closed",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if tree.CapReached {",
+      "replace": "if false {",
+      "rationale": "a recursive tree that reaches its page cap is incomplete and must not produce a successful effect or advance the watermark",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteFailsClosedOnTreePaginationCap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "no-commit-at-bound-is-legitimate-empty",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if len(page.Items) == 0 {",
+      "replace": "if len(page.Items) == 0 && false {",
+      "rationale": "the Python producer returns no file inventory when no commit exists at the requested upper bound; changing this clause would fabricate a tree ref and lose the explicit no-commit outcome",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteUsesPythonBoundRefAndDistinguishesNoCommit$", "./internal/providersync/"]]
+    },
+    {
+      "id": "malformed-tree-entry-fails-closed",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if err := json.Unmarshal(raw, &object); err != nil || object == nil {",
+      "replace": "if err := json.Unmarshal(raw, &object); err != nil && object == nil {",
+      "rationale": "a null or non-object tree item is malformed traversal evidence, not a legitimate empty entry; silently skipping it would allow a partial inventory to watermark",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteRejectsMalformedTreeItem$", "./internal/providersync/"]]
+    },
+    {
+      "id": "tree-only-entries-are-not-files",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if item.Type == \"blob\" && item.Path != \"\" {",
+      "replace": "if item.Path != \"\" {",
+      "rationale": "directories and other GitLab tree entries must not become git_files rows",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteSkipsTreeEntriesAndRejectsProjectMismatch$", "./internal/providersync/"]]
+    },
+    {
+      "id": "content-file-cap-emits-incomplete",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if len(scannable) > maxFiles {",
+      "replace": "if false {",
+      "rationale": "the 2,000-file content cap must remain observable as typed incomplete evidence with no watermark while every tree path still lands",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteMarksContentCapIncompleteWithoutWatermark$", "./internal/providersync/"], ["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 PYTHONPATH=\"$PWD/src\" DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"${DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR:?missing}\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForGitLabFilesContentCap$' ./internal/providersync/"]]
+    },
+    {
+      "id": "oversized-content-is-skipped",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if size == nil || *size <= maxBytes {",
+      "replace": "if size == nil {",
+      "rationale": "rawSize over one megabyte must not cross the GraphQL text pass, while the file path still remains in git_files",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 PYTHONPATH=\"$PWD/src\" DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=\"${DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR:?missing}\" go test -count=1 -run '^TestGenericOracleMatchesLivePythonForGitLabFilesTraversal$' ./internal/providersync/"]]
+    },
+    {
+      "id": "ordinary-text-failure-degrades",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, eligible[start:end], \"path rawTextBlob\")\n\t\tif err != nil {\n\t\t\tif !gitLabFilesContentErrorDegradable(err) {",
+      "replace": "nodes, err := fetchGitLabGraphQLBlobs(ctx, client, projectFullName, ref, eligible[start:end], \"path rawTextBlob\")\n\t\tif err != nil {\n\t\t\tif gitLabFilesContentErrorDegradable(err) {",
+      "rationale": "ordinary GraphQL text failures must produce paths-only rows with typed incompleteness and no watermark, while rate limits remain fatal",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteDegradesGraphQLTextFailureToPathsOnly$", "./internal/providersync/"]]
+    },
+    {
+      "id": "empty-text-preserves-nullability-distinction",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if node.Path != \"\" && node.RawTextBlob != nil {",
+      "replace": "if node.Path != \"\" && node.RawTextBlob == nil {",
+      "rationale": "an explicitly returned empty string is present content and must remain distinct from a missing or binary blob represented by NULL",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRoutePreservesEmptyTextAsPresentContent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "graphql-errors-preserve-paths",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if len(trimmedErrors) > 0 && !bytes.Equal(trimmedErrors, []byte(\"null\")) && !bytes.Equal(trimmedErrors, []byte(\"[]\")) {\n\t\treturn nil, providerfoundation.ErrGraphQLResponse\n\t}",
+      "replace": "if len(trimmedErrors) > 0 && !bytes.Equal(trimmedErrors, []byte(\"null\")) && !bytes.Equal(trimmedErrors, []byte(\"[]\")) {\n\t\treturn nil, nil\n\t}",
+      "rationale": "a GraphQL 200 response containing errors is an ordinary content failure: preserve path rows, emit typed incompleteness, and suppress the watermark",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteDegradesGraphQLPayloadErrorToPathsOnly$", "./internal/providersync/"]]
+    },
+    {
+      "id": "graphql-shape-preserves-paths",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if envelope.Data.Project == nil || envelope.Data.Project.Repository == nil ||\n\t\tenvelope.Data.Project.Repository.Blobs == nil {",
+      "replace": "if false {",
+      "rationale": "missing project/repository/blob data is incomplete content evidence: preserve path rows and leave the watermark nil",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteDegradesMissingGraphQLRepositoryToPathsOnly$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-migrations",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"migrations\":\n\t\t\treturn false",
+      "replace": "case \"migrations\":\n\t\t\treturn true",
+      "rationale": "the migrations exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-tests",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"tests\":\n\t\t\treturn false",
+      "replace": "case \"tests\":\n\t\t\treturn true",
+      "rationale": "the tests exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-venv",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"venv\":\n\t\t\treturn false",
+      "replace": "case \"venv\":\n\t\t\treturn true",
+      "rationale": "the venv exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-dot-venv",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \".venv\":\n\t\t\treturn false",
+      "replace": "case \".venv\":\n\t\t\treturn true",
+      "rationale": "the dot-venv exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-node-modules",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"node_modules\":\n\t\t\treturn false",
+      "replace": "case \"node_modules\":\n\t\t\treturn true",
+      "rationale": "the node_modules exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-dist",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"dist\":\n\t\t\treturn false",
+      "replace": "case \"dist\":\n\t\t\treturn true",
+      "rationale": "the dist exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-build",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"build\":\n\t\t\treturn false",
+      "replace": "case \"build\":\n\t\t\treturn true",
+      "rationale": "the build exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-next",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \".next\":\n\t\t\treturn false",
+      "replace": "case \".next\":\n\t\t\treturn true",
+      "rationale": "the .next exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-vendor",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "case \"vendor\":\n\t\t\treturn false",
+      "replace": "case \"vendor\":\n\t\t\treturn true",
+      "rationale": "the vendor exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-init",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if base == \"__init__.py\" {\n\t\treturn false",
+      "replace": "if base == \"__init__.py\" {\n\t\treturn true",
+      "rationale": "the __init__.py exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-min-js",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".min.js\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".min.js\") {\n\t\treturn true",
+      "rationale": "the minified JavaScript exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-d-ts",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".d.ts\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".d.ts\") {\n\t\treturn true",
+      "rationale": "the declaration-file exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-config-js",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".config.js\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".config.js\") {\n\t\treturn true",
+      "rationale": "the config.js exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-config-ts",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".config.ts\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".config.ts\") {\n\t\treturn true",
+      "rationale": "the config.ts exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "scanner-exclude-config-mjs",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "if strings.HasSuffix(base, \".config.mjs\") {\n\t\treturn false",
+      "replace": "if strings.HasSuffix(base, \".config.mjs\") {\n\t\treturn true",
+      "rationale": "the config.mjs exclusion is an independent scanner contract and must not be dropped",
+      "proof": [["go", "test", "-run", "^TestGitLabFileContentEligibilityMatchesComplexityScannerConfig$", "./internal/providersync/"]]
+    },
+    {
+      "id": "normalized-at-is-clickhouse-precision",
+      "file": "internal/providersync/gitlab_files_route.go",
+      "find": "LastSynced: normalizedAt.UTC().Truncate(time.Millisecond)",
+      "replace": "LastSynced: normalizedAt.UTC()",
+      "rationale": "git_files.last_synced is DateTime64(3); keeping sub-millisecond collection time would make route bytes differ from real ClickHouse readback",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesRouteTraversesTreeAndWritesNonEmptyInventory$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-provider-fence",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != \"gitlab\" ||",
+      "replace": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || false ||",
+      "rationale": "GitLab effects must reject a GitHub claim even though both providers share the physical git_files table",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesEffectsValidateProviderAndEmptyBatches$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-lease-before-decode",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != \"gitlab\" ||\n\t\tclaim.Dataset != \"files\" || effect.Destination != \"git_files\" {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err != nil {",
+      "replace": "func (sink GitLabFilesClickHouseEffects) WriteEffect(ctx context.Context, claim Claim, effect EffectBatch) error {\n\tif ctx == nil || sink.Lease == nil || claim.Validate() != nil || claim.Provider != \"gitlab\" ||\n\t\tclaim.Dataset != \"files\" || effect.Destination != \"git_files\" {\n\t\treturn ErrInvalidConfiguration\n\t}\n\tif err := sink.Lease.Assert(ctx); err == nil {",
+      "rationale": "a lost lease must stop an effect before decoding or doing any persistence work",
+      "proof": [["go", "test", "-run", "^TestGitLabFilesEffectsAssertLeaseBeforeDecoding$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-lease-before-send",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "if err := sink.Lease.Assert(ctx); err != nil {\n\t\treturn err\n\t}\n\treturn batch.Send()",
+      "replace": "return batch.Send()",
+      "rationale": "lease loss after batch preparation must abort before ClickHouse acknowledgement; otherwise a stale worker can commit after ownership expires",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesWriteRechecksLeaseBeforeClickHouseSend$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-preserve-existing-contents",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "if rows[index].Contents != nil {",
+      "replace": "if true {",
+      "rationale": "a paths-only rewrite must hydrate the tenant-qualified winning contents before inserting a newer ReplacingMergeTree version",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesWritePreservesExistingContentsForPathsOnlyRewrite$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-readback-final-row",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files FINAL",
+      "replace": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files",
+      "rationale": "ReplacingMergeTree readback must observe one winning tenant-qualified row, not mixed versions reconstructed from unreduced parts",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesReadbackResolvesWinningReplacingMergeTreeVersion$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-readback-tenant-fence",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files FINAL\nWHERE org_id = ? AND repo_id = ? AND path = ?",
+      "replace": "func (sink GitLabFilesClickHouseEffects) inspectGitLabFile(ctx context.Context, expected gitFileRow) (EffectInspection, error) {\n\trows, err := sink.Conn.Query(ctx, `\nSELECT repo_id, path, executable, contents, last_synced, org_id\nFROM git_files FINAL\nWHERE repo_id = ? AND path = ?",
+      "rationale": "the same repository/path natural key must remain isolated for two tenants in the shared ClickHouse table",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesReadbackScopesSameNaturalKeyByTenant$", "./internal/providersync/"]]
+    },
+    {
+      "id": "effects-replay-converges",
+      "file": "internal/providersync/gitlab_files_effects_clickhouse.go",
+      "find": "return batch.Send()",
+      "replace": "return nil",
+      "rationale": "an identical replay must be proven against real RMT readback; skipping the send would make recovery falsely look exact only if the row was already present",
+      "proof": [["go", "test", "-tags", "integration", "-run", "^TestGitLabFilesReadbackResolvesWinningReplacingMergeTreeVersion$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_security.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_security.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": 1,
+  "name": "GitLab security provider parity (CHAOS-3124)",
+  "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "Provider-local proof only: the route, concrete security_alerts row normalization, lease-fenced ClickHouse effects, migrated-schema integration test, and live Python differential oracle. This slice deliberately excludes registry, capability matrix, config, worker construction, scheduler, deployment activation, and unrelated provider behavior.",
+  "mutations": [
+    {
+      "id": "R1-claim-provider-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "claim.Provider != \"gitlab\"",
+      "replace": "false",
+      "rationale": "the security route must reject a claim owned by another provider before project resolution",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/wrong_claim_provider$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R2-claim-dataset-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "claim.Dataset != \"security\"",
+      "replace": "false",
+      "rationale": "security credentials must not be reused for another GitLab dataset",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/wrong_claim_dataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R3-client-provider-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "client.Provider != \"gitlab\"",
+      "replace": "false",
+      "rationale": "the request semantics require a GitLab-resolved HTTP client",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/wrong_client_provider$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R4-base-url-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "client.BaseURL == nil",
+      "replace": "false",
+      "rationale": "path construction must not run without an authority URL",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/nil_client_base_URL$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R5-normalized-at-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "client.BaseURL == nil || normalizedAt.IsZero()",
+      "replace": "client.BaseURL == nil || false",
+      "rationale": "retry-stable last_synced requires an executor-supplied normalization instant",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/zero_normalized_at$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R6-positive-cap-guard",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "if maxAlerts < 1 {",
+      "replace": "if false {",
+      "rationale": "non-positive caps are invalid configuration, not an empty fetch",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsInvalidConfigurationBeforeRequests$/negative_max_alerts$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R7-project-binding",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "strconv.FormatInt(parsedProjectID, 10) != projectID",
+      "replace": "false",
+      "rationale": "the fetched project must be the exact numeric project claimed by the unit",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteRejectsProjectMismatchAndLeaseBeforeRequests$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R8-physical-request-evidence",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "(*doer.observe.attempts)++",
+      "replace": "(*doer.observe.attempts) += 0",
+      "rationale": "accepted evidence must count every physical project and endpoint request",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R9-millisecond-normalization",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)\n\n\tfindings",
+      "replace": "normalizedAt = normalizedAt.UTC()\n\n\tfindings",
+      "rationale": "rows must match Python/DateTime64 millisecond precision across retries",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R10-optional-findings-degrade",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "if providerErr.StatusCode == http.StatusForbidden || providerErr.StatusCode == http.StatusNotFound {",
+      "replace": "if false {",
+      "rationale": "a plain forbidden/not-found optional endpoint must degrade while the other source remains usable",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteDegradesPlainOptionalErrors$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R11-combined-cap-before-window",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "if len(combined) > maxAlerts {",
+      "replace": "if false {",
+      "rationale": "the real GitLab client caps the combined source list before processor window filtering",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteSlicesCombinedAlertsBeforeWindowFiltering$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R12-vulnerability-alert-id",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "row.AlertID = \"gitlab_vuln:\" + id",
+      "replace": "row.AlertID = id",
+      "rationale": "source-qualified alert identity is part of the migrated natural key",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R13-cve-normalization",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "row.CVEID = gitLabSecurityOptionalString(item[\"name\"])",
+      "replace": "row.CVEID = nil",
+      "rationale": "the first identifier of type cve must populate the concrete cve_id column",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteMirrorsPythonSinglePageWindowAndEvidence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R14-dependency-created-at",
+      "file": "internal/providersync/gitlab_security_route.go",
+      "find": "row.CreatedAt = normalizedAt",
+      "replace": "row.CreatedAt = time.Time{}",
+      "rationale": "dependency findings have no provider timestamp and use the stable route normalization instant",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityRouteNormalizesDependencyCreatedAtAndPackage$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E1-duplicate-natural-key",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "return nil, errors.Join(providerfoundation.ErrSinkDuplicate, ErrEffectRecoveryUnsafe)",
+      "replace": "return nil, errors.New(\"duplicate row\")",
+      "rationale": "recovery cannot safely acknowledge an effect containing duplicate physical natural keys",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityEffectsRejectCrossTenantAndDuplicateRowsBeforeClickHouse$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E2-newer-version-conflict",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "actual.LastSynced.UTC().After(expected.LastSynced.UTC())",
+      "replace": "false",
+      "rationale": "readback must reject an older effect after a newer persisted version wins",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitLabSecurityAlertVersionChecksFullPayloadAndTimestamp$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E3-tenant-payload-comparison",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "actual.OrgID != expected.OrgID",
+      "replace": "false",
+      "rationale": "readback must compare every concrete tenant-scoped row field, not just the timestamp",
+      "proof": [["go", "test", "-count=1", "-run", "^TestCompareGitLabSecurityAlertVersionChecksFullPayloadAndTimestamp$", "./internal/providersync/"]]
+    },
+    {
+      "id": "E4-duplicate-final-row",
+      "file": "internal/providersync/gitlab_security_effects_clickhouse.go",
+      "find": "if found > 1 {",
+      "replace": "if false {",
+      "rationale": "ambiguous FINAL readback must not be treated as an exact acknowledgement",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabSecurityReadbackRejectsAmbiguousRows$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_work_items_derived.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_work_items_derived.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "name": "GitLab canonical work-items derived destinations (CHAOS-3733)",
+  "build": ["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "This provider-local plan proves the typed nine-destination compute/effect boundary, explicit AI producer gap, watermark withholding, canonical effect composition, and GitLab claim fencing. The migration-backed ClickHouse suite separately proves real tenant/replay/lease readback. It deliberately excludes registry, matrix, config, deployment, scheduler, and worker activation wiring.",
+  "mutations": [
+    {
+      "id": "D1-deriver-provider-guard",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "claim.Provider != \"gitlab\" || claim.Dataset != \"work-items\" || normalizedAt.IsZero()",
+      "replace": "claim.Provider == \"gitlab\" || claim.Dataset != \"work-items\" || normalizedAt.IsZero()",
+      "rationale": "the compute boundary must reject a non-GitLab claim rather than derive rows for another provider",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D2-deriver-dataset-guard",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "claim.Provider != \"gitlab\" || claim.Dataset != \"work-items\" || normalizedAt.IsZero()",
+      "replace": "claim.Provider != \"gitlab\" || claim.Dataset == \"work-items\" || normalizedAt.IsZero()",
+      "rationale": "the compute boundary must reject a GitLab claim for a non-work-items dataset",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D3-deriver-watermark-gap",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "Watermark:                      nil,",
+      "replace": "Watermark:                      &normalizedAt,",
+      "rationale": "the explicit AI producer gap must hold the derived watermark rather than acknowledging an incomplete family",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D4-typed-ai-gap-name",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "Destination:           \"ai_attribution\",",
+      "replace": "Destination:           \"work_item_metrics_daily\",",
+      "rationale": "the gap must identify the missing authoritative AI destination, not relabel a landed typed row family",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D5-route-appends-derived-effects",
+      "file": "internal/providersync/gitlab_work_items_route.go",
+      "find": "effects = append(effects, derivedEffects...)",
+      "replace": "effects = append(effects, derivedEffects[:0]...)",
+      "rationale": "the configured route must carry every typed derived effect into the completion batch",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D6-route-reports-implemented-destinations",
+      "file": "internal/providersync/gitlab_work_items_route.go",
+      "find": "derivedImplemented = derived.producedDestinations()",
+      "replace": "derivedImplemented = nil",
+      "rationale": "the typed route result must report all nine semantic destinations it actually emitted",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D7-effect-identity-provider-fence",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "claim.Validate() != nil || claim.Provider != \"gitlab\" ||",
+      "replace": "claim.Validate() != nil || claim.Provider == \"gitlab\" ||",
+      "rationale": "the effect identity must only admit canonical GitLab work-items claims",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedIdentityRejectsRawAndAIDestinations$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D8-effect-destination-switch",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemMetricsDaily)",
+      "replace": "effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemUserMetricsDaily)",
+      "rationale": "the typed effect builder must retain the canonical destination-to-row projection rather than silently returning an empty or mislabelled effect",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndExcludesAIGap$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/_gitlab_feature_flags_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_gitlab_feature_flags_common.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+import sys
+from dataclasses import asdict, dataclass, fields
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlencode
+
+from internal.providersync.testdata.python_oracle_loader import (
+    _force_annotation_evaluation,
+    _install_module,
+    _install_namespace,
+    _install_package,
+    _load_source_module,
+    _purge_dev_health_modules,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/feature_flags.py"
+PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/gitlab_feature_flags.py"
+BUILDER_SOURCE = REPO_ROOT / "src/dev_health_ops/work_graph/builder.py"
+IDS_SOURCE = REPO_ROOT / "src/dev_health_ops/work_graph/ids.py"
+MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/work_graph/models.py"
+WORKER_SOURCE = REPO_ROOT / "src/dev_health_ops/workers/feature_flag_sync.py"
+
+
+class _Record:
+    def __init__(self, **values: Any) -> None:
+        self.__dict__.update(values)
+
+
+class _GoCompatibleFloat(float):
+    """Keep Python float typing while matching Go's `%g` wire spelling."""
+
+    def __repr__(self) -> str:
+        return format(self, ".15g")
+
+
+class _CapturingEdgeSink:
+    def __init__(self) -> None:
+        self.edges: list[Any] = []
+
+    def ensure_schema(self) -> None:
+        return None
+
+    def write_work_graph_edges(self, records: list[Any]) -> None:
+        self.edges.extend(records)
+
+    def close(self) -> None:
+        return None
+
+
+class _WorkerMetricsSink:
+    def __init__(self, _dsn: str) -> None:
+        return None
+
+    def write_feature_flags(self, _records: list[Any]) -> None:
+        return None
+
+    def write_feature_flag_events(self, _records: list[Any]) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class _APIException(Exception):
+    pass
+
+
+class _AuthenticationException(_APIException):
+    pass
+
+
+class _RateLimitException(_APIException):
+    def __init__(
+        self,
+        message: str = "rate limited",
+        *,
+        retry_after_seconds: float | None = None,
+        signal: object | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+        self.signal = signal
+
+
+class _UsageRecorder:
+    def __init__(self, *, resolver: object) -> None:
+        self.resolver = resolver
+
+    def record(self, **_values: Any) -> None:
+        return None
+
+    def drain(self) -> list[dict[str, Any]]:
+        return []
+
+
+class _RateLimitSignal:
+    def __init__(self, **_values: Any) -> None:
+        return None
+
+    @staticmethod
+    def reset_at_from_epoch_seconds(_value: object) -> None:
+        return None
+
+
+class _BudgetDimension:
+    REST_CORE = "rest_core"
+
+
+class _HTTPResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: object,
+        *,
+        headers: dict[str, str] | None = None,
+        url: str,
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.headers = headers or {}
+        self.url = url
+        self.text = json.dumps(payload)
+
+    def json(self) -> object:
+        return self._payload
+
+
+class _AsyncClient:
+    pass
+
+
+class _TimeoutException(Exception):
+    pass
+
+
+class _ConnectError(Exception):
+    pass
+
+
+def _configure_modules() -> None:
+    _install_namespace()
+    _install_package("dev_health_ops.api")
+    _install_package("dev_health_ops.api.utils")
+    _install_module(
+        "httpx",
+        {
+            "AsyncClient": _AsyncClient,
+            "Response": _HTTPResponse,
+            "TimeoutException": _TimeoutException,
+            "ConnectError": _ConnectError,
+        },
+    )
+    _install_module(
+        "dev_health_ops.api.utils.logging",
+        {"sanitize_for_log": lambda value: str(value)},
+    )
+    _install_module(
+        "dev_health_ops.connectors.exceptions",
+        {
+            "APIException": _APIException,
+            "AuthenticationException": _AuthenticationException,
+            "RateLimitException": _RateLimitException,
+        },
+    )
+    _install_module(
+        "dev_health_ops.providers._ratelimit",
+        {
+            "gitlab_403_is_rate_limited": lambda headers: (
+                str(headers.get("Retry-After", "")).strip() != ""
+                or str(headers.get("RateLimit-Remaining", "")).strip() == "0"
+            ),
+            "gitlab_resolve_retry_after_seconds": lambda headers: 0.0,
+        },
+    )
+    _install_module("dev_health_ops.providers.usage", {"UsageRecorder": _UsageRecorder})
+    _install_module(
+        "dev_health_ops.providers.gitlab.budget",
+        {"GITLAB_USAGE_RESOLVER": object()},
+    )
+    _install_module(
+        "dev_health_ops.sync.budget_types", {"BudgetDimension": _BudgetDimension}
+    )
+    _install_module(
+        "dev_health_ops.sync.rate_limit_signal", {"RateLimitSignal": _RateLimitSignal}
+    )
+    _install_module(
+        "dev_health_ops.metrics.schemas",
+        {"FeatureFlagEventRecord": _Record, "FeatureFlagRecord": _Record},
+    )
+
+
+def _load_targets() -> tuple[Any, Any]:
+    # The generic runner imports this helper as a plain repository module. Load
+    # the two fixed production sources under their real module names, with only
+    # dependency-free shape stubs for imports unrelated to this provider-local
+    # boundary. The client and both normalizers themselves are never copied.
+    _purge_dev_health_modules()
+    _configure_modules()
+    client_module = _load_source_module(
+        "dev_health_ops.providers.gitlab.feature_flags", CLIENT_SOURCE
+    )
+    _force_annotation_evaluation(
+        "dev_health_ops.providers.gitlab.feature_flags", client_module
+    )
+    processor_module = _load_source_module(
+        "dev_health_ops.processors.gitlab_feature_flags", PROCESSOR_SOURCE
+    )
+    _force_annotation_evaluation(
+        "dev_health_ops.processors.gitlab_feature_flags", processor_module
+    )
+    return client_module, processor_module
+
+
+def _load_edge_targets() -> tuple[Any, Any]:
+    """Load the production builder and worker edge path with narrow sinks.
+
+    The feature-flag worker owns latest-event selection and evidence assembly;
+    the builder owns deterministic edge IDs and persisted edge fields.  The
+    oracle executes both production methods and captures their records without
+    importing the application or opening a ClickHouse connection.
+    """
+    _install_package("dev_health_ops.work_graph")
+    _install_package("dev_health_ops.work_graph.extractors")
+    _install_module(
+        "dev_health_ops.metrics.schemas",
+        {
+            "FeatureFlagEventRecord": _Record,
+            "FeatureFlagRecord": _Record,
+            "FeatureFlagLinkRecord": _Record,
+            "WorkGraphEdgeRecord": _Record,
+            "WorkGraphIssuePRRecord": _Record,
+            "WorkGraphPRCommitRecord": _Record,
+            "WorkGraphProjectionRunRecord": _Record,
+        },
+    )
+    _install_module(
+        "dev_health_ops.metrics.sinks.factory",
+        {"create_sink": lambda _dsn: _CapturingEdgeSink()},
+    )
+    _install_module(
+        "dev_health_ops.metrics.sinks.clickhouse.idempotency",
+        {"WORK_ITEMS_DEDUPED": "work_items"},
+    )
+    _install_module(
+        "dev_health_ops.work_graph.extractors.text_parser",
+        {
+            "RefType": type("RefType", (), {}),
+            "extract_flag_key_refs": lambda *_args, **_kwargs: [],
+            "extract_github_issue_refs": lambda *_args, **_kwargs: [],
+            "extract_gitlab_issue_refs": lambda *_args, **_kwargs: [],
+            "extract_jira_keys": lambda *_args, **_kwargs: [],
+            "extract_pr_refs": lambda *_args, **_kwargs: [],
+            "extract_squash_pr_refs": lambda *_args, **_kwargs: [],
+        },
+    )
+    _install_module(
+        "dev_health_ops.work_graph.operational_edges",
+        {"build_operational_incident_edges": lambda *_args, **_kwargs: []},
+    )
+    _load_source_module("dev_health_ops.work_graph.models", MODELS_SOURCE)
+    _load_source_module("dev_health_ops.work_graph.ids", IDS_SOURCE)
+    builder_module = _load_source_module(
+        "dev_health_ops.work_graph.builder", BUILDER_SOURCE
+    )
+    _force_annotation_evaluation("dev_health_ops.work_graph.builder", builder_module)
+    _install_module(
+        "dev_health_ops.workers.async_runner",
+        {"run_async": lambda coroutine: asyncio.run(coroutine)},
+    )
+    worker_module = _load_source_module(
+        "dev_health_ops.workers.feature_flag_sync", WORKER_SOURCE
+    )
+    _force_annotation_evaluation(
+        "dev_health_ops.workers.feature_flag_sync", worker_module
+    )
+    return builder_module, worker_module
+
+
+def _parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _status(case: dict[str, Any], endpoint: str) -> int:
+    return int(case.get(f"{endpoint}_status", 200))
+
+
+def _headers(
+    case: dict[str, Any], endpoint: str, page: int | None = None
+) -> dict[str, str]:
+    configured = case.get(f"{endpoint}_headers", {})
+    if isinstance(configured, list) and page is not None and page - 1 < len(configured):
+        configured = configured[page - 1]
+    if not isinstance(configured, dict):
+        configured = {}
+    return {str(key): str(value) for key, value in configured.items()}
+
+
+class _FeatureFlagsTransport:
+    def __init__(self, case: dict[str, Any]) -> None:
+        self.case = case
+        self.requests: list[str] = []
+        self.is_closed = False
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> _HTTPResponse:
+        if method != "GET":
+            raise AssertionError(f"unexpected method {method}")
+        params = params or {}
+        request_path = path
+        if params:
+            request_path += "?" + urlencode(params)
+        self.requests.append(request_path)
+        if path.endswith("/feature_flags"):
+            page = int(params.get("page", 1))
+            pages = self.case.get("flags_pages", [])
+            payload = pages[page - 1] if page - 1 < len(pages) else []
+            headers = _headers(self.case, "flags", page)
+            next_pages = self.case.get("next_pages", [])
+            if (
+                isinstance(next_pages, list)
+                and page - 1 < len(next_pages)
+                and next_pages[page - 1]
+            ):
+                headers.setdefault("X-Next-Page", str(next_pages[page - 1]))
+            return _HTTPResponse(
+                _status(self.case, "flags"), payload, headers=headers, url=request_path
+            )
+        if "/projects/" in path:
+            return _HTTPResponse(
+                _status(self.case, "project"),
+                self.case.get("project_payload", {}),
+                headers=_headers(self.case, "project"),
+                url=request_path,
+            )
+        raise AssertionError(f"unexpected path {path}")
+
+
+@dataclass(frozen=True)
+class FeatureFlagsTrace:
+    flags: list[dict[str, Any]]
+    events: list[dict[str, Any]]
+    edges: list[dict[str, Any]]
+    project_key: str
+    requests: list[str]
+    error: str
+
+
+def trace_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(FeatureFlagsTrace))
+
+
+def _error_class(exc: Exception) -> str:
+    if isinstance(exc, _RateLimitException):
+        return "rate_limited"
+    if isinstance(exc, _AuthenticationException):
+        return "authentication"
+    if isinstance(exc, _APIException):
+        return "api"
+    return type(exc).__name__
+
+
+def _build_worker_edges(
+    *,
+    raw_flags: list[dict[str, Any]],
+    project_key: str,
+    org_id: str,
+    project_id_or_path: str,
+    normalized_at: datetime,
+) -> list[dict[str, Any]]:
+    """Execute the real worker/builder edge construction into a capture sink."""
+    builder_module, worker_module = _load_edge_targets()
+    edge_sink = _CapturingEdgeSink()
+    builder_module.create_sink = lambda _dsn: edge_sink
+    production_builder = builder_module.WorkGraphBuilder
+
+    class _DeterministicBuilder(production_builder):  # type: ignore[valid-type,misc]
+        def __init__(self, config: Any) -> None:
+            super().__init__(config)
+            self._now = normalized_at
+
+    builder_module.WorkGraphBuilder = _DeterministicBuilder
+
+    class _PinnedDateTime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:  # type: ignore[override]
+            if tz is None:
+                return normalized_at.replace(tzinfo=None)
+            return normalized_at.astimezone(tz)
+
+    # WorkGraphEdge's production dataclass defaults call the models module's
+    # datetime.now directly for discovered_at/last_synced. Pin that real
+    # default factory to the oracle observation so timestamps remain
+    # comparable to the Go route without replacing the builder methods.
+    sys.modules["dev_health_ops.work_graph.models"].datetime = _PinnedDateTime  # type: ignore[attr-defined]
+
+    class _WorkerClient:
+        def __init__(self, *, private_token: str, base_url: str) -> None:
+            if not private_token or not base_url:
+                raise AssertionError("worker client was not configured")
+
+        async def __aenter__(self) -> _WorkerClient:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def get_feature_flags(self, _project: str) -> list[dict[str, Any]]:
+            return raw_flags
+
+        async def get_project_name(self, _project: str) -> str:
+            return project_key
+
+    _install_module(
+        "dev_health_ops.providers.gitlab.feature_flags",
+        {"GitLabFeatureFlagsClient": _WorkerClient},
+    )
+    _install_module(
+        "dev_health_ops.metrics.sinks.clickhouse",
+        {"ClickHouseMetricsSink": _WorkerMetricsSink},
+    )
+    _install_module(
+        "dev_health_ops.metrics.job_work_items",
+        {"attach_work_item_partial_observations": lambda *_args, **_kwargs: None},
+    )
+    _install_module(
+        "dev_health_ops.providers.usage", {"drain_provider_usage": lambda _client: []}
+    )
+    worker_module._sync_gitlab_feature_flags(
+        db_url="clickhouse://capture",
+        org_id=org_id,
+        credentials={"token": "oracle", "gitlab_url": "https://gitlab.test"},
+        sync_options={"project_id": project_id_or_path},
+    )
+    rows: list[dict[str, Any]] = []
+    for record in edge_sink.edges:
+        row = vars(record).copy()
+        # The Go generic encoder spells a float with strconv's `%g`, while
+        # Python repr(1.0) retains the trailing `.0`. Preserve the production
+        # float type and only align the two lossless type-tag wire spellings.
+        row["confidence"] = _GoCompatibleFloat(row["confidence"])
+        rows.append(row)
+    return rows
+
+
+def build_trace(case: dict[str, Any]) -> dict[str, Any]:
+    client_module, processor_module = _load_targets()
+    normalized_at = _parse_time(case["normalized_at"])
+
+    class _FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:  # type: ignore[override]
+            if tz is None:
+                return normalized_at.replace(tzinfo=None)
+            return normalized_at.astimezone(tz)
+
+    # The production normalizer stamps its own `now`; pin that live call to
+    # the same deterministic observation used by the Go route so all semantic
+    # fields remain comparable while the source functions stay executable.
+    processor_module.datetime = _FixedDateTime
+    transport = _FeatureFlagsTransport(case)
+    client = client_module.GitLabFeatureFlagsClient(
+        private_token="oracle",
+        base_url="https://gitlab.test",
+        max_retries=int(case.get("max_retries", 1)),
+        per_page=int(case.get("per_page", 100)),
+    )
+    client._client = transport
+    project_id_or_path = str(case["project_id_or_path"])
+    raw_flags: list[dict[str, Any]] = []
+    project_key = project_id_or_path
+    error = ""
+    try:
+        raw_flags = asyncio.run(
+            client.get_feature_flags(
+                project_id_or_path, per_page=int(case.get("per_page", 100))
+            )
+        )
+        project_key = asyncio.run(client.get_project_name(project_id_or_path))
+        flags = processor_module.normalize_gitlab_feature_flags(
+            raw_flags,
+            project_key=project_key,
+            org_id=str(case.get("org_id", "org-acme")),
+        )
+        events = processor_module.snapshot_gitlab_feature_flag_events(
+            raw_flags,
+            project_key=project_key,
+            org_id=str(case.get("org_id", "org-acme")),
+            observed_at=normalized_at,
+        )
+        edges = _build_worker_edges(
+            raw_flags=raw_flags,
+            project_key=project_key,
+            org_id=str(case.get("org_id", "org-acme")),
+            project_id_or_path=str(case["project_id_or_path"]),
+            normalized_at=normalized_at,
+        )
+        trace = FeatureFlagsTrace(
+            flags=sorted(
+                (vars(row) for row in flags),
+                key=lambda row: (row["flag_key"], row["environment"]),
+            ),
+            events=sorted(
+                (vars(row) for row in events),
+                key=lambda row: (row["flag_key"], row["environment"]),
+            ),
+            edges=sorted(
+                edges,
+                key=lambda row: (row["edge_id"], row["edge_type"]),
+            ),
+            project_key=project_key,
+            requests=["/api/v4" + path for path in transport.requests],
+            error=error,
+        )
+    except Exception as exc:  # noqa: BLE001 - oracle records provider outcome
+        error = _error_class(exc)
+        trace = FeatureFlagsTrace(
+            flags=[],
+            events=[],
+            edges=[],
+            project_key=project_key,
+            requests=["/api/v4" + path for path in transport.requests],
+            error=error,
+        )
+    return asdict(trace)

--- a/internal/providersync/testdata/oracle_pairs/_gitlab_files_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_gitlab_files_common.py
@@ -49,6 +49,7 @@ class FileTraceRow:
 @dataclass(frozen=True)
 class FileTraversalTrace:
     producer_requests: list[str]
+    requested_content_paths: list[str]
     usage_request_count: int
     tree_paths: list[str]
     rows: list[FileTraceRow]
@@ -57,7 +58,14 @@ class FileTraversalTrace:
 
 def reflected_trace_fields() -> frozenset[str]:
     return frozenset(
-        {"producer_requests", "usage_request_count", "tree_paths", "rows", "incomplete"}
+        {
+            "producer_requests",
+            "requested_content_paths",
+            "usage_request_count",
+            "tree_paths",
+            "rows",
+            "incomplete",
+        }
     )
 
 
@@ -82,6 +90,7 @@ def run_python_producer(case: dict[str, Any]) -> FileTraversalTrace:
     processor.write_historical_complexity = lambda **_kwargs: None
 
     requests: list[str] = []
+    requested_content_paths: list[str] = []
     tree_pages = case.get("tree_pages", [[]])
     tree_next_pages = case.get("tree_next_pages", [])
     commit_rows = case.get("commit_rows", [])
@@ -107,6 +116,8 @@ def run_python_producer(case: dict[str, Any]) -> FileTraversalTrace:
             variables = body["variables"]
             paths = [str(path) for path in variables["paths"]]
             query = str(body["query"])
+            if "rawSize" in query or "rawTextBlob" in query:
+                requested_content_paths.extend(paths)
             if case.get("content_failure") and "rawTextBlob" in query:
                 return httpx.Response(500, json={}, request=request)
             if "rawSize" in query:
@@ -212,6 +223,7 @@ def run_python_producer(case: dict[str, Any]) -> FileTraversalTrace:
         )
     return FileTraversalTrace(
         producer_requests=requests,
+        requested_content_paths=requested_content_paths,
         usage_request_count=usage_request_count,
         tree_paths=tree_paths,
         rows=rows,

--- a/internal/providersync/testdata/oracle_pairs/_gitlab_files_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_gitlab_files_common.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import pathlib
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+from urllib.parse import parse_qsl, unquote, urlencode
+
+import httpx
+
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/gitlab.py"
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    if value is None or value == "":
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _request_path(request: httpx.Request) -> str:
+    pairs = sorted(parse_qsl(request.url.query.decode(), keep_blank_values=True))
+    query = urlencode(pairs)
+    path = unquote(request.url.path)
+    marker = "/api/v4/projects/"
+    if path.startswith(marker):
+        suffix = path[len(marker) :]
+        _, separator, remainder = suffix.partition("/repository")
+        if separator:
+            path = f"{marker}{{project}}/repository{remainder}"
+    return f"{path}?{query}" if query else path
+
+
+@dataclass(frozen=True)
+class FileTraceRow:
+    path: str
+    executable: bool
+    contents: str | None
+
+
+@dataclass(frozen=True)
+class FileTraversalTrace:
+    producer_requests: list[str]
+    usage_request_count: int
+    tree_paths: list[str]
+    rows: list[FileTraceRow]
+    incomplete: list[dict[str, Any]]
+
+
+def reflected_trace_fields() -> frozenset[str]:
+    return frozenset(
+        {"producer_requests", "usage_request_count", "tree_paths", "rows", "incomplete"}
+    )
+
+
+def run_python_producer(case: dict[str, Any]) -> FileTraversalTrace:
+    logging.disable(logging.CRITICAL)
+    processor = load_live_module(PROCESSOR_SOURCE)
+    base_git = load_live_module(BASE_GIT_SOURCE)
+    code_client_module = load_live_module(CODE_CLIENT_SOURCE)
+
+    # Keep the real worker and persistence boundary in the execution path;
+    # only the unrelated commit-stats/blame gates are fixed to this files unit.
+    async def needs(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(files=True, blame=False, commit_stats=False)
+
+    async def no_blame(*_args: Any, **_kwargs: Any) -> bool:
+        return False
+
+    processor.check_backfill_needs = needs
+    processor.blame_backfill_needed = no_blame
+    processor.backfill_file_records = base_git.backfill_file_records
+    processor.historical_backfill_day = base_git.historical_backfill_day
+    processor.write_historical_complexity = lambda **_kwargs: None
+
+    requests: list[str] = []
+    tree_pages = case.get("tree_pages", [[]])
+    tree_next_pages = case.get("tree_next_pages", [])
+    commit_rows = case.get("commit_rows", [])
+    sizes = {str(path): int(value) for path, value in case.get("sizes", {}).items()}
+    contents = {
+        str(path): str(value) for path, value in case.get("contents", {}).items()
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(_request_path(request))
+        if request.url.path.endswith("/repository/commits"):
+            return httpx.Response(200, json=commit_rows, request=request)
+        if request.url.path.endswith("/repository/tree"):
+            page = int(request.url.params.get("page", "1"))
+            index = page - 1
+            payload = tree_pages[index] if index < len(tree_pages) else []
+            headers: dict[str, str] = {}
+            if index < len(tree_next_pages) and tree_next_pages[index]:
+                headers["X-Next-Page"] = str(tree_next_pages[index])
+            return httpx.Response(200, json=payload, headers=headers, request=request)
+        if request.url.path == "/api/graphql":
+            body = json_loads(request.content)
+            variables = body["variables"]
+            paths = [str(path) for path in variables["paths"]]
+            query = str(body["query"])
+            if case.get("content_failure") and "rawTextBlob" in query:
+                return httpx.Response(500, json={}, request=request)
+            if "rawSize" in query:
+                nodes = [
+                    {"path": path, "rawSize": sizes.get(path, 100)} for path in paths
+                ]
+            else:
+                nodes = [
+                    {"path": path, "rawTextBlob": contents.get(path)} for path in paths
+                ]
+            return httpx.Response(
+                200,
+                json={"data": {"project": {"repository": {"blobs": {"nodes": nodes}}}}},
+                request=request,
+            )
+        raise AssertionError(f"unexpected producer request: {request.url}")
+
+    client = code_client_module.GitLabCodeClient(
+        private_token="oracle",
+        base_url="https://gitlab.test",
+        max_retries=1,
+        transport=httpx.MockTransport(handler),
+    )
+
+    @asynccontextmanager
+    async def client_factory(_connector: object):
+        async with client:
+            yield client
+
+    processor._gitlab_code_client_from_connector = client_factory
+    usage: list[dict[str, Any]] = []
+    inserted: list[Any] = []
+
+    class Sink:
+        async def get_git_file_contents_by_path(self, _repo_id: Any) -> dict[str, str]:
+            return {}
+
+        async def insert_git_file_data(self, rows: list[Any]) -> None:
+            inserted.extend(rows)
+
+    until = _parse_time(case.get("until"))
+    asyncio.run(
+        processor._backfill_gitlab_missing_data(
+            SimpleNamespace(),
+            Sink(),
+            object(),
+            SimpleNamespace(id=case["repo_id"]),
+            case.get("project_full_name", "Acme/API"),
+            case.get("default_branch", "main"),
+            None,
+            include_files=True,
+            include_blame=False,
+            include_commit_stats=False,
+            until=until,
+            usage_sink=usage,
+        )
+    )
+    usage_request_count = sum(int(item.get("request_count") or 0) for item in usage)
+    if usage_request_count != len(requests):
+        raise ValueError(
+            "GitLab files producer usage observations lost physical requests: "
+            f"usage={usage_request_count} requests={len(requests)}"
+        )
+    rows = sorted(
+        (
+            FileTraceRow(
+                path=str(getattr(row, "path")),
+                executable=bool(getattr(row, "executable")),
+                contents=getattr(row, "contents", None),
+            )
+            for row in inserted
+        ),
+        key=lambda row: row.path,
+    )
+    tree_paths = [
+        str(item["path"])
+        for page in tree_pages
+        for item in page
+        if isinstance(item, dict) and item.get("type") == "blob" and item.get("path")
+    ]
+    scanner = processor.ComplexityScanner(
+        config_path=processor.DEFAULT_COMPLEXITY_CONFIG_PATH
+    )
+    scannable_count = sum(1 for path in tree_paths if scanner.should_process(path))
+    incomplete: list[dict[str, Any]] = []
+    if scannable_count > 2_000:
+        incomplete.append(
+            {
+                "cause": "content_cap",
+                "subject": "gitlab/files",
+                "limit": 2_000,
+                "observed": scannable_count,
+            }
+        )
+    if case.get("content_failure"):
+        incomplete.append(
+            {
+                "cause": "content_fetch",
+                "subject": "gitlab/files",
+                "limit": 0,
+                "observed": scannable_count,
+            }
+        )
+    return FileTraversalTrace(
+        producer_requests=requests,
+        usage_request_count=usage_request_count,
+        tree_paths=tree_paths,
+        rows=rows,
+        incomplete=incomplete,
+    )
+
+
+def json_loads(value: bytes) -> dict[str, Any]:
+    import json
+
+    decoded = json.loads(value)
+    if not isinstance(decoded, dict):
+        raise ValueError(f"GraphQL request was not an object: {decoded!r}")
+    return decoded
+
+
+def build_traversal(case: dict[str, Any]) -> dict[str, Any]:
+    return asdict(run_python_producer(case))

--- a/internal/providersync/testdata/oracle_pairs/_gitlab_security_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_gitlab_security_common.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+import pathlib
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass, fields
+from datetime import datetime
+from typing import Any
+from urllib.parse import parse_qsl, urlencode
+
+import httpx
+
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/gitlab.py"
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+
+
+def parse_time(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def request_path(request: httpx.Request) -> str:
+    pairs = sorted(parse_qsl(request.url.query.decode(), keep_blank_values=True))
+    query = urlencode(pairs)
+    return f"{request.url.path}?{query}" if query else request.url.path
+
+
+def _endpoint_name(path: str) -> str:
+    if path.endswith("/vulnerability_findings"):
+        return "findings"
+    if path.endswith("/dependencies"):
+        return "dependencies"
+    return "project"
+
+
+def _headers(case: dict[str, Any], endpoint: str) -> dict[str, str]:
+    configured = case.get("response_headers", {}).get(endpoint, {})
+    return {str(key): str(value) for key, value in configured.items()}
+
+
+def run_producer(
+    case: dict[str, Any], *, apply_until: bool
+) -> tuple[list[Any], list[str], int]:
+    """Execute the real processor helper with deterministic HTTP responses."""
+
+    processor = load_live_module(PROCESSOR_SOURCE)
+    code_client = load_live_module(CODE_CLIENT_SOURCE)
+    requests: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request_path(request))
+        path = request.url.path
+        endpoint = _endpoint_name(path)
+        if path == "/api/v4/projects/123":
+            payload: Any = case.get(
+                "project", {"id": 123, "name": "api", "path_with_namespace": "acme/api"}
+            )
+        elif endpoint == "findings":
+            payload = case.get("findings", [])
+        elif endpoint == "dependencies":
+            payload = case.get("dependencies", [])
+        else:
+            raise AssertionError(f"unexpected producer request: {request.url}")
+        status = int(case.get(f"{endpoint}_status", 200))
+        return httpx.Response(
+            status,
+            json=payload,
+            headers=_headers(case, endpoint),
+            request=request,
+        )
+
+    client = code_client.GitLabCodeClient(
+        private_token="oracle",
+        base_url="https://gitlab.test",
+        max_retries=1,
+        transport=httpx.MockTransport(handler),
+    )
+
+    @asynccontextmanager
+    async def client_factory(_connector: object):
+        async with client:
+            yield client
+
+    processor._gitlab_code_client_from_connector = client_factory
+    usage: list[dict[str, Any]] = []
+    # The optional GitLab endpoints deliberately exercise the producer's
+    # warning-and-degrade path.  The Go oracle subprocess consumes stdout as
+    # JSON, so suppress application logging for this isolated producer call;
+    # the trace still records the concrete request/status effects below.
+    previous_disable = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        rows = processor._fetch_gitlab_security_alerts_sync(
+            object(),
+            123,
+            case["repo_id"],
+            case["max_alerts"],
+            parse_time(case.get("since")),
+            usage,
+        )
+    finally:
+        logging.disable(previous_disable)
+    if apply_until and (until := parse_time(case.get("until"))) is not None:
+        rows = processor._filter_after(rows, until, "created_at")
+    usage_request_count = sum(int(item.get("request_count") or 0) for item in usage)
+    if usage_request_count != len(requests):
+        raise ValueError(
+            "security producer usage observations lost physical requests: "
+            f"usage={usage_request_count} requests={len(requests)}"
+        )
+    return rows, requests, usage_request_count
+
+
+@dataclass(frozen=True)
+class SecurityTraversalRow:
+    alert_id: str
+    source: str
+
+
+@dataclass(frozen=True)
+class SecurityTraversalTrace:
+    producer_requests: list[str]
+    usage_request_count: int
+    rows: list[SecurityTraversalRow]
+
+
+def traversal_fields() -> frozenset[str]:
+    return frozenset(field.name for field in fields(SecurityTraversalTrace))
+
+
+def build_traversal(case: dict[str, Any]) -> dict[str, Any]:
+    rows, requests, usage_request_count = run_producer(case, apply_until=True)
+    return asdict(
+        SecurityTraversalTrace(
+            producer_requests=requests,
+            usage_request_count=usage_request_count,
+            rows=[SecurityTraversalRow(row.alert_id, row.source) for row in rows],
+        )
+    )

--- a/internal/providersync/testdata/oracle_pairs/gitlab_feature_flags.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_feature_flags.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._gitlab_feature_flags_common import (
+    build_trace,
+    trace_fields,
+)
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/feature/flags",
+        build_row=build_trace,
+        reflected_fields=trace_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_files_http-classification.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_files_http-classification.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+RATE_LIMIT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/ratelimit.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return dataclass_field_names(
+        RATE_LIMIT_SOURCE.read_text(), "GitLabRateLimitClassification"
+    )
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    code_client = load_live_module(CODE_CLIENT_SOURCE)
+    classification = code_client.classify_gitlab_status(
+        status=int(case["status"]), headers=case.get("headers", {})
+    )
+    return asdict(classification)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/files/http-classification",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "reason": "Go's shared ProviderError exposes the stable rate-limit class but not GitLab's provider-local primary/secondary reason",
+            "retry_after_seconds": "Go's shared ProviderError stores retry delay as a duration and this oracle pins classification, not provider-specific delay serialization",
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_files_row.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_files_row.py
@@ -1,0 +1,69 @@
+"""GitLab files row oracle over the live worker persistence boundary.
+
+The pair executes ``backfill_file_records`` from the real Python worker
+module, not a hand-written GitFile constructor. The fake sink only records the
+objects handed to the persistence boundary; it does not normalize or select
+fields on the producer's behalf.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import class_annotated_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+MODEL_SOURCE = REPO_ROOT / "src/dev_health_ops/models/git.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    return class_annotated_field_names(MODEL_SOURCE.read_text(), "GitFile")
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    base_git = load_live_module(BASE_GIT_SOURCE)
+    inserted: list[Any] = []
+
+    class Sink:
+        async def get_git_file_contents_by_path(self, _repo_id: Any) -> dict[str, str]:
+            return {
+                str(path): str(value)
+                for path, value in case.get("existing_contents", {}).items()
+            }
+
+        async def insert_git_file_data(self, rows: list[Any]) -> None:
+            inserted.extend(rows)
+
+    async def run() -> None:
+        await base_git.backfill_file_records(
+            Sink(),
+            case["repo_id"],
+            [case["path"]],
+            case.get("project_full_name", "Acme/API"),
+            contents_by_path={
+                str(path): str(value)
+                for path, value in case.get("contents_by_path", {}).items()
+            },
+        )
+
+    asyncio.run(run())
+    if len(inserted) != 1:
+        raise ValueError(f"GitLab files worker produced {len(inserted)} rows")
+    return vars(inserted[0])
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/files/row",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "last_synced": "Python GitFile defaults this persistence timestamp after backfill_file_records; Go carries the normalized collection instant",
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_files_trace.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_files_trace.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._gitlab_files_common import (
+    build_traversal,
+    reflected_trace_fields,
+)
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/files/trace",
+        build_row=build_traversal,
+        reflected_fields=reflected_trace_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_pr-reviews_row.py
@@ -19,7 +19,9 @@ oracle_registry.register(
             pathlib.Path(MODEL_SOURCE).read_text(), "GitPullRequestReview"
         ),
         excluded_fields={
-            "last_synced": "stamped from the Go collection instant, not the Python mapper",
+            "last_synced": (
+                "stamped from the Go collection instant, not the Python mapper"
+            ),
         },
     )
 )

--- a/internal/providersync/testdata/oracle_pairs/gitlab_security_dependency.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_security_dependency.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    return frozenset(client.SecurityAlertData.__annotations__)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    dependency = {"name": case["package_name"]}
+    row = client._map_dependency_alert(dependency, case["raw_alert"])
+    return vars(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/security/dependency",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={
+            "created_at": "the Python dependency mapper uses wall-clock now while Go uses the executor normalized instant",
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_security_trace.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_security_trace.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.oracle_pairs._gitlab_security_common import (
+    build_traversal,
+    traversal_fields,
+)
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/security/trace",
+        build_row=build_traversal,
+        reflected_fields=traversal_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_security_vulnerability.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_security_vulnerability.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/gitlab/code_client.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    return frozenset(client.SecurityAlertData.__annotations__)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    client = load_live_module(CODE_CLIENT_SOURCE)
+    row = client._map_vulnerability_finding(case["raw_alert"])
+    return vars(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/security/vulnerability",
+        build_row=_build_row,
+        reflected_fields=_reflected_fields,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_cycle-times.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_cycle-times.py
@@ -1,0 +1,35 @@
+"""Live Python producer oracle for GitLab work-item cycle times."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_metrics_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    columns,
+    compute_triplet,
+)
+
+_RECORD = "WorkItemCycleTimeRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _group_records, _user_records, cycle_records = compute_triplet(case)
+    return columns(list(cycle_records), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/cycle-times",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_estimate-coverage.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_estimate-coverage.py
@@ -1,0 +1,34 @@
+"""Live Python producer oracle for GitLab estimate coverage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "EstimateCoverageMetricsDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).estimate_coverage()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/estimate-coverage",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_investment-classifications.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_investment-classifications.py
@@ -1,0 +1,33 @@
+"""Live Python producer oracle for GitLab investment classifications."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "InvestmentClassificationRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _rows, classifications, _metrics = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(classifications), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/investment-classifications",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_investment-metrics.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_investment-metrics.py
@@ -1,0 +1,33 @@
+"""Live Python producer oracle for GitLab investment metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "InvestmentMetricsRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _rows, _classifications, metrics = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(metrics), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/investment-metrics",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue-type-metrics.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_issue-type-metrics.py
@@ -1,0 +1,33 @@
+"""Live Python producer oracle for GitLab issue-type metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "IssueTypeMetricsRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    rows, _classifications, _metrics = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(rows), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/issue-type-metrics",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_metrics-daily.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_metrics-daily.py
@@ -1,0 +1,35 @@
+"""Live Python producer oracle for GitLab work-item group metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_metrics_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    columns,
+    compute_triplet,
+)
+
+_RECORD = "WorkItemMetricsDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    group_records, _user_records, _cycle_records = compute_triplet(case)
+    return columns(list(group_records), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/metrics-daily",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_state-durations.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_state-durations.py
@@ -1,0 +1,34 @@
+"""Live Python producer oracle for GitLab state durations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "WorkItemStateDurationDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).state_durations()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/state-durations",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_team-attributions.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_team-attributions.py
@@ -1,0 +1,34 @@
+"""Live Python producer oracle for GitLab team attributions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "WorkItemTeamAttributionRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).team_attributions()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/team-attributions",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_user-metrics-daily.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_user-metrics-daily.py
@@ -1,0 +1,35 @@
+"""Live Python producer oracle for GitLab work-item user metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_metrics_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    columns,
+    compute_triplet,
+)
+
+_RECORD = "WorkItemUserMetricsDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _group_records, user_records, _cycle_records = compute_triplet(case)
+    return columns(list(user_records), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/user-metrics-daily",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -46,6 +46,7 @@ _JIRA_BUDGET_SOURCE = _source("dev_health_ops/providers/jira/budget.py")
 _LAUNCHDARKLY_BUDGET_SOURCE = _source("dev_health_ops/providers/launchdarkly/budget.py")
 _DATASET_ADAPTERS_SOURCE = _source("dev_health_ops/processors/dataset_adapters.py")
 _BASE_GIT_SOURCE = _source("dev_health_ops/processors/base_git.py")
+_COMPLEXITY_SOURCE = _source("dev_health_ops/analytics/complexity.py")
 _GITHUB_CODE_CLIENT_SOURCE = _source("dev_health_ops/providers/github/code_client.py")
 _GITHUB_WORK_ITEM_OPTIONS_SOURCE = _source(
     "dev_health_ops/providers/github/work_item_options.py"
@@ -247,18 +248,12 @@ class _OracleAsyncBatchCollector:
 def _target_base_git() -> None:
     """Stub base_git.py's heavy, unrelated imports (CHAOS-3122).
 
-    ``BaseGitProcessor.coerce_created_at`` and the module-level
-    ``build_git_pull_request`` are pure functions; everything base_git.py
-    imports beyond them (complexity scanning, ORM models, the async batch
-    collector) is dead weight for this oracle and, more importantly, is not
-    importable under the stock interpreter this loader exists for. Each stub
-    only needs to satisfy the *names* base_git.py imports at module-load
-    time -- it never calls into any of them.
+    Most base_git.py imports remain unrelated to row construction and are
+    stubbed so this loader stays dependency-light. The real complexity module
+    is loaded because the GitLab files traversal oracle executes the live
+    processor's scanner gate before the worker persistence boundary.
     """
-    _install_module(
-        "dev_health_ops.analytics.complexity",
-        {"DEFAULT_COMPLEXITY_CONFIG_PATH": None, "ComplexityScanner": object},
-    )
+    _load_source_module("dev_health_ops.analytics.complexity", _COMPLEXITY_SOURCE)
     _install_module(
         "dev_health_ops.metrics.schemas",
         {"FileComplexitySnapshot": object, "RepoComplexityDaily": object},
@@ -607,10 +602,7 @@ def _target_gitlab_processor() -> None:
         "dev_health_ops.providers.operational_migration",
         _OPERATIONAL_MIGRATION_SOURCE,
     )
-    _install_module(
-        "dev_health_ops.analytics.complexity",
-        {"DEFAULT_COMPLEXITY_CONFIG_PATH": None, "ComplexityScanner": object},
-    )
+    _load_source_module("dev_health_ops.analytics.complexity", _COMPLEXITY_SOURCE)
     _install_module(
         "dev_health_ops.connectors.models",
         {

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -59,6 +59,7 @@ _GITLAB_REPOSITORY_SOURCE = _source("dev_health_ops/providers/gitlab/repository.
 _GITLAB_PROCESSOR_SOURCE = _source("dev_health_ops/processors/gitlab.py")
 _FETCH_UTILS_SOURCE = _source("dev_health_ops/processors/fetch_utils.py")
 _GIT_MODEL_SOURCE = _source("dev_health_ops/models/git.py")
+_CONNECTOR_MODELS_SOURCE = _source("dev_health_ops/connectors/models.py")
 _REPOSITORY_ROWS_SOURCE = _source("dev_health_ops/storage/repository_rows.py")
 _RELEASE_REF_SOURCE = _source("dev_health_ops/processors/release_ref.py")
 _TESTOPS_SCHEMAS_SOURCE = _source("dev_health_ops/metrics/testops_schemas.py")
@@ -402,21 +403,10 @@ def _target_gitlab_code_client() -> None:
         "dev_health_ops.providers.gitlab.ratelimit", _GITLAB_RATELIMIT_SOURCE
     )
     _load_source_module("dev_health_ops.providers.gitlab.budget", _GITLAB_BUDGET_SOURCE)
-    _install_module(
-        "dev_health_ops.connectors.models",
-        {
-            "Repository": type(
-                "Repository",
-                (),
-                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
-            ),
-            "SecurityAlertData": type(
-                "SecurityAlertData",
-                (),
-                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
-            ),
-        },
-    )
+    # The live security mapping returns SecurityAlertData. Load the checked-in
+    # dataclass so constructor shape and annotations remain production-owned;
+    # a kwargs container would let a field drift without the oracle noticing.
+    _load_source_module("dev_health_ops.connectors.models", _CONNECTOR_MODELS_SOURCE)
 
 
 _GITHUB_PROCESSOR_SOURCE = _source("dev_health_ops/processors/github.py")
@@ -603,18 +593,23 @@ def _target_gitlab_processor() -> None:
         _OPERATIONAL_MIGRATION_SOURCE,
     )
     _load_source_module("dev_health_ops.analytics.complexity", _COMPLEXITY_SOURCE)
-    _install_module(
-        "dev_health_ops.connectors.models",
-        {
-            name: object
-            for name in ("Author", "Repository", "RepoStats", "SecurityAlertData")
-        },
-    )
+    # The files traversal oracle executes the live complexity scanner gate,
+    # while the security mappings construct the production connector model.
+    # Keep both real modules loaded so the combined oracle cannot drift behind
+    # either producer's typed boundary.
+    _load_source_module("dev_health_ops.connectors.models", _CONNECTOR_MODELS_SOURCE)
     _install_module("dev_health_ops.metrics.sinks.ingestion", {"IngestionSink": object})
 
     class _Incident:
         def __init__(self, **kwargs: Any) -> None:
             self.__dict__.update(kwargs)
+
+    # The security helper constructs git_models.SecurityAlert directly after
+    # the live GitLab code-client normalizer returns SecurityAlertData. Load
+    # the checked-in ORM model rather than replacing it with a kwargs stub:
+    # this keeps the oracle on the production typed model and catches schema
+    # drift in the same constructor/field boundary the processor uses.
+    git_models = _load_source_module("dev_health_ops.models.git", _GIT_MODEL_SOURCE)
 
     class _GitPullRequestReview:
         # The live mapper constructs this model directly. Keep the stand-in
@@ -623,20 +618,11 @@ def _target_gitlab_processor() -> None:
         def __init__(self, **kwargs: Any) -> None:
             self.__dict__.update(kwargs)
 
-    _install_module(
-        "dev_health_ops.models.git",
-        {
-            "CiPipelineRun": object,
-            "Deployment": object,
-            "GitBlame": object,
-            "GitCommit": object,
-            "GitCommitStat": object,
-            "GitPullRequest": object,
-            "GitPullRequestReview": _GitPullRequestReview,
-            "Incident": _Incident,
-            "Repo": object,
-        },
-    )
+    # Keep the production model module for SecurityAlert and override only the
+    # review class used by the PR-family row oracle. Its kwargs-shaped output
+    # preserves the pair's field projection (without SQLAlchemy's private
+    # instance state) while security continues to exercise the typed model.
+    git_models.GitPullRequestReview = _GitPullRequestReview
     _install_module(
         "dev_health_ops.processors.base_git",
         {
@@ -1010,6 +996,11 @@ ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
     _GIT_MODEL_SOURCE: (
         "dev_health_ops.models.git",
         _GIT_MODEL_SOURCE,
+        lambda: None,
+    ),
+    _CONNECTOR_MODELS_SOURCE: (
+        "dev_health_ops.connectors.models",
+        _CONNECTOR_MODELS_SOURCE,
         lambda: None,
     ),
     _REPOSITORY_ROWS_SOURCE: (

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -622,6 +622,13 @@ def _target_gitlab_processor() -> None:
     # review class used by the PR-family row oracle. Its kwargs-shaped output
     # preserves the pair's field projection (without SQLAlchemy's private
     # instance state) while security continues to exercise the typed model.
+    # SQLAlchemy's class registry holds weak references, so retain the mapped
+    # review class before replacing the public constructor used by the oracle.
+    setattr(
+        git_models,
+        "_oracle_mapped_git_pull_request_review",
+        git_models.GitPullRequestReview,
+    )
     setattr(git_models, "GitPullRequestReview", _GitPullRequestReview)
     _install_module(
         "dev_health_ops.processors.base_git",

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -622,7 +622,7 @@ def _target_gitlab_processor() -> None:
     # review class used by the PR-family row oracle. Its kwargs-shaped output
     # preserves the pair's field projection (without SQLAlchemy's private
     # instance state) while security continues to exercise the typed model.
-    git_models.GitPullRequestReview = _GitPullRequestReview
+    setattr(git_models, "GitPullRequestReview", _GitPullRequestReview)
     _install_module(
         "dev_health_ops.processors.base_git",
         {

--- a/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
+++ b/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
@@ -95,24 +95,43 @@ async def resolve_feature_flags(
     if not include_archived:
         where_clauses.append("archived_at IS NULL")
 
+    # Migration 074 makes environment part of the physical RMT identity, but
+    # the GraphQL registry contract remains one logical item per
+    # (provider, project, flag).  Aggregate after FINAL and choose every
+    # surfaced field from the same deterministic latest environment.  The
+    # environment tie-break keeps equal last_synced values stable without
+    # changing the established environment-agnostic flag ID.
+    latest_order = "tuple(last_synced, environment)"
     query = f"""
         SELECT
             provider,
             flag_key,
             project_key,
-            flag_type,
-            created_at,
-            archived_at
-        FROM feature_flag FINAL
-        WHERE {" AND ".join(where_clauses)}
+            tupleElement(latest, 1) AS flag_type,
+            tupleElement(latest, 2) AS created_at,
+            tupleElement(latest, 3) AS archived_at
+        FROM (
+            SELECT
+                provider,
+                flag_key,
+                project_key,
+                argMax(tuple(flag_type, created_at, archived_at), {latest_order}) AS latest
+            FROM feature_flag FINAL
+            WHERE {" AND ".join(where_clauses)}
+            GROUP BY provider, project_key, flag_key
+        )
         ORDER BY provider, project_key, flag_key
         LIMIT %(limit)s
     """
 
     count_query = f"""
         SELECT count() AS total
-        FROM feature_flag FINAL
-        WHERE {" AND ".join(where_clauses)}
+        FROM (
+            SELECT provider, project_key, flag_key
+            FROM feature_flag FINAL
+            WHERE {" AND ".join(where_clauses)}
+            GROUP BY provider, project_key, flag_key
+        )
     """
     count_params = {k: v for k, v in params.items() if k != "limit"}
 

--- a/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
+++ b/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
@@ -95,7 +95,7 @@ async def resolve_feature_flags(
     if not include_archived:
         where_clauses.append("archived_at IS NULL")
 
-    # Migration 074 makes environment part of the physical RMT identity, but
+    # Migration 075 makes environment part of the physical RMT identity, but
     # the GraphQL registry contract remains one logical item per
     # (provider, project, flag).  Aggregate after FINAL and choose every
     # surfaced field from the same deterministic latest environment.  The

--- a/src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py
+++ b/src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py
@@ -1,0 +1,335 @@
+"""Migration 074: keep feature-flag environments in the RMT identity.
+
+The feature-flag producer emits one row for every environment scope.  Before
+this migration, ``feature_flag`` was a ``ReplacingMergeTree`` keyed by
+``(org_id, provider, project_key, flag_key)``.  Two environments for the same
+flag therefore represented one physical identity: a merge (or ``FINAL``)
+silently discarded one environment and readback reported a conflict or an
+incomplete provider result.
+
+The deployed identity is now:
+
+    (org_id, provider, project_key, flag_key, environment)
+
+ClickHouse cannot alter a ReplacingMergeTree sorting key in place.  This
+migration uses the same shadow-table/atomic-exchange pattern as migrations
+042 and 061:
+
+1. Read the current DDL and sorting key.
+2. Create a shadow with the environment-aware key, verifying the *actual*
+   ClickHouse sorting key before copying data.
+3. Copy the old table and compare distinct environment-aware key tuples.
+4. Atomically exchange the tables.
+5. Catch up rows written during the snapshot and only then drop the old
+   shadow.
+
+The catch-up and idempotency paths deliberately leave a post-exchange shadow
+in place when catch-up fails.  A rerun converges it without dropping rows.
+Historical rows are copied unchanged; adding ``environment`` to the sorting
+key does not rewrite values or collapse rows that differ by environment.
+
+The migration is forward-only for application compatibility: once this schema
+is deployed, application binaries must use the registry's logical
+environment aggregation. A pre-074 registry reader would expose one row per
+environment and is not a safe rollback target, although old writers remain
+able to insert rows because the original columns are unchanged.
+
+Each invocation uses a unique shadow name. The migration runner's asyncio lock
+serializes migrations within one process, but not across processes or pods.
+Unique target-key shadows plus the final source-key preflight make a
+concurrent interleaving safe: a runner that observes the target key catches
+up its shadow instead of exchanging, and every exchange candidate has the
+target key so the table cannot be exchanged back to the legacy key.
+
+This module is loaded standalone by the ClickHouse migration runner, so it
+must not import sibling migration modules.
+"""
+
+import logging
+import re
+import uuid
+
+log = logging.getLogger(__name__)
+
+
+TABLES = {
+    "feature_flag": "(org_id, provider, project_key, flag_key, environment)",
+}
+
+LEGACY_KEY = "org_id, provider, project_key, flag_key"
+
+# ORDER BY (col, ...) | ORDER BY tuple(col, ...) | ORDER BY col
+_ORDER_BY_RE = re.compile(r"ORDER BY\s+(?:tuple\([^)]+\)|\([^)]+\)|\S+)", re.IGNORECASE)
+_ORG_ID_COL_RE = re.compile(
+    r"`?org_id`?\s+(?:LowCardinality\(\s*)?String", re.IGNORECASE
+)
+_EXCHANGE_DATABASE_ENGINES = frozenset({"Atomic", "Shared"})
+
+
+def _table_name_re(table: str) -> re.Pattern:
+    return re.compile(
+        rf"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        rf"(?:`?[\w\d_]+`?\.)?`?){re.escape(table)}(`?\s|`?\()",
+        re.IGNORECASE,
+    )
+
+
+def _replace_order_by(ddl: str, new_order_by: str) -> str:
+    result, count = _ORDER_BY_RE.subn(f"ORDER BY {new_order_by}", ddl, count=1)
+    if count == 0:
+        raise ValueError(f"Could not find ORDER BY in DDL: {ddl[:300]}...")
+    return result
+
+
+def _replace_table_name(ddl: str, old_name: str, new_name: str) -> str:
+    pattern = _table_name_re(old_name)
+    result, count = pattern.subn(rf"\g<1>{new_name}\g<2>", ddl, count=1)
+    if count == 0:
+        raise ValueError(
+            f"Could not replace table name '{old_name}' in DDL: {ddl[:300]}..."
+        )
+    return result
+
+
+def _table_exists(client, table: str) -> bool:
+    try:
+        result = client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = currentDatabase() AND name = {name:String}",
+            parameters={"name": table},
+        )
+        rows = getattr(result, "result_rows", None) or []
+        return bool(rows and rows[0] and rows[0][0] > 0)
+    except Exception:
+        return False
+
+
+def _shadow_name(table: str) -> str:
+    """Return a per-run shadow name so concurrent runners never share DDL."""
+    return f"{table}_074_new_{uuid.uuid4().hex}"
+
+
+def _shadow_tables(client, table: str) -> list[str]:
+    prefix = f"{table}_074_new_"
+    result = client.query(
+        "SELECT name FROM system.tables "
+        "WHERE database = currentDatabase() AND name LIKE {prefix:String}",
+        parameters={"prefix": f"{prefix}%"},
+    )
+    rows = getattr(result, "result_rows", None) or []
+    return [str(row[0]) for row in rows if row and str(row[0]).startswith(prefix)]
+
+
+def _assert_exchange_supported(client) -> None:
+    result = client.query(
+        "SELECT engine FROM system.databases WHERE name = currentDatabase()"
+    )
+    rows = getattr(result, "result_rows", None) or []
+    engine = str(rows[0][0]) if rows and rows[0] else ""
+    if engine not in _EXCHANGE_DATABASE_ENGINES:
+        raise RuntimeError(
+            "feature_flag migration 074 requires an Atomic or Shared database "
+            f"for EXCHANGE TABLES; current engine={engine or '<unknown>'!r}"
+        )
+
+
+def _sorting_key(client, table: str) -> str:
+    result = client.query(
+        "SELECT sorting_key FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(result, "result_rows", None) or []
+    if not rows or not rows[0]:
+        raise RuntimeError(f"{table}: could not read sorting_key from system.tables")
+    return str(rows[0][0])
+
+
+def _normalize_sorting_key(key: str) -> str:
+    """Normalize ClickHouse sorting-key display forms for exact comparison."""
+    normalized = re.sub(
+        r"\s*,\s*", ", ", re.sub(r"\s+", " ", key.replace("`", ""))
+    ).strip()
+    if normalized.lower().startswith("tuple(") and normalized.endswith(")"):
+        normalized = normalized[6:-1]
+    return normalized.strip(" ()")
+
+
+def _key_columns(order_by: str) -> list[str]:
+    return [
+        column.strip() for column in order_by.strip("() ").split(",") if column.strip()
+    ]
+
+
+def _distinct_key_count(client, table: str, key_columns: list[str]) -> int:
+    key_tuple = ", ".join(f"`{column}`" for column in key_columns)
+    result = client.query(f"SELECT uniqExact(({key_tuple})) FROM `{table}`")
+    rows = getattr(result, "result_rows", None) or []
+    return int(rows[0][0]) if rows and rows[0] else 0
+
+
+def _catch_up_and_drop(client, table: str, shadow: str) -> None:
+    """Reinsert the old side of an exchange before dropping its shadow."""
+    log.info("  %s: catch-up copy from `%s`", table, shadow)
+    client.command(f"INSERT INTO `{table}` SELECT * FROM `{shadow}`")
+    client.command(f"DROP TABLE `{shadow}`")
+
+
+def _legacy_shadows(client, table: str) -> list[str]:
+    """Return migration-owned shadows that still have the legacy identity."""
+    shadows = []
+    for shadow in _shadow_tables(client, table):
+        shadow_key = _normalize_sorting_key(_sorting_key(client, shadow))
+        if shadow_key == LEGACY_KEY:
+            shadows.append(shadow)
+        elif shadow_key != _normalize_sorting_key(TABLES[table]):
+            raise RuntimeError(
+                f"{table}: migration shadow `{shadow}` has unexpected sorting key "
+                f"{shadow_key!r}"
+            )
+    return shadows
+
+
+def _drain_legacy_shadows(client, table: str) -> None:
+    """Drain every recoverable old-key shadow before reporting success.
+
+    A runner may have exchanged successfully and then failed while catching up
+    its old side.  Another runner can observe the target key while its own
+    snapshot is still in flight, so cleaning only that runner's shadow would
+    incorrectly let the migration ledger advance with the failed runner's
+    legacy shadow (and its writes) still stranded.  Re-discover after draining
+    to make the success boundary explicit.
+    """
+    for shadow in _legacy_shadows(client, table):
+        _catch_up_and_drop(client, table, shadow)
+    remaining = _legacy_shadows(client, table)
+    if remaining:
+        raise RuntimeError(
+            f"{table}: recoverable legacy migration shadows remain after drain: "
+            f"{remaining!r}"
+        )
+
+
+def _rebuild_table(
+    client, table: str, new_order_by: str, *, shadow: str | None = None
+) -> None:
+    """Rebuild one feature-flag table with environment-aware identity."""
+    shadow = shadow or _shadow_name(table)
+    target_key = _normalize_sorting_key(new_order_by)
+
+    if not _table_exists(client, table):
+        log.warning("  %s: table does not exist, skipping", table)
+        return
+
+    current_key = _normalize_sorting_key(_sorting_key(client, table))
+    if current_key == target_key:
+        # A prior run may have exchanged successfully and crashed before
+        # catch-up/drop.  Finish that operation before declaring success.
+        leftovers = _shadow_tables(client, table)
+        if leftovers:
+            for leftover in leftovers:
+                shadow_key = _normalize_sorting_key(_sorting_key(client, leftover))
+                if shadow_key not in {LEGACY_KEY, target_key}:
+                    raise RuntimeError(
+                        f"{table}: migration shadow `{leftover}` has unexpected "
+                        f"sorting key {shadow_key!r}"
+                    )
+                log.info(
+                    "  %s: target key already present with leftover `%s`; converging",
+                    table,
+                    leftover,
+                )
+                _catch_up_and_drop(client, table, leftover)
+        else:
+            log.info("  %s: target key already present, skipping", table)
+        _drain_legacy_shadows(client, table)
+        return
+
+    if current_key != LEGACY_KEY:
+        raise RuntimeError(
+            f"{table}: unexpected source sorting key {current_key!r}; "
+            f"expected legacy {LEGACY_KEY!r} or target {target_key!r}"
+        )
+
+    result = client.query(f"SHOW CREATE TABLE `{table}`")
+    rows = getattr(result, "result_rows", None) or []
+    if not rows or not rows[0]:
+        raise RuntimeError(f"{table}: SHOW CREATE TABLE returned no DDL")
+    ddl = str(rows[0][0])
+    if not _ORG_ID_COL_RE.search(ddl):
+        raise ValueError(
+            f"{table}: org_id column not found in DDL; cannot preserve tenant identity"
+        )
+
+    new_ddl = _replace_table_name(ddl, table, shadow)
+    new_ddl = _replace_order_by(new_ddl, new_order_by)
+
+    log.info("  %s: creating shadow table", table)
+    client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+    client.command(new_ddl)
+
+    # Before EXCHANGE the shadow is disposable.  After EXCHANGE it contains
+    # the old live table and must remain available for catch-up/rerun.
+    target_already_visible = False
+    try:
+        shadow_key = _normalize_sorting_key(_sorting_key(client, shadow))
+        if shadow_key != target_key:
+            raise RuntimeError(
+                f"{table}: shadow sorting key mismatch after DDL rewrite "
+                f"(expected {target_key!r}, got {shadow_key!r}); aborting"
+            )
+
+        client.command(f"INSERT INTO `{shadow}` SELECT * FROM `{table}`")
+        key_columns = _key_columns(new_order_by)
+        source_keys = _distinct_key_count(client, table, key_columns)
+        shadow_keys = _distinct_key_count(client, shadow, key_columns)
+        if shadow_keys != source_keys:
+            raise RuntimeError(
+                f"{table}: shadow copy distinct-key mismatch "
+                f"(source={source_keys}, shadow={shadow_keys}); aborting before swap"
+            )
+
+        # A second process may have completed the exchange while this runner
+        # was copying. Never exchange a legacy main table after the target key
+        # is visible; converge our independently named target shadow.
+        current_after_copy = _normalize_sorting_key(_sorting_key(client, table))
+        if current_after_copy == target_key:
+            target_already_visible = True
+        elif current_after_copy != LEGACY_KEY:
+            raise RuntimeError(
+                f"{table}: source sorting key changed during migration "
+                f"(got {current_after_copy!r}); refusing EXCHANGE"
+            )
+    except Exception:
+        try:
+            client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+        except Exception as cleanup_error:  # pragma: no cover - best effort
+            log.warning("  %s: shadow cleanup failed: %s", table, cleanup_error)
+        raise
+
+    if target_already_visible:
+        # This shadow was copied from the legacy side, but another runner won
+        # the exchange while we were copying.  Keep catch-up outside the
+        # disposable-shadow cleanup block: if it fails, the legacy shadow must
+        # remain recoverable for the next runner.
+        _catch_up_and_drop(client, table, shadow)
+        _drain_legacy_shadows(client, table)
+        return
+
+    log.info("  %s: atomic swap via EXCHANGE TABLES", table)
+    client.command(f"EXCHANGE TABLES `{table}` AND `{shadow}`")
+
+    # If this fails, the leftover shadow is intentional: rerunning the
+    # migration enters the target-key convergence branch above.
+    _catch_up_and_drop(client, table, shadow)
+    _drain_legacy_shadows(client, table)
+    log.info("  %s: done", table)
+
+
+def upgrade(client):
+    """Rebuild feature_flag so environment scopes survive RMT merges."""
+    log.info("=== Migration 074: feature_flag environment identity (CHAOS-3737) ===")
+    _assert_exchange_supported(client)
+    for table, new_order_by in TABLES.items():
+        _rebuild_table(client, table, new_order_by)
+    log.info("=== Migration 074: Complete ===")

--- a/src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py
+++ b/src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py
@@ -1,4 +1,4 @@
-"""Migration 074: keep feature-flag environments in the RMT identity.
+"""Migration 075: keep feature-flag environments in the RMT identity.
 
 The feature-flag producer emits one row for every environment scope.  Before
 this migration, ``feature_flag`` was a ``ReplacingMergeTree`` keyed by
@@ -30,7 +30,7 @@ key does not rewrite values or collapse rows that differ by environment.
 
 The migration is forward-only for application compatibility: once this schema
 is deployed, application binaries must use the registry's logical
-environment aggregation. A pre-074 registry reader would expose one row per
+environment aggregation. A pre-075 registry reader would expose one row per
 environment and is not a safe rollback target, although old writers remain
 able to insert rows because the original columns are unchanged.
 
@@ -106,11 +106,11 @@ def _table_exists(client, table: str) -> bool:
 
 def _shadow_name(table: str) -> str:
     """Return a per-run shadow name so concurrent runners never share DDL."""
-    return f"{table}_074_new_{uuid.uuid4().hex}"
+    return f"{table}_075_new_{uuid.uuid4().hex}"
 
 
 def _shadow_tables(client, table: str) -> list[str]:
-    prefix = f"{table}_074_new_"
+    prefix = f"{table}_075_new_"
     result = client.query(
         "SELECT name FROM system.tables "
         "WHERE database = currentDatabase() AND name LIKE {prefix:String}",
@@ -128,7 +128,7 @@ def _assert_exchange_supported(client) -> None:
     engine = str(rows[0][0]) if rows and rows[0] else ""
     if engine not in _EXCHANGE_DATABASE_ENGINES:
         raise RuntimeError(
-            "feature_flag migration 074 requires an Atomic or Shared database "
+            "feature_flag migration 075 requires an Atomic or Shared database "
             f"for EXCHANGE TABLES; current engine={engine or '<unknown>'!r}"
         )
 
@@ -328,11 +328,11 @@ def _rebuild_table(
 
 def upgrade(client):
     """Rebuild feature_flag so environment scopes survive RMT merges."""
-    log.info("=== Migration 074: feature_flag environment identity (CHAOS-3737) ===")
+    log.info("=== Migration 075: feature_flag environment identity (CHAOS-3737) ===")
     for table, new_order_by in TABLES.items():
         if not _table_exists(client, table):
             log.warning("  %s: table does not exist, skipping", table)
             continue
         _assert_exchange_supported(client)
         _rebuild_table(client, table, new_order_by)
-    log.info("=== Migration 074: Complete ===")
+    log.info("=== Migration 075: Complete ===")

--- a/src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py
+++ b/src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py
@@ -329,7 +329,10 @@ def _rebuild_table(
 def upgrade(client):
     """Rebuild feature_flag so environment scopes survive RMT merges."""
     log.info("=== Migration 074: feature_flag environment identity (CHAOS-3737) ===")
-    _assert_exchange_supported(client)
     for table, new_order_by in TABLES.items():
+        if not _table_exists(client, table):
+            log.warning("  %s: table does not exist, skipping", table)
+            continue
+        _assert_exchange_supported(client)
         _rebuild_table(client, table, new_order_by)
     log.info("=== Migration 074: Complete ===")

--- a/tests/graphql/test_feature_flags.py
+++ b/tests/graphql/test_feature_flags.py
@@ -86,8 +86,9 @@ async def test_feature_flags_query_scopes_org_filters_and_orders(
     assert "ORDER BY provider, project_key, flag_key" in sql
     assert "LIMIT %(limit)s" in sql
     # Registry is one-row-per-(provider, project, flag); environment is NOT
-    # surfaced (CHAOS-2632 — FINAL over an env-agnostic key collapsed envs).
-    assert "environment" not in sql
+    # surfaced (CHAOS-2632).  After 074, physical environments are aggregated
+    # back to this logical registry identity.
+    assert "GROUP BY provider, project_key, flag_key" in sql
     assert params == {
         "org_id": "test-org",
         "provider": "launchdarkly",
@@ -116,6 +117,48 @@ async def test_feature_flags_query_scopes_org_filters_and_orders(
     assert result.flags[0].created_at == created_at.isoformat()
     assert result.flags[0].archived_at is None
     assert not hasattr(result.flags[0], "environment")
+
+
+@pytest.mark.asyncio
+async def test_feature_flags_aggregate_environments_to_one_logical_registry_item(
+    mock_context: GraphQLContext,
+) -> None:
+    created_at = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        # The real aggregate returns one latest-field row after two physical
+        # environment rows are grouped.  The source contract is asserted
+        # below as well, so this test cannot pass by merely truncating rows.
+        mock_query.side_effect = [
+            [
+                {
+                    "provider": "launchdarkly",
+                    "flag_key": "checkout-v2",
+                    "project_key": "web",
+                    "flag_type": "boolean",
+                    "created_at": created_at,
+                    "archived_at": None,
+                }
+            ],
+            [{"total": 1}],
+        ]
+
+        result = await resolve_feature_flags(mock_context, provider="launchdarkly")
+
+    list_sql = mock_query.call_args_list[0][0][1]
+    count_sql = mock_query.call_args_list[1][0][1]
+    assert "argMax" in list_sql
+    assert "tuple(last_synced, environment)" in list_sql
+    assert "GROUP BY provider, project_key, flag_key" in list_sql
+    assert "argMax" not in count_sql
+    assert "GROUP BY provider, project_key, flag_key" in count_sql
+    assert len(result.flags) == 1
+    assert result.total_count == 1
+    assert result.flags[0].flag_id == generate_feature_flag_id(
+        "test-org", "launchdarkly", "web", "checkout-v2"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/graphql/test_feature_flags_live.py
+++ b/tests/graphql/test_feature_flags_live.py
@@ -1,0 +1,132 @@
+"""Real ClickHouse proof for the environment-aware feature-flag registry."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.feature_flags import resolve_feature_flags
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.work_graph.ids import generate_feature_flag_id
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI pointed at an isolated scratch database",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_registry_aggregates_two_physical_environments_to_one_logical_flag() -> (
+    None
+):
+    assert CLICKHOUSE_URI is not None
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_schema(force=True)
+
+    org_id = f"chaos-3703-registry-{uuid.uuid4()}"
+    project_key = f"project-{uuid.uuid4()}"
+    flag_key = "checkout-v2"
+    second_flag_key = "dark-mode"
+    older = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+    # Equal last_synced values intentionally exercise the deterministic
+    # environment tie-break: staging sorts after production and must win.
+    rows = [
+        [
+            org_id,
+            "launchdarkly",
+            flag_key,
+            project_key,
+            "repo-1",
+            "production",
+            "json",
+            older,
+            older + timedelta(hours=1),
+            older,
+        ],
+        [
+            org_id,
+            "launchdarkly",
+            flag_key,
+            project_key,
+            "repo-1",
+            "staging",
+            "boolean",
+            older + timedelta(minutes=1),
+            None,
+            older,
+        ],
+        [
+            org_id,
+            "launchdarkly",
+            second_flag_key,
+            project_key,
+            "repo-1",
+            "production",
+            "boolean",
+            older,
+            None,
+            older,
+        ],
+    ]
+    columns = [
+        "org_id",
+        "provider",
+        "flag_key",
+        "project_key",
+        "repo_id",
+        "environment",
+        "flag_type",
+        "created_at",
+        "archived_at",
+        "last_synced",
+    ]
+    try:
+        sink.client.insert("feature_flag", rows, column_names=columns)
+        sink.client.command("OPTIMIZE TABLE feature_flag FINAL")
+
+        result = await resolve_feature_flags(
+            GraphQLContext(
+                org_id=org_id,
+                db_url=CLICKHOUSE_URI,
+                client=sink.client,
+            ),
+            provider="launchdarkly",
+            project=project_key,
+            include_archived=True,
+        )
+
+        assert result.total_count == 2
+        assert len(result.flags) == 2
+        assert {flag.flag_id for flag in result.flags} == {
+            generate_feature_flag_id(org_id, "launchdarkly", project_key, flag_key),
+            generate_feature_flag_id(
+                org_id, "launchdarkly", project_key, second_flag_key
+            ),
+        }
+        flag = next(item for item in result.flags if item.flag_key == flag_key)
+        assert flag.flag_id == generate_feature_flag_id(
+            org_id, "launchdarkly", project_key, flag_key
+        )
+        assert flag.flag_type == "boolean"
+        assert (
+            flag.created_at
+            == (older + timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+        )
+        assert flag.archived_at is None
+        assert not hasattr(flag, "environment")
+    finally:
+        sink.client.command(
+            "ALTER TABLE feature_flag DELETE WHERE org_id = {org_id:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"org_id": org_id},
+        )
+        sink.close()

--- a/tests/test_migration_075_feature_flag_identity.py
+++ b/tests/test_migration_075_feature_flag_identity.py
@@ -1,0 +1,483 @@
+"""Contract and failure-recovery tests for ClickHouse migration 074."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import TypedDict
+
+import pytest
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "dev_health_ops"
+    / "migrations"
+    / "clickhouse"
+)
+MIGRATION = "074_feature_flag_environment_identity.py"
+LEGACY_KEY = "org_id, provider, project_key, flag_key"
+TARGET_KEY = "org_id, provider, project_key, flag_key, environment"
+
+
+def _load_migration(filename: str = MIGRATION) -> ModuleType:
+    path = MIGRATIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {filename}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_074_declares_the_deployed_feature_flag_identity() -> None:
+    migration = _load_migration()
+
+    assert callable(getattr(migration, "upgrade", None))
+    assert migration.TABLES == {
+        "feature_flag": "(org_id, provider, project_key, flag_key, environment)"
+    }
+
+
+def test_default_shadow_names_are_unique_per_invocation() -> None:
+    migration = _load_migration()
+
+    names = {migration._shadow_name("feature_flag") for _ in range(8)}
+
+    assert len(names) == 8
+    assert all(name.startswith("feature_flag_074_new_") for name in names)
+
+
+def test_migration_074_runs_after_the_feature_flag_table_exists() -> None:
+    assert (MIGRATIONS_DIR / "034_feature_flag_user_impact_tables.sql").exists()
+    assert "034_feature_flag_user_impact_tables.sql" < MIGRATION
+    assert (MIGRATIONS_DIR / "073_linear_project_lifecycle.sql").exists()
+    assert "073_linear_project_lifecycle.sql" < MIGRATION
+
+
+def test_migration_034_declares_the_legacy_key_that_074_rebuilds() -> None:
+    ddl = (MIGRATIONS_DIR / "034_feature_flag_user_impact_tables.sql").read_text(
+        encoding="utf-8"
+    )
+    feature_flag = ddl.split("CREATE TABLE IF NOT EXISTS feature_flag", 1)[1].split(
+        "CREATE TABLE IF NOT EXISTS feature_flag_event", 1
+    )[0]
+    assert re.search(
+        r"ORDER BY\s*\(org_id,\s*provider,\s*project_key,\s*flag_key\)",
+        feature_flag,
+        re.IGNORECASE,
+    )
+
+
+class _Result:
+    def __init__(self, rows: list[list[object]]) -> None:
+        self.result_rows = rows
+
+
+class _TableState(TypedDict):
+    ddl: str
+    sorting_key: str
+    rows: list[dict[str, str]]
+
+
+class _FeatureFlagClient:
+    """Small ClickHouse client model for the migration state machine.
+
+    Data is retained per table so the tests can assert that rows for both
+    environments survive the snapshot/exchange/catch-up sequence.  It is not
+    a substitute for ClickHouse FINAL; the opt-in live test and provider
+    integration suite exercise that physical behavior.
+    """
+
+    def __init__(
+        self,
+        *,
+        rows: list[dict[str, str]],
+        created_sorting_key: str = TARGET_KEY,
+        fail_on: str | None = None,
+        before_exchange: Callable[[_FeatureFlagClient], None] | None = None,
+        after_shadow_copy: Callable[[_FeatureFlagClient], None] | None = None,
+        distinct_counts: dict[str, int] | None = None,
+        database_engine: str = "Atomic",
+    ) -> None:
+        old_ddl = (
+            "CREATE TABLE feature_flag ("
+            "org_id String, provider String, project_key String, flag_key String, "
+            "repo_id String, environment String, flag_type String, "
+            "created_at DateTime64(3), archived_at Nullable(DateTime64(3)), "
+            "last_synced DateTime64(3)) ENGINE = ReplacingMergeTree(last_synced) "
+            "ORDER BY (org_id, provider, project_key, flag_key)"
+        )
+        self.tables: dict[str, _TableState] = {
+            "feature_flag": {
+                "ddl": old_ddl,
+                "sorting_key": LEGACY_KEY,
+                "rows": [dict(row) for row in rows],
+            }
+        }
+        self.created_sorting_key = created_sorting_key
+        self.fail_on = fail_on
+        self.before_exchange = before_exchange
+        self.after_shadow_copy = after_shadow_copy
+        self.distinct_counts = distinct_counts or {}
+        self.database_engine = database_engine
+        self.commands: list[str] = []
+
+    def query(self, query: str, parameters: dict[str, str] | None = None) -> _Result:
+        if "FROM system.databases" in query:
+            return _Result([[self.database_engine]])
+        if "name LIKE" in query:
+            assert parameters is not None
+            prefix = parameters["prefix"].rstrip("%")
+            return _Result([[name] for name in self.tables if name.startswith(prefix)])
+        if "count() FROM system.tables" in query:
+            assert parameters is not None
+            return _Result([[1 if parameters["name"] in self.tables else 0]])
+        if "sorting_key FROM system.tables" in query:
+            assert parameters is not None
+            table_state = self.tables.get(parameters["name"])
+            return _Result([[table_state["sorting_key"]]] if table_state else [])
+        if query.startswith("SHOW CREATE TABLE"):
+            name = query.split("`")[1]
+            return _Result([[self.tables[name]["ddl"]]])
+        if "uniqExact" in query:
+            table_name = query.split("FROM `", 1)[1].split("`", 1)[0]
+            if table_name in self.distinct_counts:
+                return _Result([[self.distinct_counts[table_name]]])
+            columns = [
+                "org_id",
+                "provider",
+                "project_key",
+                "flag_key",
+                "environment",
+            ]
+            keys = {
+                tuple(row[column] for column in columns)
+                for row in self.tables[table_name]["rows"]
+            }
+            return _Result([[len(keys)]])
+        raise AssertionError(f"unexpected query: {query}")
+
+    def command(self, command: str) -> None:
+        self.commands.append(command)
+        if self.fail_on and self.fail_on in command:
+            self.fail_on = None
+            raise RuntimeError(f"injected failure on: {command}")
+
+        if command.startswith("DROP TABLE"):
+            table = command.split("`")[1]
+            self.tables.pop(table, None)
+            return
+
+        if command.startswith("CREATE TABLE"):
+            match = re.search(r"CREATE TABLE\s+`?(\w+)`?", command)
+            assert match is not None
+            name = match.group(1)
+            self.tables[name] = {
+                "ddl": command,
+                "sorting_key": self.created_sorting_key,
+                "rows": [],
+            }
+            return
+
+        if command.startswith("INSERT INTO"):
+            destination = command.split("`")[1]
+            source = command.split("FROM `", 1)[1].split("`", 1)[0]
+            copied: list[dict[str, str]] = [
+                dict(row) for row in self.tables[source]["rows"]
+            ]
+            self.tables[destination]["rows"].extend(copied)
+            if self.after_shadow_copy is not None and destination != "feature_flag":
+                callback = self.after_shadow_copy
+                self.after_shadow_copy = None
+                callback(self)
+            return
+
+        if command.startswith("EXCHANGE TABLES"):
+            if self.before_exchange is not None:
+                self.before_exchange(self)
+            names = re.findall(r"`(\w+)`", command)
+            assert len(names) == 2
+            first, second = names
+            self.tables[first], self.tables[second] = (
+                self.tables[second],
+                self.tables[first],
+            )
+            return
+
+        raise AssertionError(f"unexpected command: {command}")
+
+
+def _row(environment: str, *, org_id: str = "org-a") -> dict[str, str]:
+    return {
+        "org_id": org_id,
+        "provider": "gitlab",
+        "project_key": "group/project",
+        "flag_key": "checkout-v2",
+        "environment": environment,
+    }
+
+
+def test_rebuild_preserves_same_flag_in_multiple_environments() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production"), _row("staging")])
+
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+    assert "feature_flag_new" not in client.tables
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "staging",
+    }
+
+
+def test_rebuild_catches_up_a_row_written_between_snapshot_and_exchange() -> None:
+    migration = _load_migration()
+
+    def write_late_environment(client: _FeatureFlagClient) -> None:
+        client.tables["feature_flag"]["rows"].append(_row("canary"))
+
+    client = _FeatureFlagClient(
+        rows=[_row("production"), _row("staging")],
+        before_exchange=write_late_environment,
+    )
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "staging",
+        "canary",
+    }
+    snapshot = client.commands.index(
+        "INSERT INTO `feature_flag_new` SELECT * FROM `feature_flag`"
+    )
+    exchange = client.commands.index(
+        "EXCHANGE TABLES `feature_flag` AND `feature_flag_new`"
+    )
+    catch_up = client.commands.index(
+        "INSERT INTO `feature_flag` SELECT * FROM `feature_flag_new`"
+    )
+    assert snapshot < exchange < catch_up
+
+
+def test_rerun_converges_leftover_old_table_after_exchange() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production")])
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    # Model a crash after EXCHANGE: main has the target key and the old table
+    # remains as feature_flag_new.  The second run must catch it up and drop it.
+    old_rows = [_row("staging")]
+    leftover = "feature_flag_074_new_crashed"
+    client.tables[leftover] = {
+        "ddl": f"CREATE TABLE {leftover} ...",
+        "sorting_key": LEGACY_KEY,
+        "rows": old_rows,
+    }
+    client.tables["feature_flag"]["rows"].append(_row("canary"))
+    before = len(client.commands)
+
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    assert leftover not in client.tables
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "canary",
+        "staging",
+    }
+    assert client.commands[before:] == [
+        f"INSERT INTO `feature_flag` SELECT * FROM `{leftover}`",
+        f"DROP TABLE `{leftover}`",
+    ]
+
+
+def test_post_exchange_failure_leaves_shadow_for_rerun() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(
+        rows=[_row("production")],
+        fail_on="INSERT INTO `feature_flag` SELECT",
+    )
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert "feature_flag_new" in client.tables
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+
+
+def test_concurrent_interleaving_of_two_unique_shadows_never_restores_legacy_key() -> (
+    None
+):
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production"), _row("staging")])
+
+    def run_second_runner(client: _FeatureFlagClient) -> None:
+        # The fake invokes this immediately before runner A's exchange. Disable
+        # the callback for runner B so this is one deterministic A/B interleave,
+        # not recursive simulation.
+        client.before_exchange = None
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_074_new_runner_b",
+        )
+
+    client.before_exchange = run_second_runner
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_074_new_runner_a",
+    )
+
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+    assert "feature_flag_074_new_runner_a" not in client.tables
+    assert "feature_flag_074_new_runner_b" not in client.tables
+    assert sum("EXCHANGE TABLES" in command for command in client.commands) == 2
+
+
+def test_target_runner_drains_failed_peer_legacy_shadow_before_success() -> None:
+    """A target-key runner cannot strand a peer's failed catch-up shadow.
+
+    B snapshots the legacy table first.  A exchanges and then fails before it
+    can catch up a canary in A's old-side shadow.  B observes A's target key
+    after its snapshot and must drain both its own snapshot and A's recoverable
+    legacy shadow before it can return successfully (and let the ledger record
+    074).
+    """
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production"), _row("staging")])
+    peer_shadow = "feature_flag_074_new_runner_a"
+    runner_shadow = "feature_flag_074_new_runner_b"
+    client.tables[peer_shadow] = {
+        "ddl": f"CREATE TABLE {peer_shadow} ...",
+        "sorting_key": TARGET_KEY,
+        "rows": [dict(row) for row in client.tables["feature_flag"]["rows"]],
+    }
+
+    def exchange_failed_peer(client: _FeatureFlagClient) -> None:
+        # A has already snapshotted and exchanges while B is between its copy
+        # and source-key preflight.  A's failed catch-up leaves a new canary in
+        # the legacy-key old side.
+        client.command(f"EXCHANGE TABLES `feature_flag` AND `{peer_shadow}`")
+        client.tables[peer_shadow]["rows"].append(_row("canary"))
+
+    client.after_shadow_copy = exchange_failed_peer
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow=runner_shadow,
+    )
+
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+    assert peer_shadow not in client.tables
+    assert runner_shadow not in client.tables
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "staging",
+        "canary",
+    }
+    assert not migration._legacy_shadows(client, "feature_flag")
+
+
+def test_distinct_key_mismatch_aborts_before_exchange() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(
+        rows=[_row("production"), _row("staging")],
+        distinct_counts={"feature_flag": 2, "feature_flag_new": 1},
+    )
+
+    with pytest.raises(RuntimeError, match="distinct-key mismatch"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert "feature_flag_new" not in client.tables
+    assert not any("EXCHANGE" in command for command in client.commands)
+
+
+def test_upgrade_fails_closed_when_database_engine_cannot_exchange_tables() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production")], database_engine="Ordinary")
+
+    with pytest.raises(RuntimeError, match="Atomic or Shared"):
+        migration.upgrade(client)
+
+    assert client.commands == []
+
+
+def test_migration_documents_forward_only_application_rollback_boundary() -> None:
+    text = (MIGRATIONS_DIR / MIGRATION).read_text(encoding="utf-8")
+
+    assert "forward-only for application compatibility" in text
+    assert "not a safe rollback target" in text
+
+
+def test_sorting_key_rewrite_fails_closed_before_copy() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(
+        rows=[_row("production")],
+        created_sorting_key="org_id, provider, project_key, flag_key",
+    )
+
+    with pytest.raises(RuntimeError, match="sorting key mismatch"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert "feature_flag_new" not in client.tables
+    assert client.tables["feature_flag"]["sorting_key"] == LEGACY_KEY
+    assert not any("INSERT INTO" in command for command in client.commands)
+    assert not any("EXCHANGE" in command for command in client.commands)
+
+
+def test_unexpected_source_key_does_not_get_silently_rewritten() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production")])
+    client.tables["feature_flag"]["sorting_key"] = "org_id, provider, flag_key"
+
+    with pytest.raises(RuntimeError, match="unexpected source sorting key"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert not any("CREATE TABLE" in command for command in client.commands)

--- a/tests/test_migration_075_feature_flag_identity.py
+++ b/tests/test_migration_075_feature_flag_identity.py
@@ -1,4 +1,4 @@
-"""Contract and failure-recovery tests for ClickHouse migration 074."""
+"""Contract and failure-recovery tests for ClickHouse migration 075."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ MIGRATIONS_DIR = (
     / "migrations"
     / "clickhouse"
 )
-MIGRATION = "074_feature_flag_environment_identity.py"
+MIGRATION = "075_feature_flag_environment_identity.py"
 LEGACY_KEY = "org_id, provider, project_key, flag_key"
 TARGET_KEY = "org_id, provider, project_key, flag_key, environment"
 
@@ -32,7 +32,7 @@ def _load_migration(filename: str = MIGRATION) -> ModuleType:
     return module
 
 
-def test_migration_074_declares_the_deployed_feature_flag_identity() -> None:
+def test_migration_075_declares_the_deployed_feature_flag_identity() -> None:
     migration = _load_migration()
 
     assert callable(getattr(migration, "upgrade", None))
@@ -47,17 +47,17 @@ def test_default_shadow_names_are_unique_per_invocation() -> None:
     names = {migration._shadow_name("feature_flag") for _ in range(8)}
 
     assert len(names) == 8
-    assert all(name.startswith("feature_flag_074_new_") for name in names)
+    assert all(name.startswith("feature_flag_075_new_") for name in names)
 
 
-def test_migration_074_runs_after_the_feature_flag_table_exists() -> None:
+def test_migration_075_runs_after_the_feature_flag_table_exists() -> None:
     assert (MIGRATIONS_DIR / "034_feature_flag_user_impact_tables.sql").exists()
     assert "034_feature_flag_user_impact_tables.sql" < MIGRATION
     assert (MIGRATIONS_DIR / "073_linear_project_lifecycle.sql").exists()
     assert "073_linear_project_lifecycle.sql" < MIGRATION
 
 
-def test_migration_034_declares_the_legacy_key_that_074_rebuilds() -> None:
+def test_migration_034_declares_the_legacy_key_that_075_rebuilds() -> None:
     ddl = (MIGRATIONS_DIR / "034_feature_flag_user_impact_tables.sql").read_text(
         encoding="utf-8"
     )
@@ -286,7 +286,7 @@ def test_rerun_converges_leftover_old_table_after_exchange() -> None:
     # Model a crash after EXCHANGE: main has the target key and the old table
     # remains as feature_flag_new.  The second run must catch it up and drop it.
     old_rows = [_row("staging")]
-    leftover = "feature_flag_074_new_crashed"
+    leftover = "feature_flag_075_new_crashed"
     client.tables[leftover] = {
         "ddl": f"CREATE TABLE {leftover} ...",
         "sorting_key": LEGACY_KEY,
@@ -348,7 +348,7 @@ def test_concurrent_interleaving_of_two_unique_shadows_never_restores_legacy_key
             client,
             "feature_flag",
             migration.TABLES["feature_flag"],
-            shadow="feature_flag_074_new_runner_b",
+            shadow="feature_flag_075_new_runner_b",
         )
 
     client.before_exchange = run_second_runner
@@ -356,12 +356,12 @@ def test_concurrent_interleaving_of_two_unique_shadows_never_restores_legacy_key
         client,
         "feature_flag",
         migration.TABLES["feature_flag"],
-        shadow="feature_flag_074_new_runner_a",
+        shadow="feature_flag_075_new_runner_a",
     )
 
     assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
-    assert "feature_flag_074_new_runner_a" not in client.tables
-    assert "feature_flag_074_new_runner_b" not in client.tables
+    assert "feature_flag_075_new_runner_a" not in client.tables
+    assert "feature_flag_075_new_runner_b" not in client.tables
     assert sum("EXCHANGE TABLES" in command for command in client.commands) == 2
 
 
@@ -372,12 +372,12 @@ def test_target_runner_drains_failed_peer_legacy_shadow_before_success() -> None
     can catch up a canary in A's old-side shadow.  B observes A's target key
     after its snapshot and must drain both its own snapshot and A's recoverable
     legacy shadow before it can return successfully (and let the ledger record
-    074).
+    075).
     """
     migration = _load_migration()
     client = _FeatureFlagClient(rows=[_row("production"), _row("staging")])
-    peer_shadow = "feature_flag_074_new_runner_a"
-    runner_shadow = "feature_flag_074_new_runner_b"
+    peer_shadow = "feature_flag_075_new_runner_a"
+    runner_shadow = "feature_flag_075_new_runner_b"
     client.tables[peer_shadow] = {
         "ddl": f"CREATE TABLE {peer_shadow} ...",
         "sorting_key": TARGET_KEY,

--- a/tests/test_migrations_clickhouse.py
+++ b/tests/test_migrations_clickhouse.py
@@ -17,8 +17,17 @@ async def test_clickhouse_migrations_dry_run_non_default_db():
 
     # Mock ClickHouse client
     mock_client = MagicMock()
-    # Mock query result for schema_migrations (empty, so all migrations run)
+    # Mock query result for schema_migrations (empty, so all migrations run).
+    # Migration 074 also fail-closes unless the database engine supports
+    # EXCHANGE TABLES; model the production Atomic database explicitly.
     mock_client.query.return_value.result_rows = []
+
+    def mock_query(query, parameters=None):
+        result = MagicMock()
+        result.result_rows = [["Atomic"]] if "FROM system.databases" in query else []
+        return result
+
+    mock_client.query.side_effect = mock_query
 
     # Capture commands executed
     executed_commands = []

--- a/tests/test_migrations_clickhouse.py
+++ b/tests/test_migrations_clickhouse.py
@@ -18,7 +18,7 @@ async def test_clickhouse_migrations_dry_run_non_default_db():
     # Mock ClickHouse client
     mock_client = MagicMock()
     # Mock query result for schema_migrations (empty, so all migrations run).
-    # Migration 074 also fail-closes unless the database engine supports
+    # Migration 075 also fail-closes unless the database engine supports
     # EXCHANGE TABLES; model the production Atomic database explicitly.
     mock_client.query.return_value.result_rows = []
 

--- a/tests/tooling/mutation-plans/feature_flag_identity.json
+++ b/tests/tooling/mutation-plans/feature_flag_identity.json
@@ -5,64 +5,64 @@
   "build": [
     ".venv/bin/python",
     "-c",
-    "import importlib.util; p='src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py'; s=importlib.util.spec_from_file_location('feature_flag_identity', p); m=importlib.util.module_from_spec(s); s.loader.exec_module(m)"
+    "import importlib.util; p='src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py'; s=importlib.util.spec_from_file_location('feature_flag_identity', p); m=importlib.util.module_from_spec(s); s.loader.exec_module(m)"
   ],
   "mutations": [
     {
       "id": "M2-rerun-convergence-branch",
-      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "file": "src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py",
       "find": "if current_key == target_key:",
       "replace": "if False:",
       "rationale": "an already-exchanged table with a leftover old shadow must converge by catch-up and drop on rerun",
-      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "rerun_converges_leftover_old_table_after_exchange"]]
+      "proof": [["pytest", "-q", "tests/test_migration_075_feature_flag_identity.py", "-k", "rerun_converges_leftover_old_table_after_exchange"]]
     },
     {
       "id": "M3-shadow-sorting-key-proof",
-      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "file": "src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py",
       "find": "if shadow_key != target_key:",
       "replace": "if False:",
       "rationale": "a DDL rewrite that creates the wrong ClickHouse sorting key must fail before copying or exchanging data",
-      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "sorting_key_rewrite_fails_closed_before_copy"]]
+      "proof": [["pytest", "-q", "tests/test_migration_075_feature_flag_identity.py", "-k", "sorting_key_rewrite_fails_closed_before_copy"]]
     },
     {
       "id": "M4-distinct-key-preservation",
-      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "file": "src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py",
       "find": "if shadow_keys != source_keys:",
       "replace": "if False:",
       "rationale": "the snapshot must abort before EXCHANGE when the environment-aware logical-key count is not preserved",
-      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "distinct_key_mismatch_aborts_before_exchange"]]
+      "proof": [["pytest", "-q", "tests/test_migration_075_feature_flag_identity.py", "-k", "distinct_key_mismatch_aborts_before_exchange"]]
     },
     {
       "id": "M5-post-exchange-catch-up",
-      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "file": "src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py",
       "find": "client.command(f\"INSERT INTO `{table}` SELECT * FROM `{shadow}`\")",
       "replace": "client.command(f\"INSERT INTO `{table}` SELECT * FROM `{table}`\")",
       "rationale": "rows written to the old side between snapshot and EXCHANGE must be reinserted before the old shadow is dropped",
-      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "rebuild_catches_up_a_row_written_between_snapshot_and_exchange"]]
+      "proof": [["pytest", "-q", "tests/test_migration_075_feature_flag_identity.py", "-k", "rebuild_catches_up_a_row_written_between_snapshot_and_exchange"]]
     },
     {
       "id": "M6-legacy-source-key-guard",
-      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "file": "src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py",
       "find": "if current_key != LEGACY_KEY:",
       "replace": "if False:",
-      "rationale": "the migration must fail closed rather than reinterpret an unexpected pre-074 sorting key",
-      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "unexpected_source_key_does_not_get_silently_rewritten"]]
+      "rationale": "the migration must fail closed rather than reinterpret an unexpected pre-075 sorting key",
+      "proof": [["pytest", "-q", "tests/test_migration_075_feature_flag_identity.py", "-k", "unexpected_source_key_does_not_get_silently_rewritten"]]
     },
     {
       "id": "M7-exchange-engine-preflight",
-      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "file": "src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py",
       "find": "if engine not in _EXCHANGE_DATABASE_ENGINES:",
       "replace": "if False:",
       "rationale": "EXCHANGE TABLES must fail closed on non-Atomic/non-Shared databases rather than run with unsupported atomicity semantics",
-      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "upgrade_fails_closed_when_database_engine_cannot_exchange_tables"]]
+      "proof": [["pytest", "-q", "tests/test_migration_075_feature_flag_identity.py", "-k", "upgrade_fails_closed_when_database_engine_cannot_exchange_tables"]]
     },
     {
       "id": "M8-unique-shadow-name",
-      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
-      "find": "return f\"{table}_074_new_{uuid.uuid4().hex}\"",
+      "file": "src/dev_health_ops/migrations/clickhouse/075_feature_flag_environment_identity.py",
+      "find": "return f\"{table}_075_new_{uuid.uuid4().hex}\"",
       "replace": "return f\"{table}_new\"",
       "rationale": "concurrent migration runners must not share one shadow table name and race DROP/CREATE/EXCHANGE",
-      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "default_shadow_names_are_unique_per_invocation"]]
+      "proof": [["pytest", "-q", "tests/test_migration_075_feature_flag_identity.py", "-k", "default_shadow_names_are_unique_per_invocation"]]
     },
     {
       "id": "M9-registry-logical-grouping",

--- a/tests/tooling/mutation-plans/feature_flag_identity.json
+++ b/tests/tooling/mutation-plans/feature_flag_identity.json
@@ -72,7 +72,7 @@
       "expect_occurrences": 2,
       "rationale": "GraphQL must aggregate all physical environment rows back to one logical flag and one totalCount while preserving distinct flag_key values under the same provider/project and the environment-agnostic ID",
       "build": [".venv/bin/python", "-c", "import dev_health_ops.api.graphql.resolvers.feature_flags"],
-      "proof": [[".venv/bin/python", "tests/tooling/run_feature_flag_identity_live_proof.py"]]
+      "proof": [["uv", "run", "--with", "pytest-asyncio", "python", "tests/tooling/run_feature_flag_identity_live_proof.py"]]
     }
   ]
 }

--- a/tests/tooling/mutation-plans/feature_flag_identity.json
+++ b/tests/tooling/mutation-plans/feature_flag_identity.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "name": "feature_flag environment identity migration (CHAOS-3737)",
+  "$limitation": "This plan covers the migration's identity, fail-closed DDL verification, distinct-key preservation, source-key guard, unique-shadow concurrency, and post-exchange catch-up. M9 deliberately uses the real migrated ClickHouse proof. Do not run this plan until reviewer/orchestrator GO.",
+  "build": [
+    ".venv/bin/python",
+    "-c",
+    "import importlib.util; p='src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py'; s=importlib.util.spec_from_file_location('feature_flag_identity', p); m=importlib.util.module_from_spec(s); s.loader.exec_module(m)"
+  ],
+  "mutations": [
+    {
+      "id": "M2-rerun-convergence-branch",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if current_key == target_key:",
+      "replace": "if False:",
+      "rationale": "an already-exchanged table with a leftover old shadow must converge by catch-up and drop on rerun",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "rerun_converges_leftover_old_table_after_exchange"]]
+    },
+    {
+      "id": "M3-shadow-sorting-key-proof",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if shadow_key != target_key:",
+      "replace": "if False:",
+      "rationale": "a DDL rewrite that creates the wrong ClickHouse sorting key must fail before copying or exchanging data",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "sorting_key_rewrite_fails_closed_before_copy"]]
+    },
+    {
+      "id": "M4-distinct-key-preservation",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if shadow_keys != source_keys:",
+      "replace": "if False:",
+      "rationale": "the snapshot must abort before EXCHANGE when the environment-aware logical-key count is not preserved",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "distinct_key_mismatch_aborts_before_exchange"]]
+    },
+    {
+      "id": "M5-post-exchange-catch-up",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "client.command(f\"INSERT INTO `{table}` SELECT * FROM `{shadow}`\")",
+      "replace": "client.command(f\"INSERT INTO `{table}` SELECT * FROM `{table}`\")",
+      "rationale": "rows written to the old side between snapshot and EXCHANGE must be reinserted before the old shadow is dropped",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "rebuild_catches_up_a_row_written_between_snapshot_and_exchange"]]
+    },
+    {
+      "id": "M6-legacy-source-key-guard",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if current_key != LEGACY_KEY:",
+      "replace": "if False:",
+      "rationale": "the migration must fail closed rather than reinterpret an unexpected pre-074 sorting key",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "unexpected_source_key_does_not_get_silently_rewritten"]]
+    },
+    {
+      "id": "M7-exchange-engine-preflight",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if engine not in _EXCHANGE_DATABASE_ENGINES:",
+      "replace": "if False:",
+      "rationale": "EXCHANGE TABLES must fail closed on non-Atomic/non-Shared databases rather than run with unsupported atomicity semantics",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "upgrade_fails_closed_when_database_engine_cannot_exchange_tables"]]
+    },
+    {
+      "id": "M8-unique-shadow-name",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "return f\"{table}_074_new_{uuid.uuid4().hex}\"",
+      "replace": "return f\"{table}_new\"",
+      "rationale": "concurrent migration runners must not share one shadow table name and race DROP/CREATE/EXCHANGE",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "default_shadow_names_are_unique_per_invocation"]]
+    },
+    {
+      "id": "M9-registry-logical-grouping",
+      "file": "src/dev_health_ops/api/graphql/resolvers/feature_flags.py",
+      "find": "GROUP BY provider, project_key, flag_key",
+      "replace": "GROUP BY provider, project_key, flag_key, environment",
+      "expect_occurrences": 2,
+      "rationale": "GraphQL must aggregate all physical environment rows back to one logical flag and one totalCount while preserving distinct flag_key values under the same provider/project and the environment-agnostic ID",
+      "build": [".venv/bin/python", "-c", "import dev_health_ops.api.graphql.resolvers.feature_flags"],
+      "proof": [[".venv/bin/python", "tests/tooling/run_feature_flag_identity_live_proof.py"]]
+    }
+  ]
+}

--- a/tests/tooling/run_feature_flag_identity_live_proof.py
+++ b/tests/tooling/run_feature_flag_identity_live_proof.py
@@ -1,0 +1,56 @@
+"""Run the feature-flag registry proof against an isolated ClickHouse database."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+import clickhouse_connect
+
+
+def main() -> int:
+    admin_dsn = os.environ.get(
+        "CLICKHOUSE_ADMIN_URI",
+        "clickhouse://ch:ch@localhost:8123/default",
+    )
+    parsed = urlsplit(admin_dsn)
+    database = f"chaos_3703_feature_flag_{uuid4().hex}"
+    scratch_dsn = urlunsplit(parsed._replace(path=f"/{database}"))
+    client = clickhouse_connect.get_client(dsn=admin_dsn)
+    client.command(f"CREATE DATABASE `{database}`")
+    try:
+        environment = os.environ.copy()
+        environment["CLICKHOUSE_URI"] = scratch_dsn
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/graphql/test_feature_flags_live.py",
+                "-m",
+                "clickhouse",
+            ],
+            check=False,
+            capture_output=True,
+            env=environment,
+            text=True,
+        )
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            return result.returncode
+        if "1 passed" not in result.stdout:
+            print("feature-flag live proof did not execute exactly one passing test")
+            return 1
+        return 0
+    finally:
+        client.command(f"DROP DATABASE IF EXISTS `{database}`")
+        client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# CHAOS-3735: Integrate GitLab provider parity stack

## Scope

- Provider-code-only Go worker migration stack.
- Base: `feat/go-worker-gitlab-completion`.
- Head: `feat/go-worker-gitlab-provider-stack`.
- No activation or merge is included.

## Checkpoint evidence

- Head commit: `f9ee12f3365cfe7b43c7151323f6aec223c8850e`.
- Ancestry check: `origin/feat/go-worker-gitlab-completion` is the verified merge-base and ancestor.
- Provider-scope check: changed paths are limited to `internal/providerfoundation/**` and `internal/providersync/**`.
- `git diff --check origin/feat/go-worker-gitlab-completion...HEAD` passed.
- Lefthook pre-push checks passed: `ruff-format-check` (200 files), `ruff-check`, and `mypy` (2197 source files).

## Integration note

This PR is intentionally stacked on the completed GitLab deployment branch and is not a merge or activation step.
