### PR TITLE
CHAOS-3141: shard Go storage integration CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Install locked ClickHouse migration dependencies
         run: python -m pip install --no-deps -r ci/requirements-clickhouse-migrations.txt
 
+      - name: Pre-pull pinned ClickHouse image with bounded retry
+        run: bash ci/check_go.sh integration-prepull
+
       - name: Run isolated storage integration shard ${{ matrix.target }} ${{ matrix.shard }}
         run: bash ci/check_go.sh integration-shard "${{ matrix.target }}" "${{ matrix.shard }}"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,7 @@ on:
       - 'tests/compatibility/river/**'
       - 'ci/check_go.sh'
       - 'ci/go_integration_shards.tsv'
+      - 'ci/go_providersync_test_shards.tsv'
       - 'ci/requirements-live-python-oracles.txt'
       - 'ci/check_go_containers.sh'
       - 'ci/check_river_compat_static.sh'
@@ -65,6 +66,7 @@ on:
       - 'tests/compatibility/river/**'
       - 'ci/check_go.sh'
       - 'ci/go_integration_shards.tsv'
+      - 'ci/go_providersync_test_shards.tsv'
       - 'ci/requirements-live-python-oracles.txt'
       - 'ci/check_go_containers.sh'
       - 'ci/check_river_compat_static.sh'
@@ -155,7 +157,7 @@ jobs:
         run: bash ci/check_go.sh integration-shard-plan
 
   go-storage-integration-shard:
-    name: go-storage-integration-shard-${{ matrix.shard }}
+    name: go-storage-integration-shard-${{ matrix.target }}-${{ matrix.shard }}
     needs: go-storage-integration-plan
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -186,8 +188,8 @@ jobs:
       - name: Install locked ClickHouse migration dependencies
         run: python -m pip install --no-deps -r ci/requirements-clickhouse-migrations.txt
 
-      - name: Run isolated storage integration shard ${{ matrix.shard }}
-        run: bash ci/check_go.sh integration-shard "${{ matrix.shard }}"
+      - name: Run isolated storage integration shard ${{ matrix.target }} ${{ matrix.shard }}
+        run: bash ci/check_go.sh integration-shard "${{ matrix.target }}" "${{ matrix.shard }}"
 
   # Preserve the existing required-check contract while the implementation
   # fans out behind it. fail-fast is disabled above, so this job observes the

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,7 @@ on:
       - 'docker/go-worker.Dockerfile'
       - 'tests/compatibility/river/**'
       - 'ci/check_go.sh'
+      - 'ci/go_integration_shards.tsv'
       - 'ci/requirements-live-python-oracles.txt'
       - 'ci/check_go_containers.sh'
       - 'ci/check_river_compat_static.sh'
@@ -63,6 +64,7 @@ on:
       - 'docker/go-worker.Dockerfile'
       - 'tests/compatibility/river/**'
       - 'ci/check_go.sh'
+      - 'ci/go_integration_shards.tsv'
       - 'ci/requirements-live-python-oracles.txt'
       - 'ci/check_go_containers.sh'
       - 'ci/check_river_compat_static.sh'
@@ -134,9 +136,32 @@ jobs:
       - name: Validate River compatibility harness
         run: bash ci/check_river_compat_static.sh
 
-  go-storage-integration:
+  go-storage-integration-plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: '**/go.sum'
+
+      - name: Validate and emit deterministic integration shards
+        id: plan
+        run: bash ci/check_go.sh integration-shard-plan
+
+  go-storage-integration-shard:
+    name: go-storage-integration-shard-${{ matrix.shard }}
+    needs: go-storage-integration-plan
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.go-storage-integration-plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -161,8 +186,33 @@ jobs:
       - name: Install locked ClickHouse migration dependencies
         run: python -m pip install --no-deps -r ci/requirements-clickhouse-migrations.txt
 
-      - name: Run isolated storage integration suite
-        run: bash ci/check_go.sh integration
+      - name: Run isolated storage integration shard ${{ matrix.shard }}
+        run: bash ci/check_go.sh integration-shard "${{ matrix.shard }}"
+
+  # Preserve the existing required-check contract while the implementation
+  # fans out behind it. fail-fast is disabled above, so this job observes the
+  # aggregate result only after every shard has reached a terminal state.
+  go-storage-integration:
+    name: go-storage-integration
+    if: ${{ always() }}
+    needs:
+      - go-storage-integration-plan
+      - go-storage-integration-shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PLAN_RESULT: ${{ needs.go-storage-integration-plan.result }}
+      SHARD_RESULT: ${{ needs.go-storage-integration-shard.result }}
+    steps:
+      - name: Require the plan and every integration shard to pass
+        run: |
+          set -euo pipefail
+          if [ "${PLAN_RESULT}" != "success" ] || [ "${SHARD_RESULT}" != "success" ]; then
+            echo "integration plan result: ${PLAN_RESULT}" >&2
+            echo "integration shard aggregate result: ${SHARD_RESULT}" >&2
+            exit 1
+          fi
+          echo "all deterministic Go integration shards passed"
 
   go-container-smoke:
     runs-on: ubuntu-latest

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -13,6 +13,7 @@ export GOCACHE="${DEV_HEALTH_GO_CACHE}"
 DEV_HEALTH_GO_BUILD_OUTPUT=""
 DEV_HEALTH_GO_BUILD_TEMP_ROOT=""
 DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST="${DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST:-${ROOT}/ci/go_integration_shards.tsv}"
