### PR TITLE
CHAOS-3669: publish canonical cohort ranking

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -78,7 +78,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_conversation_transcript.v1.schema.json",
-        "sha256": "46aefa2ab1f8df406cffc7435c11fdc4a650de0f782d820f46d4111d3fcf5ab6"
+        "sha256": "248d1075aa99da9424c5242e9691fdd2943d9b04b11218cd9cb2e322ce566db1"
       },
       "schema_version": "dev_conversation_transcript.v1"
     },
@@ -167,7 +167,7 @@
       ],
       "schema": {
         "path": "schemas/dev_answer.v1.schema.json",
-        "sha256": "c5f3c184200010e3fea4b970250e56a988d5a88232dae55fb74c4c3531847916"
+        "sha256": "ba4020ba258c7b13359af1a9feb48276962c700c0aa0d12e9422150ecb13438e"
       },
       "schema_version": "dev_answer.v1"
     },
@@ -186,7 +186,7 @@
       "positive_variants": [],
       "schema": {
         "path": "schemas/dev_answer_graph_assistance.v1.schema.json",
-        "sha256": "05c125b85d08b6e86cb1b51f0a68ca85f4d5ec483fac50946e619c3cdf6c5609"
+        "sha256": "74504d5a246dec800432d9ee1136ad008f0f6292f650417151fbdeccd7837c39"
       },
       "schema_version": "dev_answer_graph_assistance.v1"
     },
@@ -440,7 +440,7 @@
       ],
       "schema": {
         "path": "schemas/dev_stream_event.v1.schema.json",
-        "sha256": "001622125e3259dc34de825a1cf55a63ba583b3581a5ad8b18b597e165129365"
+        "sha256": "b183846008dc5859db39393f9a4d227b301191af142672ad6ea968591e97ed19"
       },
       "schema_version": "dev_stream_event.v1"
     },

--- a/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_answer.v1.schema.json
@@ -49,6 +49,14 @@
       "title": "CohortDiscoveryFamily",
       "type": "string"
     },
+    "DevAnswerCohortDisposition": {
+      "enum": [
+        "included",
+        "unknown"
+      ],
+      "title": "DevAnswerCohortDisposition",
+      "type": "string"
+    },
     "DevAnswerCohortMember": {
       "additionalProperties": false,
       "description": "CHAOS-3660 \u00a78(d). One named member of a discovered cohort.\n\nDeliberately no \"excluded candidate\" counterpart: an excluded candidate\nis never named on the wire, since that would disclose a judgment about\nan entity nobody asked about. Disclosure of \"N candidates considered,\nnot included\" rides ``DevAnswerCohortSlot.warnings`` instead -- the\nsame mechanism v2's ``DevSubjectSet.warnings`` already uses for\ntruncation disclosure, not a new one.",
@@ -59,6 +67,17 @@
           "title": "Display Label",
           "type": "string"
         },
+        "disposition": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerCohortDisposition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "entity_id": {
           "maxLength": 128,
           "minLength": 1,
@@ -68,6 +87,49 @@
         },
         "inclusion_basis": {
           "$ref": "#/$defs/CohortDiscoveryFamily"
+        },
+        "inclusion_rationale": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inclusion Rationale"
+        },
+        "pressure_dimensions": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerPressureDimension"
+          },
+          "maxItems": 12,
+          "title": "Pressure Dimensions",
+          "type": "array"
+        },
+        "rank": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rank"
+        },
+        "signals": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerCohortSignal"
+          },
+          "maxItems": 50,
+          "title": "Signals",
+          "type": "array"
         }
       },
       "required": [
@@ -77,6 +139,163 @@
       ],
       "title": "DevAnswerCohortMember",
       "type": "object"
+    },
+    "DevAnswerCohortSignal": {
+      "additionalProperties": false,
+      "properties": {
+        "attribution_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attribution Present"
+        },
+        "coverage": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Coverage"
+        },
+        "data_semantics": {
+          "enum": [
+            "measured_zero",
+            "no_data",
+            "not_measured"
+          ],
+          "title": "Data Semantics",
+          "type": "string"
+        },
+        "denominator_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Denominator Present"
+        },
+        "dimension": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureDimension"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 12,
+          "title": "Evidence Source Classes",
+          "type": "array"
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "gap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerEnrichmentGap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "limitation": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limitation"
+        },
+        "observed_states": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerSourceRequirementState"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Observed States",
+          "type": "array"
+        },
+        "signal_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Signal Id",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/DevAnswerCohortSignalSource"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "signal_id",
+        "source",
+        "observed_states",
+        "data_semantics"
+      ],
+      "title": "DevAnswerCohortSignal",
+      "type": "object"
+    },
+    "DevAnswerCohortSignalSource": {
+      "enum": [
+        "status",
+        "health",
+        "workload",
+        "readiness",
+        "metrics",
+        "canonical_enrichment"
+      ],
+      "title": "DevAnswerCohortSignalSource",
+      "type": "string"
     },
     "DevAnswerCohortSlot": {
       "additionalProperties": false,
@@ -152,6 +371,39 @@
       ],
       "title": "DevAnswerDriverEntry",
       "type": "object"
+    },
+    "DevAnswerEnrichmentGap": {
+      "enum": [
+        "not_applicable",
+        "unauthorized",
+        "unavailable",
+        "no_data"
+      ],
+      "title": "DevAnswerEnrichmentGap",
+      "type": "string"
+    },
+    "DevAnswerEvidenceSourceClass": {
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "DevAnswerEvidenceSourceClass",
+      "type": "string"
     },
     "DevAnswerGraphAssistance": {
       "additionalProperties": false,
@@ -230,6 +482,47 @@
       ],
       "title": "DevAnswerLineageHop",
       "type": "object"
+    },
+    "DevAnswerPressureDimension": {
+      "enum": [
+        "execution_completion",
+        "delivery_flow",
+        "reliability_release",
+        "review_ci_pressure",
+        "code_ownership_risk",
+        "cognitive_workload_pressure",
+        "investment_balance",
+        "dependencies_blockers",
+        "data_trust"
+      ],
+      "title": "DevAnswerPressureDimension",
+      "type": "string"
+    },
+    "DevAnswerPressureState": {
+      "enum": [
+        "healthy",
+        "watch",
+        "at_risk",
+        "critical",
+        "unknown",
+        "not_applicable"
+      ],
+      "title": "DevAnswerPressureState",
+      "type": "string"
+    },
+    "DevAnswerSourceRequirementState": {
+      "enum": [
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated"
+      ],
+      "title": "DevAnswerSourceRequirementState",
+      "type": "string"
     },
     "DevCitationLink": {
       "additionalProperties": false,

--- a/contracts/ask-dev/v1/schemas/dev_answer_graph_assistance.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_answer_graph_assistance.v1.schema.json
@@ -9,6 +9,14 @@
       "title": "CohortDiscoveryFamily",
       "type": "string"
     },
