### PR TITLE
feat(worker): add local all-routes preset

### DIFF
--- a/docker/go-worker.Dockerfile
+++ b/docker/go-worker.Dockerfile
@@ -26,6 +26,8 @@ COPY cmd ./cmd
 COPY contracts ./contracts
 COPY deploy/go-workers ./deploy/go-workers
 COPY internal ./internal
+COPY src/dev_health_ops/config/status_mapping.yaml ./src/dev_health_ops/config/status_mapping.yaml
+COPY src/dev_health_ops/config/investment_areas.yaml ./src/dev_health_ops/config/investment_areas.yaml
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -51,6 +53,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     mkdir -p \
       /runtime/worker/usr/local/bin \
       /runtime/worker/app/contracts/jobs \
+      /runtime/worker/app/config \
       /runtime/worker/app/deploy/go-workers \
       /runtime/scheduler/usr/local/bin \
       /runtime/scheduler/app/contracts/jobs \
@@ -78,6 +81,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     cp /out/worker-contractcheck /runtime/contractcheck/usr/local/bin/worker-contractcheck; \
     cp -R /src/contracts/jobs/v1 /runtime/worker/app/contracts/jobs/v1; \
     cp /src/deploy/go-workers/profiles.json /runtime/worker/app/deploy/go-workers/profiles.json; \
+    cp /src/src/dev_health_ops/config/status_mapping.yaml /runtime/worker/app/config/status_mapping.yaml; \
+    cp /src/src/dev_health_ops/config/investment_areas.yaml /runtime/worker/app/config/investment_areas.yaml; \
     cp -R /src/contracts/jobs/v1 /runtime/operator/app/contracts/jobs/v1; \
     cp /src/deploy/go-workers/profiles.json /runtime/operator/app/deploy/go-workers/profiles.json; \
     cp -R /src/contracts/jobs/v1 /runtime/contractcheck/app/contracts/jobs/v1; \

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -37,6 +37,13 @@ const (
 	// scripts/worker/provision_river_roles.sql (deployed environments).
 	defaultCoordinatorDatabaseRole = "devhealth_coordinator"
 	defaultStreamReplicas          = 1
+	localStatusMappingPath         = "/app/config/status_mapping.yaml"
+	localInvestmentAreasPath       = "/app/config/investment_areas.yaml"
+)
+
+const (
+	providerRoutesPresetEnv = "GO_PROVIDER_ROUTES"
+	devHealthEnv            = "DEV_HEALTH_ENV"
 )
 
 // QueueControlMode describes the endpoint semantics promised by the operator.
