### PR TITLE
feat(providersync): complete Jira work-item semantics

### DIFF
--- a/internal/providersync/JIRA_PROVIDER_GAP_MATRIX.md
+++ b/internal/providersync/JIRA_PROVIDER_GAP_MATRIX.md
@@ -1,10 +1,12 @@
 # Jira provider parity gap matrix
 
-This is the provider-only audit for the unregistered Jira work-item route on
-`feat/go-worker-jira-oracle-prep`. It is an explicit partial-parity record, not
-a route-readiness or cutover claim. The Python source of truth is the current
-`src/dev_health_ops/metrics/work_items.py`, Jira provider implementation, and
-the team/reference discovery worker in the same checkout.
+This is the provider-only audit for the unregistered Jira work-item route. The
+provider-local route now composes the six canonical facts, Jira worklogs, and
+all ten governed derived dispositions. It is still not an activation or
+cutover claim: shared registry, matrix, constructor selection, admission, and
+deployment wiring remain outside this slice. The Python source of truth is the
+current `src/dev_health_ops/metrics/job_work_items.py`, Jira provider
+implementation, and team/reference discovery worker in the same checkout.
 
 ## Matrix shape
 
@@ -13,11 +15,11 @@ The provider matrix has six Jira aliases:
 | Matrix alias | Canonical family | Current route state | Scope |
 | --- | --- | --- | --- |
 | `incidents` | incidents | native and route-ready | JSM incident rows only; separate handler/effects |
-| `work-items` | work-items | native handler prepared, not registered/route-ready | canonical work-item family |
-| `work-item-comments` | work-items | not route-ready | same canonical family; comments are an enrichment, not a separate Go producer |
-| `work-item-history` | work-items | not route-ready | same canonical family; changelog is an enrichment |
-| `work-item-labels` | work-items | not route-ready | same canonical family; labels are fields on the work item |
-| `work-item-projects` | work-items | not route-ready | same canonical family; project scope/reference data is enrichment |
+| `work-items` | work-items | provider-local complete; not registered | canonical work-item family |
+| `work-item-comments` | work-items | provider-local complete; not registered | same canonical family; comments are an enrichment, not a separate Go producer |
+| `work-item-history` | work-items | provider-local complete; not registered | same canonical family; changelog is an enrichment |
+| `work-item-labels` | work-items | provider-local complete; not registered | same canonical family; labels are fields on the work item |
+| `work-item-projects` | work-items | provider-local complete; not registered | same canonical family; project scope/reference data is enrichment |
 
 Linear has the same five work-item aliases (without Jira's separate
 incidents pair). Alias count must not be mistaken for five independent
@@ -29,16 +31,16 @@ the same persisted destinations.
 | Surface | Python behavior | Go in this slice | Gap / disposition |
 | --- | --- | --- | --- |
 | Project/window discovery | `fetch_jira_work_items_with_extras` builds one JQL per configured project, with `JIRA_JQL` and `JIRA_FETCH_ALL` overrides. | Requires a non-empty `SourceExternalID` project key and builds the equivalent bounded JQL. | Direct project/window behavior is covered by the live batch oracle; project enumeration is not part of this route. |
-| Project/team/member identity | `workers/team_autoimport_jira.py` discovers Jira teams, projects, members, memberships, ownership, and board sprints; `IdentityResolver` aliases are applied to both roster and assignee paths. | No Go dimension-discovery implementation in this provider-only route. | Deferred to the reference/dimension parity slice; do not add registry or wiring here. |
-| Work-item identity and fields | `jira_issue_to_work_item` emits project identity, title/description, status and status-category fallback, type, labels, priority/service class, timestamps, assignee/reporter, story points, sprint, parent/epic, URL, and due date. | Normalizes the same semantic fields. | JSON assignee/reporter identity currently differs from shipped Python (`CHAOS-3713`); do not hide it with a Go-only exclusion. |
+| Project/team/member identity | `workers/team_autoimport_jira.py` discovers Jira teams, projects, members, memberships, ownership, and board sprints; `IdentityResolver` aliases are applied to both roster and assignee paths. | Derived computation consumes the migrated, tenant-scoped ClickHouse team/project/member context and bounded donor rows. | Dimension discovery remains a separate provider unit; this route does not add registry or wiring. |
+| Work-item identity and fields | `jira_issue_to_work_item` emits project identity, title/description, status and status-category fallback, type, labels, priority/service class, timestamps, assignee/reporter, story points, sprint, parent/epic, URL, and due date. | Normalizes the same semantic fields, including Atlassian account/name identity and GraphQL-to-REST worklog fallback. | Covered by live producer oracles and route tests. |
 | Changelog/history | Python sorts Jira histories by timestamp, emits status transitions, and derives started/completed lifecycle. | Same transition ordering, status mapping, reopen derivation, and lifecycle helpers. | Direct row is covered; real producer batch comparison is the required proof boundary. |
-| Comments/interactions | Legacy producer fetches comments per issue, applies `JIRA_COMMENTS_LIMIT`, converts valid comments, and continues on a best-effort fetch error. | Paginated comment fetch, bounded limit, typed incomplete marker, and watermark withholding. | Semantics are covered in the route harness; compare the real producer batch and optional-failure behavior before activation. |
+| Comments/interactions | Legacy producer fetches comments per issue, applies `JIRA_COMMENTS_LIMIT`, converts valid comments, and continues on a best-effort fetch error. | Paginated comment fetch, bounded limit, typed incomplete marker, and watermark withholding while landed effects remain recoverable. | Covered by the live legacy-batch oracle and Atlassian route harness. |
 | Links/dependencies | Legacy normalizer extracts outward/inward links and canonicalizes blocker direction. | Same direction and relationship normalization, with canonical semantics version. | Direct row is covered; real batch and ClickHouse recovery proof remains `CHAOS-3712`. |
 | Reopen/priority | Reopen events derive from terminal-to-nonterminal transitions; priority maps to service class. | Same derivation and mapping. | Direct row is covered by the semantic/route tests. |
-| Sprint/reference cache | Legacy producer collects issue sprint IDs, reuses Jira reference sprints, fetches missing sprints, and writes newly fetched references. | Fetches issue-linked sprints but does not enumerate boards or persist a reusable reference cache in this route. | Cache/reference and incomplete-watermark semantics are deferred to `CHAOS-3714`. |
-| Boards/sprints | `team_autoimport_jira.py` enumerates boards and board sprints; the Atlassian provider can optionally fetch board sprints. | No board enumeration or board-sprint path. | Deferred to the Jira Atlassian enrichment follow-up; issue-linked sprint rows are the only current Go surface. |
+| Sprint/reference cache | Legacy producer collects issue sprint IDs, reuses Jira reference sprints, fetches missing sprints, and writes newly fetched references. | Reuses tenant-scoped reference sprints, enumerates board sprints only when references miss, and exposes a typed reference sink. | Reference reuse, board enumeration, and incomplete-watermark behavior are route-tested. |
+| Boards/sprints | `team_autoimport_jira.py` enumerates boards and board sprints; the Atlassian provider can optionally fetch board sprints. | Implements bounded board/sprint enumeration and the reference-cache skip path. | Covered by the Atlassian live producer pair. |
 | Worklogs | Atlassian provider optionally fetches worklogs through GraphQL with REST fallback under `JIRA_FETCH_WORKLOGS`; legacy batch has no worklog list. | Typed worklog effect, identity parity, and GraphQL-attempt/REST-fallback observations are covered by the Atlassian route. | Worklogs are not one of the 16 work-item matrix destinations; durable completion payload records the typed fetch observations. |
-| Atlassian alternate path | `JiraProvider`'s Atlassian path emits canonical work items/transitions/reopens and optional worklogs/sprints, but currently returns empty dependencies and interactions. | This route models the legacy REST/JQL path only. | Must not be called provider-complete until Atlassian dependency/comment parity is resolved. |
+| Atlassian alternate path | `JiraProvider`'s Atlassian path emits canonical work items/transitions/reopens and optional worklogs/sprints, but currently returns empty dependencies and interactions. | One provider-local route composes Atlassian worklogs/boards with the legacy dependency/comment semantics required by the canonical family. | Identity, GraphQL fallback observations, sprint references, dependencies, and interactions are covered together before the watermark advances. |
 | JSM incidents | Separate native JSM path and `operational_incidents` destination. | Already native and route-ready. | Out of scope for this work-item continuation; do not modify incident handler/effects/readback. |
 
 ## Destination coverage
@@ -48,26 +50,28 @@ destinations:
 
 | Destination | Python job behavior | Go status in this slice |
 | --- | --- | --- |
-| `work_items` | direct normalized work-item sink | provider handler/effect prepared; not registered |
-| `work_item_transitions` | direct changelog sink | provider handler/effect prepared; not registered |
-| `work_item_dependencies` | direct link sink | provider handler/effect prepared; not registered |
-| `work_item_reopen_events` | direct reopen sink | provider handler/effect prepared; not registered |
-| `work_item_interactions` | direct comment sink | provider handler/effect prepared; not registered |
-| `sprints` | direct issue/reference sprint sink | provider handler/effect prepared; board/reference breadth deferred |
-| `ai_attribution` | optional persisted attribution records | no Jira producer/effect in this slice |
-| `estimate_coverage_metrics_daily` | compute-time derived daily output | no Go compute/effect in this slice |
-| `investment_classifications_daily` | compute-time derived daily output | no Go compute/effect in this slice |
-| `investment_metrics_daily` | compute-time derived daily output | no Go compute/effect in this slice |
-| `issue_type_metrics_daily` | compute-time derived daily output | no Go compute/effect in this slice |
-| `work_item_cycle_times` | compute-time derived lifecycle output | no Go compute/effect in this slice |
-| `work_item_metrics_daily` | compute-time derived daily output | no Go compute/effect in this slice |
-| `work_item_state_durations_daily` | compute-time derived transition output | no Go compute/effect in this slice |
-| `work_item_team_attributions` | compute-time attribution using reference teams and bounded donors | no Go compute/effect in this slice |
-| `work_item_user_metrics_daily` | compute-time user rollup | no Go compute/effect in this slice |
+| `work_items` | direct normalized work-item sink | typed direct effect and migrated ClickHouse adapter |
+| `work_item_transitions` | direct changelog sink | typed direct effect and migrated ClickHouse adapter |
+| `work_item_dependencies` | direct link sink | typed direct effect and migrated ClickHouse adapter |
+| `work_item_reopen_events` | direct reopen sink | typed direct effect and migrated ClickHouse adapter |
+| `work_item_interactions` | direct comment sink | typed direct effect and migrated ClickHouse adapter |
+| `sprints` | direct issue/reference sprint sink | typed direct effect, board/reference breadth, and migrated ClickHouse adapter |
+| `ai_attribution` | Jira `ProviderBatch.ai_attributions` is explicitly empty; no Jira AI producer runs | evaluated-empty readback-required effect; rejects rows, performs no ClickHouse I/O, and reads `EffectAbsent` |
+| `estimate_coverage_metrics_daily` | compute-time derived daily output | live-Python-matched typed compute/effect and migrated adapter |
+| `investment_classifications_daily` | compute-time derived daily output | live-Python-matched typed compute/effect and migrated adapter |
+| `investment_metrics_daily` | compute-time derived daily output | live-Python-matched typed compute/effect and migrated adapter |
+| `issue_type_metrics_daily` | compute-time derived daily output | live-Python-matched typed compute/effect and migrated adapter |
+| `work_item_cycle_times` | compute-time derived lifecycle output | live-Python-matched typed compute/effect and migrated adapter |
+| `work_item_metrics_daily` | compute-time derived daily output | live-Python-matched typed compute/effect and migrated adapter |
+| `work_item_state_durations_daily` | compute-time derived transition output | live-Python-matched typed compute/effect and migrated adapter |
+| `work_item_team_attributions` | compute-time attribution using reference teams and bounded donors | live-Python-matched typed compute/effect with fail-closed donor context |
+| `work_item_user_metrics_daily` | compute-time user rollup | live-Python-matched typed compute/effect and migrated adapter |
 
-The first six are raw provider rows, not the whole Jira capability. The ten
-derived destinations remain a separate compute/effect gap, and no source
-inspection, sink projection, skipped route, or status claim closes it.
+`worklogs` is a seventeenth Jira-only effect outside the governed canonical
+sixteen. It retains DateTime64(6) precision and its own migrated adapter. The
+provider route emits all seventeen effects in one recoverable batch; a route
+without the injected deriver reports all ten derived destinations as missing
+and withholds its watermark.
 
 ## Evidence and intentional deferrals
 
@@ -78,16 +82,18 @@ inspection, sink projection, skipped route, or status claim closes it.
 - `jira_work_items_sink_oracle_test.go` compares the six direct ClickHouse
   projections, but its input rows are constructed at the sink boundary; it is
   not evidence that a real Jira producer populated them.
-- `CHAOS-3712` owns the real `fetch_jira_work_items_with_extras` plus direct
-  sink/recovery proof.
-- `CHAOS-3713` owns the shipped Python JSON user-identity defect before a Go
-  identity comparison is made authoritative.
-- `CHAOS-3714` owns sprint/reference cache reuse, optional incomplete markers,
-  and recovery semantics.
-- Board enumeration and Atlassian-path dependency/interaction parity remain
-  intentionally deferred to separate follow-ups. CHAOS-3720 closes only the
-  Atlassian worklog identity/fallback parity slice; no registry, matrix, config,
-  route switch, or deployment wiring is changed here.
+- `jira_work_item_derived_oracle_test.go` executes all nine checked-in Python
+  compute producers over provider=`jira`, including multi-day and donor cases.
+- `jira-work_items_atlassian.py` now compares the reflected, explicitly empty
+  `ProviderBatch.ai_attributions` field as well as worklogs and sprints.
+- `jira_work_item_derived_effects_integration_test.go` uses the production
+  ClickHouse migration chain for the attribution-context loader plus tenant,
+  replay, lease, and readback proof.
+- `jira_work_items_derived.json` is the shared-harness mutation plan for the
+  provider-local composition and evaluated-empty AI disposition.
+- No registry, matrix, shared constructor, admission, route switch, scheduler,
+  or deployment wiring is changed here.
 