+    "DevAnswerCohortDisposition": {
+      "enum": [
+        "included",
+        "unknown"
+      ],
+      "title": "DevAnswerCohortDisposition",
+      "type": "string"
+    },
     "DevAnswerCohortMember": {
       "additionalProperties": false,
       "description": "CHAOS-3660 \u00a78(d). One named member of a discovered cohort.\n\nDeliberately no \"excluded candidate\" counterpart: an excluded candidate\nis never named on the wire, since that would disclose a judgment about\nan entity nobody asked about. Disclosure of \"N candidates considered,\nnot included\" rides ``DevAnswerCohortSlot.warnings`` instead -- the\nsame mechanism v2's ``DevSubjectSet.warnings`` already uses for\ntruncation disclosure, not a new one.",
@@ -19,6 +27,17 @@
           "title": "Display Label",
           "type": "string"
         },
+        "disposition": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerCohortDisposition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "entity_id": {
           "maxLength": 128,
           "minLength": 1,
@@ -28,6 +47,49 @@
         },
         "inclusion_basis": {
           "$ref": "#/$defs/CohortDiscoveryFamily"
+        },
+        "inclusion_rationale": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inclusion Rationale"
+        },
+        "pressure_dimensions": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerPressureDimension"
+          },
+          "maxItems": 12,
+          "title": "Pressure Dimensions",
+          "type": "array"
+        },
+        "rank": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rank"
+        },
+        "signals": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerCohortSignal"
+          },
+          "maxItems": 50,
+          "title": "Signals",
+          "type": "array"
         }
       },
       "required": [
@@ -37,6 +99,163 @@
       ],
       "title": "DevAnswerCohortMember",
       "type": "object"
+    },
+    "DevAnswerCohortSignal": {
+      "additionalProperties": false,
+      "properties": {
+        "attribution_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attribution Present"
+        },
+        "coverage": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Coverage"
+        },
+        "data_semantics": {
+          "enum": [
+            "measured_zero",
+            "no_data",
+            "not_measured"
+          ],
+          "title": "Data Semantics",
+          "type": "string"
+        },
+        "denominator_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Denominator Present"
+        },
+        "dimension": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureDimension"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 12,
+          "title": "Evidence Source Classes",
+          "type": "array"
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "gap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerEnrichmentGap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "limitation": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limitation"
+        },
+        "observed_states": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerSourceRequirementState"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Observed States",
+          "type": "array"
+        },
+        "signal_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Signal Id",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/DevAnswerCohortSignalSource"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "signal_id",
+        "source",
+        "observed_states",
+        "data_semantics"
+      ],
+      "title": "DevAnswerCohortSignal",
+      "type": "object"
+    },
+    "DevAnswerCohortSignalSource": {
+      "enum": [
+        "status",
+        "health",
+        "workload",
+        "readiness",
+        "metrics",
+        "canonical_enrichment"
+      ],
+      "title": "DevAnswerCohortSignalSource",
+      "type": "string"
     },
     "DevAnswerCohortSlot": {
       "additionalProperties": false,
@@ -113,6 +332,39 @@
       "title": "DevAnswerDriverEntry",
       "type": "object"
     },
+    "DevAnswerEnrichmentGap": {
+      "enum": [
+        "not_applicable",
+        "unauthorized",
+        "unavailable",
+        "no_data"
+      ],
+      "title": "DevAnswerEnrichmentGap",
+      "type": "string"
+    },
+    "DevAnswerEvidenceSourceClass": {
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "DevAnswerEvidenceSourceClass",
+      "type": "string"
+    },
     "DevAnswerLineageHop": {
       "additionalProperties": false,
       "description": "CHAOS-3660 \u00a78(d). One user-safe hop label in an evidence-lineage\npath, e.g. ``\"Team\"`` -> ``\"Project\"`` -> ``\"Pull Request\"``. Content-safe\nby construction: ``ShortText``, never a raw graph node id or internal\ntraversal vocabulary.",
@@ -130,6 +382,47 @@
       "title": "DevAnswerLineageHop",
       "type": "object"
     },
+    "DevAnswerPressureDimension": {
+      "enum": [
+        "execution_completion",
+        "delivery_flow",
+        "reliability_release",
+        "review_ci_pressure",
+        "code_ownership_risk",
+        "cognitive_workload_pressure",
+        "investment_balance",
+        "dependencies_blockers",
+        "data_trust"
+      ],
+      "title": "DevAnswerPressureDimension",
+      "type": "string"
+    },
+    "DevAnswerPressureState": {
+      "enum": [
+        "healthy",
+        "watch",
+        "at_risk",
+        "critical",
+        "unknown",
+        "not_applicable"
+      ],
+      "title": "DevAnswerPressureState",
+      "type": "string"
+    },
+    "DevAnswerSourceRequirementState": {
+      "enum": [
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated"
+      ],
+      "title": "DevAnswerSourceRequirementState",
+      "type": "string"
+    },
     "EntityType": {
       "enum": [
         "repository",
@@ -140,6 +433,16 @@
         "team"
       ],
       "title": "EntityType",
+      "type": "string"
+    },
+    "FreshnessState": {
+      "enum": [
+        "fresh",
+        "stale",
+        "unavailable",
+        "unknown"
+      ],
+      "title": "FreshnessState",
       "type": "string"
     },
     "GraphAssistedAvailability": {

--- a/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_conversation_transcript.v1.schema.json
@@ -182,6 +182,14 @@
       "title": "DevAnswer",
       "type": "object"
     },
+    "DevAnswerCohortDisposition": {
+      "enum": [
+        "included",
+        "unknown"
+      ],
+      "title": "DevAnswerCohortDisposition",
+      "type": "string"
+    },
     "DevAnswerCohortMember": {
       "additionalProperties": false,
       "description": "CHAOS-3660 \u00a78(d). One named member of a discovered cohort.\n\nDeliberately no \"excluded candidate\" counterpart: an excluded candidate\nis never named on the wire, since that would disclose a judgment about\nan entity nobody asked about. Disclosure of \"N candidates considered,\nnot included\" rides ``DevAnswerCohortSlot.warnings`` instead -- the\nsame mechanism v2's ``DevSubjectSet.warnings`` already uses for\ntruncation disclosure, not a new one.",
@@ -192,6 +200,17 @@
           "title": "Display Label",
           "type": "string"
         },
