### PR TITLE
feat(worker): enforce provider family admission

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -393,12 +393,12 @@
       "notes": "Beat entry prune-external-ingest-batches, crontab(5,15) UTC"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:766",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:767",
       "surface": "dispatch_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 766
+        "line": 767
       },
       "queue_or_cadence": "sync",
       "dispatches": "run_sync_unit (per unit)",
@@ -417,12 +417,12 @@
       "notes": "transport-routes.json kind dispatch_sync_run, route=celery"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1194",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1190",
       "surface": "run_sync_unit",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1194
+        "line": 1190
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -441,12 +441,12 @@
       "notes": "matrix inventory: 25/59 provider/dataset pairs route-ready in Go, including GitHub 17/17; all deployment switches remain default-off and Celery/Python ownership remains active"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:2049",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:2045",
       "surface": "finalize_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2049
+        "line": 2045
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -2289,12 +2289,12 @@
       "notes": ""
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1090",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1086",
       "surface": "getattr(signature,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1090
+        "line": 1086
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dynamic per-provider signature",
@@ -2313,12 +2313,12 @@
       "notes": "grep-evading form; internal to dispatch_sync_run fan-out"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1680",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1676",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1680
+        "line": 1676
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2337,12 +2337,12 @@
       "notes": "grep-evading form; internal to unit completion"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2500",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2496",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2500
+        "line": 2496
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/jobcontract"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/providerfamilycontract"
 	"github.com/full-chaos/dev-health-ops/internal/providersync"
 	"github.com/google/uuid"
 )
@@ -234,6 +236,35 @@ func routeReconciliationError(configurationErr error) error {
 	return fmt.Errorf("%w: %w", ErrRouteReconciliationRequired, configurationErr)
 }
 
