### PR TITLE
Fix orphaned graph watermark purge retries

### DIFF
--- a/docs/contribute/architecture/graph-investigation-arm.md
+++ b/docs/contribute/architecture/graph-investigation-arm.md
@@ -430,11 +430,11 @@ covers every registered org-deletion visit, including unconfigured, unknown,
 failure, cancellation and close failure. None carries an organization,
 partition, document, question, title, body or prompt label.
 
-Known follow-up (not fixed in W7): `purge_org` drops the graph keyspace before
-deleting the separate raw watermark key. If the watermark delete fails after
-the graph drop, an orphan freshness key can remain; the deletion warning and
-visit outcome make that failure visible, but cleanup/reconciliation of orphan
-watermarks needs a separate change.
+`purge_org` drops the graph keyspace and clears the separate raw watermark key.
+If the key deletion fails after the graph drop, the failed attempt is visible
+through the purge and deletion-visit outcomes; a retry explicitly clears the
+watermark before reporting the already-absent partition. Dry-run remains
+non-mutating, so it does not clear a key while previewing deletion.
 
 ## Semantic and conversational subject resolution: a second leg
 
@@ -549,7 +549,7 @@ Two things worth knowing before reading that artifact:
 | Every bound paired with the contract's `TruncationReason` | `budgets.py` |
 | Indexed-through watermark, stale / partial / never-projected | `watermark.py` |
 | Canonical writes never wait on graph indexing | `projection.py` is pure and synchronous; the store write happens strictly after |
-| Deterministic cleanup | `store.purge_org` drops the keyspace |
+| Deterministic cleanup | `store.purge_org` drops the keyspace and clears its separate watermark key, including on retries after a partial drop |
 | Read-only deletion preview | `store.partition_exists_for` — no driver, so no keyspace is created |
 | Org-deletion registration | `EXTERNAL_DERIVED_STORES` (CHAOS-3566) |
 | Content-safe logs | `IndexWatermark.detail_for` — timestamps and counts only |

--- a/src/dev_health_ops/context_fabric/graph_arm/store.py
+++ b/src/dev_health_ops/context_fabric/graph_arm/store.py
@@ -177,6 +177,49 @@ def _watermark_key(partition: str) -> str:
     return f"{_WATERMARK_KEY_PREFIX}{partition}"
 
 
+def _bare_falkor_client(config: TrialStoreConfig, deadlines: GraphDeadlines) -> Any:
+    """Open FalkorDB without constructing a Graphiti driver or keyspace."""
+
+    return graphiti_module("driver.falkordb_driver").FalkorDB(
+        host=config.host,
+        port=config.port,
+        password=config.password,
+        socket_connect_timeout=deadlines.connect_timeout_s,
+        socket_timeout=deadlines.socket_timeout_s,
+        max_connections=deadlines.max_connections,
+    )
+
+
+async def _delete_watermark_for(
+    org_id: str,
+    config: TrialStoreConfig,
+    *,
+    deadlines: GraphDeadlines | None = None,
+) -> None:
+    """Delete an organization's raw watermark without recreating its graph.
+
+    ``partition_exists_for`` deliberately avoids ``FalkorDriver`` because
+    driver construction schedules index creation for a missing partition.
+    The same rule applies to retrying an org deletion after the graph drop
+    already succeeded: only the raw Redis key remains, so use the bare client
+    and never recreate the graph keyspace just to remove its watermark.
+    """
+
+    resolved_deadlines = deadlines or graph_deadlines()
+    client = _bare_falkor_client(config, resolved_deadlines)
+    try:
+        await _await_with_deadline(
+            client.connection.delete(_watermark_key(partition_for_org(org_id))),
+            timeout_s=resolved_deadlines.read_timeout_s,
+            operation="purge_watermark",
+            detail=f"org {org_id!r}",
+        )
+    finally:
+        aclose = getattr(client, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+
 class StoreUnavailableError(RuntimeError):
     """The trial store is not configured or not reachable."""
 
@@ -656,6 +699,20 @@ class GraphArmStore:
         )
         return self._partition in set(graphs or ())
 