@@ -169,9 +176,10 @@ type Config struct {
 	WorkerGithubWorkItemsEnabled bool
 	// WorkerGithubWorkItemsStatusMappingPath and
 	// WorkerGithubWorkItemsInvestmentConfigPath are explicit production paths
-	// for the two Python-parity config engines. There is intentionally no
-	// source-relative default: when the route is enabled, cmd/dev-health-worker
-	// validates both paths and rejects ambient STATUS_MAPPING_PATH overrides.
+	// for the two Python-parity config engines. Production has no source-relative
+	// default; the local-only all-routes preset selects artifacts packaged at
+	// fixed image paths. When the route is enabled, cmd/dev-health-worker validates
+	// both paths and rejects ambient STATUS_MAPPING_PATH overrides.
 	WorkerGithubWorkItemsStatusMappingPath    string
 	WorkerGithubWorkItemsInvestmentConfigPath string
 
@@ -235,6 +243,10 @@ func Load(spec Spec) (Config, error) {
 	cfg.OperationalBridgeAllowInsecure, err = boolEnv(
 		lookup, "WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE", false,
 	)
+	if err != nil {
+		return Config{}, err
+	}
+	allProviderRoutes, err := localAllProviderRoutes(lookup)
 	if err != nil {
 		return Config{}, err
 	}
@@ -403,7 +415,14 @@ func Load(spec Spec) (Config, error) {
 			target: &cfg.WorkerGithubWorkItemsEnabled,
 		},
 	} {
-		*item.target, err = boolEnv(lookup, item.name, false)
+		fallback := false
+		if allProviderRoutes {
+			fallback, err = providerRoutePresetDefault(lookup, item.name)
+			if err != nil {
+				return Config{}, err
+			}
+		}
+		*item.target, err = boolEnv(lookup, item.name, fallback)
 		if err != nil {
 			return Config{}, err
 		}
@@ -441,10 +460,14 @@ func Load(spec Spec) (Config, error) {
 		return Config{}, fmt.Errorf("WORKER_GITLAB_PRS_ENABLED, WORKER_GITLAB_PR_REVIEWS_ENABLED, and WORKER_GITLAB_PR_COMMENTS_ENABLED are mutually exclusive: all delegate to one complete PR-social writer")
 	}
 	cfg.WorkerGithubWorkItemsStatusMappingPath = envOrDefault(
-		lookup, "WORKER_GITHUB_WORK_ITEMS_STATUS_MAPPING_PATH", "",
+		lookup,
+		"WORKER_GITHUB_WORK_ITEMS_STATUS_MAPPING_PATH",
+		conditionalDefault(allProviderRoutes, localStatusMappingPath),
 	)
 	cfg.WorkerGithubWorkItemsInvestmentConfigPath = envOrDefault(
-		lookup, "WORKER_GITHUB_WORK_ITEMS_INVESTMENT_CONFIG_PATH", "",
+		lookup,
+		"WORKER_GITHUB_WORK_ITEMS_INVESTMENT_CONFIG_PATH",
+		conditionalDefault(allProviderRoutes, localInvestmentAreasPath),
 	)
 	cfg.HealthCheckTimeout, err = durationEnv(
 		lookup,
@@ -666,6 +689,71 @@ func Load(spec Spec) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func localAllProviderRoutes(lookup secrets.LookupEnv) (bool, error) {
+	preset, _ := lookup(providerRoutesPresetEnv)
+	preset = strings.ToLower(strings.TrimSpace(preset))
+	if preset == "" {
+		return false, nil
+	}
+	if preset != "all" {
+		return false, fmt.Errorf("%s must be empty or all", providerRoutesPresetEnv)
+	}
+	environment, _ := lookup(devHealthEnv)
+	if strings.ToLower(strings.TrimSpace(environment)) != "local" {
+		return false, fmt.Errorf("%s=all requires %s=local", providerRoutesPresetEnv, devHealthEnv)
+	}
+	return true, nil
+}
+
+func providerRoutePresetDisabledAlias(name string) bool {
+	switch name {
+	case "WORKER_GITHUB_PR_REVIEWS_ENABLED",
+		"WORKER_GITHUB_PR_COMMENTS_ENABLED",
+		"WORKER_GITHUB_TESTS_ENABLED",
+		"WORKER_GITLAB_PR_REVIEWS_ENABLED",
+		"WORKER_GITLAB_PR_COMMENTS_ENABLED",
+		"WORKER_GITLAB_TESTS_ENABLED":
+		return true
+	default:
+		return false
+	}
+}
+
+func providerRoutePresetDefault(lookup secrets.LookupEnv, name string) (bool, error) {
+	if providerRoutePresetDisabledAlias(name) {
+		return false, nil
+	}
+	alternatives := map[string][]string{
+		"WORKER_GITHUB_PRS_ENABLED": {
+			"WORKER_GITHUB_PR_REVIEWS_ENABLED",
+			"WORKER_GITHUB_PR_COMMENTS_ENABLED",
+		},
+		"WORKER_GITHUB_CICD_ENABLED": {"WORKER_GITHUB_TESTS_ENABLED"},
+		"WORKER_GITLAB_PRS_ENABLED": {
+			"WORKER_GITLAB_PR_REVIEWS_ENABLED",
+			"WORKER_GITLAB_PR_COMMENTS_ENABLED",
+		},
+		"WORKER_GITLAB_CICD_ENABLED": {"WORKER_GITLAB_TESTS_ENABLED"},
+	}
+	for _, alternative := range alternatives[name] {
+		enabled, err := boolEnv(lookup, alternative, false)
+		if err != nil {
+			return false, err
+		}
+		if enabled {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func conditionalDefault(enabled bool, value string) string {
+	if enabled {
+		return value
+	}
+	return ""
 }
 
 // SafeAttrs is the only supported startup-config logging surface. It includes

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -3,12 +3,92 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
 )
+
+func TestLocalAllProviderRoutesPreset(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(workerSpec(map[string]string{
+		"DEV_HEALTH_ENV":     "local",
+		"GO_PROVIDER_ROUTES": "all",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	disabledAliases := map[string]bool{
+		"WorkerGithubPRReviewsEnabled":  true,
+		"WorkerGithubPRCommentsEnabled": true,
+		"WorkerGithubTestsEnabled":      true,
+		"WorkerGitlabPRReviewsEnabled":  true,
+		"WorkerGitlabPRCommentsEnabled": true,
+		"WorkerGitlabTestsEnabled":      true,
+	}
+	value := reflect.ValueOf(cfg)
+	typeOfConfig := value.Type()
+	for index := 0; index < value.NumField(); index++ {
+		field := typeOfConfig.Field(index)
+		if !strings.HasPrefix(field.Name, "Worker") ||
+			!strings.HasSuffix(field.Name, "Enabled") ||
+			field.Type.Kind() != reflect.Bool {
+			continue
+		}
+		want := !disabledAliases[field.Name]
+		if got := value.Field(index).Bool(); got != want {
+			t.Errorf("%s=%t, want %t", field.Name, got, want)
+		}
+	}
+	if cfg.WorkerGithubWorkItemsStatusMappingPath != "/app/config/status_mapping.yaml" ||
+		cfg.WorkerGithubWorkItemsInvestmentConfigPath != "/app/config/investment_areas.yaml" {
+		t.Fatalf("unexpected packaged paths: status=%q investment=%q", cfg.WorkerGithubWorkItemsStatusMappingPath, cfg.WorkerGithubWorkItemsInvestmentConfigPath)
+	}
+}
+
+func TestLocalAllProviderRoutesPresetPreservesExplicitOverrides(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(workerSpec(map[string]string{
+		"DEV_HEALTH_ENV":                               "local",
+		"GO_PROVIDER_ROUTES":                           "all",
+		"WORKER_GITHUB_FILES_ENABLED":                  "false",
+		"WORKER_GITLAB_PR_REVIEWS_ENABLED":             "true",
+		"WORKER_GITHUB_WORK_ITEMS_STATUS_MAPPING_PATH": "/override/status.yaml",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorkerGithubFilesEnabled || !cfg.WorkerGithubCommitsEnabled {
+		t.Fatalf("explicit false did not override preset: %#v", cfg.SafeAttrs())
+	}
+	if !cfg.WorkerGitlabPRReviewsEnabled || cfg.WorkerGitlabPRsEnabled {
+		t.Fatal("explicit alias choice did not override canonical preset aliases")
+	}
+	if cfg.WorkerGithubWorkItemsStatusMappingPath != "/override/status.yaml" {
+		t.Fatal("explicit semantic path did not override packaged preset path")
+	}
+}
+
+func TestProviderRoutesPresetRejectsNonLocalAndUnknownValues(t *testing.T) {
+	t.Parallel()
+
+	for name, values := range map[string]map[string]string{
+		"missing environment": {"GO_PROVIDER_ROUTES": "all"},
+		"production":          {"DEV_HEALTH_ENV": "production", "GO_PROVIDER_ROUTES": "all"},
+		"unknown preset":      {"DEV_HEALTH_ENV": "local", "GO_PROVIDER_ROUTES": "some"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Load(workerSpec(values)); err == nil {
+				t.Fatal("expected invalid provider route preset to fail")
+			}
+		})
+	}
+}
 
 func lookup(values map[string]string) secrets.LookupEnv {
 	return func(key string) (string, bool) {

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -42,6 +42,25 @@ from dev_health_ops.workers.provider_family_contract import (
 _FALSE = frozenset({"", "0", "false", "no", "off"})
 _TRUE = frozenset({"1", "true", "yes", "on"})
 
+_PROVIDER_ROUTES_PRESET_ENV = "GO_PROVIDER_ROUTES"
+_DEV_HEALTH_ENV = "DEV_HEALTH_ENV"
+_LOCAL_ALL_DISABLED_ALIASES = frozenset(
+    {
+        "github_pr_reviews",
+        "github_pr_comments",
+        "github_tests",
+        "gitlab_pr_reviews",
+        "gitlab_pr_comments",
+        "gitlab_tests",
+    }
+)
+_LOCAL_ALL_CANONICAL_ALTERNATIVES = {
+    "github_prs": ("github_pr_reviews", "github_pr_comments"),
+    "github_cicd": ("github_tests",),
+    "gitlab_prs": ("gitlab_pr_reviews", "gitlab_pr_comments"),
+    "gitlab_cicd": ("gitlab_tests",),
+}
+
 # src/dev_health_ops/workers/provider_unit_route.py -> repo root is 3 parents up.
 _DEFAULT_MATRIX_CONTRACT_PATH = (
     Path(__file__).resolve().parents[3]
@@ -77,6 +96,42 @@ def _flag(environment: Mapping[str, str], name: str) -> bool:
     if value in _TRUE:
         return True
     raise ProviderUnitRouteError("provider unit route switch is invalid")
+
+
+def _provider_route_environment(
+    environment: Mapping[str, str], field_names: tuple[str, ...]
+) -> Mapping[str, str]:
+    """Apply the local-only all-routes preset as per-switch defaults.
+
+    Explicit switches win because ``setdefault`` never replaces a supplied
+    value. Production remains default-off: any non-empty preset is rejected
+    unless the process explicitly identifies its environment as local.
+    """
+
+    preset = environment.get(_PROVIDER_ROUTES_PRESET_ENV, "").strip().lower()
+    if not preset:
+        return environment
+    if preset != "all":
+        raise ProviderUnitRouteError("provider route preset must be empty or all")
+    if environment.get(_DEV_HEALTH_ENV, "").strip().lower() != "local":
+        raise ProviderUnitRouteError(
+            "all provider routes preset requires local environment"
+        )
+
+    resolved = dict(environment)
+    for field_name in field_names:
+        environment_name = f"WORKER_{field_name.upper()}_ENABLED"
+        alternative_selected = any(
+            _flag(environment, f"WORKER_{alternative.upper()}_ENABLED")
+            for alternative in _LOCAL_ALL_CANONICAL_ALTERNATIVES.get(field_name, ())
+        )
+        resolved.setdefault(
+            environment_name,
+            "false"
+            if field_name in _LOCAL_ALL_DISABLED_ALIASES or alternative_selected
+            else "true",
+        )
+    return resolved
 
 
 @cache
@@ -223,6 +278,9 @@ def provider_family_strict_admission_enabled(
         or f"WORKER_{normalized_provider.upper()}_WORK_ITEMS_ENABLED"
     )
     source = os.environ if environment is None else environment
+    source = _provider_route_environment(
+        source, tuple(ProviderUnitRouteSwitches.__dataclass_fields__)
+    )
     return _flag(source, switch_name)
 
 
@@ -296,6 +354,7 @@ class ProviderUnitRouteSwitches:
         cls, environment: Mapping[str, str] | None = None
     ) -> ProviderUnitRouteSwitches:
         source = os.environ if environment is None else environment
+        source = _provider_route_environment(source, tuple(cls.__dataclass_fields__))
         switches = cls(
             linear_work_items=_flag(source, "WORKER_LINEAR_WORK_ITEMS_ENABLED"),
             jira_work_items=_flag(source, "WORKER_JIRA_WORK_ITEMS_ENABLED"),

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -938,6 +938,48 @@ def test_platform_compose_provider_worker_consumes_sync_dispatch_queue() -> None
     assert "sync" in queues
 
 
+def test_platform_compose_wires_local_all_provider_routes_end_to_end() -> None:
+    """The optional monorepo Compose surface must wire one preset to both runtimes."""
+
+    compose_path = _platform_compose_path()
+    if compose_path is None:
+        pytest.skip("platform compose.yml is only present in the monorepo checkout")
+
+    services = _load_yaml(compose_path).get("services") or {}
+    for service_name in ("api", "worker", "beat", "go-worker"):
+        environment = services[service_name].get("environment") or {}
+        assert environment["DEV_HEALTH_ENV"] == "${DEV_HEALTH_ENV:-}"
+        assert environment["GO_PROVIDER_ROUTES"] == "${GO_PROVIDER_ROUTES:-}"
+        assert _PROVIDER_ROUTE_SWITCH_NAMES <= environment.keys(), (
+            f"{service_name} is missing provider route switches: "
+            f"{sorted(_PROVIDER_ROUTE_SWITCH_NAMES - environment.keys())}"
+        )
+
+    operator = services.get("go-workerctl")
+    assert operator is not None, "platform Compose must expose the route operator"
+    operator_environment = operator.get("environment") or {}
+    assert operator_environment["COORDINATOR_DATABASE_URI"].startswith(
+        "postgresql://${RIVER_COORDINATOR_DATABASE_ROLE"
+    )
+    assert operator_environment["WORKER_OPERATOR_TOKEN"] == (
+        "${WORKER_OPERATOR_TOKEN:-}"
+    )
+
+    preset_path = compose_path.with_name(".env.go-all")
+    assert preset_path.is_file()
+    preset = {
+        key: value
+        for line in preset_path.read_text(encoding="utf-8").splitlines()
+        if line and not line.startswith("#")
+        for key, value in (line.split("=", maxsplit=1),)
+    }
+    assert preset == {
+        "COMPOSE_PROFILES": "go",
+        "DEV_HEALTH_ENV": "local",
+        "GO_PROVIDER_ROUTES": "all",
+    }
+
+
 def test_compose_workers_override_runner_entrypoint() -> None:
     for path in (_LEGACY_COMPOSE, _PROD_COMPOSE, _SWARM_STACK):
         services = _load_yaml(path).get("services") or {}

--- a/tests/tooling/mutation-plans/local_all_provider_routes.json
+++ b/tests/tooling/mutation-plans/local_all_provider_routes.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "name": "local-only all-provider-routes preset",
+  "$limitation": "Pins the local-environment guard and canonical alias selection in both runtime configuration readers. Docker artifact packaging is covered by a static deployment-contract test because mutating Dockerfile staging without a platform build cannot distinguish a behavioral kill from invalid image construction.",
+  "mutations": [
+    {
+      "id": "LAR01-go-local-environment-guard",
+      "file": "internal/platform/config/config.go",
+      "find": "\tif strings.ToLower(strings.TrimSpace(environment)) != \"local\" {",
+      "replace": "\tif strings.ToLower(strings.TrimSpace(environment)) == \"local\" {",
+      "expect_occurrences": 1,
+      "rationale": "The all-routes shorthand must be rejected outside an explicitly local environment and admitted in local development.",
+      "build": ["go", "test", "-run", "^$", "./internal/platform/config/"],
+      "proof": [["go", "test", "-count=1", "-run", "^Test(LocalAllProviderRoutesPreset|ProviderRoutesPresetRejectsNonLocalAndUnknownValues)$", "./internal/platform/config/"]]
+    },
+    {
+      "id": "LAR02-go-canonical-testops-alias",
+      "file": "internal/platform/config/config.go",
+      "find": "\t\t\"WORKER_GITHUB_TESTS_ENABLED\",",
+      "replace": "\t\t\"WORKER_GITHUB_TESTS_DISABLED\",",
+      "expect_occurrences": 1,
+      "rationale": "The local preset chooses CICD as the sole GitHub TestOps alias and must leave TESTS disabled.",
+      "build": ["go", "test", "-run", "^$", "./internal/platform/config/"],
+      "proof": [["go", "test", "-count=1", "-run", "^TestLocalAllProviderRoutesPreset$", "./internal/platform/config/"]]
+    },
+    {
+      "id": "LAR03-python-local-environment-guard",
+      "file": "src/dev_health_ops/workers/provider_unit_route.py",
+      "find": "    if environment.get(_DEV_HEALTH_ENV, \"\").strip().lower() != \"local\":",
+      "replace": "    if environment.get(_DEV_HEALTH_ENV, \"\").strip().lower() == \"local\":",
+      "expect_occurrences": 1,
+      "rationale": "Python producer admission must enforce the same local-only boundary as the Go executor.",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/workers/provider_unit_route.py"],
+      "proof": [["pytest", "-q", "tests/workers/test_provider_unit_route.py", "-k", "local_all_routes or routes_preset"]]
+    },
+    {
+      "id": "LAR04-python-canonical-pr-alias",
+      "file": "src/dev_health_ops/workers/provider_unit_route.py",
+      "find": "        \"gitlab_pr_reviews\",",
+      "replace": "        \"gitlab_pr_reviews_disabled\",",
+      "expect_occurrences": 1,
+      "rationale": "The local preset chooses PRS as the sole GitLab PR-social alias and must leave PR_REVIEWS disabled.",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/workers/provider_unit_route.py"],
+      "proof": [["pytest", "-q", "tests/workers/test_provider_unit_route.py::test_local_all_routes_preset_enables_every_compatible_family"]]
+    }
+  ]
+}

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -31,6 +31,11 @@ _GO_SWARM_ONLY = _REPO_ROOT / "deploy" / "docker-swarm" / "stack.go-workers-only
 _GO_KUBERNETES = _KUBERNETES / "go-workers.yaml"
 _GO_KUBERNETES_ONLY = _KUBERNETES / "go-workers-only.yaml"
 
+_PACKAGED_WORK_ITEM_CONFIG = {
+    "status_mapping.yaml": "/app/config/status_mapping.yaml",
+    "investment_areas.yaml": "/app/config/investment_areas.yaml",
+}
+
 _MIGRATION_CONFIG_DEFAULTS = {
     "RIVER_DATABASE_SCHEMA": "river",
     "RIVER_DOMAIN_DATABASE_ROLE": "devhealth_domain",
@@ -281,6 +286,17 @@ def test_go_profiles_are_disabled_future_topology() -> None:
             "WORKER_OPERATOR_TOKEN",
         ],
     }
+
+
+def test_go_worker_image_packages_work_item_semantic_config() -> None:
+    dockerfile = _GO_WORKER_DOCKERFILE.read_text(encoding="utf-8")
+
+    for filename, runtime_path in _PACKAGED_WORK_ITEM_CONFIG.items():
+        source = f"src/dev_health_ops/config/{filename}"
+        staged = f"/runtime/worker{runtime_path}"
+        assert (_REPO_ROOT / source).is_file()
+        assert f"COPY {source} ./src/dev_health_ops/config/{filename}" in dockerfile
+        assert staged in dockerfile
 
 
 def test_go_deployment_surfaces_are_additive_default_off_and_profile_complete() -> None:

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -36,6 +36,54 @@ def test_route_switch_is_exact_and_independent() -> None:
     assert not switches.routes_to_river("gitlab", "feature-flags")
 
 
+def test_local_all_routes_preset_enables_every_compatible_family() -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"DEV_HEALTH_ENV": "local", "GO_PROVIDER_ROUTES": "all"}
+    )
+
+    disabled_aliases = {
+        "github_pr_reviews",
+        "github_pr_comments",
+        "github_tests",
+        "gitlab_pr_reviews",
+        "gitlab_pr_comments",
+        "gitlab_tests",
+    }
+    for field_name in switches.__dataclass_fields__:
+        assert getattr(switches, field_name) is (field_name not in disabled_aliases)
+
+
+def test_local_all_routes_preset_preserves_explicit_switch_override() -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {
+            "DEV_HEALTH_ENV": "local",
+            "GO_PROVIDER_ROUTES": "all",
+            "WORKER_GITHUB_FILES_ENABLED": "false",
+            "WORKER_GITLAB_PR_REVIEWS_ENABLED": "true",
+        }
+    )
+
+    assert switches.github_files is False
+    assert switches.github_commits is True
+    assert switches.gitlab_pr_reviews is True
+    assert switches.gitlab_prs is False
+
+
+@pytest.mark.parametrize(
+    "environment",
+    (
+        {"GO_PROVIDER_ROUTES": "all"},
+        {"DEV_HEALTH_ENV": "production", "GO_PROVIDER_ROUTES": "all"},
+        {"DEV_HEALTH_ENV": "local", "GO_PROVIDER_ROUTES": "some"},
+    ),
+)
+def test_routes_preset_rejects_nonlocal_or_unknown_configuration(
+    environment: dict[str, str],
+) -> None:
+    with pytest.raises(ProviderUnitRouteError):
+        ProviderUnitRouteSwitches.from_environment(environment)
+
+
 _AGGREGATE_ROUTE_SWITCH_CASES = (
     (
         "gitlab",


### PR DESCRIPTION
## Summary

- add a local-only `GO_PROVIDER_ROUTES=all` preset shared by Python producer admission and the Go executor
- preserve explicit per-route overrides and choose one canonical alias for PR-social and TestOps families
- package the existing status-mapping and investment-area YAML files inside the Go worker image
- fail startup for unknown presets or any `all` preset outside `DEV_HEALTH_ENV=local`

This is stacked on `feat/go-worker-runtime-migration`. It does not activate, deploy, or cut over any production route.

## TEST-EVIDENCE

- Go config and worker focused tests: passed
- Python route, deployment, and Compose contracts: `225 passed`
- shared mutation harness: `4/4 KILLED`, restore verified clean
- worker Docker image built successfully; both `/app/config/*.yaml` files copied from the image and SHA-256 matched their checked-in source files
- Ruff, gofmt, mypy (2203 source files), `git diff --check`, pre-commit, and pre-push hooks: passed

## RISK-NOTES

- production remains default-off and rejects the preset unless `DEV_HEALTH_ENV=local`
- explicit `WORKER_*_ENABLED=true|false` values override preset defaults
- mutually exclusive aliases remain fail-closed
- this PR does not change the durable `sync.provider_unit` transport, start containers, or modify deployment manifests
