### PR TITLE
CHAOS-3758: add focused backfill planner and API selectors

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -2481,12 +2481,12 @@
       "notes": "grep-evading form; POST /webhooks/pagerduty/{binding_id}"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:476",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:482",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 476
+        "line": 482
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2505,12 +2505,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/sync"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:548",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/integrations.py:573",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 548
+        "line": 573
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2529,12 +2529,12 @@
       "notes": "grep-evading form; POST /integrations/{integration_id}/backfill"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2501",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2502",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2501
+        "line": 2502
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2553,12 +2553,12 @@
       "notes": "grep-evading form; POST /sync-configs/{config_id}/trigger"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2646",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/api/admin/routers/sync.py:2669",
       "surface": "getattr(dispatch_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2646
+        "line": 2669
       },
       "queue_or_cadence": "sync",
       "dispatches": "dispatch_sync_run",
@@ -2602,12 +2602,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:425",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:431",
       "surface": "POST /integrations/{integration_id}/sync",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 425
+        "line": 431
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2627,12 +2627,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:497",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/integrations.py:503",
       "surface": "POST /integrations/{integration_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/integrations.py",
-        "line": 497
+        "line": 503
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2652,12 +2652,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2399",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2400",
       "surface": "POST /sync-configs/{config_id}/trigger",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2399