+DEV_HEALTH_GO_PROVIDER_TEST_SHARD_MANIFEST="${DEV_HEALTH_GO_PROVIDER_TEST_SHARD_MANIFEST:-${ROOT}/ci/go_providersync_test_shards.tsv}"
 
 usage() {
   # Backticks in the literal help text document commands; they are not substitutions.
@@ -62,10 +63,12 @@ usage() {
          derive deterministic longest-processing-time-first shard assignments,
          print the complete assignment, and write a GitHub Actions `matrix`
          output when GITHUB_OUTPUT is set. No Docker required.
-  integration-shard SHARD [--dry-run]
-         Run exactly one validated integration shard. `--dry-run` prints the
-         exact package selection without starting Docker-backed tests; CI never
-         passes that option.
+  integration-shard TARGET SHARD [--dry-run]
+         Run exactly one validated integration shard. TARGET is `packages` for
+         a package-level shard or `providersync` for a top-level test shard of
+         the dominant internal/providersync package. `--dry-run` prints the
+         exact selection without starting Docker-backed tests; CI never passes
+         that option.
   integration
          Discover and run EVERY integration-tagged package'\''s suite against
          real containers, except the (small, justified) INTEGRATION_DENYLIST.
@@ -380,7 +383,20 @@ declare -A INTEGRATION_SHARD_WEIGHTS=()
 declare -A INTEGRATION_SHARD_BY_KEY=()
 declare -a INTEGRATION_SHARD_TOTALS=()
 declare -a INTEGRATION_SHARD_PACKAGE_COUNTS=()
+declare -a INTEGRATION_SHARD_NON_PROVIDER_COUNTS=()
 INTEGRATION_SHARD_COUNT=0
+PROVIDER_INTEGRATION_PACKAGE_KEY="internal/providersync"
+declare -A PROVIDER_INTEGRATION_TEST_NAMES=()
+declare -A PROVIDER_TEST_WEIGHTS=()
+declare -A PROVIDER_TEST_CLASS=()
+declare -A PROVIDER_TEST_SHARD_BY_NAME=()
+declare -a PROVIDER_TEST_NAMES=()
+declare -a PROVIDER_TEST_SHARD_TOTALS=()
+declare -a PROVIDER_TEST_SHARD_COUNTS=()
+declare -a PROVIDER_TEST_SHARD_INTEGRATION_COUNTS=()
+PROVIDER_TEST_SHARD_COUNT=0
+PROVIDER_INTEGRATION_TEST_WEIGHT=0
+PROVIDER_ORDINARY_TEST_WEIGHT=0
 
 # discover_integration_packages populates parallel module/package arrays with
 # every module-relative "./pkg/dir" entry that has at least one tracked or
@@ -577,9 +593,11 @@ plan_integration_shards() {
   INTEGRATION_SHARD_BY_KEY=()
   INTEGRATION_SHARD_TOTALS=()
   INTEGRATION_SHARD_PACKAGE_COUNTS=()
+  INTEGRATION_SHARD_NON_PROVIDER_COUNTS=()
   for ((shard = 1; shard <= INTEGRATION_SHARD_COUNT; shard++)); do
     INTEGRATION_SHARD_TOTALS[shard]=0
     INTEGRATION_SHARD_PACKAGE_COUNTS[shard]=0
+    INTEGRATION_SHARD_NON_PROVIDER_COUNTS[shard]=0
   done
 
   while IFS=$'\t' read -r weight key; do
@@ -598,6 +616,11 @@ plan_integration_shards() {
     INTEGRATION_SHARD_PACKAGE_COUNTS[selected_shard]=$((
       INTEGRATION_SHARD_PACKAGE_COUNTS[selected_shard] + 1
     ))
+    if [ "${key}" != "${PROVIDER_INTEGRATION_PACKAGE_KEY}" ]; then
+      INTEGRATION_SHARD_NON_PROVIDER_COUNTS[selected_shard]=$((
+        INTEGRATION_SHARD_NON_PROVIDER_COUNTS[selected_shard] + 1
+      ))
+    fi
   done < <(
     for key in "${!INTEGRATION_SHARD_WEIGHTS[@]}"; do
       printf '%s\t%s\n' "${INTEGRATION_SHARD_WEIGHTS[${key}]}" "${key}"
@@ -624,10 +647,234 @@ plan_integration_shards() {
   done
 }
 
+# The providersync manifest owns only the number of test shards and the two
+# source-derived relative weights. The complete test-name set always comes
+# from the current Go package, so a checked-in list cannot silently drift.
+load_providersync_test_shard_manifest() {
+  local manifest="${DEV_HEALTH_GO_PROVIDER_TEST_SHARD_MANIFEST}"
+  local line_number=0 key value extra
+  local shards_seen=0 integration_weight_seen=0 ordinary_weight_seen=0
+
+  [ -f "${manifest}" ] \
+    || die "provider test shard manifest not found: ${manifest}"
+
+  PROVIDER_TEST_SHARD_COUNT=0
+  PROVIDER_INTEGRATION_TEST_WEIGHT=0
+  PROVIDER_ORDINARY_TEST_WEIGHT=0
+  while IFS=$'\t ' read -r key value extra; do
+    line_number=$((line_number + 1))
+    case "${key}" in
+      ""|\#*) continue ;;
+    esac
+    if [ -n "${extra}" ]; then
+      die "provider test shard manifest ${manifest}:${line_number} must contain exactly two fields"
+    fi
+    case "${value}" in
+      ""|*[!0-9]*)
+        die "provider test shard manifest ${manifest}:${line_number} has non-numeric value '${value}'"
+        ;;
+    esac
+    if [ "${value}" -le 0 ]; then
+      die "provider test shard manifest ${manifest}:${line_number} values must be positive"
+    fi
+
+    case "${key}" in
+      shards)
+        [ "${shards_seen}" -eq 0 ] \
+          || die "provider test shard manifest declares 'shards' more than once"
+        shards_seen=1
+        PROVIDER_TEST_SHARD_COUNT="${value}"
+        ;;
+      integration-test-weight)
+        [ "${integration_weight_seen}" -eq 0 ] \
+          || die "provider test shard manifest declares 'integration-test-weight' more than once"
+        integration_weight_seen=1
+        PROVIDER_INTEGRATION_TEST_WEIGHT="${value}"
+        ;;
+      ordinary-test-weight)
+        [ "${ordinary_weight_seen}" -eq 0 ] \
+          || die "provider test shard manifest declares 'ordinary-test-weight' more than once"
+        ordinary_weight_seen=1
+        PROVIDER_ORDINARY_TEST_WEIGHT="${value}"
+        ;;
+      *)
+        die "provider test shard manifest ${manifest}:${line_number} has unknown key '${key}'"
+        ;;
+    esac
+  done < "${manifest}"
+
+  [ "${shards_seen}" -eq 1 ] \
+    || die "provider test shard manifest must declare one 'shards' row"
+  [ "${integration_weight_seen}" -eq 1 ] \
+    || die "provider test shard manifest must declare one 'integration-test-weight' row"
+  [ "${ordinary_weight_seen}" -eq 1 ] \
+    || die "provider test shard manifest must declare one 'ordinary-test-weight' row"
+  [ "${PROVIDER_TEST_SHARD_COUNT}" -ge 2 ] \
+    || die "provider test shard manifest must declare at least two shards"
+}
+
+# Go's own test listing is the executable-name authority. Source inspection is
+# used only to classify those names by cost, and only across files `go list`
+# says are active for the integration build tag on this runner.
+discover_providersync_tests() {
+  local list_output files_output go_file source_file test_name
+  declare -A discovered_names=()
+
+  if ! list_output="$(
+    cd "${ROOT}"
+    GOWORK=off go test -mod=readonly -tags=integration -count=1 -run '^$' -list '^Test' ./internal/providersync
+  )"; then
+    die "failed to discover providersync top-level tests with go test -list"
+  fi
+
+  PROVIDER_TEST_NAMES=()
+  while IFS= read -r test_name; do
+    case "${test_name}" in
+      Test*[![:alnum:]_]*)
+        die "providersync test discovery returned unsupported top-level test name '${test_name}'"
+        ;;
+      Test*) ;;
+      *) continue ;;
+    esac
+    [ -z "${discovered_names[${test_name}]+set}" ] \
+      || die "providersync test discovery returned '${test_name}' more than once"
+    discovered_names["${test_name}"]=1
+    PROVIDER_TEST_NAMES+=("${test_name}")
+  done < <(printf '%s\n' "${list_output}" | LC_ALL=C sort)
+
+  [ "${#PROVIDER_TEST_NAMES[@]}" -gt 0 ] \
+    || die "providersync test discovery returned zero top-level tests"
+  [ "${PROVIDER_TEST_SHARD_COUNT}" -le "${#PROVIDER_TEST_NAMES[@]}" ] \
+    || die "provider test shard manifest declares more shards than discovered tests"
+
+  if ! files_output="$(
+    cd "${ROOT}"
+    GOWORK=off go list -mod=readonly -tags=integration \
+      -f '{{range .TestGoFiles}}{{println .}}{{end}}{{range .XTestGoFiles}}{{println .}}{{end}}' \
+      ./internal/providersync
+  )"; then
+    die "failed to discover active providersync test files with go list"
+  fi
+
+  PROVIDER_INTEGRATION_TEST_NAMES=()
+  while IFS= read -r go_file; do
+    [ -n "${go_file}" ] || continue
+    case "${go_file}" in
+      */*|..*) die "go list returned unsafe providersync test filename '${go_file}'" ;;
+    esac
+    source_file="${ROOT}/${PROVIDER_INTEGRATION_PACKAGE_KEY}/${go_file}"
+    [ -f "${source_file}" ] \
+      || die "go list returned missing providersync test file '${go_file}'"
+    grep -qE '^//go:build.*(^|[^[:alnum:]_])integration([^[:alnum:]_]|$)' \
+      "${source_file}" || continue
+    while IFS= read -r test_name; do
+      [ -n "${test_name}" ] || continue
+      [ -z "${PROVIDER_INTEGRATION_TEST_NAMES[${test_name}]+set}" ] \
+        || die "integration-tagged providersync source declares '${test_name}' more than once"
+      PROVIDER_INTEGRATION_TEST_NAMES["${test_name}"]=1
+    done < <(
+      sed -nE 's/^func[[:space:]]+(Test[A-Za-z0-9_]+)[[:space:]]*\(.*/\1/p' \
+        "${source_file}"
+    )
+  done <<< "${files_output}"
+
+  [ "${#PROVIDER_INTEGRATION_TEST_NAMES[@]}" -gt 0 ] \
+    || die "providersync source discovery returned zero integration-tagged top-level tests"
+  for test_name in "${!PROVIDER_INTEGRATION_TEST_NAMES[@]}"; do
+    [ -n "${discovered_names[${test_name}]+set}" ] \
+      || die "integration-tagged providersync source test '${test_name}' is absent from go test -list"
+  done
+
+  PROVIDER_TEST_WEIGHTS=()
+  PROVIDER_TEST_CLASS=()
+  for test_name in "${PROVIDER_TEST_NAMES[@]}"; do
+    if [ -n "${PROVIDER_INTEGRATION_TEST_NAMES[${test_name}]+set}" ]; then
+      PROVIDER_TEST_WEIGHTS["${test_name}"]="${PROVIDER_INTEGRATION_TEST_WEIGHT}"
+      PROVIDER_TEST_CLASS["${test_name}"]="integration"
+    else
+      PROVIDER_TEST_WEIGHTS["${test_name}"]="${PROVIDER_ORDINARY_TEST_WEIGHT}"
+      PROVIDER_TEST_CLASS["${test_name}"]="ordinary"
+    fi
+  done
+}
+
+# Deterministic longest-processing-time-first assignment balances the costly
+# integration-tagged top-level tests first. Test names and lowest shard number
+# are the stable tie-breakers, matching the package-level plan above.
+plan_providersync_test_shards() {
+  local test_name weight shard selected_shard selected_total
+
+  load_providersync_test_shard_manifest
+  discover_providersync_tests
+
+  PROVIDER_TEST_SHARD_BY_NAME=()
+  PROVIDER_TEST_SHARD_TOTALS=()
+  PROVIDER_TEST_SHARD_COUNTS=()
+  PROVIDER_TEST_SHARD_INTEGRATION_COUNTS=()
+  for ((shard = 1; shard <= PROVIDER_TEST_SHARD_COUNT; shard++)); do
+    PROVIDER_TEST_SHARD_TOTALS[shard]=0
+    PROVIDER_TEST_SHARD_COUNTS[shard]=0
+    PROVIDER_TEST_SHARD_INTEGRATION_COUNTS[shard]=0
+  done
+
+  while IFS=$'\t' read -r weight test_name; do
+    selected_shard=1
+    selected_total="${PROVIDER_TEST_SHARD_TOTALS[1]}"
+    for ((shard = 2; shard <= PROVIDER_TEST_SHARD_COUNT; shard++)); do
+      if [ "${PROVIDER_TEST_SHARD_TOTALS[${shard}]}" -lt "${selected_total}" ]; then
+        selected_shard="${shard}"
+        selected_total="${PROVIDER_TEST_SHARD_TOTALS[${shard}]}"
+      fi
+    done
+    PROVIDER_TEST_SHARD_BY_NAME["${test_name}"]="${selected_shard}"
+    PROVIDER_TEST_SHARD_TOTALS[selected_shard]=$((
+      PROVIDER_TEST_SHARD_TOTALS[selected_shard] + weight
+    ))
+    PROVIDER_TEST_SHARD_COUNTS[selected_shard]=$((
+      PROVIDER_TEST_SHARD_COUNTS[selected_shard] + 1
+    ))
+    if [ "${PROVIDER_TEST_CLASS[${test_name}]}" = "integration" ]; then
+      PROVIDER_TEST_SHARD_INTEGRATION_COUNTS[selected_shard]=$((
+        PROVIDER_TEST_SHARD_INTEGRATION_COUNTS[selected_shard] + 1
+      ))
+    fi
+  done < <(
+    for test_name in "${PROVIDER_TEST_NAMES[@]}"; do
+      printf '%s\t%s\n' "${PROVIDER_TEST_WEIGHTS[${test_name}]}" "${test_name}"
+    done | LC_ALL=C sort -t $'\t' -k1,1nr -k2,2
+  )
+
+  printf 'providersync test plan: %d shard(s), %d top-level test(s), %d integration-tagged\n' \
+    "${PROVIDER_TEST_SHARD_COUNT}" \
+    "${#PROVIDER_TEST_NAMES[@]}" \
+    "${#PROVIDER_INTEGRATION_TEST_NAMES[@]}"
+  for ((shard = 1; shard <= PROVIDER_TEST_SHARD_COUNT; shard++)); do
+    printf 'providersync test shard %d: relative weight %d, %d test(s), %d integration-tagged\n' \
+      "${shard}" \
+      "${PROVIDER_TEST_SHARD_TOTALS[${shard}]}" \
+      "${PROVIDER_TEST_SHARD_COUNTS[${shard}]}" \
+      "${PROVIDER_TEST_SHARD_INTEGRATION_COUNTS[${shard}]}"
+    for test_name in "${PROVIDER_TEST_NAMES[@]}"; do
+      if [ "${PROVIDER_TEST_SHARD_BY_NAME[${test_name}]:-0}" -eq "${shard}" ]; then
+        printf '  PROVIDER-SHARD %d %s weight=%d class=%s\n' \
+          "${shard}" \
+          "${test_name}" \
+          "${PROVIDER_TEST_WEIGHTS[${test_name}]}" \
+          "${PROVIDER_TEST_CLASS[${test_name}]}"
+      fi
+    done
+  done
+}
+
 emit_integration_shard_matrix() {
   local matrix='{"include":[' separator="" shard
+  for ((shard = 1; shard <= PROVIDER_TEST_SHARD_COUNT; shard++)); do
+    matrix+="${separator}{\"target\":\"providersync\",\"shard\":${shard}}"
+    separator=","
+  done
   for ((shard = 1; shard <= INTEGRATION_SHARD_COUNT; shard++)); do
-    matrix+="${separator}{\"shard\":${shard}}"
+    [ "${INTEGRATION_SHARD_NON_PROVIDER_COUNTS[${shard}]}" -gt 0 ] || continue
+    matrix+="${separator}{\"target\":\"packages\",\"shard\":${shard}}"
     separator=","
   done
   matrix+=']}'
@@ -639,27 +886,19 @@ emit_integration_shard_matrix() {
 
 check_integration_shard_plan() {
   plan_integration_shards
+  plan_providersync_test_shards
   emit_integration_shard_matrix
 }
 
-check_integration_shard() {
-  local shard="${1:-}" mode="${2:-}"
+check_integration_package_shard() {
+  local shard="$1" mode="$2"
   local index module_dir pkg key
   local selected_count=0
   local -a run_pkgs=()
   local -a run_keys=()
 
-  case "${shard}" in
-    ""|*[!0-9]*) die "integration-shard requires a numeric shard id" ;;
-  esac
-  case "${mode}" in
-    ""|--dry-run) ;;
-    *) die "integration-shard accepts only the optional --dry-run flag" ;;
-  esac
-
-  plan_integration_shards
   if [ "${shard}" -lt 1 ] || [ "${shard}" -gt "${INTEGRATION_SHARD_COUNT}" ]; then
-    die "integration shard ${shard} is outside 1..${INTEGRATION_SHARD_COUNT}"
+    die "integration package shard ${shard} is outside 1..${INTEGRATION_SHARD_COUNT}"
   fi
 
   for module_dir in "${MODULE_DIRS[@]}"; do
@@ -670,6 +909,7 @@ check_integration_shard() {
       pkg="${INTEGRATION_PACKAGES[${index}]}"
       key="${module_dir}/${pkg#./}"
       key="${key#./}"
+      [ "${key}" != "${PROVIDER_INTEGRATION_PACKAGE_KEY}" ] || continue
       [ "${INTEGRATION_SHARD_BY_KEY[${key}]:-0}" -eq "${shard}" ] || continue
       run_pkgs+=("${pkg}")
       run_keys+=("${key}")
@@ -677,7 +917,7 @@ check_integration_shard() {
     done
     [ "${#run_pkgs[@]}" -gt 0 ] || continue
 
-    printf 'go test integration shard %s: %s -> %s\n' \
+    printf 'go test integration package shard %s: %s -> %s\n' \
       "${shard}" "${module_dir}" "${run_pkgs[*]}"
     for key in "${run_keys[@]}"; do
       printf '  SHARD-RUN %s\n' "${key}"
@@ -692,18 +932,79 @@ check_integration_shard() {
   done
 
   [ "${selected_count}" -gt 0 ] \
-    || die "integration shard ${shard} selected zero packages"
-  if [ "${selected_count}" -ne "${INTEGRATION_SHARD_PACKAGE_COUNTS[${shard}]}" ]; then
-    die "integration shard ${shard} selected ${selected_count} packages but plan declared ${INTEGRATION_SHARD_PACKAGE_COUNTS[${shard}]}"
+    || die "integration package shard ${shard} selected zero packages"
+  if [ "${selected_count}" -ne "${INTEGRATION_SHARD_NON_PROVIDER_COUNTS[${shard}]}" ]; then
+    die "integration package shard ${shard} selected ${selected_count} packages but plan declared ${INTEGRATION_SHARD_NON_PROVIDER_COUNTS[${shard}]}"
   fi
   if [ "${mode}" = "--dry-run" ]; then
-    printf 'integration shard %s: DRY RUN selected %d package(s); no tests executed\n' \
+    printf 'integration package shard %s: DRY RUN selected %d package(s); no tests executed\n' \
       "${shard}" "${selected_count}"
   fi
 }
 
+check_providersync_test_shard() {
+  local shard="$1" mode="$2"
+  local test_name separator="" test_regex='^('
+  local selected_count=0
+
+  if [ "${shard}" -lt 1 ] || [ "${shard}" -gt "${PROVIDER_TEST_SHARD_COUNT}" ]; then
+    die "providersync test shard ${shard} is outside 1..${PROVIDER_TEST_SHARD_COUNT}"
+  fi
+
+  for test_name in "${PROVIDER_TEST_NAMES[@]}"; do
+    [ "${PROVIDER_TEST_SHARD_BY_NAME[${test_name}]:-0}" -eq "${shard}" ] || continue
+    printf '  PROVIDER-TEST-RUN %s\n' "${test_name}"
+    test_regex+="${separator}${test_name}"
+    separator="|"
+    selected_count=$((selected_count + 1))
+  done
+  test_regex+=')$'
+
+  [ "${selected_count}" -gt 0 ] \
+    || die "providersync test shard ${shard} selected zero tests"
+  if [ "${selected_count}" -ne "${PROVIDER_TEST_SHARD_COUNTS[${shard}]}" ]; then
+    die "providersync test shard ${shard} selected ${selected_count} tests but plan declared ${PROVIDER_TEST_SHARD_COUNTS[${shard}]}"
+  fi
+  if [ "${mode}" = "--dry-run" ]; then
+    printf 'providersync test shard %s: DRY RUN selected %d top-level test(s); no tests executed\n' \
+      "${shard}" "${selected_count}"
+    return 0
+  fi
+
+  printf 'go test providersync test shard %s: %d top-level test(s)\n' \
+    "${shard}" "${selected_count}"
+  (
+    cd "${ROOT}"
+    GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=30m -run "${test_regex}" ./internal/providersync
+  )
+}
+
+check_integration_shard() {
+  local target="${1:-}" shard="${2:-}" mode="${3:-}"
+
+  case "${target}" in
+    packages|providersync) ;;
+    *) die "integration-shard TARGET must be 'packages' or 'providersync'" ;;
+  esac
+  case "${shard}" in
+    ""|*[!0-9]*) die "integration-shard requires a numeric shard id" ;;
+  esac
+  case "${mode}" in
+    ""|--dry-run) ;;
+    *) die "integration-shard accepts only the optional --dry-run flag" ;;
+  esac
+
+  plan_integration_shards
+  plan_providersync_test_shards
+  case "${target}" in
+    packages) check_integration_package_shard "${shard}" "${mode}" ;;
+    providersync) check_providersync_test_shard "${shard}" "${mode}" ;;
+  esac
+}
+
 check_integration() {
   plan_integration_shards
+  plan_providersync_test_shards
   local index module_dir pkg key reason
   local -a run_pkgs=()
 
@@ -783,9 +1084,9 @@ case "${1:-all}" in
     check_integration_shard_plan
     ;;
   integration-shard)
