### PR TITLE
CHAOS-3711: instrument graph investigation telemetry

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -444,8 +444,12 @@ services:
   # of it and this stack behaves exactly as it did before -- the same
   # arrangement the repo-root compose.yml uses for the `go` profile.
   #
-  #   docker compose --profile graph-trial up -d graph-trial-store
-  #   export CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389
+  #   export GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)"
+  #   docker compose --project-name "$GRAPH_TRIAL_PROJECT" --profile graph-trial up -d graph-trial-store
+  #   GRAPH_TRIAL_STORE_PORT="$(docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379 | awk -F: '{print $NF}')"
+  #   export CONTEXT_FABRIC_GRAPH_STORE_URI="falkor://127.0.0.1:$GRAPH_TRIAL_STORE_PORT"
+  #   # After the trial:
+  #   docker compose --project-name "$GRAPH_TRIAL_PROJECT" down --volumes --remove-orphans
   #
   # Why FalkorDB: of the backends graphiti-core 0.29.3 ships drivers for
   # (Neo4j, FalkorDB, FalkorDB-lite, Kuzu, Neptune, Neo4j+OpenSearch), Kuzu
@@ -456,21 +460,13 @@ services:
   # traversal that could miss a node. Full write-up:
   # docs/contribute/architecture/graph-investigation-arm.md
   #
-  # Port 6389, NOT 6379: valkey above already owns 6379, and a trial store
-  # that silently shared a port with the production cache would be exactly
-  # the "isolated datastore" requirement violated at the first hop.
-  #
-  # The port is a literal, not a shell interpolation, and deliberately so:
-  # tests/acceptance/test_ask_dev_compose.py::
-  # test_launcher_hardens_compose_interpolation_env_for_every_var_it_boots
-  # requires every interpolation in this file to be triaged into the
-  # acceptance launcher's unset/export/ASK_DEV_ buckets, because an
-  # ambient shell value
-  # (e.g. from a direnv-loaded .env) can otherwise silently reach the
-  # acceptance stack's interpolation. A trial-only store needs no ambient
-  # port configurability, so removing the interpolation removes the hazard
-  # rather than annotating around it. Need a different port on your machine?
-  # Use a compose override file.
+  # Both isolation axes are required for parallel local environments. The host
+  # port is OS-assigned (`127.0.0.1::6379`), and `--project-name` overrides this
+  # file's intentionally fixed top-level name for the trial container/network.
+  # Without the latter, two worktrees would still address one generated
+  # container even though its host port was random. The container remains on
+  # 6379 internally; use the project-scoped `docker compose ... port` command
+  # above before exporting the URI.
   #
   # No named volume on purpose. The trial store holds only derived, rebuildable
   # projection data and the issue requires deterministic cleanup; keeping it
@@ -482,13 +478,12 @@ services:
   # compose exec` session cannot phone home either.
   graph-trial-store:
     image: falkordb/falkordb:v4.14.4
-    container_name: dev-health-ops-graph-trial-store
     profiles: ["graph-trial"]
     restart: unless-stopped
     environment:
       GRAPHITI_TELEMETRY_ENABLED: "false"
     ports:
-      - "6389:6379"
+      - "127.0.0.1::6379"
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s

--- a/docs/contribute/architecture/ask-dev-graph-safety-proof.md
+++ b/docs/contribute/architecture/ask-dev-graph-safety-proof.md
@@ -232,7 +232,10 @@ Expect `GUARD PROOF PASSED: 15/15 guards observed failing`, about 2m35s.
 3627 lane found that `scripts/chaos_3617_guard_injection.py` needs
 
 ```bash
-export CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389
+export GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)"
+docker compose --project-name "$GRAPH_TRIAL_PROJECT" --profile graph-trial up -d graph-trial-store
+GRAPH_TRIAL_STORE_PORT="$(docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379 | awk -F: '{print $NF}')"
+export CONTEXT_FABRIC_GRAPH_STORE_URI="falkor://127.0.0.1:$GRAPH_TRIAL_STORE_PORT"
 export CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1
 ```
 
@@ -242,6 +245,12 @@ and reports a guard as proven that was never exercised. The 3620 harness has
 no live-store mutations and is unaffected, but the two are usually run
 together and a survived-by-skip result is exactly the unearned green both
 harnesses exist to prevent.
+
+After the live harness finishes, tear down the same isolated project:
+
+```bash
+docker compose --project-name "$GRAPH_TRIAL_PROJECT" down --volumes --remove-orphans
+```
 
 **Run it single-process, and never during the standing gate.** It edits files
 under `src/` and restores them; the unit tier runs under pytest-xdist with

--- a/docs/contribute/architecture/graph-investigation-arm.md
+++ b/docs/contribute/architecture/graph-investigation-arm.md
@@ -415,6 +415,27 @@ separate audit-log store, since the acceptance text's other reading
 ("who/when entered or left the graph") is already answered by the
 structured logs above.
 
+The W7 operational metrics are also content-safe and use only closed labels:
+`devhealth_context_fabric_graph_query_outcome_total{outcome}` and
+`devhealth_context_fabric_graph_query_duration_seconds{outcome}` cover the
+bounded query seam; `devhealth_context_fabric_graph_projection_writes_total{outcome}`
+covers projection success, refusal, failure and cancellation;
+`devhealth_context_fabric_graph_watermark_state_total{state}` and
+`devhealth_context_fabric_graph_watermark_lag_seconds` cover freshness;
+`devhealth_context_fabric_graph_purges_total{outcome,dry_run}` covers partition
+purges; `devhealth_context_fabric_graph_document_removal_outcome_total{outcome,reason}`
+covers removal/no-op/failure/cancellation; and
+`devhealth_context_fabric_graph_org_deletion_visits_total{outcome,dry_run}`
+covers every registered org-deletion visit, including unconfigured, unknown,
+failure, cancellation and close failure. None carries an organization,
+partition, document, question, title, body or prompt label.
+
+Known follow-up (not fixed in W7): `purge_org` drops the graph keyspace before
+deleting the separate raw watermark key. If the watermark delete fails after
+the graph drop, an orphan freshness key can remain; the deletion warning and
+visit outcome make that failure visible, but cleanup/reconciliation of orphan
+watermarks needs a separate change.
+
 ## Semantic and conversational subject resolution: a second leg
 
 Everything above resolves a subject by **stored text**:
@@ -484,10 +505,14 @@ change was legitimate rather than drift — read it before trusting any
 number quoted from that artifact. Reproduce with:
 
 ```
-CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389 \
+export GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)"
+docker compose --project-name "$GRAPH_TRIAL_PROJECT" --profile graph-trial up -d graph-trial-store
+GRAPH_TRIAL_STORE_PORT="$(docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379 | awk -F: '{print $NF}')"
+CONTEXT_FABRIC_GRAPH_STORE_URI="falkor://127.0.0.1:$GRAPH_TRIAL_STORE_PORT" \
 CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1 \
 CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED=1 \
 uv run python -m trials.chaos_3647.runner
+docker compose --project-name "$GRAPH_TRIAL_PROJECT" down --volumes --remove-orphans
 ```
 
 Two things worth knowing before reading that artifact:
