### PR TITLE
Fix ClickHouse feature flag identity for GitLab environments

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
+++ b/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
@@ -95,24 +95,43 @@ async def resolve_feature_flags(
     if not include_archived:
         where_clauses.append("archived_at IS NULL")
 
+    # Migration 074 makes environment part of the physical RMT identity, but
+    # the GraphQL registry contract remains one logical item per
+    # (provider, project, flag).  Aggregate after FINAL and choose every
+    # surfaced field from the same deterministic latest environment.  The
+    # environment tie-break keeps equal last_synced values stable without
+    # changing the established environment-agnostic flag ID.
+    latest_order = "tuple(last_synced, environment)"
     query = f"""
         SELECT
             provider,
             flag_key,
             project_key,
-            flag_type,
-            created_at,
-            archived_at
-        FROM feature_flag FINAL
-        WHERE {" AND ".join(where_clauses)}
+            tupleElement(latest, 1) AS flag_type,
+            tupleElement(latest, 2) AS created_at,
+            tupleElement(latest, 3) AS archived_at
+        FROM (
+            SELECT
+                provider,
+                flag_key,
+                project_key,
+                argMax(tuple(flag_type, created_at, archived_at), {latest_order}) AS latest
+            FROM feature_flag FINAL
+            WHERE {" AND ".join(where_clauses)}
+            GROUP BY provider, project_key, flag_key
+        )
         ORDER BY provider, project_key, flag_key
         LIMIT %(limit)s
     """
 
     count_query = f"""
         SELECT count() AS total
-        FROM feature_flag FINAL
-        WHERE {" AND ".join(where_clauses)}
+        FROM (
+            SELECT provider, project_key, flag_key
+            FROM feature_flag FINAL
+            WHERE {" AND ".join(where_clauses)}
+            GROUP BY provider, project_key, flag_key
+        )
     """
     count_params = {k: v for k, v in params.items() if k != "limit"}
 

--- a/src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py
+++ b/src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py
@@ -1,0 +1,335 @@
+"""Migration 074: keep feature-flag environments in the RMT identity.
+
+The feature-flag producer emits one row for every environment scope.  Before
+this migration, ``feature_flag`` was a ``ReplacingMergeTree`` keyed by
+``(org_id, provider, project_key, flag_key)``.  Two environments for the same
+flag therefore represented one physical identity: a merge (or ``FINAL``)
+silently discarded one environment and readback reported a conflict or an
+incomplete provider result.
+
+The deployed identity is now:
+
+    (org_id, provider, project_key, flag_key, environment)
+
+ClickHouse cannot alter a ReplacingMergeTree sorting key in place.  This
+migration uses the same shadow-table/atomic-exchange pattern as migrations
+042 and 061:
+
+1. Read the current DDL and sorting key.
+2. Create a shadow with the environment-aware key, verifying the *actual*
+   ClickHouse sorting key before copying data.
+3. Copy the old table and compare distinct environment-aware key tuples.
+4. Atomically exchange the tables.
+5. Catch up rows written during the snapshot and only then drop the old
+   shadow.
+
+The catch-up and idempotency paths deliberately leave a post-exchange shadow
+in place when catch-up fails.  A rerun converges it without dropping rows.
+Historical rows are copied unchanged; adding ``environment`` to the sorting
+key does not rewrite values or collapse rows that differ by environment.
+
+The migration is forward-only for application compatibility: once this schema
+is deployed, application binaries must use the registry's logical
+environment aggregation. A pre-074 registry reader would expose one row per
+environment and is not a safe rollback target, although old writers remain
+able to insert rows because the original columns are unchanged.
+
+Each invocation uses a unique shadow name. The migration runner's asyncio lock
+serializes migrations within one process, but not across processes or pods.
+Unique target-key shadows plus the final source-key preflight make a
+concurrent interleaving safe: a runner that observes the target key catches
+up its shadow instead of exchanging, and every exchange candidate has the
+target key so the table cannot be exchanged back to the legacy key.
+
+This module is loaded standalone by the ClickHouse migration runner, so it
+must not import sibling migration modules.
+"""
+
+import logging
+import re
+import uuid
+
+log = logging.getLogger(__name__)
+
+
+TABLES = {
+    "feature_flag": "(org_id, provider, project_key, flag_key, environment)",
+}
+
+LEGACY_KEY = "org_id, provider, project_key, flag_key"
+
+# ORDER BY (col, ...) | ORDER BY tuple(col, ...) | ORDER BY col
+_ORDER_BY_RE = re.compile(r"ORDER BY\s+(?:tuple\([^)]+\)|\([^)]+\)|\S+)", re.IGNORECASE)
+_ORG_ID_COL_RE = re.compile(
+    r"`?org_id`?\s+(?:LowCardinality\(\s*)?String", re.IGNORECASE
+)
+_EXCHANGE_DATABASE_ENGINES = frozenset({"Atomic", "Shared"})
+
+
+def _table_name_re(table: str) -> re.Pattern:
+    return re.compile(
+        rf"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        rf"(?:`?[\w\d_]+`?\.)?`?){re.escape(table)}(`?\s|`?\()",
+        re.IGNORECASE,
+    )
+
+
+def _replace_order_by(ddl: str, new_order_by: str) -> str:
+    result, count = _ORDER_BY_RE.subn(f"ORDER BY {new_order_by}", ddl, count=1)
+    if count == 0:
+        raise ValueError(f"Could not find ORDER BY in DDL: {ddl[:300]}...")
+    return result
+
+
+def _replace_table_name(ddl: str, old_name: str, new_name: str) -> str:
+    pattern = _table_name_re(old_name)
+    result, count = pattern.subn(rf"\g<1>{new_name}\g<2>", ddl, count=1)
+    if count == 0:
+        raise ValueError(
+            f"Could not replace table name '{old_name}' in DDL: {ddl[:300]}..."
+        )
+    return result
+
+
+def _table_exists(client, table: str) -> bool:
+    try:
+        result = client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = currentDatabase() AND name = {name:String}",
+            parameters={"name": table},
+        )
+        rows = getattr(result, "result_rows", None) or []
+        return bool(rows and rows[0] and rows[0][0] > 0)
+    except Exception:
+        return False
+
+
+def _shadow_name(table: str) -> str:
+    """Return a per-run shadow name so concurrent runners never share DDL."""
+    return f"{table}_074_new_{uuid.uuid4().hex}"
+
+
+def _shadow_tables(client, table: str) -> list[str]:
+    prefix = f"{table}_074_new_"
+    result = client.query(
+        "SELECT name FROM system.tables "
+        "WHERE database = currentDatabase() AND name LIKE {prefix:String}",
+        parameters={"prefix": f"{prefix}%"},
+    )
+    rows = getattr(result, "result_rows", None) or []
+    return [str(row[0]) for row in rows if row and str(row[0]).startswith(prefix)]
+
+
+def _assert_exchange_supported(client) -> None:
+    result = client.query(
+        "SELECT engine FROM system.databases WHERE name = currentDatabase()"
+    )
+    rows = getattr(result, "result_rows", None) or []
+    engine = str(rows[0][0]) if rows and rows[0] else ""
+    if engine not in _EXCHANGE_DATABASE_ENGINES:
+        raise RuntimeError(
+            "feature_flag migration 074 requires an Atomic or Shared database "
+            f"for EXCHANGE TABLES; current engine={engine or '<unknown>'!r}"
+        )
+
+
+def _sorting_key(client, table: str) -> str:
+    result = client.query(
+        "SELECT sorting_key FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(result, "result_rows", None) or []
+    if not rows or not rows[0]:
+        raise RuntimeError(f"{table}: could not read sorting_key from system.tables")
+    return str(rows[0][0])
+
+
+def _normalize_sorting_key(key: str) -> str:
+    """Normalize ClickHouse sorting-key display forms for exact comparison."""
+    normalized = re.sub(
+        r"\s*,\s*", ", ", re.sub(r"\s+", " ", key.replace("`", ""))
+    ).strip()
+    if normalized.lower().startswith("tuple(") and normalized.endswith(")"):
+        normalized = normalized[6:-1]
+    return normalized.strip(" ()")
+
+
+def _key_columns(order_by: str) -> list[str]:
+    return [
+        column.strip() for column in order_by.strip("() ").split(",") if column.strip()
+    ]
+
+
+def _distinct_key_count(client, table: str, key_columns: list[str]) -> int:
+    key_tuple = ", ".join(f"`{column}`" for column in key_columns)
+    result = client.query(f"SELECT uniqExact(({key_tuple})) FROM `{table}`")
+    rows = getattr(result, "result_rows", None) or []
+    return int(rows[0][0]) if rows and rows[0] else 0
+
+
+def _catch_up_and_drop(client, table: str, shadow: str) -> None:
+    """Reinsert the old side of an exchange before dropping its shadow."""
+    log.info("  %s: catch-up copy from `%s`", table, shadow)
+    client.command(f"INSERT INTO `{table}` SELECT * FROM `{shadow}`")
+    client.command(f"DROP TABLE `{shadow}`")
+
+
+def _legacy_shadows(client, table: str) -> list[str]:
+    """Return migration-owned shadows that still have the legacy identity."""
+    shadows = []
+    for shadow in _shadow_tables(client, table):
+        shadow_key = _normalize_sorting_key(_sorting_key(client, shadow))
+        if shadow_key == LEGACY_KEY:
+            shadows.append(shadow)
+        elif shadow_key != _normalize_sorting_key(TABLES[table]):
+            raise RuntimeError(
+                f"{table}: migration shadow `{shadow}` has unexpected sorting key "
+                f"{shadow_key!r}"
+            )
+    return shadows
+
+
+def _drain_legacy_shadows(client, table: str) -> None:
+    """Drain every recoverable old-key shadow before reporting success.
+
+    A runner may have exchanged successfully and then failed while catching up
+    its old side.  Another runner can observe the target key while its own
+    snapshot is still in flight, so cleaning only that runner's shadow would
+    incorrectly let the migration ledger advance with the failed runner's
+    legacy shadow (and its writes) still stranded.  Re-discover after draining
+    to make the success boundary explicit.
+    """
+    for shadow in _legacy_shadows(client, table):
+        _catch_up_and_drop(client, table, shadow)
+    remaining = _legacy_shadows(client, table)
+    if remaining:
+        raise RuntimeError(
+            f"{table}: recoverable legacy migration shadows remain after drain: "
+            f"{remaining!r}"
+        )
+
+
+def _rebuild_table(
+    client, table: str, new_order_by: str, *, shadow: str | None = None
+) -> None:
+    """Rebuild one feature-flag table with environment-aware identity."""
+    shadow = shadow or _shadow_name(table)
+    target_key = _normalize_sorting_key(new_order_by)
+
+    if not _table_exists(client, table):
+        log.warning("  %s: table does not exist, skipping", table)
+        return
+
+    current_key = _normalize_sorting_key(_sorting_key(client, table))
+    if current_key == target_key:
+        # A prior run may have exchanged successfully and crashed before
+        # catch-up/drop.  Finish that operation before declaring success.
+        leftovers = _shadow_tables(client, table)
+        if leftovers:
+            for leftover in leftovers:
+                shadow_key = _normalize_sorting_key(_sorting_key(client, leftover))
+                if shadow_key not in {LEGACY_KEY, target_key}:
+                    raise RuntimeError(
+                        f"{table}: migration shadow `{leftover}` has unexpected "
+                        f"sorting key {shadow_key!r}"
+                    )
+                log.info(
+                    "  %s: target key already present with leftover `%s`; converging",
+                    table,
+                    leftover,
+                )
+                _catch_up_and_drop(client, table, leftover)
+        else:
+            log.info("  %s: target key already present, skipping", table)
+        _drain_legacy_shadows(client, table)
+        return
+
+    if current_key != LEGACY_KEY:
+        raise RuntimeError(
+            f"{table}: unexpected source sorting key {current_key!r}; "
+            f"expected legacy {LEGACY_KEY!r} or target {target_key!r}"
+        )
+
+    result = client.query(f"SHOW CREATE TABLE `{table}`")
+    rows = getattr(result, "result_rows", None) or []
+    if not rows or not rows[0]:
+        raise RuntimeError(f"{table}: SHOW CREATE TABLE returned no DDL")
+    ddl = str(rows[0][0])
+    if not _ORG_ID_COL_RE.search(ddl):
+        raise ValueError(
+            f"{table}: org_id column not found in DDL; cannot preserve tenant identity"
+        )
+
+    new_ddl = _replace_table_name(ddl, table, shadow)
+    new_ddl = _replace_order_by(new_ddl, new_order_by)
+
+    log.info("  %s: creating shadow table", table)
+    client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+    client.command(new_ddl)
+
+    # Before EXCHANGE the shadow is disposable.  After EXCHANGE it contains
+    # the old live table and must remain available for catch-up/rerun.
+    target_already_visible = False
+    try:
+        shadow_key = _normalize_sorting_key(_sorting_key(client, shadow))
+        if shadow_key != target_key:
+            raise RuntimeError(
+                f"{table}: shadow sorting key mismatch after DDL rewrite "
+                f"(expected {target_key!r}, got {shadow_key!r}); aborting"
+            )
+
+        client.command(f"INSERT INTO `{shadow}` SELECT * FROM `{table}`")
+        key_columns = _key_columns(new_order_by)
+        source_keys = _distinct_key_count(client, table, key_columns)
+        shadow_keys = _distinct_key_count(client, shadow, key_columns)
+        if shadow_keys != source_keys:
+            raise RuntimeError(
+                f"{table}: shadow copy distinct-key mismatch "
+                f"(source={source_keys}, shadow={shadow_keys}); aborting before swap"
+            )
+
+        # A second process may have completed the exchange while this runner
+        # was copying. Never exchange a legacy main table after the target key
+        # is visible; converge our independently named target shadow.
+        current_after_copy = _normalize_sorting_key(_sorting_key(client, table))
+        if current_after_copy == target_key:
+            target_already_visible = True
+        elif current_after_copy != LEGACY_KEY:
+            raise RuntimeError(
+                f"{table}: source sorting key changed during migration "
+                f"(got {current_after_copy!r}); refusing EXCHANGE"
+            )
+    except Exception:
+        try:
+            client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+        except Exception as cleanup_error:  # pragma: no cover - best effort
+            log.warning("  %s: shadow cleanup failed: %s", table, cleanup_error)
+        raise
+
+    if target_already_visible:
+        # This shadow was copied from the legacy side, but another runner won
+        # the exchange while we were copying.  Keep catch-up outside the
+        # disposable-shadow cleanup block: if it fails, the legacy shadow must
+        # remain recoverable for the next runner.
+        _catch_up_and_drop(client, table, shadow)
+        _drain_legacy_shadows(client, table)
+        return
+
+    log.info("  %s: atomic swap via EXCHANGE TABLES", table)
+    client.command(f"EXCHANGE TABLES `{table}` AND `{shadow}`")
+
+    # If this fails, the leftover shadow is intentional: rerunning the
+    # migration enters the target-key convergence branch above.
+    _catch_up_and_drop(client, table, shadow)
+    _drain_legacy_shadows(client, table)
+    log.info("  %s: done", table)
+
+
+def upgrade(client):
+    """Rebuild feature_flag so environment scopes survive RMT merges."""
+    log.info("=== Migration 074: feature_flag environment identity (CHAOS-3737) ===")
+    _assert_exchange_supported(client)
+    for table, new_order_by in TABLES.items():
+        _rebuild_table(client, table, new_order_by)
+    log.info("=== Migration 074: Complete ===")

--- a/src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py
+++ b/src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py
@@ -329,7 +329,10 @@ def _rebuild_table(
 def upgrade(client):
     """Rebuild feature_flag so environment scopes survive RMT merges."""
     log.info("=== Migration 074: feature_flag environment identity (CHAOS-3737) ===")
-    _assert_exchange_supported(client)
     for table, new_order_by in TABLES.items():
+        if not _table_exists(client, table):
+            log.warning("  %s: table does not exist, skipping", table)
+            continue
+        _assert_exchange_supported(client)
         _rebuild_table(client, table, new_order_by)
     log.info("=== Migration 074: Complete ===")

--- a/tests/graphql/test_feature_flags.py
+++ b/tests/graphql/test_feature_flags.py
@@ -86,8 +86,9 @@ async def test_feature_flags_query_scopes_org_filters_and_orders(
     assert "ORDER BY provider, project_key, flag_key" in sql
     assert "LIMIT %(limit)s" in sql
     # Registry is one-row-per-(provider, project, flag); environment is NOT
-    # surfaced (CHAOS-2632 — FINAL over an env-agnostic key collapsed envs).
-    assert "environment" not in sql
+    # surfaced (CHAOS-2632).  After 074, physical environments are aggregated
+    # back to this logical registry identity.
+    assert "GROUP BY provider, project_key, flag_key" in sql
     assert params == {
         "org_id": "test-org",
         "provider": "launchdarkly",
@@ -116,6 +117,48 @@ async def test_feature_flags_query_scopes_org_filters_and_orders(
     assert result.flags[0].created_at == created_at.isoformat()
     assert result.flags[0].archived_at is None
     assert not hasattr(result.flags[0], "environment")
+
+
+@pytest.mark.asyncio
+async def test_feature_flags_aggregate_environments_to_one_logical_registry_item(
+    mock_context: GraphQLContext,
+) -> None:
+    created_at = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        # The real aggregate returns one latest-field row after two physical
+        # environment rows are grouped.  The source contract is asserted
+        # below as well, so this test cannot pass by merely truncating rows.
+        mock_query.side_effect = [
+            [
+                {
+                    "provider": "launchdarkly",
+                    "flag_key": "checkout-v2",
+                    "project_key": "web",
+                    "flag_type": "boolean",
+                    "created_at": created_at,
+                    "archived_at": None,
+                }
+            ],
+            [{"total": 1}],
+        ]
+
+        result = await resolve_feature_flags(mock_context, provider="launchdarkly")
+
+    list_sql = mock_query.call_args_list[0][0][1]
+    count_sql = mock_query.call_args_list[1][0][1]
+    assert "argMax" in list_sql
+    assert "tuple(last_synced, environment)" in list_sql
+    assert "GROUP BY provider, project_key, flag_key" in list_sql
+    assert "argMax" not in count_sql
+    assert "GROUP BY provider, project_key, flag_key" in count_sql
+    assert len(result.flags) == 1
+    assert result.total_count == 1
+    assert result.flags[0].flag_id == generate_feature_flag_id(
+        "test-org", "launchdarkly", "web", "checkout-v2"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/graphql/test_feature_flags_live.py
+++ b/tests/graphql/test_feature_flags_live.py
@@ -1,0 +1,132 @@
+"""Real ClickHouse proof for the environment-aware feature-flag registry."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.feature_flags import resolve_feature_flags
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.work_graph.ids import generate_feature_flag_id
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI pointed at an isolated scratch database",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_registry_aggregates_two_physical_environments_to_one_logical_flag() -> (
+    None
+):
+    assert CLICKHOUSE_URI is not None
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_schema(force=True)
+
+    org_id = f"chaos-3703-registry-{uuid.uuid4()}"
+    project_key = f"project-{uuid.uuid4()}"
+    flag_key = "checkout-v2"
+    second_flag_key = "dark-mode"
+    older = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+    # Equal last_synced values intentionally exercise the deterministic
+    # environment tie-break: staging sorts after production and must win.
+    rows = [
+        [
+            org_id,
+            "launchdarkly",
+            flag_key,
+            project_key,
+            "repo-1",
+            "production",
+            "json",
+            older,
+            older + timedelta(hours=1),
+            older,
+        ],
+        [
+            org_id,
+            "launchdarkly",
+            flag_key,
+            project_key,
+            "repo-1",
+            "staging",
+            "boolean",
+            older + timedelta(minutes=1),
+            None,
+            older,
+        ],
+        [
+            org_id,
+            "launchdarkly",
+            second_flag_key,
+            project_key,
+            "repo-1",
+            "production",
+            "boolean",
+            older,
+            None,
+            older,
+        ],
+    ]
+    columns = [
+        "org_id",
+        "provider",
+        "flag_key",
+        "project_key",
+        "repo_id",
+        "environment",
+        "flag_type",
+        "created_at",
+        "archived_at",
+        "last_synced",
+    ]
+    try:
+        sink.client.insert("feature_flag", rows, column_names=columns)
+        sink.client.command("OPTIMIZE TABLE feature_flag FINAL")
+
+        result = await resolve_feature_flags(
+            GraphQLContext(
+                org_id=org_id,
+                db_url=CLICKHOUSE_URI,
+                client=sink.client,
+            ),
+            provider="launchdarkly",
+            project=project_key,
+            include_archived=True,
+        )
+
+        assert result.total_count == 2
+        assert len(result.flags) == 2
+        assert {flag.flag_id for flag in result.flags} == {
+            generate_feature_flag_id(org_id, "launchdarkly", project_key, flag_key),
+            generate_feature_flag_id(
+                org_id, "launchdarkly", project_key, second_flag_key
+            ),
+        }
+        flag = next(item for item in result.flags if item.flag_key == flag_key)
+        assert flag.flag_id == generate_feature_flag_id(
+            org_id, "launchdarkly", project_key, flag_key
+        )
+        assert flag.flag_type == "boolean"
+        assert (
+            flag.created_at
+            == (older + timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+        )
+        assert flag.archived_at is None
+        assert not hasattr(flag, "environment")
+    finally:
+        sink.client.command(
+            "ALTER TABLE feature_flag DELETE WHERE org_id = {org_id:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"org_id": org_id},
+        )
+        sink.close()

--- a/tests/test_migration_074_feature_flag_identity.py
+++ b/tests/test_migration_074_feature_flag_identity.py
@@ -1,0 +1,483 @@
+"""Contract and failure-recovery tests for ClickHouse migration 074."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import TypedDict
+
+import pytest
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "dev_health_ops"
+    / "migrations"
+    / "clickhouse"
+)
+MIGRATION = "074_feature_flag_environment_identity.py"
+LEGACY_KEY = "org_id, provider, project_key, flag_key"
+TARGET_KEY = "org_id, provider, project_key, flag_key, environment"
+
+
+def _load_migration(filename: str = MIGRATION) -> ModuleType:
+    path = MIGRATIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {filename}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_074_declares_the_deployed_feature_flag_identity() -> None:
+    migration = _load_migration()
+
+    assert callable(getattr(migration, "upgrade", None))
+    assert migration.TABLES == {
+        "feature_flag": "(org_id, provider, project_key, flag_key, environment)"
+    }
+
+
+def test_default_shadow_names_are_unique_per_invocation() -> None:
+    migration = _load_migration()
+
+    names = {migration._shadow_name("feature_flag") for _ in range(8)}
+
+    assert len(names) == 8
+    assert all(name.startswith("feature_flag_074_new_") for name in names)
+
+
+def test_migration_074_runs_after_the_feature_flag_table_exists() -> None:
+    assert (MIGRATIONS_DIR / "034_feature_flag_user_impact_tables.sql").exists()
+    assert "034_feature_flag_user_impact_tables.sql" < MIGRATION
+    assert (MIGRATIONS_DIR / "073_linear_project_lifecycle.sql").exists()
+    assert "073_linear_project_lifecycle.sql" < MIGRATION
+
+
+def test_migration_034_declares_the_legacy_key_that_074_rebuilds() -> None:
+    ddl = (MIGRATIONS_DIR / "034_feature_flag_user_impact_tables.sql").read_text(
+        encoding="utf-8"
+    )
+    feature_flag = ddl.split("CREATE TABLE IF NOT EXISTS feature_flag", 1)[1].split(
+        "CREATE TABLE IF NOT EXISTS feature_flag_event", 1
+    )[0]
+    assert re.search(
+        r"ORDER BY\s*\(org_id,\s*provider,\s*project_key,\s*flag_key\)",
+        feature_flag,
+        re.IGNORECASE,
+    )
+
+
+class _Result:
+    def __init__(self, rows: list[list[object]]) -> None:
+        self.result_rows = rows
+
+
+class _TableState(TypedDict):
+    ddl: str
+    sorting_key: str
+    rows: list[dict[str, str]]
+
+
+class _FeatureFlagClient:
+    """Small ClickHouse client model for the migration state machine.
+
+    Data is retained per table so the tests can assert that rows for both
+    environments survive the snapshot/exchange/catch-up sequence.  It is not
+    a substitute for ClickHouse FINAL; the opt-in live test and provider
+    integration suite exercise that physical behavior.
+    """
+
+    def __init__(
+        self,
+        *,
+        rows: list[dict[str, str]],
+        created_sorting_key: str = TARGET_KEY,
+        fail_on: str | None = None,
+        before_exchange: Callable[[_FeatureFlagClient], None] | None = None,
+        after_shadow_copy: Callable[[_FeatureFlagClient], None] | None = None,
+        distinct_counts: dict[str, int] | None = None,
+        database_engine: str = "Atomic",
+    ) -> None:
+        old_ddl = (
+            "CREATE TABLE feature_flag ("
+            "org_id String, provider String, project_key String, flag_key String, "
+            "repo_id String, environment String, flag_type String, "
+            "created_at DateTime64(3), archived_at Nullable(DateTime64(3)), "
+            "last_synced DateTime64(3)) ENGINE = ReplacingMergeTree(last_synced) "
+            "ORDER BY (org_id, provider, project_key, flag_key)"
+        )
+        self.tables: dict[str, _TableState] = {
+            "feature_flag": {
+                "ddl": old_ddl,
+                "sorting_key": LEGACY_KEY,
+                "rows": [dict(row) for row in rows],
+            }
+        }
+        self.created_sorting_key = created_sorting_key
+        self.fail_on = fail_on
+        self.before_exchange = before_exchange
+        self.after_shadow_copy = after_shadow_copy
+        self.distinct_counts = distinct_counts or {}
+        self.database_engine = database_engine
+        self.commands: list[str] = []
+
+    def query(self, query: str, parameters: dict[str, str] | None = None) -> _Result:
+        if "FROM system.databases" in query:
+            return _Result([[self.database_engine]])
+        if "name LIKE" in query:
+            assert parameters is not None
+            prefix = parameters["prefix"].rstrip("%")
+            return _Result([[name] for name in self.tables if name.startswith(prefix)])
+        if "count() FROM system.tables" in query:
+            assert parameters is not None
+            return _Result([[1 if parameters["name"] in self.tables else 0]])
+        if "sorting_key FROM system.tables" in query:
+            assert parameters is not None
+            table_state = self.tables.get(parameters["name"])
+            return _Result([[table_state["sorting_key"]]] if table_state else [])
+        if query.startswith("SHOW CREATE TABLE"):
+            name = query.split("`")[1]
+            return _Result([[self.tables[name]["ddl"]]])
+        if "uniqExact" in query:
+            table_name = query.split("FROM `", 1)[1].split("`", 1)[0]
+            if table_name in self.distinct_counts:
+                return _Result([[self.distinct_counts[table_name]]])
+            columns = [
+                "org_id",
+                "provider",
+                "project_key",
+                "flag_key",
+                "environment",
+            ]
+            keys = {
+                tuple(row[column] for column in columns)
+                for row in self.tables[table_name]["rows"]
+            }
+            return _Result([[len(keys)]])
+        raise AssertionError(f"unexpected query: {query}")
+
+    def command(self, command: str) -> None:
+        self.commands.append(command)
+        if self.fail_on and self.fail_on in command:
+            self.fail_on = None
+            raise RuntimeError(f"injected failure on: {command}")
+
+        if command.startswith("DROP TABLE"):
+            table = command.split("`")[1]
+            self.tables.pop(table, None)
+            return
+
+        if command.startswith("CREATE TABLE"):
+            match = re.search(r"CREATE TABLE\s+`?(\w+)`?", command)
+            assert match is not None
+            name = match.group(1)
+            self.tables[name] = {
+                "ddl": command,
+                "sorting_key": self.created_sorting_key,
+                "rows": [],
+            }
+            return
+
+        if command.startswith("INSERT INTO"):
+            destination = command.split("`")[1]
+            source = command.split("FROM `", 1)[1].split("`", 1)[0]
+            copied: list[dict[str, str]] = [
+                dict(row) for row in self.tables[source]["rows"]
+            ]
+            self.tables[destination]["rows"].extend(copied)
+            if self.after_shadow_copy is not None and destination != "feature_flag":
+                callback = self.after_shadow_copy
+                self.after_shadow_copy = None
+                callback(self)
+            return
+
+        if command.startswith("EXCHANGE TABLES"):
+            if self.before_exchange is not None:
+                self.before_exchange(self)
+            names = re.findall(r"`(\w+)`", command)
+            assert len(names) == 2
+            first, second = names
+            self.tables[first], self.tables[second] = (
+                self.tables[second],
+                self.tables[first],
+            )
+            return
+
+        raise AssertionError(f"unexpected command: {command}")
+
+
+def _row(environment: str, *, org_id: str = "org-a") -> dict[str, str]:
+    return {
+        "org_id": org_id,
+        "provider": "gitlab",
+        "project_key": "group/project",
+        "flag_key": "checkout-v2",
+        "environment": environment,
+    }
+
+
+def test_rebuild_preserves_same_flag_in_multiple_environments() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production"), _row("staging")])
+
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+    assert "feature_flag_new" not in client.tables
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "staging",
+    }
+
+
+def test_rebuild_catches_up_a_row_written_between_snapshot_and_exchange() -> None:
+    migration = _load_migration()
+
+    def write_late_environment(client: _FeatureFlagClient) -> None:
+        client.tables["feature_flag"]["rows"].append(_row("canary"))
+
+    client = _FeatureFlagClient(
+        rows=[_row("production"), _row("staging")],
+        before_exchange=write_late_environment,
+    )
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "staging",
+        "canary",
+    }
+    snapshot = client.commands.index(
+        "INSERT INTO `feature_flag_new` SELECT * FROM `feature_flag`"
+    )
+    exchange = client.commands.index(
+        "EXCHANGE TABLES `feature_flag` AND `feature_flag_new`"
+    )
+    catch_up = client.commands.index(
+        "INSERT INTO `feature_flag` SELECT * FROM `feature_flag_new`"
+    )
+    assert snapshot < exchange < catch_up
+
+
+def test_rerun_converges_leftover_old_table_after_exchange() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production")])
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    # Model a crash after EXCHANGE: main has the target key and the old table
+    # remains as feature_flag_new.  The second run must catch it up and drop it.
+    old_rows = [_row("staging")]
+    leftover = "feature_flag_074_new_crashed"
+    client.tables[leftover] = {
+        "ddl": f"CREATE TABLE {leftover} ...",
+        "sorting_key": LEGACY_KEY,
+        "rows": old_rows,
+    }
+    client.tables["feature_flag"]["rows"].append(_row("canary"))
+    before = len(client.commands)
+
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_new",
+    )
+
+    assert leftover not in client.tables
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "canary",
+        "staging",
+    }
+    assert client.commands[before:] == [
+        f"INSERT INTO `feature_flag` SELECT * FROM `{leftover}`",
+        f"DROP TABLE `{leftover}`",
+    ]
+
+
+def test_post_exchange_failure_leaves_shadow_for_rerun() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(
+        rows=[_row("production")],
+        fail_on="INSERT INTO `feature_flag` SELECT",
+    )
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert "feature_flag_new" in client.tables
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+
+
+def test_concurrent_interleaving_of_two_unique_shadows_never_restores_legacy_key() -> (
+    None
+):
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production"), _row("staging")])
+
+    def run_second_runner(client: _FeatureFlagClient) -> None:
+        # The fake invokes this immediately before runner A's exchange. Disable
+        # the callback for runner B so this is one deterministic A/B interleave,
+        # not recursive simulation.
+        client.before_exchange = None
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_074_new_runner_b",
+        )
+
+    client.before_exchange = run_second_runner
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow="feature_flag_074_new_runner_a",
+    )
+
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+    assert "feature_flag_074_new_runner_a" not in client.tables
+    assert "feature_flag_074_new_runner_b" not in client.tables
+    assert sum("EXCHANGE TABLES" in command for command in client.commands) == 2
+
+
+def test_target_runner_drains_failed_peer_legacy_shadow_before_success() -> None:
+    """A target-key runner cannot strand a peer's failed catch-up shadow.
+
+    B snapshots the legacy table first.  A exchanges and then fails before it
+    can catch up a canary in A's old-side shadow.  B observes A's target key
+    after its snapshot and must drain both its own snapshot and A's recoverable
+    legacy shadow before it can return successfully (and let the ledger record
+    074).
+    """
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production"), _row("staging")])
+    peer_shadow = "feature_flag_074_new_runner_a"
+    runner_shadow = "feature_flag_074_new_runner_b"
+    client.tables[peer_shadow] = {
+        "ddl": f"CREATE TABLE {peer_shadow} ...",
+        "sorting_key": TARGET_KEY,
+        "rows": [dict(row) for row in client.tables["feature_flag"]["rows"]],
+    }
+
+    def exchange_failed_peer(client: _FeatureFlagClient) -> None:
+        # A has already snapshotted and exchanges while B is between its copy
+        # and source-key preflight.  A's failed catch-up leaves a new canary in
+        # the legacy-key old side.
+        client.command(f"EXCHANGE TABLES `feature_flag` AND `{peer_shadow}`")
+        client.tables[peer_shadow]["rows"].append(_row("canary"))
+
+    client.after_shadow_copy = exchange_failed_peer
+    migration._rebuild_table(
+        client,
+        "feature_flag",
+        migration.TABLES["feature_flag"],
+        shadow=runner_shadow,
+    )
+
+    assert client.tables["feature_flag"]["sorting_key"] == TARGET_KEY
+    assert peer_shadow not in client.tables
+    assert runner_shadow not in client.tables
+    assert {row["environment"] for row in client.tables["feature_flag"]["rows"]} == {
+        "production",
+        "staging",
+        "canary",
+    }
+    assert not migration._legacy_shadows(client, "feature_flag")
+
+
+def test_distinct_key_mismatch_aborts_before_exchange() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(
+        rows=[_row("production"), _row("staging")],
+        distinct_counts={"feature_flag": 2, "feature_flag_new": 1},
+    )
+
+    with pytest.raises(RuntimeError, match="distinct-key mismatch"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert "feature_flag_new" not in client.tables
+    assert not any("EXCHANGE" in command for command in client.commands)
+
+
+def test_upgrade_fails_closed_when_database_engine_cannot_exchange_tables() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production")], database_engine="Ordinary")
+
+    with pytest.raises(RuntimeError, match="Atomic or Shared"):
+        migration.upgrade(client)
+
+    assert client.commands == []
+
+
+def test_migration_documents_forward_only_application_rollback_boundary() -> None:
+    text = (MIGRATIONS_DIR / MIGRATION).read_text(encoding="utf-8")
+
+    assert "forward-only for application compatibility" in text
+    assert "not a safe rollback target" in text
+
+
+def test_sorting_key_rewrite_fails_closed_before_copy() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(
+        rows=[_row("production")],
+        created_sorting_key="org_id, provider, project_key, flag_key",
+    )
+
+    with pytest.raises(RuntimeError, match="sorting key mismatch"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert "feature_flag_new" not in client.tables
+    assert client.tables["feature_flag"]["sorting_key"] == LEGACY_KEY
+    assert not any("INSERT INTO" in command for command in client.commands)
+    assert not any("EXCHANGE" in command for command in client.commands)
+
+
+def test_unexpected_source_key_does_not_get_silently_rewritten() -> None:
+    migration = _load_migration()
+    client = _FeatureFlagClient(rows=[_row("production")])
+    client.tables["feature_flag"]["sorting_key"] = "org_id, provider, flag_key"
+
+    with pytest.raises(RuntimeError, match="unexpected source sorting key"):
+        migration._rebuild_table(
+            client,
+            "feature_flag",
+            migration.TABLES["feature_flag"],
+            shadow="feature_flag_new",
+        )
+
+    assert not any("CREATE TABLE" in command for command in client.commands)

--- a/tests/test_migrations_clickhouse.py
+++ b/tests/test_migrations_clickhouse.py
@@ -17,8 +17,17 @@ async def test_clickhouse_migrations_dry_run_non_default_db():
 
     # Mock ClickHouse client
     mock_client = MagicMock()
-    # Mock query result for schema_migrations (empty, so all migrations run)
+    # Mock query result for schema_migrations (empty, so all migrations run).
+    # Migration 074 also fail-closes unless the database engine supports
+    # EXCHANGE TABLES; model the production Atomic database explicitly.
     mock_client.query.return_value.result_rows = []
+
+    def mock_query(query, parameters=None):
+        result = MagicMock()
+        result.result_rows = [["Atomic"]] if "FROM system.databases" in query else []
+        return result
+
+    mock_client.query.side_effect = mock_query
 
     # Capture commands executed
     executed_commands = []

--- a/tests/tooling/mutation-plans/feature_flag_identity.json
+++ b/tests/tooling/mutation-plans/feature_flag_identity.json
@@ -72,7 +72,7 @@
       "expect_occurrences": 2,
       "rationale": "GraphQL must aggregate all physical environment rows back to one logical flag and one totalCount while preserving distinct flag_key values under the same provider/project and the environment-agnostic ID",
       "build": [".venv/bin/python", "-c", "import dev_health_ops.api.graphql.resolvers.feature_flags"],
-      "proof": [[".venv/bin/python", "tests/tooling/run_feature_flag_identity_live_proof.py"]]
+      "proof": [["uv", "run", "--with", "pytest-asyncio", "python", "tests/tooling/run_feature_flag_identity_live_proof.py"]]
     }
   ]
 }