-    [ "$#" -ge 2 ] && [ "$#" -le 3 ] \
-      || die "integration-shard requires SHARD and accepts only optional --dry-run"
-    check_integration_shard "$2" "${3:-}"
+    [ "$#" -ge 3 ] && [ "$#" -le 4 ] \
+      || die "integration-shard requires TARGET SHARD and accepts only optional --dry-run"
+    check_integration_shard "$2" "$3" "${4:-}"
     ;;
   integration)
     check_integration
@@ -799,6 +1100,7 @@ case "${1:-all}" in
     check_contract
     check_integration_vet
     plan_integration_shards
+    plan_providersync_test_shards
     check_grant_advisory
     ;;
   all)
@@ -811,6 +1113,7 @@ case "${1:-all}" in
     check_contract
     check_integration_vet
     plan_integration_shards
+    plan_providersync_test_shards
     check_grant_advisory
     ;;
   -h|--help|help)

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -1148,8 +1148,9 @@ case "${1:-all}" in
     check_integration_prepull
     ;;
   integration-shard)
-    [ "$#" -ge 3 ] && [ "$#" -le 4 ] \
-      || die "integration-shard requires TARGET SHARD and accepts only optional --dry-run"
+    if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+      die "integration-shard requires TARGET SHARD and accepts only optional --dry-run"
+    fi
     check_integration_shard "$2" "$3" "${4:-}"
     ;;
   integration)

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -12,11 +12,12 @@ mkdir -p "${DEV_HEALTH_GO_CACHE}"
 export GOCACHE="${DEV_HEALTH_GO_CACHE}"
 DEV_HEALTH_GO_BUILD_OUTPUT=""
 DEV_HEALTH_GO_BUILD_TEMP_ROOT=""
+DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST="${DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST:-${ROOT}/ci/go_integration_shards.tsv}"
 
 usage() {
   # Backticks in the literal help text document commands; they are not substitutions.
   # shellcheck disable=SC2016
-  printf '%s\n' 'Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|integration-vet|integration-coverage|integration|fast|all]
+  printf '%s\n' 'Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|integration-vet|integration-coverage|integration-shard-plan|integration-shard|integration|fast|all]
 
   fmt    Check gofmt without modifying files.
   vet    Run go vet ./... in every Go module.
@@ -56,16 +57,25 @@ usage() {
          plan (see INTEGRATION_DENYLIST in this script). No Docker required.
          Fails if the denylist names a package discovery does not find, or if
          discovery finds nothing at all.
+  integration-shard-plan
+         Validate ci/go_integration_shards.tsv against live package discovery,
+         derive deterministic longest-processing-time-first shard assignments,
+         print the complete assignment, and write a GitHub Actions `matrix`
+         output when GITHUB_OUTPUT is set. No Docker required.
+  integration-shard SHARD [--dry-run]
+         Run exactly one validated integration shard. `--dry-run` prints the
+         exact package selection without starting Docker-backed tests; CI never
+         passes that option.
   integration
          Discover and run EVERY integration-tagged package'\''s suite against
          real containers, except the (small, justified) INTEGRATION_DENYLIST.
          Inclusion is the default; exclusion is the explicit, loud exception.
   fast   Run fmt, vet, test, live-python-oracles, build, contract,
-         integration-vet, and integration-coverage checks, then publish
-         the grant advisory report.
+         integration-vet, and the integration shard-plan checks, then
+         publish the grant advisory report.
   all    Run fmt, vet, test, race, live-python-oracles, build, contract,
-         integration-vet, and integration-coverage checks, then publish
-         the grant advisory report (default).'
+         integration-vet, and the integration shard-plan checks, then
+         publish the grant advisory report (default).'
 }
 
 die() {
@@ -366,6 +376,11 @@ check_contract() {
 # the run set, failing loudly, not hidden here. Legitimate reasons look like
 # "needs a live vendor credential CI does not provision."
 declare -A INTEGRATION_DENYLIST=()
+declare -A INTEGRATION_SHARD_WEIGHTS=()
+declare -A INTEGRATION_SHARD_BY_KEY=()
+declare -a INTEGRATION_SHARD_TOTALS=()
+declare -a INTEGRATION_SHARD_PACKAGE_COUNTS=()
+INTEGRATION_SHARD_COUNT=0
 
 # discover_integration_packages populates parallel module/package arrays with
 # every module-relative "./pkg/dir" entry that has at least one tracked or
@@ -466,8 +481,229 @@ check_integration_coverage() {
     "${total}" "${#denylist_seen[@]}" "$((total - ${#denylist_seen[@]}))"
 }
 
-check_integration() {
+# load_integration_shard_manifest validates the manifest's syntax only. The
+# package-set equality check happens in plan_integration_shards after live
+# discovery, so neither the manifest nor the source scan can silently stand in
+# for the other.
+load_integration_shard_manifest() {
+  local manifest="${DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST}"
+  local line_number=0 key value extra
+  local shards_seen=0
+
+  [ -f "${manifest}" ] \
+    || die "integration shard manifest not found: ${manifest}"
+
+  INTEGRATION_SHARD_WEIGHTS=()
+  INTEGRATION_SHARD_COUNT=0
+  while IFS=$'\t ' read -r key value extra; do
+    line_number=$((line_number + 1))
+    case "${key}" in
+      ""|\#*) continue ;;
+    esac
+    if [ -n "${extra}" ]; then
+      die "integration shard manifest ${manifest}:${line_number} must contain exactly two fields"
+    fi
+    case "${value}" in
+      ""|*[!0-9]*)
+        die "integration shard manifest ${manifest}:${line_number} has non-numeric value '${value}'"
+        ;;
+    esac
+    if [ "${value}" -le 0 ]; then
+      die "integration shard manifest ${manifest}:${line_number} values must be positive"
+    fi
+
+    if [ "${key}" = "shards" ]; then
+      [ "${shards_seen}" -eq 0 ] \
+        || die "integration shard manifest declares 'shards' more than once"
+      shards_seen=1
+      INTEGRATION_SHARD_COUNT="${value}"
+      continue
+    fi
+    if [ -n "${INTEGRATION_SHARD_WEIGHTS[${key}]+set}" ]; then
+      die "integration shard manifest lists '${key}' more than once"
+    fi
+    INTEGRATION_SHARD_WEIGHTS["${key}"]="${value}"
+  done < "${manifest}"
+
+  [ "${shards_seen}" -eq 1 ] \
+    || die "integration shard manifest must declare one 'shards' row"
+  [ "${INTEGRATION_SHARD_COUNT}" -ge 2 ] \
+    || die "integration shard manifest must declare at least two shards"
+}
+
+# plan_integration_shards performs deterministic longest-processing-time-first
+# assignment from the checked-in weights. Package paths break equal-weight
+# ties; the lowest-numbered shard breaks equal-load ties. A single dominant
+# package therefore stays isolated while the remaining packages balance across
+# the other jobs. Every call starts with fresh source discovery and exact
+# manifest equality, preserving the 24/24, zero-denylist contract independently
+# in every matrix runner.
+plan_integration_shards() {
   check_integration_coverage
+  load_integration_shard_manifest
+
+  local index module_dir pkg key reason manifest_key
+  local runnable_count=0
+  local shard selected_shard selected_total weight
+  declare -A discovered_run_packages=()
+
+  for index in "${!INTEGRATION_PACKAGES[@]}"; do
+    module_dir="${INTEGRATION_PACKAGE_MODULES[${index}]}"
+    pkg="${INTEGRATION_PACKAGES[${index}]}"
+    key="${module_dir}/${pkg#./}"
+    key="${key#./}"
+    if reason="$(integration_denylist_reason "${key}")"; then
+      continue
+    fi
+    discovered_run_packages["${key}"]=1
+    runnable_count=$((runnable_count + 1))
+    if [ -z "${INTEGRATION_SHARD_WEIGHTS[${key}]+set}" ]; then
+      die "integration shard manifest is missing discovered package '${key}'"
+    fi
+  done
+
+  for manifest_key in "${!INTEGRATION_SHARD_WEIGHTS[@]}"; do
+    if [ -z "${discovered_run_packages[${manifest_key}]+set}" ]; then
+      die "integration shard manifest names undiscovered or denylisted package '${manifest_key}'"
+    fi
+  done
+  if [ "${#INTEGRATION_SHARD_WEIGHTS[@]}" -ne "${runnable_count}" ]; then
+    die "integration shard manifest/package count mismatch after equality validation"
+  fi
+  if [ "${INTEGRATION_SHARD_COUNT}" -gt "${runnable_count}" ]; then
+    die "integration shard manifest declares more shards than runnable packages"
+  fi
+
+  INTEGRATION_SHARD_BY_KEY=()
+  INTEGRATION_SHARD_TOTALS=()
+  INTEGRATION_SHARD_PACKAGE_COUNTS=()
+  for ((shard = 1; shard <= INTEGRATION_SHARD_COUNT; shard++)); do
+    INTEGRATION_SHARD_TOTALS[shard]=0
+    INTEGRATION_SHARD_PACKAGE_COUNTS[shard]=0
+  done
+
+  while IFS=$'\t' read -r weight key; do
+    selected_shard=1
+    selected_total="${INTEGRATION_SHARD_TOTALS[1]}"
+    for ((shard = 2; shard <= INTEGRATION_SHARD_COUNT; shard++)); do
+      if [ "${INTEGRATION_SHARD_TOTALS[${shard}]}" -lt "${selected_total}" ]; then
+        selected_shard="${shard}"
+        selected_total="${INTEGRATION_SHARD_TOTALS[${shard}]}"
+      fi
+    done
+    INTEGRATION_SHARD_BY_KEY["${key}"]="${selected_shard}"
+    INTEGRATION_SHARD_TOTALS[selected_shard]=$((
+      INTEGRATION_SHARD_TOTALS[selected_shard] + weight
+    ))
+    INTEGRATION_SHARD_PACKAGE_COUNTS[selected_shard]=$((
+      INTEGRATION_SHARD_PACKAGE_COUNTS[selected_shard] + 1
+    ))
+  done < <(
+    for key in "${!INTEGRATION_SHARD_WEIGHTS[@]}"; do
+      printf '%s\t%s\n' "${INTEGRATION_SHARD_WEIGHTS[${key}]}" "${key}"
+    done | LC_ALL=C sort -t $'\t' -k1,1nr -k2,2
+  )
+
+  printf 'integration shard plan: %d shard(s), %d package(s)\n' \
+    "${INTEGRATION_SHARD_COUNT}" "${runnable_count}"
+  for ((shard = 1; shard <= INTEGRATION_SHARD_COUNT; shard++)); do
+    printf 'integration shard %d: estimated %ds, %d package(s)\n' \
+      "${shard}" \
+      "${INTEGRATION_SHARD_TOTALS[${shard}]}" \
+      "${INTEGRATION_SHARD_PACKAGE_COUNTS[${shard}]}"
+    for index in "${!INTEGRATION_PACKAGES[@]}"; do
+      module_dir="${INTEGRATION_PACKAGE_MODULES[${index}]}"
+      pkg="${INTEGRATION_PACKAGES[${index}]}"
+      key="${module_dir}/${pkg#./}"
+      key="${key#./}"
+      if [ "${INTEGRATION_SHARD_BY_KEY[${key}]:-0}" -eq "${shard}" ]; then
+        printf '  SHARD %d %s weight=%ss\n' \
+          "${shard}" "${key}" "${INTEGRATION_SHARD_WEIGHTS[${key}]}"
+      fi
+    done
+  done
+}
+
+emit_integration_shard_matrix() {
+  local matrix='{"include":[' separator="" shard
+  for ((shard = 1; shard <= INTEGRATION_SHARD_COUNT; shard++)); do
+    matrix+="${separator}{\"shard\":${shard}}"
+    separator=","
+  done
+  matrix+=']}'
+  printf 'integration shard matrix: %s\n' "${matrix}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf 'matrix=%s\n' "${matrix}" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+check_integration_shard_plan() {
+  plan_integration_shards
+  emit_integration_shard_matrix
+}
+
+check_integration_shard() {
+  local shard="${1:-}" mode="${2:-}"
+  local index module_dir pkg key
+  local selected_count=0
+  local -a run_pkgs=()
+  local -a run_keys=()
+
+  case "${shard}" in
+    ""|*[!0-9]*) die "integration-shard requires a numeric shard id" ;;
+  esac
+  case "${mode}" in
+    ""|--dry-run) ;;
+    *) die "integration-shard accepts only the optional --dry-run flag" ;;
+  esac
+
+  plan_integration_shards
+  if [ "${shard}" -lt 1 ] || [ "${shard}" -gt "${INTEGRATION_SHARD_COUNT}" ]; then
+    die "integration shard ${shard} is outside 1..${INTEGRATION_SHARD_COUNT}"
+  fi
+
+  for module_dir in "${MODULE_DIRS[@]}"; do
+    run_pkgs=()
+    run_keys=()
+    for index in "${!INTEGRATION_PACKAGES[@]}"; do
+      [ "${INTEGRATION_PACKAGE_MODULES[${index}]}" = "${module_dir}" ] || continue
+      pkg="${INTEGRATION_PACKAGES[${index}]}"
+      key="${module_dir}/${pkg#./}"
+      key="${key#./}"
+      [ "${INTEGRATION_SHARD_BY_KEY[${key}]:-0}" -eq "${shard}" ] || continue
+      run_pkgs+=("${pkg}")
+      run_keys+=("${key}")
+      selected_count=$((selected_count + 1))
+    done
+    [ "${#run_pkgs[@]}" -gt 0 ] || continue
+
+    printf 'go test integration shard %s: %s -> %s\n' \
+      "${shard}" "${module_dir}" "${run_pkgs[*]}"
+    for key in "${run_keys[@]}"; do
+      printf '  SHARD-RUN %s\n' "${key}"
+    done
+    if [ "${mode}" = "--dry-run" ]; then
+      continue
+    fi
+    (
+      cd "${ROOT}/${module_dir}"
+      GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=30m "${run_pkgs[@]}"
+    )
+  done
+
+  [ "${selected_count}" -gt 0 ] \
+    || die "integration shard ${shard} selected zero packages"
+  if [ "${selected_count}" -ne "${INTEGRATION_SHARD_PACKAGE_COUNTS[${shard}]}" ]; then
+    die "integration shard ${shard} selected ${selected_count} packages but plan declared ${INTEGRATION_SHARD_PACKAGE_COUNTS[${shard}]}"
+  fi
+  if [ "${mode}" = "--dry-run" ]; then
+    printf 'integration shard %s: DRY RUN selected %d package(s); no tests executed\n' \
+      "${shard}" "${selected_count}"
+  fi
+}
+
+check_integration() {
+  plan_integration_shards
   local index module_dir pkg key reason
   local -a run_pkgs=()
 
@@ -542,6 +778,15 @@ case "${1:-all}" in
   integration-coverage)
     check_integration_coverage
     ;;