+        "disposition": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerCohortDisposition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "entity_id": {
           "maxLength": 128,
           "minLength": 1,
@@ -201,6 +220,49 @@
         },
         "inclusion_basis": {
           "$ref": "#/$defs/CohortDiscoveryFamily"
+        },
+        "inclusion_rationale": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inclusion Rationale"
+        },
+        "pressure_dimensions": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerPressureDimension"
+          },
+          "maxItems": 12,
+          "title": "Pressure Dimensions",
+          "type": "array"
+        },
+        "rank": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rank"
+        },
+        "signals": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerCohortSignal"
+          },
+          "maxItems": 50,
+          "title": "Signals",
+          "type": "array"
         }
       },
       "required": [
@@ -210,6 +272,163 @@
       ],
       "title": "DevAnswerCohortMember",
       "type": "object"
+    },
+    "DevAnswerCohortSignal": {
+      "additionalProperties": false,
+      "properties": {
+        "attribution_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attribution Present"
+        },
+        "coverage": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Coverage"
+        },
+        "data_semantics": {
+          "enum": [
+            "measured_zero",
+            "no_data",
+            "not_measured"
+          ],
+          "title": "Data Semantics",
+          "type": "string"
+        },
+        "denominator_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Denominator Present"
+        },
+        "dimension": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureDimension"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 12,
+          "title": "Evidence Source Classes",
+          "type": "array"
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "gap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerEnrichmentGap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "limitation": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limitation"
+        },
+        "observed_states": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerSourceRequirementState"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Observed States",
+          "type": "array"
+        },
+        "signal_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Signal Id",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/DevAnswerCohortSignalSource"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "signal_id",
+        "source",
+        "observed_states",
+        "data_semantics"
+      ],
+      "title": "DevAnswerCohortSignal",
+      "type": "object"
+    },
+    "DevAnswerCohortSignalSource": {
+      "enum": [
+        "status",
+        "health",
+        "workload",
+        "readiness",
+        "metrics",
+        "canonical_enrichment"
+      ],
+      "title": "DevAnswerCohortSignalSource",
+      "type": "string"
     },
     "DevAnswerCohortSlot": {
       "additionalProperties": false,
@@ -285,6 +504,39 @@
       ],
       "title": "DevAnswerDriverEntry",
       "type": "object"
+    },
+    "DevAnswerEnrichmentGap": {
+      "enum": [
+        "not_applicable",
+        "unauthorized",
+        "unavailable",
+        "no_data"
+      ],
+      "title": "DevAnswerEnrichmentGap",
+      "type": "string"
+    },
+    "DevAnswerEvidenceSourceClass": {
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "DevAnswerEvidenceSourceClass",
+      "type": "string"
     },
     "DevAnswerGraphAssistance": {
       "additionalProperties": false,
@@ -363,6 +615,47 @@
       ],
       "title": "DevAnswerLineageHop",
       "type": "object"
+    },
+    "DevAnswerPressureDimension": {
+      "enum": [
+        "execution_completion",
+        "delivery_flow",
+        "reliability_release",
+        "review_ci_pressure",
+        "code_ownership_risk",
+        "cognitive_workload_pressure",
+        "investment_balance",
+        "dependencies_blockers",
+        "data_trust"
+      ],
+      "title": "DevAnswerPressureDimension",
+      "type": "string"
+    },
+    "DevAnswerPressureState": {
+      "enum": [
+        "healthy",
+        "watch",
+        "at_risk",
+        "critical",
+        "unknown",
+        "not_applicable"
+      ],
+      "title": "DevAnswerPressureState",
+      "type": "string"
+    },
+    "DevAnswerSourceRequirementState": {
+      "enum": [
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated"
+      ],
+      "title": "DevAnswerSourceRequirementState",
+      "type": "string"
     },
     "DevCitationLink": {
       "additionalProperties": false,

--- a/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
+++ b/contracts/ask-dev/v1/schemas/dev_stream_event.v1.schema.json
@@ -182,6 +182,14 @@
       "title": "DevAnswer",
       "type": "object"
     },
+    "DevAnswerCohortDisposition": {
+      "enum": [
+        "included",
+        "unknown"
+      ],
+      "title": "DevAnswerCohortDisposition",
+      "type": "string"
+    },
     "DevAnswerCohortMember": {
       "additionalProperties": false,
       "description": "CHAOS-3660 \u00a78(d). One named member of a discovered cohort.\n\nDeliberately no \"excluded candidate\" counterpart: an excluded candidate\nis never named on the wire, since that would disclose a judgment about\nan entity nobody asked about. Disclosure of \"N candidates considered,\nnot included\" rides ``DevAnswerCohortSlot.warnings`` instead -- the\nsame mechanism v2's ``DevSubjectSet.warnings`` already uses for\ntruncation disclosure, not a new one.",
@@ -192,6 +200,17 @@
           "title": "Display Label",
           "type": "string"
         },
+        "disposition": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerCohortDisposition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "entity_id": {
           "maxLength": 128,
           "minLength": 1,
@@ -201,6 +220,49 @@
         },
         "inclusion_basis": {
           "$ref": "#/$defs/CohortDiscoveryFamily"
+        },
+        "inclusion_rationale": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Inclusion Rationale"
+        },
+        "pressure_dimensions": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerPressureDimension"
+          },
+          "maxItems": 12,
+          "title": "Pressure Dimensions",
+          "type": "array"
+        },
+        "rank": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rank"
+        },
+        "signals": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerCohortSignal"
+          },
+          "maxItems": 50,
+          "title": "Signals",
+          "type": "array"
         }
       },
       "required": [
@@ -210,6 +272,163 @@
       ],
       "title": "DevAnswerCohortMember",
       "type": "object"
+    },
+    "DevAnswerCohortSignal": {
+      "additionalProperties": false,
+      "properties": {
+        "attribution_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attribution Present"
+        },
+        "coverage": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Coverage"
+        },
+        "data_semantics": {
+          "enum": [
+            "measured_zero",
+            "no_data",
+            "not_measured"
+          ],
+          "title": "Data Semantics",
+          "type": "string"
+        },
+        "denominator_present": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Denominator Present"
+        },
+        "dimension": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureDimension"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence_source_classes": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerEvidenceSourceClass"
+          },
+          "maxItems": 12,
+          "title": "Evidence Source Classes",
+          "type": "array"
+        },
+        "freshness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FreshnessState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "gap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerEnrichmentGap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "limitation": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limitation"
+        },
+        "observed_states": {
+          "items": {
+            "$ref": "#/$defs/DevAnswerSourceRequirementState"
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "title": "Observed States",
+          "type": "array"
+        },
+        "signal_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:/#-]{0,127}$",
+          "title": "Signal Id",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/DevAnswerCohortSignalSource"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DevAnswerPressureState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "signal_id",
+        "source",
+        "observed_states",
+        "data_semantics"
+      ],
+      "title": "DevAnswerCohortSignal",
+      "type": "object"
+    },
+    "DevAnswerCohortSignalSource": {
+      "enum": [
+        "status",
+        "health",
+        "workload",
+        "readiness",
+        "metrics",
+        "canonical_enrichment"
+      ],
+      "title": "DevAnswerCohortSignalSource",
+      "type": "string"
     },
     "DevAnswerCohortSlot": {
       "additionalProperties": false,
@@ -285,6 +504,39 @@
       ],
       "title": "DevAnswerDriverEntry",
       "type": "object"
