### PR TITLE
feat(config): add provider completion route switches

### DIFF
--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -122,6 +122,20 @@ type Config struct {
 	WorkerGitlabTestsEnabled bool
 	// WorkerGitlabIncidentsEnabled gates the canonical operational incident route.
 	WorkerGitlabIncidentsEnabled bool
+	// The remaining GitLab flags gate independently completed native routes.
+	// PR aliases are the exception: all three delegate to one complete PR-social
+	// writer and Load rejects enabling more than one alias at a time.
+	WorkerGitlabDeploymentsEnabled  bool
+	WorkerGitlabFeatureFlagsEnabled bool
+	WorkerGitlabFilesEnabled        bool
+	WorkerGitlabBlameEnabled        bool
+	WorkerGitlabPRsEnabled          bool
+	WorkerGitlabPRReviewsEnabled    bool
+	WorkerGitlabPRCommentsEnabled   bool
+	WorkerGitlabSecurityEnabled     bool
+	// WorkerGitlabWorkItemsEnabled gates the one complete five-alias GitLab
+	// work-item family; sibling alias identities are not independent routes.
+	WorkerGitlabWorkItemsEnabled bool
 	// WorkerGithubPRsEnabled is the (github, prs) half of the two-key route
 	// gate (CHAOS-3122, following CHAOS-3123's precedent). The matrix marking
 	// the pair route_ready is the other half; neither alone moves traffic.
@@ -160,6 +174,18 @@ type Config struct {
 	// validates both paths and rejects ambient STATUS_MAPPING_PATH overrides.
 	WorkerGithubWorkItemsStatusMappingPath    string
 	WorkerGithubWorkItemsInvestmentConfigPath string
+
+	// PagerDuty route switches are default-off and independent. The incidents
+	// switch owns the complete incidents family, including alert, log-entry,
+	// and note alias datasets; those aliases are not separately activatable.
+	WorkerPagerDutyServicesEnabled           bool
+	WorkerPagerDutyBusinessServicesEnabled   bool
+	WorkerPagerDutyEscalationPoliciesEnabled bool
+	WorkerPagerDutySchedulesEnabled          bool
+	WorkerPagerDutyOnCallsEnabled            bool
+	WorkerPagerDutyUsersEnabled              bool
+	WorkerPagerDutyTeamsEnabled              bool
+	WorkerPagerDutyIncidentsEnabled          bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -261,6 +287,74 @@ func Load(spec Spec) (Config, error) {
 			target: &cfg.WorkerGitlabIncidentsEnabled,
 		},
 		{
+			name:   "WORKER_GITLAB_DEPLOYMENTS_ENABLED",
+			target: &cfg.WorkerGitlabDeploymentsEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_FEATURE_FLAGS_ENABLED",
+			target: &cfg.WorkerGitlabFeatureFlagsEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_FILES_ENABLED",
+			target: &cfg.WorkerGitlabFilesEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_BLAME_ENABLED",
+			target: &cfg.WorkerGitlabBlameEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_PRS_ENABLED",
+			target: &cfg.WorkerGitlabPRsEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_PR_REVIEWS_ENABLED",
+			target: &cfg.WorkerGitlabPRReviewsEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_PR_COMMENTS_ENABLED",
+			target: &cfg.WorkerGitlabPRCommentsEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_SECURITY_ENABLED",
+			target: &cfg.WorkerGitlabSecurityEnabled,
+		},
+		{
+			name:   "WORKER_GITLAB_WORK_ITEMS_ENABLED",
+			target: &cfg.WorkerGitlabWorkItemsEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_SERVICES_ENABLED",
+			target: &cfg.WorkerPagerDutyServicesEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_BUSINESS_SERVICES_ENABLED",
+			target: &cfg.WorkerPagerDutyBusinessServicesEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_ESCALATION_POLICIES_ENABLED",
+			target: &cfg.WorkerPagerDutyEscalationPoliciesEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_SCHEDULES_ENABLED",
+			target: &cfg.WorkerPagerDutySchedulesEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_ON_CALLS_ENABLED",
+			target: &cfg.WorkerPagerDutyOnCallsEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_USERS_ENABLED",
+			target: &cfg.WorkerPagerDutyUsersEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_TEAMS_ENABLED",
+			target: &cfg.WorkerPagerDutyTeamsEnabled,
+		},
+		{
+			name:   "WORKER_PAGERDUTY_INCIDENTS_ENABLED",
+			target: &cfg.WorkerPagerDutyIncidentsEnabled,
+		},
+		{
 			name:   "WORKER_GITHUB_PRS_ENABLED",
 			target: &cfg.WorkerGithubPRsEnabled,
 		},
@@ -332,6 +426,19 @@ func Load(spec Spec) (Config, error) {
 	}
 	if cfg.WorkerGitlabCICDEnabled && cfg.WorkerGitlabTestsEnabled {
 		return Config{}, fmt.Errorf("WORKER_GITLAB_CICD_ENABLED and WORKER_GITLAB_TESTS_ENABLED are mutually exclusive: both delegate to one complete TestOps writer")
+	}
+	gitlabPRSocialAliases := 0
+	for _, enabled := range []bool{
+		cfg.WorkerGitlabPRsEnabled,
+		cfg.WorkerGitlabPRReviewsEnabled,
+		cfg.WorkerGitlabPRCommentsEnabled,
+	} {
+		if enabled {
+			gitlabPRSocialAliases++
+		}
+	}
+	if gitlabPRSocialAliases > 1 {
+		return Config{}, fmt.Errorf("WORKER_GITLAB_PRS_ENABLED, WORKER_GITLAB_PR_REVIEWS_ENABLED, and WORKER_GITLAB_PR_COMMENTS_ENABLED are mutually exclusive: all delegate to one complete PR-social writer")
 	}
 	cfg.WorkerGithubWorkItemsStatusMappingPath = envOrDefault(
 		lookup, "WORKER_GITHUB_WORK_ITEMS_STATUS_MAPPING_PATH", "",
@@ -602,6 +709,23 @@ func (c Config) SafeAttrs() []slog.Attr {
 		slog.Bool("worker_gitlab_cicd_enabled", c.WorkerGitlabCICDEnabled),
 		slog.Bool("worker_gitlab_tests_enabled", c.WorkerGitlabTestsEnabled),
 		slog.Bool("worker_gitlab_incidents_enabled", c.WorkerGitlabIncidentsEnabled),
+		slog.Bool("worker_gitlab_deployments_enabled", c.WorkerGitlabDeploymentsEnabled),
+		slog.Bool("worker_gitlab_feature_flags_enabled", c.WorkerGitlabFeatureFlagsEnabled),
+		slog.Bool("worker_gitlab_files_enabled", c.WorkerGitlabFilesEnabled),
+		slog.Bool("worker_gitlab_blame_enabled", c.WorkerGitlabBlameEnabled),
+		slog.Bool("worker_gitlab_prs_enabled", c.WorkerGitlabPRsEnabled),
+		slog.Bool("worker_gitlab_pr_reviews_enabled", c.WorkerGitlabPRReviewsEnabled),
+		slog.Bool("worker_gitlab_pr_comments_enabled", c.WorkerGitlabPRCommentsEnabled),
+		slog.Bool("worker_gitlab_security_enabled", c.WorkerGitlabSecurityEnabled),
+		slog.Bool("worker_gitlab_work_items_enabled", c.WorkerGitlabWorkItemsEnabled),
+		slog.Bool("worker_pagerduty_services_enabled", c.WorkerPagerDutyServicesEnabled),
+		slog.Bool("worker_pagerduty_business_services_enabled", c.WorkerPagerDutyBusinessServicesEnabled),
+		slog.Bool("worker_pagerduty_escalation_policies_enabled", c.WorkerPagerDutyEscalationPoliciesEnabled),
+		slog.Bool("worker_pagerduty_schedules_enabled", c.WorkerPagerDutySchedulesEnabled),
+		slog.Bool("worker_pagerduty_on_calls_enabled", c.WorkerPagerDutyOnCallsEnabled),
+		slog.Bool("worker_pagerduty_users_enabled", c.WorkerPagerDutyUsersEnabled),
+		slog.Bool("worker_pagerduty_teams_enabled", c.WorkerPagerDutyTeamsEnabled),
+		slog.Bool("worker_pagerduty_incidents_enabled", c.WorkerPagerDutyIncidentsEnabled),
 		slog.Bool("worker_github_prs_enabled", c.WorkerGithubPRsEnabled),
 		slog.Bool("worker_github_pr_reviews_enabled", c.WorkerGithubPRReviewsEnabled),
 		slog.Bool("worker_github_pr_comments_enabled", c.WorkerGithubPRCommentsEnabled),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -223,6 +223,89 @@ func TestGitLabCompleteUnitAliasesAreMutuallyExclusive(t *testing.T) {
 	}
 }
 
+func TestGitLabPRSocialAliasesAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	aliases := []string{
+		"WORKER_GITLAB_PRS_ENABLED",
+		"WORKER_GITLAB_PR_REVIEWS_ENABLED",
+		"WORKER_GITLAB_PR_COMMENTS_ENABLED",
+	}
+	for left := 0; left < len(aliases); left++ {
+		for right := left + 1; right < len(aliases); right++ {
+			_, err := Load(workerSpec(map[string]string{
+				aliases[left]:  "true",
+				aliases[right]: "true",
+			}))
+			if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+				t.Fatalf("aliases=(%s,%s) error=%v", aliases[left], aliases[right], err)
+			}
+		}
+	}
+}
+
+func TestProviderCompletionRouteSwitchesDefaultOffParseAndLogSafely(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		env  string
+		attr string
+		pick func(Config) bool
+	}{
+		{"linear work items", "WORKER_LINEAR_WORK_ITEMS_ENABLED", "worker_linear_work_items_enabled", func(cfg Config) bool { return cfg.WorkerLinearWorkItemsEnabled }},
+		{"jira work items", "WORKER_JIRA_WORK_ITEMS_ENABLED", "worker_jira_work_items_enabled", func(cfg Config) bool { return cfg.WorkerJiraWorkItemsEnabled }},
+		{"jira incidents", "WORKER_JIRA_INCIDENTS_ENABLED", "worker_jira_incidents_enabled", func(cfg Config) bool { return cfg.WorkerJiraIncidentsEnabled }},
+		{"gitlab repo metadata", "WORKER_GITLAB_REPO_METADATA_ENABLED", "worker_gitlab_repo_metadata_enabled", func(cfg Config) bool { return cfg.WorkerGitlabRepoMetadataEnabled }},
+		{"gitlab commits", "WORKER_GITLAB_COMMITS_ENABLED", "worker_gitlab_commits_enabled", func(cfg Config) bool { return cfg.WorkerGitlabCommitsEnabled }},
+		{"gitlab commit stats", "WORKER_GITLAB_COMMIT_STATS_ENABLED", "worker_gitlab_commit_stats_enabled", func(cfg Config) bool { return cfg.WorkerGitlabCommitStatsEnabled }},
+		{"gitlab cicd", "WORKER_GITLAB_CICD_ENABLED", "worker_gitlab_cicd_enabled", func(cfg Config) bool { return cfg.WorkerGitlabCICDEnabled }},
+		{"gitlab tests", "WORKER_GITLAB_TESTS_ENABLED", "worker_gitlab_tests_enabled", func(cfg Config) bool { return cfg.WorkerGitlabTestsEnabled }},
+		{"gitlab incidents", "WORKER_GITLAB_INCIDENTS_ENABLED", "worker_gitlab_incidents_enabled", func(cfg Config) bool { return cfg.WorkerGitlabIncidentsEnabled }},
+		{"gitlab deployments", "WORKER_GITLAB_DEPLOYMENTS_ENABLED", "worker_gitlab_deployments_enabled", func(cfg Config) bool { return cfg.WorkerGitlabDeploymentsEnabled }},
+		{"gitlab feature flags", "WORKER_GITLAB_FEATURE_FLAGS_ENABLED", "worker_gitlab_feature_flags_enabled", func(cfg Config) bool { return cfg.WorkerGitlabFeatureFlagsEnabled }},
+		{"gitlab files", "WORKER_GITLAB_FILES_ENABLED", "worker_gitlab_files_enabled", func(cfg Config) bool { return cfg.WorkerGitlabFilesEnabled }},
+		{"gitlab blame", "WORKER_GITLAB_BLAME_ENABLED", "worker_gitlab_blame_enabled", func(cfg Config) bool { return cfg.WorkerGitlabBlameEnabled }},
+		{"gitlab prs", "WORKER_GITLAB_PRS_ENABLED", "worker_gitlab_prs_enabled", func(cfg Config) bool { return cfg.WorkerGitlabPRsEnabled }},
+		{"gitlab pr reviews", "WORKER_GITLAB_PR_REVIEWS_ENABLED", "worker_gitlab_pr_reviews_enabled", func(cfg Config) bool { return cfg.WorkerGitlabPRReviewsEnabled }},
+		{"gitlab pr comments", "WORKER_GITLAB_PR_COMMENTS_ENABLED", "worker_gitlab_pr_comments_enabled", func(cfg Config) bool { return cfg.WorkerGitlabPRCommentsEnabled }},
+		{"gitlab security", "WORKER_GITLAB_SECURITY_ENABLED", "worker_gitlab_security_enabled", func(cfg Config) bool { return cfg.WorkerGitlabSecurityEnabled }},
+		{"gitlab work items", "WORKER_GITLAB_WORK_ITEMS_ENABLED", "worker_gitlab_work_items_enabled", func(cfg Config) bool { return cfg.WorkerGitlabWorkItemsEnabled }},
+		{"pagerduty services", "WORKER_PAGERDUTY_SERVICES_ENABLED", "worker_pagerduty_services_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutyServicesEnabled }},
+		{"pagerduty business services", "WORKER_PAGERDUTY_BUSINESS_SERVICES_ENABLED", "worker_pagerduty_business_services_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutyBusinessServicesEnabled }},
+		{"pagerduty escalation policies", "WORKER_PAGERDUTY_ESCALATION_POLICIES_ENABLED", "worker_pagerduty_escalation_policies_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutyEscalationPoliciesEnabled }},
+		{"pagerduty schedules", "WORKER_PAGERDUTY_SCHEDULES_ENABLED", "worker_pagerduty_schedules_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutySchedulesEnabled }},
+		{"pagerduty on calls", "WORKER_PAGERDUTY_ON_CALLS_ENABLED", "worker_pagerduty_on_calls_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutyOnCallsEnabled }},
+		{"pagerduty users", "WORKER_PAGERDUTY_USERS_ENABLED", "worker_pagerduty_users_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutyUsersEnabled }},
+		{"pagerduty teams", "WORKER_PAGERDUTY_TEAMS_ENABLED", "worker_pagerduty_teams_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutyTeamsEnabled }},
+		{"pagerduty incidents", "WORKER_PAGERDUTY_INCIDENTS_ENABLED", "worker_pagerduty_incidents_enabled", func(cfg Config) bool { return cfg.WorkerPagerDutyIncidentsEnabled }},
+	}
+
+	defaults, err := Load(workerSpec(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range tests {
+		if test.pick(defaults) {
+			t.Fatalf("%s must default off", test.env)
+		}
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, err := Load(workerSpec(map[string]string{test.env: "true"}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !test.pick(cfg) {
+				t.Fatalf("%s did not enable its route switch", test.env)
+			}
+			if attrs := fmt.Sprint(cfg.SafeAttrs()); !strings.Contains(attrs, test.attr+"=true") {
+				t.Fatalf("safe attrs missing %s=true: %s", test.attr, attrs)
+			}
+		})
+	}
+}
+
 func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 	t.Parallel()
 
@@ -311,35 +394,52 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 	}
 
 	for key, value := range map[string]string{
-		"WORKER_DATABASE_MODE":                      "arbitrary",
-		"WORKER_DATABASE_MAX_CONNS":                 "5",
-		"WORKER_DOMAIN_DATABASE_MAX_CONNS":          "0",
-		"RIVER_COMPLETED_JOB_RETENTION":             "23h",
-		"RIVER_JOB_CLEANER_TIMEOUT":                 "4s",
-		"RIVER_DATABASE_SCHEMA":                     "River-Bad",
-		"RIVER_DOMAIN_DATABASE_ROLE":                "Domain-Bad",
-		"RIVER_QUEUE_DATABASE_ROLE":                 "Queue-Bad",
-		"PGBOUNCER_TRANSACTION_MODE":                "sometimes",
-		"WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE":  "sometimes",
-		"DEV_HEALTH_STREAM_REPLICAS":                "9",
-		"WORKER_LINEAR_WORK_ITEMS_ENABLED":          "sometimes",
-		"WORKER_JIRA_WORK_ITEMS_ENABLED":            "sometimes",
-		"WORKER_JIRA_INCIDENTS_ENABLED":             "sometimes",
-		"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "sometimes",
-		"WORKER_GITHUB_REPO_METADATA_ENABLED":       "sometimes",
-		"WORKER_GITLAB_REPO_METADATA_ENABLED":       "sometimes",
-		"WORKER_GITLAB_COMMITS_ENABLED":             "sometimes",
-		"WORKER_GITLAB_COMMIT_STATS_ENABLED":        "sometimes",
-		"WORKER_GITLAB_CICD_ENABLED":                "sometimes",
-		"WORKER_GITLAB_TESTS_ENABLED":               "sometimes",
-		"WORKER_GITLAB_INCIDENTS_ENABLED":           "sometimes",
-		"WORKER_GITHUB_PRS_ENABLED":                 "sometimes",
-		"WORKER_GITHUB_PR_REVIEWS_ENABLED":          "sometimes",
-		"WORKER_GITHUB_PR_COMMENTS_ENABLED":         "sometimes",
-		"WORKER_GITHUB_COMMITS_ENABLED":             "sometimes",
-		"WORKER_GITHUB_COMMIT_STATS_ENABLED":        "sometimes",
-		"WORKER_GITHUB_BLAME_ENABLED":               "sometimes",
-		"WORKER_GITHUB_WORK_ITEMS_ENABLED":          "sometimes",
+		"WORKER_DATABASE_MODE":                         "arbitrary",
+		"WORKER_DATABASE_MAX_CONNS":                    "5",
+		"WORKER_DOMAIN_DATABASE_MAX_CONNS":             "0",
+		"RIVER_COMPLETED_JOB_RETENTION":                "23h",
+		"RIVER_JOB_CLEANER_TIMEOUT":                    "4s",
+		"RIVER_DATABASE_SCHEMA":                        "River-Bad",
+		"RIVER_DOMAIN_DATABASE_ROLE":                   "Domain-Bad",
+		"RIVER_QUEUE_DATABASE_ROLE":                    "Queue-Bad",
+		"PGBOUNCER_TRANSACTION_MODE":                   "sometimes",
+		"WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE":     "sometimes",
+		"DEV_HEALTH_STREAM_REPLICAS":                   "9",
+		"WORKER_LINEAR_WORK_ITEMS_ENABLED":             "sometimes",
+		"WORKER_JIRA_WORK_ITEMS_ENABLED":               "sometimes",
+		"WORKER_JIRA_INCIDENTS_ENABLED":                "sometimes",
+		"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED":    "sometimes",
+		"WORKER_GITHUB_REPO_METADATA_ENABLED":          "sometimes",
+		"WORKER_GITLAB_REPO_METADATA_ENABLED":          "sometimes",
+		"WORKER_GITLAB_COMMITS_ENABLED":                "sometimes",
+		"WORKER_GITLAB_COMMIT_STATS_ENABLED":           "sometimes",
+		"WORKER_GITLAB_CICD_ENABLED":                   "sometimes",
+		"WORKER_GITLAB_TESTS_ENABLED":                  "sometimes",
+		"WORKER_GITLAB_INCIDENTS_ENABLED":              "sometimes",
+		"WORKER_GITLAB_DEPLOYMENTS_ENABLED":            "sometimes",
+		"WORKER_GITLAB_FEATURE_FLAGS_ENABLED":          "sometimes",
+		"WORKER_GITLAB_FILES_ENABLED":                  "sometimes",
+		"WORKER_GITLAB_BLAME_ENABLED":                  "sometimes",
+		"WORKER_GITLAB_PRS_ENABLED":                    "sometimes",
+		"WORKER_GITLAB_PR_REVIEWS_ENABLED":             "sometimes",
+		"WORKER_GITLAB_PR_COMMENTS_ENABLED":            "sometimes",
+		"WORKER_GITLAB_SECURITY_ENABLED":               "sometimes",
+		"WORKER_GITLAB_WORK_ITEMS_ENABLED":             "sometimes",
+		"WORKER_PAGERDUTY_SERVICES_ENABLED":            "sometimes",
+		"WORKER_PAGERDUTY_BUSINESS_SERVICES_ENABLED":   "sometimes",
+		"WORKER_PAGERDUTY_ESCALATION_POLICIES_ENABLED": "sometimes",
+		"WORKER_PAGERDUTY_SCHEDULES_ENABLED":           "sometimes",
+		"WORKER_PAGERDUTY_ON_CALLS_ENABLED":            "sometimes",
+		"WORKER_PAGERDUTY_USERS_ENABLED":               "sometimes",
+		"WORKER_PAGERDUTY_TEAMS_ENABLED":               "sometimes",
+		"WORKER_PAGERDUTY_INCIDENTS_ENABLED":           "sometimes",
+		"WORKER_GITHUB_PRS_ENABLED":                    "sometimes",
+		"WORKER_GITHUB_PR_REVIEWS_ENABLED":             "sometimes",
+		"WORKER_GITHUB_PR_COMMENTS_ENABLED":            "sometimes",
+		"WORKER_GITHUB_COMMITS_ENABLED":                "sometimes",
+		"WORKER_GITHUB_COMMIT_STATS_ENABLED":           "sometimes",
+		"WORKER_GITHUB_BLAME_ENABLED":                  "sometimes",
+		"WORKER_GITHUB_WORK_ITEMS_ENABLED":             "sometimes",
 	} {
 		if _, err := Load(workerSpec(map[string]string{key: value})); err == nil {
 			t.Fatalf("expected %s=%q to fail", key, value)

--- a/internal/platform/config/testdata/mutation-plans/provider_completion_route_switches.json
+++ b/internal/platform/config/testdata/mutation-plans/provider_completion_route_switches.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "name": "provider completion route-switch configuration",
+  "build": ["go", "test", "-run", "^$", "./internal/platform/config/"],
+  "$limitation": "This config-only plan pins default-off parsing, representative exact field mappings, safe boolean startup attributes, and GitLab PR-family exclusivity. CompleteRouteSwitches mapping and worker readiness remain dependency-blocked on registry closure and require a separate cmd plan.",
+  "mutations": [
+    {
+      "id": "C1-provider-switches-default-off",
+      "file": "internal/platform/config/config.go",
+      "find": "\t} {\n\t\t*item.target, err = boolEnv(lookup, item.name, false)",
+      "replace": "\t} {\n\t\t*item.target, err = boolEnv(lookup, item.name, item.name == \"WORKER_PAGERDUTY_SERVICES_ENABLED\")",
+      "rationale": "every provider route is an explicit opt-in; an absent PagerDuty services environment value must leave that switch off",
+      "proof": [["go", "test", "-count=1", "-run", "^TestProviderCompletionRouteSwitchesDefaultOffParseAndLogSafely$", "./internal/platform/config/"]]
+    },
+    {
+      "id": "C2-gitlab-deployments-field-mapping",
+      "file": "internal/platform/config/config.go",
+      "find": "target: &cfg.WorkerGitlabDeploymentsEnabled,",
+      "replace": "target: &cfg.WorkerGitlabFeatureFlagsEnabled,",
+      "rationale": "the GitLab deployments environment switch must enable only its dedicated route field",
+      "proof": [["go", "test", "-count=1", "-run", "^TestProviderCompletionRouteSwitchesDefaultOffParseAndLogSafely$/^gitlab_deployments$", "./internal/platform/config/"]]
+    },
+    {
+      "id": "C3-pagerduty-incidents-family-field-mapping",
+      "file": "internal/platform/config/config.go",
+      "find": "target: &cfg.WorkerPagerDutyIncidentsEnabled,",
+      "replace": "target: &cfg.WorkerPagerDutyTeamsEnabled,",
+      "rationale": "the one complete PagerDuty incident-family switch must map to its incidents field instead of another independent route",
+      "proof": [["go", "test", "-count=1", "-run", "^TestProviderCompletionRouteSwitchesDefaultOffParseAndLogSafely$/^pagerduty_incidents$", "./internal/platform/config/"]]
+    },
+    {
+      "id": "C4-pagerduty-safe-attribute-binding",
+      "file": "internal/platform/config/config.go",
+      "find": "slog.Bool(\"worker_pagerduty_escalation_policies_enabled\", c.WorkerPagerDutyEscalationPoliciesEnabled),",
+      "replace": "slog.Bool(\"worker_pagerduty_escalation_policies_enabled\", c.WorkerPagerDutySchedulesEnabled),",
+      "rationale": "startup diagnostics must expose the enabled state of the named PagerDuty route without logging configuration payloads",
+      "proof": [["go", "test", "-count=1", "-run", "^TestProviderCompletionRouteSwitchesDefaultOffParseAndLogSafely$/^pagerduty_escalation_policies$", "./internal/platform/config/"]]
+    },
+    {
+      "id": "C5-gitlab-pr-family-mutual-exclusion",
+      "file": "internal/platform/config/config.go",
+      "find": "if gitlabPRSocialAliases > 1 {",
+      "replace": "if gitlabPRSocialAliases > 3 {",
+      "rationale": "any two GitLab PR-family alias switches would activate the same complete writer under different claim identities and must be rejected at startup",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabPRSocialAliasesAreMutuallyExclusive$", "./internal/platform/config/"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- What changed: adds default-off Go config switches for completed GitLab and PagerDuty provider routes, rejects conflicting GitLab PR-social aliases, exposes safe boolean startup attributes, and adds a config-local mutation plan.
- Why: provide the fail-closed configuration half of per-pair provider enablement without activating or wiring any route.

## Checklist

- [x] I added/updated tests, or provided required governance evidence below.
- [x] I ran relevant local validation for this isolated Go config surface.
- [x] I documented risk and rollback considerations.
- [x] Config impact is called out below; there are no migrations or breaking changes.

## Test Evidence

TEST-EVIDENCE:
- `GOTOOLCHAIN=go1.25.9 GOCACHE=/tmp/go-provider-config-readiness-test-cache go test -mod=readonly -count=1 ./internal/platform/config` — PASS
- `GOTOOLCHAIN=go1.25.9 GOCACHE=/tmp/go-provider-config-readiness-vet-cache go vet ./internal/platform/config` — PASS
- Static JSON/plan integrity check — PASS (`schema=1`, 5 unique mutations, every source anchor exactly once)
- Stable patch ID matches the original config commit; `git diff --check` and the exact three-path scope check pass.

## Risk Notes

RISK-NOTES: All switches default off and currently have no consumers outside config. This PR does not change `cmd/` wiring, `CompleteRouteSwitches`, the registry, provider matrix, route policy, deployment manifests, or activation. Rollback is a revert of this additive config commit.

## Optional Context

- Linked issues: CHAOS-3033
- Additional notes: based directly on `fb71a9beea5900ab78934c3ae279d83504335ae3`. The shared mutation harness and full repository gates were intentionally not run for this isolated config publication lane.