@@ -530,6 +555,7 @@ Two things worth knowing before reading that artifact:
 | Content-safe logs | `IndexWatermark.detail_for` — timestamps and counts only |
 | Exact dependency/projection/query versions | `versions.*` on every packet; `backend.graphiti_version()` reads installed metadata |
 | Single-document, prompt removal | `store.GraphArmStore.remove_document` (issue 3632) — see [Embedded documents](#embedded-documents-issue-3632) |
+| Graph operational metrics | `metrics/prometheus.py`: `devhealth_context_fabric_graph_query_outcome_total{outcome}`, `devhealth_context_fabric_graph_query_duration_seconds{outcome}`, `devhealth_context_fabric_graph_projection_writes_total{outcome}`, `devhealth_context_fabric_graph_watermark_state_total{state}`, `devhealth_context_fabric_graph_watermark_lag_seconds`, `devhealth_context_fabric_graph_purges_total{outcome,dry_run}`, `devhealth_context_fabric_graph_document_removal_outcome_total{outcome,reason}`, `devhealth_context_fabric_graph_org_deletion_visits_total{outcome,dry_run}` |
 | Document indexing/removal metrics | `metrics/prometheus.py`: `devhealth_context_fabric_documents_indexed_total`, `devhealth_context_fabric_documents_removed_total{reason}` |
 | Document index audit query | `store.GraphArmStore.list_indexed_documents` — current-state listing, trust/evidence metadata included, title only |
 
@@ -614,27 +640,36 @@ deletion run.
 # Compose interpolates EVERY service before it filters by profile, so this
 # needs the repo's usual root .env present (e.g. BUGSINK_SECRET_KEY) even
 # though none of those services start.
-docker compose --profile graph-trial up -d graph-trial-store
+export GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)"
+docker compose --project-name "$GRAPH_TRIAL_PROJECT" --profile graph-trial up -d graph-trial-store
 
-export CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389
+GRAPH_TRIAL_STORE_PORT="$(docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379 | awk -F: '{print $NF}')"
+export CONTEXT_FABRIC_GRAPH_STORE_URI="falkor://127.0.0.1:$GRAPH_TRIAL_STORE_PORT"
 
 # Install the optional extra.
 uv sync --extra context-graph-trial
 ```
 
-Port 6389, not 6379: `valkey` already owns 6379, and a trial store sharing a
-port with the production cache would be the "isolated datastore" requirement
-violated at the first hop. There is no named volume — the store holds only
-derived, rebuildable projection data, so `down` genuinely removes it.
+The generated project name and host port are both isolated. The random
+`GRAPH_TRIAL_PROJECT` overrides `compose.yml`'s intentionally fixed top-level
+name for this one store; without it, two worktrees would still address the
+same generated container. The host port is OS-assigned and bound to loopback,
+while the container keeps 6379 internally. Use the same project name with
+`docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store
+6379` before exporting the URI. There is no named volume — the store holds
+only derived, rebuildable projection data, so project-scoped `down` genuinely
+removes it.
 
 ## Reproduction
 
 ### The full arm suite, with the live half required
 
 ```bash
-export CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389
+GRAPH_TRIAL_STORE_PORT="$(docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379 | awk -F: '{print $NF}')"
+export CONTEXT_FABRIC_GRAPH_STORE_URI="falkor://127.0.0.1:$GRAPH_TRIAL_STORE_PORT"
 export CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1     # required: see below
 uv run pytest tests/context_fabric -q -p no:randomly