-Therefore this branch is **partial provider parity preparation**, not Jira
-provider completion and not route readiness.
+Therefore this branch closes Jira's **provider-local semantic route**. It is
+not activated route readiness or cutover until the separately owned shared
+wiring and admission gates select this handler and composite sink.

--- a/internal/providersync/github_work_item_derived_effects_clickhouse.go
+++ b/internal/providersync/github_work_item_derived_effects_clickhouse.go
@@ -97,9 +97,10 @@ func validGitHubWorkItemDerivedWriteRows[T any](
 	return true
 }
 
-// validGitHubWorkItemDerivedRowTenancy is shared by the GitHub and GitLab
-// adapters. The JSON effect ledger is not allowed to become a bypass around
-// the provider and tenant fences that the typed compute rows already carry.
+// validGitHubWorkItemDerivedRowTenancy is shared by the GitHub, GitLab, and
+// Jira adapters. The JSON effect ledger is not allowed to become a bypass
+// around the provider and tenant fences that the typed compute rows already
+// carry.
 func validGitHubWorkItemDerivedRowTenancy[T any](
 	row T,
 	identity GitHubWorkItemEffectIdentity,

--- a/internal/providersync/github_work_item_metric_triplet.go
+++ b/internal/providersync/github_work_item_metric_triplet.go
@@ -174,8 +174,8 @@ func buildGitHubWorkItemMetricTriplet(
 
 // buildWorkItemMetricTripletForProvider keeps the metric computation identical
 // across providers while retaining the provider value on every schema row.
-// GitLab uses the same canonical WorkItem fields and resolver, but must never
-// be made to look like GitHub merely to reuse this arithmetic.
+// GitLab and Jira use the same canonical WorkItem fields and resolver, but
+// must never be made to look like GitHub merely to reuse this arithmetic.
 func buildWorkItemMetricTripletForProvider(
 	provider string,
 	claim Claim,

--- a/internal/providersync/github_work_items_derivation_context.go
+++ b/internal/providersync/github_work_items_derivation_context.go
@@ -152,9 +152,10 @@ func loadGitHubWorkItemDerivationContext(
 }
 
 // loadWorkItemDerivationContextForProvider is the provider-neutral context
-// loader shared by the GitHub and GitLab work-item families. The source facts
-// are already provider-keyed, so the resolver can apply the same canonical
-// precedence without copying or weakening the team-attribution contract.
+// loader shared by the GitHub, GitLab, and Jira work-item families. The source
+// facts are already provider-keyed, so the resolver can apply the same
+// canonical precedence without copying or weakening the team-attribution
+// contract.
 func loadWorkItemDerivationContextForProvider(
 	ctx context.Context,
 	provider string,

--- a/internal/providersync/jira_atlassian_oracle_test.go
+++ b/internal/providersync/jira_atlassian_oracle_test.go
@@ -17,8 +17,9 @@ import (
 // sprint contract and invokes JiraAtlassianRouteHandler.Collect, including its
 // real REST pagination and reference-cache branch.
 type jiraAtlassianOracleSurfaces struct {
-	Worklogs []jiraWorklogRow `json:"worklogs"`
-	Sprints  []jiraSprintRow  `json:"sprints"`
+	Worklogs       []jiraWorklogRow  `json:"worklogs"`
+	Sprints        []jiraSprintRow   `json:"sprints"`
+	AIAttributions []json.RawMessage `json:"ai_attributions"`
 }
 
 func TestJiraAtlassianSurfacesMatchLivePythonProducer(t *testing.T) {
@@ -106,12 +107,25 @@ func buildJiraAtlassianOracleSurfaces(t *testing.T, input map[string]any) jiraAt
 	if jiraBatchBool(input["graphql_fallback"], false) {
 		graphqlClient = jiraWorkItemsTestClient(t, &jiraAtlassianOracleDoer{t: t, graphqlFailure: true}, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
 	}
-	batch, err := (JiraAtlassianRouteHandler{StatusMapping: loadRealStatusMapping(t), Identity: jiraOracleIdentity, ReferenceSprints: refs, CloudID: "cloud-301", GraphQLClient: graphqlClient}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt)
+	handler := jiraAtlassianCompleteHandler(t)
+	handler.Identity = jiraOracleIdentity
+	handler.ReferenceSprints = refs
+	handler.CloudID = "cloud-301"
+	handler.GraphQLClient = graphqlClient
+	batch, err := handler.Collect(context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	result := jiraAtlassianOracleSurfaces{Worklogs: make([]jiraWorklogRow, 0), Sprints: make([]jiraSprintRow, 0)}
+	result := jiraAtlassianOracleSurfaces{
+		Worklogs: make([]jiraWorklogRow, 0), Sprints: make([]jiraSprintRow, 0),
+		AIAttributions: make([]json.RawMessage, 0),
+	}
+	foundAI := false
 	for _, effect := range batch.Effects {
+		if effect.Destination == "ai_attribution" {
+			foundAI = true
+			result.AIAttributions = append(result.AIAttributions, effect.Rows...)
+		}
 		for _, raw := range effect.Rows {
 			switch effect.Destination {
 			case "worklogs":
@@ -128,6 +142,9 @@ func buildJiraAtlassianOracleSurfaces(t *testing.T, input map[string]any) jiraAt
 				result.Sprints = append(result.Sprints, row)
 			}
 		}
+	}
+	if !foundAI {
+		t.Fatal("Jira route did not record the live producer's evaluated-empty AI disposition")
 	}
 	return result
 }

--- a/internal/providersync/jira_atlassian_route.go
+++ b/internal/providersync/jira_atlassian_route.go
@@ -63,6 +63,25 @@ type JiraWorklogFetchObservation struct {
 	RESTRequests     int
 }
 
+var jiraAtlassianRawDestinations = JiraAtlassianEffectDestinations()
+
+// JiraAtlassianWorkItemsResult keeps route breadth and readiness explicit even
+// though CompleteRouteBatch predates provider-specific result types. Worklogs
+// are a Jira-only extra and do not replace any of the canonical sixteen.
+type JiraAtlassianWorkItemsResult struct {
+	WorkItemsSynced                  int      `json:"work_items_synced"`
+	TransitionsSynced                int      `json:"transitions_synced"`
+	DependenciesSynced               int      `json:"dependencies_synced"`
+	ReopenEventsSynced               int      `json:"reopen_events_synced"`
+	InteractionsSynced               int      `json:"interactions_synced"`
+	SprintsSynced                    int      `json:"sprints_synced"`
+	WorklogsSynced                   int      `json:"worklogs_synced"`
+	RawDestinations                  []string `json:"raw_destinations"`
+	DerivedDestinationsImplemented   []string `json:"derived_destinations_implemented"`
+	DerivedDestinationsUnimplemented []string `json:"derived_destinations_unimplemented"`
+	WatermarkHeldForIncomplete       bool     `json:"watermark_held_for_incomplete"`
+}
+
 // JiraSprintReferenceSink is the narrow reference-cache boundary used by the
 // provider path.  It is intentionally not a registry or activation hook.
 type JiraSprintReferenceSink func([]jiraSprintRow) error
@@ -83,6 +102,7 @@ type JiraAtlassianRouteHandler struct {
 	PerPage          int
 	ReferenceSprints []jiraSprintRow
 	ReferenceSink    JiraSprintReferenceSink
+	Derived          jiraWorkItemsDeriver
 }
 
 func (handler JiraAtlassianRouteHandler) limits() (int, int, int, error) {
@@ -283,24 +303,67 @@ func (handler JiraAtlassianRouteHandler) Collect(
 	if err != nil {
 		return CompleteRouteBatch{}, err
 	}
+	derivedImplemented := []string{}
+	derivedUnimplemented := append([]string(nil), jiraWorkItemDerivedDestinations...)
+	derivedRecords := 0
+	var derivedWatermark *time.Time
+	if handler.Derived != nil {
+		derived, deriveErr := handler.Derived.Derive(
+			ctx, claim, rows.jiraWorkItemRows, normalizedAt,
+		)
+		if deriveErr != nil {
+			return CompleteRouteBatch{}, deriveErr
+		}
+		if derived.Watermark == nil || !derived.Watermark.Equal(*claim.BeforeAt) {
+			return CompleteRouteBatch{}, ErrInvalidConfiguration
+		}
+		derivedEffects, effectErr := BuildJiraWorkItemDerivedEffects(derived.EffectRows())
+		if effectErr != nil {
+			return CompleteRouteBatch{}, effectErr
+		}
+		effects = append(effects, derivedEffects...)
+		derivedImplemented = derived.producedDestinations()
+		derivedUnimplemented = []string{}
+		derivedWatermark = derived.Watermark
+		derivedRecords = len(derived.EstimateCoverageMetricsDaily) +
+			len(derived.InvestmentClassificationsDaily) + len(derived.InvestmentMetricsDaily) +
+			len(derived.IssueTypeMetricsDaily) + len(derived.WorkItemCycleTimes) +
+			len(derived.WorkItemMetricsDaily) + len(derived.WorkItemStateDurationsDaily) +
+			len(derived.WorkItemTeamAttributions) + len(derived.WorkItemUserMetricsDaily)
+	}
+	summary := JiraAtlassianWorkItemsResult{
+		WorkItemsSynced: len(rows.WorkItems), TransitionsSynced: len(rows.Transitions),
+		DependenciesSynced: len(rows.Dependencies), ReopenEventsSynced: len(rows.ReopenEvents),
+		InteractionsSynced: len(rows.Interactions), SprintsSynced: len(rows.Sprints),
+		WorklogsSynced:                   len(rows.Worklogs),
+		RawDestinations:                  append([]string(nil), jiraAtlassianRawDestinations...),
+		DerivedDestinationsImplemented:   append([]string(nil), derivedImplemented...),
+		DerivedDestinationsUnimplemented: append([]string(nil), derivedUnimplemented...),
+		WatermarkHeldForIncomplete:       len(optionalIncomplete) > 0 || derivedWatermark == nil,
+	}
 	result := map[string]any{
 		"work_items_synced": len(rows.WorkItems), "transitions_synced": len(rows.Transitions),
 		"dependencies_synced": len(rows.Dependencies), "reopen_events_synced": len(rows.ReopenEvents),
 		"interactions_synced": len(rows.Interactions), "sprints_synced": len(rows.Sprints),
 		"worklogs_synced": len(rows.Worklogs), "project_key": projectKey,
+		"raw_destinations":                   append([]string(nil), jiraAtlassianRawDestinations...),
+		"derived_destinations_implemented":   append([]string(nil), derivedImplemented...),
+		"derived_destinations_unimplemented": append([]string(nil), derivedUnimplemented...),
+		"watermark_held_for_incomplete":      summary.WatermarkHeldForIncomplete,
+		"jira_work_items":                    summary,
 	}
 	if len(optionalIncomplete) > 0 {
 		result["incomplete"] = optionalIncomplete
 	}
 	var watermark *time.Time
-	if len(optionalIncomplete) == 0 {
-		value := claim.BeforeAt.UTC()
+	if len(optionalIncomplete) == 0 && derivedWatermark != nil {
+		value := derivedWatermark.UTC()
 		watermark = &value
 	}
 	return CompleteRouteBatch{
 		Effects: effects, Result: result, Watermark: watermark,
 		Evidence: FetchEvidence{Provider: claim.Provider, Dataset: claim.Dataset,
-			Requests: requests, Pages: searchPages, Records: len(rows.WorkItems)},
+			Requests: requests, Pages: searchPages, Records: len(rows.WorkItems) + derivedRecords},
 		WorklogObservations: worklogObservations,
 	}, nil
 }

--- a/internal/providersync/jira_atlassian_route_test.go
+++ b/internal/providersync/jira_atlassian_route_test.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -61,11 +62,29 @@ func jiraAtlassianClaim() Claim {
 	return claim
 }
 
+func jiraAtlassianCompleteHandler(t *testing.T) JiraAtlassianRouteHandler {
+	t.Helper()
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusMapping := loadRealStatusMapping(t)
+	return JiraAtlassianRouteHandler{
+		StatusMapping: statusMapping,
+		Identity:      jiraRouteIdentity,
+		Derived: JiraWorkItemDeriver{
+			Source:               &githubMultiDayOracleSource{},
+			statusMapping:        statusMapping,
+			investmentClassifier: classifier,
+		},
+	}
+}
+
 func TestJiraAtlassianRouteCollectsWorklogsBoardsAndCanonicalEdges(t *testing.T) {
 	claim := jiraAtlassianClaim()
 	doer := &jiraAtlassianDoer{t: t}
 	client := jiraWorkItemsTestClient(t, doer, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
-	batch, err := (JiraAtlassianRouteHandler{StatusMapping: loadRealStatusMapping(t), Identity: jiraRouteIdentity}).Collect(
+	batch, err := jiraAtlassianCompleteHandler(t).Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client,
 		time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
 	)
@@ -75,8 +94,8 @@ func TestJiraAtlassianRouteCollectsWorklogsBoardsAndCanonicalEdges(t *testing.T)
 	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
 		t.Fatalf("watermark=%v want=%v", batch.Watermark, claim.BeforeAt)
 	}
-	if len(batch.Effects) != 7 {
-		t.Fatalf("effects=%d want=7", len(batch.Effects))
+	if len(batch.Effects) != 17 {
+		t.Fatalf("effects=%d want=17 (six canonical facts, worklogs, and ten derived)", len(batch.Effects))
 	}
 	if batch.Result["worklogs_synced"] != 1 || batch.Result["sprints_synced"] != 1 || batch.Result["dependencies_synced"] != 1 || batch.Result["interactions_synced"] != 1 {
 		t.Fatalf("result=%#v", batch.Result)
@@ -123,7 +142,9 @@ func TestJiraAtlassianRouteReferenceCacheSkipsBoardEnumeration(t *testing.T) {
 	refName, refState := "August", "active"
 	refs := []jiraSprintRow{{Provider: "jira", SprintID: "9001", Name: &refName, State: &refState, LastSynced: normalizedAt, OrgID: claim.OrgID}}
 	client := jiraWorkItemsTestClient(t, doer, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
-	batch, err := (JiraAtlassianRouteHandler{StatusMapping: loadRealStatusMapping(t), ReferenceSprints: refs}).Collect(
+	handler := jiraAtlassianCompleteHandler(t)
+	handler.ReferenceSprints = refs
+	batch, err := handler.Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt,
 	)
 	if err != nil {
@@ -146,7 +167,7 @@ func TestJiraAtlassianRouteWorklogFailureIsTypedAndWithholdsWatermark(t *testing
 		return (&jiraAtlassianDoer{t: t}).Do(request)
 	})
 	client := jiraWorkItemsTestClient(t, doer, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
-	batch, err := (JiraAtlassianRouteHandler{StatusMapping: loadRealStatusMapping(t), Identity: jiraRouteIdentity}).Collect(
+	batch, err := jiraAtlassianCompleteHandler(t).Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client, time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
 	)
 	if err != nil {
@@ -155,8 +176,39 @@ func TestJiraAtlassianRouteWorklogFailureIsTypedAndWithholdsWatermark(t *testing
 	if batch.Watermark != nil {
 		t.Fatalf("optional worklog failure advanced watermark: %v", batch.Watermark)
 	}
+	if len(batch.Effects) != 17 {
+		t.Fatalf("optional worklog failure dropped recoverable effects: %d", len(batch.Effects))
+	}
 	incomplete, ok := batch.Result["incomplete"].([]string)
 	if !ok || len(incomplete) != 1 || incomplete[0] != "worklogs:jira:OPS-201" {
+		t.Fatalf("incomplete=%#v", batch.Result["incomplete"])
+	}
+}
+
+func TestJiraAtlassianReferenceSinkFailureLandsEffectsAndWithholdsWatermark(t *testing.T) {
+	claim := jiraAtlassianClaim()
+	client := jiraWorkItemsTestClient(
+		t,
+		&jiraAtlassianDoer{t: t},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	handler := jiraAtlassianCompleteHandler(t)
+	handler.ReferenceSink = func([]jiraSprintRow) error { return errors.New("reference unavailable") }
+	batch, err := handler.Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Watermark != nil {
+		t.Fatalf("reference sink failure advanced watermark: %v", batch.Watermark)
+	}
+	if len(batch.Effects) != 17 {
+		t.Fatalf("reference sink failure dropped recoverable effects: %d", len(batch.Effects))
+	}
+	incomplete, ok := batch.Result["incomplete"].([]string)
+	if !ok || len(incomplete) != 1 || incomplete[0] != "reference_sink" {
 		t.Fatalf("incomplete=%#v", batch.Result["incomplete"])
 	}
 }
@@ -178,10 +230,9 @@ func TestJiraAtlassianGraphQLWorklogPreservesNameIdentity(t *testing.T) {
 	})
 	client := jiraWorkItemsTestClient(t, rest, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
 	graphqlClient := jiraWorkItemsTestClient(t, graphql, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
-	batch, err := (JiraAtlassianRouteHandler{
-		StatusMapping: loadRealStatusMapping(t), Identity: jiraRouteIdentity,
-		CloudID: "cloud-301", GraphQLClient: graphqlClient,
-	}).Collect(
+	handler := jiraAtlassianCompleteHandler(t)
+	handler.CloudID, handler.GraphQLClient = "cloud-301", graphqlClient
+	batch, err := handler.Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client,
 		time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
 	)
@@ -195,8 +246,8 @@ func TestJiraAtlassianGraphQLWorklogPreservesNameIdentity(t *testing.T) {
 	if !observation.GraphQLAttempted || !observation.GraphQLSucceeded || observation.RESTFallbackUsed || observation.GraphQLRequests != 1 || observation.RESTRequests != 0 {
 		t.Fatalf("GraphQL observation=%+v", observation)
 	}
-	if len(batch.Effects) != 7 {
-		t.Fatalf("effects=%d want=7", len(batch.Effects))
+	if len(batch.Effects) != 17 {
+		t.Fatalf("effects=%d want=17", len(batch.Effects))
 	}
 	var worklog jiraWorklogRow
 	for _, effect := range batch.Effects {
@@ -228,10 +279,9 @@ func TestJiraAtlassianGraphQLFailureRecordsRESTFallbackObservation(t *testing.T)
 	})
 	client := jiraWorkItemsTestClient(t, rest, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
 	graphqlClient := jiraWorkItemsTestClient(t, graphql, providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }))
-	batch, err := (JiraAtlassianRouteHandler{
-		StatusMapping: loadRealStatusMapping(t), Identity: jiraRouteIdentity,
-		CloudID: "cloud-301", GraphQLClient: graphqlClient,
-	}).Collect(
+	handler := jiraAtlassianCompleteHandler(t)
+	handler.CloudID, handler.GraphQLClient = "cloud-301", graphqlClient
+	batch, err := handler.Collect(
 		context.Background(), claim, providerfoundation.Credential{}, client,
 		time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
 	)

--- a/internal/providersync/jira_work_item_derived.go
+++ b/internal/providersync/jira_work_item_derived.go
@@ -1,0 +1,638 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// Jira's canonical work-item job has nine schema-backed computed destinations.
+// ai_attribution is included as an explicit evaluated-empty effect: the live
+// Jira ProviderBatch has that field but no Jira AI producer populates it. This
+// is distinct from GitLab, whose producer exists and needs MR fields that are
+// absent from its six normalized facts.
+var jiraWorkItemDerivedDestinations = []string{
+	"ai_attribution",
+	"estimate_coverage_metrics_daily",
+	"investment_classifications_daily",
+	"investment_metrics_daily",
+	"issue_type_metrics_daily",
+	"work_item_cycle_times",
+	"work_item_metrics_daily",
+	"work_item_state_durations_daily",
+	"work_item_team_attributions",
+	"work_item_user_metrics_daily",
+}
+
+type JiraEstimateCoverageMetricsDailyRow = githubEstimateCoverageMetricsDailyRow
+type JiraInvestmentClassificationDailyRow = githubInvestmentClassificationDailyRow
+type JiraInvestmentMetricsDailyRow = githubInvestmentMetricsDailyRow
+type JiraIssueTypeMetricsDailyRow = githubIssueTypeMetricsDailyRow
+type JiraWorkItemCycleTimePersistenceRow = githubWorkItemCycleTimePersistenceRow
+type JiraWorkItemMetricsDailyRow = githubWorkItemMetricsDailyRow
+type JiraWorkItemStateDurationDailyRow = githubWorkItemStateDurationDailyRow
+type JiraWorkItemTeamAttributionRow = githubWorkItemTeamAttributionRow
+type JiraWorkItemUserMetricsDailyRow = githubWorkItemUserMetricsDailyRow
+
+// JiraWorkItemDerivedRows is the concrete compute result. Each field is the
+// row type owned by its ClickHouse table; no string-keyed evidence envelope can
+// substitute for a destination's schema.
+type JiraWorkItemDerivedRows struct {
+	EstimateCoverageMetricsDaily   []JiraEstimateCoverageMetricsDailyRow
+	InvestmentClassificationsDaily []JiraInvestmentClassificationDailyRow
+	InvestmentMetricsDaily         []JiraInvestmentMetricsDailyRow
+	IssueTypeMetricsDaily          []JiraIssueTypeMetricsDailyRow
+	WorkItemCycleTimes             []JiraWorkItemCycleTimePersistenceRow
+	WorkItemMetricsDaily           []JiraWorkItemMetricsDailyRow
+	WorkItemStateDurationsDaily    []JiraWorkItemStateDurationDailyRow
+	WorkItemTeamAttributions       []JiraWorkItemTeamAttributionRow
+	WorkItemUserMetricsDaily       []JiraWorkItemUserMetricsDailyRow
+	Watermark                      *time.Time
+}
+
+func (rows JiraWorkItemDerivedRows) producedDestinations() []string {
+	return append([]string(nil), jiraWorkItemDerivedDestinations...)
+}
+
+func jiraWorkItemRowsAsGitHub(rows jiraWorkItemRows) githubWorkItemRows {
+	return githubWorkItemRows{
+		WorkItems:         rows.WorkItems,
+		StatusTransitions: rows.Transitions,
+		Dependencies:      rows.Dependencies,
+		ReopenEvents:      rows.ReopenEvents,
+		Interactions:      rows.Interactions,
+		Sprints:           rows.Sprints,
+	}
+}
+
+// jiraWorkItemsDeriver is injected at the provider route boundary. It is not a
+// registry, constructor-selection, or activation seam.
+type jiraWorkItemsDeriver interface {
+	Derive(context.Context, Claim, jiraWorkItemRows, time.Time) (JiraWorkItemDerivedRows, error)
+}
+
+// JiraWorkItemDeriver owns the Jira compute boundary and reuses the
+// provider-neutral arithmetic already differential-tested against Python.
+type JiraWorkItemDeriver struct {
+	Source               githubWorkItemDerivationContextSource
+	statusMapping        *StatusMapping
+	investmentClassifier *InvestmentClassifier
+}
+
+// jiraWorkItemClickHouseDerivationContextSource is provider-local because the
+// older shared source currently fences only GitHub/GitLab. It calls the same
+// migrated ClickHouse loaders and keeps both lease checks without expanding a
+// shared provider switch in this slice.
+type jiraWorkItemClickHouseDerivationContextSource struct {
+	delegate githubWorkItemClickHouseDerivationContextSource
+}
+
+func (source jiraWorkItemClickHouseDerivationContextSource) Load(
+	ctx context.Context,
+	claim Claim,
+	request githubWorkItemDerivationLoadRequest,
+) (githubWorkItemDerivationFacts, error) {
+	delegate := source.delegate
+	if ctx == nil || delegate.Conn == nil || delegate.Lease == nil ||
+		claim.Validate() != nil || claim.Provider != "jira" ||
+		claim.Dataset != "work-items" || request.AsOf.IsZero() {
+		return githubWorkItemDerivationFacts{}, ErrInvalidConfiguration
+	}
+	if err := delegate.Lease.Assert(ctx); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	facts := githubWorkItemDerivationFacts{}
+	var err error
+	if facts.Teams, err = delegate.loadTeams(ctx, claim.OrgID); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	if facts.Projects, err = delegate.loadProjects(ctx, claim.OrgID, request.AsOf); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	if facts.Repos, err = delegate.loadRepos(ctx, claim.OrgID, request.AsOf); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	if facts.Members, err = delegate.loadMembers(ctx, claim.OrgID, request.AsOf); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	if facts.ManualFallbacks, err = delegate.loadManualFallbacks(ctx, claim.OrgID, request.AsOf); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	if facts.DonorItems, err = delegate.loadDonors(ctx, claim.OrgID, request); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	if err := delegate.Lease.Assert(ctx); err != nil {
+		return githubWorkItemDerivationFacts{}, err
+	}
+	return facts, nil
+}
+
+func NewJiraWorkItemDeriver(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+	statusMappingConfigPath string,
+	investmentConfigPath string,
+) (*JiraWorkItemDeriver, error) {
+	if conn == nil || lease == nil || strings.TrimSpace(statusMappingConfigPath) == "" ||
+		strings.TrimSpace(investmentConfigPath) == "" {
+		return nil, ErrInvalidConfiguration
+	}
+	statusMapping, err := LoadStatusMapping(statusMappingConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	classifier, err := NewInvestmentClassifier(investmentConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return &JiraWorkItemDeriver{
+		Source: jiraWorkItemClickHouseDerivationContextSource{delegate: githubWorkItemClickHouseDerivationContextSource{
+			Conn: conn, Lease: lease,
+		}},
+		statusMapping: statusMapping, investmentClassifier: classifier,
+	}, nil
+}
+
+// Derive mirrors job_work_items.py's one-context, per-UTC-day execution. The
+// five historical Jira aliases retain their frozen claim identity; only the
+// internal context-load call is canonicalized because the shared loader's
+// contract predates alias-family routing.
+func (deriver JiraWorkItemDeriver) Derive(
+	ctx context.Context,
+	claim Claim,
+	rows jiraWorkItemRows,
+	normalizedAt time.Time,
+) (JiraWorkItemDerivedRows, error) {
+	if ctx == nil || deriver.Source == nil || deriver.statusMapping == nil ||
+		deriver.investmentClassifier == nil || claim.Validate() != nil ||
+		claim.Provider != "jira" || !isWorkItemFamilyDataset(claim.Dataset) ||
+		claim.BeforeAt == nil || normalizedAt.IsZero() {
+		return JiraWorkItemDerivedRows{}, ErrInvalidConfiguration
+	}
+	days, err := githubWorkItemDerivedDays(claim, normalizedAt)
+	if err != nil {
+		return JiraWorkItemDerivedRows{}, err
+	}
+	canonicalClaim := claim
+	canonicalClaim.Dataset = "work-items"
+	canonicalCapability, ok := Capability("jira", "work-items")
+	if !ok {
+		return JiraWorkItemDerivedRows{}, ErrInvalidConfiguration
+	}
+	canonicalClaim.CostClass = canonicalCapability.CostClass
+	githubRows := jiraWorkItemRowsAsGitHub(rows)
+	contextFacts, err := loadWorkItemDerivationContextForProvider(
+		ctx, "jira", canonicalClaim, githubRows, deriver.Source, normalizedAt,
+	)
+	if err != nil {
+		return JiraWorkItemDerivedRows{}, err
+	}
+	result := JiraWorkItemDerivedRows{
+		EstimateCoverageMetricsDaily:   []JiraEstimateCoverageMetricsDailyRow{},
+		InvestmentClassificationsDaily: []JiraInvestmentClassificationDailyRow{},
+		InvestmentMetricsDaily:         []JiraInvestmentMetricsDailyRow{},
+		IssueTypeMetricsDaily:          []JiraIssueTypeMetricsDailyRow{},
+		WorkItemCycleTimes:             []JiraWorkItemCycleTimePersistenceRow{},
+		WorkItemMetricsDaily:           []JiraWorkItemMetricsDailyRow{},
+		WorkItemStateDurationsDaily:    []JiraWorkItemStateDurationDailyRow{},
+		WorkItemTeamAttributions:       []JiraWorkItemTeamAttributionRow{},
+		WorkItemUserMetricsDaily:       []JiraWorkItemUserMetricsDailyRow{},
+	}
+	for _, day := range days {
+		triplet, err := buildWorkItemMetricTripletForProvider(
+			"jira", claim, githubRows, day, normalizedAt, contextFacts,
+		)
+		if err != nil {
+			return JiraWorkItemDerivedRows{}, err
+		}
+		result.WorkItemMetricsDaily = append(result.WorkItemMetricsDaily, triplet.MetricsDaily...)
+		result.WorkItemUserMetricsDaily = append(result.WorkItemUserMetricsDaily, triplet.UserMetricsDaily...)
+		for _, cycle := range triplet.CycleTimes {
+			result.WorkItemCycleTimes = append(result.WorkItemCycleTimes, cycle.persistenceRow())
+		}
+
+		surfaces, err := buildWorkItemDerivedSurfacesForProvider(
+			"jira", claim, githubRows, day, normalizedAt, contextFacts,
+		)
+		if err != nil {
+			return JiraWorkItemDerivedRows{}, err
+		}
+		result.EstimateCoverageMetricsDaily = append(result.EstimateCoverageMetricsDaily, surfaces.EstimateCoverage...)
+		result.WorkItemTeamAttributions = append(result.WorkItemTeamAttributions, surfaces.TeamAttributions...)
+		result.WorkItemStateDurationsDaily = append(result.WorkItemStateDurationsDaily, surfaces.StateDurations...)
+
+		engine := GitHubWorkItemEngineDeriver{
+			statusMapping: deriver.statusMapping, investmentClassifier: deriver.investmentClassifier,
+		}
+		engineRows, err := engine.deriveRowsForProvider(
+			ctx, "jira", claim, githubRows, day, normalizedAt, contextFacts,
+		)
+		if err != nil {
+			return JiraWorkItemDerivedRows{}, err
+		}
+		result.IssueTypeMetricsDaily = append(result.IssueTypeMetricsDaily, engineRows.IssueTypes...)
+		result.InvestmentClassificationsDaily = append(result.InvestmentClassificationsDaily, engineRows.Classifications...)
+		result.InvestmentMetricsDaily = append(result.InvestmentMetricsDaily, engineRows.InvestmentMetrics...)
+	}
+	watermark := claim.BeforeAt.UTC()
+	result.Watermark = &watermark
+	return result, nil
+}
+
+// JiraWorkItemDerivedEffectRows is the explicit ten-effect projection. There
+// is intentionally no arbitrary AI row field; the builder below owns the sole
+// legal Jira AI disposition, an empty slice.
+type JiraWorkItemDerivedEffectRows struct {
+	EstimateCoverageMetricsDaily   []JiraEstimateCoverageMetricsDailyRow
+	InvestmentClassificationsDaily []JiraInvestmentClassificationDailyRow
+	InvestmentMetricsDaily         []JiraInvestmentMetricsDailyRow
+	IssueTypeMetricsDaily          []JiraIssueTypeMetricsDailyRow
+	WorkItemCycleTimes             []JiraWorkItemCycleTimePersistenceRow
+	WorkItemMetricsDaily           []JiraWorkItemMetricsDailyRow
+	WorkItemStateDurationsDaily    []JiraWorkItemStateDurationDailyRow
+	WorkItemTeamAttributions       []JiraWorkItemTeamAttributionRow
+	WorkItemUserMetricsDaily       []JiraWorkItemUserMetricsDailyRow
+}
+
+func (rows JiraWorkItemDerivedRows) EffectRows() JiraWorkItemDerivedEffectRows {
+	return JiraWorkItemDerivedEffectRows{
+		EstimateCoverageMetricsDaily:   rows.EstimateCoverageMetricsDaily,
+		InvestmentClassificationsDaily: rows.InvestmentClassificationsDaily,
+		InvestmentMetricsDaily:         rows.InvestmentMetricsDaily,
+		IssueTypeMetricsDaily:          rows.IssueTypeMetricsDaily,
+		WorkItemCycleTimes:             rows.WorkItemCycleTimes,
+		WorkItemMetricsDaily:           rows.WorkItemMetricsDaily,
+		WorkItemStateDurationsDaily:    rows.WorkItemStateDurationsDaily,
+		WorkItemTeamAttributions:       rows.WorkItemTeamAttributions,
+		WorkItemUserMetricsDaily:       rows.WorkItemUserMetricsDaily,
+	}
+}
+
+func BuildJiraWorkItemDerivedEffects(rows JiraWorkItemDerivedEffectRows) ([]EffectBatch, error) {
+	effects := make([]EffectBatch, 0, len(jiraWorkItemDerivedDestinations))
+	for _, destination := range jiraWorkItemDerivedDestinations {
+		var effect EffectBatch
+		var err error
+		switch destination {
+		case "ai_attribution":
+			effect, err = BuildEffectBatch(destination, EffectReadbackRequired, []json.RawMessage{})
+		case "estimate_coverage_metrics_daily":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.EstimateCoverageMetricsDaily)
+		case "investment_classifications_daily":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.InvestmentClassificationsDaily)
+		case "investment_metrics_daily":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.InvestmentMetricsDaily)
+		case "issue_type_metrics_daily":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.IssueTypeMetricsDaily)
+		case "work_item_cycle_times":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.WorkItemCycleTimes)
+		case "work_item_metrics_daily":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.WorkItemMetricsDaily)
+		case "work_item_state_durations_daily":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.WorkItemStateDurationsDaily)
+		case "work_item_team_attributions":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.WorkItemTeamAttributions)
+		case "work_item_user_metrics_daily":
+			effect, err = buildJiraTypedDerivedEffect(destination, rows.WorkItemUserMetricsDaily)
+		default:
+			return nil, ErrInvalidConfiguration
+		}
+		if err != nil {
+			return nil, err
+		}
+		effects = append(effects, effect)
+	}
+	return effects, nil
+}
+
+func buildJiraTypedDerivedEffect[T any](destination string, rows []T) (EffectBatch, error) {
+	encoded, err := json.Marshal(rows)
+	if err != nil {
+		return EffectBatch{}, err
+	}
+	var effectRows []json.RawMessage
+	if err := json.Unmarshal(encoded, &effectRows); err != nil {
+		return EffectBatch{}, ErrEffectRecoveryUnsafe
+	}
+	return BuildEffectBatch(destination, EffectReadbackRequired, effectRows)
+}
+
+// jiraDerivedGitHubAdapter supplies Jira's frozen identity to the migrated
+// schema-specific adapters. The evaluated-empty AI destination is deliberately
+// a no-I/O adapter: write is a no-op and readback remains EffectAbsent.
+type jiraDerivedGitHubAdapter struct {
+	destination string
+	delegate    JiraWorkItemEffectAdapter
+}
+
+func (adapter jiraDerivedGitHubAdapter) validate(
+	identity JiraWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	if identity.Provider != "jira" || !isWorkItemFamilyDataset(identity.Dataset) ||
+		identity.Destination != adapter.destination || effect.Destination != adapter.destination ||
+		effect.Recovery != EffectReadbackRequired || identity.OrgID == "" ||
+		identity.RowCount != len(effect.Rows) || identity.ContentDigest != effect.ContentDigest {
+		return ErrInvalidConfiguration
+	}
+	rebuilt, err := BuildEffectBatch(effect.Destination, effect.Recovery, effect.Rows)
+	if err != nil || rebuilt.ContentDigest != effect.ContentDigest || rebuilt.PayloadBytes != effect.PayloadBytes {
+		return ErrInvalidConfiguration
+	}
+	if adapter.destination == "ai_attribution" {
+		if len(effect.Rows) != 0 {
+			return ErrInvalidConfiguration
+		}
+		return nil
+	}
+	for _, raw := range effect.Rows {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+			return ErrInvalidConfiguration
+		}
+		if adapter.destination != "investment_metrics_daily" {
+			var provider string
+			providerRaw, ok := fields["provider"]
+			if !ok || json.Unmarshal(providerRaw, &provider) != nil || provider != "jira" {
+				return ErrInvalidConfiguration
+			}
+		}
+		var orgID string
+		orgRaw, ok := fields["org_id"]
+		if !ok || json.Unmarshal(orgRaw, &orgID) != nil || orgID != identity.OrgID {
+			return ErrInvalidConfiguration
+		}
+	}
+	return nil
+}
+
+func (adapter jiraDerivedGitHubAdapter) WriteGitHubWorkItemEffect(
+	ctx context.Context,
+	identity JiraWorkItemEffectIdentity,
+	effect EffectBatch,
+) error {
+	if err := adapter.validate(identity, effect); err != nil {
+		return err
+	}
+	if adapter.destination == "ai_attribution" {
+		return nil
+	}
+	if adapter.delegate == nil {
+		return ErrInvalidConfiguration
+	}
+	return adapter.delegate.WriteGitHubWorkItemEffect(ctx, identity, effect)
+}
+
+func (adapter jiraDerivedGitHubAdapter) InspectGitHubWorkItemEffect(
+	ctx context.Context,
+	identity JiraWorkItemEffectIdentity,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if err := adapter.validate(identity, effect); err != nil {
+		return EffectConflict, err
+	}
+	if adapter.destination == "ai_attribution" {
+		return EffectAbsent, nil
+	}
+	if adapter.delegate == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	return adapter.delegate.InspectGitHubWorkItemEffect(ctx, identity, effect)
+}
+
+var _ JiraWorkItemEffectAdapter = jiraDerivedGitHubAdapter{}
+
+// JiraWorkItemDerivedClickHouseEffects is the provider-local ten-destination
+// dispatcher. Direct Jira facts and worklogs stay in their existing sinks.
+type JiraWorkItemDerivedClickHouseEffects struct {
+	Lease                          providerfoundation.LeaseGuard
+	AIAttribution                  JiraWorkItemEffectAdapter
+	EstimateCoverageMetricsDaily   JiraWorkItemEffectAdapter
+	InvestmentClassificationsDaily JiraWorkItemEffectAdapter
+	InvestmentMetricsDaily         JiraWorkItemEffectAdapter
+	IssueTypeMetricsDaily          JiraWorkItemEffectAdapter
+	WorkItemCycleTimes             JiraWorkItemEffectAdapter
+	WorkItemMetricsDaily           JiraWorkItemEffectAdapter
+	WorkItemStateDurationsDaily    JiraWorkItemEffectAdapter
+	WorkItemTeamAttributions       JiraWorkItemEffectAdapter
+	WorkItemUserMetricsDaily       JiraWorkItemEffectAdapter
+}
+
+func NewJiraWorkItemDerivedClickHouseEffects(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+) (JiraWorkItemDerivedClickHouseEffects, error) {
+	if conn == nil || lease == nil {
+		return JiraWorkItemDerivedClickHouseEffects{}, ErrInvalidConfiguration
+	}
+	wrap := func(destination string, delegate JiraWorkItemEffectAdapter) JiraWorkItemEffectAdapter {
+		return jiraDerivedGitHubAdapter{destination: destination, delegate: delegate}
+	}
+	sink := JiraWorkItemDerivedClickHouseEffects{
+		Lease:                          lease,
+		AIAttribution:                  wrap("ai_attribution", nil),
+		EstimateCoverageMetricsDaily:   wrap("estimate_coverage_metrics_daily", GitHubEstimateCoverageClickHouseEffects{Conn: conn, Lease: lease}),
+		InvestmentClassificationsDaily: wrap("investment_classifications_daily", GitHubInvestmentClassificationsClickHouseEffects{Conn: conn, Lease: lease}),
+		InvestmentMetricsDaily:         wrap("investment_metrics_daily", GitHubInvestmentMetricsClickHouseEffects{Conn: conn, Lease: lease}),
+		IssueTypeMetricsDaily:          wrap("issue_type_metrics_daily", GitHubIssueTypeMetricsClickHouseEffects{Conn: conn, Lease: lease}),
+		WorkItemCycleTimes:             wrap("work_item_cycle_times", GitHubWorkItemCycleTimesClickHouseEffects{Conn: conn, Lease: lease}),
+		WorkItemMetricsDaily:           wrap("work_item_metrics_daily", GitHubWorkItemMetricsDailyClickHouseEffects{Conn: conn, Lease: lease}),
+		WorkItemStateDurationsDaily:    wrap("work_item_state_durations_daily", GitHubWorkItemStateDurationsClickHouseEffects{Conn: conn, Lease: lease}),
+		WorkItemTeamAttributions:       wrap("work_item_team_attributions", GitHubWorkItemTeamAttributionsClickHouseEffects{Conn: conn, Lease: lease}),
+		WorkItemUserMetricsDaily:       wrap("work_item_user_metrics_daily", GitHubWorkItemUserMetricsDailyClickHouseEffects{Conn: conn, Lease: lease}),
+	}
+	if len(sink.MissingDestinations()) > 0 {
+		return sink, ErrInvalidConfiguration
+	}
+	return sink, nil
+}
+
+func (sink JiraWorkItemDerivedClickHouseEffects) adapterForDestination(
+	destination string,
+) (JiraWorkItemEffectAdapter, bool) {
+	switch destination {
+	case "ai_attribution":
+		return sink.AIAttribution, true
+	case "estimate_coverage_metrics_daily":
+		return sink.EstimateCoverageMetricsDaily, true
+	case "investment_classifications_daily":
+		return sink.InvestmentClassificationsDaily, true
+	case "investment_metrics_daily":
+		return sink.InvestmentMetricsDaily, true
+	case "issue_type_metrics_daily":
+		return sink.IssueTypeMetricsDaily, true
+	case "work_item_cycle_times":
+		return sink.WorkItemCycleTimes, true
+	case "work_item_metrics_daily":
+		return sink.WorkItemMetricsDaily, true
+	case "work_item_state_durations_daily":
+		return sink.WorkItemStateDurationsDaily, true
+	case "work_item_team_attributions":
+		return sink.WorkItemTeamAttributions, true
+	case "work_item_user_metrics_daily":
+		return sink.WorkItemUserMetricsDaily, true
+	default:
+		return nil, false
+	}
+}
+
+func (sink JiraWorkItemDerivedClickHouseEffects) MissingDestinations() []string {
+	missing := make([]string, 0, len(jiraWorkItemDerivedDestinations))
+	for _, destination := range jiraWorkItemDerivedDestinations {
+		adapter, known := sink.adapterForDestination(destination)
+		if !known || adapter == nil {
+			missing = append(missing, destination)
+		}
+	}
+	return missing
+}
+
+func (sink JiraWorkItemDerivedClickHouseEffects) resolve(
+	claim Claim,
+	effect EffectBatch,
+) (JiraWorkItemEffectIdentity, JiraWorkItemEffectAdapter, error) {
+	if claim.Validate() != nil || claim.Provider != "jira" ||
+		!isWorkItemFamilyDataset(claim.Dataset) ||
+		!slices.Contains(jiraWorkItemDerivedDestinations, effect.Destination) ||
+		effect.Recovery != EffectReadbackRequired || !validDigest(effect.ContentDigest) ||
+		effect.PayloadBytes < 0 || sink.Lease == nil || len(sink.MissingDestinations()) > 0 {
+		return JiraWorkItemEffectIdentity{}, nil, ErrInvalidConfiguration
+	}
+	rebuilt, err := BuildEffectBatch(effect.Destination, effect.Recovery, effect.Rows)
+	if err != nil || rebuilt.ContentDigest != effect.ContentDigest || rebuilt.PayloadBytes != effect.PayloadBytes {
+		return JiraWorkItemEffectIdentity{}, nil, ErrInvalidConfiguration
+	}
+	identity := JiraWorkItemEffectIdentity{
+		OrgID: claim.OrgID, Provider: claim.Provider, Dataset: claim.Dataset,
+		Generation: claim.GenerationKey(), Destination: effect.Destination,
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}
+	if strings.TrimSpace(identity.OrgID) == "" || strings.TrimSpace(identity.Generation) == "" {
+		return JiraWorkItemEffectIdentity{}, nil, ErrInvalidConfiguration
+	}
+	adapter, known := sink.adapterForDestination(effect.Destination)
+	if !known || adapter == nil {
+		return JiraWorkItemEffectIdentity{}, nil, ErrInvalidConfiguration
+	}
+	return identity, adapter, nil
+}
+
+func (sink JiraWorkItemDerivedClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	identity, adapter, err := sink.resolve(claim, effect)
+	if err != nil || ctx == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	if err := adapter.WriteGitHubWorkItemEffect(ctx, identity, effect); err != nil {
+		return err
+	}
+	return sink.Lease.Assert(ctx)
+}
+
+func (sink JiraWorkItemDerivedClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	identity, adapter, err := sink.resolve(claim, effect)
+	if err != nil || ctx == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	inspection, err := adapter.InspectGitHubWorkItemEffect(ctx, identity, effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	switch inspection {
+	case EffectExact, EffectAbsent, EffectConflict:
+		return inspection, nil
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+var _ EffectSink = JiraWorkItemDerivedClickHouseEffects{}
+var _ EffectReadback = JiraWorkItemDerivedClickHouseEffects{}
+
+// JiraWorkItemCompositeClickHouseEffects is the provider-local dispatcher for
+// the complete route batch: seven direct Jira effects (the canonical six plus
+// worklogs) and ten derived effects. Activation remains outside this file.
+type JiraWorkItemCompositeClickHouseEffects struct {
+	Direct  JiraAtlassianClickHouseEffects
+	Derived JiraWorkItemDerivedClickHouseEffects
+}
+
+func NewJiraWorkItemCompositeClickHouseEffects(
+	conn driver.Conn,
+	lease providerfoundation.LeaseGuard,
+) (JiraWorkItemCompositeClickHouseEffects, error) {
+	if conn == nil || lease == nil {
+		return JiraWorkItemCompositeClickHouseEffects{}, ErrInvalidConfiguration
+	}
+	derived, err := NewJiraWorkItemDerivedClickHouseEffects(conn, lease)
+	if err != nil {
+		return JiraWorkItemCompositeClickHouseEffects{}, err
+	}
+	sink := JiraWorkItemCompositeClickHouseEffects{
+		Direct: NewJiraAtlassianClickHouseEffects(conn, lease), Derived: derived,
+	}
+	if len(sink.MissingDestinations()) > 0 {
+		return sink, ErrInvalidConfiguration
+	}
+	return sink, nil
+}
+
+func (sink JiraWorkItemCompositeClickHouseEffects) MissingDestinations() []string {
+	missing := sink.Direct.MissingDestinations()
+	missing = append(missing, sink.Derived.MissingDestinations()...)
+	return missing
+}
+
+func (sink JiraWorkItemCompositeClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	switch {
+	case slices.Contains(jiraAtlassianEffectDestinations, effect.Destination):
+		return sink.Direct.WriteEffect(ctx, claim, effect)
+	case slices.Contains(jiraWorkItemDerivedDestinations, effect.Destination):
+		return sink.Derived.WriteEffect(ctx, claim, effect)
+	default:
+		return ErrInvalidConfiguration
+	}
+}
+
+func (sink JiraWorkItemCompositeClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	switch {
+	case slices.Contains(jiraAtlassianEffectDestinations, effect.Destination):
+		return sink.Direct.InspectEffect(ctx, claim, effect)
+	case slices.Contains(jiraWorkItemDerivedDestinations, effect.Destination):
+		return sink.Derived.InspectEffect(ctx, claim, effect)
+	default:
+		return EffectConflict, ErrInvalidConfiguration
+	}
+}
+
+var _ EffectSink = JiraWorkItemCompositeClickHouseEffects{}
+var _ EffectReadback = JiraWorkItemCompositeClickHouseEffects{}

--- a/internal/providersync/jira_work_item_derived_effects_integration_test.go
+++ b/internal/providersync/jira_work_item_derived_effects_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+// This suite applies the production ClickHouse migration chain through
+// githubDerivedIntegrationConn and then exercises the Jira context loader and
+// every derived adapter. It authors no local DDL. The evaluated-empty AI
+// effect is the sole no-I/O destination and must remain EffectAbsent before
+// and after its write call.
+func TestJiraWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	conn := githubDerivedIntegrationConn(t, ctx)
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink, err := NewJiraWorkItemDerivedClickHouseEffects(conn, lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claim := nativeTestClaim("jira", "work-items")
+	claim.OrgID = "jira-derived-integration"
+	now := time.Date(2026, 8, 11, 15, 30, 0, 123000000, time.UTC)
+	contextSource := jiraWorkItemClickHouseDerivationContextSource{
+		delegate: githubWorkItemClickHouseDerivationContextSource{Conn: conn, Lease: lease},
+	}
+	facts, err := contextSource.Load(ctx, claim, githubWorkItemDerivationLoadRequest{
+		AsOf: now, DonorWorkItemIDs: []string{"jira:OPS-missing"},
+	})
+	if err != nil {
+		t.Fatalf("real migrated context load: %v", err)
+	}
+	if len(facts.Teams)+len(facts.Projects)+len(facts.Repos)+len(facts.Members)+
+		len(facts.ManualFallbacks)+len(facts.DonorItems) != 0 {
+		t.Fatalf("fresh migrated context was not empty: %+v", facts)
+	}
+
+	day := newGitHubWorkItemDerivedDay(now)
+	metricDay := newGitHubWorkItemMetricDay(now)
+	repoID := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+	teamID, teamName := "team-jira", "Jira Team"
+	area, rule := "security", "sec_general"
+	assignee := "jira:accountid:dev"
+	ratio := 0.5
+
+	estimate := JiraEstimateCoverageMetricsDailyRow{
+		Day: day, Provider: "jira", WorkScopeID: "OPS", TeamID: &teamID,
+		TeamName: &teamName, EstimatedCount: 1, UnestimatedCount: 1, BacklogSize: 2,
+		Ratio: &ratio, ComputedAt: now, OrgID: claim.OrgID,
+	}
+	classification := JiraInvestmentClassificationDailyRow{
+		RepoID: &repoID, Day: day, ArtifactType: "work_item", ArtifactID: "jira:OPS-1",
+		Provider: "jira", InvestmentArea: &area, ProjectStream: "general", Confidence: 1,
+		RuleID: &rule, ComputedAt: now, OrgID: claim.OrgID,
+	}
+	investment := JiraInvestmentMetricsDailyRow{
+		RepoID: &repoID, Day: day, TeamID: teamID, InvestmentArea: &area,
+		ProjectStream: "general", DeliveryUnits: 3, WorkItemsCompleted: 2, PRsMerged: 0,
+		ChurnLOC: 0, CycleP50Hours: 5, ComputedAt: now, OrgID: claim.OrgID,
+	}
+	issueType := JiraIssueTypeMetricsDailyRow{
+		RepoID: &repoID, Day: day, Provider: "jira", TeamID: teamID,
+		IssueTypeNorm: "bug", CreatedCount: 1, CompletedCount: 2, ActiveCount: 3,
+		CycleP50Hours: 4, CycleP90Hours: 5, LeadP50Hours: 6, ComputedAt: now,
+		OrgID: claim.OrgID,
+	}
+	cycle := JiraWorkItemCycleTimePersistenceRow{
+		WorkItemID: "jira:OPS-1", Provider: "jira", Day: metricDay,
+		WorkScopeID: "OPS", TeamID: teamID, TeamName: teamName, Assignee: &assignee,
+		Type: "feature", Status: "done", CreatedAt: now.Add(-72 * time.Hour),
+		CompletedAt: timePtr(now.Add(-2 * time.Hour)), CycleTimeHours: floatPtr(2),
+		LeadTimeHours: floatPtr(72), ComputedAt: now, OrgID: claim.OrgID,
+	}
+	metrics := githubWorkItemMetricTestGroupRow()
+	metrics.Provider, metrics.OrgID, metrics.Day = "jira", claim.OrgID, metricDay
+	users := githubWorkItemMetricTestUserRow()
+	users.Provider, users.OrgID, users.Day = "jira", claim.OrgID, metricDay
+	state := JiraWorkItemStateDurationDailyRow{
+		Day: day, Provider: "jira", WorkScopeID: "OPS", TeamID: teamID,
+		TeamName: teamName, Status: "in_progress", DurationHours: 6, ItemsTouched: 1,
+		ComputedAt: now, AvgWIP: 0.25, OrgID: claim.OrgID,
+	}
+	team := JiraWorkItemTeamAttributionRow{
+		WorkItemID: "jira:OPS-1", Provider: "jira", Source: "project_ownership",
+		IsPrimary: 1, Confidence: "high", Evidence: "project_ownership=10001",
+		ComputedAt: now, RepoID: &repoID, TeamID: &teamID, TeamName: &teamName,
+		OrgID: claim.OrgID,
+	}
+
+	effects, err := BuildJiraWorkItemDerivedEffects(JiraWorkItemDerivedEffectRows{
+		EstimateCoverageMetricsDaily:   []JiraEstimateCoverageMetricsDailyRow{estimate},
+		InvestmentClassificationsDaily: []JiraInvestmentClassificationDailyRow{classification},
+		InvestmentMetricsDaily:         []JiraInvestmentMetricsDailyRow{investment},
+		IssueTypeMetricsDaily:          []JiraIssueTypeMetricsDailyRow{issueType},
+		WorkItemCycleTimes:             []JiraWorkItemCycleTimePersistenceRow{cycle},
+		WorkItemMetricsDaily:           []JiraWorkItemMetricsDailyRow{metrics},
+		WorkItemStateDurationsDaily:    []JiraWorkItemStateDurationDailyRow{state},
+		WorkItemTeamAttributions:       []JiraWorkItemTeamAttributionRow{team},
+		WorkItemUserMetricsDaily:       []JiraWorkItemUserMetricsDailyRow{users},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, effect := range effects {
+		t.Run(effect.Destination, func(t *testing.T) {
+			inspection, inspectErr := sink.InspectEffect(ctx, claim, effect)
+			if inspectErr != nil || inspection != EffectAbsent {
+				t.Fatalf("before write: inspection=%v error=%v", inspection, inspectErr)
+			}
+			if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+				t.Fatal(err)
+			}
+			inspection, inspectErr = sink.InspectEffect(ctx, claim, effect)
+			want := EffectExact
+			if effect.Destination == "ai_attribution" {
+				want = EffectAbsent
+			}
+			if inspectErr != nil || inspection != want {
+				t.Fatalf("after write: inspection=%v want=%v error=%v", inspection, want, inspectErr)
+			}
+			if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+				t.Fatalf("replay write: %v", err)
+			}
+		})
+	}
+
+	foreign := claim
+	foreign.OrgID = "org-other"
+	for _, effect := range effects {
+		if effect.Destination == "ai_attribution" {
+			if inspection, err := sink.InspectEffect(ctx, foreign, effect); err != nil || inspection != EffectAbsent {
+				t.Fatalf("foreign evaluated-empty AI=%v err=%v", inspection, err)
+			}
+			continue
+		}
+		if err := sink.WriteEffect(ctx, foreign, effect); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("foreign tenant %s write=%v", effect.Destination, err)
+		}
+	}
+
+	lost, err := NewJiraWorkItemDerivedClickHouseEffects(
+		conn,
+		providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return providerfoundation.ErrLeaseLost
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lost.WriteEffect(ctx, claim, effects[1]); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("lease-lost real-store write=%v", err)
+	}
+}

--- a/internal/providersync/jira_work_item_derived_oracle_test.go
+++ b/internal/providersync/jira_work_item_derived_oracle_test.go
@@ -1,0 +1,303 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+func jiraDerivedOracleCases(cases []oracleCase) []oracleCase {
+	result := make([]oracleCase, 0, len(cases))
+	for _, testCase := range cases {
+		result = append(result, oracleCase{
+			ID:    "jira_" + testCase.ID,
+			Input: jiraDerivedOracleValue(testCase.Input).(map[string]any),
+		})
+	}
+	return result
+}
+
+func jiraDerivedOracleValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			result[key] = jiraDerivedOracleValue(nested)
+		}
+		return result
+	case []any:
+		result := make([]any, len(typed))
+		for index, nested := range typed {
+			result[index] = jiraDerivedOracleValue(nested)
+		}
+		return result
+	case string:
+		if typed == "github" {
+			return "jira"
+		}
+		if strings.HasPrefix(typed, "gh:") {
+			return "jira:" + strings.TrimPrefix(typed, "gh:")
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+func jiraDerivedOracleRows(
+	t *testing.T,
+	input map[string]any,
+) (Claim, githubWorkItemRows, githubWorkItemDerivationContext) {
+	t.Helper()
+	_, rows, derived := gitlabWorkItemOracleRows(t, input)
+	claim := nativeTestClaim("jira", "work-items")
+	claim.OrgID = input["OrgID"].(string)
+	return claim, rows, derived
+}
+
+func TestJiraWorkItemMetricTripletMatchesLivePythonProduction(t *testing.T) {
+	cases := jiraDerivedOracleCases(githubWorkItemMetricTripletOracleCases())
+	compareRowsAgainstPythonOracle(t, "jira/work-items/metrics-daily", cases,
+		func(t *testing.T, input map[string]any) githubWorkItemMetricsDailyOracleColumns {
+			claim, rows, derived := jiraDerivedOracleRows(t, input)
+			triplet, err := buildWorkItemMetricTripletForProvider(
+				"jira", claim, rows, gitlabWorkItemOracleDay(t, input),
+				gitlabWorkItemOracleComputedAt(t, input), derived,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return newGitHubWorkItemMetricsDailyOracleColumns(len(triplet.MetricsDaily)).fromRows(triplet.MetricsDaily)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "jira/work-items/user-metrics-daily", cases,
+		func(t *testing.T, input map[string]any) githubWorkItemUserMetricsDailyOracleColumns {
+			claim, rows, derived := jiraDerivedOracleRows(t, input)
+			triplet, err := buildWorkItemMetricTripletForProvider(
+				"jira", claim, rows, gitlabWorkItemOracleDay(t, input),
+				gitlabWorkItemOracleComputedAt(t, input), derived,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return newGitHubWorkItemUserMetricsDailyOracleColumns(len(triplet.UserMetricsDaily)).fromRows(triplet.UserMetricsDaily)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "jira/work-items/cycle-times", cases,
+		func(t *testing.T, input map[string]any) githubWorkItemCycleTimeOracleColumns {
+			claim, rows, derived := jiraDerivedOracleRows(t, input)
+			triplet, err := buildWorkItemMetricTripletForProvider(
+				"jira", claim, rows, gitlabWorkItemOracleDay(t, input),
+				gitlabWorkItemOracleComputedAt(t, input), derived,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return newGitHubWorkItemCycleTimeOracleColumns(len(triplet.CycleTimes)).fromRows(triplet.CycleTimes)
+		}, nil)
+}
+
+func TestJiraDerivedSurfacesMatchLivePythonProduction(t *testing.T) {
+	cases := jiraDerivedOracleCases(githubDerivedOracleCases())
+	compareRowsAgainstPythonOracle(t, "jira/work-items/estimate-coverage", cases,
+		func(t *testing.T, input map[string]any) githubEstimateCoverageColumns {
+			claim, rows, derived := jiraDerivedOracleRows(t, input)
+			surfaces, err := buildWorkItemDerivedSurfacesForProvider(
+				"jira", claim, rows, gitlabWorkItemOracleDay(t, input),
+				gitlabWorkItemOracleComputedAt(t, input), derived,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return newGitHubEstimateCoverageColumns(surfaces.EstimateCoverage)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "jira/work-items/team-attributions", cases,
+		func(t *testing.T, input map[string]any) githubTeamAttributionColumns {
+			claim, rows, derived := jiraDerivedOracleRows(t, input)
+			surfaces, err := buildWorkItemDerivedSurfacesForProvider(
+				"jira", claim, rows, gitlabWorkItemOracleDay(t, input),
+				gitlabWorkItemOracleComputedAt(t, input), derived,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return newGitHubTeamAttributionColumns(surfaces.TeamAttributions)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "jira/work-items/state-durations", cases,
+		func(t *testing.T, input map[string]any) githubStateDurationColumns {
+			claim, rows, derived := jiraDerivedOracleRows(t, input)
+			surfaces, err := buildWorkItemDerivedSurfacesForProvider(
+				"jira", claim, rows, gitlabWorkItemOracleDay(t, input),
+				gitlabWorkItemOracleComputedAt(t, input), derived,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return newGitHubStateDurationColumns(surfaces.StateDurations)
+		}, nil)
+}
+
+func TestJiraEngineDestinationsMatchLivePythonProduction(t *testing.T) {
+	cases := jiraDerivedOracleCases(githubWorkItemEngineOracleCases())
+	compareRowsAgainstPythonOracle(t, "jira/work-items/issue-type-metrics", cases,
+		func(t *testing.T, input map[string]any) githubIssueTypeMetricsColumns {
+			return newGitHubIssueTypeMetricsColumns(jiraEngineOracleResult(t, input).IssueTypeMetricsDaily)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "jira/work-items/investment-classifications", cases,
+		func(t *testing.T, input map[string]any) githubInvestmentClassificationColumns {
+			return newGitHubInvestmentClassificationColumns(jiraEngineOracleResult(t, input).InvestmentClassificationsDaily)
+		}, nil)
+	compareRowsAgainstPythonOracle(t, "jira/work-items/investment-metrics", cases,
+		func(t *testing.T, input map[string]any) githubInvestmentMetricsColumns {
+			return newGitHubInvestmentMetricsColumns(jiraEngineOracleResult(t, input).InvestmentMetricsDaily)
+		}, nil)
+}
+
+func jiraEngineOracleResult(t *testing.T, input map[string]any) JiraWorkItemDerivedRows {
+	t.Helper()
+	claim, rows, _ := jiraDerivedOracleRows(t, input)
+	facts := githubWorkItemDerivationFacts{}
+	encoded, err := json.Marshal(input["Facts"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &facts); err != nil {
+		t.Fatal(err)
+	}
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deriver := JiraWorkItemDeriver{
+		Source:        &githubMultiDayOracleSource{facts: facts},
+		statusMapping: loadRealStatusMapping(t), investmentClassifier: classifier,
+	}
+	if sinceRaw, ok := input["SinceAt"].(string); ok {
+		since := githubDerivedOracleTime(t, sinceRaw)
+		before := githubDerivedOracleTime(t, input["BeforeAt"].(string))
+		claim.SinceAt, claim.BeforeAt = &since, &before
+	} else {
+		day := gitlabWorkItemOracleDay(t, input)
+		before := day.AddDate(0, 0, 1)
+		claim.SinceAt, claim.BeforeAt = &day, &before
+	}
+	result, err := deriver.Derive(
+		context.Background(), claim, jiraRowsFromGitHub(rows),
+		gitlabWorkItemOracleComputedAt(t, input),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Watermark == nil || !result.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("derived watermark=%v want=%v", result.Watermark, claim.BeforeAt)
+	}
+	return result
+}
+
+func jiraRowsFromGitHub(rows githubWorkItemRows) jiraWorkItemRows {
+	return jiraWorkItemRows{
+		WorkItems: rows.WorkItems, Transitions: rows.StatusTransitions,
+		Dependencies: rows.Dependencies, ReopenEvents: rows.ReopenEvents,
+		Interactions: rows.Interactions, Sprints: rows.Sprints,
+	}
+}
+
+// TestJiraWorkItemsRouteIncludesLivePythonMetricEffect is baseline capability
+// proof, not a destination-count assertion. It feeds the concrete rows emitted
+// by the Jira Atlassian route into Python's checked-in job computation, then
+// compares those produced rows with the route's actual effect ledger.
+func TestJiraWorkItemsRouteIncludesLivePythonMetricEffect(t *testing.T) {
+	claim := jiraAtlassianClaim()
+	since := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	claim.SinceAt, claim.BeforeAt = &since, &before
+	normalizedAt := time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC)
+	client := jiraWorkItemsTestClient(
+		t,
+		&jiraAtlassianDoer{t: t},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deriver := JiraWorkItemDeriver{
+		Source:               &githubMultiDayOracleSource{},
+		statusMapping:        loadRealStatusMapping(t),
+		investmentClassifier: classifier,
+	}
+	batch, err := (JiraAtlassianRouteHandler{
+		StatusMapping: loadRealStatusMapping(t),
+		Identity:      jiraRouteIdentity,
+		Derived:       deriver,
+	}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, normalizedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := map[string]any{
+		// The fixture's required changelog moves the item to Done at 09:00
+		// on August 1, and Jira lifecycle normalization uses that transition
+		// as completed_at. This day therefore produces a real completion row.
+		"Day":        "2026-08-01",
+		"ComputedAt": normalizedAt.Format(time.RFC3339Nano),
+		"OrgID":      claim.OrgID,
+		"WorkItems":  jiraEffectObjects(t, batch.Effects, "work_items"),
+		"Transitions": jiraEffectObjects(
+			t, batch.Effects, "work_item_transitions",
+		),
+		"Dependencies": jiraEffectObjects(
+			t, batch.Effects, "work_item_dependencies",
+		),
+		"Donors": []any{},
+		"Facts": map[string]any{
+			"Teams": []any{}, "Projects": []any{}, "Repos": []any{},
+			"Members": []any{}, "ManualFallbacks": []any{},
+		},
+	}
+	compareRowsAgainstPythonOracle(
+		t,
+		"jira/work-items/metrics-daily",
+		[]oracleCase{{ID: "atlassian_route_non_empty", Input: input}},
+		func(t *testing.T, _ map[string]any) githubWorkItemMetricsDailyOracleColumns {
+			t.Helper()
+			rows := make([]githubWorkItemMetricsDailyRow, 0)
+			for _, effect := range batch.Effects {
+				if effect.Destination != "work_item_metrics_daily" {
+					continue
+				}
+				for _, raw := range effect.Rows {
+					var row githubWorkItemMetricsDailyRow
+					if err := json.Unmarshal(raw, &row); err != nil {
+						t.Fatal(err)
+					}
+					rows = append(rows, row)
+				}
+			}
+			return newGitHubWorkItemMetricsDailyOracleColumns(len(rows)).fromRows(rows)
+		},
+		nil,
+	)
+}
+
+func jiraEffectObjects(t *testing.T, effects []EffectBatch, destination string) []any {
+	t.Helper()
+	for _, effect := range effects {
+		if effect.Destination != destination {
+			continue
+		}
+		objects := make([]any, 0, len(effect.Rows))
+		for _, raw := range effect.Rows {
+			var object map[string]any
+			if err := json.Unmarshal(raw, &object); err != nil {
+				t.Fatal(err)
+			}
+			objects = append(objects, object)
+		}
+		return objects
+	}
+	t.Fatalf("Jira route omitted direct destination %q", destination)
+	return nil
+}

--- a/internal/providersync/jira_work_item_derived_test.go
+++ b/internal/providersync/jira_work_item_derived_test.go
@@ -1,0 +1,482 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/full-chaos/dev-health-ops/internal/workitemcontract"
+)
+
+type jiraDerivedStubConn struct{ driver.Conn }
+
+var errJiraDerivedPrepare = errors.New("jira derived prepare reached")
+
+type jiraDerivedProbeConn struct{ driver.Conn }
+
+func (jiraDerivedProbeConn) PrepareBatch(
+	context.Context,
+	string,
+	...driver.PrepareBatchOption,
+) (driver.Batch, error) {
+	return nil, errJiraDerivedPrepare
+}
+
+func (jiraDerivedProbeConn) Query(context.Context, string, ...any) (driver.Rows, error) {
+	return nil, errJiraDerivedPrepare
+}
+
+func TestBuildJiraWorkItemDerivedEffectsKeepsTenTypedDestinations(t *testing.T) {
+	metric := githubWorkItemMetricTestGroupRow()
+	metric.Provider = "jira"
+	metric.ItemsCompletedUnassigned = 7
+	effects, err := BuildJiraWorkItemDerivedEffects(JiraWorkItemDerivedEffectRows{
+		WorkItemMetricsDaily: []JiraWorkItemMetricsDailyRow{metric},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(effects) != len(jiraWorkItemDerivedDestinations) {
+		t.Fatalf("effects=%d want=%d", len(effects), len(jiraWorkItemDerivedDestinations))
+	}
+	for index, effect := range effects {
+		if effect.Destination != jiraWorkItemDerivedDestinations[index] ||
+			effect.Recovery != EffectReadbackRequired {
+			t.Fatalf("effect[%d]=%+v", index, effect)
+		}
+		wantRows := 0
+		if effect.Destination == "work_item_metrics_daily" {
+			wantRows = 1
+		}
+		if len(effect.Rows) != wantRows {
+			t.Fatalf("effect[%d] rows=%d want=%d", index, len(effect.Rows), wantRows)
+		}
+	}
+	if effects[0].Destination != "ai_attribution" || len(effects[0].Rows) != 0 {
+		t.Fatalf("AI no-producer disposition=%+v", effects[0])
+	}
+	var persisted JiraWorkItemMetricsDailyRow
+	for _, effect := range effects {
+		if effect.Destination == "work_item_metrics_daily" {
+			if err := json.Unmarshal(effect.Rows[0], &persisted); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if persisted.Provider != "jira" || persisted.ItemsCompletedUnassigned != 7 {
+		t.Fatalf("typed metric projection=%+v", persisted)
+	}
+}
+
+type jiraDerivedRecordingAdapter struct {
+	writes, inspections int
+}
+
+func (adapter *jiraDerivedRecordingAdapter) WriteGitHubWorkItemEffect(
+	context.Context,
+	GitHubWorkItemEffectIdentity,
+	EffectBatch,
+) error {
+	adapter.writes++
+	return nil
+}
+
+func (adapter *jiraDerivedRecordingAdapter) InspectGitHubWorkItemEffect(
+	context.Context,
+	GitHubWorkItemEffectIdentity,
+	EffectBatch,
+) (EffectInspection, error) {
+	adapter.inspections++
+	return EffectExact, nil
+}
+
+func TestJiraEvaluatedEmptyAIIsNoIOAndReadsAbsent(t *testing.T) {
+	claim := nativeTestClaim("jira", "work-items")
+	effect, err := BuildEffectBatch(
+		"ai_attribution", EffectReadbackRequired, []json.RawMessage{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := JiraWorkItemEffectIdentity{
+		OrgID: claim.OrgID, Provider: claim.Provider, Dataset: claim.Dataset,
+		Generation: claim.GenerationKey(), Destination: effect.Destination,
+		ContentDigest: effect.ContentDigest, RowCount: len(effect.Rows),
+	}
+	recording := &jiraDerivedRecordingAdapter{}
+	adapter := jiraDerivedGitHubAdapter{
+		destination: "ai_attribution", delegate: recording,
+	}
+	if err := adapter.WriteGitHubWorkItemEffect(context.Background(), identity, effect); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := adapter.InspectGitHubWorkItemEffect(
+		context.Background(), identity, effect,
+	)
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("empty AI inspection=%s err=%v", inspection, err)
+	}
+	if recording.writes != 0 || recording.inspections != 0 {
+		t.Fatalf("evaluated-empty AI reached ClickHouse delegate: %+v", recording)
+	}
+
+	nonEmpty, err := BuildEffectBatch(
+		"ai_attribution", EffectReadbackRequired,
+		[]json.RawMessage{json.RawMessage(`{"unexpected":true}`)},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity.ContentDigest, identity.RowCount = nonEmpty.ContentDigest, 1
+	if err := adapter.WriteGitHubWorkItemEffect(
+		context.Background(), identity, nonEmpty,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("non-empty Jira AI error=%v want ErrInvalidConfiguration", err)
+	}
+	identity.Provider = "github"
+	identity.ContentDigest, identity.RowCount = effect.ContentDigest, 0
+	if err := adapter.WriteGitHubWorkItemEffect(
+		context.Background(), identity, effect,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("foreign-provider AI identity error=%v want ErrInvalidConfiguration", err)
+	}
+}
+
+func TestJiraEvaluatedEmptyAIRecoversAnInterruptedEffect(t *testing.T) {
+	claim := nativeTestClaim("jira", "work-items")
+	effect, err := BuildEffectBatch("ai_attribution", EffectReadbackRequired, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 11, 16, 0, 0, 0, time.UTC)
+	state, err := NewEffectLedgerState(claim, []EffectBatch{effect}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.Effects[0].Status = GenerationBlockWriting
+	state.Effects[0].StartedAt = &now
+	ledger := &memoryEffectLedger{state: state}
+	sink, err := NewJiraWorkItemDerivedClickHouseEffects(
+		jiraDerivedStubConn{},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := (EffectCommitter{
+		Ledger: ledger, Sink: sink, Readback: sink,
+		Now: func() time.Time { return now.Add(time.Minute) },
+	}).Commit(context.Background(), claim, []EffectBatch{effect}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ResetForReplay != 1 || result.Written != 1 ||
+		ledger.state.Effects[0].Status != GenerationBlockCommitted {
+		t.Fatalf("recovery result=%+v state=%+v", result, ledger.state.Effects[0])
+	}
+}
+
+func TestJiraCompositeSinkOwnsDirectDerivedAndEvaluatedEmptyAI(t *testing.T) {
+	lease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+	sink, err := NewJiraWorkItemCompositeClickHouseEffects(jiraDerivedStubConn{}, lease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing := sink.MissingDestinations(); len(missing) != 0 {
+		t.Fatalf("missing destinations=%v", missing)
+	}
+	effect, err := BuildEffectBatch("ai_attribution", EffectReadbackRequired, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("jira", "work-items")
+	if err := sink.WriteEffect(context.Background(), claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	if inspection, err := sink.InspectEffect(
+		context.Background(), claim, effect,
+	); err != nil || inspection != EffectAbsent {
+		t.Fatalf("composite AI readback=%v err=%v", inspection, err)
+	}
+	unknown, err := BuildEffectBatch("not-a-jira-destination", EffectReadbackRequired, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(context.Background(), claim, unknown); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("unknown composite effect error=%v", err)
+	}
+}
+
+func TestJiraMetricTripletEffectsReachTheirMigratedStores(t *testing.T) {
+	claim := nativeTestClaim("jira", "work-items")
+	group := githubWorkItemMetricTestGroupRow()
+	group.Provider, group.OrgID = "jira", claim.OrgID
+	user := githubWorkItemMetricTestUserRow()
+	user.Provider, user.OrgID = "jira", claim.OrgID
+	cycle := githubWorkItemMetricTestCycleRow()
+	cycle.Provider, cycle.OrgID = "jira", claim.OrgID
+	effects, err := BuildJiraWorkItemDerivedEffects(JiraWorkItemDerivedEffectRows{
+		WorkItemMetricsDaily:     []JiraWorkItemMetricsDailyRow{group},
+		WorkItemUserMetricsDaily: []JiraWorkItemUserMetricsDailyRow{user},
+		WorkItemCycleTimes:       []JiraWorkItemCycleTimePersistenceRow{cycle},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink, err := NewJiraWorkItemDerivedClickHouseEffects(
+		jiraDerivedProbeConn{},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := 0
+	for _, effect := range effects {
+		switch effect.Destination {
+		case "work_item_metrics_daily", "work_item_user_metrics_daily", "work_item_cycle_times":
+			seen++
+			if err := sink.WriteEffect(context.Background(), claim, effect); !errors.Is(err, errJiraDerivedPrepare) {
+				t.Fatalf("%s write=%v want migrated store call", effect.Destination, err)
+			}
+			if inspection, err := sink.InspectEffect(context.Background(), claim, effect); inspection != EffectConflict || !errors.Is(err, errJiraDerivedPrepare) {
+				t.Fatalf("%s readback=%v/%v want migrated store call", effect.Destination, inspection, err)
+			}
+		}
+	}
+	if seen != 3 {
+		t.Fatalf("metric triplet effects exercised=%d want=3", seen)
+	}
+}
+
+func TestJiraWorkItemDeriverRejectsForeignProviderAndTenant(t *testing.T) {
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &githubMultiDayOracleSource{}
+	deriver := JiraWorkItemDeriver{
+		Source: source, statusMapping: loadRealStatusMapping(t),
+		investmentClassifier: classifier,
+	}
+	claim := nativeTestClaim("jira", "work-items")
+	day := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	before := day.AddDate(0, 0, 1)
+	claim.SinceAt, claim.BeforeAt = &day, &before
+	foreignProvider := claim
+	foreignProvider.Provider = "github"
+	if _, err := deriver.Derive(
+		context.Background(), foreignProvider, jiraWorkItemRows{}, day.Add(time.Hour),
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("foreign provider error=%v want ErrInvalidConfiguration", err)
+	}
+	if source.loads != 0 {
+		t.Fatalf("foreign provider reached attribution context: %d load(s)", source.loads)
+	}
+	foreignTenant := jiraWorkItemRow{
+		WorkItemID: "jira:OPS-1", Provider: "jira", Title: "foreign", Type: "task",
+		Status: "todo", CreatedAt: day, UpdatedAt: day, OrgID: "org-other",
+	}
+	if _, err := deriver.Derive(
+		context.Background(), claim,
+		jiraWorkItemRows{WorkItems: []jiraWorkItemRow{foreignTenant}}, day.Add(time.Hour),
+	); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant error=%v want ErrInvalidScope", err)
+	}
+	if source.loads != 0 {
+		t.Fatalf("foreign tenant reached attribution context: %d load(s)", source.loads)
+	}
+}
+
+type jiraDerivedFailingContextSource struct{ err error }
+
+func (source jiraDerivedFailingContextSource) Load(
+	context.Context,
+	Claim,
+	githubWorkItemDerivationLoadRequest,
+) (githubWorkItemDerivationFacts, error) {
+	return githubWorkItemDerivationFacts{}, source.err
+}
+
+func TestJiraWorkItemDeriverFailsClosedWhenAttributionContextCannotLoad(t *testing.T) {
+	wantErr := errors.New("attribution context unavailable")
+	classifier, err := NewInvestmentClassifier(investmentConfigPath(t, "real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deriver := JiraWorkItemDeriver{
+		Source:               jiraDerivedFailingContextSource{err: wantErr},
+		statusMapping:        loadRealStatusMapping(t),
+		investmentClassifier: classifier,
+	}
+	claim := nativeTestClaim("jira", "work-items")
+	if _, err := deriver.Derive(
+		context.Background(), claim, jiraWorkItemRows{},
+		time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	); !errors.Is(err, wantErr) {
+		t.Fatalf("derive error=%v want=%v", err, wantErr)
+	}
+}
+
+func TestJiraClickHouseDerivationSourceUsesTenantScopedLoadersAndLease(t *testing.T) {
+	claim := nativeTestClaim("jira", "work-items")
+	conn := &recordingGitHubWorkItemDerivationConn{}
+	leaseChecks := 0
+	source := jiraWorkItemClickHouseDerivationContextSource{
+		delegate: githubWorkItemClickHouseDerivationContextSource{
+			Conn: conn,
+			Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+				leaseChecks++
+				return nil
+			}),
+		},
+	}
+	_, err := source.Load(
+		context.Background(), claim,
+		githubWorkItemDerivationLoadRequest{
+			AsOf:             time.Date(2026, 8, 11, 16, 0, 0, 0, time.UTC),
+			DonorWorkItemIDs: []string{"jira:OPS-2"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaseChecks != 2 {
+		t.Fatalf("lease checks=%d want=2", leaseChecks)
+	}
+	if len(conn.queries) != 6 {
+		t.Fatalf("migrated context queries=%d want=6", len(conn.queries))
+	}
+	for index, args := range conn.args {
+		if len(args) == 0 || args[0] != claim.OrgID {
+			t.Fatalf("query %d lost tenant fence: %#v", index, args)
+		}
+	}
+
+	lostConn := &recordingGitHubWorkItemDerivationConn{}
+	lost := jiraWorkItemClickHouseDerivationContextSource{
+		delegate: githubWorkItemClickHouseDerivationContextSource{
+			Conn: lostConn,
+			Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+				return providerfoundation.ErrLeaseLost
+			}),
+		},
+	}
+	if _, err := lost.Load(
+		context.Background(), claim,
+		githubWorkItemDerivationLoadRequest{AsOf: time.Date(2026, 8, 11, 16, 0, 0, 0, time.UTC)},
+	); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("lost lease error=%v", err)
+	}
+	if len(lostConn.queries) != 0 {
+		t.Fatalf("lost lease reached context store: %d queries", len(lostConn.queries))
+	}
+
+	lostAfterConn := &recordingGitHubWorkItemDerivationConn{}
+	lostAfterChecks := 0
+	lostAfter := jiraWorkItemClickHouseDerivationContextSource{
+		delegate: githubWorkItemClickHouseDerivationContextSource{
+			Conn: lostAfterConn,
+			Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+				lostAfterChecks++
+				if lostAfterChecks == 2 {
+					return providerfoundation.ErrLeaseLost
+				}
+				return nil
+			}),
+		},
+	}
+	if _, err := lostAfter.Load(
+		context.Background(), claim,
+		githubWorkItemDerivationLoadRequest{
+			AsOf:             time.Date(2026, 8, 11, 16, 0, 0, 0, time.UTC),
+			DonorWorkItemIDs: []string{"jira:OPS-2"},
+		},
+	); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+		t.Fatalf("post-load lost lease error=%v", err)
+	}
+	if lostAfterChecks != 2 || len(lostAfterConn.queries) != 6 {
+		t.Fatalf("post-load lease checks/queries=%d/%d want=2/6", lostAfterChecks, len(lostAfterConn.queries))
+	}
+}
+
+func TestJiraAtlassianRawOnlyRouteHoldsWatermarkForDerivedGap(t *testing.T) {
+	claim := jiraAtlassianClaim()
+	client := jiraWorkItemsTestClient(
+		t,
+		&jiraAtlassianDoer{t: t},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	batch, err := (JiraAtlassianRouteHandler{
+		StatusMapping: loadRealStatusMapping(t), Identity: jiraRouteIdentity,
+	}).Collect(
+		context.Background(), claim, providerfoundation.Credential{}, client,
+		time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Watermark != nil || len(batch.Effects) != len(jiraAtlassianRawDestinations) {
+		t.Fatalf("raw-only route watermark/effects=%v/%d", batch.Watermark, len(batch.Effects))
+	}
+	summary, ok := batch.Result["jira_work_items"].(JiraAtlassianWorkItemsResult)
+	if !ok || len(summary.DerivedDestinationsImplemented) != 0 ||
+		len(summary.DerivedDestinationsUnimplemented) != len(jiraWorkItemDerivedDestinations) ||
+		!summary.WatermarkHeldForIncomplete {
+		t.Fatalf("raw-only typed result=%#v", batch.Result["jira_work_items"])
+	}
+}
+
+func TestJiraCanonicalAliasesComposeSixteenDestinationsPlusWorklogs(t *testing.T) {
+	for _, dataset := range workitemcontract.FamilyDatasets() {
+		dataset := dataset
+		t.Run(dataset, func(t *testing.T) {
+			claim := jiraAtlassianClaim()
+			claim.Dataset = dataset
+			capability, ok := Capability("jira", dataset)
+			if !ok {
+				t.Fatalf("missing Jira capability for %q", dataset)
+			}
+			claim.CostClass = capability.CostClass
+			client := jiraWorkItemsTestClient(
+				t,
+				&jiraAtlassianDoer{t: t},
+				providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+			)
+			batch, err := jiraAtlassianCompleteHandler(t).Collect(
+				context.Background(), claim, providerfoundation.Credential{}, client,
+				time.Date(2026, 8, 10, 12, 0, 0, 123456000, time.UTC),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+				t.Fatalf("watermark=%v want=%v", batch.Watermark, claim.BeforeAt)
+			}
+			if len(batch.Effects) != len(workItemRouteDestinations())+1 {
+				t.Fatalf("effects=%d want=%d", len(batch.Effects), len(workItemRouteDestinations())+1)
+			}
+			seen := make(map[string]int, len(batch.Effects))
+			for _, effect := range batch.Effects {
+				seen[effect.Destination]++
+			}
+			for _, destination := range workItemRouteDestinations() {
+				if seen[destination] != 1 {
+					t.Fatalf("canonical destination %q count=%d", destination, seen[destination])
+				}
+			}
+			if seen["worklogs"] != 1 || len(seen) != len(workItemRouteDestinations())+1 {
+				t.Fatalf("destination set=%v", seen)
+			}
+			summary, ok := batch.Result["jira_work_items"].(JiraAtlassianWorkItemsResult)
+			if !ok || len(summary.DerivedDestinationsImplemented) != 10 ||
+				len(summary.DerivedDestinationsUnimplemented) != 0 ||
+				summary.WatermarkHeldForIncomplete {
+				t.Fatalf("typed completion result=%#v", batch.Result["jira_work_items"])
+			}
+		})
+	}
+}

--- a/internal/providersync/testdata/mutation-plans/jira_work_items_derived.json
+++ b/internal/providersync/testdata/mutation-plans/jira_work_items_derived.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "name": "Jira canonical work-items derived composition",
+  "build": ["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-run", "^$", "./internal/providersync/"],
+  "$limitation": "This provider-local plan proves the Jira provider fence, five-alias canonicalization, ten-effect composition, evaluated-empty AI no-I/O disposition, watermark withholding, and typed destination projection. The migration-backed ClickHouse suite separately proves real writes and readback. Registry, matrix, shared constructors, admission, deployment, and activation are intentionally excluded.",
+  "mutations": [
+    {
+      "id": "J2-alias-canonical-cost",
+      "file": "internal/providersync/jira_work_item_derived.go",
+      "find": "canonicalClaim.CostClass = canonicalCapability.CostClass",
+      "replace": "canonicalClaim.CostClass = claim.CostClass\n\t_ = canonicalCapability.CostClass",
+      "rationale": "lightweight labels/projects claims must canonicalize their internal context load without invalidating the frozen alias claim",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraCanonicalAliasesComposeSixteenDestinationsPlusWorklogs$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J3-route-appends-derived-effects",
+      "file": "internal/providersync/jira_atlassian_route.go",
+      "find": "effects = append(effects, derivedEffects...)",
+      "replace": "effects = append(effects, derivedEffects[:0]...)",
+      "rationale": "a configured Jira route must carry all ten derived effects into the same recoverable batch as direct facts and worklogs",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraCanonicalAliasesComposeSixteenDestinationsPlusWorklogs$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J4-route-reports-implemented-destinations",
+      "file": "internal/providersync/jira_atlassian_route.go",
+      "find": "derivedImplemented = derived.producedDestinations()",
+      "replace": "derivedImplemented = nil",
+      "rationale": "the typed completion result must report the ten destinations the route actually evaluated",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraCanonicalAliasesComposeSixteenDestinationsPlusWorklogs$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J5-raw-only-watermark-withheld",
+      "file": "internal/providersync/jira_atlassian_route.go",
+      "find": "var derivedWatermark *time.Time",
+      "replace": "derivedWatermark := claim.BeforeAt",
+      "rationale": "the direct-only route must not acknowledge a unit whose ten derived destinations were never evaluated",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraAtlassianRawOnlyRouteHoldsWatermarkForDerivedGap$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J6-typed-metric-effect-projection",
+      "file": "internal/providersync/jira_work_item_derived.go",
+      "find": "effect, err = buildJiraTypedDerivedEffect(destination, rows.WorkItemMetricsDaily)",
+      "replace": "effect, err = buildJiraTypedDerivedEffect(destination, rows.WorkItemUserMetricsDaily)",
+      "rationale": "work_item_metrics_daily must retain its concrete row family rather than serialize a different valid schema under the right destination name",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestBuildJiraWorkItemDerivedEffectsKeepsTenTypedDestinations$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J7-ai-rejects-fabricated-rows",
+      "file": "internal/providersync/jira_work_item_derived.go",
+      "find": "if len(effect.Rows) != 0 {",
+      "replace": "if len(effect.Rows) < 0 {",
+      "rationale": "the no-producer Jira AI disposition admits only an empty effect and rejects fabricated attribution rows",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraEvaluatedEmptyAIIsNoIOAndReadsAbsent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J8-ai-write-is-no-io",
+      "file": "internal/providersync/jira_work_item_derived.go",
+      "find": "if adapter.destination == \"ai_attribution\" {\n\t\treturn nil\n\t}\n\tif adapter.delegate == nil",
+      "replace": "if adapter.destination == \"not_ai_attribution\" {\n\t\treturn nil\n\t}\n\tif adapter.delegate == nil",
+      "rationale": "an evaluated-empty AI effect must not call any ClickHouse delegate",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraEvaluatedEmptyAIIsNoIOAndReadsAbsent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J9-ai-readback-remains-absent",
+      "file": "internal/providersync/jira_work_item_derived.go",
+      "find": "return EffectAbsent, nil",
+      "replace": "return EffectExact, nil",
+      "rationale": "no durable AI row exists to read back; the explicit empty effect must remain Absent rather than claim a ClickHouse match",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraEvaluatedEmptyAIIsNoIOAndReadsAbsent$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J10-metric-triplet-provider-family",
+      "file": "internal/providersync/work_item_derived_provider.go",
+      "find": "return provider == \"github\" || provider == \"gitlab\" || provider == \"jira\" || provider == \"linear\"",
+      "replace": "return provider == \"github\" || provider == \"gitlab\" || provider == \"linear\"",
+      "rationale": "all three Jira metric-triplet effects must pass the provider-neutral typed validator and reach their migrated stores",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraMetricTripletEffectsReachTheirMigratedStores$", "./internal/providersync/"]]
+    },
+    {
+      "id": "J11-reference-incomplete-watermark",
+      "file": "internal/providersync/jira_atlassian_route.go",
+      "find": "len(optionalIncomplete) == 0 &&",
+      "replace": "len(optionalIncomplete) >= 0 &&",
+      "rationale": "a reference-cache write failure may land recoverable effects but must withhold the claim watermark",
+      "proof": [["env", "GOCACHE=/tmp/jira-derived-go-cache", "GOWORK=off", "go", "test", "-mod=readonly", "-count=1", "-run", "^TestJiraAtlassianReferenceSinkFailureLandsEffectsAndWithholdsWatermark$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_atlassian.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_atlassian.py
@@ -329,7 +329,6 @@ oracle_registry.register(
             "dependencies": "The Atlassian provider returns explicit empty dependencies; legacy parity is covered elsewhere.",
             "interactions": "The Atlassian provider returns explicit empty interactions; legacy parity is covered elsewhere.",
             "reopen_events": "This pair owns Atlassian enrichment only.",
-            "ai_attributions": "The Jira provider does not emit AI attribution records.",
             "observations": "Usage observations are transport metadata, not the worklog/sprint persistence contract.",
         },
     )

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_cycle-times.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_cycle-times.py
@@ -1,0 +1,35 @@
+"""Live Python producer oracle for Jira work-item cycle-time rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_metrics_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    columns,
+    compute_triplet,
+)
+
+_RECORD = "WorkItemCycleTimeRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _group_records, _user_records, cycle_records = compute_triplet(case)
+    return columns(list(cycle_records), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/cycle-times",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_estimate-coverage.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_estimate-coverage.py
@@ -1,0 +1,34 @@
+"""Live Python producer oracle for Jira estimate coverage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "EstimateCoverageMetricsDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).estimate_coverage()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/estimate-coverage",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_investment-classifications.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_investment-classifications.py
@@ -1,0 +1,33 @@
+"""Live Python producer oracle for Jira investment classifications."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "InvestmentClassificationRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _rows, classifications, _metrics = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(classifications), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/investment-classifications",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_investment-metrics.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_investment-metrics.py
@@ -1,0 +1,33 @@
+"""Live Python producer oracle for Jira investment metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "InvestmentMetricsRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _rows, _classifications, metrics = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(metrics), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/investment-metrics",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_issue-type-metrics.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_issue-type-metrics.py
@@ -1,0 +1,33 @@
+"""Live Python producer oracle for Jira issue-type metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "IssueTypeMetricsRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    rows, _classifications, _metrics = DerivedCase(case).engine_destinations_all_days()
+    return columns(list(rows), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/issue-type-metrics",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_metrics-daily.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_metrics-daily.py
@@ -1,0 +1,41 @@
+"""Live Python producer oracle for Jira work-item group metrics.
+
+The Jira route feeds the same provider-neutral daily computation invoked by
+``job_work_items.py``.  This pair deliberately executes that checked-in
+production function over rows emitted by the Go Jira route; it does not infer
+required effects from the route manifest or from a hand-maintained count.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_metrics_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    columns,
+    compute_triplet,
+)
+
+_RECORD = "WorkItemMetricsDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    group_records, _user_records, _cycle_records = compute_triplet(case)
+    return columns(list(group_records), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/metrics-daily",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_state-durations.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_state-durations.py
@@ -1,0 +1,34 @@
+"""Live Python producer oracle for Jira state-duration rows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "WorkItemStateDurationDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).state_durations()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/state-durations",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_team-attributions.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_team-attributions.py
@@ -1,0 +1,32 @@
+"""Live Python producer oracle for Jira work-item team attributions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_derived_helpers import (
+    SCHEMA_SOURCE,
+    DerivedCase,
+    columns,
+)
+
+_RECORD = "WorkItemTeamAttributionRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    return columns(list(DerivedCase(case).team_attributions()), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/team-attributions",
+        build_row=_build_row,
+        reflected_fields=_fields,
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/jira_work-items_user-metrics-daily.py
+++ b/internal/providersync/testdata/oracle_pairs/jira_work-items_user-metrics-daily.py
@@ -1,0 +1,35 @@
+"""Live Python producer oracle for Jira work-item user metrics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.oracle_pairs._github_work_item_metrics_helpers import (
+    ORG_ID_EXCLUSION,
+    SCHEMA_SOURCE,
+    columns,
+    compute_triplet,
+)
+
+_RECORD = "WorkItemUserMetricsDailyRecord"
+
+
+def _fields() -> frozenset[str]:
+    return dataclass_field_names(SCHEMA_SOURCE.read_text(), _RECORD)
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    _group_records, user_records, _cycle_records = compute_triplet(case)
+    return columns(list(user_records), _fields())
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="jira/work-items/user-metrics-daily",
+        build_row=_build_row,
+        reflected_fields=_fields,
+        excluded_fields={"org_id": ORG_ID_EXCLUSION},
+    )
+)

--- a/internal/providersync/work_item_derived_provider.go
+++ b/internal/providersync/work_item_derived_provider.go
@@ -5,5 +5,5 @@ package providersync
 // validation seams. Collection and raw effect routes remain provider-owned;
 // callers of the builders still pass an exact expected provider.
 func isDerivedWorkItemProvider(provider string) bool {
-	return provider == "github" || provider == "gitlab" || provider == "linear"
+	return provider == "github" || provider == "gitlab" || provider == "jira" || provider == "linear"
 }


### PR DESCRIPTION
## Summary

- Rebases source commit `6340834c1b578414fcc3775ec43b688edb5c450f` onto feature-integration base `fb71a9beea5900ab78934c3ae279d83504335ae3` as `ceca1e2c17cbdb71ba78db038e7843667b2d3b88`.
- Completes the Jira canonical work-item semantic family: ten typed derived destinations, canonical alias composition, evaluated-empty AI semantics, real effect readback/replay fencing, typed incomplete outcomes, and watermark advancement only after the complete family is accounted for.
- The base had generalized provider admission behind `isDerivedWorkItemProvider`; the two cherry-pick conflicts were resolved by retaining that abstraction, adding Jira to its bounded provider set, and retargeting J10 to mutate the shared guard.
- This is a provider-local semantic and proof slice only. It adds no registry, capability-matrix, config, constructor/startup, scheduler, deployment, activation, wiring, or cutover behavior.

## Source-commit evidence

The source branch was never pushed and had no prior PR or GitHub CI. The following evidence was recorded locally on `6340834c1`; the fresh checks below are authoritative for the rebased composition.

- `internal/providersync/testdata/mutation-plans/jira_work_items_derived.json`: **10/10 KILLED** with the shared mutation harness.
- `TestJiraWorkItemDerivedEffectsWriteReadbackAgainstRealClickHouse`: **PASS** against a real ClickHouse testcontainer after applying the production migration chain. It exercised the real context loader, nine durable derived destinations plus evaluated-empty AI, before/after readback, replay, cross-tenant rejection, and lease-loss fencing.

## Fresh post-rebase evidence

- Focused `TestJira*` package tests plus `TestMutationPlansHaveLiveAnchorsAndExistingProofTests`: **PASS**; the static sweep checked 49 plans and 1,065 entries.
- Focused live-Python Jira oracle selection: **PASS** for Atlassian collection, metric triplet, derived surfaces, engine destinations, and a non-empty route effect; all ten expected Jira proof markers recorded `executed`.
- `go vet -mod=readonly ./internal/providersync/`: **PASS**.
- `go vet -mod=readonly -tags=integration ./internal/providersync/`: **PASS** without starting Docker.
- `bash ci/check_go.sh fmt`: **PASS**.
- `python3 scripts/mutation_harness.py verify`: **PASS**; no mutation was active or leaked.
- Ruff check and format for the ten Jira oracle-pair files: **PASS**.
- Explicit pre-push hooks: Ruff format/check **PASS**; mypy **PASS** over 2,201 source files.
- `git diff --check` against `fb71a9bee`: **PASS**.

Per publication scope, Docker, mutation execution, and the full local gate were not rerun on the rebased branch. No merge is requested by this publication step.