+    async def _delete_watermark(self) -> None:
+        """Remove this partition's raw watermark key.
+
+        The graph keyspace and watermark are separate Redis state. Keeping
+        this cleanup as one operation lets a retry repair a watermark left
+        behind after a graph drop succeeded but the first key deletion did
+        not.
+        """
+
+        await self._bounded_read(
+            self._driver.client.connection.delete(_watermark_key(self._partition)),
+            operation="purge_watermark",
+        )
+
     async def count_nodes(self) -> int:
         if not await self.partition_exists():
             return 0
@@ -693,6 +750,13 @@ class GraphArmStore:
 
         try:
             if not await self.partition_exists():
+                # A previous attempt may have dropped the graph and failed
+                # before its separate watermark key was deleted. An absent
+                # graph is therefore not necessarily a clean partition; the
+                # retry must still remove the key before reporting absent.
+                # Dry-run remains read-only and deliberately leaves it alone.
+                if not dry_run:
+                    await self._delete_watermark()
                 record_context_fabric_graph_purge(outcome="absent", dry_run=dry_run)
                 return 0
             total = await self.count_nodes()
@@ -708,10 +772,7 @@ class GraphArmStore:
                 self._driver.client.select_graph(self._partition).delete(),
                 operation="purge_org",
             )
-            await self._bounded_read(
-                self._driver.client.connection.delete(_watermark_key(self._partition)),
-                operation="purge_watermark",
-            )
+            await self._delete_watermark()
             record_context_fabric_graph_purge(outcome="completed", dry_run=False)
             return total
         except asyncio.CancelledError:
@@ -873,14 +934,7 @@ async def partition_exists_for(
     """
 
     resolved_deadlines = deadlines or graph_deadlines()
-    client = graphiti_module("driver.falkordb_driver").FalkorDB(
-        host=config.host,
-        port=config.port,
-        password=config.password,
-        socket_connect_timeout=resolved_deadlines.connect_timeout_s,
-        socket_timeout=resolved_deadlines.socket_timeout_s,
-        max_connections=resolved_deadlines.max_connections,
-    )
+    client = _bare_falkor_client(config, resolved_deadlines)
     try:
         graphs = await _await_with_deadline(
             client.list_graphs(),
@@ -924,7 +978,8 @@ async def org_deletion_visit(org_id: str, dry_run: bool) -> int:
     :class:`DeletionCompletenessUnknownError` — a missing graphiti-core does
     not make the data disappear, and an unreachable endpoint is an unknown
     rather than an absence. ``0`` is returned only after a positive existence
-    check proved the partition absent.
+    check proved the partition absent and, for a real deletion, its separate
+    watermark key was cleaned up.
 
     The **one** exception is a store that is not configured at all, which is
     the production default and returns ``0`` with a logged warning rather
@@ -1013,11 +1068,32 @@ async def org_deletion_visit(org_id: str, dry_run: bool) -> int:
             "was neither verified absent nor purged"
         ) from exc
     if not exists:
-        # Positively checked, and absent. This is the only path that may
-        # report zero -- and it constructs no store, which is what keeps the
-        # preview read-only (see partition_exists_for).
+        # Positively checked, and absent. A previous attempt can have dropped
+        # the graph and failed before deleting its separate watermark key, so
+        # a real retry must clean that raw key without constructing a
+        # Graphiti/FalkorDriver (which would recreate the missing keyspace).
+        # Dry-run deliberately skips this write and remains read-only.
+        if not dry_run:
+            try:
+                await _delete_watermark_for(org_id, config)
+            except asyncio.CancelledError:
+                record_context_fabric_graph_org_deletion_visit(
+                    outcome="cancelled", dry_run=dry_run
+                )
+                raise
+            except Exception as exc:
+                record_context_fabric_graph_org_deletion_visit(
+                    outcome="failed", dry_run=dry_run
+                )
+                raise DeletionCompletenessUnknownError(
+                    f"deletion completeness unknown for org {org_id}: the "
+                    "graph partition is absent but its watermark cleanup "
+                    f"could not be completed ({type(exc).__name__}: {exc})"
+                ) from exc
         logger.info(
-            "context-fabric graph trial store holds no partition for org %s", org_id
+            "context-fabric graph trial store holds no partition for org %s%s",
+            org_id,
+            "; watermark cleanup completed" if not dry_run else "",
         )
         record_context_fabric_graph_org_deletion_visit(
             outcome="absent", dry_run=dry_run

--- a/tests/context_fabric/test_chaos_3617_containment.py
+++ b/tests/context_fabric/test_chaos_3617_containment.py
@@ -521,9 +521,16 @@ class TestOrgDeletionRegistration:
             checked.append(org_id)
             return False
 
+        cleaned: list[str] = []
+
+        async def _cleanup(org_id: str, _config: object) -> None:
+            cleaned.append(org_id)
+
         monkeypatch.setattr(store_module, "partition_exists_for", _absent)
+        monkeypatch.setattr(store_module, "_delete_watermark_for", _cleanup)
         assert await store_module.org_deletion_visit("org_alpha", False) == 0
         assert checked == ["org_alpha"], "zero was reported without checking"
+        assert cleaned == ["org_alpha"], "absent retries must clean the watermark"
         assert (
             CONTEXT_FABRIC_GRAPH_ORG_DELETION_VISITS_TOTAL.labels(
                 outcome="absent", dry_run="false"

--- a/tests/context_fabric/test_chaos_3711_telemetry_wiring.py
+++ b/tests/context_fabric/test_chaos_3711_telemetry_wiring.py
@@ -137,6 +137,11 @@ async def test_purge_records_cancel_once(monkeypatch) -> None:
         return False
 
     cast(Any, store).partition_exists = absent
+
+    async def delete_watermark() -> None:
+        pass
+
+    cast(Any, store)._delete_watermark = delete_watermark
     assert await store.purge_org() == 0
     assert outcomes[-1] == ("absent", False)
 

--- a/tests/context_fabric/test_chaos_3740_graph_purge.py
+++ b/tests/context_fabric/test_chaos_3740_graph_purge.py
@@ -1,0 +1,169 @@
+"""CHAOS-3740: graph purge retries must remove orphaned watermark keys."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.services.org_deletion import (
+    DeletionResult,
+    OrganizationDeletionService,
+)
+from dev_health_ops.context_fabric.graph_arm import store as store_module
+from dev_health_ops.context_fabric.graph_arm.backend import DeterministicEmbedder
+from dev_health_ops.context_fabric.graph_arm.flags import TrialStoreConfig
+from dev_health_ops.context_fabric.graph_arm.store import GraphArmStore
+
+
+class _FakeConnection:
+    def __init__(self, *, fail_first_delete: bool = False) -> None:
+        self.watermark_present = True
+        self.delete_calls = 0
+        self._fail_first_delete = fail_first_delete
+
+    async def delete(self, _key: str) -> int:
+        self.delete_calls += 1
+        if self._fail_first_delete:
+            self._fail_first_delete = False
+            raise RuntimeError("simulated watermark deletion failure")
+        self.watermark_present = False
+        return 1
+
+    async def get(self, _key: str) -> bytes | None:
+        return b"{}" if self.watermark_present else None
+
+
+class _FakeGraph:
+    def __init__(self, client: _FakeClient) -> None:
+        self._client = client
+
+    async def delete(self) -> None:
+        self._client.graph_present = False
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.graph_present = True
+        self.connection = _FakeConnection(fail_first_delete=True)
+        self.partition = ""
+
+    async def list_graphs(self) -> list[str]:
+        return [self.partition] if self.graph_present else []
+
+    def select_graph(self, _partition: str) -> _FakeGraph:
+        return _FakeGraph(self)
+
+
+class _FakeDriver:
+    def __init__(self) -> None:
+        self.client = _FakeClient()
+
+    async def execute_query(
+        self, _query: str
+    ) -> tuple[list[dict[str, Any]], None, None]:
+        return ([{"total": 3}], None, None)
+
+
+class _FakeBareClient:
+    def __init__(self) -> None:
+        self.connection = _FakeConnection()
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _store() -> tuple[GraphArmStore, _FakeDriver]:
+    driver = _FakeDriver()
+    store = GraphArmStore(
+        org_id="org_chaos_3740",
+        driver=driver,
+        embedder=DeterministicEmbedder(),
+    )
+    driver.client.partition = store.partition
+    return store, driver
+
+
+@pytest.mark.asyncio
+async def test_retry_cleans_watermark_after_partition_delete_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        store_module,
+        "record_context_fabric_graph_purge",
+        lambda *, outcome, dry_run: outcomes.append((outcome, dry_run)),
+    )
+    store, driver = _store()
+
+    with pytest.raises(RuntimeError, match="simulated watermark deletion failure"):
+        await store.purge_org()
+
+    assert driver.client.graph_present is False
+    assert driver.client.connection.watermark_present is True
+    assert outcomes == [("failed", False)]
+
+    assert await store.purge_org() == 0
+    assert driver.client.connection.delete_calls == 2
+    assert driver.client.connection.watermark_present is False
+    assert outcomes == [("failed", False), ("absent", False)]
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_clean_an_absent_partition_watermark() -> None:
+    store, driver = _store()
+    driver.client.graph_present = False
+
+    assert await store.purge_org(dry_run=True) == 0
+    assert driver.client.connection.delete_calls == 0
+    assert driver.client.connection.watermark_present is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dry_run", [False, True])
+async def test_registered_org_deletion_handles_absent_partition_watermark(
+    monkeypatch: pytest.MonkeyPatch,
+    dry_run: bool,
+) -> None:
+    """The registry path repairs retries but keeps dry-run read-only."""
+
+    config = TrialStoreConfig(uri="falkor://127.0.0.1:6389")
+    bare_client = _FakeBareClient()
+    created_clients: list[_FakeBareClient] = []
+
+    class _FakeFalkorDBModule:
+        @staticmethod
+        def FalkorDB(**_kwargs: Any) -> _FakeBareClient:
+            created_clients.append(bare_client)
+            return bare_client
+
+        @staticmethod
+        def FalkorDriver(**_kwargs: Any) -> None:
+            raise AssertionError("absent cleanup must not construct a graph driver")
+
+    monkeypatch.setattr(store_module, "trial_store_config", lambda: config)
+
+    async def absent(*_args: Any, **_kwargs: Any) -> bool:
+        return False
+
+    monkeypatch.setattr(store_module, "partition_exists_for", absent)
+    monkeypatch.setattr(
+        store_module,
+        "graphiti_module",
+        lambda dotted="": _FakeFalkorDBModule,
+    )
+
+    service = OrganizationDeletionService(cast(AsyncSession, None))
+    result = DeletionResult(organization_id="org_chaos_3740", dry_run=dry_run)
+    await service._purge_external_stores(
+        "org_chaos_3740", dry_run=dry_run, result=result
+    )
+
+    assert created_clients == ([] if dry_run else [bare_client])
+    assert bare_client.connection.delete_calls == (0 if dry_run else 1)
+    assert bare_client.connection.watermark_present is dry_run
+    assert bare_client.closed is (not dry_run)
+    assert result.external.tables["context_fabric_graph_trial"] == 0
+    assert result.warnings == []