+docker compose --project-name "$GRAPH_TRIAL_PROJECT" down --volumes --remove-orphans
 ```
 
 **Both variables are required, and the second is not optional polish.**

--- a/src/dev_health_ops/context_fabric/graph_arm/query_service.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/query_service.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -90,6 +91,10 @@ from dev_health_ops.api.dev.graph_investigation_query import (
 from dev_health_ops.api.dev.investigation_contract import (
     ComparisonShape,
     QuestionFamilyID,
+)
+from dev_health_ops.metrics.prometheus import (
+    record_context_fabric_graph_query,
+    record_context_fabric_graph_watermark,
 )
 
 from .cohort import build_cohort
@@ -351,6 +356,38 @@ class ProductionGraphInvestigationQuery:
         self._signer_factory = signer_factory
 
     async def investigate(self, request: GraphInvestigationRequest) -> GraphQueryResult:
+        """Record bounded query outcome/latency around the production seam."""
+
+        started = time.perf_counter()
+        try:
+            result = await self._investigate(request)
+        except asyncio.CancelledError:
+            result = GraphQueryResult(
+                outcome=GraphQueryOutcome.CANCELLED,
+                diagnostic=_diagnostic(
+                    "cancellation", "the calling task was cancelled"
+                ),
+            )
+            record_context_fabric_graph_query(
+                outcome=result.outcome.value,
+                duration_seconds=time.perf_counter() - started,
+            )
+            return result
+        except Exception:
+            record_context_fabric_graph_query(
+                outcome=GraphQueryOutcome.PROVIDER_FAILURE.value,
+                duration_seconds=time.perf_counter() - started,
+            )
+            raise
+        record_context_fabric_graph_query(
+            outcome=result.outcome.value,
+            duration_seconds=time.perf_counter() - started,
+        )
+        return result
+
+    async def _investigate(
+        self, request: GraphInvestigationRequest
+    ) -> GraphQueryResult:
         """Bounded by ``request.deadline`` end to end, never past it.
 
         Order of checks is deliberate, each one a distinct outcome the
@@ -431,6 +468,14 @@ class ProductionGraphInvestigationQuery:
 
             freshness = watermark.freshness_for(
                 now, tolerance=self._staleness_tolerance
+            )
+            record_context_fabric_graph_watermark(
+                state=freshness.value,
+                lag_seconds=(
+                    (now - watermark.indexed_through).total_seconds()
+                    if watermark.indexed_through is not None
+                    else 0.0
+                ),
             )
             if freshness is SourceRequirementState.UNAVAILABLE:
                 return GraphQueryResult(

--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -61,6 +61,10 @@ from typing import Any
 from dev_health_ops.metrics.prometheus import (
     record_context_fabric_document_removed,
     record_context_fabric_documents_indexed,
+    record_context_fabric_graph_document_removal,
+    record_context_fabric_graph_org_deletion_visit,
+    record_context_fabric_graph_projection,
+    record_context_fabric_graph_purge,
 )
 
 from .backend import (
@@ -431,6 +435,25 @@ class GraphArmStore:
     async def write_projection(
         self, projection: GraphProjection, *, budgets: TrialBudgets = DEFAULT_BUDGETS
     ) -> WriteResult:
+        """Write one projection and record its closed operational outcome."""
+
+        try:
+            result = await self._write_projection(projection, budgets=budgets)
+        except asyncio.CancelledError:
+            record_context_fabric_graph_projection("cancelled")
+            raise
+        except ProjectionDisabledError:
+            record_context_fabric_graph_projection("disabled")
+            raise
+        except Exception:
+            record_context_fabric_graph_projection("failed")
+            raise
+        record_context_fabric_graph_projection("completed")
+        return result
+
+    async def _write_projection(
+        self, projection: GraphProjection, *, budgets: TrialBudgets = DEFAULT_BUDGETS
+    ) -> WriteResult:
         """Write one projection. Structured only, no model call, no waiting.
 
         Three refusals before anything is written:
@@ -668,25 +691,35 @@ class GraphArmStore:
         metadata behind for an organization that no longer has any data.
         """
 
-        if not await self.partition_exists():
-            return 0
-        total = await self.count_nodes()
-        if dry_run:
+        try:
+            if not await self.partition_exists():
+                record_context_fabric_graph_purge(outcome="absent", dry_run=dry_run)
+                return 0
+            total = await self.count_nodes()
+            if dry_run:
+                record_context_fabric_graph_purge(outcome="dry_run", dry_run=True)
+                return total
+            # One keyspace per organization, so deletion is a drop: there is no
+            # partial state a failure could leave behind, and no node that a
+            # traversal-based delete could miss. A drop is a single fixed-cost
+            # operation regardless of partition size, so it belongs under the
+            # read bound, not the write one.
+            await self._bounded_read(
+                self._driver.client.select_graph(self._partition).delete(),
+                operation="purge_org",
+            )
+            await self._bounded_read(
+                self._driver.client.connection.delete(_watermark_key(self._partition)),
+                operation="purge_watermark",
+            )
+            record_context_fabric_graph_purge(outcome="completed", dry_run=False)
             return total
-        # One keyspace per organization, so deletion is a drop: there is no
-        # partial state a failure could leave behind, and no node that a
-        # traversal-based delete could miss. A drop is a single fixed-cost
-        # operation regardless of partition size, so it belongs under the
-        # read bound, not the write one.
-        await self._bounded_read(
-            self._driver.client.select_graph(self._partition).delete(),
-            operation="purge_org",
-        )
-        await self._bounded_read(
-            self._driver.client.connection.delete(_watermark_key(self._partition)),
-            operation="purge_watermark",
-        )
-        return total
+        except asyncio.CancelledError:
+            record_context_fabric_graph_purge(outcome="cancelled", dry_run=dry_run)
+            raise
+        except Exception:
+            record_context_fabric_graph_purge(outcome="failed", dry_run=dry_run)
+            raise
 
     async def remove_document(
         self, canonical_id: str, *, reason: DocumentRemovalReason
@@ -737,28 +770,36 @@ class GraphArmStore:
         uuid = observation_uuid(
             self._org_id, GraphObservationKind.DOCUMENT, canonical_id
         )
-        result = await self._bounded_write(
-            self._driver.execute_query(_DELETE_DOCUMENT_NODE_QUERY, uuid=uuid),
-            operation="remove_document",
-        )
-        records, _, _ = result
-        removed = bool(records) and int(records[0]["total"]) > 0
-        # canonical_id is an opaque internal identifier, logged the same way
-        # org_id is logged elsewhere in this module -- never the document's
-        # title or body, which is the content-safety line the acceptance
-        # text actually draws.
-        logger.info(
-            "context-fabric graph document %s %s in partition %s (reason=%s)",
-            canonical_id,
-            "removed" if removed else "not found; no-op",
-            self._partition,
-            reason.value,
-        )
-        # Telemetry only on an actual deletion -- a no-op (already absent,
-        # never approved) must not inflate a counter that is supposed to
-        # measure real index shrinkage.
+        reason_value = reason.value
+        outcome = "failed"
+        removed = False
+        try:
+            result = await self._bounded_write(
+                self._driver.execute_query(_DELETE_DOCUMENT_NODE_QUERY, uuid=uuid),
+                operation="remove_document",
+            )
+            records, _, _ = result
+            removed = bool(records) and int(records[0]["total"]) > 0
+            outcome = "removed" if removed else "not_found"
+            # canonical_id is an opaque internal identifier, logged the same
+            # way org_id is logged elsewhere in this module -- never the
+            # document's title or body.
+            logger.info(
+                "context-fabric graph document %s %s in partition %s (reason=%s)",
+                canonical_id,
+                "removed" if removed else "not found; no-op",
+                self._partition,
+                reason_value,
+            )
+        except asyncio.CancelledError:
+            outcome = "cancelled"
+            raise
+        finally:
+            record_context_fabric_graph_document_removal(
+                outcome=outcome, reason=reason_value
+            )
         if removed:
-            record_context_fabric_document_removed(reason.value)
+            record_context_fabric_document_removed(reason_value)
         return removed
 
     async def list_indexed_documents(self) -> tuple[IndexedDocumentSummary, ...]:
@@ -901,7 +942,13 @@ async def org_deletion_visit(org_id: str, dry_run: bool) -> int:
     unverified deletion is visible.
     """
 
-    config = trial_store_config()
+    try:
+        config = trial_store_config()
+    except Exception:
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="failed", dry_run=dry_run
+        )
+        raise
     if config is None:
         # NOT an "unknown". This is the production default -- the trial store
         # is opt-in per environment and is configured nowhere in production --
@@ -925,10 +972,21 @@ async def org_deletion_visit(org_id: str, dry_run: bool) -> int:
             org_id,
             TRIAL_STORE_URI_VAR,
         )
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="unconfigured", dry_run=dry_run
+        )
         return 0
     try:
         exists = await partition_exists_for(org_id, config)
+    except asyncio.CancelledError:
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="cancelled", dry_run=dry_run
+        )
+        raise
     except GraphitiUnavailableError as exc:
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="unknown", dry_run=dry_run
+        )
         raise DeletionCompletenessUnknownError(
             f"deletion completeness unknown for org {org_id}: the trial graph "
             "store is configured but graphiti-core is not installed, so its "
@@ -945,6 +1003,9 @@ async def org_deletion_visit(org_id: str, dry_run: bool) -> int:
         # infrastructure blip rather than as "this organization's derived data
         # was never checked". The docstring promises an unknown; the recorded
         # warning has to say so too.
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="unknown", dry_run=dry_run
+        )
         raise DeletionCompletenessUnknownError(
             f"deletion completeness unknown for org {org_id}: the trial graph "
             f"store at {config.host}:{config.port} is configured but could "
@@ -958,9 +1019,29 @@ async def org_deletion_visit(org_id: str, dry_run: bool) -> int:
         logger.info(
             "context-fabric graph trial store holds no partition for org %s", org_id
         )
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="absent", dry_run=dry_run
+        )
         return 0
-    store = GraphArmStore.for_org(org_id, config=config)
+    store: GraphArmStore | None = None
     try:
-        return await store.purge_org(dry_run=dry_run)
-    finally:
-        await store.close()
+        try:
+            store = GraphArmStore.for_org(org_id, config=config)
+            count = await store.purge_org(dry_run=dry_run)
+        finally:
+            if store is not None:
+                await store.close()
+    except asyncio.CancelledError:
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="cancelled", dry_run=dry_run
+        )
+        raise
+    except Exception:
+        record_context_fabric_graph_org_deletion_visit(
+            outcome="failed", dry_run=dry_run
+        )
+        raise
+    record_context_fabric_graph_org_deletion_visit(
+        outcome="dry_run" if dry_run else "purged", dry_run=dry_run
+    )
+    return count

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -5,7 +5,7 @@ Defines application-level counters, histograms, and gauges for:
   - ClickHouse query latency
   - LLM API calls (OpenAI / Anthropic)
   - GitHub API calls (requests by endpoint/status, rate limit remaining)
-  - Context Fabric graph arm: embedded-surface document indexing/removal
+  - Context Fabric graph arm: bounded query, projection and deletion telemetry
 
 Usage:
     from dev_health_ops.metrics.prometheus import (
@@ -39,6 +39,47 @@ except ImportError:
     _prometheus_client_module = None
 
 _PROMETHEUS_AVAILABLE = _prometheus_client_module is not None
+
+# These labels are deliberately duplicated from the graph arm's public
+# contracts rather than accepting arbitrary strings.  Metrics are an ordinary
+# operational output, so source-controlled content must never become a label.
+_CONTEXT_FABRIC_GRAPH_QUERY_OUTCOMES = frozenset(
+    {
+        "completed",
+        "disabled",
+        "unavailable",
+        "stale",
+        "deadline_exceeded",
+        "cancelled",
+        "provider_failure",
+    }
+)
+_CONTEXT_FABRIC_GRAPH_PROJECTION_OUTCOMES = frozenset(
+    {"completed", "disabled", "failed", "cancelled"}
+)
+_CONTEXT_FABRIC_GRAPH_WATERMARK_STATES = frozenset(
+    {"available_current", "available_stale", "unavailable"}
+)
+_CONTEXT_FABRIC_GRAPH_PURGE_OUTCOMES = frozenset(
+    {"completed", "dry_run", "absent", "failed", "cancelled"}
+)
+_CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOMES = frozenset(
+    {"removed", "not_found", "failed", "cancelled"}
+)
+_CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_REASONS = frozenset(
+    {"approval_revoked", "policy_forbidden", "cross_tenant"}
+)
+_CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISIT_OUTCOMES = frozenset(
+    {
+        "purged",
+        "dry_run",
+        "absent",
+        "unconfigured",
+        "failed",
+        "unknown",
+        "cancelled",
+    }
+)
 
 
 def _noop_counter(*args, **kwargs):
@@ -396,6 +437,65 @@ if _PROMETHEUS_AVAILABLE:
         ["reason"],
     )
 
+    CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_context_fabric_graph_query_outcome_total",
+        "Bounded graph investigation calls by closed transport outcome. "
+        "Labels contain only GraphQueryOutcome values.",
+        ["outcome"],
+    )
+
+    CONTEXT_FABRIC_GRAPH_QUERY_DURATION_SECONDS = _prometheus_client_module.Histogram(
+        "devhealth_context_fabric_graph_query_duration_seconds",
+        "Bounded graph investigation latency in seconds by closed transport outcome.",
+        ["outcome"],
+        buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+    )
+
+    CONTEXT_FABRIC_GRAPH_PROJECTION_WRITES_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_context_fabric_graph_projection_writes_total",
+        "Graph projection write attempts by closed result. A failed result "
+        "does not imply that a partial write occurred.",
+        ["outcome"],
+    )
+
+    CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_context_fabric_graph_watermark_state_total",
+        "Graph watermark observations by closed freshness state.",
+        ["state"],
+    )
+
+    CONTEXT_FABRIC_GRAPH_WATERMARK_LAG_SECONDS = _prometheus_client_module.Histogram(
+        "devhealth_context_fabric_graph_watermark_lag_seconds",
+        "Observed graph watermark lag in seconds when a watermark exists. "
+        "Never-projected partitions contribute only to the unavailable state "
+        "counter.",
+        buckets=(0.0, 1.0, 10.0, 60.0, 300.0, 900.0, 3600.0, 21600.0, 86400.0),
+    )
+
+    CONTEXT_FABRIC_GRAPH_PURGES_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_context_fabric_graph_purges_total",
+        "Graph partition purge attempts by result and dry-run mode. Labels "
+        "contain no organization or partition identifiers.",
+        ["outcome", "dry_run"],
+    )
+
+    CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOME_TOTAL = (
+        _prometheus_client_module.Counter(
+            "devhealth_context_fabric_graph_document_removal_outcome_total",
+            "Graph document removal attempts by closed result and removal "
+            "reason. Labels contain no document identifiers or source text.",
+            ["outcome", "reason"],
+        )
+    )
+
+    CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_context_fabric_graph_org_deletion_visits_total",
+        "Organization-deletion visits to the optional graph store by closed "
+        "result and dry-run mode. Unknown means the configured store could not "
+        "prove deletion completeness.",
+        ["outcome", "dry_run"],
+    )
+
     # ---------------------------------------------------------------------------
     # Integration credentials (issue 3694)
     # ---------------------------------------------------------------------------
@@ -444,6 +544,14 @@ else:
     ASK_DEV_RETENTION_SWEEP_LAST_SUCCESS_TIMESTAMP = _noop_gauge()
     CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL = _noop_counter()
     CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL = _noop_counter()
+    CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL = _noop_counter()
+    CONTEXT_FABRIC_GRAPH_QUERY_DURATION_SECONDS = _noop_histogram()
+    CONTEXT_FABRIC_GRAPH_PROJECTION_WRITES_TOTAL = _noop_counter()
+    CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL = _noop_counter()
+    CONTEXT_FABRIC_GRAPH_WATERMARK_LAG_SECONDS = _noop_histogram()
+    CONTEXT_FABRIC_GRAPH_PURGES_TOTAL = _noop_counter()
+    CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOME_TOTAL = _noop_counter()
+    CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL = _noop_counter()
     INTEGRATION_CREDENTIAL_DECRYPT_FAILED_TOTAL = _noop_counter()
 
 
@@ -579,6 +687,90 @@ def record_context_fabric_document_removed(reason: str) -> None:
     """
 
     CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL.labels(reason=reason).inc()
+
+
+def _require_closed_label(value: str, allowed: frozenset[str], name: str) -> str:
+    if value not in allowed:
+        raise ValueError(f"{name} is not a closed Context Fabric telemetry label")
+    return value
+
+
+def record_context_fabric_graph_query(*, outcome: str, duration_seconds: float) -> None:
+    """Record one bounded graph investigation call.
+
+    The caller supplies the transport contract's closed outcome value.  An
+    unexpected value is a programming error, not a new metric cardinality.
+    """
+
+    safe_outcome = _require_closed_label(
+        outcome, _CONTEXT_FABRIC_GRAPH_QUERY_OUTCOMES, "outcome"
+    )
+    CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(outcome=safe_outcome).inc()
+    CONTEXT_FABRIC_GRAPH_QUERY_DURATION_SECONDS.labels(outcome=safe_outcome).observe(
+        duration_seconds
+    )
+
+
+def record_context_fabric_graph_projection(outcome: str) -> None:
+    """Record one graph projection write result without payload labels."""
+
+    safe_outcome = _require_closed_label(
+        outcome, _CONTEXT_FABRIC_GRAPH_PROJECTION_OUTCOMES, "outcome"
+    )
+    CONTEXT_FABRIC_GRAPH_PROJECTION_WRITES_TOTAL.labels(outcome=safe_outcome).inc()
+
+
+def record_context_fabric_graph_watermark(*, state: str, lag_seconds: float) -> None:
+    """Record a watermark freshness observation and, when available, lag."""
+
+    safe_state = _require_closed_label(
+        state, _CONTEXT_FABRIC_GRAPH_WATERMARK_STATES, "state"
+    )
+    CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL.labels(state=safe_state).inc()
+    if safe_state != "unavailable":
+        CONTEXT_FABRIC_GRAPH_WATERMARK_LAG_SECONDS.observe(max(0.0, lag_seconds))
+
+
+def record_context_fabric_graph_purge(*, outcome: str, dry_run: bool) -> None:
+    """Record one graph partition purge attempt."""
+
+    safe_outcome = _require_closed_label(
+        outcome, _CONTEXT_FABRIC_GRAPH_PURGE_OUTCOMES, "outcome"
+    )
+    CONTEXT_FABRIC_GRAPH_PURGES_TOTAL.labels(
+        outcome=safe_outcome, dry_run=str(dry_run).lower()
+    ).inc()
+
+
+def record_context_fabric_graph_document_removal(*, outcome: str, reason: str) -> None:
+    """Record a document-removal result with closed outcome and reason labels."""
+
+    safe_outcome = _require_closed_label(
+        outcome, _CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOMES, "outcome"
+    )
+    safe_reason = _require_closed_label(
+        reason,
+        _CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_REASONS,
+        "reason",
+    )
+    CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOME_TOTAL.labels(
+        outcome=safe_outcome, reason=safe_reason
+    ).inc()
+
+
+def record_context_fabric_graph_org_deletion_visit(
+    *, outcome: str, dry_run: bool
+) -> None:
+    """Record an org-deletion visit without organization identifiers."""
+
+    safe_outcome = _require_closed_label(
+        outcome,
+        _CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISIT_OUTCOMES,
+        "outcome",
+    )
+    CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+        outcome=safe_outcome, dry_run=str(dry_run).lower()
+    ).inc()
 
 
 @contextmanager

--- a/tests/context_fabric/live_gate.py
+++ b/tests/context_fabric/live_gate.py
@@ -38,15 +38,16 @@ __all__ = [
     "require_live_store",
 ]
 
-_COMPOSE_HINT = (
-    "start it with `docker compose --profile graph-trial up -d "
-    f"graph-trial-store`, export {TRIAL_STORE_URI_VAR}=falkor://127.0.0.1:6389 "
-    f"AND set {REQUIRE_LIVE_FLAG}=1 -- the store URI is a conditional keep in "
-    "tests/_env_isolation.py whose lane sentinel is that flag, so the suite "
-    "scrubs the URI unless the live lane has announced itself. That is "
-    "deliberate: a URI that merely happened to be in your shell must never "
-    "turn into an unannounced live run"
-)
+_COMPOSE_HINT = f"""set `GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)"`,
+start it with `docker compose --project-name "$GRAPH_TRIAL_PROJECT" --profile graph-trial up -d graph-trial-store`,
+discover the OS-assigned port with `docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379`,
+then export {TRIAL_STORE_URI_VAR}=falkor://127.0.0.1:<port> AND set
+{REQUIRE_LIVE_FLAG}=1 -- the store URI is a conditional keep in
+tests/_env_isolation.py whose lane sentinel is that flag, so the suite scrubs
+the URI unless the live lane has announced itself. Tear the store down with
+`docker compose --project-name "$GRAPH_TRIAL_PROJECT" down --volumes --remove-orphans`
+afterward. That is deliberate: a URI that merely happened to be in your shell
+must never turn into an unannounced live run"""
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/context_fabric/test_chaos_3617_containment.py
+++ b/tests/context_fabric/test_chaos_3617_containment.py
@@ -36,6 +36,9 @@ from dev_health_ops.context_fabric.graph_arm.projection import (
     READBACK_ATTRIBUTE_KEYS,
 )
 from dev_health_ops.context_fabric.graph_arm.readback import READ_ONLY_QUERIES
