### PR TITLE
CHAOS-3039: back off idle Go stream polls

### DIFF
--- a/internal/streamrunner/runner.go
+++ b/internal/streamrunner/runner.go
@@ -18,6 +18,8 @@ import (
 var errNotReady = errors.New("stream runner has not completed a successful stream window")
 var errTransientWrite = errors.New("transient stream durable-write failure")
 
+const initialIdleDelay = 10 * time.Millisecond
+
 // Runner owns a long-lived XREADGROUP loop. It has one in-flight message per
 // configured stream lane, so shutdown can either finish that message or leave
 // it pending; it never ACKs a message merely because the process is stopping.
@@ -45,6 +47,7 @@ type Runner struct {
 	lastStats   map[string]StreamStats
 	streams     []string
 	readCursor  int
+	waitIdle    func(context.Context, time.Duration) bool
 }
 
 func New(transport Transport, handler Handler, config Config, registry *health.Registry) (*Runner, error) {
@@ -57,6 +60,7 @@ func New(transport Transport, handler Handler, config Config, registry *health.R
 		config:    config,
 		registry:  registry,
 		lastStats: make(map[string]StreamStats, len(config.Streams)),
+		waitIdle:  waitForContext,
 	}
 	if err := registry.RegisterRequired(config.Name+"_loop", runner.readiness); err != nil {
 		return nil, fmt.Errorf("register stream readiness: %w", err)
@@ -96,43 +100,60 @@ func (r *Runner) Start(parent context.Context) error {
 func (r *Runner) run(ctx context.Context, done chan struct{}) {
 	defer close(done)
 	nextMaintenance := time.Time{}
+	idleDelay := initialIdleDelay
+	maxIdleDelay := minDuration(r.config.Block, time.Second)
 	for {
 		maintain := nextMaintenance.IsZero() || !time.Now().Before(nextMaintenance)
 		if maintain {
 			nextMaintenance = time.Now().Add(r.config.ReclaimEvery)
 		}
-		if err := r.cycle(ctx, maintain); err != nil {
+		active, err := r.cycle(ctx, maintain)
+		if err != nil {
 			r.recordFailure()
+			idleDelay = initialIdleDelay
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(minDuration(r.config.ReclaimEvery, time.Second)):
 			}
+			continue
 		}
+		if active {
+			idleDelay = initialIdleDelay
+			continue
+		}
+		if !r.waitIdle(ctx, idleDelay) {
+			return
+		}
+		idleDelay = minDuration(idleDelay*2, maxIdleDelay)
 	}
 }
 
 func (r *Runner) window(ctx context.Context) error {
-	return r.cycle(ctx, true)
+	_, err := r.cycle(ctx, true)
+	return err
 }
 
-func (r *Runner) cycle(ctx context.Context, maintain bool) error {
+func (r *Runner) cycle(ctx context.Context, maintain bool) (bool, error) {
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return false, ctx.Err()
 	}
 	if maintain {
 		if err := r.refreshStreams(ctx); err != nil {
-			return err
+			return false, err
 		}
 	}
 	r.mu.Lock()
 	streams := append([]string(nil), r.streams...)
 	r.mu.Unlock()
 
+	active := false
 	var failures []error
 	for _, stream := range streams {
 		if maintain {
-			if err := r.reclaim(ctx, stream); err != nil {
+			reclaimed, err := r.reclaim(ctx, stream)
+			active = active || reclaimed
+			if err != nil {
 				failures = append(failures, err)
 			}
 		}
@@ -143,6 +164,7 @@ func (r *Runner) cycle(ctx context.Context, maintain bool) error {
 		if err != nil {
 			failures = append(failures, fmt.Errorf("read streams: %w", err))
 		} else {
+			active = active || len(messages) > 0
 			for _, message := range messages {
 				if err := r.process(ctx, message); err != nil {
 					failures = append(failures, err)
@@ -167,13 +189,13 @@ func (r *Runner) cycle(ctx context.Context, maintain bool) error {
 		r.mu.Lock()
 		r.up = false
 		r.mu.Unlock()
-		return err
+		return active, err
 	}
 	r.mu.Lock()
 	r.lastSuccess, r.up = time.Now().UTC(), true
 	r.mu.Unlock()
 	r.ready.Store(true)
-	return nil
+	return active, nil
 }
 
 // nextReadLanes keeps one XREADGROUP response bounded by BatchSize even when
@@ -243,10 +265,10 @@ func (r *Runner) refreshStreams(ctx context.Context) error {
 	return nil
 }
 
-func (r *Runner) reclaim(ctx context.Context, stream string) error {
+func (r *Runner) reclaim(ctx context.Context, stream string) (bool, error) {
 	pending, err := r.transport.Pending(ctx, stream, r.config.ConsumerGroup, r.config.BatchSize, r.config.ReclaimIdle)
 	if err != nil {
-		return fmt.Errorf("inspect pending: %w", err)
+		return false, fmt.Errorf("inspect pending: %w", err)
 	}
 	claim := make([]string, 0, len(pending))
 	poison := make(map[string]struct{})
@@ -257,11 +279,11 @@ func (r *Runner) reclaim(ctx context.Context, stream string) error {
 		claim = append(claim, item.MessageID)
 	}
 	if len(claim) == 0 {
-		return nil
+		return false, nil
 	}
 	claimed, err := r.transport.Claim(ctx, stream, r.config.ConsumerGroup, r.config.ConsumerName, claim, r.config.ReclaimIdle)
 	if err != nil {
-		return fmt.Errorf("claim pending: %w", err)
+		return false, fmt.Errorf("claim pending: %w", err)
 	}
 	claimedByID := make(map[string]Message, len(claimed))
 	for _, message := range claimed {
@@ -292,7 +314,7 @@ func (r *Runner) reclaim(ctx context.Context, stream string) error {
 			failures = append(failures, err)
 		}
 	}
-	return errors.Join(failures...)
+	return len(claimed) > 0, errors.Join(failures...)
 }
 
 func sortedUnique(values []string) []string {
@@ -447,4 +469,15 @@ func minDuration(left, right time.Duration) time.Duration {
 		return left
 	}
 	return right
+}
+
+func waitForContext(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }

--- a/internal/streamrunner/runner_test.go
+++ b/internal/streamrunner/runner_test.go
@@ -179,7 +179,7 @@ func TestRunnerLeavesTransientFailurePendingForReclaim(t *testing.T) {
 	transport.pending = []Pending{{MessageID: "1-0", TimesDelivered: 1, Idle: time.Second}}
 	transport.claimed = []Message{{Stream: "test:stream", ID: "1-0"}}
 	runner.handler = handlerFunc(func(context.Context, Message) error { return nil })
-	if err := runner.reclaim(context.Background(), "test:stream"); err != nil {
+	if _, err := runner.reclaim(context.Background(), "test:stream"); err != nil {
 		t.Fatal(err)
 	}
 	if !slices.Equal(transport.acked, []string{"1-0"}) {
@@ -279,6 +279,92 @@ func TestRunnerReadsContinuouslyBetweenReclaimCadences(t *testing.T) {
 	}
 }
 
+func TestRunnerBacksOffAfterZeroStreamCycle(t *testing.T) {
+	transport := &fakeTransport{}
+	config := dynamicTestConfig()
+	config.Block = 80 * time.Millisecond
+	config.ReclaimEvery = 100 * time.Millisecond
+	config.ReclaimIdle = 100 * time.Millisecond
+	runner, err := New(transport, handlerFunc(func(context.Context, Message) error { return nil }), config, health.NewRegistry(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	waited := make(chan []time.Duration, 1)
+	var delays []time.Duration
+	runner.waitIdle = func(_ context.Context, delay time.Duration) bool {
+		delays = append(delays, delay)
+		if len(delays) == 5 {
+			waited <- append([]time.Duration(nil), delays...)
+			return false
+		}
+		return true
+	}
+	if err := runner.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-waited:
+		want := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond, 80 * time.Millisecond, 80 * time.Millisecond}
+		if !slices.Equal(got, want) {
+			t.Fatalf("idle delays = %v, want %v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("zero-stream cycle was not throttled")
+	}
+	if err := runner.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	if len(transport.readStreams) != 0 {
+		t.Fatalf("zero-stream cycle attempted reads: %v", transport.readStreams)
+	}
+}
+
+func TestRunnerDoesNotBackOffAfterActiveCycle(t *testing.T) {
+	transport := &fakeTransport{new: []Message{{Stream: "test:stream", ID: "1-0"}}}
+	runner, err := New(transport, handlerFunc(func(context.Context, Message) error { return nil }), testConfig(), health.NewRegistry(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	readsAtWait := make(chan int, 1)
+	runner.waitIdle = func(_ context.Context, _ time.Duration) bool {
+		transport.mu.Lock()
+		defer transport.mu.Unlock()
+		readsAtWait <- len(transport.readStreams)
+		return false
+	}
+	if err := runner.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case reads := <-readsAtWait:
+		if reads != 2 {
+			t.Fatalf("reads before idle wait = %d, want active cycle plus immediate next read", reads)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runner did not reach its first idle cycle")
+	}
+	if err := runner.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(transport.acked, []string{"1-0"}) {
+		t.Fatalf("active message was not processed before idle wait: %v", transport.acked)
+	}
+}
+
+func TestRunnerIdleWaitStopsOnContextCancellation(t *testing.T) {
+	runner, err := New(&fakeTransport{}, handlerFunc(func(context.Context, Message) error { return nil }), testConfig(), health.NewRegistry(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if runner.waitIdle(ctx, time.Hour) {
+		t.Fatal("idle wait reported elapsed after context cancellation")
+	}
+}
+
 func TestRunnerRestartReclaimsPendingAndAckFailureReplaysDurableWrite(t *testing.T) {
 	transport := &fakeTransport{
 		new:    []Message{{Stream: "test:stream", ID: "1-0"}},
@@ -371,7 +457,7 @@ func TestRunnerClaimsPoisonFieldsBeforeDLQFinalization(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := runner.reclaim(context.Background(), message.Stream); err != nil {
+	if _, err := runner.reclaim(context.Background(), message.Stream); err != nil {
 		t.Fatal(err)
 	}
 	if len(handler.finalized) != 1 || handler.finalized[0].Fields["ingestion_id"] != "batch-a" {
@@ -385,7 +471,7 @@ func TestRunnerReclaimsPoisonDeliveryCountAndExportsBoundedMetrics(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := runner.reclaim(context.Background(), "test:stream"); err != nil {
+	if _, err := runner.reclaim(context.Background(), "test:stream"); err != nil {
 		t.Fatal(err)
 	}
 	if !slices.Equal(transport.quarantined, []string{"1-0:max_deliveries_exceeded"}) || !slices.Equal(transport.acked, []string{"1-0"}) {

--- a/tests/tooling/mutation-plans/streamrunner-idle-backoff.json
+++ b/tests/tooling/mutation-plans/streamrunner-idle-backoff.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "name": "stream runner idle backoff",
+  "build": [
+    "go",
+    "test",
+    "./internal/streamrunner",
+    "-run",
+    "^$"
+  ],
+  "mutations": [
+    {
+      "id": "SIB01",
+      "file": "internal/streamrunner/runner.go",
+      "find": "if !r.waitIdle(ctx, idleDelay) {",
+      "replace": "if false && !r.waitIdle(ctx, idleDelay) {",
+      "expect_occurrences": 1,
+      "rationale": "an empty successful cycle must yield instead of immediately polling again",
+      "proof": [
+        [
+          "go",
+          "test",
+          "./internal/streamrunner",
+          "-run",
+          "^TestRunnerBacksOffAfterZeroStreamCycle$",
+          "-count=1"
+        ]
+      ]
+    },
+    {
+      "id": "SIB02",
+      "file": "internal/streamrunner/runner.go",
+      "find": "if active {",
+      "replace": "if false && active {",
+      "expect_occurrences": 1,
+      "rationale": "a cycle that handled work must start its next read without an idle delay",
+      "proof": [
+        [
+          "go",
+          "test",
+          "./internal/streamrunner",
+          "-run",
+          "^TestRunnerDoesNotBackOffAfterActiveCycle$",
+          "-count=1"
+        ]
+      ]
+    },
+    {
+      "id": "SIB03",
+      "file": "internal/streamrunner/runner.go",
+      "find": "idleDelay = minDuration(idleDelay*2, maxIdleDelay)",
+      "replace": "idleDelay = minDuration(idleDelay, maxIdleDelay)",
+      "expect_occurrences": 1,
+      "rationale": "repeated empty cycles must increase the delay up to the bounded cap",
+      "proof": [
+        [
+          "go",
+          "test",
+          "./internal/streamrunner",
+          "-run",
+          "^TestRunnerBacksOffAfterZeroStreamCycle$",
+          "-count=1"
+        ]
+      ]
+    },
+    {
+      "id": "SIB04",
+      "file": "internal/streamrunner/runner.go",
+      "find": "case <-ctx.Done():\n\t\treturn false",
+      "replace": "case <-ctx.Done():\n\t\treturn true",
+      "expect_occurrences": 1,
+      "rationale": "shutdown cancellation must interrupt an idle wait",
+      "proof": [
+        [
+          "go",
+          "test",
+          "./internal/streamrunner",
+          "-run",
+          "^TestRunnerIdleWaitStopsOnContextCancellation$",
+          "-count=1"
+        ]
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- stop Go stream-runner profiles from spinning after successful empty cycles
- apply a context-cancellable exponential idle wait from 10 ms to `min(Block, 1s)`
- reset the delay after new or reclaimed work so active queues continue immediately
- stack this fix on coordinator PR #1740

## TEST-EVIDENCE

- `go test ./internal/streamrunner ./cmd/dev-health-stream-runner -count=1`
- `go test -race ./internal/streamrunner -count=1`
- `go vet ./internal/streamrunner ./cmd/dev-health-stream-runner`
- `python3 scripts/mutation_harness.py run --plan tests/tooling/mutation-plans/streamrunner-idle-backoff.json --assert-all-killed` — SIB01-SIB04 killed
- `bash ci/check_go.sh fast` — passed, including uncached live Python oracles
- `bash ci/local_validate.sh` — passed 9/9 stages; 13,846 passed, 248 skipped, 1 xfailed; scratch ClickHouse database dropped

## RISK-NOTES

- The maximum added latency applies only after an empty successful cycle and is capped at one second.
- A cycle that processes or reclaims work resets the delay and starts the next read immediately.
- Shutdown cancellation interrupts the idle timer.
- The existing shared Compose stack was not rebuilt, so live post-fix CPU is not yet measured.

Linear: CHAOS-3039

Depends on #1740.