+func validateProviderFamilyExecutionClaim(
+	claim providersync.Claim,
+	switches providersync.CompleteRouteSwitches,
+) error {
+	policy, family := providerfamilycontract.PolicyFor(claim.Provider, claim.Dataset)
+	if !family || policy.Mode == providerfamilycontract.Independent {
+		return nil
+	}
+	// GitHub retains its already-landed always-exact claim contract. Other
+	// work-item providers remain on their D16 legacy claim shape until their
+	// actual typed Go switch is enabled. GitLab deliberately has no switch yet,
+	// so cataloguing its family cannot activate admission or execution.
+	strict := false
+	switch strings.ToLower(strings.TrimSpace(claim.Provider)) {
+	case "github":
+		strict = true
+	case "jira":
+		strict = switches.JiraWorkItems
+	case "linear":
+		strict = switches.LinearWorkItems
+	}
+	if err := providerfamilycontract.ValidateClaim(
+		claim.Provider, claim.Dataset, claim.ProcessorFlags, strict,
+	); err != nil {
+		return fmt.Errorf("%w: %w", providersync.ErrInvalidConfiguration, err)
+	}
+	return nil
+}
+
 func (handler *Handler) Work(
 	ctx context.Context,
 	execution *jobruntime.Execution[jobruntime.ProviderUnitArgs],
@@ -267,9 +298,7 @@ func (handler *Handler) Work(
 	// BuildExecutor. A stale River unit can otherwise fetch credentials and
 	// commit an incomplete work-item family before the completion-side
 	// defense-in-depth check observes its flags.
-	familyClaimErr := providersync.ValidateGitHubWorkItemExecutionClaim(
-		claim.Provider, claim.Dataset, claim.ProcessorFlags,
-	)
+	familyClaimErr := validateProviderFamilyExecutionClaim(claim, handler.Switches)
 	if familyClaimErr != nil || !descriptorPresent ||
 		!descriptor.RouteReady || !descriptor.RouteEnabled {
 		return handler.reconcileRouteFault(

--- a/internal/jobs/providerunit/route_fault_test.go
+++ b/internal/jobs/providerunit/route_fault_test.go
@@ -235,6 +235,122 @@ func TestGitHubWorkItemFamilyClaimReconcilesBeforeExecutorCredentialsOrEffects(t
 	}
 }
 
+func TestEnabledProviderNeutralWorkItemFamilyReconcilesBeforeExecutorCredentialsOrEffects(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	completeFlags := map[string]bool{
+		"family_dataset_work_items":         true,
+		"family_dataset_work_item_labels":   true,
+		"family_dataset_work_item_projects": true,
+		"family_dataset_work_item_history":  true,
+		"family_dataset_work_item_comments": true,
+	}
+	claims := map[string]struct {
+		dataset string
+		flags   map[string]bool
+	}{
+		"direct alias": {
+			dataset: "work-item-comments", flags: completeFlags,
+		},
+		"missing flag": {
+			dataset: "work-items",
+			flags: map[string]bool{
+				"family_dataset_work_items":         true,
+				"family_dataset_work_item_labels":   true,
+				"family_dataset_work_item_projects": true,
+				"family_dataset_work_item_history":  true,
+			},
+		},
+		"false flag": {
+			dataset: "work-items",
+			flags: map[string]bool{
+				"family_dataset_work_items":         true,
+				"family_dataset_work_item_labels":   true,
+				"family_dataset_work_item_projects": true,
+				"family_dataset_work_item_history":  true,
+				"family_dataset_work_item_comments": false,
+			},
+		},
+		"unknown flag": {
+			dataset: "work-items",
+			flags: map[string]bool{
+				"family_dataset_work_items":         true,
+				"family_dataset_work_item_labels":   true,
+				"family_dataset_work_item_projects": true,
+				"family_dataset_work_item_history":  true,
+				"family_dataset_work_item_comments": true,
+				"family_dataset_unknown":            true,
+			},
+		},
+	}
+	providers := map[string]providersync.CompleteRouteSwitches{
+		"jira":   {JiraWorkItems: true},
+		"linear": {LinearWorkItems: true},
+	}
+	for provider, switches := range providers {
+		provider, switches := provider, switches
+		for name, claim := range claims {
+			name, claim := name, claim
+			t.Run(provider+"/"+name, func(t *testing.T) {
+				t.Parallel()
+				unit := providerUnit()
+				capability, ok := providersync.Capability(provider, claim.dataset)
+				if !ok {
+					t.Fatalf("%s/%s capability missing", provider, claim.dataset)
+				}
+				unit.Provider, unit.Dataset, unit.CostClass = provider, claim.dataset, capability.CostClass
+				unit.ProcessorFlags = maps.Clone(claim.flags)
+				repository := newMemoryUnitRepository(unit)
+				builds := 0
+				handler := &Handler{
+					Repository:    repository,
+					Switches:      switches,
+					LeaseDuration: time.Minute,
+					Heartbeat:     10 * time.Second,
+					Now:           func() time.Time { return now },
+					BuildExecutor: func(
+						*providersync.LeaseSession,
+					) (providersync.CompleteRouteExecutor, error) {
+						builds++
+						t.Fatal("invalid family claim reached executor/credential/I/O construction")
+						return providersync.CompleteRouteExecutor{}, nil
+					},
+				}
+
+				err := handler.Work(context.Background(), providerExecution(unit, now, 1))
+
+				if !errors.Is(err, providersync.ErrInvalidConfiguration) {
+					t.Fatalf("error=%v want ErrInvalidConfiguration", err)
+				}
+				if !errors.Is(err, ErrRouteReconciliationRequired) || err.Error() != retryableCategory {
+					t.Fatalf("error=%v want retryable route reconciliation", err)
+				}
+				if builds != 0 {
+					t.Fatalf("executor constructions=%d want 0", builds)
+				}
+			})
+		}
+	}
+}
+
+func TestDefaultOffProviderNeutralWorkItemFamilyKeepsLegacyClaimAdmissible(t *testing.T) {
+	t.Parallel()
+	for _, provider := range []string{"gitlab", "jira", "linear"} {
+		unit := providerUnit()
+		unit.Provider = provider
+		unit.Dataset = "work-items"
+		unit.ProcessorFlags = map[string]bool{"family_dataset_work_items": true}
+		claim := providersync.Claim{
+			Unit: unit,
+		}
+		if err := validateProviderFamilyExecutionClaim(
+			claim, providersync.CompleteRouteSwitches{},
+		); err != nil {
+			t.Fatalf("provider=%s error=%v", provider, err)
+		}
+	}
+}
+
 func TestGitHubWorkItemCompleteFamilyClaimReachesExecutorFactory(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)

--- a/internal/providerfamilycontract/contract.go
+++ b/internal/providerfamilycontract/contract.go
@@ -1,0 +1,119 @@
+// Package providerfamilycontract owns provider-neutral execution-family
+// admission without changing each provider's D16 unit boundary.
+package providerfamilycontract
+
+import (
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/full-chaos/dev-health-ops/internal/workitemcontract"
+)
+
+type ExecutionMode string
+
+const (
+	AtomicCanonical ExecutionMode = "atomic_canonical"
+	Independent     ExecutionMode = "independent"
+)
+
+var ErrInvalidClaim = errors.New("provider family claim is invalid")
+
+const familyDatasetFlagPrefix = "family_dataset_"
+
+// Policy declares one related dataset family. AtomicCanonical families admit
+// exactly one canonical claim once their Go family switch is enabled.
+// Independent families remain one claim per dataset; their membership is
+// catalogued for ownership and tests, not used to collapse execution.
+type Policy struct {
+	Mode             ExecutionMode
+	CanonicalDataset string
+	Datasets         []string
+	providers        map[string]struct{}
+}
+
+var policies = []Policy{
+	{
+		Mode:             AtomicCanonical,
+		CanonicalDataset: "work-items",
+		Datasets:         workitemcontract.FamilyDatasets(),
+		providers: stringSet(
+			"github", "gitlab", "jira", "linear",
+		),
+	},
+	{
+		Mode:             Independent,
+		CanonicalDataset: "incidents",
+		Datasets: []string{
+			"incidents", "incident-alerts", "incident-log-entries", "incident-notes",
+		},
+		providers: stringSet("pagerduty"),
+	},
+}
+
+func stringSet(values ...string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+// PolicyFor returns a defensive copy of the family policy containing the
+// provider/dataset pair.
+func PolicyFor(provider, dataset string) (Policy, bool) {
+	provider = normalize(provider)
+	dataset = normalize(dataset)
+	for _, policy := range policies {
+		if _, ok := policy.providers[provider]; !ok || !slices.Contains(policy.Datasets, dataset) {
+			continue
+		}
+		policy.Datasets = slices.Clone(policy.Datasets)
+		policy.providers = nil
+		return policy, true
+	}
+	return Policy{}, false
+}
+
+// ValidateClaim enforces an atomic policy only after its Go family switch is
+// enabled. Default-off claims keep their existing legacy shape. Independent
+// families always preserve their per-dataset D16 boundary.
+func ValidateClaim(
+	provider string,
+	dataset string,
+	processorFlags map[string]bool,
+	strictAtomic bool,
+) error {
+	policy, ok := PolicyFor(provider, dataset)
+	if !ok || policy.Mode == Independent || !strictAtomic {
+		return nil
+	}
+	if normalize(dataset) != policy.CanonicalDataset {
+		return ErrInvalidClaim
+	}
+	expected := make(map[string]struct{}, len(policy.Datasets))
+	for _, familyDataset := range policy.Datasets {
+		flag := familyDatasetFlag(familyDataset)
+		expected[flag] = struct{}{}
+		if !processorFlags[flag] {
+			return ErrInvalidClaim
+		}
+	}
+	for flag := range processorFlags {
+		if !strings.HasPrefix(flag, familyDatasetFlagPrefix) {
+			continue
+		}
+		if _, known := expected[flag]; !known {
+			return ErrInvalidClaim
+		}
+	}
+	return nil
+}
+
+func familyDatasetFlag(dataset string) string {
+	return familyDatasetFlagPrefix + strings.ReplaceAll(dataset, "-", "_")
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/providerfamilycontract/contract_test.go
+++ b/internal/providerfamilycontract/contract_test.go
@@ -1,0 +1,93 @@
+package providerfamilycontract
+
+import (
+	"errors"
+	"maps"
+	"testing"
+)
+
+func TestAtomicWorkItemPoliciesAreProviderNeutralAndExact(t *testing.T) {
+	t.Parallel()
+	complete := map[string]bool{
+		"family_dataset_work_items":         true,
+		"family_dataset_work_item_labels":   true,
+		"family_dataset_work_item_projects": true,
+		"family_dataset_work_item_history":  true,
+		"family_dataset_work_item_comments": true,
+	}
+	for _, provider := range []string{"github", "gitlab", "jira", "linear"} {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateClaim(provider, "work-items", complete, true); err != nil {
+				t.Fatalf("complete claim error=%v", err)
+			}
+			for _, alias := range []string{
+				"work-item-labels", "work-item-projects",
+				"work-item-history", "work-item-comments",
+			} {
+				if err := ValidateClaim(provider, alias, complete, true); !errors.Is(err, ErrInvalidClaim) {
+					t.Fatalf("direct alias %q error=%v", alias, err)
+				}
+			}
+			for flag := range complete {
+				missing := maps.Clone(complete)
+				delete(missing, flag)
+				if err := ValidateClaim(provider, "work-items", missing, true); !errors.Is(err, ErrInvalidClaim) {
+					t.Fatalf("missing %q error=%v", flag, err)
+				}
+				falseFlag := maps.Clone(complete)
+				falseFlag[flag] = false
+				if err := ValidateClaim(provider, "work-items", falseFlag, true); !errors.Is(err, ErrInvalidClaim) {
+					t.Fatalf("false %q error=%v", flag, err)
+				}
+			}
+			unknown := maps.Clone(complete)
+			unknown["family_dataset_unknown"] = true
+			if err := ValidateClaim(provider, "work-items", unknown, true); !errors.Is(err, ErrInvalidClaim) {
+				t.Fatalf("unknown family flag error=%v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultOffAtomicPoliciesPreserveLegacyClaims(t *testing.T) {
+	t.Parallel()
+	for _, provider := range []string{"gitlab", "jira", "linear"} {
+		if err := ValidateClaim(
+			provider,
+			"work-items",
+			map[string]bool{"family_dataset_work_items": true},
+			false,
+		); err != nil {
+			t.Fatalf("provider=%s error=%v", provider, err)
+		}
+	}
+}
+
+func TestPagerDutyIncidentPolicyPreservesIndependentD16Claims(t *testing.T) {
+	t.Parallel()
+	for _, dataset := range []string{
+		"incidents", "incident-alerts", "incident-log-entries", "incident-notes",
+	} {
+		policy, ok := PolicyFor("pagerduty", dataset)
+		if !ok || policy.Mode != Independent {
+			t.Fatalf("dataset=%s policy=%+v ok=%t", dataset, policy, ok)
+		}
+		if err := ValidateClaim("pagerduty", dataset, nil, true); err != nil {
+			t.Fatalf("dataset=%s error=%v", dataset, err)
+		}
+	}
+}
+
+func TestIndependentProviderRoutesRemainOutsideFamilyAdmission(t *testing.T) {
+	t.Parallel()
+	for _, dataset := range []string{"prs", "cicd", "tests"} {
+		if _, ok := PolicyFor("github", dataset); ok {
+			t.Fatalf("github/%s unexpectedly acquired a family policy", dataset)
+		}
+		if err := ValidateClaim("github", dataset, nil, true); err != nil {
+			t.Fatalf("github/%s error=%v", dataset, err)
+		}
+	}
+}

--- a/internal/providerfamilycontract/testdata/mutation-plans/provider_family_admission.json
+++ b/internal/providerfamilycontract/testdata/mutation-plans/provider_family_admission.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": 1,
+  "name": "provider-neutral family admission",
+  "$limitation": "This plan pins exact switch-gated atomic work-item ownership, default-off legacy compatibility, PagerDuty's independent D16 unit boundary, and producer/worker admission before transport or executor construction. It does not activate a route, add a missing GitLab switch, change planner unit boundaries, or prove provider runtime effects.",
+  "mutations": [
+    {
+      "id": "F1-go-independent-family-clause",
+      "file": "internal/providerfamilycontract/contract.go",
+      "find": "if !ok || policy.Mode == Independent || !strictAtomic {",
+      "replace": "if !ok || false || !strictAtomic {",
+      "rationale": "PagerDuty's catalogued incident quartet must remain four independently admissible claims even when family admission is strict elsewhere",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-run", "^$", "./internal/providerfamilycontract/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-count=1", "-run", "^TestPagerDutyIncidentPolicyPreservesIndependentD16Claims$", "./internal/providerfamilycontract/"]]
+    },
+    {
+      "id": "F2-go-default-off-clause",
+      "file": "internal/providerfamilycontract/contract.go",
+      "find": "if !ok || policy.Mode == Independent || !strictAtomic {",
+      "replace": "if !ok || policy.Mode == Independent || false {",
+      "rationale": "a known atomic family must keep its legacy contributing-flag claim admissible while its typed Go switch is off",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-run", "^$", "./internal/providerfamilycontract/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-count=1", "-run", "^TestDefaultOffAtomicPoliciesPreserveLegacyClaims$", "./internal/providerfamilycontract/"]]
+    },
+    {
+      "id": "F3-go-canonical-claim-guard",
+      "file": "internal/providerfamilycontract/contract.go",
+      "find": "if normalize(dataset) != policy.CanonicalDataset {",
+      "replace": "if false {",
+      "rationale": "an enabled atomic family must reject every direct sibling alias rather than grant it a partial writer",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-run", "^$", "./internal/providerfamilycontract/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-count=1", "-run", "^TestAtomicWorkItemPoliciesAreProviderNeutralAndExact$", "./internal/providerfamilycontract/"]]
+    },
+    {
+      "id": "F4-go-required-literal-true-guard",
+      "file": "internal/providerfamilycontract/contract.go",
+      "find": "\t\tif !processorFlags[flag] {",
+      "replace": "\t\tif false {",
+      "rationale": "every declared family ownership flag must be present and literal true before an atomic claim is admitted",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-run", "^$", "./internal/providerfamilycontract/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-count=1", "-run", "^TestAtomicWorkItemPoliciesAreProviderNeutralAndExact$", "./internal/providerfamilycontract/"]]
+    },
+    {
+      "id": "F5-go-unknown-family-flag-guard",
+      "file": "internal/providerfamilycontract/contract.go",
+      "find": "\t\tif _, known := expected[flag]; !known {",
+      "replace": "\t\tif _, known := expected[flag]; false && !known {",
+      "rationale": "an enabled atomic claim must fail closed when persisted state names an undeclared family member",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-run", "^$", "./internal/providerfamilycontract/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-count=1", "-run", "^TestAtomicWorkItemPoliciesAreProviderNeutralAndExact$", "./internal/providerfamilycontract/"]]
+    },
+    {
+      "id": "F6-go-jira-switch-clause",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\t\tstrict = switches.JiraWorkItems",
+      "replace": "\t\tstrict = false",
+      "rationale": "Jira's typed work-items switch must activate exact family admission before executor and credential construction",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-run", "^$", "./internal/jobs/providerunit/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-count=1", "-run", "^TestEnabledProviderNeutralWorkItemFamilyReconcilesBeforeExecutorCredentialsOrEffects$/jira/", "./internal/jobs/providerunit/"]]
+    },
+    {
+      "id": "F7-go-linear-switch-clause",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\t\tstrict = switches.LinearWorkItems",
+      "replace": "\t\tstrict = false",
+      "rationale": "Linear's typed work-items switch must activate exact family admission before executor and credential construction",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-run", "^$", "./internal/jobs/providerunit/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/family-admission-go-cache", "go", "test", "-count=1", "-run", "^TestEnabledProviderNeutralWorkItemFamilyReconcilesBeforeExecutorCredentialsOrEffects$/linear/", "./internal/jobs/providerunit/"]]
+    },
+    {
+      "id": "F8-python-independent-family-clause",
+      "file": "src/dev_health_ops/workers/provider_family_contract.py",
+      "find": "        or policy.mode is FamilyExecutionMode.INDEPENDENT\n",
+      "replace": "        or False\n",
+      "rationale": "Python producer admission must catalog PagerDuty without collapsing or rejecting its four independent claims",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/workers/provider_family_contract.py"],
+      "proof": [[".venv/bin/python", "-m", "pytest", "-q", "tests/workers/test_provider_unit_route.py", "-k", "pagerduty_incident_family_preserves_d16_independent_claims"]]
+    },
+    {
+      "id": "F9-python-default-off-clause",
+      "file": "src/dev_health_ops/workers/provider_family_contract.py",
+      "find": "        or not strict_atomic\n",
+      "replace": "        or False\n",
+      "rationale": "Python producer admission must preserve existing non-GitHub Celery claims until an actual Go family switch is on",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/workers/provider_family_contract.py"],
+      "proof": [[".venv/bin/python", "-m", "pytest", "-q", "tests/workers/test_provider_unit_route.py", "-k", "default_off_work_item_family_keeps_legacy_claims_admissible"]]
+    },
+    {
+      "id": "F10-python-canonical-claim-guard",
+      "file": "src/dev_health_ops/workers/provider_family_contract.py",
+      "find": "    if normalized_dataset != policy.canonical_dataset:\n",
+      "replace": "    if False:\n",
+      "rationale": "Python must reject each direct sibling alias for an enabled atomic work-items family",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/workers/provider_family_contract.py"],
+      "proof": [[".venv/bin/python", "-m", "pytest", "-q", "tests/workers/test_provider_unit_route.py", "-k", "provider_work_item_family_policy_is_exact"]]
+    },
+    {
+      "id": "F11-python-unknown-family-flag-clause",
+      "file": "src/dev_health_ops/workers/provider_family_contract.py",
+      "find": "        name.startswith(FAMILY_DATASET_FLAG_PREFIX) and name not in expected\n",
+      "replace": "        name.startswith(FAMILY_DATASET_FLAG_PREFIX) and False\n",
+      "rationale": "Python must fail closed on unknown family_dataset flags rather than silently widen atomic ownership",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/workers/provider_family_contract.py"],
+      "proof": [[".venv/bin/python", "-m", "pytest", "-q", "tests/workers/test_provider_unit_route.py", "-k", "provider_work_item_family_policy_is_exact"]]
+    },
+    {
+      "id": "F12-python-literal-true-guard",
+      "file": "src/dev_health_ops/workers/provider_family_contract.py",
+      "find": "    return all(flags.get(name) is True for name in expected)\n",
+      "replace": "    return all(flags.get(name) is not None for name in expected)\n",
+      "rationale": "Python persisted JSON truthiness must not let false-valued family ownership flags acquire the writer",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/workers/provider_family_contract.py"],
+      "proof": [[".venv/bin/python", "-m", "pytest", "-q", "tests/workers/test_provider_unit_route.py", "-k", "provider_work_item_family_policy_is_exact"]]
+    },
+    {
+      "id": "F13-python-producer-pre-transport-admission",
+      "file": "src/dev_health_ops/workers/sync_units.py",
+      "find": "            strict_family = provider_family_strict_admission_enabled(\n",
+      "replace": "            strict_family = False and provider_family_strict_admission_enabled(\n",
+      "rationale": "the producer must calculate strict family admission before either River outbox or Celery signature staging",
+      "build": [".venv/bin/python", "-m", "py_compile", "src/dev_health_ops/workers/sync_units.py"],
+      "proof": [[".venv/bin/python", "-m", "pytest", "-q", "tests/test_sync_units.py", "-k", "dispatch_enabled_atomic_work_item_family_rejects_before_any_transport"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/github_work_items_activation.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_activation.json
@@ -186,15 +186,15 @@
     },
     {
       "id": "A7-python-admission-requires-exact-booleans",
-      "file": "src/dev_health_ops/workers/provider_unit_route.py",
-      "find": "    return all(flags.get(name) is True for name in _GITHUB_WORK_ITEM_FAMILY_FLAGS)",
+      "file": "src/dev_health_ops/workers/provider_family_contract.py",
+      "find": "    return all(flags.get(name) is True for name in expected)",
       "replace": "    return True",
       "rationale": "persisted JSON flag truthiness is unsafe: missing, false, string, integer, and unknown family flag shapes must never acquire either writer",
       "build": [
         ".venv/bin/python",
         "-m",
         "py_compile",
-        "src/dev_health_ops/workers/provider_unit_route.py"
+        "src/dev_health_ops/workers/provider_family_contract.py"
       ],
       "proof": [
         [
@@ -206,15 +206,15 @@
     },
     {
       "id": "A7b-python-unknown-family-flags-are-rejected",
-      "file": "src/dev_health_ops/workers/provider_unit_route.py",
-      "find": "        and name not in _GITHUB_WORK_ITEM_FAMILY_FLAGS",
-      "replace": "        and False",
+      "file": "src/dev_health_ops/workers/provider_family_contract.py",
+      "find": "        name.startswith(FAMILY_DATASET_FLAG_PREFIX) and name not in expected",
+      "replace": "        name.startswith(FAMILY_DATASET_FLAG_PREFIX) and False",
       "rationale": "the unknown-family clause is distinct from exact-boolean evaluation: an otherwise complete canonical claim carrying an unrecognized family_dataset_* key must be rejected before either transport stages it",
       "build": [
         ".venv/bin/python",
         "-m",
         "py_compile",
-        "src/dev_health_ops/workers/provider_unit_route.py"
+        "src/dev_health_ops/workers/provider_family_contract.py"
       ],
       "proof": [
         [
@@ -232,8 +232,8 @@
     {
       "id": "A8-pretransport-partial-family-guard-fences-river-and-celery",
       "file": "src/dev_health_ops/workers/sync_units.py",
-      "find": "            ) and not is_complete_github_work_item_family_claim(",
-      "replace": "            ) and False and is_complete_github_work_item_family_claim(",
+      "find": "            if not validate_provider_family_claim(",
+      "replace": "            if False and not validate_provider_family_claim(",
       "rationale": "the full-family admission guard sits before transport selection; bypassing it must show the same stale partial canonical claim staging neither forward River nor rollback Celery",
       "build": [
         ".venv/bin/python",

--- a/src/dev_health_ops/workers/provider_family_contract.py
+++ b/src/dev_health_ops/workers/provider_family_contract.py
@@ -1,0 +1,128 @@
+"""Provider-neutral execution-family admission contracts.
+
+This module describes relationships between persisted provider datasets without
+changing their D16 execution boundary. Work-item providers use one atomic,
+canonical claim once their Go family switch is enabled. PagerDuty's incident
+quartet remains four independent claims; cataloguing it here must never collapse
+or reject those units.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class FamilyExecutionMode(StrEnum):
+    ATOMIC_CANONICAL = "atomic_canonical"
+    INDEPENDENT = "independent"
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderFamilyPolicy:
+    providers: frozenset[str]
+    canonical_dataset: str
+    datasets: tuple[str, ...]
+    mode: FamilyExecutionMode
+    switch_environment_names: tuple[tuple[str, str], ...] = ()
+
+    def applies_to(self, provider: str, dataset: str) -> bool:
+        return provider in self.providers and dataset in self.datasets
+
+    def switch_environment_name(self, provider: str) -> str | None:
+        normalized_provider = provider.strip().lower()
+        return next(
+            (
+                name
+                for policy_provider, name in self.switch_environment_names
+                if policy_provider == normalized_provider
+            ),
+            None,
+        )
+
+
+WORK_ITEM_DATASETS = (
+    "work-items",
+    "work-item-labels",
+    "work-item-projects",
+    "work-item-history",
+    "work-item-comments",
+)
+
+PAGERDUTY_INCIDENT_DATASETS = (
+    "incidents",
+    "incident-alerts",
+    "incident-log-entries",
+    "incident-notes",
+)
+
+_POLICIES = (
+    ProviderFamilyPolicy(
+        providers=frozenset({"github", "gitlab", "jira", "linear"}),
+        canonical_dataset="work-items",
+        datasets=WORK_ITEM_DATASETS,
+        mode=FamilyExecutionMode.ATOMIC_CANONICAL,
+        switch_environment_names=(
+            ("github", "WORKER_GITHUB_WORK_ITEMS_ENABLED"),
+            ("jira", "WORKER_JIRA_WORK_ITEMS_ENABLED"),
+            ("linear", "WORKER_LINEAR_WORK_ITEMS_ENABLED"),
+        ),
+    ),
+    ProviderFamilyPolicy(
+        providers=frozenset({"pagerduty"}),
+        canonical_dataset="incidents",
+        datasets=PAGERDUTY_INCIDENT_DATASETS,
+        mode=FamilyExecutionMode.INDEPENDENT,
+    ),
+)
+
+FAMILY_DATASET_FLAG_PREFIX = "family_dataset_"
+
+
+def family_dataset_flag(dataset: str) -> str:
+    return FAMILY_DATASET_FLAG_PREFIX + dataset.replace("-", "_")
+
+
+def provider_family_policy(provider: str, dataset: str) -> ProviderFamilyPolicy | None:
+    normalized_provider = provider.strip().lower()
+    normalized_dataset = dataset.strip().lower()
+    for policy in _POLICIES:
+        if policy.applies_to(normalized_provider, normalized_dataset):
+            return policy
+    return None
+
+
+def validate_provider_family_claim(
+    provider: str,
+    dataset: str,
+    processor_flags: Mapping[str, object] | None,
+    *,
+    strict_atomic: bool,
+) -> bool:
+    """Validate one claim without changing default-off legacy ownership.
+
+    Atomic validation is switch-gated. Once enabled, only the canonical claim
+    carrying every declared family flag as the literal boolean ``True`` is
+    admissible. Unknown ``family_dataset_*`` flags fail closed. Independent
+    families preserve their existing per-dataset claim shape under D16.
+    """
+
+    policy = provider_family_policy(provider, dataset)
+    if (
+        policy is None
+        or policy.mode is FamilyExecutionMode.INDEPENDENT
+        or not strict_atomic
+    ):
+        return True
+    normalized_dataset = dataset.strip().lower()
+    if normalized_dataset != policy.canonical_dataset:
+        return False
+    expected = frozenset(family_dataset_flag(item) for item in policy.datasets)
+    flags = processor_flags or {}
+    if any(
+        name.startswith(FAMILY_DATASET_FLAG_PREFIX) and name not in expected
+        for name in flags
+    ):
+        return False
+    return all(flags.get(name) is True for name in expected)

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -33,6 +33,11 @@ from dev_health_ops.sync.planner import (
     _WORK_ITEM_FAMILY_DATASET_ORDER,
     _family_dataset_flag,
 )
+from dev_health_ops.workers.provider_family_contract import (
+    FamilyExecutionMode,
+    provider_family_policy,
+    validate_provider_family_claim,
+)
 
 _FALSE = frozenset({"", "0", "false", "no", "off"})
 _TRUE = frozenset({"1", "true", "yes", "on"})
@@ -170,23 +175,39 @@ def is_complete_github_work_item_family_claim(
     and is refused before the producer enqueues either runtime.
     """
 
-    if (
-        provider.strip().lower() != "github"
-        or dataset.strip().lower() != _FAMILY_CANONICAL_DATASET_KEY
-    ):
+    return (
+        provider.strip().lower() == "github"
+        and dataset.strip().lower() == _FAMILY_CANONICAL_DATASET_KEY
+        and validate_provider_family_claim(
+            provider, dataset, processor_flags, strict_atomic=True
+        )
+    )
+
+
+def provider_family_strict_admission_enabled(
+    provider: str,
+    dataset: str,
+    environment: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether the provider's atomic Go family switch is enabled.
+
+    GitHub keeps its already-landed always-exact producer contract because its
+    planner always emits all five ownership flags. Other providers remain on
+    their D16 legacy claim shape while default-off; enabling their Go family
+    switch makes strict validation apply before either transport stages work.
+    """
+
+    normalized_provider = provider.strip().lower()
+    policy = provider_family_policy(normalized_provider, dataset.strip().lower())
+    if policy is None or policy.mode is not FamilyExecutionMode.ATOMIC_CANONICAL:
         return False
-    flags = processor_flags or {}
-    # Persisted flag JSON is untyped at this boundary. Truthiness is unsafe:
-    # e.g. the string "false" must not acquire the Go writer. Reject unknown
-    # family flags too, matching completion's reconciliation contract while
-    # allowing unrelated canonical flags such as sync_prs.
-    if any(
-        name.startswith("family_dataset_")
-        and name not in _GITHUB_WORK_ITEM_FAMILY_FLAGS
-        for name in flags
-    ):
+    if normalized_provider == "github":
+        return True
+    switch_name = policy.switch_environment_name(normalized_provider)
+    if switch_name is None:
         return False
-    return all(flags.get(name) is True for name in _GITHUB_WORK_ITEM_FAMILY_FLAGS)
+    source = os.environ if environment is None else environment
+    return _flag(source, switch_name)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -116,11 +116,12 @@ from dev_health_ops.workers.job_routes import (
     resolve_worker_job_route,
 )
 from dev_health_ops.workers.post_sync_dispatch import build_post_sync_dispatch_payload
+from dev_health_ops.workers.provider_family_contract import (
+    validate_provider_family_claim,
+)
 from dev_health_ops.workers.provider_unit_route import (
     ProviderUnitRouteSwitches,
-    is_complete_github_work_item_family_claim,
-    is_github_work_item_direct_alias,
-    is_github_work_item_family_dataset,
+    provider_family_strict_admission_enabled,
 )
 from dev_health_ops.workers.queues import _cost_class_queues_enabled
 from dev_health_ops.workers.rate_limit_defer import (
@@ -999,27 +1000,22 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         for unit in units:
             unit_provider = str(unit.provider)
             unit_dataset = str(unit.dataset_key)
-            # Planner never emits a direct sibling alias. Reject a malformed
-            # persisted one before choosing any transport, including rollback
-            # Celery, so it cannot become a partial legacy writer.
-            if is_github_work_item_direct_alias(unit_provider, unit_dataset):
-                raise WorkerJobRouteError(
-                    "github work-item provider-unit claim requires the canonical dataset"
-                )
-            # The five GitHub aliases are one indivisible family, regardless of
-            # which writer the durable route currently selects. A stale partial
-            # canonical unit cannot be handed to rollback Celery any more than it
-            # can enter the River outbox: the planner now emits all five literal
-            # flags even when one sibling window is caught up. Reject it before
-            # transport selection so neither writer can produce a subset effect
-            # batch or watermark outcome.
-            if is_github_work_item_family_dataset(
+            # Atomic provider families are admitted before transport selection,
+            # so a malformed claim can reach neither River nor rollback Celery.
+            # GitHub retains its already-landed always-exact ownership contract;
+            # the other work-item providers become strict only with their Go
+            # family switch enabled, preserving default-off D16 legacy claims.
+            strict_family = provider_family_strict_admission_enabled(
                 unit_provider, unit_dataset
-            ) and not is_complete_github_work_item_family_claim(
-                unit_provider, unit_dataset, unit.processor_flags
+            )
+            if not validate_provider_family_claim(
+                unit_provider,
+                unit_dataset,
+                unit.processor_flags,
+                strict_atomic=strict_family,
             ):
                 raise WorkerJobRouteError(
-                    "github work-item provider-unit claim requires the complete canonical family"
+                    "provider-unit claim requires the complete canonical family"
                 )
             # Routability is decided per pair, not per run: the matrix
             # (ProviderUnitRouteSwitches.is_route_ready) is the only source of

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -2913,6 +2913,166 @@ def test_dispatch_sync_run_github_work_items_rejects_partial_canonical_claim(
     assert db_session.query(WorkerJobOutbox).count() == 0
 
 
+@pytest.mark.parametrize("provider", ("jira", "linear"))
+@pytest.mark.parametrize("transport", ("river_canary", "celery"))
+@pytest.mark.parametrize(
+    ("dataset_key", "processor_flags"),
+    (
+        pytest.param(
+            "work-item-comments",
+            _GITHUB_WORK_ITEM_FAMILY_FLAGS,
+            id="direct-alias",
+        ),
+        pytest.param(
+            "work-items",
+            {
+                "family_dataset_work_items": True,
+                "family_dataset_work_item_labels": True,
+                "family_dataset_work_item_projects": True,
+                "family_dataset_work_item_history": True,
+            },
+            id="missing-flag",
+        ),
+        pytest.param(
+            "work-items",
+            {
+                **_GITHUB_WORK_ITEM_FAMILY_FLAGS,
+                "family_dataset_work_item_comments": False,
+            },
+            id="false-flag",
+        ),
+        pytest.param(
+            "work-items",
+            {**_GITHUB_WORK_ITEM_FAMILY_FLAGS, "family_dataset_unknown": True},
+            id="unknown-flag",
+        ),
+    ),
+)
+def test_dispatch_enabled_atomic_work_item_family_rejects_before_any_transport(
+    db_session,
+    monkeypatch,
+    provider: str,
+    transport: str,
+    dataset_key: str,
+    processor_flags: dict[str, bool],
+) -> None:
+    """An enabled Go family rejects stale ownership before River or Celery."""
+
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.job_routes import WorkerJobRouteError
+    from dev_health_ops.workers.provider_unit_route import ProviderUnitRouteSwitches
+
+    run, unit = _seed_run(
+        db_session,
+        provider=provider,
+        dataset_key=dataset_key,
+        processor_flags=processor_flags,
+    )
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: transport})
+    db_session.commit()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv(f"WORKER_{provider.upper()}_WORK_ITEMS_ENABLED", "true")
+    if transport == "river_canary":
+        # c901 deliberately rejects these incomplete routes during config
+        # construction. Bypass only that separate baseline gate so this test
+        # proves family admission itself wins before routes_to_river/outbox.
+        switches = ProviderUnitRouteSwitches(
+            jira_work_items=provider == "jira",
+            linear_work_items=provider == "linear",
+        )
+        monkeypatch.setattr(
+            ProviderUnitRouteSwitches,
+            "from_environment",
+            classmethod(lambda _cls, _environment=None: switches),
+        )
+
+    with pytest.raises(WorkerJobRouteError, match="complete canonical family"):
+        sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.PLANNED.value
+    assert unit_publish_calls == []
+    assert db_session.query(WorkerJobOutbox).count() == 0
+
+
+@pytest.mark.parametrize("provider", ("gitlab", "jira", "linear"))
+@pytest.mark.parametrize("transport", ("river_canary", "celery"))
+def test_dispatch_default_off_work_item_family_keeps_legacy_claim_admissible(
+    db_session, monkeypatch, provider: str, transport: str
+) -> None:
+    """Default-off admission does not break D16's contributing-flag claims."""
+
+    from dev_health_ops.workers import sync_units
+
+    run, _ = _seed_run(
+        db_session,
+        provider=provider,
+        dataset_key="work-items",
+        processor_flags={"family_dataset_work_items": True},
+    )
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: transport})
+    db_session.commit()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+
+    assert sync_units.dispatch_sync_run(str(run.id)) == {
+        "status": "dispatched",
+        "queued_units": 1,
+    }
+    assert len(unit_publish_calls) == 1
+    assert db_session.query(WorkerJobOutbox).count() == 0
+
+
+@pytest.mark.parametrize(
+    ("dataset_key", "processor_flags"),
+    (
+        ("incidents", {"sync_incidents": True}),
+        ("incident-alerts", {}),
+        ("incident-log-entries", {}),
+        ("incident-notes", {}),
+    ),
+)
+@pytest.mark.parametrize("transport", ("river_canary", "celery"))
+def test_dispatch_pagerduty_incident_family_preserves_independent_d16_claims(
+    db_session,
+    monkeypatch,
+    dataset_key: str,
+    processor_flags: dict[str, bool],
+    transport: str,
+) -> None:
+    from dev_health_ops.workers import sync_units
+
+    run, _ = _seed_run(
+        db_session,
+        provider="pagerduty",
+        dataset_key=dataset_key,
+        processor_flags=processor_flags,
+    )
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: transport})
+    db_session.commit()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(
+        sync_units,
+        "require_canonical_incident_feature_for_update_sync",
+        lambda *_args: None,
+    )
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+
+    assert sync_units.dispatch_sync_run(str(run.id)) == {
+        "status": "dispatched",
+        "queued_units": 1,
+    }
+    assert len(unit_publish_calls) == 1
+    assert db_session.query(WorkerJobOutbox).count() == 0
+
+
 def test_dispatch_sync_run_river_canary_requires_enabled_capability(
     db_session, monkeypatch
 ):

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from dev_health_ops.workers import provider_unit_route
+from dev_health_ops.workers.provider_family_contract import WORK_ITEM_DATASETS
 from dev_health_ops.workers.provider_unit_route import (
     ProviderUnitRouteError,
     ProviderUnitRouteSwitches,
@@ -540,6 +541,116 @@ def test_github_work_item_family_admission_requires_exact_boolean_flags() -> Non
     )
     assert not provider_unit_route.is_complete_github_work_item_family_claim(
         "github", "work-item-comments", _GITHUB_WORK_ITEM_FAMILY_FLAGS
+    )
+    assert not provider_unit_route.is_complete_github_work_item_family_claim(
+        "github", "prs", _GITHUB_WORK_ITEM_FAMILY_FLAGS
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "canonical", "aliases", "complete_flags"),
+    (
+        pytest.param(
+            provider,
+            "work-items",
+            (
+                "work-item-labels",
+                "work-item-projects",
+                "work-item-history",
+                "work-item-comments",
+            ),
+            _GITHUB_WORK_ITEM_FAMILY_FLAGS,
+            id=f"{provider}-work-items",
+        )
+        for provider in ("github", "gitlab", "jira", "linear")
+    ),
+)
+def test_provider_work_item_family_policy_is_exact_and_provider_neutral(
+    provider: str,
+    canonical: str,
+    aliases: tuple[str, ...],
+    complete_flags: dict[str, bool],
+) -> None:
+    assert provider_unit_route.validate_provider_family_claim(
+        provider, canonical, complete_flags, strict_atomic=True
+    )
+    for alias in aliases:
+        assert not provider_unit_route.validate_provider_family_claim(
+            provider, alias, complete_flags, strict_atomic=True
+        )
+    for flag in complete_flags:
+        missing = dict(complete_flags)
+        del missing[flag]
+        assert not provider_unit_route.validate_provider_family_claim(
+            provider, canonical, missing, strict_atomic=True
+        )
+        false = dict(complete_flags)
+        false[flag] = False
+        assert not provider_unit_route.validate_provider_family_claim(
+            provider, canonical, false, strict_atomic=True
+        )
+    unknown = dict(complete_flags)
+    unknown["family_dataset_unknown"] = True
+    assert not provider_unit_route.validate_provider_family_claim(
+        provider, canonical, unknown, strict_atomic=True
+    )
+
+
+def test_neutral_work_item_family_matches_the_live_planner_boundary() -> None:
+    assert (
+        set(WORK_ITEM_DATASETS) == provider_unit_route._GITHUB_WORK_ITEM_FAMILY_DATASETS
+    )
+
+
+@pytest.mark.parametrize(
+    "dataset",
+    (
+        "incidents",
+        "incident-alerts",
+        "incident-log-entries",
+        "incident-notes",
+    ),
+)
+def test_pagerduty_incident_family_preserves_d16_independent_claims(
+    dataset: str,
+) -> None:
+    # PagerDuty currently plans four independent units. D16 forbids collapsing
+    # that boundary inside the baseline port, so the neutral family catalog
+    # identifies the relationship without imposing canonical/flag admission.
+    assert provider_unit_route.validate_provider_family_claim(
+        "pagerduty", dataset, {}, strict_atomic=True
+    )
+
+
+@pytest.mark.parametrize("provider", ("gitlab", "jira", "linear"))
+def test_default_off_work_item_family_keeps_legacy_claims_admissible(
+    provider: str,
+) -> None:
+    assert provider_unit_route.validate_provider_family_claim(
+        provider,
+        "work-items",
+        {"family_dataset_work_items": True},
+        strict_atomic=False,
+    )
+
+
+def test_gitlab_family_catalog_does_not_invent_an_activation_switch() -> None:
+    assert not provider_unit_route.provider_family_strict_admission_enabled(
+        "gitlab",
+        "work-items",
+        {"WORKER_GITLAB_WORK_ITEMS_ENABLED": "true"},
+    )
+
+
+def test_provider_family_policy_leaves_independent_routes_unchanged() -> None:
+    assert provider_unit_route.validate_provider_family_claim(
+        "github", "prs", {"sync_prs": True}, strict_atomic=True
+    )
+    assert provider_unit_route.validate_provider_family_claim(
+        "github", "cicd", {"sync_cicd": True}, strict_atomic=True
+    )
+    assert provider_unit_route.validate_provider_family_claim(
+        "github", "tests", {"sync_tests": True}, strict_atomic=True
     )
 
 


### PR DESCRIPTION
## Summary

- Add provider-neutral execution-family admission for work-item claims.
- Preserve default-off legacy claim shapes for Jira, Linear, and GitLab until an actual typed Go family switch enables strict admission.
- Keep the four PagerDuty incident datasets as independent D16 claims; the policy catalog does not collapse or reject them.

## Validation

- go test -mod=readonly -count=1 ./internal/providerfamilycontract ./internal/jobs/providerunit
- 44 selected Python family-admission tests passed across tests/workers/test_provider_unit_route.py and tests/test_sync_units.py
- Targeted Ruff format/check and gofmt checks passed
- Static mutation-plan integrity: 13 unique mutations, exact live anchors, and non-empty proof commands
- git diff --check passed
- Replayed patch has the same stable patch ID as source commit 915fa2be

## Scope boundary

- Base is feat/go-worker-runtime-migration at fb71a9be.
- No registry, provider matrix, deployment, route activation, or cutover changes.
- Shared mutation harness and full repository gates were intentionally not run for this focused publication lane.
- SCREENSHOT-WAIVER: backend worker policy and test change with no rendered UI.