### PR DESCRIPTION
## Summary
- repair orphaned Context Fabric watermark metadata after a partial graph purge
- make the production organization-deletion retry use a bare Falkor client so it never recreates an absent graph keyspace
- keep dry-run non-mutating and preserve cancellation, failure, close, and telemetry semantics

## Reproduction and validation
- baseline `42063ceb8f70d03648cc4401b4f37c7e36def38e`: graph deletion succeeded, watermark deletion failed, and the production service retry incorrectly returned zero while leaving the watermark
- current production-path replay: graph absent, watermark absent, two delete attempts, no retry graph-driver construction, and all bare clients closed
- Context Fabric: 1,547 passed, 22 skipped, 127 deselected
- full local gate: 16,090 passed, 384 skipped, 4 expected xfails; 10/10 stages green including live ClickHouse proofs
- focused registry/lifecycle: 54 passed, 1 expected live-store skip
- full-project mypy: 2,364 files green; Ruff, format, docs, and diff checks green
- independent adversarial re-review: APPROVE

## Mutation evidence
- shared harness mutation removing absent-partition cleanup: KILLED at the service-level regression
- post-mutation verify confirmed content restoration
- harness provenance: canonical CHAOS-3155 shared harness at `fb8229f396d34f024d5f3c886e8b79f31eb56856`, blob `46d94d20f97dd9218a85801d6da6c044d1bc3e03`
- boundary: the harness is merged into the Go-worker feature base by PR #1401 but is not currently present on `main`; no ad hoc harness was used

## Release boundary
This repairs a required lifecycle invariant but does not complete W7 or enable the beta. Deployed purge/rebuild/rollback evidence remains required.

Part of CHAOS-3740