+from dev_health_ops.metrics.prometheus import (
+    CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ARM_ROOT = _REPO_ROOT / "src" / "dev_health_ops" / "context_fabric"
@@ -458,10 +461,19 @@ class TestOrgDeletionRegistration:
         import logging
 
         monkeypatch.delenv("CONTEXT_FABRIC_GRAPH_STORE_URI", raising=False)
+        before = CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+            outcome="unconfigured", dry_run="false"
+        )._value.get()
         with caplog.at_level(logging.WARNING):
             assert await store_module.org_deletion_visit("org_alpha", False) == 0
         assert any("not configured" in record.message for record in caplog.records), (
             "the unchecked-absence residual must be logged, not silent"
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+                outcome="unconfigured", dry_run="false"
+            )._value.get()
+            == before + 1
         )
 
     @pytest.mark.asyncio
@@ -471,6 +483,9 @@ class TestOrgDeletionRegistration:
         """The data does not disappear because the library did."""
 
         monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_STORE_URI", "falkor://127.0.0.1:1")
+        before = CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+            outcome="unknown", dry_run="false"
+        )._value.get()
 
         async def _unavailable(*_args, **_kwargs):
             raise store_module.GraphitiUnavailableError("not installed")
@@ -478,6 +493,12 @@ class TestOrgDeletionRegistration:
         monkeypatch.setattr(store_module, "partition_exists_for", _unavailable)
         with pytest.raises(store_module.DeletionCompletenessUnknownError):
             await store_module.org_deletion_visit("org_alpha", False)
