### PR TITLE
fix(admin): commit credentials before response

### DIFF
--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -269,6 +269,11 @@ async def create_credential(
         name=payload.name,
         config=payload.config,
     )
+    # Commit before responding (CHAOS-3739): ``svc.set`` only flushes, while
+    # the yielded request-session dependency commits during teardown after
+    # FastAPI has already sent the response. A following request that links
+    # this credential would otherwise fail its foreign-key check.
+    await session.commit()
     return _integration_credential_response(cred)
 
 

--- a/tests/api/admin/test_add_member_visibility.py
+++ b/tests/api/admin/test_add_member_visibility.py
@@ -47,12 +47,19 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from dev_health_ops.api.admin.routers.credentials import create_credential
 from dev_health_ops.api.admin.routers.orgs import add_member
 from dev_health_ops.api.admin.routers.users import create_user
-from dev_health_ops.api.admin.schemas_flat import MembershipCreate, UserCreate
+from dev_health_ops.api.admin.schemas_flat import (
+    IntegrationCredentialCreate,
+    MembershipCreate,
+    UserCreate,
+)
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.users import MembershipService
 from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import Integration
+from dev_health_ops.models.settings import IntegrationCredential
 from dev_health_ops.models.users import Membership, Organization, User
 from tests._helpers import tables_of
 
@@ -118,7 +125,13 @@ async def org_schema() -> AsyncIterator[
             await connection.run_sync(
                 lambda sync_connection: Base.metadata.create_all(
                     sync_connection,
-                    tables=tables_of(Organization, User, Membership),
+                    tables=tables_of(
+                        Organization,
+                        User,
+                        Membership,
+                        IntegrationCredential,
+                        Integration,
+                    ),
                 )
             )
         maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -259,3 +272,55 @@ async def test_create_organization_with_owner_is_durable_before_returning(
             "owner membership row was never durably committed"
         )
         assert str(seen_owner_membership.role) == "owner"
+
+
+@pytest.mark.asyncio
+async def test_create_credential_is_durable_before_dependent_request(
+    org_schema: tuple[async_sessionmaker[AsyncSession], uuid.UUID],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A credential returned by one request must satisfy the next request's FK.
+
+    ``IntegrationCredentialsService.set`` flushes the new row but deliberately
+    leaves transaction ownership to the request boundary.  FastAPI sends the
+    response before a yielded dependency's post-response commit, so a second
+    request can otherwise try to create an ``Integration`` whose
+    ``credential_id`` is not visible yet and fail ``integration_credentials_id_fkey``.
+    Each session below represents one real HTTP request. The test never commits
+    on behalf of the credential endpoint whose durability is under test; the
+    dependent request commits only after its foreign-key flush succeeds.
+    """
+    maker, org_id = org_schema
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "chaos-3739-credential-test-key")
+
+    async with maker() as create_credential_session:
+        credential_response = await create_credential(
+            payload=IntegrationCredentialCreate(
+                provider="github",
+                credentials={"token": "ghp_chaos_3739"},
+            ),
+            session=create_credential_session,
+            org_id=str(org_id),
+        )
+
+    credential_id = uuid.UUID(credential_response.id)
+
+    async with maker() as dependent_request_session:
+        dependent_request_session.add(
+            Integration(
+                org_id=str(org_id),
+                provider="github",
+                credential_id=credential_id,
+                name="github-default",
+                config={},
+            )
+        )
+        await dependent_request_session.flush()
+        await dependent_request_session.commit()
+
+    async with maker() as verify_session:
+        seen_credential = await verify_session.get(IntegrationCredential, credential_id)
+        assert seen_credential is not None, (
+            "create_credential reported success, but its row was not durably "
+            "committed before the dependent request -- integration_credentials_id_fkey"
+        )


### PR DESCRIPTION
Closes CHAOS-3739.\n\n## Outcome\n\nPOST /api/v1/admin/credentials now durably commits the credential before returning its ID, so an immediate dependent sync-config request cannot race request-session teardown and fail the credential foreign key.\n\n## Evidence\n\n- Baseline mutation: the independent-session regression failed with the exact integrations_credential_id_fkey violation.\n- Fixed: focused regression 1 passed; full visibility module 3 passed; credential and journey neighbors 41 passed.\n- Independent review approved transaction ownership and rollback behavior.\n- Ruff, formatting, mypy, and diff checks pass.\n\n## Scope\n\nNo schema, migration, feature-flag, security, retention, or rollout change. The shared session context manager still owns rollback and final request cleanup; this endpoint commits before response because its returned ID is immediately consumable by another request.\n\nSCREENSHOT-WAIVER: Backend transaction-boundary fix with no rendered UI change.