+        "line": 2400
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",
@@ -2677,12 +2677,12 @@
       "route_mount_prefix": ""
     },
     {
-      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2545",
+      "id": "api_trigger_endpoint:src/dev_health_ops/api/admin/routers/sync.py:2546",
       "surface": "POST /sync-configs/{config_id}/backfill",
       "class": "api_trigger_endpoint",
       "source": {
         "file": "src/dev_health_ops/api/admin/routers/sync.py",
-        "line": 2545
+        "line": 2546
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dispatch_sync_run",

--- a/src/dev_health_ops/api/admin/routers/integrations.py
+++ b/src/dev_health_ops/api/admin/routers/integrations.py
@@ -37,7 +37,13 @@ from dev_health_ops.sync.canonical_incident_gate import (
 )
 from dev_health_ops.sync.datasets import get_dataset_spec
 from dev_health_ops.sync.discovery import discover_sources_for_integration
-from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
+from dev_health_ops.sync.planner import (
+    BackfillSelector as SyncBackfillSelector,
+)
+from dev_health_ops.sync.planner import (
+    SyncPlanRequest,
+    plan_sync_run,
+)
 from dev_health_ops.sync.trigger_routing import map_sync_mode
 from dev_health_ops.workers.sync_units import dispatch_sync_run
 
@@ -510,19 +516,30 @@ async def trigger_integration_backfill(
     if await int_svc.get_by_id(integration_id) is None:
         raise HTTPException(status_code=404, detail="Integration not found")
 
+    selector = payload.resolved_selector()
     request = SyncPlanRequest(
         integration_id=integration_id,
         org_id=org_id,
         mode="backfill",
         triggered_by="admin-api",
-        source_ids=tuple(payload.source_ids)
-        if payload.source_ids is not None
+        backfill_selector=SyncBackfillSelector(
+            since=selector.since,
+            before=selector.before,
+            source_ids=tuple(selector.source_ids)
+            if selector.source_ids is not None
+            else None,
+            dataset_keys=tuple(selector.dataset_keys)
+            if selector.dataset_keys is not None
+            else None,
+        ),
+        source_ids=tuple(selector.source_ids)
+        if selector.source_ids is not None
         else None,
-        dataset_keys=tuple(payload.dataset_keys)
-        if payload.dataset_keys is not None
+        dataset_keys=tuple(selector.dataset_keys)
+        if selector.dataset_keys is not None
         else None,
-        since=payload.since,
-        before=payload.before,
+        since=selector.since,
+        before=selector.before,
     )
 
     try:

--- a/src/dev_health_ops/api/admin/routers/integrations.py
+++ b/src/dev_health_ops/api/admin/routers/integrations.py
@@ -516,31 +516,39 @@ async def trigger_integration_backfill(
     if await int_svc.get_by_id(integration_id) is None:
         raise HTTPException(status_code=404, detail="Integration not found")
 
-    selector = payload.resolved_selector()
-    request = SyncPlanRequest(
-        integration_id=integration_id,
-        org_id=org_id,
-        mode="backfill",
-        triggered_by="admin-api",
-        backfill_selector=SyncBackfillSelector(
-            since=selector.since,
-            before=selector.before,
-            source_ids=tuple(selector.source_ids)
-            if selector.source_ids is not None
+    if payload.selector is not None:
+        selector = payload.selector
+        request = SyncPlanRequest(
+            integration_id=integration_id,
+            org_id=org_id,
+            mode="backfill",
+            triggered_by="admin-api",
+            backfill_selector=SyncBackfillSelector(
+                since=selector.since,
+                before=selector.before,
+                source_ids=tuple(selector.source_ids)
+                if selector.source_ids is not None
+                else None,
+                dataset_keys=tuple(selector.dataset_keys)
+                if selector.dataset_keys is not None
+                else None,
+            ),
+        )
+    else:
+        request = SyncPlanRequest(
+            integration_id=integration_id,
+            org_id=org_id,
+            mode="backfill",
+            triggered_by="admin-api",
+            source_ids=tuple(payload.source_ids)
+            if payload.source_ids is not None
             else None,
-            dataset_keys=tuple(selector.dataset_keys)
-            if selector.dataset_keys is not None
+            dataset_keys=tuple(payload.dataset_keys)
+            if payload.dataset_keys is not None
             else None,
-        ),
-        source_ids=tuple(selector.source_ids)
-        if selector.source_ids is not None
-        else None,
-        dataset_keys=tuple(selector.dataset_keys)
-        if selector.dataset_keys is not None
-        else None,
-        since=selector.since,
-        before=selector.before,
-    )
+            since=payload.since,
+            before=payload.before,
+        )
 
     try:
         plan = await session.run_sync(

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -86,6 +86,7 @@ from dev_health_ops.sync.pagerduty_repair import (
     PagerDutyOperationalTargetError,
     repair_pagerduty_operational_integration,
 )
+from dev_health_ops.sync.planner import BackfillSelector as SyncBackfillSelector
 from dev_health_ops.sync.trigger_routing import (
     mark_sync_run_failed,
 )
@@ -2564,7 +2565,9 @@ async def trigger_sync_config_backfill(
             detail="Sync configuration is paused and cannot be backfilled",
         )
 
-    requested_days = (payload.before - payload.since).days
+    selector = payload.resolved_selector()
+    structured_selector = payload.selector
+    requested_days = (selector.before - selector.since).days
 
     def _check_backfill_limit(sync_session) -> tuple[bool, str | None]:
         tier_svc = TierLimitService(sync_session)
@@ -2592,12 +2595,32 @@ async def trigger_sync_config_backfill(
                     org_id,
                     triggered_by="backfill",
                     mode="backfill",
+                    backfill_selector=SyncBackfillSelector(
+                        since=datetime.combine(
+                            selector.since, datetime.min.time(), tzinfo=timezone.utc
+                        ),
+                        before=datetime.combine(
+                            selector.before, datetime.max.time(), tzinfo=timezone.utc
+                        ),
+                        source_ids=tuple(selector.source_ids)
+                        if selector.source_ids is not None
+                        else None,
+                        dataset_keys=tuple(selector.dataset_keys)
+                        if selector.dataset_keys is not None
+                        else None,
+                    )
+                    if structured_selector is not None
+                    else None,
                     since=datetime.combine(
-                        payload.since, datetime.min.time(), tzinfo=timezone.utc
-                    ),
+                        selector.since, datetime.min.time(), tzinfo=timezone.utc
+                    )
+                    if structured_selector is None
+                    else None,
                     before=datetime.combine(
-                        payload.before, datetime.max.time(), tzinfo=timezone.utc
-                    ),
+                        selector.before, datetime.max.time(), tzinfo=timezone.utc
+                    )
+                    if structured_selector is None
+                    else None,
                     initial_job_result={"planner_managed": True},
                 )
             )
@@ -2631,8 +2654,8 @@ async def trigger_sync_config_backfill(
             org_id=org_id,
             sync_config_id=uuid.UUID(config_id),
             status="pending",
-            since_date=payload.since,
-            before_date=payload.before,
+            since_date=selector.since,
+            before_date=selector.before,
             total_chunks=0,
         )
         session.add(backfill_job)
@@ -2684,8 +2707,8 @@ async def trigger_sync_config_backfill(
             "backfill_job_id": backfill_job_id,
             "sync_run_id": trigger.sync_run_id,
             "mode": "fanout",
-            "since": payload.since.isoformat(),
-            "before": payload.before.isoformat(),
+            "since": selector.since.isoformat(),
+            "before": selector.before.isoformat(),
         }
     except HTTPException:
         raise

--- a/src/dev_health_ops/api/admin/schemas/integrations.py
+++ b/src/dev_health_ops/api/admin/schemas/integrations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # ---------------------------------------------------------------------------
 # Integration
@@ -123,11 +123,41 @@ class SyncTriggerRequest(BaseModel):
     full_resync: bool = False
 
 
-class BackfillTriggerRequest(BaseModel):
+class BackfillSelector(BaseModel):
+    """Explicit backfill scope for date and repository/unit selectors."""
+
     since: datetime
     before: datetime
     source_ids: list[str] | None = None
     dataset_keys: list[str] | None = None
+
+
+class BackfillTriggerRequest(BaseModel):
+    selector: BackfillSelector | None = None
+    since: datetime | None = None
+    before: datetime | None = None
+    source_ids: list[str] | None = None
+    dataset_keys: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _validate_selector(self) -> BackfillTriggerRequest:
+        if self.selector is None and (self.since is None or self.before is None):
+            raise ValueError(
+                "backfill requires since and before, either top-level or in selector"
+            )
+        return self
+
+    def resolved_selector(self) -> BackfillSelector:
+        if self.selector is not None:
+            return self.selector
+        assert self.since is not None
+        assert self.before is not None
+        return BackfillSelector(
+            since=self.since,
+            before=self.before,
+            source_ids=self.source_ids,
+            dataset_keys=self.dataset_keys,
+        )
 
 
 class SyncTriggerResponse(BaseModel):

--- a/src/dev_health_ops/api/admin/schemas/integrations.py
+++ b/src/dev_health_ops/api/admin/schemas/integrations.py
@@ -141,7 +141,16 @@ class BackfillTriggerRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_selector(self) -> BackfillTriggerRequest:
-        if self.selector is None and (self.since is None or self.before is None):
+        selector_present = self.selector is not None
+        flat_fields_present = any(
+            value is not None
+            for value in (self.since, self.before, self.source_ids, self.dataset_keys)
+        )
+        if selector_present and flat_fields_present:
+            raise ValueError(
+                "backfill selector cannot be mixed with legacy flat fields"
+            )
+        if not selector_present and (self.since is None or self.before is None):
             raise ValueError(
                 "backfill requires since and before, either top-level or in selector"
             )

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 
 class SettingResponse(BaseModel):
@@ -273,9 +280,38 @@ class DiscoveredReposResponse(BaseModel):
     total: int
 
 
-class BackfillRequest(BaseModel):
+class BackfillSelectorRequest(BaseModel):
     since: date
     before: date
+    source_ids: list[str] | None = None
+    dataset_keys: list[str] | None = None
+
+
+class BackfillRequest(BaseModel):
+    selector: BackfillSelectorRequest | None = None
+    since: date | None = None
+    before: date | None = None
+
+    @model_validator(mode="after")
+    def _validate_selector(self) -> BackfillRequest:
+        if self.selector is not None and (
+            self.since is not None or self.before is not None
+        ):
+            raise ValueError(
+                "backfill selector cannot be mixed with legacy flat fields"
+            )
+        if self.selector is None and (self.since is None or self.before is None):
+            raise ValueError(
+                "backfill requires since and before, either top-level or in selector"
+            )
+        return self
+
+    def resolved_selector(self) -> BackfillSelectorRequest:
+        if self.selector is not None:
+            return self.selector
+        assert self.since is not None
+        assert self.before is not None
+        return BackfillSelectorRequest(since=self.since, before=self.before)
 
 
 JOB_RUN_STATUS_LABELS: dict[int, str] = {

--- a/src/dev_health_ops/sync/execution_trigger.py
+++ b/src/dev_health_ops/sync/execution_trigger.py
@@ -23,7 +23,7 @@ from dev_health_ops.sync.canonical_incident_gate import (
     sync_targets_require_canonical_incident_feature,
 )
 from dev_health_ops.sync.error_sanitize import sanitize_error_text
-from dev_health_ops.sync.planner import plan_sync_run
+from dev_health_ops.sync.planner import BackfillSelector, plan_sync_run
 from dev_health_ops.sync.trigger_routing import planner_request_for_config_if_routed
 
 SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION = "sync_scheduler_occurrence_v1"
@@ -262,6 +262,7 @@ def create_sync_execution_trigger(
     mode: str,
     since: datetime | None = None,
     before: datetime | None = None,
+    backfill_selector: BackfillSelector | None = None,
     initial_job_result: dict[str, Any] | None = None,
 ) -> SyncExecutionTriggerResult | None:
     sync_targets = [str(target) for target in (config.sync_targets or [])]
@@ -272,7 +273,16 @@ def create_sync_execution_trigger(
     )
     if request is None:
         return None
-    if since is not None or before is not None:
+    if backfill_selector is not None:
+        request = replace(
+            request,
+            backfill_selector=backfill_selector,
+            source_ids=None,
+            dataset_keys=None,
+            since=None,
+            before=None,
+        )
+    elif since is not None or before is not None:
         request = replace(request, since=since, before=before)
 
     job_run_id = ensure_pending_sync_job_run(

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -255,6 +255,7 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
     repair_outcome = repair_pagerduty_operational_integration(session, integration)
     _repair_github_work_item_runtime_options(session, integration)
     mode = _validate_mode(request.mode)
+    _validate_backfill_selector_compatibility(request)
     request = _normalize_backfill_selector(request)
     if repair_outcome is not None:
         return _terminalize_pagerduty_disabled_plan(
@@ -398,6 +399,23 @@ def _terminalize_pagerduty_disabled_plan(
         dispatch_required=False,
         terminal_reason=reason,
     )
+
+
+def _validate_backfill_selector_compatibility(request: SyncPlanRequest) -> None:
+    """Reject mixed structured/legacy backfill scopes before planning."""
+    selector = request.backfill_selector
+    if selector is None:
+        return
+    if any(
+        value is not None
+        for value in (
+            request.since,
+            request.before,
+            request.source_ids,
+            request.dataset_keys,
+        )
+    ):
+        raise ValueError("backfill selector cannot be mixed with legacy flat fields")
 
 
 def _normalize_backfill_selector(request: SyncPlanRequest) -> SyncPlanRequest:

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -78,7 +78,7 @@ import logging
 import os
 import uuid
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING
 
@@ -162,17 +162,30 @@ class WatermarkKey:
 
 
 @dataclass(frozen=True)
+class BackfillSelector:
+    """Explicit backfill scope for date and repository/unit selectors."""
+
+    since: datetime
+    before: datetime
+    source_ids: tuple[str, ...] | None = None
+    dataset_keys: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
 class SyncPlanRequest:
     """Input to :func:`plan_sync_run`.
 
     ``source_ids`` / ``dataset_keys`` of ``None`` mean "all enabled". Explicit
     tuples filter to the given subset (still intersected with enabled rows).
+    ``backfill_selector`` is the newer structured form used by partial
+    backfill callers; the flat fields remain as compatibility aliases.
     """
 
     integration_id: str
     org_id: str
     mode: str  # one of models.integrations.SyncRunMode
     triggered_by: str
+    backfill_selector: BackfillSelector | None = None
     source_ids: tuple[str, ...] | None = None
     dataset_keys: tuple[str, ...] | None = None
     since: datetime | None = None
@@ -242,6 +255,7 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
     repair_outcome = repair_pagerduty_operational_integration(session, integration)
     _repair_github_work_item_runtime_options(session, integration)
     mode = _validate_mode(request.mode)
+    request = _normalize_backfill_selector(request)
     if repair_outcome is not None:
         return _terminalize_pagerduty_disabled_plan(
             session=session,
@@ -383,6 +397,20 @@ def _terminalize_pagerduty_disabled_plan(
         unit_ids=(),
         dispatch_required=False,
         terminal_reason=reason,
+    )
+
+
+def _normalize_backfill_selector(request: SyncPlanRequest) -> SyncPlanRequest:
+    """Project the structured backfill selector onto the legacy flat fields."""
+    selector = request.backfill_selector
+    if selector is None:
+        return request
+    return replace(
+        request,
+        source_ids=selector.source_ids,
+        dataset_keys=selector.dataset_keys,
+        since=selector.since,
+        before=selector.before,
     )
 
 

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -286,6 +286,60 @@ async def test_backfill_config_created_via_plain_endpoint_succeeds(
     assert len(backfill_jobs) == 1
 
 
+@pytest.mark.asyncio
+async def test_sync_config_backfill_accepts_nested_selector_and_resolves_integration(
+    client, session_maker, seeded_state
+):
+    """The web-facing config route forwards focused scope to its integration."""
+    ac, _ = client
+    create_resp = await _create_sync_config(
+        ac, name="bf-focused-selector", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+    integration_id = await _link_migrated_integration(
+        session_maker, seeded_state["org_id"], config_id
+    )
+    source_id = str(uuid.uuid4())
+    captured: dict[str, object] = {}
+
+    def _fake_trigger(session, config, org_id, **kwargs):
+        captured["integration_id"] = getattr(config, "integration_id")
+        captured["backfill_selector"] = kwargs.get("backfill_selector")
+        return MagicMock(
+            sync_run_id=str(uuid.uuid4()),
+            job_run_id=str(uuid.uuid4()),
+            total_units=1,
+            dispatch_required=True,
+        )
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.create_sync_execution_trigger",
+            side_effect=_fake_trigger,
+        ),
+        _patch_dispatch(),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={
+                "selector": {
+                    "since": "2026-01-01",
+                    "before": "2026-01-08",
+                    "source_ids": [source_id],
+                    "dataset_keys": ["commits"],
+                }
+            },
+        )
+
+    assert resp.status_code == 202, resp.text
+    assert captured["integration_id"] == integration_id
+    selector = captured["backfill_selector"]
+    assert selector is not None
+    assert getattr(selector, "source_ids") == (source_id,)
+    assert getattr(selector, "dataset_keys") == ("commits",)
+
+
 # ---------------------------------------------------------------------------
 # Endpoint tests — fanout (planner) path
 # ---------------------------------------------------------------------------

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -943,6 +943,68 @@ async def test_trigger_backfill_org_scoped(client, seeded_state):
 
 
 @pytest.mark.asyncio
+async def test_trigger_backfill_selector_object_org_scoped(client, seeded_state):
+    """Selector-shaped backfill requests must still plan through the admin API."""
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+
+    source_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+    dataset_keys = ["work-item-labels", "work-item-comments"]
+
+    mock_plan = MagicMock()
+    mock_plan.sync_run_id = str(uuid.uuid4())
+    mock_plan.total_units = 0
+    mock_plan.unit_ids = ()
+
+    captured_request = {}
+
+    def _fake_plan(session, request):
+        captured_request["org_id"] = request.org_id
+        captured_request["mode"] = request.mode
+        captured_request["source_ids"] = request.source_ids
+        captured_request["dataset_keys"] = request.dataset_keys
+        captured_request["backfill_selector"] = request.backfill_selector
+        return mock_plan
+
+    mock_dispatch = MagicMock()
+    mock_dispatch.apply_async = MagicMock()
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.integrations.plan_sync_run",
+            side_effect=_fake_plan,
+        ),
+        patch(
+            "dev_health_ops.api.admin.routers.integrations.dispatch_sync_run",
+            mock_dispatch,
+        ),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/integrations/{integration_id}/backfill",
+            json={
+                "selector": {
+                    "since": "2024-01-01T00:00:00Z",
+                    "before": "2024-02-01T00:00:00Z",
+                    "source_ids": source_ids,
+                    "dataset_keys": dataset_keys,
+                }
+            },
+        )
+
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["status"] == "accepted"
+    assert captured_request["org_id"] == seeded_state["org_id"]
+    assert captured_request["mode"] == "backfill"
+    assert captured_request["source_ids"] == tuple(source_ids)
+    assert captured_request["dataset_keys"] == tuple(dataset_keys)
+    assert captured_request["backfill_selector"] is not None
+    assert captured_request["backfill_selector"].source_ids == tuple(source_ids)
+    assert captured_request["backfill_selector"].dataset_keys == tuple(dataset_keys)
+
+
+@pytest.mark.asyncio
 async def test_trigger_backfill_returns_202_when_enqueue_fails(
     client,
     session_maker,

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -997,11 +997,37 @@ async def test_trigger_backfill_selector_object_org_scoped(client, seeded_state)
     assert data["status"] == "accepted"
     assert captured_request["org_id"] == seeded_state["org_id"]
     assert captured_request["mode"] == "backfill"
-    assert captured_request["source_ids"] == tuple(source_ids)
-    assert captured_request["dataset_keys"] == tuple(dataset_keys)
+    assert captured_request["source_ids"] is None
+    assert captured_request["dataset_keys"] is None
     assert captured_request["backfill_selector"] is not None
     assert captured_request["backfill_selector"].source_ids == tuple(source_ids)
     assert captured_request["backfill_selector"].dataset_keys == tuple(dataset_keys)
+
+
+@pytest.mark.asyncio
+async def test_trigger_backfill_rejects_mixed_selector_shapes(client):
+    """Structured selector plus legacy flat fields must fail validation."""
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+
+    with patch(
+        "dev_health_ops.api.admin.routers.integrations.plan_sync_run",
+        side_effect=AssertionError("planner should not be called on invalid payload"),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/integrations/{integration_id}/backfill",
+            json={
+                "selector": {
+                    "since": "2024-01-01T00:00:00Z",
+                    "before": "2024-02-01T00:00:00Z",
+                    "source_ids": [str(uuid.uuid4())],
+                },
+                "source_ids": [str(uuid.uuid4())],
+            },
+        )
+
+    assert resp.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -371,6 +371,28 @@ def test_backfill_selector_object_collapses_family_and_preserves_source_order(
     }
 
 
+def test_backfill_selector_object_rejects_legacy_flat_fields(db_session):
+    integration = _create_integration(db_session)
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+
+    with pytest.raises(ValueError, match="backfill selector cannot be mixed"):
+        plan_sync_run(
+            db_session,
+            SyncPlanRequest(
+                integration_id=str(integration.id),
+                org_id=ORG_ID,
+                mode=SyncRunMode.BACKFILL.value,
+                triggered_by="manual",
+                backfill_selector=BackfillSelector(
+                    since=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                    before=datetime(2026, 6, 2, tzinfo=timezone.utc),
+                ),
+                source_ids=(str(uuid.uuid4()),),
+            ),
+        )
+
+
 def test_disabled_source_produces_zero_units_without_hydrating_credentials(
     db_session, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -30,7 +30,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_KIND_DISCOVERY,
     OUTBOX_STATUS_PENDING,
 )
-from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
+from dev_health_ops.sync.planner import BackfillSelector, SyncPlanRequest, plan_sync_run
 from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
 _POSTGRES_TEST_URI_ENV = "DEV_HEALTH_POSTGRES_TEST_URI"
@@ -327,6 +327,47 @@ def test_backfill_creates_one_unit_per_source_dataset_window(db_session):
     assert windows == {
         (datetime(2026, 6, 1).date(), datetime(2026, 6, 7).date()),
         (datetime(2026, 6, 8).date(), datetime(2026, 6, 14).date()),
+    }
+
+
+def test_backfill_selector_object_collapses_family_and_preserves_source_order(
+    db_session,
+):
+    integration = _create_integration(db_session, provider="linear")
+    source_z = _create_source(db_session, integration, external_id="full-chaos/z-repo")
+    source_a = _create_source(db_session, integration, external_id="full-chaos/a-repo")
+    _create_dataset(db_session, integration, "work-item-comments")
+    _create_dataset(db_session, integration, "work-item-labels")
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.BACKFILL.value,
+            triggered_by="manual",
+            backfill_selector=BackfillSelector(
+                since=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                before=datetime(2026, 6, 2, tzinfo=timezone.utc),
+                source_ids=(str(source_z.id), str(source_a.id)),
+                dataset_keys=("work-item-labels", "work-item-comments"),
+            ),
+        ),
+    )
+
+    units = [
+        db_session.get(SyncRunUnit, uuid.UUID(unit_id)) for unit_id in plan.unit_ids
+    ]
+
+    assert plan.total_units == 2
+    assert all(unit is not None for unit in units)
+    assert [str(unit.source_id) for unit in units if unit is not None] == [
+        str(source_a.id),
+        str(source_z.id),
+    ]
+    assert {unit.dataset_key for unit in units if unit is not None} == {"work-items"}
+    assert {unit.mode for unit in units if unit is not None} == {
+        SyncRunMode.BACKFILL.value
     }
 
 


### PR DESCRIPTION
## Summary

- add a structured focused-backfill selector for `[since, before)`, source/repository IDs, and dataset/unit keys
- resolve and canonicalize selector scope in the existing planner while preserving legacy flat backfill callers
- support the web-facing `/sync-configs/{config_id}/backfill` route without exposing or guessing integration IDs; the config resolves its authoritative integration internally
- reject mixed structured and legacy selector shapes and retain deterministic planner ordering/chunking

## Contract boundary

- Partial-backfill units remain `mode=backfill`; this slice does not stamp, advance, or overwrite continuation watermarks.
- Explicit nested selectors replace config-derived source/dataset scope, so no unrequested repository or unit is broadened into the plan.
- Legacy flat `since`/`before` requests keep their existing behavior.
- This is planner/request-contract publication only: no deployment, activation, route switch, cutover, or merge claim.

<!-- TEST-EVIDENCE -->
## Test evidence

- Red reproduction: nested selector sent to `/sync-configs/{config_id}/backfill` returned HTTP 422 for missing top-level `since` and `before`; the execution trigger was not reached.
- Green endpoint proof: the same nested request returns HTTP 202, resolves the config-owned integration internally, and forwards exact source/dataset scope.
- Focused API/planner suite: 174 passed, 1 environment-gated skip.
- Transitional inventory discovery contract: pass.
- Mutation harness `verify`: clean, no mutation applied.
- Ruff format/check and mypy: pass.
- `bash ci/local_validate.sh`: PASS, 9/9 declared stages; 13,840 passed, 245 skipped, 1 expected xfail; isolated ClickHouse migration and live argMax proof passed.

<!-- RISK-NOTES -->
## Risk notes

- Selector IDs are still fenced by the existing tenant/integration-aware planner; unknown or foreign identities fail rather than falling back to all enabled scope.
- Structured and flat fields cannot be mixed, preventing ambiguous precedence.
- The sync-config compatibility path clears config-derived source/dataset fields only when an explicit nested selector is present; legacy flat requests remain unchanged.
- No worker execution, persistence schema, deployment manifest, activation, or cutover behavior changes.

SCREENSHOT-WAIVER: Backend/API-only change; no rendered UI changes.

Linear: https://linear.app/fullchaos/issue/CHAOS-3758/partial-backfill-planner-and-api-date-repository-and-unit-selectors