--- a/tests/tooling/mutation-plans/feature_flag_identity.json
+++ b/tests/tooling/mutation-plans/feature_flag_identity.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "name": "feature_flag environment identity migration (CHAOS-3737)",
+  "$limitation": "This plan covers the migration's identity, fail-closed DDL verification, distinct-key preservation, source-key guard, unique-shadow concurrency, and post-exchange catch-up. M9 deliberately uses the real migrated ClickHouse proof. Do not run this plan until reviewer/orchestrator GO.",
+  "build": [
+    ".venv/bin/python",
+    "-c",
+    "import importlib.util; p='src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py'; s=importlib.util.spec_from_file_location('feature_flag_identity', p); m=importlib.util.module_from_spec(s); s.loader.exec_module(m)"
+  ],
+  "mutations": [
+    {
+      "id": "M2-rerun-convergence-branch",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if current_key == target_key:",
+      "replace": "if False:",
+      "rationale": "an already-exchanged table with a leftover old shadow must converge by catch-up and drop on rerun",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "rerun_converges_leftover_old_table_after_exchange"]]
+    },
+    {
+      "id": "M3-shadow-sorting-key-proof",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if shadow_key != target_key:",
+      "replace": "if False:",
+      "rationale": "a DDL rewrite that creates the wrong ClickHouse sorting key must fail before copying or exchanging data",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "sorting_key_rewrite_fails_closed_before_copy"]]
+    },
+    {
+      "id": "M4-distinct-key-preservation",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if shadow_keys != source_keys:",
+      "replace": "if False:",
+      "rationale": "the snapshot must abort before EXCHANGE when the environment-aware logical-key count is not preserved",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "distinct_key_mismatch_aborts_before_exchange"]]
+    },
+    {
+      "id": "M5-post-exchange-catch-up",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "client.command(f\"INSERT INTO `{table}` SELECT * FROM `{shadow}`\")",
+      "replace": "client.command(f\"INSERT INTO `{table}` SELECT * FROM `{table}`\")",
+      "rationale": "rows written to the old side between snapshot and EXCHANGE must be reinserted before the old shadow is dropped",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "rebuild_catches_up_a_row_written_between_snapshot_and_exchange"]]
+    },
+    {
+      "id": "M6-legacy-source-key-guard",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if current_key != LEGACY_KEY:",
+      "replace": "if False:",
+      "rationale": "the migration must fail closed rather than reinterpret an unexpected pre-074 sorting key",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "unexpected_source_key_does_not_get_silently_rewritten"]]
+    },
+    {
+      "id": "M7-exchange-engine-preflight",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "if engine not in _EXCHANGE_DATABASE_ENGINES:",
+      "replace": "if False:",
+      "rationale": "EXCHANGE TABLES must fail closed on non-Atomic/non-Shared databases rather than run with unsupported atomicity semantics",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "upgrade_fails_closed_when_database_engine_cannot_exchange_tables"]]
+    },
+    {
+      "id": "M8-unique-shadow-name",
+      "file": "src/dev_health_ops/migrations/clickhouse/074_feature_flag_environment_identity.py",
+      "find": "return f\"{table}_074_new_{uuid.uuid4().hex}\"",
+      "replace": "return f\"{table}_new\"",
+      "rationale": "concurrent migration runners must not share one shadow table name and race DROP/CREATE/EXCHANGE",
+      "proof": [["pytest", "-q", "tests/test_migration_074_feature_flag_identity.py", "-k", "default_shadow_names_are_unique_per_invocation"]]
+    },
+    {
+      "id": "M9-registry-logical-grouping",
+      "file": "src/dev_health_ops/api/graphql/resolvers/feature_flags.py",
+      "find": "GROUP BY provider, project_key, flag_key",
+      "replace": "GROUP BY provider, project_key, flag_key, environment",
+      "expect_occurrences": 2,
+      "rationale": "GraphQL must aggregate all physical environment rows back to one logical flag and one totalCount while preserving distinct flag_key values under the same provider/project and the environment-agnostic ID",
+      "build": [".venv/bin/python", "-c", "import dev_health_ops.api.graphql.resolvers.feature_flags"],
+      "proof": [[".venv/bin/python", "tests/tooling/run_feature_flag_identity_live_proof.py"]]
+    }
+  ]
+}