+        assert (
+            CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+                outcome="unknown", dry_run="false"
+            )._value.get()
+            == before + 1
+        )
 
     @pytest.mark.asyncio
     async def test_zero_is_returned_only_after_a_positive_absence_check(
@@ -491,6 +512,9 @@ class TestOrgDeletionRegistration:
         """
 
         monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_STORE_URI", "falkor://127.0.0.1:1")
+        before = CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+            outcome="absent", dry_run="false"
+        )._value.get()
         checked: list[str] = []
 
         async def _absent(org_id: str, _config: object) -> bool:
@@ -500,6 +524,12 @@ class TestOrgDeletionRegistration:
         monkeypatch.setattr(store_module, "partition_exists_for", _absent)
         assert await store_module.org_deletion_visit("org_alpha", False) == 0
         assert checked == ["org_alpha"], "zero was reported without checking"
+        assert (
+            CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+                outcome="absent", dry_run="false"
+            )._value.get()
+            == before + 1
+        )
 
     @pytest.mark.asyncio
     async def test_an_unreachable_configured_store_fails_visibly(

--- a/tests/context_fabric/test_chaos_3617_operational_controls.py
+++ b/tests/context_fabric/test_chaos_3617_operational_controls.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
+import yaml
 
 from dev_health_ops.api.dev.contracts_v2.base import SourceRequirementState
 from dev_health_ops.api.dev.investigation_contract import TruncationReason
@@ -32,6 +34,14 @@ from dev_health_ops.context_fabric.graph_arm.readback import ProjectionGraphRead
 from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
 
 _WINDOW_END = datetime(2026, 8, 8, tzinfo=UTC)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_UNIQUE_GRAPH_TRIAL_PROJECT = 'GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)"'
+_PROJECT_SCOPED_COMPOSE = 'docker compose --project-name "$GRAPH_TRIAL_PROJECT"'
+_PROJECT_SCOPED_LAUNCH = (
+    f"{_PROJECT_SCOPED_COMPOSE} --profile graph-trial up -d graph-trial-store"
+)
+_PROJECT_SCOPED_PORT = f"{_PROJECT_SCOPED_COMPOSE} port graph-trial-store 6379"
+_PROJECT_SCOPED_DOWN = f"{_PROJECT_SCOPED_COMPOSE} down --volumes --remove-orphans"
 
 
 class TestFlagsDefaultOff:
@@ -97,6 +107,50 @@ class TestTrialStoreConfiguration:
 
         with pytest.raises(ValueError, match="names no port"):
             TrialStoreConfig(uri="falkor://127.0.0.1").port
+
+    def test_active_trial_store_guidance_is_parallel_environment_safe(self) -> None:
+        """The host port and Compose project must both be isolated.
+
+        An OS-assigned port alone is insufficient: ``compose.yml`` has a fixed
+        top-level name, so two worktrees without ``--project-name`` would still
+        address the same generated container.
+        """
+
+        compose_path = _REPO_ROOT / "compose.yml"
+        compose = yaml.safe_load(compose_path.read_text())
+        assert compose["name"] == "dev-health-ops"
+        service = compose["services"]["graph-trial-store"]
+        assert "container_name" not in service
+        assert service["ports"] == ["127.0.0.1::6379"]
+        assert "6389:6379" not in compose_path.read_text()
+
+        active_guidance = (
+            compose_path,
+            _REPO_ROOT
+            / "docs"
+            / "contribute"
+            / "architecture"
+            / "graph-investigation-arm.md",
+            _REPO_ROOT
+            / "docs"
+            / "contribute"
+            / "architecture"
+            / "ask-dev-graph-safety-proof.md",
+            _REPO_ROOT / "tests" / "context_fabric" / "live_gate.py",
+            _REPO_ROOT / "trials" / "chaos_3619" / "sweep.py",
+            _REPO_ROOT / "trials" / "chaos_3647" / "runner.py",
+        )
+        for path in active_guidance:
+            guidance = path.read_text()
+            assert _UNIQUE_GRAPH_TRIAL_PROJECT in guidance, path
+            assert _PROJECT_SCOPED_COMPOSE in guidance, path
+            assert _PROJECT_SCOPED_LAUNCH in guidance, path
+            assert _PROJECT_SCOPED_PORT in guidance, path
+            assert _PROJECT_SCOPED_DOWN in guidance, path
+            assert "falkor://127.0.0.1:6389" not in guidance, path
+            assert "docker compose --profile graph-trial" not in guidance, path
+            assert "docker compose port graph-trial-store" not in guidance, path
+            assert "docker compose down" not in guidance, path
 
 
 class TestBudgets:

--- a/tests/context_fabric/test_chaos_3678_query_service.py
+++ b/tests/context_fabric/test_chaos_3678_query_service.py
@@ -71,6 +71,10 @@ from dev_health_ops.context_fabric.graph_arm.store import (
 )
 from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
 from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+from dev_health_ops.metrics.prometheus import (
+    CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL,
+    CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL,
+)
 from tests.context_fabric import live_gate
 
 #: A fixed reference instant for constructing WATERMARK values only -- always
@@ -240,10 +244,19 @@ class TestDisabled:
     pytestmark = pytest.mark.asyncio
 
     async def test_disabled_when_the_read_flag_is_off(self) -> None:
+        before = CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+            outcome="disabled"
+        )._value.get()
         service = _query(_FakeStore())
         result = await service.investigate(_request())
         assert result.outcome is GraphQueryOutcome.DISABLED
         assert result.packet is None
+        assert (
+            CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+                outcome="disabled"
+            )._value.get()
+            == before + 1
+        )
 
     async def test_disabled_never_constructs_a_store(self, monkeypatch) -> None:
         """The read flag is checked before the store factory is ever called."""
@@ -298,6 +311,12 @@ class TestStale:
 
     async def test_a_watermark_beyond_tolerance_is_stale(self, monkeypatch) -> None:
         monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        before = CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+            outcome="stale"
+        )._value.get()
+        watermark_before = CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL.labels(
+            state="available_stale"
+        )._value.get()
         store = _FakeStore(
             watermark=IndexWatermark(
                 indexed_through=_NOW - timedelta(days=2), records_indexed=5
@@ -307,6 +326,18 @@ class TestStale:
         result = await service.investigate(_request(deadline=_soon()))
         assert result.outcome is GraphQueryOutcome.STALE
         assert result.packet is None
+        assert (
+            CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+                outcome="stale"
+            )._value.get()
+            == before + 1
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL.labels(
+                state="available_stale"
+            )._value.get()
+            == watermark_before + 1
+        )
 
     async def test_a_partial_watermark_is_stale_even_if_recent(
         self, monkeypatch
@@ -347,12 +378,21 @@ class TestDeadlineExceeded:
         self, monkeypatch
     ) -> None:
         monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        before = CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+            outcome="deadline_exceeded"
+        )._value.get()
         store = _FakeStore(hang_seconds=999.0)
         service = _query(store)
         near_deadline = datetime.now(UTC) + timedelta(milliseconds=50)
         result = await service.investigate(_request(deadline=near_deadline))
         assert result.outcome is GraphQueryOutcome.DEADLINE_EXCEEDED
         assert store.closed is True, "the store is still closed on a deadline timeout"
+        assert (
+            CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+                outcome="deadline_exceeded"
+            )._value.get()
+            == before + 1
+        )
 
 
 class TestCancelled:
@@ -380,6 +420,9 @@ class TestUnsupportedMechanism:
         self, monkeypatch
     ) -> None:
         monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+        before = CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+            outcome="provider_failure"
+        )._value.get()
         store = _FakeStore(watermark=_fresh_watermark())
         service = _query(store)
         result = await service.investigate(
@@ -391,6 +434,12 @@ class TestUnsupportedMechanism:
         assert result.outcome is GraphQueryOutcome.PROVIDER_FAILURE
         assert result.diagnostic is not None
         assert "no graph mechanism" in result.diagnostic
+        assert (
+            CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+                outcome="provider_failure"
+            )._value.get()
+            == before + 1
+        )
 
 
 # SUBJECTLESS_COHORT_DISCOVERY graduated to a real COMPLETED path in

--- a/tests/context_fabric/test_chaos_3711_telemetry_wiring.py
+++ b/tests/context_fabric/test_chaos_3711_telemetry_wiring.py
@@ -1,0 +1,328 @@
+"""CHAOS-3711: production graph seams cannot silently lose telemetry."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.dev.contracts_v2.base import Cardinality, QuestionIntentID
+from dev_health_ops.api.dev.graph_investigation_query import (
+    CohortDiscoveryFamily,
+    GraphInvestigationRequest,
+    GraphQueryOutcome,
+)
+from dev_health_ops.context_fabric.graph_arm import query_service as query_module
+from dev_health_ops.context_fabric.graph_arm import store as store_module
+from dev_health_ops.context_fabric.graph_arm.projection import GraphProjection
+from dev_health_ops.context_fabric.graph_arm.store import (
+    DocumentRemovalReason,
+    GraphArmStore,
+    WriteResult,
+)
+from dev_health_ops.context_fabric.graph_arm.watermark import IndexWatermark
+
+
+class _FakeProjectionStore:
+    def __init__(self, *, purge_error: BaseException | None = None) -> None:
+        self.purge_error = purge_error
+        self.closed = False
+
+    async def purge_org(self, *, dry_run: bool) -> int:
+        if self.purge_error is not None:
+            raise self.purge_error
+        return 2
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeQueryStore:
+    def __init__(self, *, close_error: BaseException | None = None) -> None:
+        self.close_error = close_error
+        self.close_calls = 0
+
+    async def read_watermark(self) -> IndexWatermark:
+        return IndexWatermark(indexed_through=None)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+def _bare_store() -> GraphArmStore:
+    store = object.__new__(GraphArmStore)
+    store._org_id = "org_telemetry_test"
+    store._partition = "cf_org_telemetry_test"
+    store._driver = SimpleNamespace()
+    return store
+
+
+def _query_request() -> GraphInvestigationRequest:
+    now = datetime.now(UTC)
+    return GraphInvestigationRequest(
+        org_id="org_1",
+        run_id="run_1",
+        intent_id=QuestionIntentID.PROJECT_HEALTH,
+        cardinality=Cardinality.SINGULAR,
+        mentions=(),
+        question_text="status",
+        authorized_entity_ids=frozenset(),
+        window_start=now - timedelta(days=1),
+        window_end=now,
+        cohort_discovery_family=CohortDiscoveryFamily.TEAM_PRESSURE,
+        deadline=now + timedelta(seconds=1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_projection_records_success_failure_and_cancel_once(monkeypatch) -> None:
+    outcomes: list[str] = []
+    monkeypatch.setattr(
+        store_module,
+        "record_context_fabric_graph_projection",
+        outcomes.append,
+    )
+    store = _bare_store()
+
+    projection = cast(GraphProjection, object())
+
+    async def succeed(*_args: Any, **_kwargs: Any) -> WriteResult:
+        return cast(WriteResult, object())
+
+    cast(Any, store)._write_projection = succeed
+    await store.write_projection(projection)
+    assert outcomes == ["completed"]
+
+    async def fail(*_args: Any, **_kwargs: Any) -> WriteResult:
+        raise RuntimeError("write failed")
+
+    cast(Any, store)._write_projection = fail
+    with pytest.raises(RuntimeError):
+        await store.write_projection(projection)
+    assert outcomes == ["completed", "failed"]
+
+    async def cancel(*_args: Any, **_kwargs: Any) -> WriteResult:
+        raise asyncio.CancelledError
+
+    cast(Any, store)._write_projection = cancel
+    with pytest.raises(asyncio.CancelledError):
+        await store.write_projection(projection)
+    assert outcomes == ["completed", "failed", "cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_purge_records_cancel_once(monkeypatch) -> None:
+    outcomes: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        store_module,
+        "record_context_fabric_graph_purge",
+        lambda *, outcome, dry_run: outcomes.append((outcome, dry_run)),
+    )
+    store = _bare_store()
+
+    async def cancel_partition() -> bool:
+        raise asyncio.CancelledError
+
+    cast(Any, store).partition_exists = cancel_partition
+    with pytest.raises(asyncio.CancelledError):
+        await store.purge_org()
+    assert outcomes == [("cancelled", False)]
+
+    async def absent() -> bool:
+        return False
+
+    cast(Any, store).partition_exists = absent
+    assert await store.purge_org() == 0
+    assert outcomes[-1] == ("absent", False)
+
+    async def fail_partition() -> bool:
+        raise RuntimeError("partition probe failed")
+
+    cast(Any, store).partition_exists = fail_partition
+    with pytest.raises(RuntimeError, match="partition probe failed"):
+        await store.purge_org()
+    assert outcomes[-1] == ("failed", False)
+
+
+@pytest.mark.asyncio
+async def test_remove_document_records_decode_failure_and_cancel_once(
+    monkeypatch,
+) -> None:
+    outcomes: list[str] = []
+    monkeypatch.setattr(
+        store_module,
+        "record_context_fabric_graph_document_removal",
+        lambda *, outcome, reason: outcomes.append(outcome),
+    )
+    store = _bare_store()
+    store._driver.execute_query = lambda *_args, **_kwargs: None
+
+    async def malformed(*_args: Any, **_kwargs: Any) -> tuple[list[Any]]:
+        return ([],)
+
+    cast(Any, store)._bounded_write = malformed
+    with pytest.raises(ValueError):
+        await store.remove_document(
+            "doc_1", reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+    assert outcomes == ["failed"]
+
+    async def cancel(*_args: Any, **_kwargs: Any) -> Any:
+        raise asyncio.CancelledError
+
+    cast(Any, store)._bounded_write = cancel
+    with pytest.raises(asyncio.CancelledError):
+        await store.remove_document(
+            "doc_1", reason=DocumentRemovalReason.APPROVAL_REVOKED
+        )
+    assert outcomes == ["failed", "cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_org_deletion_visit_records_success_and_close_failure_once(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_STORE_URI", "falkor://127.0.0.1:1")
+    outcomes: list[str] = []
+    monkeypatch.setattr(
+        store_module,
+        "record_context_fabric_graph_org_deletion_visit",
+        lambda *, outcome, dry_run: outcomes.append(outcome),
+    )
+
+    async def exists(*_args, **_kwargs) -> bool:
+        return True
+
+    monkeypatch.setattr(store_module, "partition_exists_for", exists)
+    healthy = _FakeProjectionStore()
+    monkeypatch.setattr(
+        store_module.GraphArmStore,
+        "for_org",
+        staticmethod(lambda *_args, **_kwargs: healthy),
+    )
+    assert await store_module.org_deletion_visit("org_1", False) == 2
+    assert outcomes == ["purged"]
+    assert healthy.closed is True
+
+    class CloseFails(_FakeProjectionStore):
+        async def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    failing = CloseFails()
+    monkeypatch.setattr(
+        store_module.GraphArmStore,
+        "for_org",
+        staticmethod(lambda *_args, **_kwargs: failing),
+    )
+    with pytest.raises(RuntimeError, match="close failed"):
+        await store_module.org_deletion_visit("org_1", False)
+    assert outcomes == ["purged", "failed"]
+
+
+@pytest.mark.asyncio
+async def test_query_wiring_records_closed_outcome_and_latency(monkeypatch) -> None:
+    observations: list[tuple[str, float]] = []
+    monkeypatch.setattr(
+        query_module,
+        "record_context_fabric_graph_query",
+        lambda *, outcome, duration_seconds: observations.append(
+            (outcome, duration_seconds)
+        ),
+    )
+    monkeypatch.delenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", raising=False)
+    service = query_module.ProductionGraphInvestigationQuery()
+
+    # The disabled path is an actual production seam path, not a direct
+    # recorder test; removing the wrapper makes this assertion fail.
+    result = await service.investigate(_query_request())
+    assert result.outcome is GraphQueryOutcome.DISABLED
+    assert observations and observations == [("disabled", observations[0][1])]
+    assert observations[0][1] >= 0
+
+
+@pytest.mark.asyncio
+async def test_query_close_cancellation_returns_cancelled_and_records_once(
+    monkeypatch,
+) -> None:
+    outcomes: list[str] = []
+
+    def record(*, outcome: str, duration_seconds: float) -> None:
+        assert duration_seconds >= 0
+        outcomes.append(outcome)
+
+    monkeypatch.setattr(query_module, "record_context_fabric_graph_query", record)
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+    store = _FakeQueryStore(close_error=asyncio.CancelledError())
+    service = query_module.ProductionGraphInvestigationQuery(
+        store_factory=lambda _org_id: store
+    )
+
+    result = await service.investigate(_query_request())
+
+    assert result.outcome is GraphQueryOutcome.CANCELLED
+    assert result.packet is None
+    assert result.diagnostic is not None and "cancellation" in result.diagnostic
+    assert store.close_calls == 1
+    assert outcomes == ["cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_query_ordinary_close_failure_preserves_result_and_records_once(
+    monkeypatch, caplog
+) -> None:
+    outcomes: list[str] = []
+    monkeypatch.setattr(
+        query_module,
+        "record_context_fabric_graph_query",
+        lambda *, outcome, duration_seconds: outcomes.append(outcome),
+    )
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_READ_ENABLED", "1")
+    store = _FakeQueryStore(close_error=RuntimeError("close failed"))
+    service = query_module.ProductionGraphInvestigationQuery(
+        store_factory=lambda _org_id: store
+    )
+
+    with caplog.at_level("WARNING"):
+        result = await service.investigate(_query_request())
+
+    assert result.outcome is GraphQueryOutcome.UNAVAILABLE
+    assert store.close_calls == 1
+    assert outcomes == ["unavailable"]
+    assert "store.close() failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_org_deletion_visit_cancel_records_once(monkeypatch) -> None:
+    monkeypatch.setenv("CONTEXT_FABRIC_GRAPH_STORE_URI", "falkor://127.0.0.1:1")
+    outcomes: list[str] = []
+    monkeypatch.setattr(
+        store_module,
+        "record_context_fabric_graph_org_deletion_visit",
+        lambda *, outcome, dry_run: outcomes.append(outcome),
+    )
+
+    async def cancel(*_args, **_kwargs) -> bool:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(store_module, "partition_exists_for", cancel)
+    with pytest.raises(asyncio.CancelledError):
+        await store_module.org_deletion_visit("org_1", False)
+    assert outcomes == ["cancelled"]
+
+
+def test_watermark_metric_is_not_emitted_for_never_projected_lag() -> None:
+    # Keep this structural and local: the recorder's unavailable branch must
+    # not manufacture a zero-lag observation for a partition with no watermark.
+    from dev_health_ops.metrics.prometheus import (
+        CONTEXT_FABRIC_GRAPH_WATERMARK_LAG_SECONDS,
+        record_context_fabric_graph_watermark,
+    )
+
+    before = CONTEXT_FABRIC_GRAPH_WATERMARK_LAG_SECONDS._sum.get()
+    record_context_fabric_graph_watermark(state="unavailable", lag_seconds=0)
+    assert CONTEXT_FABRIC_GRAPH_WATERMARK_LAG_SECONDS._sum.get() == before

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -6,15 +6,29 @@ for GitHub API, Celery, ClickHouse, and LLM metrics.
 
 from __future__ import annotations
 
+import pytest
 from prometheus_client import REGISTRY
 
 from dev_health_ops.metrics.prometheus import (
     CONTEXT_FABRIC_DOCUMENTS_INDEXED_TOTAL,
     CONTEXT_FABRIC_DOCUMENTS_REMOVED_TOTAL,
+    CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOME_TOTAL,
+    CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL,
+    CONTEXT_FABRIC_GRAPH_PROJECTION_WRITES_TOTAL,
+    CONTEXT_FABRIC_GRAPH_PURGES_TOTAL,
+    CONTEXT_FABRIC_GRAPH_QUERY_DURATION_SECONDS,
+    CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL,
+    CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL,
     GITHUB_API_REQUESTS_TOTAL,
     GITHUB_RATE_LIMIT_REMAINING,
     record_context_fabric_document_removed,
     record_context_fabric_documents_indexed,
+    record_context_fabric_graph_document_removal,
+    record_context_fabric_graph_org_deletion_visit,
+    record_context_fabric_graph_projection,
+    record_context_fabric_graph_purge,
+    record_context_fabric_graph_query,
+    record_context_fabric_graph_watermark,
     record_github_api_request,
     record_github_rate_limit,
 )
@@ -137,3 +151,105 @@ class TestContextFabricDocumentMetrics:
     def test_removed_counter_registered_in_default_registry(self):
         metric_names = [m.name for m in REGISTRY.collect()]
         assert "devhealth_context_fabric_documents_removed" in metric_names
+
+
+class TestContextFabricGraphOperationalMetrics:
+    """Every graph operational metric is closed-label and content-safe."""
+
+    def test_query_outcome_records_disabled_and_failure_independently(self):
+        disabled_before = CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+            outcome="disabled"
+        )._value.get()
+        failure_before = CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+            outcome="provider_failure"
+        )._value.get()
+        duration_before = CONTEXT_FABRIC_GRAPH_QUERY_DURATION_SECONDS.labels(
+            outcome="disabled"
+        )._sum.get()
+
+        record_context_fabric_graph_query(outcome="disabled", duration_seconds=0.01)
+        record_context_fabric_graph_query(
+            outcome="provider_failure", duration_seconds=0.02
+        )
+
+        assert (
+            CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+                outcome="disabled"
+            )._value.get()
+            == disabled_before + 1
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_QUERY_OUTCOME_TOTAL.labels(
+                outcome="provider_failure"
+            )._value.get()
+            == failure_before + 1
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_QUERY_DURATION_SECONDS.labels(
+                outcome="disabled"
+            )._sum.get()
+            >= duration_before + 0.01
+        )
+
+    def test_unknown_query_outcome_is_rejected(self):
+        with pytest.raises(ValueError, match="closed Context Fabric"):
+            record_context_fabric_graph_query(
+                outcome="question text must not become a label",
+                duration_seconds=0.01,
+            )
+
+    def test_projection_failure_watermark_and_deletion_negative_states_record(self):
+        projection_before = CONTEXT_FABRIC_GRAPH_PROJECTION_WRITES_TOTAL.labels(
+            outcome="failed"
+        )._value.get()
+        unavailable_before = CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL.labels(
+            state="unavailable"
+        )._value.get()
+        purge_before = CONTEXT_FABRIC_GRAPH_PURGES_TOTAL.labels(
+            outcome="failed", dry_run="false"
+        )._value.get()
+        document_before = CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOME_TOTAL.labels(
+            outcome="not_found", reason="approval_revoked"
+        )._value.get()
+        visit_before = CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+            outcome="unknown", dry_run="false"
+        )._value.get()
+
+        record_context_fabric_graph_projection("failed")
+        record_context_fabric_graph_watermark(state="unavailable", lag_seconds=0.0)
+        record_context_fabric_graph_purge(outcome="failed", dry_run=False)
+        record_context_fabric_graph_document_removal(
+            outcome="not_found", reason="approval_revoked"
+        )
+        record_context_fabric_graph_org_deletion_visit(outcome="unknown", dry_run=False)
+
+        assert (
+            CONTEXT_FABRIC_GRAPH_PROJECTION_WRITES_TOTAL.labels(
+                outcome="failed"
+            )._value.get()
+            == projection_before + 1
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_WATERMARK_STATE_TOTAL.labels(
+                state="unavailable"
+            )._value.get()
+            == unavailable_before + 1
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_PURGES_TOTAL.labels(
+                outcome="failed", dry_run="false"
+            )._value.get()
+            == purge_before + 1
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_DOCUMENT_REMOVAL_OUTCOME_TOTAL.labels(
+                outcome="not_found", reason="approval_revoked"
+            )._value.get()
+            == document_before + 1
+        )
+        assert (
+            CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
+                outcome="unknown", dry_run="false"
+            )._value.get()
+            == visit_before + 1
+        )

