### PR TITLE
fix: persist randomized acceptance API URL

### DIFF
--- a/scripts/acceptance/run_ask_dev_compose.sh
+++ b/scripts/acceptance/run_ask_dev_compose.sh
@@ -120,6 +120,11 @@ export ASK_DEV_ACCEPTANCE_ACR="${acr_armed}"
 # repo state -- a fresh runtime artifact per acceptance run, same lifecycle
 # as the containers themselves.
 org_ids_output="${ASK_DEV_ACCEPTANCE_ORG_IDS_OUTPUT:-/tmp/ask-dev-acceptance-org-ids.json}"
+# A retained stack is consumed by a second process (for example the Wave 4
+# corpus), so the dynamically assigned API port must survive this shell. Keep
+# the path overrideable for CI, and namespace the default by Compose project so
+# two local acceptance projects do not overwrite each other's URL artifact.
+api_url_output="${ASK_DEV_ACCEPTANCE_API_URL_OUTPUT:-/tmp/ask-dev-acceptance-api-url-${project_name}.env}"
 read_oracle_field() {
   "${ops_root}/.venv/bin/python" -c \
     'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))[sys.argv[2]])' \
@@ -242,6 +247,7 @@ if [[ ! "${acceptance_api_port}" =~ ^[0-9]+$ ]] || [[ "${acceptance_api_port}" =
   exit 70
 fi
 acceptance_api_url="http://127.0.0.1:${acceptance_api_port}"
+export ASK_DEV_ACCEPTANCE_API_URL="${acceptance_api_url}"
 
 # urllib honors both spellings when resolving ambient HTTP(S) proxies. Local
 # acceptance API calls must bypass them: a proxy on this host can route
@@ -607,9 +613,16 @@ TEST_SUPERUSER_PASSWORD="${graph_primary_user_password}" \
 # ask-dev-acceptance.yml does it in an `if: always()` step, so a cancelled or
 # failed job still releases the runner's disk.
 if [[ "${ASK_DEV_ACCEPTANCE_KEEP_STACK:-0}" == "1" ]]; then
+  mkdir -p "$(dirname -- "${api_url_output}")"
+  printf 'export ASK_DEV_ACCEPTANCE_API_URL=%q\n' "${acceptance_api_url}" > "${api_url_output}"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    printf 'ASK_DEV_ACCEPTANCE_API_URL=%s\n' "${acceptance_api_url}" >> "${GITHUB_ENV}"
+  fi
   trap - EXIT
   echo "Ask Dev Compose acceptance completed successfully; stack retained (ASK_DEV_ACCEPTANCE_KEEP_STACK=1)."
   echo "ASK_DEV_ACCEPTANCE_API_URL=${acceptance_api_url}"
+  echo "ASK_DEV_ACCEPTANCE_API_URL_FILE=${api_url_output}"
+  echo "Source it before an external corpus invocation: source ${api_url_output}"
   # Deliberately NOT spelled with the same literal as the real teardown command
   # below. Adversarial review 2026-08-06 (HIGH): the first version of this hint
   # printed `down --volumes --remove-orphans` verbatim, which put a SECOND

--- a/tests/acceptance/test_ask_dev_compose.py
+++ b/tests/acceptance/test_ask_dev_compose.py
@@ -401,6 +401,36 @@ def test_keep_stack_is_opt_in_and_skips_only_the_teardown() -> None:
         )
 
 
+def test_keep_stack_exports_and_persists_discovered_api_url() -> None:
+    """A dynamically published port must reach a corpus started later.
+
+    The launcher is a child process of both a developer shell and the CI
+    workflow, so an ordinary shell ``export`` cannot update the caller. Keep
+    the three delivery paths distinct: export for commands inside this
+    launcher, a sourceable file for local callers, and ``GITHUB_ENV`` for a
+    later workflow step.
+    """
+
+    launcher = _LAUNCHER.read_text(encoding="utf-8")
+    discovery = launcher.index(
+        'acceptance_api_url="http://127.0.0.1:${acceptance_api_port}"'
+    )
+    export = launcher.index('export ASK_DEV_ACCEPTANCE_API_URL="${acceptance_api_url}"')
+    keep = launcher.index('if [[ "${ASK_DEV_ACCEPTANCE_KEEP_STACK:-0}" == "1" ]]')
+    persist = launcher.index("printf 'export ASK_DEV_ACCEPTANCE_API_URL=%q\\n'")
+    github_env = launcher.index('>> "${GITHUB_ENV}"')
+    printed_file = launcher.index("ASK_DEV_ACCEPTANCE_API_URL_FILE=${api_url_output}")
+
+    assert discovery < export < keep < persist < github_env < printed_file
+    assert (
+        "ASK_DEV_ACCEPTANCE_API_URL_OUTPUT:-/tmp/ask-dev-acceptance-api-url-"
+        in launcher
+    )
+    assert 'mkdir -p "$(dirname -- "${api_url_output}")"' in launcher
+    assert 'if [[ -n "${GITHUB_ENV:-}" ]]' in launcher
+    assert "Source it before an external corpus invocation: source" in launcher
+
+
 def test_oracle_is_versioned_and_requires_exact_grounded_answer_parts() -> None:
     oracle = json.loads(_ORACLE.read_text(encoding="utf-8"))
     assert oracle == {


### PR DESCRIPTION
## Summary
- export the dynamically discovered acceptance API URL inside the launcher
- persist a sourceable per-project URL artifact for retained local stacks
- publish the URL through GITHUB_ENV for later CI steps
- add conformance coverage for all three delivery paths

## Validation
- full local Ops gate: PASSED, 10/10 stages executed
- 16,058 passed, 383 skipped, 4 expected xfails
- Ruff, mypy, scratch ClickHouse migrations, argMax proof, declared-state history, and migration 075 reconciliation all passed