### PR TITLE
feat(providersync): complete GitLab work-item effects

### DIFF
--- a/internal/providersync/gitlab_work_item_derived.go
+++ b/internal/providersync/gitlab_work_item_derived.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 
@@ -10,13 +11,16 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 )
 
-// The GitLab derived family is the nine schema-backed projections that can be
-// computed from the six normalized work-item facts. ai_attribution is kept out
-// of this set intentionally: the authoritative producer consumes the original
-// merge-request payload (including source branch and bot/author signals), but
-// those fields are not part of the six raw ClickHouse projections. An empty
-// AI effect would falsely claim that producer ran.
+var ErrGitLabWorkItemDerivedProducerUnavailable = errors.New(
+	"gitlab work-item authoritative derived producer is unavailable",
+)
+
+// The GitLab derived family is the ten schema-backed projections emitted by
+// Python's work-item job. AI attribution is normalized while the route still
+// owns the original merge-request payload; the other nine projections are
+// computed from the six normalized work-item facts below.
 var gitlabWorkItemDerivedDestinations = []string{
+	"ai_attribution",
 	"estimate_coverage_metrics_daily",
 	"investment_classifications_daily",
 	"investment_metrics_daily",
@@ -40,8 +44,8 @@ type gitlabInvestmentClassificationDailyRow = githubInvestmentClassificationDail
 type gitlabInvestmentMetricsDailyRow = githubInvestmentMetricsDailyRow
 
 // GitLabWorkItemDerivedGap is a typed explanation of a destination that was
-// evaluated and deliberately withheld because its authoritative producer is
-// not reconstructible from the raw fact contract.
+// evaluated and deliberately withheld because its authoritative producer did
+// not complete. A complete result carries no gaps and may advance watermark.
 type GitLabWorkItemDerivedGap struct {
 	Destination           string `json:"destination"`
 	AuthoritativeProducer string `json:"authoritative_producer"`
@@ -51,9 +55,9 @@ type GitLabWorkItemDerivedGap struct {
 // GitLabWorkItemDerivedRows is the provider result at the compute boundary.
 // Every destination is a concrete ClickHouse row slice, so callers cannot
 // accidentally smuggle an untyped map or generic evidence envelope into the
-// effect ledger. AIAttribution is represented by the explicit typed gap below,
-// never by an empty slice.
+// effect ledger.
 type GitLabWorkItemDerivedRows struct {
+	AIAttributions                 []gitlabAIAttributionRow
 	EstimateCoverageMetricsDaily   []gitlabEstimateCoverageMetricsDailyRow
 	InvestmentClassificationsDaily []gitlabInvestmentClassificationDailyRow
 	InvestmentMetricsDaily         []gitlabInvestmentMetricsDailyRow
@@ -68,6 +72,9 @@ type GitLabWorkItemDerivedRows struct {
 }
 
 func (rows GitLabWorkItemDerivedRows) producedDestinations() []string {
+	if len(rows.Gaps) > 0 {
+		return nil
+	}
 	return append([]string(nil), gitlabWorkItemDerivedDestinations...)
 }
 
@@ -79,6 +86,7 @@ func gitlabWorkItemRowsAsGitHub(rows gitlabWorkItemRows) githubWorkItemRows {
 		ReopenEvents:      rows.ReopenEvents,
 		Interactions:      rows.Interactions,
 		Sprints:           rows.Sprints,
+		AIAttributions:    rows.AIAttributions,
 	}
 }
 
@@ -117,10 +125,11 @@ func NewGitLabWorkItemDeriver(
 	}, nil
 }
 
-// Derive computes all nine available destinations for every UTC day in the
-// claim window. Context is loaded once, before the day loop, matching the
-// Python job's donor/ownership snapshot semantics. Since AI attribution is a
-// declared producer gap, Watermark remains nil and no AI effect is emitted.
+// Derive computes all ten destinations for the claim window. AI attribution
+// was already produced at the provider normalization boundary from the raw MR
+// payload; this compute boundary passes those rows through and derives the
+// other nine surfaces. Context is loaded once, before the day loop, matching
+// the Python job's donor/ownership snapshot semantics.
 func (deriver GitLabWorkItemDeriver) Derive(
 	ctx context.Context,
 	claim Claim,
@@ -142,7 +151,13 @@ func (deriver GitLabWorkItemDeriver) Derive(
 	if err != nil {
 		return GitLabWorkItemDerivedRows{}, err
 	}
+	var watermark *time.Time
+	if claim.BeforeAt != nil {
+		value := claim.BeforeAt.UTC()
+		watermark = &value
+	}
 	result := GitLabWorkItemDerivedRows{
+		AIAttributions:                 append([]gitlabAIAttributionRow(nil), rows.AIAttributions...),
 		EstimateCoverageMetricsDaily:   []gitlabEstimateCoverageMetricsDailyRow{},
 		InvestmentClassificationsDaily: []gitlabInvestmentClassificationDailyRow{},
 		InvestmentMetricsDaily:         []gitlabInvestmentMetricsDailyRow{},
@@ -152,13 +167,8 @@ func (deriver GitLabWorkItemDeriver) Derive(
 		WorkItemStateDurationsDaily:    []gitlabWorkItemStateDurationDailyRow{},
 		WorkItemTeamAttributions:       []gitlabWorkItemTeamAttributionRow{},
 		WorkItemUserMetricsDaily:       []gitlabWorkItemUserMetricsDailyRow{},
-		Watermark:                      nil,
-		Gaps: []GitLabWorkItemDerivedGap{{
-			Destination:           "ai_attribution",
-			AuthoritativeProducer: "gitlab_mr_ai_attributions",
-			Reason: "the six raw work-item facts do not retain source_branch, bot-author, " +
-				"or the original merge-request signal payload required by the producer",
-		}},
+		Watermark:                      watermark,
+		Gaps:                           []GitLabWorkItemDerivedGap{},
 	}
 	for _, day := range days {
 		triplet, err := buildWorkItemMetricTripletForProvider(
@@ -204,6 +214,7 @@ func (deriver GitLabWorkItemDeriver) Derive(
 // one field per landed destination and therefore cannot silently omit a row
 // family through a string-keyed map.
 type GitLabWorkItemDerivedEffectRows struct {
+	AIAttributions                 []gitlabAIAttributionRow
 	EstimateCoverageMetricsDaily   []gitlabEstimateCoverageMetricsDailyRow
 	InvestmentClassificationsDaily []gitlabInvestmentClassificationDailyRow
 	InvestmentMetricsDaily         []gitlabInvestmentMetricsDailyRow
@@ -217,6 +228,7 @@ type GitLabWorkItemDerivedEffectRows struct {
 
 func (rows GitLabWorkItemDerivedRows) EffectRows() GitLabWorkItemDerivedEffectRows {
 	return GitLabWorkItemDerivedEffectRows{
+		AIAttributions:                 rows.AIAttributions,
 		EstimateCoverageMetricsDaily:   rows.EstimateCoverageMetricsDaily,
 		InvestmentClassificationsDaily: rows.InvestmentClassificationsDaily,
 		InvestmentMetricsDaily:         rows.InvestmentMetricsDaily,
@@ -230,14 +242,15 @@ func (rows GitLabWorkItemDerivedRows) EffectRows() GitLabWorkItemDerivedEffectRo
 }
 
 // BuildGitLabWorkItemDerivedEffects serializes only concrete typed row slices,
-// in canonical destination order. The AI gap is not represented as an empty
-// effect and is therefore impossible to mistake for successful computation.
+// in canonical destination order.
 func BuildGitLabWorkItemDerivedEffects(rows GitLabWorkItemDerivedEffectRows) ([]EffectBatch, error) {
 	effects := make([]EffectBatch, 0, len(gitlabWorkItemDerivedDestinations))
 	for _, destination := range gitlabWorkItemDerivedDestinations {
 		var effect EffectBatch
 		var err error
 		switch destination {
+		case "ai_attribution":
+			effect, err = buildGitLabTypedDerivedEffect(destination, rows.AIAttributions)
 		case "estimate_coverage_metrics_daily":
 			effect, err = buildGitLabTypedDerivedEffect(destination, rows.EstimateCoverageMetricsDaily)
 		case "investment_classifications_daily":
@@ -327,12 +340,13 @@ func gitlabDerivedGitHubIdentity(
 	}
 }
 
-// GitLabWorkItemDerivedClickHouseEffects is the nine-destination provider
+// GitLabWorkItemDerivedClickHouseEffects is the ten-destination provider
 // sink. Its fields are concrete adapter types and its dispatcher is an
 // explicit switch, so a destination cannot be accepted without a corresponding
 // schema-specific write/readback implementation.
 type GitLabWorkItemDerivedClickHouseEffects struct {
 	Lease                          providerfoundation.LeaseGuard
+	AIAttribution                  GitLabAIAttributionClickHouseAdapter
 	EstimateCoverageMetricsDaily   GitHubEstimateCoverageClickHouseEffects
 	InvestmentClassificationsDaily GitHubInvestmentClassificationsClickHouseEffects
 	InvestmentMetricsDaily         GitHubInvestmentMetricsClickHouseEffects
@@ -353,6 +367,7 @@ func NewGitLabWorkItemDerivedClickHouseEffects(
 	}
 	sink := GitLabWorkItemDerivedClickHouseEffects{
 		Lease:                          lease,
+		AIAttribution:                  GitLabAIAttributionClickHouseAdapter{Conn: conn},
 		EstimateCoverageMetricsDaily:   GitHubEstimateCoverageClickHouseEffects{Conn: conn, Lease: lease},
 		InvestmentClassificationsDaily: GitHubInvestmentClassificationsClickHouseEffects{Conn: conn, Lease: lease},
 		InvestmentMetricsDaily:         GitHubInvestmentMetricsClickHouseEffects{Conn: conn, Lease: lease},
@@ -376,6 +391,7 @@ func (sink GitLabWorkItemDerivedClickHouseEffects) MissingDestinations() []strin
 		conn  driver.Conn
 		lease providerfoundation.LeaseGuard
 	}{
+		{"ai_attribution", sink.AIAttribution.Conn, sink.Lease},
 		{"estimate_coverage_metrics_daily", sink.EstimateCoverageMetricsDaily.Conn, sink.EstimateCoverageMetricsDaily.Lease},
 		{"investment_classifications_daily", sink.InvestmentClassificationsDaily.Conn, sink.InvestmentClassificationsDaily.Lease},
 		{"investment_metrics_daily", sink.InvestmentMetricsDaily.Conn, sink.InvestmentMetricsDaily.Lease},
@@ -408,6 +424,8 @@ func (sink GitLabWorkItemDerivedClickHouseEffects) WriteEffect(
 	}
 	gitHubIdentity := gitlabDerivedGitHubIdentity(identity)
 	switch effect.Destination {
+	case "ai_attribution":
+		err = sink.AIAttribution.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
 	case "estimate_coverage_metrics_daily":
 		err = sink.EstimateCoverageMetricsDaily.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
 	case "investment_classifications_daily":
@@ -450,6 +468,8 @@ func (sink GitLabWorkItemDerivedClickHouseEffects) InspectEffect(
 	gitHubIdentity := gitlabDerivedGitHubIdentity(identity)
 	var inspection EffectInspection
 	switch effect.Destination {
+	case "ai_attribution":
+		inspection, err = sink.AIAttribution.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
 	case "estimate_coverage_metrics_daily":
 		inspection, err = sink.EstimateCoverageMetricsDaily.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)
 	case "investment_classifications_daily":
@@ -487,3 +507,59 @@ func (sink GitLabWorkItemDerivedClickHouseEffects) InspectEffect(
 
 var _ EffectSink = GitLabWorkItemDerivedClickHouseEffects{}
 var _ EffectReadback = GitLabWorkItemDerivedClickHouseEffects{}
+
+// GitLabAIAttributionClickHouseAdapter preserves the provider fence before
+// delegating the shared ai_attribution column projection. The shared adapter
+// correctly fences tenant UUIDs but intentionally serves multiple providers,
+// so this provider-local boundary must reject a recovered or forged GitHub row
+// carried by a GitLab effect.
+type GitLabAIAttributionClickHouseAdapter struct{ Conn driver.Conn }
+
+func (adapter GitLabAIAttributionClickHouseAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	if !validGitLabAIAttributionEffect(identity, effect) {
+		return ErrInvalidConfiguration
+	}
+	return (GitHubAIAttributionClickHouseAdapter{Conn: adapter.Conn}).
+		WriteGitHubWorkItemEffect(ctx, identity, effect)
+}
+
+func (adapter GitLabAIAttributionClickHouseAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if !validGitLabAIAttributionEffect(identity, effect) {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return (GitHubAIAttributionClickHouseAdapter{Conn: adapter.Conn}).
+		InspectGitHubWorkItemEffect(ctx, identity, effect)
+}
+
+func validGitLabAIAttributionEffect(
+	identity GitHubWorkItemEffectIdentity,
+	effect EffectBatch,
+) bool {
+	if identity.Provider != "gitlab" || identity.Dataset != "work-items" ||
+		identity.Destination != "ai_attribution" || effect.Destination != "ai_attribution" {
+		return false
+	}
+	rows, err := decodeEffectRows[gitlabAIAttributionRow](effect)
+	if err != nil || identity.RowCount != len(rows) {
+		return false
+	}
+	claim := Claim{Unit: Unit{
+		OrgID: identity.OrgID, Provider: identity.Provider, Dataset: identity.Dataset,
+	}}
+	for _, row := range rows {
+		if validateGitLabAIAttributionRow(row, claim) != nil {
+			return false
+		}
+	}
+	return true
+}
+
+var _ GitHubWorkItemEffectAdapter = GitLabAIAttributionClickHouseAdapter{}

--- a/internal/providersync/gitlab_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/gitlab_work_item_derived_effects_integration_test.go
@@ -15,7 +15,7 @@ import (
 
 // This suite deliberately uses githubDerivedIntegrationConn: it applies the
 // production ClickHouse migration chain and authors no local DDL. The GitLab
-// dispatcher is then exercised through the same nine schema-specific adapters
+// dispatcher is then exercised through the same ten schema-specific adapters
 // used by the provider route, with the provider identity kept as "gitlab".
 func TestGitLabWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
@@ -28,15 +28,26 @@ func TestGitLabWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse(t *testi
 	}
 
 	claim := nativeTestClaim("gitlab", "work-items")
-	claim.OrgID = githubDerivedIntegrationOrg
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
 	now := time.Date(2026, 8, 5, 0, 30, 0, 123000000, time.UTC)
 	day := newGitHubWorkItemDerivedDay(now)
 	metricDay := newGitHubWorkItemMetricDay(now)
 	repoID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	orgID := uuid.MustParse(claim.OrgID)
 	teamID, teamName := "team-a", "Team A"
 	area, rule := "security", "sec_general"
 	assignee := "dev@example.com"
 	ratio := 0.5
+	actor := "chatgpt-codex[bot]"
+	aiAttribution := gitlabAIAttributionRow{
+		RecordID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("gitlab-integration-ai")),
+		OrgID:    orgID, Provider: "gitlab", SubjectType: "pull_request", SubjectID: "9",
+		RepoID: &repoID, Kind: "agent_created", Source: "bot_author", Confidence: 0.9,
+		Actor: &actor, Evidence: map[string]any{
+			"login": actor, "user_type": "Bot", "app_slug": nil, "known_ai_bot": true,
+		},
+		ObservedAt: now.Add(-48 * time.Hour), IngestedAt: now,
+	}
 
 	estimate := gitlabEstimateCoverageMetricsDailyRow{
 		Day: day, Provider: "gitlab", WorkScopeID: "acme/api", TeamID: &teamID,
@@ -82,6 +93,7 @@ func TestGitLabWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse(t *testi
 	}
 
 	effects, err := BuildGitLabWorkItemDerivedEffects(GitLabWorkItemDerivedEffectRows{
+		AIAttributions:                 []gitlabAIAttributionRow{aiAttribution},
 		EstimateCoverageMetricsDaily:   []gitlabEstimateCoverageMetricsDailyRow{estimate},
 		InvestmentClassificationsDaily: []gitlabInvestmentClassificationDailyRow{classification},
 		InvestmentMetricsDaily:         []gitlabInvestmentMetricsDailyRow{investment},
@@ -143,10 +155,20 @@ func TestGitLabWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse(t *testi
 	recoveryGuard := &secondAssertionLosesLease{}
 	recoverySink := sink
 	recoverySink.EstimateCoverageMetricsDaily.Lease = recoveryGuard
-	if err := recoverySink.WriteEffect(ctx, claim, effects[0]); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+	var estimateEffect EffectBatch
+	for _, effect := range effects {
+		if effect.Destination == "estimate_coverage_metrics_daily" {
+			estimateEffect = effect
+			break
+		}
+	}
+	if estimateEffect.Destination == "" {
+		t.Fatal("estimate effect missing")
+	}
+	if err := recoverySink.WriteEffect(ctx, claim, estimateEffect); !errors.Is(err, providerfoundation.ErrLeaseLost) {
 		t.Fatalf("post-write lease loss error=%v", err)
 	}
-	if inspection, inspectErr := sink.InspectEffect(ctx, claim, effects[0]); inspectErr != nil || inspection != EffectExact {
+	if inspection, inspectErr := sink.InspectEffect(ctx, claim, estimateEffect); inspectErr != nil || inspection != EffectExact {
 		t.Fatalf("recovery readback: inspection=%v error=%v", inspection, inspectErr)
 	}
 }

--- a/internal/providersync/gitlab_work_item_derived_oracle_test.go
+++ b/internal/providersync/gitlab_work_item_derived_oracle_test.go
@@ -3,10 +3,14 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
 )
 
 // The GitLab cases reuse the same boundary-rich inputs as the already-landed
@@ -114,6 +118,161 @@ func gitlabWorkItemOracleDay(t *testing.T, input map[string]any) time.Time {
 func gitlabWorkItemOracleComputedAt(t *testing.T, input map[string]any) time.Time {
 	t.Helper()
 	return githubDerivedOracleTime(t, input["ComputedAt"].(string))
+}
+
+func TestGitLabAIAttributionMatchesLivePythonProductionRows(t *testing.T) {
+	base := map[string]any{
+		"iid": 9, "title": "Repair delivery path", "description": "Routine repair",
+		"state": "opened", "created_at": "2026-08-01T08:00:00Z",
+		"updated_at": "2026-08-03T09:30:00Z", "assignees": []any{},
+		"source_branch": "feature/repair",
+	}
+	labelMR := cloneSemanticOracleMap(base)
+	labelMR["created_at"] = nil
+	labelMR["labels"] = []any{"codex"}
+	labelMR["author"] = map[string]any{"username": "author", "bot": false}
+	botMR := cloneSemanticOracleMap(base)
+	botMR["labels"] = []any{}
+	botMR["author"] = map[string]any{"username": "chatgpt-codex[bot]", "bot": true}
+	unknownBotMR := cloneSemanticOracleMap(base)
+	unknownBotMR["labels"] = []any{}
+	unknownBotMR["author"] = map[string]any{"username": "ai-helper[bot]", "bot": true}
+	trailerMR := cloneSemanticOracleMap(base)
+	trailerMR["labels"] = []any{}
+	trailerMR["description"] = "Repair delivery path\n\nAI-Assisted-By: Claude Code"
+	trailerMR["author"] = map[string]any{"username": "author", "bot": false}
+	branchMR := cloneSemanticOracleMap(base)
+	branchMR["labels"] = []any{}
+	branchMR["source_branch"] = "copilot/repair"
+	branchMR["author"] = map[string]any{"username": "author", "bot": false}
+	bodyMR := cloneSemanticOracleMap(base)
+	bodyMR["labels"] = []any{}
+	bodyMR["description"] = "Initial scaffold created with Codex."
+	bodyMR["author"] = map[string]any{"username": "author", "bot": false}
+	cases := []oracleCase{
+		{ID: "codex_label", Input: gitlabAIAttributionOracleInput(labelMR, "pr_label")},
+		{ID: "known_bot_author", Input: gitlabAIAttributionOracleInput(botMR, "bot_author")},
+		{ID: "unknown_bot_author", Input: gitlabAIAttributionOracleInput(unknownBotMR, "bot_author")},
+		{ID: "commit_trailer", Input: gitlabAIAttributionOracleInput(trailerMR, "commit_trailer")},
+		{ID: "source_branch", Input: gitlabAIAttributionOracleInput(branchMR, "branch_name")},
+		{ID: "description_body", Input: gitlabAIAttributionOracleInput(bodyMR, "pr_body")},
+	}
+	compareRowsAgainstPythonOracle(
+		t, "gitlab/work-items/ai-attribution", cases,
+		buildGitLabAIAttributionOracleRow, nil,
+	)
+}
+
+func TestGitLabAIAttributionIsRetryStableAndDoesNotFabricateSignals(t *testing.T) {
+	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	updated := "2026-08-03T09:30:00Z"
+	username := "author"
+	bot := false
+	payload := gitlabMergeRequestWorkItemPayload{
+		IID: 9, Labels: []string{"codex"}, UpdatedAt: &updated,
+		Author:       &gitlabWorkItemUserPayload{Username: &username, Bot: bot},
+		SourceBranch: "feature/repair",
+	}
+	normalizedAt := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	first, err := normalizeGitLabMRAIAttributions(claim, repoID, payload, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := normalizeGitLabMRAIAttributions(claim, repoID, payload, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantObserved := time.Date(2026, 8, 3, 9, 30, 0, 0, time.UTC)
+	if len(first) != 1 || len(second) != 1 || first[0].RecordID != second[0].RecordID ||
+		!first[0].IngestedAt.Equal(second[0].IngestedAt) ||
+		!first[0].ObservedAt.Equal(wantObserved) {
+		t.Fatalf("retry/fallback rows=%+v/%+v", first, second)
+	}
+
+	description := "Routine repair without an AI signal."
+	nonAI := payload
+	nonAI.Labels = []string{"maintenance"}
+	nonAI.Description = &description
+	nonAI.SourceBranch = "feature/repair"
+	if rows, err := normalizeGitLabMRAIAttributions(claim, repoID, nonAI, normalizedAt); err != nil || len(rows) != 0 {
+		t.Fatalf("non-AI MR rows=%+v error=%v", rows, err)
+	}
+	ciUsername := "dependabot[bot]"
+	nonAI.Author = &gitlabWorkItemUserPayload{Username: &ciUsername, Bot: true}
+	if rows, err := normalizeGitLabMRAIAttributions(claim, repoID, nonAI, normalizedAt); err != nil || len(rows) != 0 {
+		t.Fatalf("CI bot rows=%+v error=%v", rows, err)
+	}
+}
+
+func gitlabAIAttributionOracleInput(rawMR map[string]any, source string) map[string]any {
+	return map[string]any{
+		"repo_full_name": "acme/api",
+		"repo_id":        "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		"org_id":         "77777777-7777-4777-8777-777777777777",
+		"raw_mr":         rawMR,
+		"signal_source":  source,
+	}
+}
+
+func buildGitLabAIAttributionOracleRow(
+	t *testing.T,
+	input map[string]any,
+) githubAIAttributionRow {
+	t.Helper()
+	responses := gitLabWorkItemResponses()
+	root := "/api/v4/projects/123"
+	rawMR, err := json.Marshal([]any{input["raw_mr"]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	responses[root+"/issues?page=1"] = []string{"[]"}
+	responses[root+"/merge_requests?page=1"] = []string{string(rawMR), "[]"}
+	no := false
+	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = input["org_id"].(string)
+	statusMapping := loadRealStatusMapping(t)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	batch, err := (GitLabWorkItemsRouteHandler{
+		StatusMapping: statusMapping,
+		Derived: GitLabWorkItemDeriver{
+			Source:               &githubMultiDayOracleSource{},
+			statusMapping:        statusMapping,
+			investmentClassifier: classifier,
+		},
+		FetchComments: &no, FetchHistory: &no, FetchLabels: &no,
+		FetchLinks: &no, FetchMilestones: &no,
+	}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "gitlab", ID: claim.CredentialID},
+		gitLabWorkItemsClient(t, &gitLabWorkItemsDoer{responses: responses}),
+		time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, effect := range batch.Effects {
+		if effect.Destination != "ai_attribution" {
+			continue
+		}
+		for _, raw := range effect.Rows {
+			var row githubAIAttributionRow
+			if err := json.Unmarshal(raw, &row); err != nil {
+				t.Fatal(err)
+			}
+			if row.Source == input["signal_source"] {
+				return row
+			}
+		}
+	}
+	t.Errorf("Go GitLab work-items route omitted authoritative ai_attribution source %q", input["signal_source"])
+	return githubAIAttributionRow{
+		Evidence: map[string]any{"oracle_failure": fmt.Sprint(input["signal_source"])},
+	}
 }
 
 func (columns githubWorkItemMetricsDailyOracleColumns) fromRows(
@@ -306,7 +465,8 @@ func gitlabEngineOracleResult(t *testing.T, input map[string]any) GitLabWorkItem
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(result.Gaps) != 1 || result.Watermark != nil {
+	if len(result.Gaps) != 0 || result.Watermark == nil ||
+		claim.BeforeAt == nil || !result.Watermark.Equal(*claim.BeforeAt) {
 		t.Fatalf("gap/watermark contract violated: gaps=%v watermark=%v", result.Gaps, result.Watermark)
 	}
 	return result
@@ -320,7 +480,7 @@ func gitlabRowsFromGitHub(rows githubWorkItemRows) gitlabWorkItemRows {
 	}
 }
 
-func TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark(t *testing.T) {
+func TestGitLabWorkItemDerivedResultIsTypedAndComplete(t *testing.T) {
 	statusMapping := loadRealStatusMapping(t)
 	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
 	if err != nil {
@@ -351,12 +511,11 @@ func TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark(t *testing.T)
 		counts[6] += len(result.WorkItemStateDurationsDaily)
 		counts[7] += len(result.WorkItemTeamAttributions)
 		counts[8] += len(result.WorkItemUserMetricsDaily)
-		if len(result.Gaps) != 1 || result.Gaps[0].Destination != "ai_attribution" ||
-			result.Gaps[0].AuthoritativeProducer != "gitlab_mr_ai_attributions" {
-			t.Fatalf("unexpected typed gap: %+v", result.Gaps)
+		if len(result.Gaps) != 0 || len(result.producedDestinations()) != 10 {
+			t.Fatalf("unexpected derived completeness: gaps=%+v produced=%v", result.Gaps, result.producedDestinations())
 		}
-		if result.Watermark != nil {
-			t.Fatalf("watermark advanced despite AI producer gap: %v", result.Watermark)
+		if result.Watermark == nil || !result.Watermark.Equal(before) {
+			t.Fatalf("watermark=%v want=%v", result.Watermark, before)
 		}
 	}
 	for index, count := range counts {
@@ -366,7 +525,7 @@ func TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark(t *testing.T)
 	}
 }
 
-func TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndExcludesAIGap(t *testing.T) {
+func TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndIncludesAI(t *testing.T) {
 	metric := githubWorkItemMetricTestGroupRow()
 	metric.Provider = "gitlab"
 	metric.ItemsCompletedUnassigned = 7
@@ -385,20 +544,18 @@ func TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndExcludesAIGap(t *testing
 			t.Fatalf("effect[%d]=%q want=%q", index, effect.Destination, gitlabWorkItemDerivedDestinations[index])
 		}
 		wantRows := 0
-		if index == 5 {
+		if index == 6 {
 			wantRows = 1
 		}
 		if effect.Recovery != EffectReadbackRequired || len(effect.Rows) != wantRows {
 			t.Fatalf("effect[%d] recovery/rows = %s/%d", index, effect.Recovery, len(effect.Rows))
 		}
 	}
-	for _, effect := range effects {
-		if effect.Destination == "ai_attribution" {
-			t.Fatal("AI producer gap was fabricated as an empty effect")
-		}
+	if effects[0].Destination != "ai_attribution" || effects[0].Rows == nil {
+		t.Fatalf("AI destination was not evaluated: %+v", effects[0])
 	}
 	var metrics gitlabWorkItemMetricsDailyRow
-	if err := json.Unmarshal(effects[5].Rows[0], &metrics); err != nil {
+	if err := json.Unmarshal(effects[6].Rows[0], &metrics); err != nil {
 		t.Fatal(err)
 	}
 	if metrics.ItemsCompletedUnassigned != 7 {
@@ -406,21 +563,22 @@ func TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndExcludesAIGap(t *testing
 	}
 }
 
-func TestGitLabWorkItemDerivedIdentityRejectsRawAndAIDestinations(t *testing.T) {
+func TestGitLabWorkItemDerivedIdentityAcceptsAIAndRejectsRawDestinations(t *testing.T) {
 	claim := nativeTestClaim("gitlab", "work-items")
 	effects, err := BuildGitLabWorkItemDerivedEffects(GitLabWorkItemDerivedEffectRows{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := newGitLabWorkItemDerivedEffectIdentity(claim, effects[0]); err != nil {
-		t.Fatalf("first derived destination rejected: %v", err)
+		t.Fatalf("AI destination rejected: %v", err)
 	}
-	ai, err := BuildEffectBatch("ai_attribution", EffectReadbackRequired, []json.RawMessage{})
-	if err != nil {
-		t.Fatal(err)
+	if _, err := newGitLabWorkItemDerivedEffectIdentity(claim, effects[1]); err != nil {
+		t.Fatalf("computed destination rejected: %v", err)
 	}
-	if _, err := newGitLabWorkItemDerivedEffectIdentity(claim, ai); err == nil {
-		t.Fatal("AI gap accepted as a derived effect")
+	foreign := claim
+	foreign.Provider = "github"
+	if _, err := newGitLabWorkItemDerivedEffectIdentity(foreign, effects[0]); err == nil {
+		t.Fatal("foreign provider accepted by GitLab derived identity")
 	}
 	raw, err := BuildEffectBatch("work_items", EffectReadbackRequired, []json.RawMessage{})
 	if err != nil {
@@ -431,7 +589,7 @@ func TestGitLabWorkItemDerivedIdentityRejectsRawAndAIDestinations(t *testing.T) 
 	}
 }
 
-func TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap(t *testing.T) {
+func TestGitLabWorkItemsRouteComposesSixteenEffectsAndAdvancesWatermark(t *testing.T) {
 	statusMapping := loadRealStatusMapping(t)
 	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
 	if err != nil {
@@ -442,8 +600,15 @@ func TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap(t *testing
 		statusMapping:        statusMapping,
 		investmentClassifier: classifier,
 	}
-	doer := &gitLabWorkItemsDoer{responses: gitLabWorkItemResponses()}
+	responses := gitLabWorkItemResponses()
+	root := "/api/v4/projects/123"
+	responses[root+"/merge_requests?page=1"] = []string{
+		`[{"iid":9,"title":"Ship the API","description":"","state":"opened","created_at":"2026-07-04T09:00:00Z","updated_at":"2026-07-04T10:00:00Z","labels":["priority::low","codex"],"assignees":[],"author":{"username":"alice","bot":false},"source_branch":"feature/ship-api"}]`,
+		`[]`,
+	}
+	doer := &gitLabWorkItemsDoer{responses: responses}
 	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
 	batch, err := (GitLabWorkItemsRouteHandler{
 		StatusMapping: loadRealStatusMapping(t), Derived: deriver,
 		PerPage: 2, MaxPages: 10, NestedMaxPages: 10,
@@ -455,26 +620,107 @@ func TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(batch.Effects) != 15 {
-		t.Fatalf("effects=%d want 15 raw+nine-derived", len(batch.Effects))
+	if len(batch.Effects) != 16 {
+		t.Fatalf("effects=%d want 16 raw+derived", len(batch.Effects))
 	}
+	if err := batch.validate(CompleteRouteDescriptor{Destinations: workItemRouteDestinations()}); err != nil {
+		t.Fatalf("sixteen-destination governed contract: %v", err)
+	}
+	var aiEffect *EffectBatch
 	for _, effect := range batch.Effects {
 		if effect.Destination == "ai_attribution" {
-			t.Fatal("AI gap was fabricated as an effect")
+			copy := effect
+			aiEffect = &copy
 		}
+	}
+	if aiEffect == nil || len(aiEffect.Rows) != 1 {
+		t.Fatalf("AI effect=%+v want one authoritative MR signal", aiEffect)
+	}
+	var attribution gitlabAIAttributionRow
+	if err := json.Unmarshal(aiEffect.Rows[0], &attribution); err != nil {
+		t.Fatal(err)
+	}
+	if attribution.Provider != "gitlab" || attribution.Source != "pr_label" ||
+		attribution.SubjectID != "9" || attribution.Confidence != 0.95 {
+		t.Fatalf("AI attribution=%+v", attribution)
 	}
 	summary, ok := batch.Result["gitlab_work_items"].(GitLabWorkItemsResult)
 	if !ok {
 		t.Fatalf("summary type=%T", batch.Result["gitlab_work_items"])
 	}
-	if len(summary.DerivedDestinationsUnimplemented) != 1 ||
-		summary.DerivedDestinationsUnimplemented[0] != "ai_attribution" ||
-		len(summary.DerivedDestinationsImplemented) != 9 ||
-		!summary.WatermarkHeldForDerivedGap || batch.Watermark != nil {
+	if len(summary.DerivedDestinationsUnimplemented) != 0 ||
+		len(summary.DerivedDestinationsImplemented) != 10 ||
+		summary.WatermarkHeldForDerivedGap || batch.Watermark == nil ||
+		claim.BeforeAt == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
 		t.Fatalf("derived summary/watermark=%+v/%v", summary, batch.Watermark)
 	}
 	implemented, ok := batch.Result["derived_destinations_implemented"].([]string)
-	if !ok || len(implemented) != 9 {
+	if !ok || len(implemented) != 10 {
 		t.Fatalf("implemented destinations=%T/%v", batch.Result["derived_destinations_implemented"], batch.Result["derived_destinations_implemented"])
+	}
+}
+
+type unavailableGitLabAIDeriver struct{}
+
+func (unavailableGitLabAIDeriver) Derive(
+	_ context.Context,
+	claim Claim,
+	_ gitlabWorkItemRows,
+	_ time.Time,
+) (GitLabWorkItemDerivedRows, error) {
+	var watermark *time.Time
+	if claim.BeforeAt != nil {
+		value := claim.BeforeAt.UTC()
+		watermark = &value
+	}
+	return GitLabWorkItemDerivedRows{Watermark: watermark, Gaps: []GitLabWorkItemDerivedGap{{
+		Destination:           "ai_attribution",
+		AuthoritativeProducer: "gitlab_mr_ai_attributions",
+		Reason:                "authoritative producer unavailable",
+	}}}, nil
+}
+
+func TestGitLabWorkItemsRouteRejectsUnavailableDerivedProducerBeforeEffects(t *testing.T) {
+	claim := nativeTestClaim("gitlab", "work-items")
+	_, err := (GitLabWorkItemsRouteHandler{
+		StatusMapping: loadRealStatusMapping(t), Derived: unavailableGitLabAIDeriver{},
+		PerPage: 2, MaxPages: 10, NestedMaxPages: 10,
+	}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "gitlab", ID: claim.CredentialID},
+		gitLabWorkItemsClient(t, &gitLabWorkItemsDoer{responses: gitLabWorkItemResponses()}),
+		time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrGitLabWorkItemDerivedProducerUnavailable) ||
+		!strings.Contains(err.Error(), "ai_attribution") {
+		t.Fatalf("unavailable producer error=%v", err)
+	}
+}
+
+type wrongWatermarkGitLabDeriver struct{}
+
+func (wrongWatermarkGitLabDeriver) Derive(
+	_ context.Context,
+	_ Claim,
+	_ gitlabWorkItemRows,
+	normalizedAt time.Time,
+) (GitLabWorkItemDerivedRows, error) {
+	wrong := normalizedAt.UTC()
+	return GitLabWorkItemDerivedRows{Watermark: &wrong, Gaps: []GitLabWorkItemDerivedGap{}}, nil
+}
+
+func TestGitLabWorkItemsRouteRejectsDerivedWatermarkOutsideClaimBound(t *testing.T) {
+	claim := nativeTestClaim("gitlab", "work-items")
+	_, err := (GitLabWorkItemsRouteHandler{
+		StatusMapping: loadRealStatusMapping(t), Derived: wrongWatermarkGitLabDeriver{},
+		PerPage: 2, MaxPages: 10, NestedMaxPages: 10,
+	}).Collect(
+		context.Background(), claim,
+		providerfoundation.Credential{Provider: "gitlab", ID: claim.CredentialID},
+		gitLabWorkItemsClient(t, &gitLabWorkItemsDoer{responses: gitLabWorkItemResponses()}),
+		time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("wrong watermark error=%v", err)
 	}
 }

--- a/internal/providersync/gitlab_work_items_composition.go
+++ b/internal/providersync/gitlab_work_items_composition.go
@@ -1,0 +1,119 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// ErrGitLabWorkItemSinkIncomplete names the provider-local construction
+// failure that would otherwise let a six- or ten-destination partial sink be
+// handed to EffectCommitter for a sixteen-effect route batch.
+var ErrGitLabWorkItemSinkIncomplete = errors.New(
+	"gitlab work-item clickhouse sink is missing destination adapters",
+)
+
+// GitLabWorkItemFamilyClickHouseEffects composes the six raw-fact adapters
+// with the ten derived adapters behind the one EffectSink/EffectReadback pair
+// EffectCommitter accepts. It registers or activates no route.
+type GitLabWorkItemFamilyClickHouseEffects struct {
+	Raw     GitLabWorkItemClickHouseEffects
+	Derived GitLabWorkItemDerivedClickHouseEffects
+}
+
+func NewGitLabWorkItemFamilyClickHouseEffects(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+) (GitLabWorkItemFamilyClickHouseEffects, error) {
+	if conn == nil || lease == nil {
+		return GitLabWorkItemFamilyClickHouseEffects{}, ErrInvalidConfiguration
+	}
+	derived, err := NewGitLabWorkItemDerivedClickHouseEffects(conn, lease)
+	if err != nil {
+		return GitLabWorkItemFamilyClickHouseEffects{}, err
+	}
+	sink := GitLabWorkItemFamilyClickHouseEffects{
+		Raw:     NewGitLabWorkItemClickHouseEffects(conn, lease),
+		Derived: derived,
+	}
+	if missing := sink.MissingDestinations(); len(missing) > 0 {
+		return sink, fmt.Errorf(
+			"%w: %s", ErrGitLabWorkItemSinkIncomplete, strings.Join(missing, ", "),
+		)
+	}
+	return sink, nil
+}
+
+func (sink GitLabWorkItemFamilyClickHouseEffects) MissingDestinations() []string {
+	rawMissing := make(map[string]struct{})
+	for _, destination := range sink.Raw.MissingDestinations() {
+		rawMissing[destination] = struct{}{}
+	}
+	derivedMissing := make(map[string]struct{})
+	for _, destination := range sink.Derived.MissingDestinations() {
+		derivedMissing[destination] = struct{}{}
+	}
+	missing := make([]string, 0, len(rawMissing)+len(derivedMissing))
+	for _, destination := range workItemRouteDestinations() {
+		switch {
+		case gitLabWorkItemDestination(destination):
+			if _, absent := rawMissing[destination]; absent {
+				missing = append(missing, destination)
+			}
+		case gitlabWorkItemDerivedDestination(destination):
+			if _, absent := derivedMissing[destination]; absent {
+				missing = append(missing, destination)
+			}
+		default:
+			missing = append(missing, destination)
+		}
+	}
+	return missing
+}
+
+func (sink GitLabWorkItemFamilyClickHouseEffects) complete() bool {
+	return len(sink.MissingDestinations()) == 0
+}
+
+func (sink GitLabWorkItemFamilyClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	if ctx == nil || !sink.complete() {
+		return ErrInvalidConfiguration
+	}
+	switch {
+	case gitLabWorkItemDestination(effect.Destination):
+		return sink.Raw.WriteEffect(ctx, claim, effect)
+	case gitlabWorkItemDerivedDestination(effect.Destination):
+		return sink.Derived.WriteEffect(ctx, claim, effect)
+	default:
+		return ErrInvalidConfiguration
+	}
+}
+
+func (sink GitLabWorkItemFamilyClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if ctx == nil || !sink.complete() {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	switch {
+	case gitLabWorkItemDestination(effect.Destination):
+		return sink.Raw.InspectEffect(ctx, claim, effect)
+	case gitlabWorkItemDerivedDestination(effect.Destination):
+		return sink.Derived.InspectEffect(ctx, claim, effect)
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+var _ EffectSink = GitLabWorkItemFamilyClickHouseEffects{}
+var _ EffectReadback = GitLabWorkItemFamilyClickHouseEffects{}

--- a/internal/providersync/gitlab_work_items_composition_test.go
+++ b/internal/providersync/gitlab_work_items_composition_test.go
@@ -1,0 +1,131 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+func TestGitLabWorkItemFamilyEffectsComposeAllSixteenDestinations(t *testing.T) {
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink, err := NewGitLabWorkItemFamilyClickHouseEffects(inertGitHubDerivedConn{}, lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing := sink.MissingDestinations(); len(missing) != 0 {
+		t.Fatalf("missing=%v", missing)
+	}
+	raw, err := BuildGitLabWorkItemEffects(GitLabWorkItemEffectRows{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	derived, err := BuildGitLabWorkItemDerivedEffects(GitLabWorkItemDerivedEffectRows{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	effects := append(raw, derived...)
+	canonical := workItemRouteDestinations()
+	if len(effects) != len(canonical) || len(effects) != 16 {
+		t.Fatalf("effects=%d canonical=%d", len(effects), len(canonical))
+	}
+	seen := make(map[string]struct{}, len(effects))
+	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
+	for _, effect := range effects {
+		if _, duplicate := seen[effect.Destination]; duplicate {
+			t.Fatalf("duplicate destination %q", effect.Destination)
+		}
+		seen[effect.Destination] = struct{}{}
+		inspection, inspectErr := sink.InspectEffect(context.Background(), claim, effect)
+		if inspectErr != nil || inspection != EffectAbsent {
+			t.Fatalf("%s empty readback=%s error=%v", effect.Destination, inspection, inspectErr)
+		}
+		if writeErr := sink.WriteEffect(context.Background(), claim, effect); writeErr != nil {
+			t.Fatalf("%s empty write: %v", effect.Destination, writeErr)
+		}
+	}
+	for _, destination := range canonical {
+		if _, present := seen[destination]; !present {
+			t.Fatalf("canonical destination %q was not composed", destination)
+		}
+	}
+}
+
+func TestGitLabWorkItemFamilyEffectsFailClosedWhenAnyAdapterIsMissing(t *testing.T) {
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink, err := NewGitLabWorkItemFamilyClickHouseEffects(inertGitHubDerivedConn{}, lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink.Derived.AIAttribution.Conn = nil
+	missing := sink.MissingDestinations()
+	if len(missing) != 1 || missing[0] != "ai_attribution" {
+		t.Fatalf("missing=%v", missing)
+	}
+	raw, err := BuildGitLabWorkItemEffects(GitLabWorkItemEffectRows{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
+	if err := sink.WriteEffect(context.Background(), claim, raw[0]); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("partial family write error=%v", err)
+	}
+	if inspection, err := sink.InspectEffect(
+		context.Background(), claim, raw[0],
+	); !errors.Is(err, ErrInvalidConfiguration) || inspection != EffectConflict {
+		t.Fatalf("partial family readback=%s error=%v", inspection, err)
+	}
+}
+
+func TestGitLabWorkItemFamilyEffectsRejectForeignAIProviderAndTenant(t *testing.T) {
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink, err := NewGitLabWorkItemFamilyClickHouseEffects(inertGitHubDerivedConn{}, lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
+	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	base := gitlabAIAttributionRow{
+		RecordID: uuid.NewSHA1(uuid.NameSpaceURL, []byte("gitlab-ai-tenant-fence")),
+		OrgID:    uuid.MustParse(claim.OrgID), Provider: "gitlab", SubjectType: "pull_request",
+		SubjectID: "9", RepoID: &repoID, Kind: "ai_assisted", Source: "pr_label",
+		Confidence: 0.95, Evidence: map[string]any{"label": "codex"},
+		ObservedAt: now, IngestedAt: now,
+	}
+	assertRejected := func(t *testing.T, row gitlabAIAttributionRow) {
+		t.Helper()
+		effects, err := BuildGitLabWorkItemDerivedEffects(GitLabWorkItemDerivedEffectRows{
+			AIAttributions: []gitlabAIAttributionRow{row},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		aiEffect := effects[0]
+		identity, err := newGitLabWorkItemDerivedEffectIdentity(claim, aiEffect)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if validGitLabAIAttributionEffect(gitlabDerivedGitHubIdentity(identity), aiEffect) {
+			t.Fatal("foreign AI row passed the provider-local semantic fence")
+		}
+		if err := sink.WriteEffect(context.Background(), claim, aiEffect); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("write error=%v", err)
+		}
+		if inspection, err := sink.InspectEffect(context.Background(), claim, aiEffect); !errors.Is(err, ErrInvalidConfiguration) || inspection != EffectConflict {
+			t.Fatalf("readback=%s error=%v", inspection, err)
+		}
+	}
+	foreignProvider := base
+	foreignProvider.Provider = "github"
+	t.Run("provider", func(t *testing.T) { assertRejected(t, foreignProvider) })
+	foreignTenant := base
+	foreignTenant.OrgID = uuid.MustParse("88888888-8888-4888-8888-888888888888")
+	t.Run("tenant", func(t *testing.T) { assertRejected(t, foreignTenant) })
+}

--- a/internal/providersync/gitlab_work_items_effects_integration_test.go
+++ b/internal/providersync/gitlab_work_items_effects_integration_test.go
@@ -13,11 +13,14 @@ import (
 
 // This test uses the shared migration-backed ClickHouse fixture. It authors no
 // DDL: every table and column is supplied by the real ClickHouse migration
-// chain, and the same six adapters used by the route are exercised through the
-// provider-owned dispatcher.
-func TestGitLabWorkItemEffectsWriteReadBackAllSixFactsAgainstRealClickHouse(t *testing.T) {
+// chain, and all sixteen adapters used by the route are exercised through the
+// provider-owned composite dispatcher. The ten derived effects are empty here
+// because their non-empty schema projections are covered by the companion
+// derived integration suite.
+func TestGitLabWorkItemEffectsComposeAllSixteenAgainstRealClickHouse(t *testing.T) {
 	ctx, conn := newWorkItemEffectsConn(t)
 	claim := nativeTestClaim("gitlab", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
 	now := time.Date(2026, 8, 3, 12, 0, 0, 123000000, time.UTC)
 	repoID := uuid.MustParse("c7198fbc-1945-3717-05d8-eb78866b4e79")
 	item := gitlabWorkItemRow{
@@ -62,7 +65,20 @@ func TestGitLabWorkItemEffectsWriteReadBackAllSixFactsAgainstRealClickHouse(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	sink := NewGitLabWorkItemClickHouseEffects(conn, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
+	derived, err := BuildGitLabWorkItemDerivedEffects(GitLabWorkItemDerivedEffectRows{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	effects = append(effects, derived...)
+	if len(effects) != 16 {
+		t.Fatalf("composed effects=%d want=16", len(effects))
+	}
+	sink, err := NewGitLabWorkItemFamilyClickHouseEffects(
+		conn, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, effect := range effects {
 		if err := sink.WriteEffect(ctx, claim, effect); err != nil {
 			t.Fatalf("write %s: %v", effect.Destination, err)
@@ -71,7 +87,11 @@ func TestGitLabWorkItemEffectsWriteReadBackAllSixFactsAgainstRealClickHouse(t *t
 			t.Fatalf("replay %s: %v", effect.Destination, err)
 		}
 		inspection, err := sink.InspectEffect(ctx, claim, effect)
-		if err != nil || inspection != EffectExact {
+		wantInspection := EffectExact
+		if len(effect.Rows) == 0 {
+			wantInspection = EffectAbsent
+		}
+		if err != nil || inspection != wantInspection {
 			t.Fatalf("inspect %s: %s %v", effect.Destination, inspection, err)
 		}
 	}

--- a/internal/providersync/gitlab_work_items_route.go
+++ b/internal/providersync/gitlab_work_items_route.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -37,9 +38,7 @@ var gitLabWorkItemRawDestinations = []string{
 
 // gitLabWorkItemDerivedGap is the raw-only route's honest remainder of the
 // 16-destination canonical work-item family. Once the typed deriver is injected
-// at the processor boundary, its nine concrete destinations are removed and
-// only the AI producer gap remains. No empty effect is manufactured for that
-// missing producer.
+// at the processor boundary, all ten concrete derived destinations are emitted.
 var gitLabWorkItemDerivedGap = []string{
 	"ai_attribution",
 	"estimate_coverage_metrics_daily",
@@ -64,8 +63,9 @@ type GitLabWorkItemsRequestUsage struct {
 }
 
 // GitLabWorkItemsResult is the concrete provider result carried inside the
-// framework's legacy result map. It keeps the six-fact/gap claim typed even
-// though CompleteRouteBatch predates provider-specific result structs.
+// framework's legacy result map. It keeps raw/derived completion and watermark
+// withholding typed even though CompleteRouteBatch predates provider-specific
+// result structs.
 type GitLabWorkItemsResult struct {
 	WorkItemsSynced                  int      `json:"work_items_synced"`
 	TransitionsSynced                int      `json:"transitions_synced"`
@@ -341,6 +341,13 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 			rows.WorkItems = append(rows.WorkItems, item)
 			rows.StatusTransitions = append(rows.StatusTransitions, transitions...)
 			rows.ReopenEvents = append(rows.ReopenEvents, reopens...)
+			attributions, attributionErr := normalizeGitLabMRAIAttributions(
+				claim, repoID, payload, normalizedAt,
+			)
+			if attributionErr != nil {
+				return CompleteRouteBatch{}, attributionErr
+			}
+			rows.AIAttributions = append(rows.AIAttributions, attributions...)
 			if fetchComments {
 				notes, notePages, noteErr := collectGitLabNotes(
 					ctx, &counted, root+"/merge_requests/"+strconv.Itoa(payload.IID)+"/notes",
@@ -363,10 +370,25 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 	derivedUnimplemented := append([]string(nil), gitLabWorkItemDerivedGap...)
 	derivedImplemented := []string{}
 	derivedRecords := 0
+	var watermark *time.Time
 	if handler.Derived != nil {
 		derived, deriveErr := handler.Derived.Derive(ctx, claim, rows, normalizedAt)
 		if deriveErr != nil {
 			return CompleteRouteBatch{}, deriveErr
+		}
+		if len(derived.Gaps) > 0 {
+			gaps := make([]string, 0, len(derived.Gaps))
+			for _, gap := range derived.Gaps {
+				if !gitlabWorkItemDerivedDestination(gap.Destination) ||
+					strings.TrimSpace(gap.AuthoritativeProducer) == "" ||
+					strings.TrimSpace(gap.Reason) == "" {
+					return CompleteRouteBatch{}, ErrInvalidConfiguration
+				}
+				gaps = append(gaps, gap.Destination)
+			}
+			return CompleteRouteBatch{}, fmt.Errorf(
+				"%w: %s", ErrGitLabWorkItemDerivedProducerUnavailable, strings.Join(gaps, ", "),
+			)
 		}
 		derivedEffects, effectErr := BuildGitLabWorkItemDerivedEffects(derived.EffectRows())
 		if effectErr != nil {
@@ -374,11 +396,13 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 		}
 		effects = append(effects, derivedEffects...)
 		derivedImplemented = derived.producedDestinations()
-		derivedUnimplemented = make([]string, 0, len(derived.Gaps))
-		for _, gap := range derived.Gaps {
-			derivedUnimplemented = append(derivedUnimplemented, gap.Destination)
+		derivedUnimplemented = []string{}
+		if len(derivedUnimplemented) == 0 && claim.BeforeAt != nil &&
+			(derived.Watermark == nil || !derived.Watermark.Equal(claim.BeforeAt.UTC())) {
+			return CompleteRouteBatch{}, ErrInvalidConfiguration
 		}
-		derivedRecords = len(derived.EstimateCoverageMetricsDaily) +
+		watermark = derived.Watermark
+		derivedRecords = len(derived.AIAttributions) + len(derived.EstimateCoverageMetricsDaily) +
 			len(derived.InvestmentClassificationsDaily) + len(derived.InvestmentMetricsDaily) +
 			len(derived.IssueTypeMetricsDaily) + len(derived.WorkItemCycleTimes) +
 			len(derived.WorkItemMetricsDaily) + len(derived.WorkItemStateDurationsDaily) +
@@ -391,7 +415,7 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 		RawDestinations:                  append([]string(nil), gitLabWorkItemRawDestinations...),
 		DerivedDestinationsImplemented:   append([]string(nil), derivedImplemented...),
 		DerivedDestinationsUnimplemented: derivedUnimplemented,
-		WatermarkHeldForDerivedGap:       true,
+		WatermarkHeldForDerivedGap:       len(derivedUnimplemented) > 0,
 	}
 	result := map[string]any{
 		"work_items_synced":                  len(rows.WorkItems),
@@ -403,11 +427,11 @@ func (handler GitLabWorkItemsRouteHandler) Collect(
 		"raw_destinations":                   append([]string(nil), gitLabWorkItemRawDestinations...),
 		"derived_destinations_implemented":   derivedImplemented,
 		"derived_destinations_unimplemented": derivedUnimplemented,
-		"watermark_held_for_derived_gap":     true,
+		"watermark_held_for_derived_gap":     len(derivedUnimplemented) > 0,
 		"gitlab_work_items":                  summary,
 	}
 	return CompleteRouteBatch{
-		Effects: effects, Result: result, Watermark: nil,
+		Effects: effects, Result: result, Watermark: watermark,
 		Evidence: FetchEvidence{
 			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
 			Pages: pages, Records: len(rows.WorkItems) + len(rows.StatusTransitions) +

--- a/internal/providersync/gitlab_work_items_rows.go
+++ b/internal/providersync/gitlab_work_items_rows.go
@@ -24,6 +24,7 @@ type gitlabWorkItemDependencyRow = githubWorkItemDependencyRow
 type gitlabWorkItemReopenRow = githubWorkItemReopenRow
 type gitlabWorkItemInteractionRow = githubWorkItemInteractionRow
 type gitlabSprintRow = githubSprintRow
+type gitlabAIAttributionRow = githubAIAttributionRow
 
 type gitlabWorkItemRows struct {
 	WorkItems         []gitlabWorkItemRow
@@ -32,12 +33,14 @@ type gitlabWorkItemRows struct {
 	ReopenEvents      []gitlabWorkItemReopenRow
 	Interactions      []gitlabWorkItemInteractionRow
 	Sprints           []gitlabSprintRow
+	AIAttributions    []gitlabAIAttributionRow
 }
 
 type gitlabWorkItemUserPayload struct {
 	Email    *string `json:"email"`
 	Username *string `json:"username"`
 	Name     *string `json:"name"`
+	Bot      bool    `json:"bot"`
 }
 
 type gitlabIssueMilestonePayload struct {
@@ -66,21 +69,22 @@ type gitlabIssueWorkItemPayload struct {
 }
 
 type gitlabMergeRequestWorkItemPayload struct {
-	IID         int                          `json:"iid"`
-	Title       string                       `json:"title"`
-	Description *string                      `json:"description"`
-	State       string                       `json:"state"`
-	CreatedAt   *string                      `json:"created_at"`
-	UpdatedAt   *string                      `json:"updated_at"`
-	ClosedAt    *string                      `json:"closed_at"`
-	MergedAt    *string                      `json:"merged_at"`
-	Labels      []string                     `json:"labels"`
-	Assignees   []gitlabWorkItemUserPayload  `json:"assignees"`
-	Author      *gitlabWorkItemUserPayload   `json:"author"`
-	WebURL      *string                      `json:"web_url"`
-	URL         *string                      `json:"url"`
-	Weight      *float64                     `json:"weight"`
-	Milestone   *gitlabIssueMilestonePayload `json:"milestone"`
+	IID          int                          `json:"iid"`
+	Title        string                       `json:"title"`
+	Description  *string                      `json:"description"`
+	State        string                       `json:"state"`
+	CreatedAt    *string                      `json:"created_at"`
+	UpdatedAt    *string                      `json:"updated_at"`
+	ClosedAt     *string                      `json:"closed_at"`
+	MergedAt     *string                      `json:"merged_at"`
+	Labels       []string                     `json:"labels"`
+	Assignees    []gitlabWorkItemUserPayload  `json:"assignees"`
+	Author       *gitlabWorkItemUserPayload   `json:"author"`
+	WebURL       *string                      `json:"web_url"`
+	URL          *string                      `json:"url"`
+	Weight       *float64                     `json:"weight"`
+	Milestone    *gitlabIssueMilestonePayload `json:"milestone"`
+	SourceBranch string                       `json:"source_branch"`
 }
 
 type gitlabLabelEventPayload struct {
@@ -382,6 +386,69 @@ func normalizeGitLabMergeRequestWorkItem(
 		return gitlabWorkItemRow{}, nil, nil, err
 	}
 	return row, transitions, reopens, nil
+}
+
+// normalizeGitLabMRAIAttributions mirrors gitlab_mr_ai_attributions at the
+// same provider-normalization boundary that still owns the original merge
+// request payload. The six raw ClickHouse facts deliberately do not retain
+// source_branch or author.bot, so postponing this producer until the derived
+// compute boundary would lose authoritative signals.
+func normalizeGitLabMRAIAttributions(
+	claim Claim,
+	repoID uuid.UUID,
+	payload gitlabMergeRequestWorkItemPayload,
+	normalizedAt time.Time,
+) ([]gitlabAIAttributionRow, error) {
+	if claim.Validate() != nil || claim.Provider != "gitlab" ||
+		claim.Dataset != "work-items" || repoID == uuid.Nil || payload.IID < 1 ||
+		normalizedAt.IsZero() {
+		return nil, ErrInvalidConfiguration
+	}
+	pull := githubPullRequestWorkItemPayload{}
+	pull.Number = payload.IID
+	pull.Body = payload.Description
+	pull.CreatedAt = payload.CreatedAt
+	if parseGitLabWorkItemTime(pull.CreatedAt) == nil {
+		pull.CreatedAt = payload.UpdatedAt
+	}
+	pull.UpdatedAt = payload.UpdatedAt
+	pull.Head.Ref = payload.SourceBranch
+	pull.Labels = make([]githubWorkItemLabelPayload, 0, len(payload.Labels))
+	for _, label := range payload.Labels {
+		if label != "" {
+			pull.Labels = append(pull.Labels, githubWorkItemLabelPayload{Name: label})
+		}
+	}
+	if payload.Author != nil {
+		user := githubWorkItemUserPayload{Login: payload.Author.Username}
+		if payload.Author.Bot {
+			user.Type = stringPointer("Bot")
+		}
+		pull.User = &user
+	}
+	rows, err := detectGitHubPullRequestAttributions(claim, repoID, pull, normalizedAt)
+	if err != nil {
+		return nil, err
+	}
+	for index := range rows {
+		rows[index].Provider = "gitlab"
+		if err := validateGitLabAIAttributionRow(rows[index], claim); err != nil {
+			return nil, err
+		}
+	}
+	return rows, nil
+}
+
+func validateGitLabAIAttributionRow(row gitlabAIAttributionRow, claim Claim) error {
+	if claim.Provider != "gitlab" || claim.Dataset != "work-items" ||
+		row.RecordID == uuid.Nil || row.OrgID == uuid.Nil || row.OrgID.String() != claim.OrgID ||
+		row.Provider != "gitlab" || row.SubjectType != "pull_request" || row.SubjectID == "" ||
+		row.RepoID == nil || *row.RepoID == uuid.Nil || row.Kind == "" || row.Source == "" ||
+		row.Confidence < 0 || row.Confidence > 1 || row.Evidence == nil ||
+		row.ObservedAt.IsZero() || row.IngestedAt.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
 }
 
 func normalizeGitLabMRStateEvents(

--- a/internal/providersync/testdata/mutation-plans/gitlab_work_items.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_work_items.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "GitLab canonical work-items raw parity (CHAOS-3723)",
   "build": ["env", "GOCACHE=/tmp/chaos-gitlab-go-cache", "go", "test", "-run", "^$", "./internal/providersync/"],
-  "$limitation": "This provider-local plan covers canonical-claim admission, project binding through the real GitLab route, pagination caps, label/history/comment/link/MR collection, Unicode comment measurement, derived-gap watermark withholding, typed six-fact effects, deterministic effect identity, and lease fencing. The integration-tagged ClickHouse test is the real schema/readback proof. It deliberately excludes registry, capability matrix, config, deployment, scheduler, and worker activation wiring; those are separate slices.",
+  "$limitation": "This provider-local plan covers canonical-claim admission, project binding through the real GitLab route, pagination caps, label/history/comment/link/MR collection, Unicode comment measurement, raw-only derived-gap watermark withholding, typed six-fact effects, deterministic effect identity, and lease fencing. The complete ten-destination derived family and sixteen-effect composition have their own plan. The integration-tagged ClickHouse test is the real schema/readback proof. It deliberately excludes registry, capability matrix, config, deployment, scheduler, and worker activation wiring; those are separate slices.",
   "mutations": [
     {
       "id": "W1-claim-provider-guard",
@@ -91,7 +91,7 @@
       "file": "internal/providersync/gitlab_work_items_route.go",
       "find": "if includeMRs {",
       "replace": "if false && includeMRs {",
-      "rationale": "the canonical provider batch includes merge-request work items and their history/comments, even though fetch_gitlab_work_items uses MRs only for blank-tenant attribution avoidance",
+      "rationale": "the canonical provider batch includes merge-request work items, authoritative AI inputs, history, and comments",
       "proof": [["env", "GOCACHE=/tmp/chaos-gitlab-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteNormalizesSixRawFactsAndReportsDerivedGap$", "./internal/providersync/"]]
     },
     {
@@ -105,16 +105,16 @@
     {
       "id": "W13-derived-gap-holds-watermark",
       "file": "internal/providersync/gitlab_work_items_route.go",
-      "find": "WatermarkHeldForDerivedGap:       true",
-      "replace": "WatermarkHeldForDerivedGap:       false",
+      "find": "WatermarkHeldForDerivedGap:       len(derivedUnimplemented) > 0,",
+      "replace": "WatermarkHeldForDerivedGap:       false,",
       "rationale": "the typed result must honestly report that ten of sixteen derived destinations are not implemented, so callers cannot advance completion as if the family were whole",
       "proof": [["env", "GOCACHE=/tmp/chaos-gitlab-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteNormalizesSixRawFactsAndReportsDerivedGap$", "./internal/providersync/"]]
     },
     {
       "id": "W14-watermark-is-withheld",
       "file": "internal/providersync/gitlab_work_items_route.go",
-      "find": "Effects: effects, Result: result, Watermark: nil",
-      "replace": "Effects: effects, Result: result, Watermark: claim.BeforeAt",
+      "find": "var watermark *time.Time",
+      "replace": "watermark := claim.BeforeAt",
       "rationale": "a route with an explicit ten-destination derived gap must not advance the leased watermark",
       "proof": [["env", "GOCACHE=/tmp/chaos-gitlab-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteNormalizesSixRawFactsAndReportsDerivedGap$", "./internal/providersync/"]]
     },

--- a/internal/providersync/testdata/mutation-plans/gitlab_work_items_derived.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_work_items_derived.json
@@ -1,72 +1,216 @@
 {
   "schema_version": 1,
-  "name": "GitLab canonical work-items derived destinations (CHAOS-3733)",
+  "name": "GitLab canonical work-items complete semantic family (CHAOS-3733)",
   "build": ["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-run", "^$", "./internal/providersync/"],
-  "$limitation": "This provider-local plan proves the typed nine-destination compute/effect boundary, explicit AI producer gap, watermark withholding, canonical effect composition, and GitLab claim fencing. The migration-backed ClickHouse suite separately proves real tenant/replay/lease readback. It deliberately excludes registry, matrix, config, deployment, scheduler, and worker activation wiring.",
+  "$limitation": "This provider-local plan proves the authoritative GitLab MR AI producer, ten typed derived effects, complete sixteen-effect composition, conditional watermark advancement, provider/tenant fencing, and fail-closed sink completeness. The migration-backed ClickHouse suites separately prove physical schema, replay, tenant, and lease behavior. Registry, matrix, config, deployment, scheduler, constructor activation, and alias-collapse wiring remain outside this lane.",
   "mutations": [
     {
-      "id": "D1-deriver-provider-guard",
+      "id": "D3-ai-rows-reach-derived-effect",
       "file": "internal/providersync/gitlab_work_item_derived.go",
-      "find": "claim.Provider != \"gitlab\" || claim.Dataset != \"work-items\" || normalizedAt.IsZero()",
-      "replace": "claim.Provider == \"gitlab\" || claim.Dataset != \"work-items\" || normalizedAt.IsZero()",
-      "rationale": "the compute boundary must reject a non-GitLab claim rather than derive rows for another provider",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
+      "find": "AIAttributions:                 append([]gitlabAIAttributionRow(nil), rows.AIAttributions...),",
+      "replace": "AIAttributions:                 nil,",
+      "rationale": "the compute boundary must pass the provider-normalized authoritative AI rows into the derived manifest",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesSixteenEffectsAndAdvancesWatermark$", "./internal/providersync/"]]
     },
     {
-      "id": "D2-deriver-dataset-guard",
+      "id": "D4-complete-deriver-watermark",
       "file": "internal/providersync/gitlab_work_item_derived.go",
-      "find": "claim.Provider != \"gitlab\" || claim.Dataset != \"work-items\" || normalizedAt.IsZero()",
-      "replace": "claim.Provider != \"gitlab\" || claim.Dataset == \"work-items\" || normalizedAt.IsZero()",
-      "rationale": "the compute boundary must reject a GitLab claim for a non-work-items dataset",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
-    },
-    {
-      "id": "D3-deriver-watermark-gap",
-      "file": "internal/providersync/gitlab_work_item_derived.go",
-      "find": "Watermark:                      nil,",
-      "replace": "Watermark:                      &normalizedAt,",
-      "rationale": "the explicit AI producer gap must hold the derived watermark rather than acknowledging an incomplete family",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
-    },
-    {
-      "id": "D4-typed-ai-gap-name",
-      "file": "internal/providersync/gitlab_work_item_derived.go",
-      "find": "Destination:           \"ai_attribution\",",
-      "replace": "Destination:           \"work_item_metrics_daily\",",
-      "rationale": "the gap must identify the missing authoritative AI destination, not relabel a landed typed row family",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndWithholdsAIWatermark$", "./internal/providersync/"]]
+      "find": "watermark = &value",
+      "replace": "value = normalizedAt.UTC(); watermark = &value",
+      "rationale": "a complete ten-destination derived family must acknowledge the exact leased upper bound",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedResultIsTypedAndComplete$", "./internal/providersync/"]]
     },
     {
       "id": "D5-route-appends-derived-effects",
       "file": "internal/providersync/gitlab_work_items_route.go",
       "find": "effects = append(effects, derivedEffects...)",
       "replace": "effects = append(effects, derivedEffects[:0]...)",
-      "rationale": "the configured route must carry every typed derived effect into the completion batch",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap$", "./internal/providersync/"]]
+      "rationale": "the configured route must carry all ten typed derived effects into the six-effect raw batch",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesSixteenEffectsAndAdvancesWatermark$", "./internal/providersync/"]]
     },
     {
       "id": "D6-route-reports-implemented-destinations",
       "file": "internal/providersync/gitlab_work_items_route.go",
       "find": "derivedImplemented = derived.producedDestinations()",
       "replace": "derivedImplemented = nil",
-      "rationale": "the typed route result must report all nine semantic destinations it actually emitted",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesNineDerivedEffectsAndLeavesAIGap$", "./internal/providersync/"]]
+      "rationale": "the typed route result must report all ten semantic destinations it emitted",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesSixteenEffectsAndAdvancesWatermark$", "./internal/providersync/"]]
     },
     {
-      "id": "D7-effect-identity-provider-fence",
+      "id": "D7-route-complete-gap-flag",
+      "file": "internal/providersync/gitlab_work_items_route.go",
+      "find": "WatermarkHeldForDerivedGap:       len(derivedUnimplemented) > 0,",
+      "replace": "WatermarkHeldForDerivedGap:       true,",
+      "rationale": "the typed result must stop reporting a derived gap once all ten authoritative producers completed",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesSixteenEffectsAndAdvancesWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D8-effect-identity-provider-fence",
       "file": "internal/providersync/gitlab_work_item_derived.go",
-      "find": "claim.Validate() != nil || claim.Provider != \"gitlab\" ||",
-      "replace": "claim.Validate() != nil || claim.Provider == \"gitlab\" ||",
-      "rationale": "the effect identity must only admit canonical GitLab work-items claims",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedIdentityRejectsRawAndAIDestinations$", "./internal/providersync/"]]
+      "find": "claim.Validate() != nil || claim.Provider != \"gitlab\" || claim.Dataset != \"work-items\" ||",
+      "replace": "claim.Validate() != nil || false || claim.Dataset != \"work-items\" ||",
+      "rationale": "the derived effect identity must only admit canonical GitLab work-items claims",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemDerivedIdentityAcceptsAIAndRejectsRawDestinations$", "./internal/providersync/"]]
     },
     {
-      "id": "D8-effect-destination-switch",
+      "id": "D9-effect-destination-switch",
       "file": "internal/providersync/gitlab_work_item_derived.go",
       "find": "effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemMetricsDaily)",
       "replace": "effect, err = buildGitLabTypedDerivedEffect(destination, rows.WorkItemUserMetricsDaily)",
-      "rationale": "the typed effect builder must retain the canonical destination-to-row projection rather than silently returning an empty or mislabelled effect",
-      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndExcludesAIGap$", "./internal/providersync/"]]
+      "rationale": "the typed effect builder must retain the canonical destination-to-row projection",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestBuildGitLabWorkItemDerivedEffectsIsCanonicalAndIncludesAI$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D9b-ai-effect-row-projection",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "effect, err = buildGitLabTypedDerivedEffect(destination, rows.AIAttributions)",
+      "replace": "effect, err = buildGitLabTypedDerivedEffect(destination, []gitlabAIAttributionRow(nil))",
+      "rationale": "the AI destination must carry the authoritative provider-normalized rows rather than an evaluated-looking empty slice",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteComposesSixteenEffectsAndAdvancesWatermark$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D10-ai-created-updated-fallback",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "pull.CreatedAt = payload.UpdatedAt",
+      "replace": "pull.CreatedAt = nil",
+      "rationale": "GitLab AI observed_at must fall back from missing created_at to the real provider updated_at before using ingest time",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp PYTHONPATH=\"$PWD/src\" GOCACHE=/tmp/gitlab-derived-go-cache go test -count=1 -run '^TestGitLabAIAttributionMatchesLivePythonProductionRows$' ./internal/providersync/"]]
+    },
+    {
+      "id": "D10b-ai-subject-id",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "pull.Number = payload.IID",
+      "replace": "pull.Number = payload.IID + 1",
+      "rationale": "GitLab attribution subject_id must remain the bare MR IID used by governance joins",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp PYTHONPATH=\"$PWD/src\" GOCACHE=/tmp/gitlab-derived-go-cache go test -count=1 -run '^TestGitLabAIAttributionMatchesLivePythonProductionRows$' ./internal/providersync/"]]
+    },
+    {
+      "id": "D11-ai-source-branch-signal",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "pull.Head.Ref = payload.SourceBranch",
+      "replace": "pull.Head.Ref = \"\"",
+      "rationale": "the provider-local producer must retain GitLab's authoritative source-branch signal",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp PYTHONPATH=\"$PWD/src\" GOCACHE=/tmp/gitlab-derived-go-cache go test -count=1 -run '^TestGitLabAIAttributionMatchesLivePythonProductionRows$' ./internal/providersync/"]]
+    },
+    {
+      "id": "D11b-ai-description-signals",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "pull.Body = payload.Description",
+      "replace": "pull.Body = nil",
+      "rationale": "GitLab MR descriptions are the authoritative commit-trailer and PR-body inputs",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp PYTHONPATH=\"$PWD/src\" GOCACHE=/tmp/gitlab-derived-go-cache go test -count=1 -run '^TestGitLabAIAttributionMatchesLivePythonProductionRows$' ./internal/providersync/"]]
+    },
+    {
+      "id": "D11c-ai-label-signal",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "pull.Labels = append(pull.Labels, githubWorkItemLabelPayload{Name: label})",
+      "replace": "pull.Labels = append(pull.Labels, githubWorkItemLabelPayload{})",
+      "rationale": "GitLab MR label values must reach the authoritative label detector without normalization loss",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp PYTHONPATH=\"$PWD/src\" GOCACHE=/tmp/gitlab-derived-go-cache go test -count=1 -run '^TestGitLabAIAttributionMatchesLivePythonProductionRows$' ./internal/providersync/"]]
+    },
+    {
+      "id": "D12-ai-author-bot-signal",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "if payload.Author.Bot {",
+      "replace": "if false && payload.Author.Bot {",
+      "rationale": "GitLab author.bot must reach the shared detector so an unknown bot is not silently treated as a human",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp PYTHONPATH=\"$PWD/src\" GOCACHE=/tmp/gitlab-derived-go-cache go test -count=1 -run '^TestGitLabAIAttributionMatchesLivePythonProductionRows$' ./internal/providersync/"]]
+    },
+    {
+      "id": "D12b-ai-author-login-signal",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "user := githubWorkItemUserPayload{Login: payload.Author.Username}",
+      "replace": "user := githubWorkItemUserPayload{Login: nil}",
+      "rationale": "GitLab author usernames must reach the authoritative known and unknown bot detectors",
+      "proof": [["bash", "-lc", "DEV_HEALTH_LIVE_PYTHON_ORACLES=1 DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR=/tmp PYTHONPATH=\"$PWD/src\" GOCACHE=/tmp/gitlab-derived-go-cache go test -count=1 -run '^TestGitLabAIAttributionMatchesLivePythonProductionRows$' ./internal/providersync/"]]
+    },
+    {
+      "id": "D13-ai-provider-identity",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "rows[index].Provider = \"gitlab\"",
+      "replace": "rows[index].Provider = \"github\"",
+      "rationale": "authoritative rows must remain GitLab-scoped for tenant/readback keys rather than inheriting the shared detector's GitHub identity",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabAIAttributionIsRetryStableAndDoesNotFabricateSignals$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D14-ai-effect-sink-dispatch",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "err = sink.AIAttribution.WriteGitHubWorkItemEffect(ctx, gitHubIdentity, effect)",
+      "replace": "err = ErrInvalidConfiguration",
+      "rationale": "the complete provider sink must dispatch the AI effect to its schema-backed writer",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsComposeAllSixteenDestinations$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D14b-ai-effect-readback-dispatch",
+      "file": "internal/providersync/gitlab_work_item_derived.go",
+      "find": "inspection, err = sink.AIAttribution.InspectGitHubWorkItemEffect(ctx, gitHubIdentity, effect)",
+      "replace": "inspection, err = EffectConflict, ErrInvalidConfiguration",
+      "rationale": "the complete provider readback must dispatch the AI effect to its schema-backed inspector",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsComposeAllSixteenDestinations$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D15-family-derived-write-dispatch",
+      "file": "internal/providersync/gitlab_work_items_composition.go",
+      "find": "return sink.Derived.WriteEffect(ctx, claim, effect)",
+      "replace": "return sink.Raw.WriteEffect(ctx, claim, effect)",
+      "rationale": "one committer-facing sink must route every derived effect to the ten-destination dispatcher",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsComposeAllSixteenDestinations$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D15b-family-derived-readback-dispatch",
+      "file": "internal/providersync/gitlab_work_items_composition.go",
+      "find": "return sink.Derived.InspectEffect(ctx, claim, effect)",
+      "replace": "return sink.Raw.InspectEffect(ctx, claim, effect)",
+      "rationale": "one committer-facing readback must route every derived effect to the ten-destination dispatcher",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsComposeAllSixteenDestinations$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D16-family-write-completeness-gate",
+      "file": "internal/providersync/gitlab_work_items_composition.go",
+      "find": ") error {\n\tif ctx == nil || !sink.complete() {",
+      "replace": ") error {\n\tif ctx == nil {",
+      "rationale": "a family missing even one adapter must fail closed before any raw or derived write",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsFailClosedWhenAnyAdapterIsMissing$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D17-family-readback-completeness-gate",
+      "file": "internal/providersync/gitlab_work_items_composition.go",
+      "find": ") (EffectInspection, error) {\n\tif ctx == nil || !sink.complete() {",
+      "replace": ") (EffectInspection, error) {\n\tif ctx == nil {",
+      "rationale": "a family missing even one adapter must fail closed before any raw or derived readback",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsFailClosedWhenAnyAdapterIsMissing$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D18-ai-effect-provider-fence",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "row.Provider != \"gitlab\" || row.SubjectType != \"pull_request\" || row.SubjectID == \"\" ||",
+      "replace": "false || row.SubjectType != \"pull_request\" || row.SubjectID == \"\" ||",
+      "rationale": "a recovered GitLab effect must reject an AI row whose natural-key provider is GitHub",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsRejectForeignAIProviderAndTenant$/provider$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D19-ai-effect-tenant-fence",
+      "file": "internal/providersync/gitlab_work_items_rows.go",
+      "find": "row.RecordID == uuid.Nil || row.OrgID == uuid.Nil || row.OrgID.String() != claim.OrgID ||",
+      "replace": "row.RecordID == uuid.Nil || row.OrgID == uuid.Nil || false ||",
+      "rationale": "a recovered GitLab AI effect must not let its row choose a tenant outside the leased claim",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemFamilyEffectsRejectForeignAIProviderAndTenant$/tenant$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D20-unavailable-producer-fails-closed",
+      "file": "internal/providersync/gitlab_work_items_route.go",
+      "find": "if len(derived.Gaps) > 0 {",
+      "replace": "if false && len(derived.Gaps) > 0 {",
+      "rationale": "a declared authoritative-producer gap must stop before an empty effect can masquerade as evaluated",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteRejectsUnavailableDerivedProducerBeforeEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "D21-route-watermark-bound-fence",
+      "file": "internal/providersync/gitlab_work_items_route.go",
+      "find": "!derived.Watermark.Equal(claim.BeforeAt.UTC())",
+      "replace": "false",
+      "rationale": "a complete deriver must return the exact leased upper bound rather than any non-nil timestamp",
+      "proof": [["env", "GOCACHE=/tmp/gitlab-derived-go-cache", "go", "test", "-count=1", "-run", "^TestGitLabWorkItemsRouteRejectsDerivedWatermarkOutsideClaimBound$", "./internal/providersync/"]]
     }
   ]
 }

--- a/internal/providersync/testdata/oracle_pairs/gitlab_work-items_ai-attribution.py
+++ b/internal/providersync/testdata/oracle_pairs/gitlab_work-items_ai-attribution.py
@@ -1,0 +1,62 @@
+"""Live Python oracle for GitLab MR AI attribution records."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import pathlib
+from typing import Any
+from uuid import UUID
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_items_helpers import (
+    install_minimal_oracle_imports,
+    object_from_case,
+)
+
+install_minimal_oracle_imports()
+
+with (
+    contextlib.redirect_stdout(io.StringIO()),
+    contextlib.redirect_stderr(io.StringIO()),
+):
+    from dev_health_ops.providers.gitlab.normalize import gitlab_mr_ai_attributions
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/ai_attribution.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    rows = gitlab_mr_ai_attributions(
+        mr=object_from_case(case["raw_mr"]),
+        project_full_path=case["repo_full_name"],
+        org_id=UUID(case["org_id"]),
+        repo_id=UUID(case["repo_id"]),
+    )
+    source = case["signal_source"]
+    row = next(candidate for candidate in rows if candidate.source.value == source)
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="gitlab/work-items/ai-attribution",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "AIAttributionRecord"
+        ),
+        excluded_fields={
+            "ingested_at": (
+                "the production constructor stamps wall-clock now and has no clock "
+                "parameter; Go stamps the complete unit normalizedAt and its retry "
+                "stability is asserted separately"
+            ),
+            "record_id": (
+                "the Python producer assigns uuid4 while Go derives a stable retry "
+                "identifier; non-zero and retry-stable Go IDs are asserted separately"
+            ),
+        },
+    )
+)


### PR DESCRIPTION
## Summary

- Cleanly cherry-picks source commit cee2228a9cf47834bcf6666914a41a46a3bc251e onto feature-integration base fb71a9beea5900ab78934c3ae279d83504335ae3 as f9177275c24aa99282971866a3d856b99a18eb95. The stable patch ID remains 1ad1783de88243e7af602821e7663d27c0309c3b.
- Completes the GitLab work-item semantic family: authoritative merge-request AI attribution, ten typed derived destinations, sixteen-effect composition, exact leased-bound watermark advancement only for a complete family, provider and tenant fencing, and fail-closed write/readback composition.
- This is a provider-local semantic and proof slice only. It adds no registry, capability-matrix, config, constructor/startup, scheduler, deployment, activation, or cutover wiring.

## Source-commit evidence

The source branch was never pushed and had no prior PR or GitHub CI. The following same-patch evidence was recorded locally on cee2228a9; fresh checks on f9177275c and this PR are authoritative for the rebased composition.

- Migrated ClickHouse integration proof passed both GitLab derived-effects readback and complete sixteen-effect composition tests.
- Raw mutation plan internal/providersync/testdata/mutation-plans/gitlab_work_items.json: 16/16 KILLED.
- Derived mutation plan internal/providersync/testdata/mutation-plans/gitlab_work_items_derived.json: 26/26 KILLED, including all seven live-Python signal mutations.
- scripts/mutation_harness.py verify passed afterward with digest restoration and a clean tree.
- Fresh source providersync package tests passed with count=1 and mod=readonly.
- The focused live-Python GitLab oracle selection passed in 4.057s; the scheduled-producer seam also passed.
- The focused Python provider sink test passed: 1 passed.
- Provider-sync vet, Go formatting, Ruff for the oracle file, mutation-plan JSON/unique-anchor checks, git diff hygiene, and commit-hook mypy over 2,201 source files were green.

## Fresh post-rebase evidence

- GOTOOLCHAIN=go1.25.9 GOWORK=off GOCACHE=/tmp/gitlab-semantic-v2-go-cache go test -mod=readonly -count=1 ./internal/providersync/... — PASS.
- DEV_HEALTH_GO_CACHE=/tmp/gitlab-semantic-v2-go-cache bash ci/check_go.sh live-python-oracles — PASS for internal/providersync and internal/scheduler/sync.
- bash ci/check_go.sh fmt — PASS.
- bash ci/check_go.sh vet — PASS across the root and River N-1 modules.
- Explicit pre-push hooks — Ruff format/check PASS; mypy PASS over 2,201 source files.
- git diff --check against fb71a9bee — PASS.

Per publication scope, Docker, mutation, and the full local gate were not rerun on the cherry-picked branch. No merge is requested by this publication step.