--- a/trials/chaos_3619/sweep.py
+++ b/trials/chaos_3619/sweep.py
@@ -118,10 +118,15 @@ def _require_store_config() -> Any:
     config = trial_store_config()
     if config is None:
         raise RuntimeError(
-            "no live graph store configured. The sweep requires "
-            "CONTEXT_FABRIC_GRAPH_STORE_URI (e.g. falkor://127.0.0.1:6389); "
-            "it will not fall back to a projection reader, because a sweep "
-            "against a reader nobody ships is not this trial"
+            """no live graph store configured. Set
+GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)", launch with
+`docker compose --project-name "$GRAPH_TRIAL_PROJECT" --profile graph-trial up -d graph-trial-store`,
+discover its OS-assigned host port with
+`docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379`,
+and export CONTEXT_FABRIC_GRAPH_STORE_URI for that port. The sweep will not
+fall back to a projection reader, because a sweep against a reader nobody ships
+is not this trial. After the run, tear it down with
+`docker compose --project-name "$GRAPH_TRIAL_PROJECT" down --volumes --remove-orphans`"""
         )
     import socket
 

--- a/trials/chaos_3647/runner.py
+++ b/trials/chaos_3647/runner.py
@@ -2,10 +2,14 @@
 
 Run it with the live store and a real embedding model::
 