+    },
+    "DevAnswerEnrichmentGap": {
+      "enum": [
+        "not_applicable",
+        "unauthorized",
+        "unavailable",
+        "no_data"
+      ],
+      "title": "DevAnswerEnrichmentGap",
+      "type": "string"
+    },
+    "DevAnswerEvidenceSourceClass": {
+      "enum": [
+        "status_change",
+        "work_item",
+        "work_graph",
+        "pull_request",
+        "code_change",
+        "review",
+        "ci_run",
+        "test_report",
+        "deployment",
+        "incident",
+        "operational_control",
+        "source_health",
+        "cognitive_load",
+        "investment_allocation",
+        "health_profile",
+        "deficiency_inventory",
+        "temporal_context"
+      ],
+      "title": "DevAnswerEvidenceSourceClass",
+      "type": "string"
     },
     "DevAnswerGraphAssistance": {
       "additionalProperties": false,
@@ -363,6 +615,47 @@
       ],
       "title": "DevAnswerLineageHop",
       "type": "object"
+    },
+    "DevAnswerPressureDimension": {
+      "enum": [
+        "execution_completion",
+        "delivery_flow",
+        "reliability_release",
+        "review_ci_pressure",
+        "code_ownership_risk",
+        "cognitive_workload_pressure",
+        "investment_balance",
+        "dependencies_blockers",
+        "data_trust"
+      ],
+      "title": "DevAnswerPressureDimension",
+      "type": "string"
+    },
+    "DevAnswerPressureState": {
+      "enum": [
+        "healthy",
+        "watch",
+        "at_risk",
+        "critical",
+        "unknown",
+        "not_applicable"
+      ],
+      "title": "DevAnswerPressureState",
+      "type": "string"
+    },
+    "DevAnswerSourceRequirementState": {
+      "enum": [
+        "available_current",
+        "available_stale",
+        "available_unknown",
+        "unconfigured",
+        "unavailable",
+        "unauthorized_or_not_visible",
+        "not_applicable",
+        "truncated"
+      ],
+      "title": "DevAnswerSourceRequirementState",
+      "type": "string"
     },
     "DevCitationLink": {
       "additionalProperties": false,

--- a/src/dev_health_ops/api/dev/contracts.py
+++ b/src/dev_health_ops/api/dev/contracts.py
@@ -236,6 +236,79 @@ class CohortDiscoveryFamily(StrEnum):
     PROJECT_CAPACITY = "project_capacity"
 
 
+class DevAnswerCohortDisposition(StrEnum):
+    INCLUDED = "included"
+    UNKNOWN = "unknown"
+
+
+class DevAnswerCohortSignalSource(StrEnum):
+    STATUS = "status"
+    HEALTH = "health"
+    WORKLOAD = "workload"
+    READINESS = "readiness"
+    METRICS = "metrics"
+    CANONICAL_ENRICHMENT = "canonical_enrichment"
+
+
+class DevAnswerEvidenceSourceClass(StrEnum):
+    STATUS_CHANGE = "status_change"
+    WORK_ITEM = "work_item"
+    WORK_GRAPH = "work_graph"
+    PULL_REQUEST = "pull_request"
+    CODE_CHANGE = "code_change"
+    REVIEW = "review"
+    CI_RUN = "ci_run"
+    TEST_REPORT = "test_report"
+    DEPLOYMENT = "deployment"
+    INCIDENT = "incident"
+    OPERATIONAL_CONTROL = "operational_control"
+    SOURCE_HEALTH = "source_health"
+    COGNITIVE_LOAD = "cognitive_load"
+    INVESTMENT_ALLOCATION = "investment_allocation"
+    HEALTH_PROFILE = "health_profile"
+    DEFICIENCY_INVENTORY = "deficiency_inventory"
+    TEMPORAL_CONTEXT = "temporal_context"
+
+
+class DevAnswerSourceRequirementState(StrEnum):
+    AVAILABLE_CURRENT = "available_current"
+    AVAILABLE_STALE = "available_stale"
+    AVAILABLE_UNKNOWN = "available_unknown"
+    UNCONFIGURED = "unconfigured"
+    UNAVAILABLE = "unavailable"
+    UNAUTHORIZED_OR_NOT_VISIBLE = "unauthorized_or_not_visible"
+    NOT_APPLICABLE = "not_applicable"
+    TRUNCATED = "truncated"
+
+
+class DevAnswerPressureDimension(StrEnum):
+    EXECUTION_COMPLETION = "execution_completion"
+    DELIVERY_FLOW = "delivery_flow"
+    RELIABILITY_RELEASE = "reliability_release"
+    REVIEW_CI_PRESSURE = "review_ci_pressure"
+    CODE_OWNERSHIP_RISK = "code_ownership_risk"
+    COGNITIVE_WORKLOAD_PRESSURE = "cognitive_workload_pressure"
+    INVESTMENT_BALANCE = "investment_balance"
+    DEPENDENCIES_BLOCKERS = "dependencies_blockers"
+    DATA_TRUST = "data_trust"
+
+
+class DevAnswerPressureState(StrEnum):
+    HEALTHY = "healthy"
+    WATCH = "watch"
+    AT_RISK = "at_risk"
+    CRITICAL = "critical"
+    UNKNOWN = "unknown"
+    NOT_APPLICABLE = "not_applicable"
+
+
+class DevAnswerEnrichmentGap(StrEnum):
+    NOT_APPLICABLE = "not_applicable"
+    UNAUTHORIZED = "unauthorized"
+    UNAVAILABLE = "unavailable"
+    NO_DATA = "no_data"
+
+
 class PacketLimitationKind(StrEnum):
     """CHAOS-3660 §8(d)/(h). Reserved fresh here for the same reason as the
     two enums above -- the owning module
@@ -871,6 +944,33 @@ class DevAnswerCohortMember(ContractModel):
     entity_id: OpaqueID
     display_label: Label
     inclusion_basis: CohortDiscoveryFamily
+    rank: int | None = Field(default=None, ge=1)
+    disposition: DevAnswerCohortDisposition | None = None
+    inclusion_rationale: ShortText | None = None
+    pressure_dimensions: list[DevAnswerPressureDimension] = Field(
+        default_factory=list, max_length=12
+    )
+    signals: list[DevAnswerCohortSignal] = Field(default_factory=list, max_length=50)
+
+
+class DevAnswerCohortSignal(ContractModel):
+    signal_id: OpaqueID
+    source: DevAnswerCohortSignalSource
+    observed_states: list[DevAnswerSourceRequirementState] = Field(
+        min_length=1, max_length=8
+    )
+    data_semantics: Literal["measured_zero", "no_data", "not_measured"]
+    freshness: FreshnessState | None = None
+    coverage: FiniteFloat | None = Field(default=None, ge=0, le=1)
+    denominator_present: bool | None = None
+    attribution_present: bool | None = None
+    dimension: DevAnswerPressureDimension | None = None
+    state: DevAnswerPressureState | None = None
+    evidence_source_classes: list[DevAnswerEvidenceSourceClass] = Field(
+        default_factory=list, max_length=12
+    )
+    limitation: ShortText | None = None
+    gap: DevAnswerEnrichmentGap | None = None
 
 
 class DevAnswerCohortSlot(ContractModel):

--- a/src/dev_health_ops/api/dev/orchestrator.py
+++ b/src/dev_health_ops/api/dev/orchestrator.py
@@ -18,7 +18,7 @@ from collections import Counter
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 import annotated_types
 from pydantic import ValidationError
@@ -36,6 +36,12 @@ from dev_health_ops.llm.agent.contracts import (
     AgentToolRequest,
     AgentUsage,
 )
+
+if TYPE_CHECKING:
+    from dev_health_ops.context_fabric.graph_arm.cohort import CohortProposal
+    from dev_health_ops.context_fabric.graph_arm.cohort_ranking import (
+        CohortRankingResult,
+    )
 from dev_health_ops.llm.agent.errors import (
     AgentProviderError,
     AgentProviderErrorCode,
@@ -71,7 +77,17 @@ from .contracts import (
     V1_SCOPE_LIST_LIMIT,
     AnswerStatus,
     DevAnswer,
+    DevAnswerCohortDisposition,
+    DevAnswerCohortMember,
+    DevAnswerCohortSignal,
+    DevAnswerCohortSignalSource,
+    DevAnswerCohortSlot,
+    DevAnswerEnrichmentGap,
+    DevAnswerEvidenceSourceClass,
     DevAnswerGraphAssistance,
+    DevAnswerPressureDimension,
+    DevAnswerPressureState,
+    DevAnswerSourceRequirementState,
     DevClaim,
     DevContractVersions,
     DevCoverage,
@@ -94,6 +110,9 @@ from .contracts import (
     ScopeResolutionOutcome,
     ToolID,
     dev_error_remediation,
+)
+from .contracts import (
+    CohortDiscoveryFamily as ContractCohortDiscoveryFamily,
 )
 from .contracts import (
     GraphAssistedAvailability as ContractGraphAssistedAvailability,
@@ -131,7 +150,11 @@ from .graph_routing_policy import (
     describe_availability,
     limitation_kinds_of,
 )
-from .investigation_contract import AskDevInvestigationPacket, InvestigationOutcome
+from .investigation_contract import (
+    AskDevInvestigationPacket,
+    CohortCompleteness,
+    InvestigationOutcome,
+)
 from .investigation_plans import PlanExecutor, StepContext
 from .investigation_plans.state_mapping import UNMEASURED_REQUIREMENT_STATES
 from .investigation_shadow import (
@@ -579,10 +602,147 @@ class OrchestratorEvent:
     graph_state: DevAnswerGraphAssistance | None = None
 
 
+def _cohort_proposal_from_packet(packet: AskDevInvestigationPacket) -> CohortProposal:
+    """Rehydrate only the graph-discovered membership the canonical ranker reads."""
+
+    from dev_health_ops.context_fabric.graph_arm.cohort import (
+        CohortCandidate,
+        CohortEntryMode,
+        CohortProposal,
+    )
+    from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+    cohort = packet.comparison_cohort
+    return CohortProposal(
+        subject_id="",
+        members=tuple(
+            CohortCandidate(
+                canonical_id=member.canonical_id,
+                kind=GraphEntityKind(member.subject_kind.value),
+                display_label=member.display_label,
+                basis_anchors=tuple((basis, ()) for basis in member.inclusion_basis),
+            )
+            for member in cohort.members
+        ),
+        exclusions=(),
+        dimensions=cohort.supported_comparison_dimensions,
+        truncated=cohort.completeness is CohortCompleteness.TRUNCATED,
+        truncated_count=0,
+        authorization_filtered_count=cohort.authorization_filtered_count,
+        entry_mode=CohortEntryMode.SCOPE_ENUMERATED,
+    )
+
+
+def _public_cohort_slot(
+    *,
+    packet: AskDevInvestigationPacket,
+    family: CohortDiscoveryFamily,
+    ranking: CohortRankingResult,
+) -> DevAnswerCohortSlot | None:
+    """Project canonical ranking facts without inventing a scalar score."""
+
+    if not ranking.ranked_members:
+        return None
+    packet_members = {
+        member.canonical_id: member for member in packet.comparison_cohort.members
+    }
+    members: list[DevAnswerCohortMember] = []
+    for rank, ranked in enumerate(ranking.ranked_members, start=1):
+        packet_member = packet_members[ranked.candidate.canonical_id]
+        members.append(
+            DevAnswerCohortMember(
+                entity_id=ranked.candidate.canonical_id,
+                display_label=ranked.candidate.display_label,
+                inclusion_basis=ContractCohortDiscoveryFamily(family.value),
+                rank=rank,
+                disposition=DevAnswerCohortDisposition(ranked.disposition.value),
+                inclusion_rationale=packet_member.inclusion_rationale,
+                pressure_dimensions=[
+                    DevAnswerPressureDimension(item.value)
+                    for item in ranked.pressure_dimensions
+                ],
+                signals=[
+                    DevAnswerCohortSignal(
+                        signal_id=signal.signal_id,
+                        source=DevAnswerCohortSignalSource(signal.source),
+                        observed_states=[
+                            DevAnswerSourceRequirementState(item.value)
+                            for item in signal.observed_states
+                        ],
+                        data_semantics=signal.data_semantics,
+                        freshness=signal.freshness,
+                        coverage=signal.coverage,
+                        denominator_present=signal.denominator_present,
+                        attribution_present=signal.attribution_present,
+                        dimension=(
+                            DevAnswerPressureDimension(signal.dimension.value)
+                            if signal.dimension is not None
+                            else None
+                        ),
+                        state=(
+                            DevAnswerPressureState(signal.state.value)
+                            if signal.state is not None
+                            else None
+                        ),
+                        evidence_source_classes=[
+                            DevAnswerEvidenceSourceClass(item.value)
+                            for item in signal.evidence_source_classes
+                        ],
+                        limitation=signal.limitation,
+                        gap=(
+                            DevAnswerEnrichmentGap(signal.gap.value)
+                            if signal.gap is not None
+                            else None
+                        ),
+                    )
+                    for signal in ranked.signals
+                ],
+            )
+        )
+    warnings: list[str] = []
+    if ranking.authorization_filtered_count:
+        noun = (
+            "candidate" if ranking.authorization_filtered_count == 1 else "candidates"
+        )
+        verb = "was" if ranking.authorization_filtered_count == 1 else "were"
+        warnings.append(
+            f"{ranking.authorization_filtered_count} cohort {noun} "
+            f"{verb} hidden by authorization."
+        )
+    if packet.comparison_cohort.exclusions:
+        warnings.append(
+            f"{len(packet.comparison_cohort.exclusions)} graph-discovered "
+            "candidate was excluded before canonical ranking."
+            if len(packet.comparison_cohort.exclusions) == 1
+            else f"{len(packet.comparison_cohort.exclusions)} graph-discovered "
+            "candidates were excluded before canonical ranking."
+        )
+    if packet.comparison_cohort.completeness is CohortCompleteness.TRUNCATED:
+        warnings.append("The discovered cohort was truncated.")
+    elif (
+        packet.comparison_cohort.completeness
+        is CohortCompleteness.BEST_EFFORT_UNCERTAIN
+    ):
+        warnings.append("The discovered cohort is best-effort and may be incomplete.")
+    if ranking.exclusions:
+        warnings.append(
+            f"{len(ranking.exclusions)} candidates did not meet this question's inclusion rule."
+        )
+    return DevAnswerCohortSlot(
+        entity_kind=EntityType(ranking.ranked_members[0].candidate.kind.value),
+        members=members,
+        cohort_complete=(
+            packet.comparison_cohort.completeness is CohortCompleteness.COMPLETE
+        ),
+        warnings=warnings,
+    )
+
+
 def _graph_assistance_for_result(
     result: GraphQueryResult,
     *,
     graph_answered: bool,
+    cohort: DevAnswerCohortSlot | None = None,
 ) -> DevAnswerGraphAssistance:
     """Project one graph attempt into the public answer/event contract.
 
@@ -612,6 +772,7 @@ def _graph_assistance_for_result(
         schema_version="dev_answer_graph_assistance.v1",
         state=ContractGraphAssistedAvailability(availability.value),
         as_of=(packet.produced_at if packet is not None else datetime.now(UTC)),
+        cohort=cohort,
         limitations=limitations,
     )
 
@@ -1201,6 +1362,7 @@ class GraphAssemblyOutcome:
     answer: DevAnswer | None
     evidence_refused: bool
     enrichment_gap: bool
+    cohort: DevAnswerCohortSlot | None = None
 
 
 def _graph_assembly_outcome_label(evidence_refused: bool, enrichment_gap: bool) -> str:
@@ -3365,7 +3527,7 @@ class DevOrchestrator:
                     # ``packet is not None`` iff ``outcome is COMPLETED`` --
                     # narrowed here for mypy, not a new runtime check.
                     assert graph_result.packet is not None
-                    graph_answer = await self._attempt_graph_grounded_answer(
+                    graph_assembly = await self._attempt_graph_grounded_answer(
                         run_id=run_id,
                         answer_id=answer_id,
                         conversation_id=conversation_id,
@@ -3374,15 +3536,21 @@ class DevOrchestrator:
                         org_id=org_id,
                         permission_fingerprint=permission_fingerprint,
                         packet=graph_result.packet,
+                        cohort_discovery_family=cohort_discovery_family,
+                        authorized_entity_ids=(
+                            graph_authorization_scope.authorized_entity_ids
+                        ),
                     )
-                    if graph_answer is not None:
+                    if graph_assembly is not None:
                         graph_assistance = _graph_assistance_for_result(
-                            graph_result, graph_answered=True
+                            graph_result,
+                            graph_answered=True,
+                            cohort=graph_assembly.cohort,
                         )
                         await emit_graph_state(graph_assistance)
                         return await finish(
                             RunState.COMPLETED,
-                            answer=graph_answer,
+                            answer=graph_assembly.answer,
                             grounding_validation_status=(
                                 GRAPH_ASSISTED_GROUNDING_STATUS
                             ),
@@ -5410,7 +5578,9 @@ class DevOrchestrator:
         org_id: str,
         permission_fingerprint: str,
         packet: AskDevInvestigationPacket,
-    ) -> DevAnswer | None:
+        cohort_discovery_family: CohortDiscoveryFamily,
+        authorized_entity_ids: frozenset[str],
+    ) -> GraphAssemblyOutcome | None:
         """The gate, observability and exception-containment wrapper around
         :meth:`_graph_grounded_answer` -- CHAOS-3502/3650.
 
@@ -5501,6 +5671,8 @@ class DevOrchestrator:
                 org_id=org_id,
                 permission_fingerprint=permission_fingerprint,
                 packet=packet,
+                cohort_discovery_family=cohort_discovery_family,
+                authorized_entity_ids=authorized_entity_ids,
                 now=datetime.now(UTC),
             )
         except Exception as exc:  # noqa: BLE001 -- see docstring: contained and counted, never re-raised
@@ -5530,7 +5702,7 @@ class DevOrchestrator:
             },
         )
         ASK_DEV_GRAPH_ASSEMBLY_OUTCOME_TOTAL.labels(outcome=label).inc()
-        return outcome.answer
+        return outcome
 
     async def _graph_grounded_answer(
         self,
@@ -5542,6 +5714,8 @@ class DevOrchestrator:
         org_id: str,
         permission_fingerprint: str,
         packet: AskDevInvestigationPacket,
+        cohort_discovery_family: CohortDiscoveryFamily,
+        authorized_entity_ids: frozenset[str],
         now: datetime,
     ) -> GraphAssemblyOutcome:
         """The graph-frame path's own assembler -- CHAOS-3502/3650.
@@ -5638,6 +5812,23 @@ class DevOrchestrator:
             for metric in enrichment.metrics
         ]
 