+  integration-shard-plan)
+    [ "$#" -eq 1 ] || die "integration-shard-plan accepts no arguments"
+    check_integration_shard_plan
+    ;;
+  integration-shard)
+    [ "$#" -ge 2 ] && [ "$#" -le 3 ] \
+      || die "integration-shard requires SHARD and accepts only optional --dry-run"
+    check_integration_shard "$2" "${3:-}"
+    ;;
   integration)
     check_integration
     ;;
@@ -553,7 +798,7 @@ case "${1:-all}" in
     check_build
     check_contract
     check_integration_vet
-    check_integration_coverage
+    plan_integration_shards
     check_grant_advisory
     ;;
   all)
@@ -565,7 +810,7 @@ case "${1:-all}" in
     check_build
     check_contract
     check_integration_vet
-    check_integration_coverage
+    plan_integration_shards
     check_grant_advisory
     ;;
   -h|--help|help)

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -14,11 +14,12 @@ DEV_HEALTH_GO_BUILD_OUTPUT=""
 DEV_HEALTH_GO_BUILD_TEMP_ROOT=""
 DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST="${DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST:-${ROOT}/ci/go_integration_shards.tsv}"
 DEV_HEALTH_GO_PROVIDER_TEST_SHARD_MANIFEST="${DEV_HEALTH_GO_PROVIDER_TEST_SHARD_MANIFEST:-${ROOT}/ci/go_providersync_test_shards.tsv}"
+INTEGRATION_CONTAINER_HARNESS="${ROOT}/internal/testsupport/containers/harness.go"
 
 usage() {
   # Backticks in the literal help text document commands; they are not substitutions.
   # shellcheck disable=SC2016
-  printf '%s\n' 'Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|integration-vet|integration-coverage|integration-shard-plan|integration-shard|integration|fast|all]
+  printf '%s\n' 'Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|integration-vet|integration-coverage|integration-shard-plan|integration-prepull|integration-shard|integration|fast|all]
 
   fmt    Check gofmt without modifying files.
   vet    Run go vet ./... in every Go module.
@@ -63,6 +64,10 @@ usage() {
          derive deterministic longest-processing-time-first shard assignments,
          print the complete assignment, and write a GitHub Actions `matrix`
          output when GITHUB_OUTPUT is set. No Docker required.
+  integration-prepull
+         Pre-pull the exact pinned ClickHouse image declared by the Go test
+         container harness, retrying transient registry failures at most three
+         times before failing loudly. CI runs this before each real shard.
   integration-shard TARGET SHARD [--dry-run]
          Run exactly one validated integration shard. TARGET is `packages` for
          a package-level shard or `providersync` for a top-level test shard of
@@ -890,6 +895,61 @@ check_integration_shard_plan() {
   emit_integration_shard_matrix
 }
 
+# Read the test dependency from the production Go harness instead of copying a
+# digest into the workflow. Exact hosted evidence for this retry is PR #1735,
+# run 31524982512, job 93891310235: Docker Hub returned 502 for this pinned
+# manifest and testcontainers made no second pull attempt. The bounded pre-pull
+# keeps the immutable digest contract and makes each registry attempt visible.
+discover_pinned_clickhouse_image() {
+  local image
+  local -a images=()
+
+  [ -f "${INTEGRATION_CONTAINER_HARNESS}" ] \
+    || die "integration container harness not found: ${INTEGRATION_CONTAINER_HARNESS}"
+  while IFS= read -r image; do
+    [ -n "${image}" ] || continue
+    images+=("${image}")
+  done < <(
+    sed -nE \
+      's/^[[:space:]]*ClickHouseImage[[:space:]]*=[[:space:]]*"([^"]+)".*$/\1/p' \
+      "${INTEGRATION_CONTAINER_HARNESS}"
+  )
+
+  [ "${#images[@]}" -eq 1 ] \
+    || die "expected exactly one ClickHouseImage declaration in ${INTEGRATION_CONTAINER_HARNESS}, found ${#images[@]}"
+  image="${images[0]}"
+  if [[ ! "${image}" =~ ^[^@[:space:]]+@sha256:[0-9a-f]{64}$ ]]; then
+    die "ClickHouseImage must be pinned by a full sha256 digest, got '${image}'"
+  fi
+  printf '%s\n' "${image}"
+}
+
+check_integration_prepull() {
+  local image attempt delay
+  local max_attempts=3
+
+  command -v docker >/dev/null 2>&1 || die "docker is required for integration-prepull"
+  image="$(discover_pinned_clickhouse_image)"
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    printf 'pre-pull pinned ClickHouse image %s (attempt %d/%d)\n' \
+      "${image}" "${attempt}" "${max_attempts}"
+    if docker pull "${image}"; then
+      printf 'pre-pulled pinned ClickHouse image %s on attempt %d/%d\n' \
+        "${image}" "${attempt}" "${max_attempts}"
+      return 0
+    fi
+    if [ "${attempt}" -eq "${max_attempts}" ]; then
+      printf 'ERROR: failed to pre-pull pinned ClickHouse image %s after %d attempts\n' \
+        "${image}" "${max_attempts}" >&2
+      return 1
+    fi
+    delay=$((attempt * 5))
+    printf 'WARN: ClickHouse image pull attempt %d/%d failed; retrying in %ds\n' \
+      "${attempt}" "${max_attempts}" "${delay}" >&2
+    sleep "${delay}"
+  done
+}
+
 check_integration_package_shard() {
   local shard="$1" mode="$2"
   local index module_dir pkg key
@@ -1082,6 +1142,10 @@ case "${1:-all}" in
   integration-shard-plan)
     [ "$#" -eq 1 ] || die "integration-shard-plan accepts no arguments"
     check_integration_shard_plan
+    ;;
+  integration-prepull)
+    [ "$#" -eq 1 ] || die "integration-prepull accepts no arguments"
+    check_integration_prepull
     ;;
   integration-shard)
     [ "$#" -ge 3 ] && [ "$#" -le 4 ] \

--- a/ci/go_integration_shards.tsv
+++ b/ci/go_integration_shards.tsv
@@ -1,0 +1,38 @@
+# CHAOS-3141 deterministic package weights for Go integration CI sharding.
+#
+# The first data row declares the shard count. Remaining rows are
+# <repository-relative package key><TAB><estimated seconds>. The package set is
+# checked against ci/check_go.sh's live integration-tag discovery before any
+# shard runs, so this file cannot silently omit or duplicate a package.
+#
+# Most weights are rounded up from the latest complete go-storage-integration
+# runner (2026-08-03) or PR #1733's completed package lines (2026-08-11).
+# internal/providersync is rounded from the exact current-feature local run,
+# 1165.894s. Longest-processing-time-first assignment keeps the two
+# non-dominant shards balanced while isolating that indivisible dominant
+# package under the unchanged 25-minute job budget.
+shards	3
+cmd/dev-health-worker	19
+cmd/dev-health-workerctl	13
+internal/externalrecompute	15
+internal/joboperator	13
+internal/joboutbox	12
+internal/jobroute	6
+internal/jobruntime	5
+internal/jobs/metrics/daily	6
+internal/jobs/metrics/remaining	6
+internal/jobs/pagerduty	9
+internal/jobs/report	33
+internal/jobs/system	12
+internal/jobs/workgraph	7
+internal/providerfoundation	12
+internal/providersync	1166
+internal/scheduler/fixed	143
+internal/scheduler/sync	32
+internal/storage/postgres	91
+internal/storage/river	9
+internal/streamrunner	2
+internal/syncdispatchruntime	6
+internal/syncreconciler	16
+internal/syncroute	3
+internal/testsupport/containers	13

--- a/ci/go_providersync_test_shards.tsv
+++ b/ci/go_providersync_test_shards.tsv
@@ -1,0 +1,15 @@
+# CHAOS-3141 deterministic top-level-test weights for providersync integration CI.
+#
+# internal/providersync alone exceeded the unchanged 25-minute workflow cap in
+# PR #1735. Its top-level tests are therefore assigned independently from the
+# other integration packages. ci/check_go.sh discovers the complete executable
+# test-name set from `go test -list`, identifies the active integration-tagged
+# source files through `go list`, and applies these relative weights before
+# deterministic longest-processing-time-first assignment.
+#
+# These are intentionally relative source classes, not invented wall-clock
+# seconds: integration-tagged tests dominate container-backed runtime, while
+# ordinary tests are retained in the exact-once partition at the base weight.
+shards	4
+integration-test-weight	100
+ordinary-test-weight	1

--- a/tests/tooling/test_check_go_integration_coverage.py
+++ b/tests/tooling/test_check_go_integration_coverage.py
@@ -29,4 +29,4 @@ def test_integration_coverage_inventory_completes_and_stays_nonempty() -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "  RUN  internal/providersync" in result.stdout
-    assert "package(s) discovered, 0 denylisted" in result.stdout
+    assert "24 package(s) discovered, 0 denylisted, 24 will run" in result.stdout