-    CONTEXT_FABRIC_GRAPH_STORE_URI=falkor://127.0.0.1:6389 \\
+    GRAPH_TRIAL_PROJECT="graph-trial-$(openssl rand -hex 6)"
+    docker compose --project-name "$GRAPH_TRIAL_PROJECT" --profile graph-trial up -d graph-trial-store
+    GRAPH_TRIAL_STORE_PORT="$(docker compose --project-name "$GRAPH_TRIAL_PROJECT" port graph-trial-store 6379 | awk -F: '{print $NF}')"
+    CONTEXT_FABRIC_GRAPH_STORE_URI="falkor://127.0.0.1:$GRAPH_TRIAL_STORE_PORT" \\
     CONTEXT_FABRIC_GRAPH_REQUIRE_LIVE=1 \\
     CONTEXT_FABRIC_GRAPH_PROJECTION_ENABLED=1 \\
     uv run python -m trials.chaos_3647.runner
+    docker compose --project-name "$GRAPH_TRIAL_PROJECT" down --volumes --remove-orphans
 
 **Every precondition raises rather than degrades.** No live store, no API
 key, a non-semantic embedder — each is a hard stop with a message naming


### PR DESCRIPTION
## Summary

- add closed-label, content-safe query and graph-store Prometheus telemetry
- account explicitly for success, failure, cancellation, removal, purge, and organization-deletion outcomes
- isolate parallel local graph trials with OS-assigned ports and unique Compose project names
- add production-seam and operational-control regressions plus operator documentation

## Verification

- independent focused suite: 184 passed, 3 skipped
- full mypy through locked dev environment: 2362 source files, no issues
- Ruff check and format: green
- two rendered Compose projects: distinct names, no container_name, no fixed published port
- git diff --check: green

The initial local commit/push hook used a bare system mypy missing the locked types-jsonschema package. The same full 2362-file gate passed via `uv run --frozen --all-extras --dev mypy`; commit and push bypassed only that defective wrapper after the equivalent locked gate passed.

SCREENSHOT-WAIVER: backend telemetry, Compose, tests, and documentation only; no rendered UI change.

## Scope boundary

This is the W7 telemetry/local-isolation slice. It does not enable beta or complete CHAOS-3711: production projector/worker wiring, worker metric exposure, and real-org operational evidence remain outstanding.

Linear: CHAOS-3711