+        from dev_health_ops.context_fabric.graph_arm.cohort_ranking import (
+            CanonicalCohortRankingAdapter,
+        )
+
+        ranking = await CanonicalCohortRankingAdapter(self._canonical_enrichment).rank(
+            proposal=_cohort_proposal_from_packet(packet),
+            authorized_entity_ids=authorized_entity_ids,
+            scope=scope,
+            permission_fingerprint=permission_fingerprint,
+            now=now,
+        )
+        public_cohort = _public_cohort_slot(
+            packet=packet,
+            family=cohort_discovery_family,
+            ranking=ranking,
+        )
+
         enrichment_gap = any(
             isinstance(value, EnrichmentGap)
             and value is not EnrichmentGap.NOT_APPLICABLE
@@ -5690,6 +5881,7 @@ class DevOrchestrator:
             answer=answer,
             evidence_refused=evidence_refused,
             enrichment_gap=enrichment_gap,
+            cohort=public_cohort,
         )
 
     def _server_grounded_answer(

--- a/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
+++ b/tests/api/dev/test_chaos_3650_graph_grounded_assembler.py
@@ -38,7 +38,9 @@ from dev_health_ops.api.dev.contract_fixtures import (
 )
 from dev_health_ops.api.dev.contracts import (
     AnswerStatus,
+    DevAnswerCohortDisposition,
     DevMetricRef,
+    EntityType,
     FreshnessState,
     GraphAssistedAvailability,
     PacketLimitationKind,
@@ -52,6 +54,7 @@ from dev_health_ops.api.dev.investigation_contract import AskDevInvestigationPac
 from dev_health_ops.api.dev.investigation_contract.fixtures import (
     positive_fixtures as packet_positive_fixtures,
 )
+from dev_health_ops.api.dev.investigation_corpus.reference import reference_packet
 from dev_health_ops.api.dev.orchestrator import (
     GRAPH_ASSISTED_GROUNDING_STATUS,
     GRAPH_GROUNDED_WARNING_ENRICHMENT_GAP,
@@ -336,6 +339,72 @@ async def test_completed_with_admissible_evidence_produces_a_graph_grounded_answ
     # The legacy model-tool-choice loop must never even start: the graph
     # path returned directly through finish().
     assert output.calls == []
+
+
+@pytest.mark.asyncio
+async def test_discovered_project_cohort_is_ranked_and_projected_publicly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real graph-answer seam must publish the W4 ranking, not just state."""
+
+    monkeypatch.setenv(GRAPH_ROUTING_RUNTIME_FLAG, "1")
+    payload = reference_packet("S03_shared_dependency_portfolio_risk")
+    payload["organization_id"] = ORG_ID
+    packet = AskDevInvestigationPacket.model_validate(payload)
+    # Deliberately authorize only two of the packet's three names. The packet
+    # is evidence, never authorization authority; the third project must not
+    # cross the public projection boundary.
+    authorized_packet_members = packet.comparison_cohort.members[:2]
+    project_entities = [
+        (
+            ORG_ID,
+            AuthorizedEntity(
+                EntityKind.PROJECT, member.canonical_id, member.display_label
+            ),
+        )
+        for member in authorized_packet_members
+    ]
+    metric_payload = deepcopy(v1_positive_fixtures()["dev_metric_ref.v1"])
+    metric_payload["metric_ref_id"] = "metric_graph_cohort_projection_01"
+    metric_payload["value"] = 24681357.0
+    metric_ref = DevMetricRef.model_validate(metric_payload)
+
+    output = await run_preflight_orchestrator(
+        question="Which projects are capacity-constrained right now?",
+        entities=project_entities,
+        org_id=ORG_ID,
+        script_id="chaos3669-public-cohort",
+        graph_investigation_query=FakeGraphInvestigationQuery(packet=packet),
+        evidence_service=_evidence_service(),
+        graph_routing_entitlement=_Entitlement(),
+        canonical_enrichment=_canonical_enrichment(metric_refs=(metric_ref,)),
+    )
+
+    assert output.result.state is RunState.COMPLETED
+    assert output.calls == []
+    answer = output.result.answer
+    assert answer is not None
+    assert [item.metric_ref_id for item in answer.metrics] == [
+        "metric_graph_cohort_projection_01"
+    ]
+    graph = answer.graph_assisted
+    assert graph is not None
+    assert graph.cohort is not None
+    assert graph.cohort.entity_kind is EntityType.PROJECT
+    assert graph.cohort.cohort_complete is True
+    assert [member.entity_id for member in graph.cohort.members] == sorted(
+        member.canonical_id for member in authorized_packet_members
+    )
+    assert [member.rank for member in graph.cohort.members] == [1, 2]
+    assert packet.comparison_cohort.members[2].canonical_id not in {
+        member.entity_id for member in graph.cohort.members
+    }
+    assert graph.cohort.warnings == ["1 cohort candidate was hidden by authorization."]
+    assert all(
+        member.disposition is DevAnswerCohortDisposition.UNKNOWN
+        for member in graph.cohort.members
+    )
+    assert graph.ranked_drivers == []
 
 
 @pytest.mark.asyncio

--- a/tests/api/dev/test_chaos_3669_public_cohort_projection.py
+++ b/tests/api/dev/test_chaos_3669_public_cohort_projection.py
@@ -1,0 +1,192 @@
+"""CHAOS-3669: lossless public projection of canonical cohort ranking facts."""
+
+from dev_health_ops.api.dev.canonical_enrichment import EnrichmentGap
+from dev_health_ops.api.dev.contracts import (
+    DevAnswerCohortDisposition,
+    DevAnswerCohortSignalSource,
+    DevAnswerEnrichmentGap,
+    DevAnswerEvidenceSourceClass,
+    DevAnswerPressureDimension,
+    DevAnswerPressureState,
+    DevAnswerSourceRequirementState,
+    FreshnessState,
+)
+from dev_health_ops.api.dev.contracts_v2.base import (
+    SourceClass,
+    SourceRequirementState,
+)
+from dev_health_ops.api.dev.contracts_v2.health_rules import (
+    DimensionState,
+    HealthDimension,
+)
+from dev_health_ops.api.dev.graph_investigation_query import CohortDiscoveryFamily
+from dev_health_ops.api.dev.investigation_contract import (
+    AskDevInvestigationPacket,
+    CohortCompleteness,
+    CohortExclusion,
+    CohortExclusionReason,
+    InvestigationSubjectKind,
+)
+from dev_health_ops.api.dev.investigation_corpus.reference import reference_packet
+from dev_health_ops.api.dev.orchestrator import _public_cohort_slot
+from dev_health_ops.context_fabric.graph_arm.cohort import CohortCandidate
+from dev_health_ops.context_fabric.graph_arm.cohort_ranking import (
+    CanonicalCohortSignal,
+    CohortRankDisposition,
+    CohortRankedMember,
+    CohortRankingResult,
+)
+from dev_health_ops.context_fabric.graph_arm.vocabulary import GraphEntityKind
+
+
+def test_public_vocabularies_are_total_over_internal_ranking_vocabularies() -> None:
+    assert {item.value for item in DevAnswerSourceRequirementState} == {
+        item.value for item in SourceRequirementState
+    }
+    assert {item.value for item in DevAnswerPressureDimension} == {
+        item.value for item in HealthDimension
+    }
+    assert {item.value for item in DevAnswerPressureState} == {
+        item.value for item in DimensionState
+    }
+    assert {item.value for item in DevAnswerEnrichmentGap} == {
+        item.value for item in EnrichmentGap
+    }
+    assert {item.value for item in DevAnswerEvidenceSourceClass} == {
+        item.value for item in SourceClass
+    }
+    assert {item.value for item in DevAnswerCohortSignalSource} == {
+        "status",
+        "health",
+        "workload",
+        "readiness",
+        "metrics",
+        "canonical_enrichment",
+    }
+
+
+def test_projection_preserves_rank_signal_quality_and_unknown_disposition() -> None:
+    payload = reference_packet("S03_shared_dependency_portfolio_risk")
+    payload["organization_id"] = "org_projection_test"
+    packet = AskDevInvestigationPacket.model_validate(payload)
+    packet_member = packet.comparison_cohort.members[0]
+    signal = CanonicalCohortSignal(
+        signal_id="health:capacity",
+        source="health",
+        observed_states=(SourceRequirementState.AVAILABLE_STALE,),
+        data_semantics="no_data",
+        freshness=FreshnessState.STALE,
+        coverage=0.4,
+        denominator_present=False,
+        attribution_present=False,
+        dimension=HealthDimension.COGNITIVE_WORKLOAD_PRESSURE,
+        state=DimensionState.UNKNOWN,
+        evidence_ref_ids=("evidence:capacity",),
+        evidence_source_classes=(SourceClass.WORK_GRAPH,),
+        limitation="partial canonical coverage",
+        gap=EnrichmentGap.NO_DATA,
+    )
+    ranked = CohortRankedMember(
+        candidate=CohortCandidate(
+            canonical_id=packet_member.canonical_id,
+            kind=GraphEntityKind.PROJECT,
+            display_label=packet_member.display_label,
+            basis_anchors=tuple((basis, ()) for basis in packet_member.inclusion_basis),
+        ),
+        signals=(signal,),
+        disposition=CohortRankDisposition.UNKNOWN,
+        pressure_dimensions=(HealthDimension.COGNITIVE_WORKLOAD_PRESSURE,),
+    )
+    slot = _public_cohort_slot(
+        packet=packet,
+        family=CohortDiscoveryFamily.PROJECT_CAPACITY,
+        ranking=CohortRankingResult(
+            ranked_members=(ranked,),
+            exclusions=(),
+            authorization_filtered_count=0,
+        ),
+    )
+
+    assert slot is not None
+    member = slot.members[0]
+    assert member.rank == 1
+    assert member.disposition is DevAnswerCohortDisposition.UNKNOWN
+    assert member.inclusion_rationale == packet_member.inclusion_rationale
+    assert member.pressure_dimensions == [
+        DevAnswerPressureDimension.COGNITIVE_WORKLOAD_PRESSURE
+    ]
+    projected = member.signals[0]
+    assert projected.observed_states == [
+        DevAnswerSourceRequirementState.AVAILABLE_STALE
+    ]
+    assert projected.data_semantics == "no_data"
+    assert projected.freshness is FreshnessState.STALE
+    assert projected.coverage == 0.4
+    assert projected.denominator_present is False
+    assert projected.attribution_present is False
+    assert projected.dimension is DevAnswerPressureDimension.COGNITIVE_WORKLOAD_PRESSURE
+    assert projected.state is DevAnswerPressureState.UNKNOWN
+    assert projected.evidence_source_classes == [
+        DevAnswerEvidenceSourceClass.WORK_GRAPH
+    ]
+    assert projected.limitation == "partial canonical coverage"
+    assert projected.gap is DevAnswerEnrichmentGap.NO_DATA
+
+
+def test_packet_exclusions_and_uncertain_completeness_are_disclosed_without_ids() -> (
+    None
+):
+    payload = reference_packet("S03_shared_dependency_portfolio_risk")
+    payload["organization_id"] = "org_projection_test"
+    packet = AskDevInvestigationPacket.model_validate(payload)
+    packet_member = packet.comparison_cohort.members[0]
+    cohort = packet.comparison_cohort.model_copy(
+        update={
+            "completeness": CohortCompleteness.BEST_EFFORT_UNCERTAIN,
+            "exclusions": (
+                CohortExclusion(
+                    subject_kind=InvestigationSubjectKind.PROJECT,
+                    canonical_id="private_project_not_for_public_output",
+                    reason=CohortExclusionReason.EXCLUDED_BY_QUESTION,
+                    rationale="Not relevant to this comparison.",
+                ),
+            ),
+        }
+    )
+    packet = packet.model_copy(update={"comparison_cohort": cohort})
+    ranked = CohortRankedMember(
+        candidate=CohortCandidate(
+            canonical_id=packet_member.canonical_id,
+            kind=GraphEntityKind.PROJECT,
+            display_label=packet_member.display_label,
+            basis_anchors=tuple((basis, ()) for basis in packet_member.inclusion_basis),
+        ),
+        signals=(
+            CanonicalCohortSignal(
+                signal_id="canonical_enrichment",
+                source="canonical_enrichment",
+                observed_states=(SourceRequirementState.AVAILABLE_UNKNOWN,),
+                data_semantics="no_data",
+                gap=EnrichmentGap.NO_DATA,
+            ),
+        ),
+        disposition=CohortRankDisposition.UNKNOWN,
+    )
+
+    slot = _public_cohort_slot(
+        packet=packet,
+        family=CohortDiscoveryFamily.PROJECT_CAPACITY,
+        ranking=CohortRankingResult(
+            ranked_members=(ranked,),
+            exclusions=(),
+            authorization_filtered_count=0,
+        ),
+    )
+
+    assert slot is not None
+    assert slot.cohort_complete is False
+    assert slot.warnings == [
+        "1 graph-discovered candidate was excluded before canonical ranking.",
+        "The discovered cohort is best-effort and may be incomplete.",
+    ]
+    assert "private_project_not_for_public_output" not in slot.model_dump_json()


### PR DESCRIPTION
## Summary
- invoke the canonical cohort-ranking adapter on the graph-grounded production answer path
- publish additive member rank, disposition, canonical signal state, quality, pressure dimensions, and safe cohort completeness warnings
- preserve server-owned authorization and withhold unauthorized or excluded entity identities
- keep ranked drivers empty because no authoritative contribution scalar exists
- regenerate the Ask Dev v1 contract artifacts

## Verification
- full local gate: 16,132 passed, 319 skipped, 4 expected xfails
- repository Ruff format/check and mypy green
- focused production seam and containment tests green
- 84 Ask Dev contract artifacts regenerate and verify
- mutation proof: removing the final cohort assignment makes the production-seam oracle fail, then restoring it returns green
- independent adversarial review: APPROVE

## Evidence boundary
This proves the public contract/orchestrator projection. Live graph-store and ClickHouse stages were explicitly excluded from the local gate and remain separate deployment evidence.

SCREENSHOT-WAIVER: backend contract and orchestration only; no rendered web UI changes.

Linear: CHAOS-3669