### PR TITLE
CHAOS-3720: preserve Jira worklog fallback observations

### DIFF
--- a/ci/requirements-live-python-oracles.txt
+++ b/ci/requirements-live-python-oracles.txt
@@ -2,11 +2,15 @@
 # Keep direct imports and their transitives explicit: CI installs this file
 # with --no-deps so an undeclared dependency fails instead of drifting latest.
 annotated-types==0.7.0
+annotated-doc==0.0.4
 anyio==4.13.0
 atlassian-gen-client==0.1.0b3
 certifi==2026.4.22
+cffi==2.0.0
+charset-normalizer==3.4.7
 colorama==0.4.6
 defusedxml==0.7.1
+fastapi==0.136.3
 gitdb==4.0.12
 GitPython==3.1.54
 graphql-core==3.2.8
@@ -23,10 +27,16 @@ pydantic==2.13.4
 pydantic-core==2.46.4
 pygments==2.20.0
 pytest==9.0.3
+pycparser==3.0
+PyJWT==2.13.0
+PyNaCl==1.6.2
 PyYAML==6.0.3
 radon==6.0.1
+requests==2.34.0
 six==1.17.0
 smmap==5.0.3
 SQLAlchemy==2.0.49
+starlette==1.3.1
 typing-extensions==4.15.0
 typing-inspection==0.4.2
