### PR TITLE
W4: close subjectless drivers and canonical cohort ranking

### DIFF
--- a/docs/contribute/architecture/graph-investigation-arm.md
+++ b/docs/contribute/architecture/graph-investigation-arm.md
@@ -47,8 +47,10 @@ product feature, and nothing about it is on a user-visible path.
 The outcome is **derived from what was produced**, never passed in. A packet
 with no asserted driver is, by the frozen contract's own
 `validate_supported_outcome_asserts_a_judgment`, a redirect rather than an
-answer — so for as long as the arm synthesized no drivers it could only emit
-`unsupported`, and it did.
+answer. The seeded paths retain that unsupported control; the subjectless
+production path now runs the structural rules independently for each cohort
+member and can therefore emit a supported outcome only when one of those
+findings carries current lineage and closed evidence.
 
 With structural drivers it now emits `supported_with_gaps` for
 `proj_identity_rewrite`, credited to `drv_block_wu_authcore_release`, and the
@@ -991,10 +993,13 @@ comparison here" must not score identically.
 the packet to mistake for one: it is populated, structured, and looks like a
 comparison was performed. `derive_outcome` evaluates the frozen contract's
 own rule — a supported outcome needs a driver with asserted standing and a
-non-empty evidence index — and this revision synthesizes no drivers, so every
-cohort-bearing packet it emits is still `unsupported`. The function exists
-rather than a constant precisely so both branches can be observed; a constant
-would make "the arm cannot over-claim" unfalsifiable.
+non-empty evidence index. The subjectless production path now supplies
+structural findings per member, while keeping cited measurements
+candidate-only; an empty or evidence-closed failure still emits
+`unsupported`, and a disclosed traversal/driver bound weakens a supported
+result to `supported_with_gaps`. The function exists rather than a constant
+precisely so both branches can be observed; a constant would make "the arm
+cannot over-claim" unfalsifiable.
 
 ## What the differential oracle found
 