--- a/tests/tooling/run_feature_flag_identity_live_proof.py
+++ b/tests/tooling/run_feature_flag_identity_live_proof.py
@@ -1,0 +1,56 @@
+"""Run the feature-flag registry proof against an isolated ClickHouse database."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+import clickhouse_connect
+
+
+def main() -> int:
+    admin_dsn = os.environ.get(
+        "CLICKHOUSE_ADMIN_URI",
+        "clickhouse://ch:ch@localhost:8123/default",
+    )
+    parsed = urlsplit(admin_dsn)
+    database = f"chaos_3703_feature_flag_{uuid4().hex}"
+    scratch_dsn = urlunsplit(parsed._replace(path=f"/{database}"))
+    client = clickhouse_connect.get_client(dsn=admin_dsn)
+    client.command(f"CREATE DATABASE `{database}`")
+    try:
+        environment = os.environ.copy()
+        environment["CLICKHOUSE_URI"] = scratch_dsn
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "tests/graphql/test_feature_flags_live.py",
+                "-m",
+                "clickhouse",
+            ],
+            check=False,
+            capture_output=True,
+            env=environment,
+            text=True,
+        )
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            return result.returncode
+        if "1 passed" not in result.stdout:
+            print("feature-flag live proof did not execute exactly one passing test")
+            return 1
+        return 0
+    finally:
+        client.command(f"DROP DATABASE IF EXISTS `{database}`")
+        client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add migration 074 rebuilding `feature_flag` with `(org_id, provider, project_key, flag_key, environment)` identity
- preserve one logical registry item per provider/project/flag through deterministic environment aggregation
- add migration rerun/convergence, provider emission, live ClickHouse readback, and shared mutation-plan coverage

## Scope
ClickHouse migration/schema plus provider persistence/readback compatibility only. No route activation, registry, matrix, config, deployment, or cutover changes.

## Baseline reproduction
- Baseline SHA: `cfe94369368ca3c81f0d6a3ce9e80a8f3530320e`
- Command: real `ClickHouseMetricsSink.ensure_schema(force=True)` migration chain, insert GitLab `production` and `staging` rows for the same `(org, provider, project, flag)`, `OPTIMIZE TABLE feature_flag FINAL`, then `SELECT environment FROM feature_flag FINAL`.
- Failing state: expected `[production, staging]`; observed `[staging]`; `feature_flag FINAL collapsed environment variants`.

## Evidence
- Migration head: `074_feature_flag_environment_identity.py`
- Green migrated ClickHouse proof: isolated scratch database, live registry readback, `1 passed`; final full gate `8/8` stages, `13649 passed, 240 skipped, 1 xfailed`.
- Mutation evidence: M2-M9 all `KILLED`; harness restored every mutation. M9 used the live migrated ClickHouse proof.
- LSP diagnostics: clean on all changed Python files.

## Risk notes
Migration uses shadow-table copy, actual sorting-key verification, distinct-key preservation, atomic exchange, post-exchange catch-up, unique shadows, and rerun convergence. Missing `feature_flag` tables are skipped for compatibility with partial schemas.

Fixes CHAOS-3737