+urllib3==2.7.0

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -287,6 +287,9 @@ func (handler *Handler) Work(
 		result, err = executor.Execute(ctx, session, descriptor)
 		if err == nil {
 			payload := cloneResult(result.Result)
+			if len(result.WorklogObservations) > 0 {
+				payload["go_worklog_observations"] = result.WorklogObservations
+			}
 			payload["go_provider_route"] = map[string]any{
 				"effects_written": result.Effects.Written,
 				"effects_skipped": result.Effects.Skipped,

--- a/internal/jobs/providerunit/providerunit_test.go
+++ b/internal/jobs/providerunit/providerunit_test.go
@@ -55,6 +55,10 @@ func TestEnabledProviderUnitExecutesCompleteRouteAndTerminalizes(t *testing.T) {
 	if _, ok := repository.result["go_provider_route"]; !ok {
 		t.Fatalf("terminal result=%#v", repository.result)
 	}
+	observations, ok := repository.result["go_worklog_observations"].([]providersync.JiraWorklogFetchObservation)
+	if !ok || len(observations) != 1 || !observations[0].RESTFallbackUsed {
+		t.Fatalf("persisted worklog observations=%#v", repository.result["go_worklog_observations"])
+	}
 }
 
 func TestProviderUnitPersistsCanonicalProviderUsageObservations(t *testing.T) {
@@ -355,7 +359,7 @@ func successfulExecutor(
 			) providerfoundation.BackoffGate {
 				return testBackoffGate{}
 			},
-			Handler:           testCompleteRouteHandler{t: t, now: now},
+			Handler:           testCompleteRouteHandler{t: t, now: now, WorklogObservations: []providersync.JiraWorklogFetchObservation{{IssueKey: "FLAGS-1", RESTFallbackUsed: true}}},
 			Comparator:        providersync.ProductionContractComparator{},
 			Committer:         providersync.EffectCommitter{Ledger: &testEffectLedger{}, Sink: testEffectSink{}, Readback: testEffectReadback{}, Now: func() time.Time { return now }},
 			HeartbeatInterval: 10 * time.Second,
@@ -609,8 +613,9 @@ func (testBackoffGate) Penalize(context.Context, time.Duration) error {
 }
 
 type testCompleteRouteHandler struct {
-	t   *testing.T
-	now time.Time
+	t                   *testing.T
+	now                 time.Time
+	WorklogObservations []providersync.JiraWorklogFetchObservation
 }
 
 func (handler testCompleteRouteHandler) Collect(
@@ -650,7 +655,8 @@ func (handler testCompleteRouteHandler) Collect(
 				}},
 			},
 		},
-		Watermark: &watermark,
+		Watermark:           &watermark,
+		WorklogObservations: handler.WorklogObservations,
 		Evidence: providersync.FetchEvidence{
 			Provider: "launchdarkly", Dataset: "feature-flags", Records: 4,
 		},

--- a/internal/providersync/JIRA_PROVIDER_GAP_MATRIX.md
+++ b/internal/providersync/JIRA_PROVIDER_GAP_MATRIX.md
@@ -37,7 +37,7 @@ the same persisted destinations.
 | Reopen/priority | Reopen events derive from terminal-to-nonterminal transitions; priority maps to service class. | Same derivation and mapping. | Direct row is covered by the semantic/route tests. |
 | Sprint/reference cache | Legacy producer collects issue sprint IDs, reuses Jira reference sprints, fetches missing sprints, and writes newly fetched references. | Fetches issue-linked sprints but does not enumerate boards or persist a reusable reference cache in this route. | Cache/reference and incomplete-watermark semantics are deferred to `CHAOS-3714`. |
 | Boards/sprints | `team_autoimport_jira.py` enumerates boards and board sprints; the Atlassian provider can optionally fetch board sprints. | No board enumeration or board-sprint path. | Deferred to the Jira Atlassian enrichment follow-up; issue-linked sprint rows are the only current Go surface. |
-| Worklogs | Atlassian provider optionally fetches worklogs through GraphQL with REST fallback under `JIRA_FETCH_WORKLOGS`; legacy batch has no worklog list. | No worklog producer/effect in this route. | Worklogs are not one of the 16 work-item matrix destinations, but are still provider behavior and remain intentionally deferred. |
+| Worklogs | Atlassian provider optionally fetches worklogs through GraphQL with REST fallback under `JIRA_FETCH_WORKLOGS`; legacy batch has no worklog list. | Typed worklog effect, identity parity, and GraphQL-attempt/REST-fallback observations are covered by the Atlassian route. | Worklogs are not one of the 16 work-item matrix destinations; durable completion payload records the typed fetch observations. |
 | Atlassian alternate path | `JiraProvider`'s Atlassian path emits canonical work items/transitions/reopens and optional worklogs/sprints, but currently returns empty dependencies and interactions. | This route models the legacy REST/JQL path only. | Must not be called provider-complete until Atlassian dependency/comment parity is resolved. |
 | JSM incidents | Separate native JSM path and `operational_incidents` destination. | Already native and route-ready. | Out of scope for this work-item continuation; do not modify incident handler/effects/readback. |
 
@@ -84,10 +84,10 @@ inspection, sink projection, skipped route, or status claim closes it.
   identity comparison is made authoritative.
 - `CHAOS-3714` owns sprint/reference cache reuse, optional incomplete markers,
   and recovery semantics.
-- Jira Atlassian worklogs, board enumeration, and Atlassian-path
-  dependency/interaction parity are intentionally deferred to a separate
-  follow-up. No registry, matrix, config, route switch, or deployment wiring
-  is changed here.
+- Board enumeration and Atlassian-path dependency/interaction parity remain
+  intentionally deferred to separate follow-ups. CHAOS-3720 closes only the
+  Atlassian worklog identity/fallback parity slice; no registry, matrix, config,
+  route switch, or deployment wiring is changed here.
 
 Therefore this branch is **partial provider parity preparation**, not Jira
 provider completion and not route readiness.

--- a/internal/providersync/complete_route.go
+++ b/internal/providersync/complete_route.go
@@ -11,10 +11,11 @@ import (
 )
 
 type CompleteRouteBatch struct {
-	Effects   []EffectBatch
-	Result    map[string]any
-	Watermark *time.Time
-	Evidence  FetchEvidence
+	Effects             []EffectBatch
+	Result              map[string]any
+	Watermark           *time.Time
+	Evidence            FetchEvidence
+	WorklogObservations []JiraWorklogFetchObservation
 }
 
 func (batch CompleteRouteBatch) validate(descriptor CompleteRouteDescriptor) error {
@@ -103,12 +104,13 @@ type CompleteRouteExecutor struct {
 }
 
 type CompleteRouteExecutionResult struct {
-	Fetch      FetchEvidence
-	Result     map[string]any
-	Watermark  *time.Time
-	Comparison ShadowComparison
-	Effects    EffectCommitResult
-	ShadowOnly bool
+	Fetch               FetchEvidence
+	Result              map[string]any
+	Watermark           *time.Time
+	Comparison          ShadowComparison
+	Effects             EffectCommitResult
+	ShadowOnly          bool
+	WorklogObservations []JiraWorklogFetchObservation
 }
 
 func (executor CompleteRouteExecutor) now() time.Time {
@@ -208,6 +210,7 @@ func (executor CompleteRouteExecutor) Execute(
 			}
 			result.Fetch, result.Result, result.Watermark =
 				manifest.Batch.Evidence, manifest.Batch.Result, manifest.Batch.Watermark
+			result.WorklogObservations = manifest.Batch.WorklogObservations
 			result.Comparison = manifest.Comparison
 			result.Effects, err = executor.Committer.CommitPrepared(
 				workContext, session.Claim, manifest.Batch.Effects, *recoveredEffects,
@@ -305,6 +308,7 @@ func (executor CompleteRouteExecutor) Execute(
 		}
 		result.Fetch, result.Result, result.Watermark =
 			batch.Evidence, batch.Result, batch.Watermark
+		result.WorklogObservations = batch.WorklogObservations
 		comparison, err := executor.Comparator.CompareCompleteRoute(
 			workContext, session.Claim, batch,
 		)

--- a/internal/providersync/jira_atlassian_oracle_test.go
+++ b/internal/providersync/jira_atlassian_oracle_test.go
@@ -55,6 +55,16 @@ func jiraAtlassianOracleCases() []oracleCase {
 				"board_sprints":     []any{map[string]any{"id": "9999", "name": "must-not-fetch", "state": "active"}},
 			},
 		},
+		{
+			ID: "graphql_failure_falls_back_to_rest_worklog",
+			Input: map[string]any{
+				"org_id": "org-acme", "since": "2026-08-01T00:00:00Z", "until": "2026-08-10T00:00:00Z",
+				"project_key": "OPS", "fetch_worklogs": true, "fetch_board_sprints": false,
+				"graphql_fallback": true, "issue": jiraAtlassianOracleIssue("OPS-303"),
+				"worklogs": []any{map[string]any{"id": "wl-303", "author": map[string]any{"accountId": "account-303", "name": "GraphQL Worker"}, "started": "2026-08-03T10:00:00.123456Z", "timeSpentSeconds": 1200, "created": "2026-08-03T10:01:00.123456Z", "updated": "2026-08-03T10:02:00.123456Z"}},
+				"board_sprints": []any{}, "reference_sprints": []any{},
+			},
+		},
 	}
 }
 
@@ -75,6 +85,7 @@ func buildJiraAtlassianOracleSurfaces(t *testing.T, input map[string]any) jiraAt
 	claim.SourceExternalID = "OPS"
 	claim.DatasetOptions = map[string]any{
 		"fetch_worklogs": jiraBatchBool(input["fetch_worklogs"], false), "fetch_board_sprints": jiraBatchBool(input["fetch_board_sprints"], false),
+		"atlassian_gql_enabled": jiraBatchBool(input["graphql_fallback"], false),
 		"sprint_field": "customfield_10020",
 	}
 	normalizedAt := jiraProducerBatchNormalizedAt()
@@ -91,7 +102,11 @@ func buildJiraAtlassianOracleSurfaces(t *testing.T, input map[string]any) jiraAt
 	}
 	doer := &jiraAtlassianOracleDoer{t: t, issue: issue, worklogs: worklogs, boardSprints: boardSprints}
 	client := jiraWorkItemsTestClient(t, doer, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
-	batch, err := (JiraAtlassianRouteHandler{StatusMapping: loadRealStatusMapping(t), Identity: jiraOracleIdentity, ReferenceSprints: refs, CloudID: "cloud-301"}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt)
+	var graphqlClient *providerfoundation.HTTPClient
+	if jiraBatchBool(input["graphql_fallback"], false) {
+		graphqlClient = jiraWorkItemsTestClient(t, &jiraAtlassianOracleDoer{t: t, graphqlFailure: true}, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	}
+	batch, err := (JiraAtlassianRouteHandler{StatusMapping: loadRealStatusMapping(t), Identity: jiraOracleIdentity, ReferenceSprints: refs, CloudID: "cloud-301", GraphQLClient: graphqlClient}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,12 +136,15 @@ type jiraAtlassianOracleDoer struct {
 	t                      *testing.T
 	issue                  map[string]any
 	worklogs, boardSprints []map[string]any
+	graphqlFailure         bool
 }
 
 func (doer *jiraAtlassianOracleDoer) Do(request *http.Request) (*http.Response, error) {
 	doer.t.Helper()
 	var value any
 	switch {
+	case request.URL.Path == "/graphql" && doer.graphqlFailure:
+		return &http.Response{StatusCode: http.StatusBadGateway, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(`{"errors":[{"message":"temporary"}]}`)), Request: request}, nil
 	case request.URL.Path == "/rest/api/3/search":
 		value = map[string]any{"issues": []any{doer.issue}, "startAt": 0, "total": 1}
 	case strings.HasSuffix(request.URL.Path, "/changelog"):

--- a/internal/providersync/jira_atlassian_oracle_test.go
+++ b/internal/providersync/jira_atlassian_oracle_test.go
@@ -61,7 +61,7 @@ func jiraAtlassianOracleCases() []oracleCase {
 				"org_id": "org-acme", "since": "2026-08-01T00:00:00Z", "until": "2026-08-10T00:00:00Z",
 				"project_key": "OPS", "fetch_worklogs": true, "fetch_board_sprints": false,
 				"graphql_fallback": true, "issue": jiraAtlassianOracleIssue("OPS-303"),
-				"worklogs": []any{map[string]any{"id": "wl-303", "author": map[string]any{"accountId": "account-303", "name": "GraphQL Worker"}, "started": "2026-08-03T10:00:00.123456Z", "timeSpentSeconds": 1200, "created": "2026-08-03T10:01:00.123456Z", "updated": "2026-08-03T10:02:00.123456Z"}},
+				"worklogs":      []any{map[string]any{"id": "wl-303", "author": map[string]any{"accountId": "account-303", "name": "GraphQL Worker"}, "started": "2026-08-03T10:00:00.123456Z", "timeSpentSeconds": 1200, "created": "2026-08-03T10:01:00.123456Z", "updated": "2026-08-03T10:02:00.123456Z"}},
 				"board_sprints": []any{}, "reference_sprints": []any{},
 			},
 		},
@@ -86,7 +86,7 @@ func buildJiraAtlassianOracleSurfaces(t *testing.T, input map[string]any) jiraAt
 	claim.DatasetOptions = map[string]any{
 		"fetch_worklogs": jiraBatchBool(input["fetch_worklogs"], false), "fetch_board_sprints": jiraBatchBool(input["fetch_board_sprints"], false),
 		"atlassian_gql_enabled": jiraBatchBool(input["graphql_fallback"], false),
-		"sprint_field": "customfield_10020",
+		"sprint_field":          "customfield_10020",
 	}
 	normalizedAt := jiraProducerBatchNormalizedAt()
 	issue := input["issue"].(map[string]any)

--- a/internal/providersync/jira_atlassian_route.go
+++ b/internal/providersync/jira_atlassian_route.go
@@ -50,6 +50,19 @@ type jiraAtlassianRows struct {
 	Worklogs []jiraWorklogRow
 }
 
+// JiraWorklogFetchObservation records both sides of the optional GraphQL
+// worklog route. It is returned as typed fetch evidence so a GraphQL failure
+// followed by a successful REST read cannot look like an uninstrumented REST
+// fetch.
+type JiraWorklogFetchObservation struct {
+	IssueKey         string
+	GraphQLAttempted bool
+	GraphQLRequests  int
+	GraphQLSucceeded bool
+	RESTFallbackUsed bool
+	RESTRequests     int
+}
+
 // JiraSprintReferenceSink is the narrow reference-cache boundary used by the
 // provider path.  It is intentionally not a registry or activation hook.
 type JiraSprintReferenceSink func([]jiraSprintRow) error
@@ -128,6 +141,7 @@ func (handler JiraAtlassianRouteHandler) Collect(
 		Sprints:      cloneJiraSprintRows(handler.ReferenceSprints),
 	}, Worklogs: make([]jiraWorklogRow, 0)}
 	optionalIncomplete := make([]string, 0)
+	worklogObservations := make([]JiraWorklogFetchObservation, 0)
 	requests := searchPages
 	fetchComments := jiraOptionBool(claim, "fetch_comments", false)
 	commentsLimit := jiraOptionInt(claim, "comments_limit", 0)
@@ -178,10 +192,11 @@ func (handler JiraAtlassianRouteHandler) Collect(
 			if handler.GraphQLClient != nil {
 				worklogClient = handler.GraphQLClient
 			}
-			worklogs, worklogRequests, worklogErr := collectJiraAtlassianWorklogs(
+			worklogs, worklogRequests, worklogObservation, worklogErr := collectJiraAtlassianWorklogs(
 				ctx, client, worklogClient, key, useGraphQL, maxPages, handler.CloudID,
 			)
 			requests += worklogRequests
+			worklogObservations = append(worklogObservations, worklogObservation)
 			if worklogErr != nil {
 				optionalIncomplete = append(optionalIncomplete, "worklogs:"+item.WorkItemID)
 			} else {
@@ -286,6 +301,7 @@ func (handler JiraAtlassianRouteHandler) Collect(
 		Effects: effects, Result: result, Watermark: watermark,
 		Evidence: FetchEvidence{Provider: claim.Provider, Dataset: claim.Dataset,
 			Requests: requests, Pages: searchPages, Records: len(rows.WorkItems)},
+		WorklogObservations: worklogObservations,
 	}, nil
 }
 
@@ -539,13 +555,19 @@ func collectJiraBoardSprints(ctx context.Context, client *providerfoundation.HTT
 	}
 }
 
-func collectJiraAtlassianWorklogs(ctx context.Context, client, graphqlClient *providerfoundation.HTTPClient, issueKey string, graphql bool, maxPages int, cloudID string) ([]map[string]any, int, error) {
+func collectJiraAtlassianWorklogs(ctx context.Context, client, graphqlClient *providerfoundation.HTTPClient, issueKey string, graphql bool, maxPages int, cloudID string) ([]map[string]any, int, JiraWorklogFetchObservation, error) {
+	observation := JiraWorklogFetchObservation{IssueKey: issueKey}
 	graphqlRequests := 0
 	if graphql && strings.TrimSpace(cloudID) != "" {
+		observation.GraphQLAttempted = true
 		if values, requests, err := collectJiraGraphQLWorklogs(ctx, graphqlClient, issueKey, maxPages, cloudID); err == nil {
-			return values, requests, nil
+			observation.GraphQLRequests = requests
+			observation.GraphQLSucceeded = true
+			return values, requests, observation, nil
 		} else {
 			graphqlRequests = requests
+			observation.GraphQLRequests = requests
+			observation.RESTFallbackUsed = true
 		}
 	}
 	values := make([]map[string]any, 0)
@@ -553,10 +575,10 @@ func collectJiraAtlassianWorklogs(ctx context.Context, client, graphqlClient *pr
 	seen := make(map[int]struct{})
 	for pages := 0; ; pages++ {
 		if pages >= maxPages {
-			return nil, graphqlRequests + requests, ErrPaginationCapExceeded
+			return nil, graphqlRequests + requests, observation, ErrPaginationCapExceeded
 		}
 		if _, ok := seen[start]; ok {
-			return nil, graphqlRequests + requests, ErrPaginationCapExceeded
+			return nil, graphqlRequests + requests, observation, ErrPaginationCapExceeded
 		}
 		seen[start] = struct{}{}
 		query := url.Values{"startAt": {strconv.Itoa(start)}, "maxResults": {strconv.Itoa(jiraAtlassianWorklogPerPage)}}
@@ -565,27 +587,29 @@ func collectJiraAtlassianWorklogs(ctx context.Context, client, graphqlClient *pr
 			Total    *int              `json:"total"`
 		}
 		if err := jiraFetchObject(ctx, client, http.MethodGet, "/rest/api/3/issue/"+url.PathEscape(issueKey)+"/worklog?"+query.Encode(), nil, &page); err != nil {
-			return nil, graphqlRequests + requests + 1, err
+			observation.RESTRequests = requests + 1
+			return nil, graphqlRequests + requests + 1, observation, err
 		}
 		requests++
+		observation.RESTRequests = requests
 		if page.Worklogs == nil {
-			return nil, graphqlRequests + requests, providerfoundation.ErrNormalizationInvalid
+			return nil, graphqlRequests + requests, observation, providerfoundation.ErrNormalizationInvalid
 		}
 		for _, raw := range page.Worklogs {
 			var value map[string]any
 			if err := decodeJiraJSON(raw, &value); err != nil {
-				return nil, graphqlRequests + requests, err
+				return nil, graphqlRequests + requests, observation, err
 			}
 			values = append(values, value)
 		}
 		if page.Total != nil && start+len(page.Worklogs) >= *page.Total {
-			return values, graphqlRequests + requests, nil
+			return values, graphqlRequests + requests, observation, nil
 		}
 		if page.Total == nil && len(page.Worklogs) < jiraAtlassianWorklogPerPage {
-			return values, graphqlRequests + requests, nil
+			return values, graphqlRequests + requests, observation, nil
 		}
 		if len(page.Worklogs) == 0 {
-			return nil, graphqlRequests + requests, ErrPaginationCapExceeded
+			return nil, graphqlRequests + requests, observation, ErrPaginationCapExceeded
 		}
 		start += len(page.Worklogs)
 	}

--- a/internal/providersync/jira_atlassian_route_test.go
+++ b/internal/providersync/jira_atlassian_route_test.go
@@ -161,6 +161,92 @@ func TestJiraAtlassianRouteWorklogFailureIsTypedAndWithholdsWatermark(t *testing
 	}
 }
 
+func TestJiraAtlassianGraphQLWorklogPreservesNameIdentity(t *testing.T) {
+	claim := jiraAtlassianClaim()
+	claim.DatasetOptions["atlassian_gql_enabled"] = true
+	rest := &jiraAtlassianDoer{t: t}
+	graphql := jiraAtlassianDoerFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/graphql" {
+			t.Fatalf("unexpected GraphQL request %s", request.URL.String())
+		}
+		body := `{"data":{"issue":{"worklogs":{"pageInfo":{"hasNextPage":false,"endCursor":""},"edges":[{"node":{"worklogId":"wl-gql","author":{"name":"GraphQL Worker"},"timeSpent":{"timeInSeconds":1800},"created":"2026-08-01T10:01:00.123456Z","updated":"2026-08-01T10:02:00.123456Z","startDate":"2026-08-01T10:00:00.123456Z"}}]}}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)), Request: request,
+		}, nil
+	})
+	client := jiraWorkItemsTestClient(t, rest, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	graphqlClient := jiraWorkItemsTestClient(t, graphql, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	batch, err := (JiraAtlassianRouteHandler{
+		StatusMapping: loadRealStatusMapping(t), Identity: jiraRouteIdentity,
+		CloudID: "cloud-301", GraphQLClient: graphqlClient,
+	}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.WorklogObservations) != 1 {
+		t.Fatalf("worklog observations=%+v", batch.WorklogObservations)
+	}
+	observation := batch.WorklogObservations[0]
+	if !observation.GraphQLAttempted || !observation.GraphQLSucceeded || observation.RESTFallbackUsed || observation.GraphQLRequests != 1 || observation.RESTRequests != 0 {
+		t.Fatalf("GraphQL observation=%+v", observation)
+	}
+	if len(batch.Effects) != 7 {
+		t.Fatalf("effects=%d want=7", len(batch.Effects))
+	}
+	var worklog jiraWorklogRow
+	for _, effect := range batch.Effects {
+		if effect.Destination != "worklogs" || len(effect.Rows) != 1 {
+			continue
+		}
+		if err := json.Unmarshal(effect.Rows[0], &worklog); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if worklog.Author == nil || *worklog.Author != "GraphQL Worker" {
+		t.Fatalf("GraphQL name identity=%v want GraphQL Worker", worklog.Author)
+	}
+}
+
+func TestJiraAtlassianGraphQLFailureRecordsRESTFallbackObservation(t *testing.T) {
+	claim := jiraAtlassianClaim()
+	claim.DatasetOptions["atlassian_gql_enabled"] = true
+	rest := &jiraAtlassianDoer{t: t}
+	graphql := jiraAtlassianDoerFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path != "/graphql" {
+			t.Fatalf("unexpected GraphQL request %s", request.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"temporary"}]}`)), Request: request,
+		}, nil
+	})
+	client := jiraWorkItemsTestClient(t, rest, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	graphqlClient := jiraWorkItemsTestClient(t, graphql, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	batch, err := (JiraAtlassianRouteHandler{
+		StatusMapping: loadRealStatusMapping(t), Identity: jiraRouteIdentity,
+		CloudID: "cloud-301", GraphQLClient: graphqlClient,
+	}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(batch.WorklogObservations) != 1 {
+		t.Fatalf("worklog observations=%+v", batch.WorklogObservations)
+	}
+	observation := batch.WorklogObservations[0]
+	if !observation.GraphQLAttempted || observation.GraphQLSucceeded || !observation.RESTFallbackUsed || observation.GraphQLRequests != 1 || observation.RESTRequests != 1 {
+		t.Fatalf("fallback observation=%+v", observation)
+	}
+}
+
 type jiraAtlassianDoerFunc func(*http.Request) (*http.Response, error)
 
 func (doer jiraAtlassianDoerFunc) Do(request *http.Request) (*http.Response, error) {

--- a/internal/providersync/jira_work_items_rows.go
+++ b/internal/providersync/jira_work_items_rows.go
@@ -513,6 +513,9 @@ func jiraResolveUser(value any, objectShape bool, resolver jiraIdentityResolver)
 	if objectShape {
 		mapped, _ := jiraMapValue(value)
 		email, accountID, displayName = stringFrom(mapped["emailAddress"]), stringFrom(mapped["accountId"]), stringFrom(mapped["displayName"])
+		if displayName == "" {
+			displayName = stringFrom(mapped["name"])
+		}
 	} else {
 		// This is deliberate: the shipped JSON branch calls getattr(dict,...)
 		// and therefore passes three None values to IdentityResolver.
@@ -537,6 +540,9 @@ func jiraResolveMapUser(value any, resolver jiraIdentityResolver) string {
 	email := stringFrom(mapped["emailAddress"])
 	accountID := stringFrom(mapped["accountId"])
 	displayName := stringFrom(mapped["displayName"])
+	if displayName == "" {
+		displayName = stringFrom(mapped["name"])
+	}
 	if resolver != nil {
 		return resolver(email, accountID, displayName)
 	}

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_atlassian.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_atlassian.py
@@ -34,6 +34,7 @@ with (
 ):
     import atlassian
     from atlassian import canonical_models
+    from atlassian.graph.api import jira_worklogs as jira_worklogs_api
     from atlassian.rest.api import jira_boards
 
     from dev_health_ops.models.work_items import Sprint
@@ -203,17 +204,28 @@ def _build_row(case: dict[str, Any]) -> dict[str, Any]:
         atlassian.iter_issues_via_rest,
         atlassian.iter_issue_changelog_via_rest,
         atlassian.iter_issue_worklogs_via_rest,
+        jira_worklogs_api.iter_issue_worklogs_via_graphql,
         atlassian.iter_board_sprints_via_rest,
         jira_boards.iter_boards_via_rest,
         atlassian_compat.build_atlassian_rest_client,
+        atlassian_compat.build_atlassian_graphql_client,
         atlassian_compat.get_atlassian_cloud_id,
     )
+    graphql_attempted = False
+
+    def _failing_graphql_iter(*_args: Any, **_kwargs: Any):
+        nonlocal graphql_attempted
+        graphql_attempted = True
+        raise RuntimeError("graphql worklog test failure")
+
     try:
         os.environ["JIRA_FETCH_WORKLOGS"] = "1" if case.get("fetch_worklogs") else "0"
         os.environ["JIRA_FETCH_BOARD_SPRINTS"] = (
             "1" if case.get("fetch_board_sprints") else "0"
         )
-        os.environ["ATLASSIAN_GQL_ENABLED"] = "0"
+        os.environ["ATLASSIAN_GQL_ENABLED"] = (
+            "1" if case.get("graphql_fallback") else "0"
+        )
         atlassian.iter_issues_via_rest = lambda _client, cloud_id, jql, **kwargs: (
             _fake_issue_iter(client, cloud_id, jql, **kwargs)
         )
@@ -227,6 +239,7 @@ def _build_row(case: dict[str, Any]) -> dict[str, Any]:
                 client, issue_key=issue_key, **kwargs
             )
         )
+        jira_worklogs_api.iter_issue_worklogs_via_graphql = _failing_graphql_iter
         atlassian.iter_board_sprints_via_rest = lambda _client, *, board_id, **kwargs: (
             _fake_sprint_iter(client, board_id=board_id, **kwargs)
         )
@@ -237,6 +250,11 @@ def _build_row(case: dict[str, Any]) -> dict[str, Any]:
             atlassian_compat,
             "build_atlassian_rest_client",
             lambda *args: client,
+        )
+        setattr(
+            atlassian_compat,
+            "build_atlassian_graphql_client",
+            lambda *args, **kwargs: client,
         )
         setattr(
             atlassian_compat,
@@ -254,17 +272,23 @@ def _build_row(case: dict[str, Any]) -> dict[str, Any]:
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
-        setattr(atlassian_compat, "build_atlassian_rest_client", old_functions[5])
-        setattr(atlassian_compat, "get_atlassian_cloud_id", old_functions[6])
         (
             atlassian.iter_issues_via_rest,
             atlassian.iter_issue_changelog_via_rest,
             atlassian.iter_issue_worklogs_via_rest,
+        ) = old_functions[:3]
+        (
+            jira_worklogs_api.iter_issue_worklogs_via_graphql,
             atlassian.iter_board_sprints_via_rest,
             jira_boards.iter_boards_via_rest,
-        ) = old_functions[:5]
+        ) = old_functions[3:6]
+        setattr(atlassian_compat, "build_atlassian_rest_client", old_functions[6])
+        setattr(atlassian_compat, "build_atlassian_graphql_client", old_functions[7])
+        setattr(atlassian_compat, "get_atlassian_cloud_id", old_functions[8])
     if not client.closed:
         raise RuntimeError("Atlassian Jira producer did not close REST client")
+    if case.get("graphql_fallback") and not graphql_attempted:
+        raise RuntimeError("Atlassian Jira producer did not attempt GraphQL worklogs")
     return {
         "work_items": [_deterministic(row, org_id) for row in batch.work_items],
         "status_transitions": [

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_atlassian.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_atlassian.py
@@ -15,6 +15,8 @@ import os
 import pathlib
 import sys
 from datetime import datetime, timezone
+from importlib.machinery import ModuleSpec
+from types import ModuleType
 from typing import Any, cast
 
 from internal.providersync.testdata import oracle_registry
@@ -27,6 +29,12 @@ SRC_ROOT = REPO_ROOT / "src"
 PROVIDER_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/jira/provider.py"
 sys.path.insert(0, str(SRC_ROOT))
 install_minimal_oracle_imports()
+
+# Import the real connector utility without executing unrelated connector clients.
+_connectors = ModuleType("dev_health_ops.connectors")
+setattr(_connectors, "__path__", [str(SRC_ROOT / "dev_health_ops/connectors")])
+_connectors.__spec__ = ModuleSpec(_connectors.__name__, loader=None, is_package=True)
+sys.modules[_connectors.__name__] = _connectors
 
 with (
     contextlib.redirect_stdout(io.StringIO()),

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_batch.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_batch.py
@@ -25,6 +25,8 @@ import os
 import pathlib
 import sys
 from datetime import datetime, timezone
+from importlib.machinery import ModuleSpec
+from types import ModuleType
 from typing import Any, cast
 
 from internal.providersync.testdata import oracle_registry
@@ -43,6 +45,16 @@ CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/jira/client.py"
 # worktree's producer.
 sys.path.insert(0, str(SRC_ROOT))
 install_minimal_oracle_imports()
+
+# This oracle injects its dependency bundle below; importing the production
+# module must not construct the application's provider/client graph first.
+_metrics_dependencies = ModuleType("dev_health_ops.metrics.dependencies")
+setattr(_metrics_dependencies, "get_metrics_dependencies", None)
+sys.modules[_metrics_dependencies.__name__] = _metrics_dependencies
+_connectors = ModuleType("dev_health_ops.connectors")
+setattr(_connectors, "__path__", [str(SRC_ROOT / "dev_health_ops/connectors")])
+_connectors.__spec__ = ModuleSpec(_connectors.__name__, loader=None, is_package=True)
+sys.modules[_connectors.__name__] = _connectors
 
 
 def _source_path(value: Any) -> pathlib.Path:


### PR DESCRIPTION
## Summary
- preserve Jira Atlassian GraphQL-to-REST worklog fallback observations through completion and durable provider results
- align GraphQL author identity with the Python producer
- add live differential, persistence, ClickHouse recovery, and mutation evidence

## Validation
- `bash ci/local_validate.sh` — 9/9 stages passed
- `bash ci/check_go.sh live-python-oracles`
- `go test -race -shuffle=on ./internal/providersync`
- `go test -race -shuffle=on ./...`

## Scope
- CHAOS-3720
- excludes registry, matrix, config, route activation, deployment, merge, and attribution edits

SCREENSHOT-WAIVER: backend-only change; no rendered UI