--- a/src/dev_health_ops/context_fabric/graph_arm/cohort_ranking.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/cohort_ranking.py
@@ -1,0 +1,733 @@
+"""CHAOS-3667 W4 slice 2: rank an authorized cohort with canonical signals.
+
+The graph discovers who is comparable. This adapter asks the already-built
+canonical enrichment services what each authorized member can support, then
+keeps the service-owned states attached to that member. It does not read
+graph measurement attributes, derive a ratio, or create a health score.
+
+Two boundaries are intentional:
+
+* healthy and single-signal members are recorded as question-specific
+  exclusions, while unknown, stale, unavailable and not-applicable members
+  stay visible in the adapter result so a coverage gap cannot read as health;
+* ordering is a lexicographic vector over the canonical dimensions, followed
+  by the canonical id. There is no sum, weight, percentile or universal
+  composite score for a team or project.
+
+This is an internal adapter result. The frozen packet's
+``ComparisonCohort`` has no rank field, so packet assembly can consume this
+result in a later slice without changing the wire contract here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Protocol, cast
+
+from dev_health_ops.api.dev.canonical_enrichment import (
+    CanonicalEnrichment,
+    EnrichmentGap,
+)
+from dev_health_ops.api.dev.contracts import (
+    DevEntityRef,
+    DevMetricRef,
+    DevScope,
+    DirectScope,
+    EntityType,
+    FreshnessState,
+)
+from dev_health_ops.api.dev.contracts_v2.base import (
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.deficiency import (
+    DeficiencyFinding,
+    OperationalDeficiencyInventory,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import (
+    DimensionState,
+    HealthDimension,
+)
+from dev_health_ops.api.dev.health_profile_synthesis import HealthProfileResult
+from dev_health_ops.api.dev.investigation_contract import (
+    CohortExclusionReason,
+)
+
+from .cohort import CohortCandidate, CohortExclusionRecord, CohortProposal
+from .vocabulary import GraphEntityKind
+
+__all__ = [
+    "CanonicalCohortRankingAdapter",
+    "CanonicalCohortSignal",
+    "CohortRankDisposition",
+    "CohortRankedMember",
+    "CohortRankingResult",
+]
+
+
+class _CanonicalEnrichmentSource(Protocol):
+    async def enrich(
+        self,
+        *,
+        org_id: str,
+        permission_fingerprint: str,
+        scope: DevScope,
+        now: datetime | None = None,
+    ) -> CanonicalEnrichment: ...
+
+
+class CohortRankDisposition(StrEnum):
+    """How the adapter treats an authorized candidate."""
+
+    INCLUDED = "included"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCohortSignal:
+    """One service-owned signal retained for a cohort member.
+
+    ``observed_states`` and ``data_semantics`` are copied from the canonical
+    source rather than normalized into a single boolean. ``coverage`` and
+    denominator/attribution flags stay separate for the same reason: a stale
+    measurement, a partial denominator and an inapplicable rule are different
+    facts, even when all three prevent a current ranking claim.
+    """
+
+    signal_id: str
+    source: str
+    observed_states: tuple[SourceRequirementState, ...]
+    data_semantics: str
+    freshness: FreshnessState | None = None
+    coverage: float | None = None
+    denominator_present: bool | None = None
+    attribution_present: bool | None = None
+    dimension: HealthDimension | None = None
+    state: DimensionState | None = None
+    evidence_ref_ids: tuple[str, ...] = ()
+    evidence_source_classes: tuple[SourceClass, ...] = ()
+    limitation: str | None = None
+    gap: EnrichmentGap | None = None
+
+    @property
+    def is_current(self) -> bool:
+        """Whether this signal can support a current, qualified comparison."""
+
+        return (
+            bool(self.observed_states)
+            and all(
+                state is SourceRequirementState.AVAILABLE_CURRENT
+                for state in self.observed_states
+            )
+            and (self.coverage is None or self.coverage >= 1.0)
+            and self.denominator_present is not False
+            and self.attribution_present is not False
+        )
+
+    @property
+    def has_usable_value(self) -> bool:
+        """Whether the signal is measured, rather than only disclosed."""
+
+        return bool(
+            self.observed_states
+            and all(
+                state
+                in {
+                    SourceRequirementState.AVAILABLE_CURRENT,
+                    SourceRequirementState.AVAILABLE_STALE,
+                    SourceRequirementState.AVAILABLE_UNKNOWN,
+                }
+                for state in self.observed_states
+            )
+            and self.data_semantics in {"measured_zero", "no_data"}
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CohortRankedMember:
+    """An authorized candidate with its uncollapsed canonical disclosures."""
+
+    candidate: CohortCandidate
+    signals: tuple[CanonicalCohortSignal, ...]
+    disposition: CohortRankDisposition
+    pressure_dimensions: tuple[HealthDimension, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CohortRankingResult:
+    """The internal ranked cohort plus safe exclusions and authorization count."""
+
+    ranked_members: tuple[CohortRankedMember, ...]
+    exclusions: tuple[CohortExclusionRecord, ...]
+    authorization_filtered_count: int
+
+
+_ENTITY_SCOPE: Mapping[GraphEntityKind, tuple[DirectScope, EntityType]] = {
+    GraphEntityKind.PROJECT: (DirectScope.PROJECT, EntityType.PROJECT),
+    GraphEntityKind.TEAM: (DirectScope.TEAM, EntityType.TEAM),
+}
+
+_PRESSURE_STATES: frozenset[DimensionState] = frozenset(
+    {
+        DimensionState.WATCH,
+        DimensionState.AT_RISK,
+        DimensionState.CRITICAL,
+    }
+)
+
+# This is an ordering of independent dimensions, not a scoring formula. A
+# dimension may be added only by an explicit contract change, and ties still
+# resolve by canonical id. No value is summed or weighted.
+_DIMENSION_ORDER: tuple[HealthDimension, ...] = tuple(HealthDimension)
+_DIMENSION_ORDINAL = {
+    dimension: index for index, dimension in enumerate(_DIMENSION_ORDER)
+}
+_SEVERITY_ORDINAL = {
+    DimensionState.CRITICAL: 3,
+    DimensionState.AT_RISK: 2,
+    DimensionState.WATCH: 1,
+}
+
+
+def _gap_state(gap: EnrichmentGap) -> SourceRequirementState:
+    if gap is EnrichmentGap.NOT_APPLICABLE:
+        return SourceRequirementState.NOT_APPLICABLE
+    if gap is EnrichmentGap.UNAUTHORIZED:
+        return SourceRequirementState.UNAUTHORIZED_OR_NOT_VISIBLE
+    if gap is EnrichmentGap.UNAVAILABLE:
+        return SourceRequirementState.UNAVAILABLE
+    # ``NO_DATA`` is a queried-but-empty canonical result, not an unavailable
+    # source. The adapter retains that distinction in ``gap`` while mapping
+    # it to the contract's queried unknown state for ordering.
+    return SourceRequirementState.AVAILABLE_UNKNOWN
+
+
+def _gap_signal(source: str, gap: EnrichmentGap) -> CanonicalCohortSignal:
+    return CanonicalCohortSignal(
+        signal_id=source,
+        source=source,
+        observed_states=(_gap_state(gap),),
+        data_semantics=(
+            "not_measured"
+            if _gap_state(gap)
+            in {
+                SourceRequirementState.UNAVAILABLE,
+                SourceRequirementState.UNAUTHORIZED_OR_NOT_VISIBLE,
+                SourceRequirementState.NOT_APPLICABLE,
+            }
+            else "no_data"
+        ),
+        limitation=f"canonical_{gap.value}",
+        gap=gap,
+    )
+
+
+def _states(
+    value: object, default: SourceRequirementState
+) -> tuple[SourceRequirementState, ...]:
+    raw = getattr(value, "observed_states", ())
+    if not raw:
+        return (default,)
+    return tuple(raw)
+
+
+def _observation_default_state(observation: object) -> DimensionState:
+    """Keep an observation's source state from becoming implicit health."""
+
+    observed_states = _states(observation, SourceRequirementState.AVAILABLE_UNKNOWN)
+    if all(state is SourceRequirementState.NOT_APPLICABLE for state in observed_states):
+        return DimensionState.NOT_APPLICABLE
+    if any(
+        state is not SourceRequirementState.AVAILABLE_CURRENT
+        for state in observed_states
+    ):
+        return DimensionState.UNKNOWN
+    coverage = getattr(observation, "coverage", None)
+    if (
+        (coverage is not None and coverage < 1.0)
+        or getattr(observation, "denominator_present", None) is False
+        or getattr(observation, "attribution_present", None) is False
+    ):
+        return DimensionState.UNKNOWN
+    return DimensionState.HEALTHY
+
+
+def _profile_signals(
+    source: str, profile: HealthProfileResult
+) -> tuple[CanonicalCohortSignal, ...]:
+    """Copy health/workload profile observations and findings without folding them."""
+
+    all_findings = tuple(
+        getattr(profile, name, ())
+        for name in ("launch_findings", "shadow_findings", "suppressed_findings")
+    )
+    findings = tuple(finding for bucket in all_findings for finding in bucket)
+    by_rule: Mapping[str, object] = getattr(profile, "observations_by_rule", {})
+    observations = tuple(sorted(by_rule.items(), key=lambda item: item[0]))
+    if not observations:
+        observations = tuple(
+            (
+                str(index),
+                observation,
+            )
+            for index, observation in enumerate(getattr(profile, "observations", ()))
+        )
+
+    output: list[CanonicalCohortSignal] = []
+    seen_rules: set[str] = set()
+    for rule_id, observation in observations:
+        rule = str(rule_id)
+        seen_rules.add(rule)
+        matching = tuple(item for item in findings if item.rule_id == rule)
+        if not matching:
+            output.append(
+                _observation_signal(
+                    source,
+                    rule,
+                    observation,
+                    dimension=None,
+                    state=_observation_default_state(observation),
+                    limitation=None,
+                )
+            )
+            continue
+        for finding in matching:
+            output.append(
+                _observation_signal(
+                    source,
+                    rule,
+                    observation,
+                    dimension=getattr(finding, "dimension", None),
+                    state=getattr(finding, "state", None),
+                    limitation=getattr(finding, "suppressed_reason", None),
+                    evidence_ref_ids=tuple(getattr(finding, "evidence_ref_ids", ())),
+                    evidence_source_classes=tuple(
+                        getattr(finding, "evidence_source_classes", ())
+                    ),
+                )
+            )
+
+    # A malformed/partially mocked canonical result must not cause a finding
+    # to disappear merely because its observation map was incomplete. Real
+    # profiles are closed by their own service contract; this branch is the
+    # adapter's defensive preservation boundary for an unavailable source or
+    # an additive future rule.
+    for finding in sorted(findings, key=lambda item: str(item.rule_id)):
+        rule = str(finding.rule_id)
+        if rule in seen_rules:
+            continue
+        output.append(
+            _finding_signal(
+                source,
+                rule,
+                finding,
+            )
+        )
+    return tuple(sorted(output, key=lambda item: item.signal_id))
+
+
+def _observation_signal(
+    source: str,
+    rule_id: str,
+    observation: object,
+    *,
+    dimension: HealthDimension | None,
+    state: DimensionState | None,
+    limitation: str | None,
+    evidence_ref_ids: tuple[str, ...] = (),
+    evidence_source_classes: tuple[SourceClass, ...] = (),
+) -> CanonicalCohortSignal:
+    observed_states = _states(observation, SourceRequirementState.AVAILABLE_UNKNOWN)
+    return CanonicalCohortSignal(
+        signal_id=f"{source}:{rule_id}",
+        source=source,
+        observed_states=observed_states,
+        data_semantics=str(getattr(observation, "data_semantics", "not_measured")),
+        coverage=getattr(observation, "coverage", None),
+        denominator_present=getattr(observation, "denominator_present", None),
+        attribution_present=getattr(observation, "attribution_present", None),
+        dimension=dimension,
+        state=state,
+        evidence_ref_ids=evidence_ref_ids,
+        evidence_source_classes=evidence_source_classes,
+        limitation=limitation,
+    )
+
+
+def _finding_signal(
+    source: str, rule_id: str, finding: object
+) -> CanonicalCohortSignal:
+    state = getattr(finding, "state", None)
+    return CanonicalCohortSignal(
+        signal_id=f"{source}:{rule_id}",
+        source=source,
+        observed_states=(SourceRequirementState.AVAILABLE_UNKNOWN,),
+        data_semantics="no_data",
+        dimension=getattr(finding, "dimension", None),
+        state=state,
+        evidence_ref_ids=tuple(getattr(finding, "evidence_ref_ids", ())),
+        evidence_source_classes=tuple(getattr(finding, "evidence_source_classes", ())),
+        limitation=getattr(finding, "suppressed_reason", None),
+    )
+
+
+def _deficiency_signals(
+    inventory: OperationalDeficiencyInventory,
+) -> tuple[CanonicalCohortSignal, ...]:
+    output: list[CanonicalCohortSignal] = []
+    findings_by_category: dict[object, list[DeficiencyFinding]] = {}
+    for finding in inventory.findings:
+        findings_by_category.setdefault(finding.category, []).append(finding)
+    for status in inventory.category_statuses:
+        findings = findings_by_category.get(status.category, [])
+        if not findings:
+            observed = status.applicability_states_observed or (
+                (SourceRequirementState.AVAILABLE_CURRENT,)
+                if status.evaluated
+                else (SourceRequirementState.AVAILABLE_UNKNOWN,)
+            )
+            output.append(
+                CanonicalCohortSignal(
+                    signal_id=f"readiness:{status.category.value}",
+                    source="readiness",
+                    observed_states=tuple(observed),
+                    data_semantics=("no_data" if status.evaluated else "not_measured"),
+                    state=(DimensionState.HEALTHY if status.evaluated else None),
+                    limitation=status.limitation,
+                )
+            )
+            continue
+        for finding in findings:
+            state = {
+                "critical": DimensionState.CRITICAL,
+                "at_risk": DimensionState.AT_RISK,
+                "watch": DimensionState.WATCH,
+            }.get(finding.severity.value)
+            output.append(
+                CanonicalCohortSignal(
+                    signal_id=f"readiness:{finding.rule_id}",
+                    source="readiness",
+                    observed_states=(finding.observed_state,),
+                    data_semantics=finding.data_semantics,
+                    coverage=finding.coverage,
+                    dimension=None,
+                    state=state,
+                    evidence_ref_ids=tuple(finding.evidence_ref_ids),
+                    limitation=(
+                        finding.limitations[0] if finding.limitations else None
+                    ),
+                )
+            )
+    return tuple(sorted(output, key=lambda item: item.signal_id))
+
+
+def _metric_signals(
+    metrics: Sequence[DevMetricRef],
+) -> tuple[CanonicalCohortSignal, ...]:
+    output: list[CanonicalCohortSignal] = []
+    freshness_to_state = {
+        FreshnessState.FRESH: SourceRequirementState.AVAILABLE_CURRENT,
+        FreshnessState.STALE: SourceRequirementState.AVAILABLE_STALE,
+        FreshnessState.UNKNOWN: SourceRequirementState.AVAILABLE_UNKNOWN,
+        FreshnessState.UNAVAILABLE: SourceRequirementState.UNAVAILABLE,
+    }
+    for metric in metrics:
+        freshness = getattr(metric, "freshness", FreshnessState.UNKNOWN)
+        value = getattr(metric, "value", None)
+        output.append(
+            CanonicalCohortSignal(
+                signal_id=f"metrics:{metric.metric_ref_id}",
+                source="metrics",
+                observed_states=(freshness_to_state[freshness],),
+                data_semantics=("measured_zero" if value is not None else "no_data"),
+                freshness=freshness,
+                coverage=getattr(metric, "coverage", None),
+                evidence_ref_ids=tuple(getattr(metric, "evidence_ref_ids", ())),
+            )
+        )
+    return tuple(sorted(output, key=lambda item: item.signal_id))
+
+
+def _enrichment_signals(
+    enrichment: CanonicalEnrichment,
+) -> tuple[CanonicalCohortSignal, ...]:
+    output: list[CanonicalCohortSignal] = []
+    for source_name, value in (
+        ("status", enrichment.status),
+        ("health", enrichment.health),
+        ("workload", enrichment.workload),
+        ("readiness", enrichment.readiness),
+    ):
+        if isinstance(value, EnrichmentGap):
+            output.append(_gap_signal(source_name, value))
+        elif source_name in {"health", "workload"}:
+            output.extend(
+                _profile_signals(source_name, cast(HealthProfileResult, value))
+            )
+        elif source_name == "readiness":
+            output.extend(
+                _deficiency_signals(cast(OperationalDeficiencyInventory, value))
+            )
+        else:
+            # StatusSnapshotResult has no DimensionObservation equivalent.
+            # Its own state and source freshness stay visible as one
+            # canonical signal; no status-derived scalar is invented here.
+            result_state = getattr(value, "state", None)
+            observed = {
+                "complete": SourceRequirementState.AVAILABLE_CURRENT,
+                "partial": SourceRequirementState.AVAILABLE_STALE,
+                "degraded": SourceRequirementState.AVAILABLE_UNKNOWN,
+                "insufficient_evidence": SourceRequirementState.AVAILABLE_UNKNOWN,
+            }.get(
+                str(getattr(result_state, "value", result_state)),
+                SourceRequirementState.AVAILABLE_UNKNOWN,
+            )
+            output.append(
+                CanonicalCohortSignal(
+                    signal_id="status:snapshot",
+                    source="status",
+                    observed_states=(observed,),
+                    data_semantics="no_data",
+                    limitation=(
+                        str(getattr(value, "state", "unknown"))
+                        if observed is not SourceRequirementState.AVAILABLE_CURRENT
+                        else None
+                    ),
+                )
+            )
+    output.extend(_metric_signals(enrichment.metrics))
+    if not output:
+        output.append(_gap_signal("canonical_enrichment", EnrichmentGap.NO_DATA))
+    return tuple(sorted(output, key=lambda item: item.signal_id))
+
+
+def _pressure_signals(
+    signals: Sequence[CanonicalCohortSignal],
+) -> tuple[CanonicalCohortSignal, ...]:
+    return tuple(
+        signal
+        for signal in signals
+        if signal.state in _PRESSURE_STATES
+        and signal.is_current
+        and signal.dimension is not None
+    )
+
+
+def _has_state_gap(signals: Sequence[CanonicalCohortSignal]) -> bool:
+    # A canonical service may disclose that one dimension is structurally
+    # inapplicable (for example, a status source for a project that has no
+    # status integration) alongside current observations from other sources.
+    # Preserve that disclosure on the member, but do not let it turn an
+    # otherwise current healthy/single-signal result into ``unknown``.  An
+    # all-inapplicable result remains unknown because there is no comparable
+    # observation at all.
+    applicable = tuple(
+        signal
+        for signal in signals
+        if signal.gap is not EnrichmentGap.NOT_APPLICABLE
+        and any(
+            state is not SourceRequirementState.NOT_APPLICABLE
+            for state in signal.observed_states
+        )
+    )
+    if not applicable:
+        return True
+    return any(
+        signal.gap is not None
+        or any(
+            state
+            in {
+                SourceRequirementState.AVAILABLE_STALE,
+                SourceRequirementState.AVAILABLE_UNKNOWN,
+                SourceRequirementState.UNCONFIGURED,
+                SourceRequirementState.UNAVAILABLE,
+                SourceRequirementState.UNAUTHORIZED_OR_NOT_VISIBLE,
+                SourceRequirementState.TRUNCATED,
+            }
+            for state in signal.observed_states
+        )
+        or signal.coverage is not None
+        and signal.coverage < 1.0
+        or signal.denominator_present is False
+        or signal.attribution_present is False
+        for signal in applicable
+    )
+
+
+def _critical_is_qualified(signal: CanonicalCohortSignal) -> bool:
+    return (
+        signal.state is DimensionState.CRITICAL
+        and signal.is_current
+        and bool(signal.evidence_ref_ids or signal.evidence_source_classes)
+    )
+
+
+def _classify(
+    candidate: CohortCandidate,
+    signals: tuple[CanonicalCohortSignal, ...],
+) -> tuple[CohortRankDisposition, tuple[HealthDimension, ...], str | None]:
+    pressure = _pressure_signals(signals)
+    dimensions = tuple(
+        sorted(
+            {signal.dimension for signal in pressure if signal.dimension is not None},
+            key=lambda item: _DIMENSION_ORDINAL[item],
+        )
+    )
+    if len(dimensions) >= 2 or any(
+        _critical_is_qualified(signal) for signal in pressure
+    ):
+        return CohortRankDisposition.INCLUDED, dimensions, None
+
+    if _has_state_gap(signals):
+        return CohortRankDisposition.UNKNOWN, dimensions, None
+
+    if pressure:
+        return (
+            CohortRankDisposition.UNKNOWN,
+            dimensions,
+            (
+                f"this {candidate.kind.value} has one canonical pressure signal, "
+                "which is a single signal and insufficient corroboration for "
+                "this cohort question"
+            ),
+        )
+
+    return (
+        CohortRankDisposition.UNKNOWN,
+        dimensions,
+        (
+            f"this {candidate.kind.value} has no canonical pressure signal; "
+            "the service observations are current and complete"
+        ),
+    )
+
+
+def _member_rank_key(
+    member: CohortRankedMember,
+) -> tuple[int, tuple[int, ...], str]:
+    """A deterministic vector order, not a composite score.
+
+    The first component keeps current qualified pressure ahead of unknown
+    members. The second is one slot per canonical dimension, so two members
+    with different dimensions are not collapsed into one invented number.
+    Canonical id is the final total-order tie-break.
+    """
+
+    current_pressure = _pressure_signals(member.signals)
+    state_class = 0 if current_pressure else 1
+    severity_by_dimension = {
+        signal.dimension: _SEVERITY_ORDINAL[signal.state]
+        for signal in current_pressure
+        if signal.dimension is not None and signal.state in _SEVERITY_ORDINAL
+    }
+    vector = tuple(
+        -severity_by_dimension.get(dimension, 0) for dimension in _DIMENSION_ORDER
+    )
+    return (state_class, vector, member.candidate.canonical_id)
+
+
+def _member_scope(base_scope: DevScope, candidate: CohortCandidate) -> DevScope | None:
+    resolved = _ENTITY_SCOPE.get(candidate.kind)
+    if resolved is None:
+        return None
+    direct_scope, entity_type = resolved
+    return DevScope(
+        schema_version=base_scope.schema_version,
+        organization_id=base_scope.organization_id,
+        direct_scope=direct_scope,
+        entity_refs=[
+            DevEntityRef(
+                entity_type=entity_type,
+                entity_id=candidate.canonical_id,
+                display_label=candidate.display_label,
+            )
+        ],
+        team_ids=([candidate.canonical_id] if direct_scope is DirectScope.TEAM else []),
+        time_range=base_scope.time_range,
+        comparison_range=base_scope.comparison_range,
+    )
+
+
+class CanonicalCohortRankingAdapter:
+    """Evaluate and deterministically order one authorized cohort.
+
+    The adapter deliberately evaluates members sequentially: the canonical
+    services share production database clients, and a ranking result must not
+    turn a per-member source failure into a whole-cohort failure. A service
+    exception becomes one disclosed unavailable signal for that member.
+    """
+
+    def __init__(self, source: _CanonicalEnrichmentSource) -> None:
+        self._source = source
+
+    async def rank(
+        self,
+        *,
+        proposal: CohortProposal,
+        authorized_entity_ids: Sequence[str] | frozenset[str],
+        scope: DevScope,
+        permission_fingerprint: str,
+        now: datetime | None = None,
+    ) -> CohortRankingResult:
+        authorized = frozenset(authorized_entity_ids)
+        observed_at = now or datetime.now(UTC)
+        if observed_at.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+
+        ranked: list[CohortRankedMember] = []
+        exclusions: list[CohortExclusionRecord] = []
+        filtered = proposal.authorization_filtered_count
+        for candidate in sorted(proposal.members, key=lambda item: item.canonical_id):
+            if candidate.canonical_id not in authorized:
+                # An unauthorized id is counted but never re-emitted as a
+                # member or an exclusion. Naming a withheld candidate in a
+                # rationale would disclose the same entity the filter hides.
+                filtered += 1
+                continue
+
+            member_scope = _member_scope(scope, candidate)
+            if member_scope is None:
+                signals: tuple[CanonicalCohortSignal, ...] = (
+                    _gap_signal("canonical_enrichment", EnrichmentGap.NOT_APPLICABLE),
+                )
+            else:
+                try:
+                    enrichment = await self._source.enrich(
+                        org_id=scope.organization_id,
+                        permission_fingerprint=permission_fingerprint,
+                        scope=member_scope,
+                        now=observed_at,
+                    )
+                    signals = _enrichment_signals(enrichment)
+                except Exception:
+                    signals = (
+                        _gap_signal("canonical_enrichment", EnrichmentGap.UNAVAILABLE),
+                    )
+
+            disposition, dimensions, exclusion_rationale = _classify(candidate, signals)
+            member = CohortRankedMember(
+                candidate=candidate,
+                signals=signals,
+                disposition=disposition,
+                pressure_dimensions=dimensions,
+            )
+            if exclusion_rationale is not None:
+                exclusions.append(
+                    CohortExclusionRecord(
+                        canonical_id=candidate.canonical_id,
+                        kind=candidate.kind,
+                        reason=CohortExclusionReason.EXCLUDED_BY_QUESTION,
+                        rationale=exclusion_rationale,
+                    )
+                )
+            else:
+                ranked.append(member)
+
+        return CohortRankingResult(
+            ranked_members=tuple(sorted(ranked, key=_member_rank_key)),
+            exclusions=tuple(sorted(exclusions, key=lambda item: item.canonical_id)),
+            authorization_filtered_count=filtered,
+        )