--- a/tests/tooling/test_check_go_public_verbs.py
+++ b/tests/tooling/test_check_go_public_verbs.py
@@ -19,6 +19,7 @@ PUBLIC_VERBS = (
     "integration-vet",
     "integration-coverage",
     "integration-shard-plan",
+    "integration-prepull",
     "integration-shard",
     "integration",
     "fast",

--- a/tests/tooling/test_check_go_public_verbs.py
+++ b/tests/tooling/test_check_go_public_verbs.py
@@ -18,6 +18,8 @@ PUBLIC_VERBS = (
     "grant-advisory",
     "integration-vet",
     "integration-coverage",
+    "integration-shard-plan",
+    "integration-shard",
     "integration",
     "fast",
     "all",

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,12 @@ CHECK_GO = ROOT / "ci" / "check_go.sh"
 MANIFEST = ROOT / "ci" / "go_integration_shards.tsv"
 PROVIDER_MANIFEST = ROOT / "ci" / "go_providersync_test_shards.tsv"
 PROVIDER_PACKAGE = "internal/providersync"
+CONTAINER_HARNESS = ROOT / "internal" / "testsupport" / "containers" / "harness.go"
+TEST_GO_CACHE = Path(tempfile.gettempdir()) / "chaos3141-go-sharding-test-cache"
+# Hosted job 93890967576 measured 49.596s for a cold planner invocation. This
+# test-process guard is deliberately above twice that observed completion; it
+# does not change the workflow job cap or the Go test timeout.
+CHECK_GO_TIMEOUT_SECONDS = 120
 
 EXPECTED_PACKAGES = {
     "cmd/dev-health-worker",
@@ -55,6 +62,7 @@ def _run_check_go(
     env = os.environ.copy()
     env["DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST"] = str(manifest)
     env["DEV_HEALTH_GO_PROVIDER_TEST_SHARD_MANIFEST"] = str(provider_manifest)
+    env["DEV_HEALTH_GO_CACHE"] = str(TEST_GO_CACHE)
     if github_output is not None:
         env["GITHUB_OUTPUT"] = str(github_output)
     return subprocess.run(
@@ -64,7 +72,7 @@ def _run_check_go(
         check=False,
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=CHECK_GO_TIMEOUT_SECONDS,
     )
 
 
@@ -72,11 +80,24 @@ def _workflow() -> dict[str, Any]:
     return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
 
+def _pinned_clickhouse_image() -> str:
+    match = re.search(
+        r'(?m)^\s*ClickHouseImage\s*=\s*"(?P<image>[^"]+)"',
+        CONTAINER_HARNESS.read_text(encoding="utf-8"),
+    )
+    assert match is not None
+    image = match.group("image")
+    assert re.fullmatch(r"[^@]+@sha256:[0-9a-f]{64}", image)
+    return image
+
+
 def _providersync_top_level_tests() -> set[str]:
     env = os.environ.copy()
     env["GOTOOLCHAIN"] = "go1.25.9"
     env["GOWORK"] = "off"
-    env["GOCACHE"] = "/tmp/chaos3141-provider-test-discovery-cache"
+    # Reuse the production subprocess cache. The previous distinct cache made
+    # this independent oracle pay for a second cold compile in the same test.
+    env["GOCACHE"] = str(TEST_GO_CACHE)
     result = subprocess.run(
         [
             "go",
@@ -93,7 +114,7 @@ def _providersync_top_level_tests() -> set[str]:
         check=False,
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=CHECK_GO_TIMEOUT_SECONDS,
     )
     assert result.returncode == 0, result.stdout + result.stderr
     candidates = [
@@ -290,6 +311,99 @@ def test_manifest_drift_and_duplicate_packages_fail_loudly(tmp_path: Path) -> No
     )
 
 
+def test_clickhouse_prepull_retries_the_exact_source_pinned_image(
+    tmp_path: Path,
+) -> None:
+    attempts = tmp_path / "attempts"
+    docker_args = tmp_path / "docker-args"
+    sleep_args = tmp_path / "sleep-args"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+attempt=0
+if [ -f "${DOCKER_ATTEMPTS_FILE}" ]; then
+  attempt="$(<"${DOCKER_ATTEMPTS_FILE}")"
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "${attempt}" > "${DOCKER_ATTEMPTS_FILE}"
+printf '%s\n' "$*" >> "${DOCKER_ARGS_FILE}"
+[ "${attempt}" -ge "${DOCKER_SUCCEED_ON}" ]
+""",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    sleep = bin_dir / "sleep"
+    sleep.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${SLEEP_ARGS_FILE}"
+""",
+        encoding="utf-8",
+    )
+    sleep.chmod(0o755)
+
+    image = _pinned_clickhouse_image()
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "DOCKER_ATTEMPTS_FILE": str(attempts),
+            "DOCKER_ARGS_FILE": str(docker_args),
+            "DOCKER_SUCCEED_ON": "3",
+            "SLEEP_ARGS_FILE": str(sleep_args),
+        }
+    )
+    result = subprocess.run(
+        ["bash", "ci/check_go.sh", "integration-prepull"],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert attempts.read_text(encoding="utf-8") == "3\n"
+    assert docker_args.read_text(encoding="utf-8").splitlines() == [
+        f"pull {image}",
+        f"pull {image}",
+        f"pull {image}",
+    ]
+    assert sleep_args.read_text(encoding="utf-8").splitlines() == ["5", "10"]
+    assert f"pre-pulled pinned ClickHouse image {image} on attempt 3/3" in (
+        result.stdout
+    )
+
+    attempts.unlink()
+    docker_args.unlink()
+    sleep_args.unlink()
+    env["DOCKER_SUCCEED_ON"] = "4"
+    failed = subprocess.run(
+        ["bash", "ci/check_go.sh", "integration-prepull"],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert failed.returncode == 1
+    assert attempts.read_text(encoding="utf-8") == "3\n"
+    assert docker_args.read_text(encoding="utf-8").splitlines() == [
+        f"pull {image}",
+        f"pull {image}",
+        f"pull {image}",
+    ]
+    assert sleep_args.read_text(encoding="utf-8").splitlines() == ["5", "10"]
+    assert f"failed to pre-pull pinned ClickHouse image {image} after 3 attempts" in (
+        failed.stderr
+    )
+
+
 def test_workflow_runs_all_shards_and_preserves_required_check_name() -> None:
     workflow = _workflow()
     jobs = workflow["jobs"]
@@ -310,10 +424,17 @@ def test_workflow_runs_all_shards_and_preserves_required_check_name() -> None:
         "${{ fromJSON(needs.go-storage-integration-plan.outputs.matrix) }}"
     )
     shard_commands = [str(step.get("run", "")) for step in shards["steps"]]
+    assert "bash ci/check_go.sh integration-prepull" in shard_commands
     assert (
         'bash ci/check_go.sh integration-shard "${{ matrix.target }}" '
         '"${{ matrix.shard }}"'
     ) in shard_commands
+    assert shard_commands.index("bash ci/check_go.sh integration-prepull") < (
+        shard_commands.index(
+            'bash ci/check_go.sh integration-shard "${{ matrix.target }}" '
+            '"${{ matrix.shard }}"'
+        )
+    )
     assert all("--dry-run" not in command for command in shard_commands)
     assert shards["name"] == (
         "go-storage-integration-shard-${{ matrix.target }}-${{ matrix.shard }}"

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -15,6 +15,8 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "go.yml"
 CHECK_GO = ROOT / "ci" / "check_go.sh"
 MANIFEST = ROOT / "ci" / "go_integration_shards.tsv"
+PROVIDER_MANIFEST = ROOT / "ci" / "go_providersync_test_shards.tsv"
+PROVIDER_PACKAGE = "internal/providersync"
 
 EXPECTED_PACKAGES = {
     "cmd/dev-health-worker",
@@ -47,10 +49,12 @@ EXPECTED_PACKAGES = {
 def _run_check_go(
     *args: str,
     manifest: Path = MANIFEST,
+    provider_manifest: Path = PROVIDER_MANIFEST,
     github_output: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST"] = str(manifest)
+    env["DEV_HEALTH_GO_PROVIDER_TEST_SHARD_MANIFEST"] = str(provider_manifest)
     if github_output is not None:
         env["GITHUB_OUTPUT"] = str(github_output)
     return subprocess.run(
@@ -68,6 +72,47 @@ def _workflow() -> dict[str, Any]:
     return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
 
+def _providersync_top_level_tests() -> set[str]:
+    env = os.environ.copy()
+    env["GOTOOLCHAIN"] = "go1.25.9"
+    env["GOWORK"] = "off"
+    env["GOCACHE"] = "/tmp/chaos3141-provider-test-discovery-cache"
+    result = subprocess.run(
+        [
+            "go",
+            "test",
+            "-mod=readonly",
+            "-tags=integration",
+            "-count=1",
+            "-run=^$",
+            "-list=^Test",
+            f"./{PROVIDER_PACKAGE}",
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    candidates = [
+        line for line in result.stdout.splitlines() if line.startswith("Test")
+    ]
+    assert all(re.fullmatch(r"Test[A-Za-z0-9_]+", line) for line in candidates)
+    return set(candidates)
+
+
+def _providersync_integration_tagged_tests() -> set[str]:
+    tests: set[str] = set()
+    for path in ROOT.joinpath(PROVIDER_PACKAGE).glob("*_test.go"):
+        source = path.read_text(encoding="utf-8")
+        if not re.search(r"(?m)^//go:build.*\bintegration\b", source):
+            continue
+        tests.update(re.findall(r"(?m)^func (Test[A-Za-z0-9_]+)", source))
+    return tests
+
+
 def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     tmp_path: Path,
 ) -> None:
@@ -82,9 +127,16 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
         line.split("=", maxsplit=1)
         for line in github_output.read_text(encoding="utf-8").splitlines()
     )
-    assert json.loads(output["matrix"]) == {
-        "include": [{"shard": 1}, {"shard": 2}, {"shard": 3}]
+    matrix = json.loads(output["matrix"])["include"]
+    assert {(entry["target"], entry["shard"]) for entry in matrix} == {
+        ("providersync", 1),
+        ("providersync", 2),
+        ("providersync", 3),
+        ("providersync", 4),
+        ("packages", 2),
+        ("packages", 3),
     }
+    assert len(matrix) == 6
 
     assignments: dict[int, set[str]] = {}
     for line in result.stdout.splitlines():
@@ -113,21 +165,88 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     assert set(estimated) == {1, 2, 3}
     assert abs(estimated[2] - estimated[3]) <= 1
 
+    expected_provider_tests = _providersync_top_level_tests()
+    expected_integration_tests = _providersync_integration_tagged_tests()
+    assert len(expected_provider_tests) == 873
+    assert len(expected_integration_tests) == 102
+    assert expected_integration_tests < expected_provider_tests
+
+    provider_assignments: dict[int, set[str]] = {}
+    provider_class: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if not line.startswith("  PROVIDER-SHARD "):
+            continue
+        _label, shard, test_name, _weight, classification = line.split()
+        provider_assignments.setdefault(int(shard), set()).add(test_name)
+        provider_class[test_name] = classification.removeprefix("class=")
+
+    assert set(provider_assignments) == {1, 2, 3, 4}
+    provider_flattened = [
+        test_name for tests in provider_assignments.values() for test_name in tests
+    ]
+    assert len(provider_flattened) == len(set(provider_flattened)) == 873
+    assert set(provider_flattened) == expected_provider_tests
+    assert {
+        name
+        for name, classification in provider_class.items()
+        if classification == "integration"
+    } == expected_integration_tests
+    assert set(provider_class.values()) == {"integration", "ordinary"}
+
+    provider_totals: dict[int, int] = {}
+    provider_integration_counts: dict[int, int] = {}
+    for line in result.stdout.splitlines():
+        match = re.fullmatch(
+            r"providersync test shard (?P<shard>\d+): relative weight "
+            r"(?P<weight>\d+), (?P<count>\d+) test\(s\), "
+            r"(?P<integration>\d+) integration-tagged",
+            line,
+        )
+        if match:
+            provider_totals[int(match.group("shard"))] = int(match.group("weight"))
+            provider_integration_counts[int(match.group("shard"))] = int(
+                match.group("integration")
+            )
+    assert set(provider_totals) == {1, 2, 3, 4}
+    assert max(provider_totals.values()) - min(provider_totals.values()) <= 1
+    assert (
+        max(provider_integration_counts.values())
+        - min(provider_integration_counts.values())
+        <= 1
+    )
+
 
 def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
-    selected: list[str] = []
-    for shard in (1, 2, 3):
-        result = _run_check_go("integration-shard", str(shard), "--dry-run")
+    selected_packages: list[str] = []
+    for shard in (2, 3):
+        result = _run_check_go("integration-shard", "packages", str(shard), "--dry-run")
         assert result.returncode == 0, result.stdout + result.stderr
-        assert f"integration shard {shard}: DRY RUN" in result.stdout
-        selected.extend(
+        assert f"integration package shard {shard}: DRY RUN" in result.stdout
+        selected_packages.extend(
             line.removeprefix("  SHARD-RUN ")
             for line in result.stdout.splitlines()
             if line.startswith("  SHARD-RUN ")
         )
 
-    assert len(selected) == len(set(selected)) == 24
-    assert set(selected) == EXPECTED_PACKAGES
+    assert len(selected_packages) == len(set(selected_packages)) == 23
+    assert set(selected_packages) == EXPECTED_PACKAGES - {PROVIDER_PACKAGE}
+
+    selected_tests: list[str] = []
+    for shard in (1, 2, 3, 4):
+        result = _run_check_go(
+            "integration-shard", "providersync", str(shard), "--dry-run"
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert f"providersync test shard {shard}: DRY RUN" in result.stdout
+        selected_tests.extend(
+            line.removeprefix("  PROVIDER-TEST-RUN ")
+            for line in result.stdout.splitlines()
+            if line.startswith("  PROVIDER-TEST-RUN ")
+        )
+
+    expected_tests = _providersync_top_level_tests()
+    assert len(selected_tests) == len(set(selected_tests)) == 873
+    assert set(selected_tests) == expected_tests
 
 
 def test_manifest_drift_and_duplicate_packages_fail_loudly(tmp_path: Path) -> None:
@@ -157,6 +276,19 @@ def test_manifest_drift_and_duplicate_packages_fail_loudly(tmp_path: Path) -> No
         duplicate_result.stderr
     )
 
+    invalid_provider = tmp_path / "invalid-provider.tsv"
+    invalid_provider.write_text(
+        "shards\t1\nintegration-test-weight\t100\nordinary-test-weight\t1\n",
+        encoding="utf-8",
+    )
+    invalid_provider_result = _run_check_go(
+        "integration-shard-plan", provider_manifest=invalid_provider
+    )
+    assert invalid_provider_result.returncode == 2
+    assert "provider test shard manifest must declare at least two shards" in (
+        invalid_provider_result.stderr
+    )
+
 
 def test_workflow_runs_all_shards_and_preserves_required_check_name() -> None:
     workflow = _workflow()
@@ -178,10 +310,14 @@ def test_workflow_runs_all_shards_and_preserves_required_check_name() -> None:
         "${{ fromJSON(needs.go-storage-integration-plan.outputs.matrix) }}"
     )
     shard_commands = [str(step.get("run", "")) for step in shards["steps"]]
-    assert 'bash ci/check_go.sh integration-shard "${{ matrix.shard }}"' in (
-        shard_commands
-    )
+    assert (
+        'bash ci/check_go.sh integration-shard "${{ matrix.target }}" '
+        '"${{ matrix.shard }}"'
+    ) in shard_commands
     assert all("--dry-run" not in command for command in shard_commands)
+    assert shards["name"] == (
+        "go-storage-integration-shard-${{ matrix.target }}-${{ matrix.shard }}"
+    )
 
     for job in (planner, shards):
         go_setup = next(
@@ -222,6 +358,7 @@ def test_workflow_runs_all_shards_and_preserves_required_check_name() -> None:
 
     workflow_source = WORKFLOW.read_text(encoding="utf-8")
     assert workflow_source.count("- 'ci/go_integration_shards.tsv'") == 2
+    assert workflow_source.count("- 'ci/go_providersync_test_shards.tsv'") == 2
 
     check_go_source = CHECK_GO.read_text(encoding="utf-8")
     assert 'GO_TOOLCHAIN="go1.25.9"' in check_go_source
@@ -230,4 +367,8 @@ def test_workflow_runs_all_shards_and_preserves_required_check_name() -> None:
     assert (
         "GOWORK=off go test -mod=readonly -tags=integration -count=1 "
         '-timeout=30m "${run_pkgs[@]}"'
+    ) in check_go_source
+    assert (
+        "GOWORK=off go test -mod=readonly -tags=integration -count=1 "
+        '-timeout=30m -run "${test_regex}" ./internal/providersync'
     ) in check_go_source

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -91,6 +91,31 @@ def _pinned_clickhouse_image() -> str:
     return image
 
 
+def test_integration_shard_arity_guard_uses_an_explicit_conditional() -> None:
+    """Keep the public CLI guard compatible with the hosted ShellCheck gate."""
+
+    source = CHECK_GO.read_text(encoding="utf-8")
+    match = re.search(
+        r"(?ms)^  integration-shard\)\n(?P<body>.*?^    ;;)$",
+        source,
+    )
+    assert match is not None
+    assert (
+        'if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then\n'
+        '      die "integration-shard requires TARGET SHARD and accepts only '
+        'optional --dry-run"\n'
+        "    fi"
+    ) in match.group("body")
+
+    for args in (("packages",), ("packages", "2", "--dry-run", "extra")):
+        result = _run_check_go("integration-shard", *args)
+        assert result.returncode == 2
+        assert (
+            "integration-shard requires TARGET SHARD and accepts only optional "
+            "--dry-run" in result.stderr
+        )
+
+
 def _providersync_top_level_tests() -> set[str]:
     env = os.environ.copy()
     env["GOTOOLCHAIN"] = "go1.25.9"

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -1,0 +1,233 @@
+"""Contracts for deterministic Go storage-integration CI sharding."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "go.yml"
+CHECK_GO = ROOT / "ci" / "check_go.sh"
+MANIFEST = ROOT / "ci" / "go_integration_shards.tsv"
+
+EXPECTED_PACKAGES = {
+    "cmd/dev-health-worker",
+    "cmd/dev-health-workerctl",
+    "internal/externalrecompute",
+    "internal/joboperator",
+    "internal/joboutbox",
+    "internal/jobroute",
+    "internal/jobruntime",
+    "internal/jobs/metrics/daily",
+    "internal/jobs/metrics/remaining",
+    "internal/jobs/pagerduty",
+    "internal/jobs/report",
+    "internal/jobs/system",
+    "internal/jobs/workgraph",
+    "internal/providerfoundation",
+    "internal/providersync",
+    "internal/scheduler/fixed",
+    "internal/scheduler/sync",
+    "internal/storage/postgres",
+    "internal/storage/river",
+    "internal/streamrunner",
+    "internal/syncdispatchruntime",
+    "internal/syncreconciler",
+    "internal/syncroute",
+    "internal/testsupport/containers",
+}
+
+
+def _run_check_go(
+    *args: str,
+    manifest: Path = MANIFEST,
+    github_output: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DEV_HEALTH_GO_INTEGRATION_SHARD_MANIFEST"] = str(manifest)
+    if github_output is not None:
+        env["GITHUB_OUTPUT"] = str(github_output)
+    return subprocess.run(
+        ["bash", "ci/check_go.sh", *args],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
+    tmp_path: Path,
+) -> None:
+    github_output = tmp_path / "github-output"
+    result = _run_check_go("integration-shard-plan", github_output=github_output)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "24 package(s) discovered, 0 denylisted, 24 will run" in result.stdout
+    assert "integration shard plan: 3 shard(s), 24 package(s)" in result.stdout
+
+    output = dict(
+        line.split("=", maxsplit=1)
+        for line in github_output.read_text(encoding="utf-8").splitlines()
+    )
+    assert json.loads(output["matrix"]) == {
+        "include": [{"shard": 1}, {"shard": 2}, {"shard": 3}]
+    }
+
+    assignments: dict[int, set[str]] = {}
+    for line in result.stdout.splitlines():
+        if not line.startswith("  SHARD "):
+            continue
+        _, shard, package, _weight = line.split()
+        assignments.setdefault(int(shard), set()).add(package)
+
+    assert set(assignments) == {1, 2, 3}
+    flattened = [package for packages in assignments.values() for package in packages]
+    assert len(flattened) == len(set(flattened)) == 24
+    assert set(flattened) == EXPECTED_PACKAGES
+    assert assignments[1] == {"internal/providersync"}
+
+    estimated = {
+        int(match.group("shard")): int(match.group("seconds"))
+        for line in result.stdout.splitlines()
+        if (
+            match := re.fullmatch(
+                r"integration shard (?P<shard>\d+): estimated "
+                r"(?P<seconds>\d+)s, \d+ package\(s\)",
+                line,
+            )
+        )
+    }
+    assert set(estimated) == {1, 2, 3}
+    assert abs(estimated[2] - estimated[3]) <= 1
+
+
+def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
+    selected: list[str] = []
+    for shard in (1, 2, 3):
+        result = _run_check_go("integration-shard", str(shard), "--dry-run")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert f"integration shard {shard}: DRY RUN" in result.stdout
+        selected.extend(
+            line.removeprefix("  SHARD-RUN ")
+            for line in result.stdout.splitlines()
+            if line.startswith("  SHARD-RUN ")
+        )
+
+    assert len(selected) == len(set(selected)) == 24
+    assert set(selected) == EXPECTED_PACKAGES
+
+
+def test_manifest_drift_and_duplicate_packages_fail_loudly(tmp_path: Path) -> None:
+    original = MANIFEST.read_text(encoding="utf-8")
+
+    missing = tmp_path / "missing.tsv"
+    missing.write_text(
+        "\n".join(
+            line
+            for line in original.splitlines()
+            if not line.startswith("internal/providersync\t")
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    missing_result = _run_check_go("integration-shard-plan", manifest=missing)
+    assert missing_result.returncode == 2
+    assert "manifest is missing discovered package 'internal/providersync'" in (
+        missing_result.stderr
+    )
+
+    duplicate = tmp_path / "duplicate.tsv"
+    duplicate.write_text(original + "internal/providersync\t1166\n", encoding="utf-8")
+    duplicate_result = _run_check_go("integration-shard-plan", manifest=duplicate)
+    assert duplicate_result.returncode == 2
+    assert "manifest lists 'internal/providersync' more than once" in (
+        duplicate_result.stderr
+    )
+
+
+def test_workflow_runs_all_shards_and_preserves_required_check_name() -> None:
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+
+    planner = jobs["go-storage-integration-plan"]
+    assert planner["outputs"]["matrix"] == "${{ steps.plan.outputs.matrix }}"
+    assert any(
+        step.get("id") == "plan"
+        and step.get("run") == "bash ci/check_go.sh integration-shard-plan"
+        for step in planner["steps"]
+    )
+
+    shards = jobs["go-storage-integration-shard"]
+    assert shards["needs"] == "go-storage-integration-plan"
+    assert shards["timeout-minutes"] == 25
+    assert shards["strategy"]["fail-fast"] is False
+    assert shards["strategy"]["matrix"] == (
+        "${{ fromJSON(needs.go-storage-integration-plan.outputs.matrix) }}"
+    )
+    shard_commands = [str(step.get("run", "")) for step in shards["steps"]]
+    assert 'bash ci/check_go.sh integration-shard "${{ matrix.shard }}"' in (
+        shard_commands
+    )
+    assert all("--dry-run" not in command for command in shard_commands)
+
+    for job in (planner, shards):
+        go_setup = next(
+            step
+            for step in job["steps"]
+            if str(step.get("uses", "")).startswith("actions/setup-go@")
+        )
+        assert go_setup["uses"] == (
+            "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e"
+        )
+        assert go_setup["with"] == {
+            "go-version-file": "go.mod",
+            "cache-dependency-path": "**/go.sum",
+        }
+    assert re.search(
+        r"(?m)^go 1\.25\.9$", (ROOT / "go.mod").read_text(encoding="utf-8")
+    )
+
+    aggregate = jobs["go-storage-integration"]
+    assert aggregate["name"] == "go-storage-integration"
+    assert aggregate["if"] == "${{ always() }}"
+    assert set(aggregate["needs"]) == {
+        "go-storage-integration-plan",
+        "go-storage-integration-shard",
+    }
+    assert aggregate["env"] == {
+        "PLAN_RESULT": "${{ needs.go-storage-integration-plan.result }}",
+        "SHARD_RESULT": "${{ needs.go-storage-integration-shard.result }}",
+    }
+    aggregate_command = "\n".join(
+        str(step.get("run", "")) for step in aggregate["steps"]
+    )
+    assert (
+        'if [ "${PLAN_RESULT}" != "success" ] '
+        '|| [ "${SHARD_RESULT}" != "success" ]; then'
+    ) in aggregate_command
+    assert "exit 1" in aggregate_command
+
+    workflow_source = WORKFLOW.read_text(encoding="utf-8")
+    assert workflow_source.count("- 'ci/go_integration_shards.tsv'") == 2
+
+    check_go_source = CHECK_GO.read_text(encoding="utf-8")
+    assert 'GO_TOOLCHAIN="go1.25.9"' in check_go_source
+    assert 'export GOTOOLCHAIN="${GO_TOOLCHAIN}"' in check_go_source
+    assert 'export GOCACHE="${DEV_HEALTH_GO_CACHE}"' in check_go_source
+    assert (
+        "GOWORK=off go test -mod=readonly -tags=integration -count=1 "
+        '-timeout=30m "${run_pkgs[@]}"'
+    ) in check_go_source


### PR DESCRIPTION
## Summary

- Keep deterministic package sharding for the 23 non-providersync integration packages.
- Split the dominant `internal/providersync` package by every live top-level test name into four source-weighted deterministic groups.
- Validate live package and providersync discovery in the planner and every shard: 24 packages discovered, 0 denylisted, all 24 covered; 873 providersync top-level tests assigned exactly once, including all 102 tests from active integration-tagged source files.
- Pre-pull the exact source-declared pinned ClickHouse image with three bounded attempts before real shard execution, closing a reproduced Docker Hub 502 without weakening image immutability.
- Keep matrix fail-fast disabled and aggregate all terminal shard results behind the existing required check name `go-storage-integration`.
- Preserve the 25-minute job cap, Go 1.25.9, `**/go.sum` setup-go cache semantics, locked Python dependencies, and fresh `-count=1` execution.

## Exact reproduced failures

PRs #1730, #1731, and #1733 repeatedly reached the workflow cap after their other package/check work passed. In #1733 job 93834923751, the serial runner was cancelled at 25m18s after 14 packages completed; the orphaned `providersync.test` process was killed with no assertion or panic. The exact current-feature local providersync package run took 1165.894s by itself.

The first revision of this PR proved package isolation was still insufficient. Run 31520757841 passed the planner and non-provider shards, but providersync-only job 93877005863 spent 24m52s in real `go test` before cancellation at the unchanged cap. Aggregate job 93884352216 failed correctly.

The second-level revision proved the new topology under budget in run 31524982512:

- package shard 3: pass, 3m48s
- package shard 2: pass, 3m52s
- providersync shard 4: pass, 7m29s
- providersync shard 2: pass, 8m16s
- providersync shard 3: pass, 8m52s
- providersync shard 1: failed in 7m53s only because Docker Hub returned 502 while testcontainers fetched the pinned ClickHouse digest; no Go assertion or timeout failed
- required aggregate 93893845367: failed correctly

The same head also reproduced a test-harness timeout in Tests run 31524982232 / job 93891010092: exactly two sharding subprocesses stopped at 30.03s. The successful dedicated planner job measured the same cold command at 49.596s. The repair shares one Go cache between the production subprocess and independent discovery oracle and uses a 120-second test-process guard; the workflow cap and Go test timeout remain unchanged.

There has been no blind rerun and no timeout increase to the production workflow.

## Deterministic execution plan

Package plan:

- package shard 1: `internal/providersync` only in the weight plan, omitted from package execution after second-level expansion
- package shard 2: 11 non-provider packages, estimated 242s
- package shard 3: 12 non-provider packages, estimated 241s

Providersync plan from current live discovery:

- shard 1: relative weight 2743, 169 tests, 26 integration-tagged
- shard 2: relative weight 2743, 169 tests, 26 integration-tagged
- shard 3: relative weight 2743, 268 tests, 25 integration-tagged
- shard 4: relative weight 2742, 267 tests, 25 integration-tagged

The provider manifest declares four shards and relative weights of 100 for tests declared in active integration-tagged source files and 1 for ordinary tests. Go supplies executable names through `go test -list`; `go list` supplies active files. LPT assignment uses test name and lowest shard number as stable tie-breakers. The workflow matrix is exactly providersync 1-4 plus packages 2-3.

The ClickHouse pre-pull reads `ClickHouseImage` directly from `internal/testsupport/containers/harness.go`, requires one full sha256-pinned value, retries failed pulls after 5s and 10s, and fails loudly after attempt three. It does not copy or retag the digest.

## Verification

- Second-level test-first baseline on `d28ce5d51`: 4 focused failures for the absent target matrix, TARGET+SHARD CLI, provider manifest, and workflow target/name contract.
- Registry-repair test-first baseline on `af093a9f1`: 2 focused failures for the absent pre-pull verb and workflow step.
- Repair head `83161fe80`: focused sharding/discovery/public-verb suite 7 passed.
- Behavioral Docker/sleep stubs prove the exact source-derived digest, failures on attempts one and two, 5s/10s backoff, success on attempt three, and loud failure after exactly three attempts.
- `bash -n`, ShellCheck, Actionlint, Ruff, diff hygiene, pre-commit/pre-push hooks, and independent read-only review passed.
- Clean-tree `bash ci/check_go.sh fast` passed on the prior second-level head with localhost sockets permitted, covering fmt, vet, Go tests, forced live-Python oracles, build, contracts, integration vet, 24/0/24 discovery, and both planners. The repair changes only the explicit pre-pull verb/workflow step and test harness.
- Six dry invocations selected package counts 11/12 and providersync test counts 169/169/268/267; contracts prove exact-once coverage of all 23 non-provider packages and all 873 provider tests.

## Validation boundary

No Docker/full integration suite was run locally. Current hosted acceptance is Go run 31526685980 and Tests run 31526685923 at exact head `83161fe80`. Do not merge unless the required evidence is fully terminal green, the PR remains clean/mergeable, and no review requirement blocks it.

SCREENSHOT-WAIVER: CI workflow and shell tooling only; no rendered UI changes.