--- a/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/packet_builder.py
@@ -7,11 +7,14 @@ against the JSON Schema, because the manifest is explicit that
 ``schema_only_validation_is_sufficient`` is ``false`` and a schema-valid
 packet has had none of its cross-field rules checked.
 
-**What this revision does and does not claim.** PR1 of the arm performs
+**What this revision does and does not claim.** The seeded paths perform
 subject resolution over canonical ids, bounded authorized traversal, related
-entity and lineage-path discovery, and evidence indexing. It performs **no
-driver synthesis**. So :func:`build_packet` never emits a supported outcome:
-a packet with no asserted driver is, by the contract's own
+entity and lineage-path discovery, and evidence indexing; those callers pass
+no drivers. The subjectless production path additionally supplies bounded
+structural findings discovered independently for each cohort member. Those
+findings are still checked here for packet-local lineage/evidence closure,
+and canonical measurements remain candidate-only context. A packet with no
+asserted driver is, by the contract's own
 ``validate_supported_outcome_asserts_a_judgment``, a redirect rather than an
 answer, and claiming ``SUPPORTED`` for one would be precisely the
 "dashboard redirect without a direct judgment" fault mode. The outcome is
@@ -608,11 +611,13 @@ def derive_outcome(
     makes that rule mean what it appears to mean is
     :func:`_assert_support_is_closed`, which runs first and refuses any
     asserted driver whose support is not actually in this packet. This
-    revision synthesizes no drivers, so it reaches ``UNSUPPORTED`` every
-    time — but it reaches it by evaluating the rule, not by asserting the
-    answer. Written as a function precisely so both branches can be observed:
-    a constant here would make "the arm never over-claims" untestable, which
-    is the same thing as unproven.
+    An empty driver set reaches ``UNSUPPORTED`` — but it reaches it by
+    evaluating the rule, not by asserting the answer. A structural driver
+    with closed support can reach ``SUPPORTED`` (or ``SUPPORTED_WITH_GAPS``
+    when a disclosed bound bites), while candidate-only measurements cannot.
+    Written as a function precisely so both branches can be observed: a
+    constant here would make "the arm never over-claims" untestable, which is
+    the same thing as unproven.
 
     ``gaps`` is whether the run was degraded (stale, truncated or missing a
     required source). It only ever weakens a supported outcome; it can never
@@ -1944,14 +1949,24 @@ def _assemble_core(
             )
 
     # ---- limitations ---------------------------------------------------
+    if scope_enumerated and drivers:
+        interpretation_detail = (
+            "this production path performs subjectless cohort discovery, "
+            "authorized traversal and evidence indexing, then synthesizes "
+            "bounded structural driver candidates independently for each "
+            "cohort member; canonical measurements remain candidate-only "
+            "context"
+        )
+    else:
+        interpretation_detail = (
+            "this arm revision performs subject resolution, authorized "
+            "traversal and evidence indexing only; it synthesizes no "
+            "drivers, so it asserts no judgment about causes"
+        )
     limitations: list[PacketLimitation] = [
         PacketLimitation(
             kind=PacketLimitationKind.INTERPRETATION_UNCERTAINTY,
-            detail=(
-                "this arm revision performs subject resolution, authorized "
-                "traversal and evidence indexing only; it synthesizes no "
-                "drivers, so it asserts no judgment about causes"
-            ),
+            detail=interpretation_detail,
         )
     ]
     if missing:
@@ -2262,10 +2277,11 @@ def _assemble_core(
         organization_id=readout.org_id,
         produced_at=produced_at,
         # Derived, never passed in: an arm that could be told its own outcome
-        # could claim one it did not earn. This revision synthesizes no
-        # drivers, so the rule below always lands on UNSUPPORTED -- but it
-        # lands there by evaluating the contract's own standing rule against
-        # what was produced, which is what makes "the arm cannot over-claim"
+        # could claim one it did not earn. Seeded paths still supply no
+        # drivers; the subjectless production path supplies only the bounded
+        # structural findings it discovered per cohort member. In either
+        # case, the rule below evaluates the contract's own standing rule
+        # against what was produced, which makes "the arm cannot over-claim"
         # a checked property rather than a constant.
         outcome=derive_outcome(
             driver_analysis.candidates,

--- a/src/dev_health_ops/context_fabric/graph_arm/query_service.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/query_service.py
@@ -24,9 +24,9 @@ CHAOS-3679's persisted watermark.
 display-label match only — see that module's own docstring for why this is
 narrower than the trial's ``discovery.search_candidates``),
 :class:`~.readback.LiveGraphReader` traversal, and
-:func:`~.packet_builder.build_production_packet` with ``drivers=None`` (no
-driver synthesis — mirrors the trial's own PR1 scope, which never
-synthesized drivers either).
+:func:`~.packet_builder.build_production_packet` without driver synthesis on
+seeded paths. The subjectless production path additionally runs bounded
+structural synthesis once per cohort member; see the later increment note.
 
 **Increment 3 adds ``SEEDED_EXPLICIT_COHORT``** (CHAOS-3688), following the
 trial's own construction (``trials/chaos_3619/graph_leg.py``'s
@@ -57,9 +57,11 @@ _live_graph_snapshot` (CHAOS-3689's adapter PR) supplies the live
 AS-IS, unmodified — needs; the discovered cohort's own members (canonical-
 id order, the same non-ranking discipline as the trial) become the
 traversal seeds, never a single anchor subject, because there is none.
-Like ``SEEDED_EXPLICIT_COHORT``, this mode attributes no drivers — a scope-
-enumerated cohort has no subject for ``discover_drivers`` to explain, the
-same scope boundary the trial itself already drew and documented.
+Unlike ``SEEDED_EXPLICIT_COHORT``, this mode does not need a committed anchor
+subject: it runs the existing structural rules once for each scope-enumerated
+cohort member. Each finding keeps that member, its own lineage and its own
+edge-scoped evidence. Canonical measurements remain candidate-only context
+and cannot acquire asserted standing from this wiring.
 """
 
 from __future__ import annotations
@@ -67,6 +69,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Protocol, cast
@@ -91,6 +94,7 @@ from dev_health_ops.api.dev.investigation_contract import (
 
 from .cohort import build_cohort
 from .cohort_discovery import discover_cohort
+from .drivers import DriverFinding, discover_drivers
 from .flags import graph_read_enabled
 from .live_snapshot import _live_graph_snapshot
 from .packet_builder import (
@@ -98,7 +102,7 @@ from .packet_builder import (
     build_production_packet,
     signer_from_environment,
 )
-from .readback import GraphReader, LiveGraphReader
+from .readback import GraphReader, InvestigationReadout, LiveGraphReader
 from .store import GraphArmStore, StoreUnavailableError
 from .subject_resolution import (
     _live_cohort_edges,
@@ -144,6 +148,62 @@ _COHORT_DISCOVERY_QUESTION_FAMILY: dict[CohortDiscoveryFamily, QuestionFamilyID]
 #: partially -- and that is disclosed by the packet's own truncation
 #: machinery, not silently).
 _MAX_COHORT_SEEDS = 12
+
+# The packet contract caps driver candidates at fifty. Subjectless discovery
+# runs the same structural rules once per committed cohort member, so the
+# bound has to be applied after the per-member results are combined rather
+# than allowing one member to consume the whole packet by construction.
+_MAX_COHORT_DRIVER_CANDIDATES = 50
+
+
+def _subjectless_drivers(
+    readout: InvestigationReadout,
+    member_ids: tuple[str, ...],
+    *,
+    as_of: datetime,
+) -> tuple[tuple[DriverFinding, ...], bool]:
+    """Discover bounded, structural drivers for every cohort member.
+
+    A scope-enumerated cohort has no committed *anchor* subject, but each
+    member is still a subject of the comparison. Running the existing
+    ``discover_drivers`` rules once per member preserves their edge-scoped
+    evidence and status/currency guards; inventing one synthetic anchor would
+    make a driver's lineage and affected subject mean something the question
+    never supplied.
+
+    Results are ordered by canonical member id and driver id, never by
+    relevance or magnitude. ``discover_drivers`` returns excluded candidates
+    as well as asserted findings, and those are retained so evidence and
+    refusal reasons remain visible. A duplicate cause across members is
+    namespaced only when needed to satisfy the packet's unique-driver-id
+    invariant; its ``subject_id`` and affected subject remain the member that
+    produced it.
+    """
+
+    findings: list[DriverFinding] = []
+    seen_driver_ids: set[str] = set()
+    truncated = False
+    for member_id in sorted(set(member_ids)):
+        member_findings, member_truncated = discover_drivers(
+            readout, member_id, as_of=as_of
+        )
+        truncated = truncated or member_truncated
+        for finding in member_findings:
+            driver_id = finding.driver_id
+            if driver_id in seen_driver_ids:
+                driver_id = f"{driver_id}__{member_id}"
+                suffix = 2
+                while driver_id in seen_driver_ids:
+                    driver_id = f"{finding.driver_id}__{member_id}_{suffix}"
+                    suffix += 1
+                finding = replace(finding, driver_id=driver_id)
+            seen_driver_ids.add(driver_id)
+            findings.append(finding)
+
+    ordered = sorted(findings, key=lambda item: (item.subject_id, item.driver_id))
+    if len(ordered) > _MAX_COHORT_DRIVER_CANDIDATES:
+        truncated = True
+    return tuple(ordered[:_MAX_COHORT_DRIVER_CANDIDATES]), truncated
 
 
 class GraphMechanism(StrEnum):
@@ -631,10 +691,10 @@ class ProductionGraphInvestigationQuery:
         this arm does not own), become the traversal seeds, capped at
         :data:`_MAX_COHORT_SEEDS` -- a cohort larger than that is read
         partially, disclosed by the packet's own truncation machinery
-        rather than by an unbounded neighbourhood read. No drivers are
-        attributed, the same scope boundary ``SEEDED_EXPLICIT_COHORT``
-        already draws: a scope-enumerated cohort has no subject for
-        ``discover_drivers`` to explain.
+        rather than by an unbounded neighbourhood read. Each discovered
+        member is then passed through ``discover_drivers`` independently;
+        no synthetic anchor is introduced and no measurement candidate is
+        promoted by this wiring.
 
         An unsupported family (structurally unreachable given the closed
         table above, but not assumed to be), no comparable cohort
@@ -683,11 +743,29 @@ class ProductionGraphInvestigationQuery:
             seeds = sorted(
                 member.canonical_id for member in discovery.proposal.members
             )[:_MAX_COHORT_SEEDS]
+            omitted_seed_count = len(discovery.proposal.members) - len(seeds)
+            readback_cohort = replace(
+                discovery.proposal,
+                # ``discover_cohort``'s count covers peers it dropped before
+                # returning the proposal. The readback seed cap is a second,
+                # later bound over the members that proposal retained, so its
+                # omissions must be added rather than replacing the existing
+                # disclosure.
+                truncated=discovery.proposal.truncated or bool(omitted_seed_count),
+                truncated_count=(
+                    discovery.proposal.truncated_count + omitted_seed_count
+                ),
+            )
             reader = self._reader_factory(traversal_store)
             readout = await reader.neighbourhood(
                 org_id=request.org_id,
                 seed_canonical_ids=seeds,
                 authorized_entity_ids=tuple(request.authorized_entity_ids),
+            )
+            drivers, drivers_truncated = _subjectless_drivers(
+                readout,
+                tuple(seeds),
+                as_of=request.window_end,
             )
             packet = build_production_packet(
                 readout=readout,
@@ -700,7 +778,9 @@ class ProductionGraphInvestigationQuery:
                     window_start=request.window_start,
                     window_end=request.window_end,
                 ),
-                cohort=discovery.proposal,
+                cohort=readback_cohort,
+                drivers=drivers,
+                drivers_truncated=drivers_truncated,
                 watermark=watermark,
                 signer=self._signer_factory(),
                 produced_at=datetime.now(UTC),

--- a/tests/context_fabric/test_chaos_3667_canonical_cohort_ranking.py
+++ b/tests/context_fabric/test_chaos_3667_canonical_cohort_ranking.py
@@ -1,0 +1,481 @@
+"""CHAOS-3667 W4 slice 2: canonical-service-backed cohort ranking.
+
+These tests deliberately exercise the adapter below the packet assembler. A
+cohort is not a scalar score: canonical services return independent findings
+and their own source-state disclosures, so the adapter keeps those facts
+attached to each member while applying the qualification rule and a
+deterministic per-dimension ordering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from dev_health_ops.api.dev.canonical_enrichment import (
+    CanonicalEnrichment,
+    EnrichmentGap,
+)
+from dev_health_ops.api.dev.contracts import (
+    DevMetricRef,
+    DevScope,
+    DevTimeRange,
+    DirectScope,
+    FreshnessState,
+)
+from dev_health_ops.api.dev.contracts_v2.base import SourceRequirementState
+from dev_health_ops.api.dev.contracts_v2.deficiency import (
+    OperationalDeficiencyInventory,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import (
+    DimensionState,
+    HealthDimension,
+)
+from dev_health_ops.api.dev.health_profile_synthesis import HealthProfileResult
+from dev_health_ops.api.dev.investigation_contract import (
+    CohortExclusionReason,
+    CohortInclusionBasis,
+    ComparisonDimension,
+)
+from dev_health_ops.api.dev.status_change_service import StatusSnapshotResult
+from dev_health_ops.context_fabric.graph_arm.cohort import (
+    CohortCandidate,
+    CohortProposal,
+)
+from dev_health_ops.context_fabric.graph_arm.cohort_ranking import (
+    CanonicalCohortRankingAdapter,
+    CohortRankDisposition,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+_ORG_ID = "org_cohort_ranking_test"
+_PERMISSION = "permission-fingerprint"
+_NOW = datetime(2026, 8, 9, 12, tzinfo=UTC)
+
+
+def _scope() -> DevScope:
+    return DevScope(
+        schema_version="dev_scope.v1",
+        organization_id=_ORG_ID,
+        direct_scope=DirectScope.ORGANIZATION,
+        time_range=DevTimeRange(
+            start=_NOW - timedelta(days=14), end=_NOW, timezone="UTC"
+        ),
+        comparison_range=DevTimeRange(
+            start=_NOW - timedelta(days=28),
+            end=_NOW - timedelta(days=14),
+            timezone="UTC",
+        ),
+    )
+
+
+def _proposal(*member_ids: str, kind: GraphEntityKind = GraphEntityKind.PROJECT):
+    return CohortProposal(
+        subject_id="",
+        members=tuple(
+            CohortCandidate(
+                canonical_id=member_id,
+                kind=kind,
+                display_label=member_id,
+                basis_anchors=(
+                    (CohortInclusionBasis.SAME_PORTFOLIO, ("portfolio_a",)),
+                ),
+            )
+            for member_id in member_ids
+        ),
+        exclusions=(),
+        dimensions=(ComparisonDimension.CYCLE_TIME,),
+        truncated=False,
+        truncated_count=0,
+        authorization_filtered_count=0,
+    )
+
+
+def _observation(
+    rule_id: str,
+    *,
+    observed_state: SourceRequirementState = SourceRequirementState.AVAILABLE_CURRENT,
+    coverage: float = 1.0,
+    denominator_present: bool = True,
+    attribution_present: bool = True,
+    data_semantics: str = "measured_zero",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        observed_states=(observed_state,),
+        data_semantics=data_semantics,
+        coverage=coverage,
+        current_value=10.0,
+        denominator_present=denominator_present,
+        attribution_present=attribution_present,
+        rule_id=rule_id,
+    )
+
+
+def _finding(
+    rule_id: str,
+    dimension: HealthDimension,
+    state: DimensionState,
+    *,
+    suppressed_reason: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        rule_id=rule_id,
+        dimension=dimension,
+        state=state,
+        suppressed_reason=suppressed_reason,
+        evidence_ref_ids=(f"evidence:{rule_id}",),
+    )
+
+
+def _profile(
+    observations: tuple[SimpleNamespace, ...],
+    *,
+    launch_findings: tuple[SimpleNamespace, ...] = (),
+    shadow_findings: tuple[SimpleNamespace, ...] = (),
+    suppressed_findings: tuple[SimpleNamespace, ...] = (),
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        observations=observations,
+        observations_by_rule={
+            observation.rule_id: observation for observation in observations
+        },
+        launch_findings=launch_findings,
+        shadow_findings=shadow_findings,
+        suppressed_findings=suppressed_findings,
+    )
+
+
+def _enrichment(
+    *,
+    health: object,
+    workload: object = EnrichmentGap.NOT_APPLICABLE,
+    readiness: object = EnrichmentGap.NOT_APPLICABLE,
+    status: object = EnrichmentGap.NOT_APPLICABLE,
+    metrics: tuple[object, ...] = (),
+) -> CanonicalEnrichment:
+    return CanonicalEnrichment(
+        status=cast(StatusSnapshotResult | EnrichmentGap, status),
+        health=cast(HealthProfileResult | EnrichmentGap, health),
+        workload=cast(HealthProfileResult | EnrichmentGap, workload),
+        readiness=cast(OperationalDeficiencyInventory | EnrichmentGap, readiness),
+        metrics=cast(tuple[DevMetricRef, ...], metrics),
+    )
+
+
+@dataclass
+class _FakeEnrichment:
+    by_subject: dict[str, CanonicalEnrichment]
+    calls: list[str] = field(default_factory=list)
+
+    async def enrich(self, *, org_id, permission_fingerprint, scope, now=None):
+        assert org_id == _ORG_ID
+        assert permission_fingerprint == _PERMISSION
+        subject_id = scope.entity_refs[0].entity_id
+        self.calls.append(subject_id)
+        return self.by_subject[subject_id]
+
+
+def _adapter(source: _FakeEnrichment) -> CanonicalCohortRankingAdapter:
+    return CanonicalCohortRankingAdapter(source)
+
+
+@pytest.mark.asyncio
+async def test_healthy_and_single_noisy_members_are_excluded_but_unknown_is_kept() -> (
+    None
+):
+    healthy_a = _observation("healthy_a")
+    healthy_b = _observation("healthy_b")
+    noisy_observation = _observation("noisy_review")
+    noisy = _finding(
+        "noisy_review", HealthDimension.REVIEW_CI_PRESSURE, DimensionState.AT_RISK
+    )
+    pressure_a = _observation("pressure_review")
+    pressure_b = _observation("pressure_delivery")
+    pressure = (
+        _finding(
+            "pressure_review",
+            HealthDimension.REVIEW_CI_PRESSURE,
+            DimensionState.AT_RISK,
+        ),
+        _finding(
+            "pressure_delivery",
+            HealthDimension.DELIVERY_FLOW,
+            DimensionState.CRITICAL,
+        ),
+    )
+    source = _FakeEnrichment(
+        {
+            "project_healthy": _enrichment(health=_profile((healthy_a, healthy_b))),
+            "project_noisy": _enrichment(
+                health=_profile((noisy_observation,), shadow_findings=(noisy,))
+            ),
+            "project_pressure": _enrichment(
+                health=_profile((pressure_a, pressure_b), shadow_findings=pressure)
+            ),
+            "project_unknown": _enrichment(health=EnrichmentGap.UNAVAILABLE),
+        }
+    )
+
+    result = await _adapter(source).rank(
+        proposal=_proposal(
+            "project_unknown",
+            "project_noisy",
+            "project_healthy",
+            "project_pressure",
+        ),
+        authorized_entity_ids=frozenset(source.by_subject),
+        scope=_scope(),
+        permission_fingerprint=_PERMISSION,
+        now=_NOW,
+    )
+
+    assert source.calls == [
+        "project_healthy",
+        "project_noisy",
+        "project_pressure",
+        "project_unknown",
+    ]
+    assert [item.candidate.canonical_id for item in result.ranked_members] == [
+        "project_pressure",
+        "project_unknown",
+    ]
+    assert [item.disposition for item in result.ranked_members] == [
+        CohortRankDisposition.INCLUDED,
+        CohortRankDisposition.UNKNOWN,
+    ]
+    exclusions = {item.canonical_id: item for item in result.exclusions}
+    assert set(exclusions) == {"project_healthy", "project_noisy"}
+    assert (
+        exclusions["project_healthy"].reason
+        is CohortExclusionReason.EXCLUDED_BY_QUESTION
+    )
+    assert "no canonical pressure" in exclusions["project_healthy"].rationale
+    assert (
+        exclusions["project_noisy"].reason is CohortExclusionReason.EXCLUDED_BY_QUESTION
+    )
+    assert "single" in exclusions["project_noisy"].rationale
+
+
+@pytest.mark.asyncio
+async def test_stale_denominator_and_coverage_states_are_retained() -> None:
+    stale_observation = _observation(
+        "stale_capacity",
+        observed_state=SourceRequirementState.AVAILABLE_STALE,
+        coverage=0.4,
+        denominator_present=False,
+        data_semantics="no_data",
+    )
+    stale_finding = _finding(
+        "stale_capacity",
+        HealthDimension.COGNITIVE_WORKLOAD_PRESSURE,
+        DimensionState.AT_RISK,
+    )
+    stale_metric = SimpleNamespace(
+        metric_ref_id="metric:stale",
+        metric_id="avg_wip",
+        freshness=FreshnessState.STALE,
+        coverage=0.4,
+        value=12.0,
+        evidence_ref_ids=["metric-source:stale"],
+    )
+    source = _FakeEnrichment(
+        {
+            "project_stale": _enrichment(
+                health=_profile((stale_observation,), shadow_findings=(stale_finding,)),
+                metrics=(stale_metric,),
+            ),
+            "project_not_applicable": _enrichment(
+                health=EnrichmentGap.NOT_APPLICABLE,
+                workload=EnrichmentGap.NOT_APPLICABLE,
+                readiness=EnrichmentGap.NOT_APPLICABLE,
+                status=EnrichmentGap.NOT_APPLICABLE,
+            ),
+        }
+    )
+
+    result = await _adapter(source).rank(
+        proposal=_proposal("project_stale", "project_not_applicable"),
+        authorized_entity_ids=frozenset(source.by_subject),
+        scope=_scope(),
+        permission_fingerprint=_PERMISSION,
+        now=_NOW,
+    )
+
+    stale = next(
+        item
+        for item in result.ranked_members
+        if item.candidate.canonical_id == "project_stale"
+    )
+    stale_signal = next(
+        item for item in stale.signals if item.signal_id == "health:stale_capacity"
+    )
+    assert stale_signal.observed_states == (SourceRequirementState.AVAILABLE_STALE,)
+    assert stale_signal.coverage == 0.4
+    assert stale_signal.denominator_present is False
+    assert stale_signal.data_semantics == "no_data"
+    assert stale_signal.state is DimensionState.AT_RISK
+    metric_signal = next(item for item in stale.signals if item.source == "metrics")
+    assert metric_signal.freshness is FreshnessState.STALE
+    assert metric_signal.coverage == 0.4
+
+    not_applicable = next(
+        item
+        for item in result.ranked_members
+        if item.candidate.canonical_id == "project_not_applicable"
+    )
+    assert not_applicable.disposition is CohortRankDisposition.UNKNOWN
+    assert {signal.observed_states[0] for signal in not_applicable.signals} == {
+        SourceRequirementState.NOT_APPLICABLE
+    }
+
+
+@pytest.mark.asyncio
+async def test_unknown_observation_is_not_collapsed_to_healthy() -> None:
+    unknown = _observation(
+        "unknown_capacity",
+        observed_state=SourceRequirementState.AVAILABLE_UNKNOWN,
+        data_semantics="no_data",
+    )
+    source = _FakeEnrichment(
+        {"project_unknown_observation": _enrichment(health=_profile((unknown,)))}
+    )
+
+    result = await _adapter(source).rank(
+        proposal=_proposal("project_unknown_observation"),
+        authorized_entity_ids=frozenset(source.by_subject),
+        scope=_scope(),
+        permission_fingerprint=_PERMISSION,
+        now=_NOW,
+    )
+
+    member = result.ranked_members[0]
+    signal = next(
+        item for item in member.signals if item.signal_id.endswith("unknown_capacity")
+    )
+    assert member.disposition is CohortRankDisposition.UNKNOWN
+    assert signal.state is DimensionState.UNKNOWN
+    assert signal.observed_states == (SourceRequirementState.AVAILABLE_UNKNOWN,)
+
+
+@pytest.mark.asyncio
+async def test_ranking_is_deterministic_per_dimension_with_no_composite_score() -> None:
+    def pressured(subject: str) -> CanonicalEnrichment:
+        first = _observation(f"{subject}:review")
+        second = _observation(f"{subject}:delivery")
+        findings = (
+            _finding(
+                f"{subject}:review",
+                HealthDimension.REVIEW_CI_PRESSURE,
+                DimensionState.AT_RISK,
+            ),
+            _finding(
+                f"{subject}:delivery",
+                HealthDimension.DELIVERY_FLOW,
+                DimensionState.AT_RISK,
+            ),
+        )
+        return _enrichment(health=_profile((second, first), shadow_findings=findings))
+
+    source_a = _FakeEnrichment(
+        {subject: pressured(subject) for subject in ("project_b", "project_a")}
+    )
+    source_b = _FakeEnrichment(
+        {subject: pressured(subject) for subject in ("project_a", "project_b")}
+    )
+    proposal = _proposal("project_b", "project_a")
+
+    first = await _adapter(source_a).rank(
+        proposal=proposal,
+        authorized_entity_ids=frozenset(source_a.by_subject),
+        scope=_scope(),
+        permission_fingerprint=_PERMISSION,
+        now=_NOW,
+    )
+    second = await _adapter(source_b).rank(
+        proposal=proposal,
+        authorized_entity_ids=frozenset(source_b.by_subject),
+        scope=_scope(),
+        permission_fingerprint=_PERMISSION,
+        now=_NOW,
+    )
+
+    assert [item.candidate.canonical_id for item in first.ranked_members] == [
+        "project_a",
+        "project_b",
+    ]
+    assert [item.candidate.canonical_id for item in first.ranked_members] == [
+        item.candidate.canonical_id for item in second.ranked_members
+    ]
+    assert not hasattr(first.ranked_members[0], "score")
+    assert not hasattr(first.ranked_members[0], "composite_score")
+
+
+@pytest.mark.asyncio
+async def test_removing_one_pressure_dimension_flips_the_member_to_noisy_exclusion() -> (
+    None
+):
+    first = _observation("review")
+    second = _observation("delivery")
+    review = _finding(
+        "review", HealthDimension.REVIEW_CI_PRESSURE, DimensionState.AT_RISK
+    )
+    delivery = _finding(
+        "delivery", HealthDimension.DELIVERY_FLOW, DimensionState.AT_RISK
+    )
+
+    async def rank_with(findings: tuple[SimpleNamespace, ...]):
+        source = _FakeEnrichment(
+            {
+                "project_mutation": _enrichment(
+                    health=_profile((first, second), shadow_findings=findings)
+                )
+            }
+        )
+        return await _adapter(source).rank(
+            proposal=_proposal("project_mutation"),
+            authorized_entity_ids=frozenset(source.by_subject),
+            scope=_scope(),
+            permission_fingerprint=_PERMISSION,
+            now=_NOW,
+        )
+
+    included = await rank_with((review, delivery))
+    noisy = await rank_with((review,))
+    assert [item.candidate.canonical_id for item in included.ranked_members] == [
+        "project_mutation"
+    ]
+    assert not included.exclusions
+    assert not noisy.ranked_members
+    assert noisy.exclusions[0].reason is CohortExclusionReason.EXCLUDED_BY_QUESTION
+    assert "single" in noisy.exclusions[0].rationale
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_cohort_member_is_not_called_or_named() -> None:
+    visible = _profile((_observation("visible_a"), _observation("visible_b")))
+    hidden = _profile((_observation("hidden_a"), _observation("hidden_b")))
+    source = _FakeEnrichment(
+        {
+            "project_visible": _enrichment(health=visible),
+            "project_hidden": _enrichment(health=hidden),
+        }
+    )
+
+    result = await _adapter(source).rank(
+        proposal=_proposal("project_hidden", "project_visible"),
+        authorized_entity_ids=frozenset({"project_visible"}),
+        scope=_scope(),
+        permission_fingerprint=_PERMISSION,
+        now=_NOW,
+    )
+
+    assert source.calls == ["project_visible"]
+    assert result.authorization_filtered_count == 1
+    disclosed_ids = {item.candidate.canonical_id for item in result.ranked_members} | {
+        item.canonical_id for item in result.exclusions
+    }
+    assert "project_hidden" not in disclosed_ids

--- a/tests/context_fabric/test_chaos_3689_query_service.py
+++ b/tests/context_fabric/test_chaos_3689_query_service.py
@@ -25,7 +25,7 @@ Two halves:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -42,8 +42,19 @@ from dev_health_ops.api.dev.graph_investigation_query import (
     GraphQueryOutcome,
 )
 from dev_health_ops.api.dev.investigation_contract import (
+    AssertionBasis,
+    CohortCompleteness,
     CohortInclusionBasis,
     ComparisonDimension,
+    ConfidenceQualifier,
+    DriverCategory,
+    DriverExclusionReason,
+    DriverRole,
+    DriverStanding,
+    InvestigationOutcome,
+    PacketLimitationKind,
+    RelationshipDirection,
+    RelationshipType,
 )
 from dev_health_ops.context_fabric.graph_arm import (
     query_service as query_service_module,
@@ -57,13 +68,27 @@ from dev_health_ops.context_fabric.graph_arm.cohort_discovery import (
     FAMILY_CANDIDATE_KINDS,
     CohortDiscovery,
 )
+from dev_health_ops.context_fabric.graph_arm.drivers import (
+    DriverFinding,
+    StandingMechanism,
+)
 from dev_health_ops.context_fabric.graph_arm.query_service import (
     _COHORT_DISCOVERY_QUESTION_FAMILY,
     _MAX_COHORT_SEEDS,
     ProductionGraphInvestigationQuery,
+    _subjectless_drivers,
 )
-from dev_health_ops.context_fabric.graph_arm.readback import InvestigationReadout
-from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+from dev_health_ops.context_fabric.graph_arm.readback import (
+    DiscoveredEntity,
+    DiscoveredObservation,
+    DiscoveredPath,
+    InvestigationReadout,
+    PathStep,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import (
+    GraphEntityKind,
+    GraphObservationKind,
+)
 from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
 
 _TEST_SIGNING_SECRET = "chaos-3689-query-service-test-signing-secret-not-real"
@@ -236,6 +261,98 @@ def _empty_readout() -> InvestigationReadout:
     )
 
 
+def _capped_readout(members: tuple[str, ...]) -> InvestigationReadout:
+    """A bounded readout with one real driver on the first seeded member.
+
+    The proposal may contain more members than the reader seeds. The reader
+    therefore returns the seeded project entities plus the blocker they reach,
+    while the authorization envelope still names the complete proposal.
+    """
+
+    observed_at = datetime(2026, 8, 8, tzinfo=UTC)
+    seeds = tuple(sorted(members)[:_MAX_COHORT_SEEDS])
+    blocker_id = "wu_blocker"
+    entities = tuple(
+        DiscoveredEntity(
+            canonical_id=member_id,
+            kind=GraphEntityKind.PROJECT,
+            display_label=member_id,
+            source_class=SourceClass.WORK_GRAPH,
+            observed_at=observed_at,
+        )
+        for member_id in seeds
+    ) + (
+        DiscoveredEntity(
+            canonical_id=blocker_id,
+            kind=GraphEntityKind.WORK_UNIT,
+            display_label="Open blocker",
+            source_class=SourceClass.WORK_GRAPH,
+            observed_at=observed_at,
+        ),
+    )
+    observation_id = "obs_blocker"
+    path = DiscoveredPath(
+        path_id="p0001",
+        origin_canonical_id=seeds[0],
+        terminal_canonical_id=blocker_id,
+        steps=(
+            PathStep(
+                from_canonical_id=seeds[0],
+                from_kind=GraphEntityKind.PROJECT,
+                relationship=RelationshipType.BLOCKED_BY,
+                direction=RelationshipDirection.FORWARD,
+                to_canonical_id=blocker_id,
+                to_kind=GraphEntityKind.WORK_UNIT,
+                source_class=SourceClass.WORK_GRAPH,
+                observed_at=observed_at,
+                observation_ids=(observation_id,),
+            ),
+        ),
+    )
+    observation = DiscoveredObservation(
+        canonical_id=observation_id,
+        kind=GraphObservationKind.CI_RUN,
+        title="Canonical CI blocker record",
+        source_class=SourceClass.WORK_GRAPH,
+        observed_at=observed_at,
+        subject_canonical_ids=(seeds[0], blocker_id),
+        attributes={"corpus_trust": "canonical"},
+    )
+    return InvestigationReadout(
+        org_id="org_query_service_test",
+        partition="cf_query_service_test",
+        seed_canonical_ids=seeds,
+        entities=entities,
+        paths=(path,),
+        observations=(observation,),
+        authorized_entity_ids=tuple(sorted((*members, blocker_id))),
+    )
+
+
+def _excluded_finding(driver_id: str, subject_id: str) -> DriverFinding:
+    """A candidate with no support, for exercising the aggregation bound.
+
+    Excluded candidates are still part of the packet's truthful accounting,
+    but they do not require a fabricated path/evidence fixture merely to test
+    ordering, duplicate-id handling or truncation disclosure.
+    """
+
+    return DriverFinding(
+        driver_id=driver_id,
+        subject_id=subject_id,
+        cause_id=f"cause_{driver_id}",
+        category=DriverCategory.EXTERNAL_BLOCKER,
+        role=DriverRole.DRIVER,
+        standing=DriverStanding.EXCLUDED,
+        mechanism=StandingMechanism.STRUCTURAL,
+        summary_subject=f"cause_{driver_id}",
+        summary_detail="was considered but lacked canonical support",
+        exclusion_reason=DriverExclusionReason.EVIDENCE_CONFLICT_UNRESOLVED,
+        assertion_basis=AssertionBasis.SOURCE_ASSERTED,
+        confidence_qualifier=ConfidenceQualifier.QUALIFIED,
+    )
+
+
 class TestSubjectlessCohortDiscoveryRefuses:
     """The real (unmocked) path: an empty live snapshot -> an empty,
     incomparable discovery -> PROVIDER_FAILURE naming the mechanism.
@@ -345,7 +462,75 @@ class TestSubjectlessCohortDiscoveryCompletes:
             org_id="org_query_service_test",
             partition="cf_query_service_test",
             seed_canonical_ids=("proj_a", "proj_b"),
-            authorized_entity_ids=("proj_a", "proj_b", "team_x"),
+            authorized_entity_ids=("proj_a", "proj_b", "team_x", "wu_blocker"),
+            entities=(
+                DiscoveredEntity(
+                    canonical_id="proj_a",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Project A",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime(2026, 5, 1, tzinfo=UTC),
+                ),
+                DiscoveredEntity(
+                    canonical_id="proj_b",
+                    kind=GraphEntityKind.PROJECT,
+                    display_label="Project B",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime(2026, 5, 1, tzinfo=UTC),
+                ),
+                DiscoveredEntity(
+                    canonical_id="wu_blocker",
+                    kind=GraphEntityKind.WORK_UNIT,
+                    display_label="Open blocker",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime(2026, 5, 1, tzinfo=UTC),
+                ),
+            ),
+            paths=(
+                DiscoveredPath(
+                    path_id="p0001",
+                    origin_canonical_id="proj_a",
+                    terminal_canonical_id="wu_blocker",
+                    steps=(
+                        PathStep(
+                            from_canonical_id="proj_a",
+                            from_kind=GraphEntityKind.PROJECT,
+                            relationship=RelationshipType.BLOCKED_BY,
+                            direction=RelationshipDirection.FORWARD,
+                            to_canonical_id="wu_blocker",
+                            to_kind=GraphEntityKind.WORK_UNIT,
+                            source_class=SourceClass.WORK_GRAPH,
+                            observed_at=datetime(2026, 5, 1, tzinfo=UTC),
+                            observation_ids=("obs_blocker",),
+                        ),
+                    ),
+                ),
+            ),
+            observations=(
+                DiscoveredObservation(
+                    canonical_id="obs_blocker",
+                    kind=GraphObservationKind.CI_RUN,
+                    title="Canonical CI blocker record",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime(2026, 5, 1, tzinfo=UTC),
+                    subject_canonical_ids=("proj_a", "wu_blocker"),
+                    attributes={"corpus_trust": "canonical"},
+                ),
+                DiscoveredObservation(
+                    canonical_id="obs_measurement",
+                    kind=GraphObservationKind.MEASUREMENT,
+                    title="Canonical work in progress measurement",
+                    source_class=SourceClass.WORK_GRAPH,
+                    observed_at=datetime(2026, 5, 1, tzinfo=UTC),
+                    subject_canonical_ids=("proj_a",),
+                    attributes={
+                        "corpus_trust": "canonical",
+                        "measurement_metric": "work_in_progress",
+                        "measurement_value": "10",
+                        "measurement_cohort_median": "5",
+                    },
+                ),
+            ),
         )
         reader = _FakeReader(readout=readout)
         service = _service(driver=driver, reader=reader)
@@ -355,19 +540,46 @@ class TestSubjectlessCohortDiscoveryCompletes:
             query_service_module, "discover_cohort", lambda **_kwargs: discovery
         )
 
-        result = await service.investigate(_request())
+        result = await service.investigate(
+            _request(
+                authorized_entity_ids=frozenset(
+                    {"proj_a", "proj_b", "team_x", "wu_blocker"}
+                )
+            )
+        )
 
         assert result.outcome is GraphQueryOutcome.COMPLETED
         assert result.packet is not None
+        assert result.packet.outcome is InvestigationOutcome.SUPPORTED
         assert result.packet.comparison_cohort.comparison_shape.value == (
             "discovered_cohort"
         )
         assert sorted(
             member.canonical_id for member in result.packet.comparison_cohort.members
         ) == ["proj_a", "proj_b"]
-        # No drivers attributed -- the same scope boundary
-        # SEEDED_EXPLICIT_COHORT already draws (no subject to explain).
-        assert not result.packet.driver_analysis.candidates
+        # W4: scope enumeration still has no committed subject, but every
+        # cohort member can contribute its own structurally evidenced driver.
+        # ``proj_a`` is blocked by a current work unit with a canonical
+        # edge-level observation; its measurement is retained as context but
+        # may not become an asserted driver; ``proj_b`` has no such path.
+        assert [
+            candidate.driver_id
+            for candidate in result.packet.driver_analysis.candidates
+        ] == ["drv_block_wu_blocker", "drv_metric_obs_measurement"]
+        assert (
+            result.packet.driver_analysis.candidates[0].standing
+            is DriverStanding.PRINCIPAL_DRIVER
+        )
+        assert (
+            result.packet.driver_analysis.candidates[1].standing
+            is DriverStanding.CANDIDATE_ONLY
+        )
+        assert any(
+            limitation.kind is PacketLimitationKind.INTERPRETATION_UNCERTAINTY
+            and "canonical measurements remain candidate-only context"
+            in limitation.detail
+            for limitation in result.packet.evidence_coverage.limitations
+        )
         assert len(reader.calls) == 1
         assert sorted(reader.calls[0]["seed_canonical_ids"]) == ["proj_a", "proj_b"]
 
@@ -375,38 +587,143 @@ class TestSubjectlessCohortDiscoveryCompletes:
     async def test_seeds_are_capped_at_max_cohort_seeds_in_canonical_id_order(
         self, monkeypatch
     ) -> None:
-        """Never a strength/relevance ranking this arm does not own --
-        canonical-id order, capped, mirroring the trial's own
-        ``cohort_seeds_from`` exactly.
+        """The readback cap bounds both traversal and driver synthesis.
+
+        Never a strength/relevance ranking this arm does not own -- canonical-
+        id order, capped, mirroring the trial's own ``cohort_seeds_from``
+        exactly. The cap is a partial result, so a structurally supported
+        finding is weakened rather than presented as complete.
         """
 
         monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
         many_members = tuple(f"proj_{i:02d}" for i in range(_MAX_COHORT_SEEDS + 5))
         driver = _FakeDriver(entity_rows=[_entity_row(m, m) for m in many_members])
-        readout = InvestigationReadout(
-            org_id="org_query_service_test",
-            partition="cf_query_service_test",
-            seed_canonical_ids=many_members[:_MAX_COHORT_SEEDS],
-            authorized_entity_ids=many_members,
-        )
+        readout = _capped_readout(many_members)
         reader = _FakeReader(readout=readout)
         service = _service(driver=driver, reader=reader)
+
+        driver_calls: list[str] = []
+        real_discover_drivers = query_service_module.discover_drivers
+
+        def tracked_discover_drivers(readout, member_id, *, as_of):
+            driver_calls.append(member_id)
+            return real_discover_drivers(readout, member_id, as_of=as_of)
+
+        monkeypatch.setattr(
+            query_service_module, "discover_drivers", tracked_discover_drivers
+        )
 
         # Shuffle the discovery's own member order to prove the CAP+ORDER
         # comes from this wiring's own slicing, not from an
         # already-sorted discover_cohort output it happens to inherit.
         shuffled = tuple(reversed(many_members))
         discovery = _canned_discovery(members=shuffled)
+        discovery = replace(
+            discovery,
+            proposal=replace(
+                discovery.proposal,
+                truncated=True,
+                truncated_count=4,
+            ),
+        )
+        captured_cohorts: list[CohortProposal] = []
+        real_build_production_packet = query_service_module.build_production_packet
+
+        def capture_cohort(**kwargs):
+            captured_cohorts.append(kwargs["cohort"])
+            return real_build_production_packet(**kwargs)
+
+        monkeypatch.setattr(
+            query_service_module, "build_production_packet", capture_cohort
+        )
         monkeypatch.setattr(
             query_service_module, "discover_cohort", lambda **_kwargs: discovery
         )
 
         result = await service.investigate(
-            _request(authorized_entity_ids=frozenset(many_members))
+            _request(authorized_entity_ids=frozenset((*many_members, "wu_blocker")))
         )
 
         assert result.outcome is GraphQueryOutcome.COMPLETED
+        assert result.packet is not None
+        assert len(captured_cohorts) == 1
+        assert captured_cohorts[0].truncated_count == 4 + 5
+        assert result.packet.outcome is InvestigationOutcome.SUPPORTED_WITH_GAPS
+        assert (
+            result.packet.comparison_cohort.completeness is CohortCompleteness.TRUNCATED
+        )
+        assert result.packet.comparison_cohort.truncation_reason is not None
+        assert any(
+            limitation.kind is PacketLimitationKind.TRUNCATED_TRAVERSAL
+            for limitation in result.packet.evidence_coverage.limitations
+        )
         assert len(reader.calls) == 1
         seeds = reader.calls[0]["seed_canonical_ids"]
         assert len(seeds) == _MAX_COHORT_SEEDS
         assert seeds == sorted(many_members)[:_MAX_COHORT_SEEDS]
+        assert driver_calls == seeds
+        assert [
+            candidate.driver_id
+            for candidate in result.packet.driver_analysis.candidates
+            if candidate.standing
+            in {
+                DriverStanding.CONTRIBUTING_DRIVER,
+                DriverStanding.PRINCIPAL_DRIVER,
+            }
+        ] == ["drv_block_wu_blocker"]
+        assert all(
+            candidate.affected_subject_ids[0] in seeds
+            for candidate in result.packet.driver_analysis.candidates
+        )
+
+
+class TestSubjectlessDriverAggregation:
+    def test_each_member_is_discovered_in_canonical_order_without_ranking(
+        self, monkeypatch
+    ) -> None:
+        calls: list[str] = []
+
+        def fake_discover(readout, member_id, *, as_of):
+            del readout, as_of
+            calls.append(member_id)
+            return (_excluded_finding("drv_same", member_id),), False
+
+        monkeypatch.setattr(query_service_module, "discover_drivers", fake_discover)
+
+        findings, truncated = _subjectless_drivers(
+            _empty_readout(),
+            ("proj_b", "proj_a", "proj_b"),
+            as_of=datetime(2026, 8, 9, tzinfo=UTC),
+        )
+
+        assert calls == ["proj_a", "proj_b"]
+        assert not truncated
+        assert [(item.subject_id, item.driver_id) for item in findings] == [
+            ("proj_a", "drv_same"),
+            ("proj_b", "drv_same__proj_b"),
+        ]
+
+    def test_member_driver_bound_is_disclosed_as_truncation(self, monkeypatch) -> None:
+        def fake_discover(readout, member_id, *, as_of):
+            del readout, as_of
+            return (
+                tuple(
+                    _excluded_finding(f"drv_{index:02d}", member_id)
+                    for index in range(51)
+                ),
+                True,
+            )
+
+        monkeypatch.setattr(query_service_module, "discover_drivers", fake_discover)
+
+        findings, truncated = _subjectless_drivers(
+            _empty_readout(),
+            ("proj_a",),
+            as_of=datetime(2026, 8, 9, tzinfo=UTC),
+        )
+
+        assert len(findings) == 50
+        assert [item.driver_id for item in findings] == [
+            f"drv_{index:02d}" for index in range(50)
+        ]
+        assert truncated


### PR DESCRIPTION
## Summary

- cap the production subjectless cohort at 12 canonical-ID-ordered traversal seeds and disclose every omitted member
- run existing structural driver discovery independently for each seeded cohort member, retain closed evidence/lineage, and weaken supported results when bounds bite
- add an internal canonical-service-backed cohort ranking adapter that preserves unknown, stale, coverage, denominator, and attribution state without inventing a composite score
- exclude healthy and uncorroborated single-signal members with explicit question-specific rationale

Linear: CHAOS-3709, CHAOS-3689, CHAOS-3667

## Validation

- focused W4 tests: 15 passed
- full pre-commit and pre-push mypy: 2,361 source files, no issues
- Ruff check and formatting: green
- `git diff --check`: green

## Contract boundary

The ranking adapter is intentionally internal in this PR. Production answer construction has no approved projection for rank, canonical signal, freshness, denominator, coverage, and disposition state; silently mapping only member order would discard required semantics. Public answer integration remains part of CHAOS-3669 and the beta stays disabled.

SCREENSHOT-WAIVER: backend-only graph investigation and canonical ranking changes; no rendered Web surface changes.