### PR TITLE
fix(worker): close live Linear and PagerDuty failures

### DIFF
--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -427,7 +427,9 @@ func buildProviderSyncHandlerWithWorkItemsRuntimeConfig(
 					return providersync.CompleteRouteExecutor{}, err
 				}
 				routeHandler = providersync.LinearWorkItemFamilyRouteHandler{
-					Direct:  providersync.LinearWorkItemsRouteHandler{},
+					Direct: providersync.LinearWorkItemsRouteHandler{
+						GlobalDiscovery: true,
+					},
 					Derived: linearDeriver,
 				}
 				sink, readback = linearSink, linearSink

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -243,6 +243,25 @@ func buildProviderSyncHandlerWithWorkItemsRuntimeConfig(
 	logger *slog.Logger,
 	workItemsRuntime workItemsRuntimeConfig,
 ) (*providerunit.Handler, *providerfoundation.Metrics) {
+	return buildProviderSyncHandlerWithRuntimeDependencies(
+		repository, switches, decryptor, nil, clickhouseConnection, valkeyClient,
+		domainPool, jiraIncidentEntitlement, collector, logger, workItemsRuntime,
+	)
+}
+
+func buildProviderSyncHandlerWithRuntimeDependencies(
+	repository providerSyncRepository,
+	switches providersync.CompleteRouteSwitches,
+	decryptor providerfoundation.CredentialDecryptor,
+	credentialHydrator providerfoundation.CredentialHydrator,
+	clickhouseConnection driver.Conn,
+	valkeyClient valkeygo.Client,
+	domainPool *pgxpool.Pool,
+	jiraIncidentEntitlement providersync.JiraIncidentEntitlement,
+	collector *jobruntime.MetricsCollector,
+	logger *slog.Logger,
+	workItemsRuntime workItemsRuntimeConfig,
+) (*providerunit.Handler, *providerfoundation.Metrics) {
 	// providerMetrics is constructed exactly once per worker process and
 	// referenced by every claim's executor, so dev_health_provider_* actually
 	// accumulates across dispatches instead of being built and discarded per
@@ -642,6 +661,7 @@ func buildProviderSyncHandlerWithWorkItemsRuntimeConfig(
 						Pool: domainPool,
 					},
 					Decryptor: decryptor,
+					Hydrator:  credentialHydrator,
 				},
 				Doer: &http.Client{
 					Timeout: 45 * time.Second,
@@ -778,9 +798,23 @@ func constructProviderSyncWorkerWithDependencies(
 	// types below are then safe no-ops) for any other Observer implementation,
 	// such as a test double.
 	collector, _ := observer.(*jobruntime.MetricsCollector)
-	handler, providerMetrics := buildProviderSyncHandlerWithWorkItemsRuntimeConfig(
-		repository, workerRouteSwitches(cfg), decryptor, clickhouseConnection,
-		valkeyClient, postgresDatabase.pools.Domain,
+	handler, providerMetrics := buildProviderSyncHandlerWithRuntimeDependencies(
+		repository, workerRouteSwitches(cfg), decryptor,
+		providerfoundation.PagerDutyOAuthHydrator{
+			Repository: providerfoundation.PostgresPagerDutyOAuthTokenRepository{
+				Pool: postgresDatabase.pools.Domain,
+			},
+			Cipher: decryptor,
+			Doer: &http.Client{
+				Timeout: 45 * time.Second,
+				CheckRedirect: func(*http.Request, []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			},
+			AppClientID:     cfg.PagerDutyOAuthClientID,
+			AppClientSecret: cfg.PagerDutyOAuthSecret,
+		},
+		clickhouseConnection, valkeyClient, postgresDatabase.pools.Domain,
 		providersync.PostgresJiraIncidentEntitlement{Pool: postgresDatabase.pools.Domain},
 		collector, logger, workItemsRuntime,
 	)

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -208,6 +208,49 @@ func TestBuildProviderSyncHandlerConstructsPagerDutyRoutesWithCredentialBoundEff
 	}
 }
 
+func TestBuildProviderSyncHandlerWiresPagerDutyCredentialHydrator(t *testing.T) {
+	t.Parallel()
+	hydrator := providerSyncCredentialHydratorFunc(func(
+		_ context.Context,
+		_ providerfoundation.LeaseGuard,
+		_ providerfoundation.TenantScope,
+		credential providerfoundation.Credential,
+	) (providerfoundation.Credential, error) {
+		return credential, nil
+	})
+	handler, _ := buildProviderSyncHandlerWithRuntimeDependencies(
+		nil, providersync.CompleteRouteSwitches{}, nil, hydrator,
+		nil, nil, nil, nil, nil, slog.Default(), workItemsRuntimeConfig{},
+	)
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{
+		Claim: providersync.Claim{Unit: providersync.Unit{
+			Provider: "pagerduty", Dataset: "services",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executor.Credentials.Hydrator == nil {
+		t.Fatal("PagerDuty OAuth credential hydrator was not wired")
+	}
+}
+
+type providerSyncCredentialHydratorFunc func(
+	context.Context,
+	providerfoundation.LeaseGuard,
+	providerfoundation.TenantScope,
+	providerfoundation.Credential,
+) (providerfoundation.Credential, error)
+
+func (hydrate providerSyncCredentialHydratorFunc) Hydrate(
+	ctx context.Context,
+	lease providerfoundation.LeaseGuard,
+	scope providerfoundation.TenantScope,
+	credential providerfoundation.Credential,
+) (providerfoundation.Credential, error) {
+	return hydrate(ctx, lease, scope, credential)
+}
+
 // TestBuildProviderSyncHandlerSharesOneMetricsInstance is CHAOS-3118
 // mutation-tested evidence for dev_health_provider_*, not a behavioral
 // assertion: it pins the identity between the providerfoundation.Metrics

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -119,6 +119,34 @@ func TestBuildProviderSyncHandlerConstructsAggregateWorkItemRoutes(t *testing.T)
 	}
 }
 
+func TestBuildProviderSyncHandlerConfiguresLinearAccountDiscovery(t *testing.T) {
+	t.Setenv("STATUS_MAPPING_PATH", "")
+	runtimeConfig, err := githubWorkItemsRuntimeConfigFrom(validGitHubWorkItemsRuntimeConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, _ := buildProviderSyncHandlerWithGitHubWorkItemsRuntimeConfig(
+		nil, providersync.CompleteRouteSwitches{}, nil,
+		&githubWorkItemsBuildExecutorConn{}, nil, nil, nil, nil,
+		slog.Default(), runtimeConfig,
+	)
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{
+		Claim: providersync.Claim{Unit: providersync.Unit{
+			Provider: "linear", Dataset: "work-items",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	linearHandler, ok := executor.Handler.(providersync.LinearWorkItemFamilyRouteHandler)
+	if !ok {
+		t.Fatalf("handler=%T want providersync.LinearWorkItemFamilyRouteHandler", executor.Handler)
+	}
+	if !linearHandler.Direct.GlobalDiscovery {
+		t.Fatal("production Linear account unit must discover every accessible team")
+	}
+}
+
 func TestBuildProviderSyncHandlerConstructsPagerDutyRoutesWithCredentialBoundEffects(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/domaingrants/groundtruth_test.go
+++ b/internal/domaingrants/groundtruth_test.go
@@ -131,12 +131,12 @@ func TestLoadGroundTruth_MatchesKnownShape(t *testing.T) {
 		}
 	}
 
-	if len(gt.RequiredTablePrivileges) != 35 {
-		t.Errorf("domain posture: got %d tables, want 35 (Option B two-role split) -- "+
+	if len(gt.RequiredTablePrivileges) != 36 {
+		t.Errorf("domain posture: got %d tables, want 36 (Option B two-role split) -- "+
 			"if this changed intentionally, the ground-truth reader is fine, just update this pin", len(gt.RequiredTablePrivileges))
 	}
-	if len(gt.Grants) != 35 {
-		t.Errorf("runtimeGrantStatements: got %d granted tables, want 35 -- see note above", len(gt.Grants))
+	if len(gt.Grants) != 36 {
+		t.Errorf("runtimeGrantStatements: got %d granted tables, want 36 -- see note above", len(gt.Grants))
 	}
 	// The two lists agreeing on their size is the property that matters most
 	// here: this checker exists because they disagreed once.

--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -353,6 +353,7 @@ func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pg
 		"CREATE TABLE public.integration_sources (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.integration_datasets (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.integration_credentials (id uuid PRIMARY KEY)",
+		"CREATE TABLE public.provider_oauth_credentials (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY, state text NOT NULL)",
 		// Migration 0088 (#1529) added this table to domainPosture's manifest,

--- a/internal/jobs/providerunit/deterministic_terminal_category_test.go
+++ b/internal/jobs/providerunit/deterministic_terminal_category_test.go
@@ -22,6 +22,11 @@ func TestDeterministicTerminalCategoryContract(t *testing.T) {
 		category string
 	}{
 		{
+			name:     "provider dataset unavailable",
+			err:      providersync.ErrProviderDatasetUnavailable,
+			category: ProviderDatasetUnavailableCategory,
+		},
+		{
 			name:     "repository identity ambiguous",
 			err:      providersync.ErrRepositoryIdentityAmbiguous,
 			category: RepositoryIdentityCategory,

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -55,6 +55,11 @@ const GitHubFilesInventoryFailureCategory = "github_files_inventory_failed"
 // wedged effect hard to find.
 const EffectRecoveryAmbiguousCategory = "effect_recovery_ambiguous"
 
+// ProviderDatasetUnavailableCategory records an account-level provider
+// capability limitation. It is distinct from authentication and exhaustion:
+// retrying the same valid credential cannot make the dataset available.
+const ProviderDatasetUnavailableCategory = "provider_dataset_unavailable"
+
 // deterministicTerminalCategory maps executor failures that no retry can clear
 // onto their own durable category. Anything not listed keeps the ordinary
 // bounded-retry path.
@@ -65,6 +70,9 @@ const EffectRecoveryAmbiguousCategory = "effect_recovery_ambiguous"
 // thing wherever it comes from -- but it does change the recorded category and
 // the retry count for existing adapters that previously exhausted instead.
 func deterministicTerminalCategory(err error) (string, bool) {
+	if errors.Is(err, providersync.ErrProviderDatasetUnavailable) {
+		return ProviderDatasetUnavailableCategory, true
+	}
 	if errors.Is(err, providersync.ErrRepositoryIdentityAmbiguous) {
 		return RepositoryIdentityCategory, true
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -83,6 +83,8 @@ type Config struct {
 	ClickHouseURI          secrets.Value
 	ValkeyURI              secrets.Value
 	SettingsEncryptionKey  secrets.Value
+	PagerDutyOAuthClientID secrets.Value
+	PagerDutyOAuthSecret   secrets.Value
 
 	QueueDatabaseMode              QueueControlMode
 	RiverDatabaseSchema            string
@@ -503,6 +505,8 @@ func Load(spec Spec) (Config, error) {
 		{name: "CLICKHOUSE_URI", target: &cfg.ClickHouseURI},
 		{name: "VALKEY_URI", target: &cfg.ValkeyURI},
 		{name: "SETTINGS_ENCRYPTION_KEY", target: &cfg.SettingsEncryptionKey},
+		{name: "PAGER_DUTY_CLIENT_ID", target: &cfg.PagerDutyOAuthClientID},
+		{name: "PAGER_DUTY_SECRET", target: &cfg.PagerDutyOAuthSecret},
 		{name: "WORKER_OPERATIONAL_BRIDGE_TOKEN", target: &cfg.OperationalBridgeToken},
 	}
 	for _, item := range secretTargets {
@@ -833,6 +837,8 @@ func (c Config) SafeAttrs() []slog.Attr {
 		slog.Bool("clickhouse_configured", c.ClickHouseURI.Configured()),
 		slog.Bool("valkey_configured", c.ValkeyURI.Configured()),
 		slog.Bool("settings_encryption_key_configured", c.SettingsEncryptionKey.Configured()),
+		slog.Bool("pagerduty_oauth_client_id_configured", c.PagerDutyOAuthClientID.Configured()),
+		slog.Bool("pagerduty_oauth_secret_configured", c.PagerDutyOAuthSecret.Configured()),
 	}
 	if c.Profile != "" {
 		attrs = append(attrs, slog.String("profile", c.Profile))

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -154,17 +154,22 @@ func TestSafeAttrsNeverContainSecretsOrDSNs(t *testing.T) {
 
 	secret := "postgres://worker:top-secret@database.internal/app"
 	cfg, err := Load(workerSpec(map[string]string{
-		"POSTGRES_URI":        secret,
-		"WORKER_DATABASE_URI": "postgres://queue:other-secret@database.internal/app",
-		"CLICKHOUSE_URI":      "clickhouse://analytics:secret@ch.internal/default",
-		"VALKEY_URI":          "redis://:secret@valkey.internal/1",
+		"POSTGRES_URI":         secret,
+		"WORKER_DATABASE_URI":  "postgres://queue:other-secret@database.internal/app",
+		"CLICKHOUSE_URI":       "clickhouse://analytics:secret@ch.internal/default",
+		"VALKEY_URI":           "redis://:secret@valkey.internal/1",
+		"PAGER_DUTY_CLIENT_ID": "pagerduty-client-id",
+		"PAGER_DUTY_SECRET":    "pagerduty-client-secret",
 	}))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	text := fmt.Sprint(cfg.SafeAttrs())
-	for _, forbidden := range []string{secret, "top-secret", "clickhouse://", "redis://"} {
+	for _, forbidden := range []string{
+		secret, "top-secret", "clickhouse://", "redis://",
+		"pagerduty-client-id", "pagerduty-client-secret",
+	} {
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("safe attrs leaked %q: %s", forbidden, text)
 		}
@@ -174,6 +179,8 @@ func TestSafeAttrsNeverContainSecretsOrDSNs(t *testing.T) {
 		"queue_database_configured=true",
 		"clickhouse_configured=true",
 		"valkey_configured=true",
+		"pagerduty_oauth_client_id_configured=true",
+		"pagerduty_oauth_secret_configured=true",
 	} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("safe attrs missing %q: %s", expected, text)

--- a/internal/providerfoundation/credentials.go
+++ b/internal/providerfoundation/credentials.go
@@ -5,11 +5,15 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
 	"golang.org/x/crypto/pbkdf2"
@@ -56,6 +60,51 @@ func (d FernetDecryptor) Decrypt(ciphertext secrets.Value) ([]byte, error) {
 	}
 	legacy := sha256.Sum256(key)
 	return decryptFernet(raw, legacy[:])
+}
+
+// Encrypt emits the same versioned Fernet format as core/encryption.py. It is
+// used only when an OAuth refresh atomically replaces a short-lived token.
+func (d FernetDecryptor) Encrypt(plaintext []byte) (secrets.Value, error) {
+	if !d.key.Configured() {
+		return secrets.Value{}, ErrCredentialInvalid
+	}
+	key := pbkdf2.Key(
+		[]byte(d.key.Reveal()), []byte(d.salt), 600000, 32, sha256.New,
+	)
+	token, err := encryptFernet(plaintext, key, time.Now(), rand.Reader)
+	if err != nil {
+		return secrets.Value{}, ErrCredentialInvalid
+	}
+	return secrets.NewValue(credentialCiphertextV1 + token), nil
+}
+
+func encryptFernet(plaintext, key []byte, now time.Time, entropy io.Reader) (string, error) {
+	if len(key) != 32 || entropy == nil {
+		return "", ErrCredentialInvalid
+	}
+	padding := fernetBlockSize - len(plaintext)%fernetBlockSize
+	padded := make([]byte, len(plaintext)+padding)
+	copy(padded, plaintext)
+	copy(padded[len(plaintext):], bytes.Repeat([]byte{byte(padding)}, padding))
+	block, err := aes.NewCipher(key[16:])
+	if err != nil {
+		return "", ErrCredentialInvalid
+	}
+	iv := make([]byte, fernetBlockSize)
+	if _, err := io.ReadFull(entropy, iv); err != nil {
+		return "", ErrCredentialInvalid
+	}
+	payload := make([]byte, fernetHeaderSize, fernetHeaderSize+len(padded)+fernetSignatureSize)
+	payload[0] = fernetVersion
+	binary.BigEndian.PutUint64(payload[1:9], uint64(now.Unix()))
+	copy(payload[9:fernetHeaderSize], iv)
+	encrypted := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(encrypted, padded)
+	payload = append(payload, encrypted...)
+	mac := hmac.New(sha256.New, key[:16])
+	_, _ = mac.Write(payload)
+	payload = append(payload, mac.Sum(nil)...)
+	return base64.URLEncoding.EncodeToString(payload), nil
 }
 
 func decryptFernet(token string, key []byte) ([]byte, error) {

--- a/internal/providerfoundation/pagerduty_oauth.go
+++ b/internal/providerfoundation/pagerduty_oauth.go
@@ -1,0 +1,286 @@
+package providerfoundation
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+)
+
+const pagerDutyOAuthRenewalWindow = 5 * time.Minute
+
+var pagerDutyOperationalReadScopes = strings.Fields(pagerDutyReadScopes)
+
+// PagerDutyOAuthTokenRecord is the encrypted token reference loaded for one
+// exact organization, provider, credential name, and OAuth binding.
+type PagerDutyOAuthTokenRecord struct {
+	Ciphertext secrets.Value
+	Version    int
+	BindingID  string
+}
+
+// PagerDutyOAuthTokenRotation is the optimistic replacement written after a
+// successful refresh. It never carries plaintext token values.
+type PagerDutyOAuthTokenRotation struct {
+	ExpectedVersion   int
+	ExpectedBindingID string
+	Ciphertext        secrets.Value
+	ExpiresAt         time.Time
+	GrantedScopes     []string
+	HasRefreshToken   bool
+}
+
+type PagerDutyOAuthTokenRepository interface {
+	Load(context.Context, string, string) (PagerDutyOAuthTokenRecord, error)
+	Rotate(context.Context, string, string, PagerDutyOAuthTokenRotation) (bool, error)
+}
+
+// PagerDutyOAuthHydrator resolves a tokenless OAuth descriptor through the
+// Python-owned provider_oauth_credentials store. The access token exists only
+// on the returned credential copy and is never added to the descriptor row,
+// process environment, logs, or job payload.
+type PagerDutyOAuthHydrator struct {
+	Repository      PagerDutyOAuthTokenRepository
+	Cipher          CredentialCipher
+	Doer            HTTPDoer
+	AppClientID     secrets.Value
+	AppClientSecret secrets.Value
+	Now             func() time.Time
+}
+
+type pagerDutyOAuthTokens struct {
+	AccessToken   string    `json:"access_token"`
+	RefreshToken  *string   `json:"refresh_token"`
+	ExpiresAt     time.Time `json:"expires_at"`
+	GrantedScopes []string  `json:"granted_scopes"`
+}
+
+func (h PagerDutyOAuthHydrator) Hydrate(
+	ctx context.Context,
+	lease LeaseGuard,
+	scope TenantScope,
+	credential Credential,
+) (Credential, error) {
+	if credential.Provider != "pagerduty" || credentialValue(credential, "auth_mode") != "oauth" {
+		return credential, nil
+	}
+	if token, exists := credential.Secret("access_token"); exists && token.Configured() {
+		return credential, nil
+	}
+	if ctx == nil || lease == nil || h.Repository == nil || h.Cipher == nil {
+		return Credential{}, ErrCredentialInvalid
+	}
+	credentialName := credentialValue(credential, "oauth_credential_name")
+	bindingID := credentialValue(credential, "oauth_binding_id")
+	if scope.Provider != "pagerduty" || credentialName == "" || bindingID == "" {
+		return Credential{}, ErrCredentialInvalid
+	}
+	if err := lease.Assert(ctx); err != nil {
+		return Credential{}, err
+	}
+	record, err := h.Repository.Load(ctx, scope.OrgID, credentialName)
+	if err != nil {
+		return Credential{}, err
+	}
+	tokens, err := h.decode(ctx, lease, record, bindingID)
+	if err != nil {
+		return Credential{}, err
+	}
+	if !hasPagerDutyOperationalReadScopes(tokens.GrantedScopes) {
+		return Credential{}, ErrCredentialInvalid
+	}
+	if tokens.ExpiresAt.After(h.now().Add(pagerDutyOAuthRenewalWindow)) {
+		return credential.WithEphemeralSecret(
+			"access_token", secrets.NewValue(tokens.AccessToken),
+		)
+	}
+	return h.refresh(ctx, lease, scope.OrgID, credentialName, credential, record, tokens)
+}
+
+func (h PagerDutyOAuthHydrator) decode(
+	ctx context.Context,
+	lease LeaseGuard,
+	record PagerDutyOAuthTokenRecord,
+	expectedBindingID string,
+) (pagerDutyOAuthTokens, error) {
+	if record.Version < 1 || record.BindingID != expectedBindingID ||
+		!record.Ciphertext.Configured() {
+		return pagerDutyOAuthTokens{}, ErrCredentialInvalid
+	}
+	if err := lease.Assert(ctx); err != nil {
+		return pagerDutyOAuthTokens{}, err
+	}
+	plaintext, err := h.Cipher.Decrypt(record.Ciphertext)
+	if err != nil {
+		return pagerDutyOAuthTokens{}, ErrCredentialInvalid
+	}
+	var tokens pagerDutyOAuthTokens
+	if json.Unmarshal(plaintext, &tokens) != nil ||
+		strings.TrimSpace(tokens.AccessToken) == "" || tokens.ExpiresAt.IsZero() {
+		return pagerDutyOAuthTokens{}, ErrCredentialInvalid
+	}
+	tokens.GrantedScopes = normalizedPagerDutyScopes(tokens.GrantedScopes)
+	return tokens, nil
+}
+
+func (h PagerDutyOAuthHydrator) refresh(
+	ctx context.Context,
+	lease LeaseGuard,
+	orgID string,
+	credentialName string,
+	credential Credential,
+	record PagerDutyOAuthTokenRecord,
+	current pagerDutyOAuthTokens,
+) (Credential, error) {
+	if h.Doer == nil || !h.AppClientID.Configured() || current.RefreshToken == nil ||
+		strings.TrimSpace(*current.RefreshToken) == "" {
+		return Credential{}, ErrCredentialInvalid
+	}
+	if err := lease.Assert(ctx); err != nil {
+		return Credential{}, err
+	}
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {h.AppClientID.Reveal()},
+		"client_secret": {h.AppClientSecret.Reveal()},
+		"refresh_token": {*current.RefreshToken},
+	}
+	request, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, pagerDutyTokenURL, strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return Credential{}, ErrCredentialInvalid
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err := h.Doer.Do(request)
+	if err != nil {
+		return Credential{}, &ProviderError{Class: ErrorTransient}
+	}
+	defer response.Body.Close()
+	if classification := ClassifyHTTP("pagerduty", response.StatusCode, response.Header); classification != nil {
+		return Credential{}, classification
+	}
+	var payload struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    any    `json:"expires_in"`
+		Scope        string `json:"scope"`
+	}
+	if json.NewDecoder(io.LimitReader(response.Body, maxProviderErrorBody)).Decode(&payload) != nil ||
+		strings.TrimSpace(payload.AccessToken) == "" {
+		return Credential{}, ErrCredentialInvalid
+	}
+	expiresIn := pagerDutyExpiresIn(payload.ExpiresIn)
+	refreshed := pagerDutyOAuthTokens{
+		AccessToken: payload.AccessToken,
+		ExpiresAt:   h.now().Add(time.Duration(expiresIn) * time.Second),
+	}
+	if payload.RefreshToken == "" {
+		refreshed.RefreshToken = current.RefreshToken
+	} else {
+		refreshed.RefreshToken = &payload.RefreshToken
+	}
+	if strings.TrimSpace(payload.Scope) == "" {
+		refreshed.GrantedScopes = current.GrantedScopes
+	} else {
+		refreshed.GrantedScopes = normalizedPagerDutyScopes(strings.Fields(payload.Scope))
+	}
+	if !hasPagerDutyOperationalReadScopes(refreshed.GrantedScopes) {
+		return Credential{}, ErrCredentialInvalid
+	}
+	encoded, err := json.Marshal(refreshed)
+	if err != nil {
+		return Credential{}, ErrCredentialInvalid
+	}
+	ciphertext, err := h.Cipher.Encrypt(encoded)
+	if err != nil {
+		return Credential{}, ErrCredentialInvalid
+	}
+	if err := lease.Assert(ctx); err != nil {
+		return Credential{}, err
+	}
+	rotated, err := h.Repository.Rotate(ctx, orgID, credentialName, PagerDutyOAuthTokenRotation{
+		ExpectedVersion: record.Version, ExpectedBindingID: record.BindingID,
+		Ciphertext: ciphertext, ExpiresAt: refreshed.ExpiresAt,
+		GrantedScopes: refreshed.GrantedScopes, HasRefreshToken: refreshed.RefreshToken != nil,
+	})
+	if err != nil {
+		return Credential{}, err
+	}
+	if rotated {
+		return credential.WithEphemeralSecret(
+			"access_token", secrets.NewValue(refreshed.AccessToken),
+		)
+	}
+	// A concurrent worker won the optimistic rotation. Use only its freshly
+	// persisted token and re-check the binding and scopes before proceeding.
+	latest, err := h.Repository.Load(ctx, orgID, credentialName)
+	if err != nil {
+		return Credential{}, err
+	}
+	latestTokens, err := h.decode(ctx, lease, latest, record.BindingID)
+	if err != nil || !hasPagerDutyOperationalReadScopes(latestTokens.GrantedScopes) ||
+		!latestTokens.ExpiresAt.After(h.now().Add(pagerDutyOAuthRenewalWindow)) {
+		return Credential{}, ErrCredentialInvalid
+	}
+	return credential.WithEphemeralSecret(
+		"access_token", secrets.NewValue(latestTokens.AccessToken),
+	)
+}
+
+func (h PagerDutyOAuthHydrator) now() time.Time {
+	if h.Now != nil {
+		return h.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func normalizedPagerDutyScopes(scopes []string) []string {
+	result := make([]string, 0, len(scopes))
+	seen := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		if _, exists := seen[scope]; exists {
+			continue
+		}
+		seen[scope] = struct{}{}
+		result = append(result, scope)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func hasPagerDutyOperationalReadScopes(scopes []string) bool {
+	normalized := normalizedPagerDutyScopes(scopes)
+	for _, required := range pagerDutyOperationalReadScopes {
+		if !slices.Contains(normalized, required) {
+			return false
+		}
+	}
+	return true
+}
+
+func pagerDutyExpiresIn(value any) int {
+	var seconds int
+	switch typed := value.(type) {
+	case float64:
+		seconds = int(typed)
+	case string:
+		seconds, _ = strconv.Atoi(typed)
+	}
+	if seconds < 1 {
+		return 3600
+	}
+	return seconds
+}

--- a/internal/providerfoundation/pagerduty_oauth_test.go
+++ b/internal/providerfoundation/pagerduty_oauth_test.go
@@ -1,0 +1,259 @@
+package providerfoundation
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+)
+
+func TestCredentialResolverHydratesTokenlessPagerDutyOAuthBinding(t *testing.T) {
+	t.Parallel()
+	key := secrets.NewValue("test-master-key")
+	decryptor, err := NewFernetDecryptor(key, "salt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor := `{"account_id":"account-1","auth_mode":"oauth","oauth_binding_id":"binding-1","oauth_credential_name":"operations","region":"us","subdomain":"acme"}`
+	tokens := `{"access_token":"ephemeral-access-token","refresh_token":"refresh-token","expires_at":"2036-08-12T00:00:00Z","granted_scopes":["escalation_policies.read","incidents.read","oncalls.read","schedules.read","services.read","teams.read","users.read"]}`
+	oauthRepository := &fakePagerDutyOAuthTokenRepository{
+		record: PagerDutyOAuthTokenRecord{
+			Ciphertext: secrets.NewValue("v1:" + encryptForTest(t, []byte(tokens), key.Reveal(), "salt")),
+			Version:    7,
+			BindingID:  "binding-1",
+		},
+	}
+	resolver := CredentialResolver{
+		Repository: fakeEncryptedCredentialRepository{
+			record: EncryptedCredential{
+				ID: "credential-1", Provider: "pagerduty", Name: "default", Active: true,
+				Ciphertext: secrets.NewValue("v1:" + encryptForTest(t, []byte(descriptor), key.Reveal(), "salt")),
+			},
+		},
+		Decryptor: decryptor,
+		Hydrator: PagerDutyOAuthHydrator{
+			Repository: oauthRepository,
+			Cipher:     decryptor,
+			Now:        func() time.Time { return time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC) },
+		},
+	}
+	scope := TenantScope{
+		OrgID: "org-1", Provider: "pagerduty", IntegrationID: "integration-1",
+	}
+	credential, err := resolver.Resolve(
+		context.Background(),
+		LeaseGuardFunc(func(context.Context) error { return nil }),
+		scope,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateCredentialShape(credential); err != nil {
+		t.Fatalf("hydrated credential shape: %v", err)
+	}
+	accessToken, exists := credential.Secret("access_token")
+	if !exists || accessToken.Reveal() != "ephemeral-access-token" {
+		t.Fatal("resolved credential did not carry the OAuth access token")
+	}
+	if oauthRepository.loadedOrgID != "org-1" || oauthRepository.loadedName != "operations" {
+		t.Fatalf(
+			"OAuth lookup scope=(%q,%q), want (org-1,operations)",
+			oauthRepository.loadedOrgID,
+			oauthRepository.loadedName,
+		)
+	}
+}
+
+func TestPagerDutyOAuthHydratorPreservesEmbeddedAccessTokenCompatibility(t *testing.T) {
+	t.Parallel()
+	credential := testCredential("pagerduty", map[string]string{
+		"auth_mode": "oauth", "access_token": "direct-access-token", "region": "us",
+	})
+	hydrated, err := (PagerDutyOAuthHydrator{}).Hydrate(
+		context.Background(),
+		LeaseGuardFunc(func(context.Context) error { return nil }),
+		TenantScope{OrgID: "org-1", Provider: "pagerduty", IntegrationID: "integration-1"},
+		credential,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, exists := hydrated.Secret("access_token")
+	if !exists || token.Reveal() != "direct-access-token" {
+		t.Fatal("embedded PagerDuty access token compatibility was not preserved")
+	}
+}
+
+func TestPagerDutyOAuthHydratorRefreshesAndRotatesEncryptedToken(t *testing.T) {
+	t.Parallel()
+	key := secrets.NewValue("test-master-key")
+	cipher, err := NewFernetDecryptor(key, "salt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	refreshToken := "refresh-token"
+	stored := pagerDutyOAuthTokens{
+		AccessToken: "expired-token", RefreshToken: &refreshToken,
+		ExpiresAt:     time.Date(2026, 8, 12, 0, 1, 0, 0, time.UTC),
+		GrantedScopes: append([]string(nil), pagerDutyOperationalReadScopes...),
+	}
+	repository := &fakePagerDutyOAuthTokenRepository{record: PagerDutyOAuthTokenRecord{
+		Ciphertext: secrets.NewValue("v1:" + encryptForTest(t, mustJSON(t, stored), key.Reveal(), "salt")),
+		Version:    7, BindingID: "binding-1",
+	}}
+	doer := &pagerDutyRefreshDoer{}
+	hydrated, err := (PagerDutyOAuthHydrator{
+		Repository: repository, Cipher: cipher, Doer: doer,
+		AppClientID:     secrets.NewValue("client-id"),
+		AppClientSecret: secrets.NewValue("client-secret"),
+		Now:             func() time.Time { return time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC) },
+	}).Hydrate(
+		context.Background(),
+		LeaseGuardFunc(func(context.Context) error { return nil }),
+		TenantScope{OrgID: "org-1", Provider: "pagerduty", IntegrationID: "integration-1"},
+		testCredential("pagerduty", map[string]string{
+			"auth_mode": "oauth", "oauth_credential_name": "operations",
+			"oauth_binding_id": "binding-1",
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, exists := hydrated.Secret("access_token")
+	if !exists || token.Reveal() != "refreshed-access-token" {
+		t.Fatal("refreshed access token was not hydrated")
+	}
+	if doer.calls != 1 || !repository.rotated {
+		t.Fatalf("refresh calls=%d rotated=%t", doer.calls, repository.rotated)
+	}
+	if repository.rotation.ExpectedVersion != 7 ||
+		repository.rotation.ExpectedBindingID != "binding-1" ||
+		!repository.rotation.Ciphertext.Configured() {
+		t.Fatalf("unexpected optimistic rotation metadata: %+v", repository.rotation)
+	}
+	plaintext, err := cipher.Decrypt(repository.rotation.Ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(plaintext), "expired-token") ||
+		!strings.Contains(string(plaintext), "refreshed-access-token") {
+		t.Fatal("rotation did not persist only the refreshed token payload")
+	}
+}
+
+func TestPagerDutyOAuthHydratorRejectsBindingAndScopeDrift(t *testing.T) {
+	t.Parallel()
+	key := secrets.NewValue("test-master-key")
+	cipher, _ := NewFernetDecryptor(key, "salt")
+	for name, mutate := range map[string]func(*PagerDutyOAuthTokenRecord, *pagerDutyOAuthTokens){
+		"binding": func(record *PagerDutyOAuthTokenRecord, _ *pagerDutyOAuthTokens) {
+			record.BindingID = "reconnected-binding"
+		},
+		"scope": func(_ *PagerDutyOAuthTokenRecord, tokens *pagerDutyOAuthTokens) {
+			tokens.GrantedScopes = []string{"services.read"}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			tokens := pagerDutyOAuthTokens{
+				AccessToken:   "access-token",
+				ExpiresAt:     time.Date(2036, 8, 12, 0, 0, 0, 0, time.UTC),
+				GrantedScopes: append([]string(nil), pagerDutyOperationalReadScopes...),
+			}
+			record := PagerDutyOAuthTokenRecord{Version: 7, BindingID: "binding-1"}
+			mutate(&record, &tokens)
+			record.Ciphertext = secrets.NewValue("v1:" + encryptForTest(t, mustJSON(t, tokens), key.Reveal(), "salt"))
+			_, err := (PagerDutyOAuthHydrator{
+				Repository: &fakePagerDutyOAuthTokenRepository{record: record},
+				Cipher:     cipher,
+			}).Hydrate(
+				context.Background(),
+				LeaseGuardFunc(func(context.Context) error { return nil }),
+				TenantScope{OrgID: "org-1", Provider: "pagerduty", IntegrationID: "integration-1"},
+				testCredential("pagerduty", map[string]string{
+					"auth_mode": "oauth", "oauth_credential_name": "operations",
+					"oauth_binding_id": "binding-1",
+				}),
+			)
+			if err == nil {
+				t.Fatal("drifted OAuth binding was accepted")
+			}
+		})
+	}
+}
+
+type fakeEncryptedCredentialRepository struct{ record EncryptedCredential }
+
+func (r fakeEncryptedCredentialRepository) ResolveEncrypted(
+	context.Context,
+	TenantScope,
+) (EncryptedCredential, error) {
+	return r.record, nil
+}
+
+type fakePagerDutyOAuthTokenRepository struct {
+	record      PagerDutyOAuthTokenRecord
+	loadedOrgID string
+	loadedName  string
+	rotated     bool
+	rotation    PagerDutyOAuthTokenRotation
+}
+
+func (r *fakePagerDutyOAuthTokenRepository) Load(
+	_ context.Context,
+	orgID string,
+	credentialName string,
+) (PagerDutyOAuthTokenRecord, error) {
+	r.loadedOrgID = orgID
+	r.loadedName = credentialName
+	return r.record, nil
+}
+
+func (r *fakePagerDutyOAuthTokenRepository) Rotate(
+	_ context.Context,
+	_ string,
+	_ string,
+	rotation PagerDutyOAuthTokenRotation,
+) (bool, error) {
+	r.rotated = true
+	r.rotation = rotation
+	return true, nil
+}
+
+type pagerDutyRefreshDoer struct{ calls int }
+
+func (d *pagerDutyRefreshDoer) Do(request *http.Request) (*http.Response, error) {
+	d.calls++
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		return nil, err
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, err
+	}
+	if request.URL.String() != pagerDutyTokenURL ||
+		values.Get("grant_type") != "refresh_token" ||
+		values.Get("client_id") != "client-id" ||
+		values.Get("client_secret") != "client-secret" ||
+		values.Get("refresh_token") != "refresh-token" {
+		return nil, ErrCredentialInvalid
+	}
+	return testHTTPResponse(request, http.StatusOK, nil,
+		`{"access_token":"refreshed-access-token","expires_in":3600}`), nil
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}

--- a/internal/providerfoundation/repository_postgres.go
+++ b/internal/providerfoundation/repository_postgres.go
@@ -3,8 +3,12 @@ package providerfoundation
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
+	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -87,4 +91,90 @@ func decodeConfig(raw []byte, target map[string]string) error {
 	return nil
 }
 
+// PostgresPagerDutyOAuthTokenRepository reads and rotates only the encrypted
+// OAuth token row referenced by a tokenless integration descriptor.
+type PostgresPagerDutyOAuthTokenRepository struct{ Pool *pgxpool.Pool }
+
+func (r PostgresPagerDutyOAuthTokenRepository) Load(
+	ctx context.Context,
+	orgID string,
+	credentialName string,
+) (PagerDutyOAuthTokenRecord, error) {
+	if r.Pool == nil || strings.TrimSpace(orgID) == "" ||
+		strings.TrimSpace(credentialName) == "" {
+		return PagerDutyOAuthTokenRecord{}, ErrCredentialInvalid
+	}
+	var (
+		ciphertext string
+		version    int
+		bindingID  *string
+	)
+	err := r.Pool.QueryRow(ctx, `
+SELECT token_encrypted, version, binding_id
+FROM provider_oauth_credentials
+WHERE org_id = $1 AND provider = 'pagerduty' AND credential_name = $2`,
+		orgID, credentialName,
+	).Scan(&ciphertext, &version, &bindingID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return PagerDutyOAuthTokenRecord{}, ErrCredentialNotFound
+	}
+	if err != nil {
+		return PagerDutyOAuthTokenRecord{}, &ProviderError{Class: ErrorTransient}
+	}
+	if bindingID == nil || strings.TrimSpace(*bindingID) == "" ||
+		strings.TrimSpace(ciphertext) == "" || version < 1 {
+		return PagerDutyOAuthTokenRecord{}, ErrCredentialInvalid
+	}
+	return PagerDutyOAuthTokenRecord{
+		Ciphertext: secrets.NewValue(ciphertext), Version: version,
+		BindingID: *bindingID,
+	}, nil
+}
+
+func (r PostgresPagerDutyOAuthTokenRepository) Rotate(
+	ctx context.Context,
+	orgID string,
+	credentialName string,
+	rotation PagerDutyOAuthTokenRotation,
+) (bool, error) {
+	if r.Pool == nil || strings.TrimSpace(orgID) == "" ||
+		strings.TrimSpace(credentialName) == "" ||
+		rotation.ExpectedVersion < 1 ||
+		strings.TrimSpace(rotation.ExpectedBindingID) == "" ||
+		!rotation.Ciphertext.Configured() || rotation.ExpiresAt.IsZero() {
+		return false, ErrCredentialInvalid
+	}
+	scopes, err := json.Marshal(normalizedPagerDutyScopes(rotation.GrantedScopes))
+	if err != nil {
+		return false, ErrCredentialInvalid
+	}
+	var version int
+	err = r.Pool.QueryRow(ctx, `
+UPDATE provider_oauth_credentials
+SET token_encrypted = $1,
+    version = version + 1,
+    expires_at = $2,
+    granted_scopes = $3::json,
+    has_refresh_token = $4,
+    updated_at = $5
+WHERE org_id = $6
+  AND provider = 'pagerduty'
+  AND credential_name = $7
+  AND version = $8
+  AND binding_id = $9
+RETURNING version`,
+		rotation.Ciphertext.Reveal(), rotation.ExpiresAt, string(scopes),
+		rotation.HasRefreshToken, time.Now().UTC(), orgID, credentialName,
+		rotation.ExpectedVersion, rotation.ExpectedBindingID,
+	).Scan(&version)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, &ProviderError{Class: ErrorTransient}
+	}
+	return version == rotation.ExpectedVersion+1, nil
+}
+
 var _ CredentialRepository = PostgresCredentialRepository{}
+var _ PagerDutyOAuthTokenRepository = PostgresPagerDutyOAuthTokenRepository{}

--- a/internal/providerfoundation/types.go
+++ b/internal/providerfoundation/types.go
@@ -133,11 +133,27 @@ type CredentialDecryptor interface {
 	Decrypt(secrets.Value) ([]byte, error)
 }
 
+// CredentialCipher is the authenticated encryption boundary required by
+// renewable OAuth credentials. Plaintext remains a secrets.Value only at the
+// concrete credential boundary and is never returned by repositories.
+type CredentialCipher interface {
+	CredentialDecryptor
+	Encrypt([]byte) (secrets.Value, error)
+}
+
+// CredentialHydrator attaches short-lived provider secrets referenced by a
+// tokenless persisted descriptor. It runs after descriptor decryption and
+// must preserve the claim's tenant and live lease boundaries.
+type CredentialHydrator interface {
+	Hydrate(context.Context, LeaseGuard, TenantScope, Credential) (Credential, error)
+}
+
 // CredentialResolver has no environment dependency. The encryption key is
 // supplied once by process construction using the existing secret loader.
 type CredentialResolver struct {
 	Repository CredentialRepository
 	Decryptor  CredentialDecryptor
+	Hydrator   CredentialHydrator
 }
 
 func (r CredentialResolver) Resolve(ctx context.Context, lease LeaseGuard, scope TenantScope) (Credential, error) {
@@ -175,6 +191,9 @@ func (r CredentialResolver) Resolve(ctx context.Context, lease LeaseGuard, scope
 	}
 	if err := lease.Assert(ctx); err != nil {
 		return Credential{}, err
+	}
+	if r.Hydrator != nil {
+		return r.Hydrator.Hydrate(ctx, lease, scope, credential)
 	}
 	return credential, nil
 }

--- a/internal/providersync/github_work_items_derivation_context.go
+++ b/internal/providersync/github_work_items_derivation_context.go
@@ -886,9 +886,15 @@ LIMIT ?`, orgID, asOf, asOf, githubWorkItemDerivationContextLimit+1)
 	result := []githubWorkItemDerivationProjectFact{}
 	for rows.Next() {
 		var fact githubWorkItemDerivationProjectFact
-		if err := rows.Scan(&fact.Provider, &fact.TeamID, &fact.TeamName, &fact.ProjectID, &fact.ProjectKey, &fact.IsPrimary, &fact.Specificity, &fact.Priority, &fact.UpdatedAt); err != nil {
+		var isPrimary uint8
+		var specificity uint16
+		var priority int32
+		if err := rows.Scan(&fact.Provider, &fact.TeamID, &fact.TeamName, &fact.ProjectID, &fact.ProjectKey, &isPrimary, &specificity, &priority, &fact.UpdatedAt); err != nil {
 			return nil, err
 		}
+		fact.IsPrimary = int(isPrimary)
+		fact.Specificity = int(specificity)
+		fact.Priority = int(priority)
 		result = append(result, fact)
 		if len(result) > githubWorkItemDerivationContextLimit {
 			return nil, ErrEffectRecoveryUnsafe
@@ -928,9 +934,15 @@ LIMIT ?`, orgID, asOf, asOf, githubWorkItemDerivationContextLimit+1)
 	result := []githubWorkItemDerivationRepoFact{}
 	for rows.Next() {
 		var fact githubWorkItemDerivationRepoFact
-		if err := rows.Scan(&fact.Provider, &fact.TeamID, &fact.TeamName, &fact.RepoID, &fact.RepoFullName, &fact.IsPrimary, &fact.Specificity, &fact.Priority, &fact.UpdatedAt); err != nil {
+		var isPrimary uint8
+		var specificity uint16
+		var priority int32
+		if err := rows.Scan(&fact.Provider, &fact.TeamID, &fact.TeamName, &fact.RepoID, &fact.RepoFullName, &isPrimary, &specificity, &priority, &fact.UpdatedAt); err != nil {
 			return nil, err
 		}
+		fact.IsPrimary = int(isPrimary)
+		fact.Specificity = int(specificity)
+		fact.Priority = int(priority)
 		result = append(result, fact)
 		if len(result) > githubWorkItemDerivationContextLimit {
 			return nil, ErrEffectRecoveryUnsafe
@@ -973,9 +985,15 @@ LIMIT ?`, orgID, asOf, asOf, githubWorkItemDerivationContextLimit+1)
 	result := []githubWorkItemDerivationMemberFact{}
 	for rows.Next() {
 		var fact githubWorkItemDerivationMemberFact
-		if err := rows.Scan(&fact.Provider, &fact.TeamID, &fact.TeamName, &fact.MemberID, &fact.RawProviderUserID, &fact.RawEmail, &fact.IdentityFacets, &fact.IsPrimary, &fact.Specificity, &fact.Priority, &fact.UpdatedAt); err != nil {
+		var isPrimary uint8
+		var specificity uint16
+		var priority int32
+		if err := rows.Scan(&fact.Provider, &fact.TeamID, &fact.TeamName, &fact.MemberID, &fact.RawProviderUserID, &fact.RawEmail, &fact.IdentityFacets, &isPrimary, &specificity, &priority, &fact.UpdatedAt); err != nil {
 			return nil, err
 		}
+		fact.IsPrimary = int(isPrimary)
+		fact.Specificity = int(specificity)
+		fact.Priority = int(priority)
 		result = append(result, fact)
 		if len(result) > githubWorkItemDerivationContextLimit {
 			return nil, ErrEffectRecoveryUnsafe
@@ -1000,9 +1018,11 @@ LIMIT ?`, orgID, asOf, asOf, githubWorkItemDerivationContextLimit+1)
 	result := []githubWorkItemDerivationManualFallback{}
 	for rows.Next() {
 		var fact githubWorkItemDerivationManualFallback
-		if err := rows.Scan(&fact.Provider, &fact.ScopeType, &fact.ScopeID, &fact.TeamID, &fact.TeamName, &fact.Reason, &fact.Priority); err != nil {
+		var priority int32
+		if err := rows.Scan(&fact.Provider, &fact.ScopeType, &fact.ScopeID, &fact.TeamID, &fact.TeamName, &fact.Reason, &priority); err != nil {
 			return nil, err
 		}
+		fact.Priority = int(priority)
 		result = append(result, fact)
 		if len(result) > githubWorkItemDerivationContextLimit {
 			return nil, ErrEffectRecoveryUnsafe

--- a/internal/providersync/github_work_items_derivation_context_integration_test.go
+++ b/internal/providersync/github_work_items_derivation_context_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestGitHubWorkItemDerivationContextScansClickHouseNativeIntegerWidths(t *testing.T) {
+	ctx, conn := newWorkItemEffectsConn(t)
+	const (
+		orgID    = "org-derivation-scan-widths"
+		provider = "linear"
+		teamID   = "team-scan-widths"
+	)
+	validFrom := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	asOf := validFrom.Add(time.Hour)
+	updatedAt := validFrom.Add(time.Minute)
+	repoID := uuid.MustParse("3a9b0121-f9f2-4b5f-88a1-39e4a1911ef2")
+
+	for _, insert := range []struct {
+		query string
+		args  []any
+	}{
+		{
+			query: `INSERT INTO team_project_ownership
+				(org_id, provider, team_id, project_id, project_key, source, is_primary, specificity, priority, valid_from, valid_to, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{orgID, provider, teamID, "project-1", "CHAOS", "native", uint8(1), uint16(65530), int32(-27), validFrom, nil, updatedAt},
+		},
+		{
+			query: `INSERT INTO team_repo_ownership
+				(org_id, provider, team_id, repo_id, repo_full_name, match_type, source, is_primary, specificity, priority, valid_from, valid_to, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{orgID, provider, teamID, repoID, "full-chaos/dev-health", "exact", "native", uint8(0), uint16(1200), int32(18), validFrom, nil, updatedAt},
+		},
+		{
+			query: `INSERT INTO team_memberships
+				(org_id, provider, team_id, member_id, raw_provider_user_id, raw_email, identity_facets, source, is_primary, specificity, priority, valid_from, valid_to, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{orgID, provider, teamID, "member-1", "user-1", "user@example.com", []string{"email:user@example.com"}, "native", uint8(1), uint16(42), int32(-5), validFrom, nil, updatedAt},
+		},
+		{
+			query: `INSERT INTO manual_attribution_fallbacks
+				(org_id, provider, scope_type, scope_id, team_id, team_name, reason, priority, valid_from, valid_to, created_by, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{orgID, provider, "project", "project-1", teamID, "Scan Widths", "regression", int32(-9), validFrom, nil, nil, updatedAt, updatedAt},
+		},
+	} {
+		if err := conn.Exec(ctx, insert.query, insert.args...); err != nil {
+			t.Fatalf("seed derivation context: %v", err)
+		}
+	}
+
+	source := githubWorkItemClickHouseDerivationContextSource{Conn: conn}
+
+	projects, err := source.loadProjects(context.Background(), orgID, asOf)
+	if err != nil {
+		t.Fatalf("load projects: %v", err)
+	}
+	if len(projects) != 1 || projects[0].IsPrimary != 1 || projects[0].Specificity != 65530 || projects[0].Priority != -27 {
+		t.Fatalf("project numeric fields = %+v", projects)
+	}
+
+	repos, err := source.loadRepos(context.Background(), orgID, asOf)
+	if err != nil {
+		t.Fatalf("load repos: %v", err)
+	}
+	if len(repos) != 1 || repos[0].IsPrimary != 0 || repos[0].Specificity != 1200 || repos[0].Priority != 18 {
+		t.Fatalf("repo numeric fields = %+v", repos)
+	}
+
+	members, err := source.loadMembers(context.Background(), orgID, asOf)
+	if err != nil {
+		t.Fatalf("load members: %v", err)
+	}
+	if len(members) != 1 || members[0].IsPrimary != 1 || members[0].Specificity != 42 || members[0].Priority != -5 {
+		t.Fatalf("member numeric fields = %+v", members)
+	}
+
+	manual, err := source.loadManualFallbacks(context.Background(), orgID, asOf)
+	if err != nil {
+		t.Fatalf("load manual fallbacks: %v", err)
+	}
+	if len(manual) != 1 || manual[0].Priority != -9 {
+		t.Fatalf("manual numeric fields = %+v", manual)
+	}
+}

--- a/internal/providersync/lease.go
+++ b/internal/providersync/lease.go
@@ -24,8 +24,13 @@ var (
 	ErrPreparedRouteSnapshotRunTerminal = errors.New(
 		"provider sync prepared route snapshot belongs to a run that already finished",
 	)
-	ErrEffectRecoveryAmbiguous     = errors.New("provider sync effect recovery requires exact reconciliation")
-	ErrEffectRecoveryUnsafe        = errors.New("provider sync effect recovery is outside the bounded contract")
+	ErrEffectRecoveryAmbiguous = errors.New("provider sync effect recovery requires exact reconciliation")
+	ErrEffectRecoveryUnsafe    = errors.New("provider sync effect recovery is outside the bounded contract")
+	// ErrProviderDatasetUnavailable means the provider account cannot expose a
+	// specific dataset even though the credential itself is valid. Retrying
+	// cannot add an account-level product ability, and treating the response as
+	// an empty snapshot would incorrectly tombstone previously collected rows.
+	ErrProviderDatasetUnavailable  = errors.New("provider sync dataset is unavailable for this account")
 	ErrShadowMismatch              = errors.New("provider sync native shadow differs from Python compatibility output")
 	ErrRepositoryIdentityAmbiguous = errors.New(
 		"provider sync repository identity cannot be proven identical to the Python derivation",

--- a/internal/providersync/pagerduty_oncalls_route.go
+++ b/internal/providersync/pagerduty_oncalls_route.go
@@ -174,6 +174,7 @@ func (handler PagerDutyOnCallsRouteHandler) Collect(
 	}
 	return CompleteRouteBatch{
 		Effects: []EffectBatch{effect},
+		Result:  map[string]any{"on_calls_synced": len(rows)},
 		Evidence: FetchEvidence{
 			Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests,
 			Pages: pages.Pages, Records: len(rows), CapReached: pages.CapReached,

--- a/internal/providersync/pagerduty_oncalls_route_test.go
+++ b/internal/providersync/pagerduty_oncalls_route_test.go
@@ -65,12 +65,21 @@ func TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
+	comparison, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, batch,
+	)
+	if err != nil {
+		t.Fatalf("production comparator rejected collected batch: %v", err)
+	}
+	if !comparison.Match || comparison.NativeRecords != 2 || comparison.PythonRecords != 2 {
+		t.Fatalf("comparison=%+v", comparison)
+	}
 	if len(batch.Effects) != 1 || batch.Effects[0].Destination != "operational_on_call_assignments" ||
 		batch.Effects[0].Recovery != EffectReadbackRequired || len(batch.Effects[0].Rows) != 2 {
 		t.Fatalf("effects=%+v", batch.Effects)
 	}
 	if batch.Evidence.Requests != 2 || batch.Evidence.Pages != 2 || batch.Evidence.Records != 2 ||
-		batch.Evidence.CapReached || batch.Watermark != nil || batch.Result != nil {
+		batch.Evidence.CapReached || batch.Watermark != nil || batch.Result["on_calls_synced"] != 2 {
 		t.Fatalf("batch=%+v", batch)
 	}
 	if got := doer.requests[0].URL.RawQuery; got != "limit=100&offset=0" {

--- a/internal/providersync/pagerduty_services_effects_clickhouse.go
+++ b/internal/providersync/pagerduty_services_effects_clickhouse.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"math/big"
+	"os"
 	"strings"
 	"time"
 
@@ -13,13 +14,94 @@ import (
 	"github.com/google/uuid"
 )
 
-// These columns are the current migrated v2 operational schema. Keeping the
-// ordering columns in the INSERT/readback contract is important: source
-// revisions are the durable replay identity, not an in-memory annotation.
+// Migration 067 changes the operational tables from the legacy
+// source_version_at contract to the v2 source-revision contract. The Go writer
+// must use the same bridge setting as Python while both schemas are supported.
 const (
-	pagerDutyServicesOperationalServiceColumns = gitLabOperationalServiceColumns
-	pagerDutyServicesMappingColumns            = gitLabServiceMappingColumns
+	pagerDutyServicesLegacyBaseColumns    = "org_id,provider,provider_instance_id,source_entity_type,external_id,source_version_at,id,source_id,source_url,source_event_at,source_event_id,observed_at,last_synced,raw_status,raw_severity,raw_priority,normalized_status,normalized_severity,normalized_priority,relationship_provenance,relationship_confidence"
+	pagerDutyServicesLegacyServiceColumns = pagerDutyServicesLegacyBaseColumns + ",name,description,service_type,owning_team_id,escalation_policy_id,is_deleted,deleted_at"
+	pagerDutyServicesLegacyMappingColumns = pagerDutyServicesLegacyBaseColumns + ",service_id,repo_id,repo_full_name,repo_provider,mapping_kind,rule_id,valid_from,valid_to,is_active"
 )
+
+type pagerDutyServicesStorageContract uint8
+
+const (
+	pagerDutyServicesLegacyContract  pagerDutyServicesStorageContract = 1
+	pagerDutyServicesCurrentContract pagerDutyServicesStorageContract = 2
+)
+
+func configuredPagerDutyServicesStorageContract() (pagerDutyServicesStorageContract, error) {
+	raw, present := os.LookupEnv("OPERATIONAL_ORDERING_CONTRACT")
+	if !present || raw == "1" {
+		return pagerDutyServicesLegacyContract, nil
+	}
+	if raw == "2" {
+		return pagerDutyServicesCurrentContract, nil
+	}
+	return 0, ErrInvalidConfiguration
+}
+
+func (contract pagerDutyServicesStorageContract) serviceColumns() string {
+	if contract == pagerDutyServicesLegacyContract {
+		return pagerDutyServicesLegacyServiceColumns
+	}
+	return gitLabOperationalServiceColumns
+}
+
+func (contract pagerDutyServicesStorageContract) mappingColumns() string {
+	if contract == pagerDutyServicesLegacyContract {
+		return pagerDutyServicesLegacyMappingColumns
+	}
+	return gitLabServiceMappingColumns
+}
+
+func (contract pagerDutyServicesStorageContract) loadActiveServicesQuery() string {
+	columns := contract.serviceColumns()
+	if contract == pagerDutyServicesLegacyContract {
+		return "SELECT " + columns + " FROM (SELECT " + columns +
+			" FROM operational_services FINAL WHERE org_id = ?) " +
+			"WHERE provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND is_deleted = 0"
+	}
+	return "SELECT " + columns + " FROM (SELECT " + columns +
+		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? " +
+		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) " +
+		"WHERE is_deleted = 0"
+}
+
+func (contract pagerDutyServicesStorageContract) loadActiveMappingsQuery() string {
+	columns := contract.mappingColumns()
+	if contract == pagerDutyServicesLegacyContract {
+		return "SELECT " + columns + " FROM (SELECT " + columns +
+			" FROM operational_service_repository_mappings FINAL WHERE org_id = ?) " +
+			"WHERE provider = ? AND provider_instance_id = ? AND is_active = 1"
+	}
+	return "SELECT " + columns + " FROM (SELECT " + columns +
+		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? " +
+		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) " +
+		"WHERE is_active = 1"
+}
+
+func (contract pagerDutyServicesStorageContract) loadServiceQuery() string {
+	columns := contract.serviceColumns()
+	if contract == pagerDutyServicesLegacyContract {
+		return "SELECT " + columns +
+			" FROM operational_services FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? LIMIT 1"
+	}
+	return "SELECT " + columns +
+		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? " +
+		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1"
+}
+
+func (contract pagerDutyServicesStorageContract) loadMappingQuery() string {
+	columns := contract.mappingColumns()
+	if contract == pagerDutyServicesLegacyContract {
+		return "SELECT " + columns +
+			" FROM operational_service_repository_mappings FINAL WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND id = ? LIMIT 1"
+	}
+	return "SELECT " + columns +
+		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND id = ? " +
+		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1"
+}
 
 // PagerDutyServicesClickHouseEffects owns only the two destinations produced
 // by the services provider path. The repository mapping destination remains a
@@ -111,6 +193,9 @@ func (sink PagerDutyServicesClickHouseEffects) validateRequest(
 	case "operational_services", "operational_service_repository_mappings":
 	default:
 		return ErrInvalidConfiguration
+	}
+	if _, err := configuredPagerDutyServicesStorageContract(); err != nil {
+		return err
 	}
 	return sink.Lease.Assert(ctx)
 }
@@ -245,13 +330,17 @@ func (sink PagerDutyServicesClickHouseEffects) writeServicesSnapshot(
 	if len(allRows) == 0 {
 		return nil
 	}
-	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_services ("+pagerDutyServicesOperationalServiceColumns+")")
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		return err
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_services ("+contract.serviceColumns()+")")
 	if err != nil {
 		return err
 	}
 	defer batch.Abort()
 	for _, row := range allRows {
-		if err := batch.Append(pagerDutyServiceValues(row)...); err != nil {
+		if err := batch.Append(pagerDutyServiceValuesForContract(row, contract)...); err != nil {
 			return err
 		}
 	}
@@ -295,13 +384,17 @@ func (sink PagerDutyServicesClickHouseEffects) writeMappingsSnapshot(
 	if len(allRows) == 0 {
 		return nil
 	}
-	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_service_repository_mappings ("+pagerDutyServicesMappingColumns+")")
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		return err
+	}
+	batch, err := sink.Conn.PrepareBatch(ctx, "INSERT INTO operational_service_repository_mappings ("+contract.mappingColumns()+")")
 	if err != nil {
 		return err
 	}
 	defer batch.Abort()
 	for _, row := range allRows {
-		if err := batch.Append(pagerDutyServiceMappingValues(row)...); err != nil {
+		if err := batch.Append(pagerDutyServiceMappingValuesForContract(row, contract)...); err != nil {
 			return err
 		}
 	}
@@ -424,6 +517,12 @@ func pagerDutyServiceValues(row pagerDutyServiceRow) []any {
 		row.EscalationPolicyID, row.IsDeleted, row.DeletedAt)
 }
 
+func pagerDutyServiceValuesForContract(
+	row pagerDutyServiceRow, contract pagerDutyServicesStorageContract,
+) []any {
+	return pagerDutyServicesValuesForContract(pagerDutyServiceValues(row), contract)
+}
+
 func pagerDutyServiceMappingValues(row pagerDutyServiceRepositoryMappingRow) []any {
 	values := gitLabOperationalBaseValues(
 		row.OrgID, row.Provider, row.ProviderInstanceID, row.SourceEntityType,
@@ -436,6 +535,25 @@ func pagerDutyServiceMappingValues(row pagerDutyServiceRepositoryMappingRow) []a
 	)
 	return append(values, row.ServiceID, row.RepoID, row.RepoFullName, row.RepoProvider,
 		row.MappingKind, row.RuleID, row.ValidFrom, row.ValidTo, row.IsActive)
+}
+
+func pagerDutyServiceMappingValuesForContract(
+	row pagerDutyServiceRepositoryMappingRow, contract pagerDutyServicesStorageContract,
+) []any {
+	return pagerDutyServicesValuesForContract(pagerDutyServiceMappingValues(row), contract)
+}
+
+func pagerDutyServicesValuesForContract(
+	values []any, contract pagerDutyServicesStorageContract,
+) []any {
+	if contract != pagerDutyServicesLegacyContract {
+		return values
+	}
+	// The v2 ordering fields occupy the four positions immediately after
+	// source_version_at. Contract 1 stores all other canonical fields.
+	legacy := make([]any, 0, len(values)-4)
+	legacy = append(legacy, values[:6]...)
+	return append(legacy, values[10:]...)
 }
 
 func pagerDutyServiceScanValues(row *pagerDutyServiceRow, sourceRevision, ingestRevision *big.Int) []any {
@@ -452,6 +570,15 @@ func pagerDutyServiceScanValues(row *pagerDutyServiceRow, sourceRevision, ingest
 		&row.EscalationPolicyID, &row.IsDeleted, &row.DeletedAt)
 }
 
+func pagerDutyServiceScanValuesForContract(
+	row *pagerDutyServiceRow, sourceRevision, ingestRevision *big.Int,
+	contract pagerDutyServicesStorageContract,
+) []any {
+	return pagerDutyServicesValuesForContract(
+		pagerDutyServiceScanValues(row, sourceRevision, ingestRevision), contract,
+	)
+}
+
 func pagerDutyServiceMappingScanValues(row *pagerDutyServiceRepositoryMappingRow, sourceRevision, ingestRevision *big.Int) []any {
 	values := gitLabOperationalBaseScanValues(
 		&row.OrgID, &row.Provider, &row.ProviderInstanceID, &row.SourceEntityType,
@@ -466,14 +593,61 @@ func pagerDutyServiceMappingScanValues(row *pagerDutyServiceRepositoryMappingRow
 		&row.MappingKind, &row.RuleID, &row.ValidFrom, &row.ValidTo, &row.IsActive)
 }
 
+func pagerDutyServiceMappingScanValuesForContract(
+	row *pagerDutyServiceRepositoryMappingRow, sourceRevision, ingestRevision *big.Int,
+	contract pagerDutyServicesStorageContract,
+) []any {
+	return pagerDutyServicesValuesForContract(
+		pagerDutyServiceMappingScanValues(row, sourceRevision, ingestRevision), contract,
+	)
+}
+
+func pagerDutyHydrateServiceOrdering(
+	row *pagerDutyServiceRow, sourceRevision, ingestRevision *big.Int,
+	contract pagerDutyServicesStorageContract,
+) error {
+	if contract == pagerDutyServicesCurrentContract {
+		row.SourceRevision = new(big.Int).Set(sourceRevision)
+		row.IngestRevision = new(big.Int).Set(ingestRevision)
+		return nil
+	}
+	storedID := row.ID
+	if err := fillPagerDutyServiceOrdering(row); err != nil {
+		return err
+	}
+	if row.ID != storedID {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+func pagerDutyHydrateServiceMappingOrdering(
+	row *pagerDutyServiceRepositoryMappingRow, sourceRevision, ingestRevision *big.Int,
+	contract pagerDutyServicesStorageContract,
+) error {
+	if contract == pagerDutyServicesCurrentContract {
+		row.SourceRevision = new(big.Int).Set(sourceRevision)
+		row.IngestRevision = new(big.Int).Set(ingestRevision)
+		return nil
+	}
+	storedID := row.ID
+	if err := fillPagerDutyServiceMappingOrdering(row); err != nil {
+		return err
+	}
+	if row.ID != storedID {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
 func (sink PagerDutyServicesClickHouseEffects) loadActiveServices(
 	ctx context.Context, claim Claim, providerInstance string,
 ) ([]pagerDutyServiceRow, error) {
-	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesOperationalServiceColumns+
-		" FROM (SELECT "+pagerDutyServicesOperationalServiceColumns+
-		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? "+
-		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) "+
-		"WHERE is_deleted = 0",
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sink.Conn.Query(ctx, contract.loadActiveServicesQuery(),
 		claim.OrgID, claim.Provider, providerInstance, "service")
 	if err != nil {
 		return nil, err
@@ -483,10 +657,12 @@ func (sink PagerDutyServicesClickHouseEffects) loadActiveServices(
 	for rows.Next() {
 		var row pagerDutyServiceRow
 		var sourceRevision, ingestRevision big.Int
-		if err := rows.Scan(pagerDutyServiceScanValues(&row, &sourceRevision, &ingestRevision)...); err != nil {
+		if err := rows.Scan(pagerDutyServiceScanValuesForContract(&row, &sourceRevision, &ingestRevision, contract)...); err != nil {
 			return nil, err
 		}
-		row.SourceRevision, row.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		if err := pagerDutyHydrateServiceOrdering(&row, &sourceRevision, &ingestRevision, contract); err != nil {
+			return nil, err
+		}
 		result = append(result, row)
 	}
 	return result, rows.Err()
@@ -495,11 +671,11 @@ func (sink PagerDutyServicesClickHouseEffects) loadActiveServices(
 func (sink PagerDutyServicesClickHouseEffects) loadActiveMappings(
 	ctx context.Context, claim Claim, providerInstance string,
 ) ([]pagerDutyServiceRepositoryMappingRow, error) {
-	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesMappingColumns+
-		" FROM (SELECT "+pagerDutyServicesMappingColumns+
-		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? "+
-		"ORDER BY org_id, id, source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1 BY org_id, id) "+
-		"WHERE is_active = 1",
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sink.Conn.Query(ctx, contract.loadActiveMappingsQuery(),
 		claim.OrgID, claim.Provider, providerInstance)
 	if err != nil {
 		return nil, err
@@ -509,10 +685,12 @@ func (sink PagerDutyServicesClickHouseEffects) loadActiveMappings(
 	for rows.Next() {
 		var row pagerDutyServiceRepositoryMappingRow
 		var sourceRevision, ingestRevision big.Int
-		if err := rows.Scan(pagerDutyServiceMappingScanValues(&row, &sourceRevision, &ingestRevision)...); err != nil {
+		if err := rows.Scan(pagerDutyServiceMappingScanValuesForContract(&row, &sourceRevision, &ingestRevision, contract)...); err != nil {
 			return nil, err
 		}
-		row.SourceRevision, row.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		if err := pagerDutyHydrateServiceMappingOrdering(&row, &sourceRevision, &ingestRevision, contract); err != nil {
+			return nil, err
+		}
 		result = append(result, row)
 	}
 	return result, rows.Err()
@@ -609,9 +787,11 @@ func (sink PagerDutyServicesClickHouseEffects) inspectMappings(
 func (sink PagerDutyServicesClickHouseEffects) loadService(
 	ctx context.Context, claim Claim, providerInstance, id string,
 ) (pagerDutyServiceRow, bool, error) {
-	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesOperationalServiceColumns+
-		" FROM operational_services WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND source_entity_type = ? AND id = ? "+
-		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1",
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		return pagerDutyServiceRow{}, false, err
+	}
+	rows, err := sink.Conn.Query(ctx, contract.loadServiceQuery(),
 		claim.OrgID, claim.Provider, providerInstance, "service", id)
 	if err != nil {
 		return pagerDutyServiceRow{}, false, err
@@ -621,10 +801,12 @@ func (sink PagerDutyServicesClickHouseEffects) loadService(
 	found := false
 	for rows.Next() {
 		var sourceRevision, ingestRevision big.Int
-		if err := rows.Scan(pagerDutyServiceScanValues(&actual, &sourceRevision, &ingestRevision)...); err != nil {
+		if err := rows.Scan(pagerDutyServiceScanValuesForContract(&actual, &sourceRevision, &ingestRevision, contract)...); err != nil {
 			return pagerDutyServiceRow{}, false, err
 		}
-		actual.SourceRevision, actual.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		if err := pagerDutyHydrateServiceOrdering(&actual, &sourceRevision, &ingestRevision, contract); err != nil {
+			return pagerDutyServiceRow{}, false, err
+		}
 		found = true
 	}
 	return actual, found, rows.Err()
@@ -633,9 +815,11 @@ func (sink PagerDutyServicesClickHouseEffects) loadService(
 func (sink PagerDutyServicesClickHouseEffects) loadMapping(
 	ctx context.Context, claim Claim, providerInstance, id string,
 ) (pagerDutyServiceRepositoryMappingRow, bool, error) {
-	rows, err := sink.Conn.Query(ctx, "SELECT "+pagerDutyServicesMappingColumns+
-		" FROM operational_service_repository_mappings WHERE org_id = ? AND provider = ? AND provider_instance_id = ? AND id = ? "+
-		"ORDER BY source_revision DESC, source_conflict_key DESC, ingest_revision DESC LIMIT 1",
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		return pagerDutyServiceRepositoryMappingRow{}, false, err
+	}
+	rows, err := sink.Conn.Query(ctx, contract.loadMappingQuery(),
 		claim.OrgID, claim.Provider, providerInstance, id)
 	if err != nil {
 		return pagerDutyServiceRepositoryMappingRow{}, false, err
@@ -645,10 +829,12 @@ func (sink PagerDutyServicesClickHouseEffects) loadMapping(
 	found := false
 	for rows.Next() {
 		var sourceRevision, ingestRevision big.Int
-		if err := rows.Scan(pagerDutyServiceMappingScanValues(&actual, &sourceRevision, &ingestRevision)...); err != nil {
+		if err := rows.Scan(pagerDutyServiceMappingScanValuesForContract(&actual, &sourceRevision, &ingestRevision, contract)...); err != nil {
 			return pagerDutyServiceRepositoryMappingRow{}, false, err
 		}
-		actual.SourceRevision, actual.IngestRevision = new(big.Int).Set(&sourceRevision), new(big.Int).Set(&ingestRevision)
+		if err := pagerDutyHydrateServiceMappingOrdering(&actual, &sourceRevision, &ingestRevision, contract); err != nil {
+			return pagerDutyServiceRepositoryMappingRow{}, false, err
+		}
 		found = true
 	}
 	return actual, found, rows.Err()

--- a/internal/providersync/pagerduty_services_ordering_contract_test.go
+++ b/internal/providersync/pagerduty_services_ordering_contract_test.go
@@ -1,0 +1,191 @@
+package providersync
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
+)
+
+func TestPagerDutyServicesReadbackDoesNotClaimV2ColumnsFromActiveLegacySchema(t *testing.T) {
+	t.Setenv("OPERATIONAL_ORDERING_CONTRACT", "1")
+	if err := os.Unsetenv("OPERATIONAL_ORDERING_CONTRACT"); err != nil {
+		t.Fatal(err)
+	}
+	claim := nativeTestClaim("pagerduty", "services")
+	now := time.Date(2026, 8, 12, 3, 0, 0, 0, time.UTC)
+	service, err := normalizePagerDutyService(
+		claim, "acme", pagerDutyServicePayload{ID: "PS1", Name: "Payments"}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapping, err := pagerDutyServiceMappingFromReference(
+		service,
+		pagerDutyServiceRepositoryReference{Provider: "github", FullName: "full-chaos/payments"},
+		pagerDutyMappingMetadata,
+		now,
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoID := uuid.New()
+	mapping.RepoID = &repoID
+	mapping.ID, mapping.SourceConflictKey = "", ""
+	mapping.SourceRevision, mapping.IngestRevision = nil, nil
+	mapping.OrderingContract = 0
+	if err := fillPagerDutyServiceMappingOrdering(&mapping); err != nil {
+		t.Fatal(err)
+	}
+	serviceEffect, err := effectBatchFromValues(
+		"operational_services", EffectReadbackRequired, []pagerDutyServiceRow{service},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mappingEffect, err := effectBatchFromValues(
+		"operational_service_repository_mappings",
+		EffectReadbackRequired,
+		[]pagerDutyServiceRepositoryMappingRow{mapping},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := &pagerDutyLegacySchemaProbeConn{}
+	sink := PagerDutyServicesClickHouseEffects{
+		Conn: conn,
+		Lease: providerfoundation.LeaseGuardFunc(func(context.Context) error {
+			return nil
+		}),
+		ProviderInstanceID: "acme",
+	}
+	for name, effect := range map[string]EffectBatch{
+		"services": serviceEffect,
+		"mappings": mappingEffect,
+	} {
+		inspection, inspectErr := sink.InspectEffect(context.Background(), claim, effect)
+		if inspectErr != nil || inspection != EffectAbsent {
+			t.Fatalf("%s inspection=%s error=%v", name, inspection, inspectErr)
+		}
+	}
+	if len(conn.queries) != 4 {
+		t.Fatalf("queries=%d want 4: %v", len(conn.queries), conn.queries)
+	}
+}
+
+func TestPagerDutyServicesStorageContractDefaultsToLegacySchema(t *testing.T) {
+	t.Setenv("OPERATIONAL_ORDERING_CONTRACT", "1")
+	if err := os.Unsetenv("OPERATIONAL_ORDERING_CONTRACT"); err != nil {
+		t.Fatal(err)
+	}
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contract != pagerDutyServicesLegacyContract {
+		t.Fatalf("contract=%d want legacy", contract)
+	}
+	for name, query := range map[string]string{
+		"active services": contract.loadActiveServicesQuery(),
+		"active mappings": contract.loadActiveMappingsQuery(),
+		"service":         contract.loadServiceQuery(),
+		"mapping":         contract.loadMappingQuery(),
+	} {
+		if !strings.Contains(query, " FINAL ") {
+			t.Errorf("%s query does not select legacy current rows with FINAL: %s", name, query)
+		}
+		for _, column := range []string{"source_revision", "source_conflict_key", "ingest_revision", "ordering_contract"} {
+			if strings.Contains(query, column) {
+				t.Errorf("%s query claims unavailable legacy column %s: %s", name, column, query)
+			}
+		}
+	}
+	if got, want := len(pagerDutyServiceValuesForContract(pagerDutyServiceRow{}, contract)), columnCount(contract.serviceColumns()); got != want {
+		t.Fatalf("legacy service values=%d columns=%d", got, want)
+	}
+	if got, want := len(pagerDutyServiceMappingValuesForContract(pagerDutyServiceRepositoryMappingRow{}, contract)), columnCount(contract.mappingColumns()); got != want {
+		t.Fatalf("legacy mapping values=%d columns=%d", got, want)
+	}
+}
+
+func TestPagerDutyServicesStorageContractPreservesExplicitV2(t *testing.T) {
+	t.Setenv("OPERATIONAL_ORDERING_CONTRACT", "2")
+	contract, err := configuredPagerDutyServicesStorageContract()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contract != pagerDutyServicesCurrentContract {
+		t.Fatalf("contract=%d want current", contract)
+	}
+	for name, query := range map[string]string{
+		"active services": contract.loadActiveServicesQuery(),
+		"active mappings": contract.loadActiveMappingsQuery(),
+		"service":         contract.loadServiceQuery(),
+		"mapping":         contract.loadMappingQuery(),
+	} {
+		if strings.Contains(query, " FINAL ") {
+			t.Errorf("%s current query unexpectedly uses legacy FINAL: %s", name, query)
+		}
+		if !strings.Contains(query, "source_revision") || !strings.Contains(query, "ingest_revision") {
+			t.Errorf("%s current query omits v2 ordering columns: %s", name, query)
+		}
+	}
+	if got, want := len(pagerDutyServiceValuesForContract(pagerDutyServiceRow{}, contract)), columnCount(contract.serviceColumns()); got != want {
+		t.Fatalf("current service values=%d columns=%d", got, want)
+	}
+	if got, want := len(pagerDutyServiceMappingValuesForContract(pagerDutyServiceRepositoryMappingRow{}, contract)), columnCount(contract.mappingColumns()); got != want {
+		t.Fatalf("current mapping values=%d columns=%d", got, want)
+	}
+}
+
+func TestPagerDutyServicesStorageContractRejectsUnknownValue(t *testing.T) {
+	t.Setenv("OPERATIONAL_ORDERING_CONTRACT", "3")
+	if _, err := configuredPagerDutyServicesStorageContract(); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("error=%v want invalid configuration", err)
+	}
+}
+
+func columnCount(columns string) int {
+	if columns == "" {
+		return 0
+	}
+	return strings.Count(columns, ",") + 1
+}
+
+type pagerDutyLegacySchemaProbeConn struct {
+	driver.Conn
+	queries []string
+}
+
+func (conn *pagerDutyLegacySchemaProbeConn) Query(
+	_ context.Context, query string, _ ...any,
+) (driver.Rows, error) {
+	conn.queries = append(conn.queries, query)
+	for _, unavailable := range []string{
+		"source_revision", "source_conflict_key", "ingest_revision", "ordering_contract",
+	} {
+		if strings.Contains(query, unavailable) {
+			return nil, errors.New("Code: 47. DB::Exception: Unknown identifier " + unavailable)
+		}
+	}
+	return pagerDutyEmptyRows{}, nil
+}
+
+type pagerDutyEmptyRows struct{}
+
+func (pagerDutyEmptyRows) Next() bool                       { return false }
+func (pagerDutyEmptyRows) Scan(...any) error                { return nil }
+func (pagerDutyEmptyRows) ScanStruct(any) error             { return nil }
+func (pagerDutyEmptyRows) ColumnTypes() []driver.ColumnType { return nil }
+func (pagerDutyEmptyRows) Totals(...any) error              { return nil }
+func (pagerDutyEmptyRows) Columns() []string                { return nil }
+func (pagerDutyEmptyRows) Close() error                     { return nil }
+func (pagerDutyEmptyRows) Err() error                       { return nil }
+func (pagerDutyEmptyRows) HasData() bool                    { return false }

--- a/internal/providersync/pagerduty_teams_route.go
+++ b/internal/providersync/pagerduty_teams_route.go
@@ -3,6 +3,8 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"strings"
@@ -135,6 +137,10 @@ func (handler PagerDutyTeamsRouteHandler) Collect(
 		},
 	)
 	if err != nil {
+		var providerErr *providerfoundation.ProviderError
+		if errors.As(err, &providerErr) && providerErr.StatusCode == http.StatusPaymentRequired {
+			return CompleteRouteBatch{}, fmt.Errorf("pagerduty teams: %w", ErrProviderDatasetUnavailable)
+		}
 		return CompleteRouteBatch{}, err
 	}
 	if len(pages.Items) > maxRows || pages.CapReached {

--- a/internal/providersync/pagerduty_teams_route_test.go
+++ b/internal/providersync/pagerduty_teams_route_test.go
@@ -135,6 +135,29 @@ func TestPagerDutyTeamsRoutePreservesRetryAndPermanentErrorSemantics(t *testing.
 	}
 }
 
+func TestPagerDutyTeamsRouteClassifiesUnavailableAccountAbility(t *testing.T) {
+	t.Parallel()
+	claim := nativeTestClaim("pagerduty", "teams")
+	credential := providerfoundation.Credential{
+		Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"},
+	}
+	doer := &pagerDutyTeamsDoer{t: t, responses: []pagerDutyTeamsResponse{{
+		status: http.StatusPaymentRequired,
+		body:   `{"error":{"code":2014,"message":"Required abilities are unavailable"}}`,
+	}}}
+	client := pagerDutyTeamsTestClient(t, doer, providerfoundation.RetryPolicy{
+		MaxAttempts: 3, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+	})
+
+	_, err := (PagerDutyTeamsRouteHandler{}).Collect(
+		context.Background(), claim, credential, client,
+		time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC),
+	)
+	if !errors.Is(err, ErrProviderDatasetUnavailable) || len(doer.requests) != 1 {
+		t.Fatalf("error=%v requests=%d", err, len(doer.requests))
+	}
+}
+
 func TestPagerDutyTeamsRouteFailsClosedOnPaginationCapAndWrongDataset(t *testing.T) {
 	t.Parallel()
 	claim := nativeTestClaim("pagerduty", "teams")

--- a/internal/providersync/testdata/mutation-plans/github_work_items_derivation_context.json
+++ b/internal/providersync/testdata/mutation-plans/github_work_items_derivation_context.json
@@ -201,6 +201,16 @@
       "replace": "for _, candidate := range candidates {\n\t\tif candidate.IsPrimary == 0 {\n\t\t\tcontinue\n\t\t}\n\t\tresult.Source = append(result.Source, candidate.Source)",
       "rationale": "the differential oracle must compare every ordered provenance candidate, including lower-precedence rows persisted with is_primary zero",
       "proof": [["./ci/check_go.sh", "live-python-oracles"]]
+    },
+    {
+      "id": "D25-clickhouse-native-integer-widths",
+      "file": "internal/providersync/github_work_items_derivation_context.go",
+      "find": "&isPrimary, &specificity, &priority, &fact.UpdatedAt",
+      "replace": "&fact.IsPrimary, &fact.Specificity, &fact.Priority, &fact.UpdatedAt",
+      "expect_occurrences": 3,
+      "rationale": "ClickHouse exposes ownership fields as UInt8, UInt16, and Int32; scanning them into Go int fails at runtime before Linear or another work-item family can derive any effects",
+      "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
+      "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestGitHubWorkItemDerivationContextScansClickHouseNativeIntegerWidths$", "./internal/providersync/"]]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/go_provider_aggregate_wiring.json
+++ b/internal/providersync/testdata/mutation-plans/go_provider_aggregate_wiring.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "Go provider aggregate wiring",
-  "$limitation": "This plan pins only the Go worker's aggregate construction and admission wiring: provider-family selection, concrete GitLab and PagerDuty route selection, descriptor readiness/default-off behavior, config-to-switch/readiness translation, PagerDuty's one incidents config flag projected onto four independent claim switches, and provider-worker construction. It does not retest provider fetch/normalize algorithms, effects or readback semantics, Python producer routing, packaging or deployment, matrix census counts, live services, Docker, or cutover activation; those remain owned by their dedicated plans and gates.",
+  "$limitation": "This plan pins only the Go worker's aggregate construction and admission wiring: provider-family selection, Linear account-unit global discovery, concrete GitLab and PagerDuty route selection, descriptor readiness/default-off behavior, config-to-switch/readiness translation, PagerDuty's one incidents config flag projected onto four independent claim switches, and provider-worker construction. It does not retest provider fetch/normalize algorithms, effects or readback semantics, Python producer routing, packaging or deployment, matrix census counts, live services, Docker, or cutover activation; those remain owned by their dedicated plans and gates.",
   "build": [
     "env",
     "GOTOOLCHAIN=go1.25.9",
@@ -271,6 +271,14 @@
       "replace": "\t\t{\"pagerduty\", \"incident-notes-disabled\", cfg.WorkerPagerDutyIncidentsEnabled},",
       "rationale": "readiness must validate the independent PagerDuty incident-notes claim whenever the shared incident-family config flag is enabled",
       "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOWORK=off", "GOCACHE=/tmp/go-worker-aggregate-wiring-mutation-cache", "go", "test", "-count=1", "-run", "^TestProviderRouteSwitchesAreIndependentAndRejectIncompleteRoutes$", "./cmd/dev-health-worker/"]]
+    },
+    {
+      "id": "GW33-linear-account-units-discover-all-teams",
+      "file": "cmd/dev-health-worker/provider_sync.go",
+      "find": "\t\t\t\t\tDirect: providersync.LinearWorkItemsRouteHandler{\n\t\t\t\t\t\tGlobalDiscovery: true,\n\t\t\t\t\t},",
+      "replace": "\t\t\t\t\tDirect: providersync.LinearWorkItemsRouteHandler{\n\t\t\t\t\t\tGlobalDiscovery: false,\n\t\t\t\t\t},",
+      "rationale": "production Linear work-item units identify the provider account as their source, so they must discover every accessible Linear team instead of interpreting the account identity as a team key",
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOWORK=off", "GOCACHE=/tmp/go-worker-aggregate-wiring-mutation-cache", "go", "test", "-count=1", "-run", "^TestBuildProviderSyncHandlerConfiguresLinearAccountDiscovery$", "./cmd/dev-health-worker/"]]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/pagerduty_on-calls.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_on-calls.json
@@ -93,6 +93,14 @@
       "expect_occurrences": 1,
       "rationale": "PagerDuty on-call escalation_level is normalized as int32 and included in the canonical operational ordering conflict key. Rejecting int32 at the shared encoder must make a concrete on-calls row with escalation_level fail normalization.",
       "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment$", "./internal/providersync/"]]
+    },
+    {
+      "id": "OC12-route-result-is-comparator-valid",
+      "file": "internal/providersync/pagerduty_oncalls_route.go",
+      "find": "Result:  map[string]any{\"on_calls_synced\": len(rows)},",
+      "replace": "Result:  nil,",
+      "rationale": "The production comparator rejects a nil route result before effects reach the ledger or ClickHouse, so an otherwise valid on-calls page must retain a non-nil result",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyOnCallsRouteUsesOffsetPaginationAndCanonicalAssignment$", "./internal/providersync/"]]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/pagerduty_services.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_services.json
@@ -93,6 +93,14 @@
       "rationale": "Mapping reconciliation is an independent complete snapshot. An omitted source mapping must become inactive with valid_to evidence, even when its service row remains present.",
       "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
       "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyServicesEffectsUseMigratedClickHouseForReplayTombstonesTenantAndLease$", "./internal/providersync/"]]
+    },
+    {
+      "id": "S12-unset-ordering-contract-uses-live-legacy-schema",
+      "file": "internal/providersync/pagerduty_services_effects_clickhouse.go",
+      "find": "if !present || raw == \"1\" {\n\t\treturn pagerDutyServicesLegacyContract, nil",
+      "replace": "if !present || raw == \"1\" {\n\t\treturn pagerDutyServicesCurrentContract, nil",
+      "rationale": "The local stack has not applied deferred migration 067 and leaves OPERATIONAL_ORDERING_CONTRACT unset; selecting v2 columns makes every services write or readback fail with ClickHouse code 47",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyServices(ReadbackDoesNotClaimV2ColumnsFromActiveLegacySchema|StorageContractDefaultsToLegacySchema)$", "./internal/providersync/"]]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/pagerduty_teams.json
+++ b/internal/providersync/testdata/mutation-plans/pagerduty_teams.json
@@ -68,6 +68,23 @@
       "rationale": "A complete successful teams snapshot must reconcile every previously active row omitted by the source into a tombstone; skipping omitted rows leaves stale teams active and readback must reject the partial write.",
       "build": ["go", "test", "-tags", "integration", "-run", "^$", "./internal/providersync/"],
       "proof": [["go", "test", "-tags", "integration", "-count=1", "-run", "^TestPagerDutyTeamsEffectUsesMigratedClickHouseTombstonesAndExactReplay$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T9-account-ability-failure-is-not-an-empty-snapshot",
+      "file": "internal/providersync/pagerduty_teams_route.go",
+      "find": "providerErr.StatusCode == http.StatusPaymentRequired",
+      "replace": "providerErr.StatusCode == http.StatusOK",
+      "rationale": "PagerDuty returns HTTP 402/code 2014 when the account lacks the teams product ability; the route must preserve that as unavailable rather than retry to exhaustion or fabricate an empty authoritative snapshot",
+      "proof": [["go", "test", "-count=1", "-run", "^TestPagerDutyTeamsRouteClassifiesUnavailableAccountAbility$", "./internal/providersync/"]]
+    },
+    {
+      "id": "T10-dataset-unavailable-terminalizes-on-first-attempt",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "if errors.Is(err, providersync.ErrProviderDatasetUnavailable) {\n\t\treturn ProviderDatasetUnavailableCategory, true",
+      "replace": "if errors.Is(err, providersync.ErrProviderDatasetUnavailable) {\n\t\treturn \"\", false",
+      "rationale": "An account-level product ability cannot appear on a retry; the unit must retain a truthful provider_dataset_unavailable category instead of burning all attempts and becoming generic exhaustion",
+      "build": ["go", "test", "-run", "^$", "./internal/jobs/providerunit/"],
+      "proof": [["go", "test", "-count=1", "-run", "^TestDeterministicTerminalCategoryContract$", "./internal/jobs/providerunit/"]]
     }
   ]
 }

--- a/internal/scheduler/sync/testdata/python_planner_oracle.py
+++ b/internal/scheduler/sync/testdata/python_planner_oracle.py
@@ -55,6 +55,7 @@ _package("dev_health_ops.credentials")
 _package("dev_health_ops.providers")
 _package("dev_health_ops.providers.github")
 _package("dev_health_ops.sync")
+_package("dev_health_ops.workers")
 _module(
     "dev_health_ops.backfill.chunker",
     chunk_date_range=lambda **_kwargs: (),
@@ -88,6 +89,10 @@ _module(
     sync_datasets_require_canonical_incident_feature=lambda *_args, **_kwargs: False,
 )
 datasets = _load("dev_health_ops.sync.datasets", SOURCE / "sync/datasets.py")
+_load(
+    "dev_health_ops.workers.provider_family_contract",
+    SOURCE / "workers/provider_family_contract.py",
+)
 _load(
     "dev_health_ops.providers.github.work_item_options",
     SOURCE / "providers/github/work_item_options.py",

--- a/internal/storage/postgres/domain_authorization.go
+++ b/internal/storage/postgres/domain_authorization.go
@@ -557,6 +557,10 @@ func domainPosture() RolePosture {
 			{"integration_sources", true, true, false},
 			{"integration_datasets", true, true, false},
 			{"integration_credentials", false, false, false},
+			// Provider-sync workers resolve tokenless PagerDuty OAuth descriptors
+			// through this encrypted token row and atomically rotate an expiring
+			// token. They need no INSERT or DELETE authority.
+			{"provider_oauth_credentials", false, true, false},
 			{"sync_runs", true, true, false},
 			{"sync_dispatch_transport_routes", false, false, false},
 			{"sync_run_units", true, true, false},

--- a/internal/storage/postgres/domain_authorization_integration_test.go
+++ b/internal/storage/postgres/domain_authorization_integration_test.go
@@ -45,6 +45,7 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 		"CREATE TABLE public.integration_sources (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.integration_datasets (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.integration_credentials (id bigint PRIMARY KEY)",
+		"CREATE TABLE public.provider_oauth_credentials (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id bigint PRIMARY KEY)",
 		// worker_job_routes is coordinator-exclusive under the Option B split
 		// (role-partition manifest, removed in e23ede618; see git history at
@@ -92,6 +93,7 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 		"GRANT CONNECT ON DATABASE worker_test TO " + authorizedDomainRole,
 		"GRANT USAGE ON SCHEMA public TO " + authorizedDomainRole,
 		"GRANT SELECT ON TABLE public.integrations, public.integration_credentials, public.sync_dispatch_transport_routes, public.sync_configurations, public.organizations, public.billing_notifications, public.external_ingest_sources, public.feature_flags, public.org_feature_overrides, public.org_licenses, public.webhook_deliveries TO " + authorizedDomainRole,
+		"GRANT SELECT, UPDATE ON TABLE public.provider_oauth_credentials TO " + authorizedDomainRole,
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_sources, public.integration_datasets, public.sync_runs, public.sync_run_units TO " + authorizedDomainRole,
 		"GRANT SELECT, UPDATE ON TABLE public.report_runs, public.saved_reports TO " + authorizedDomainRole,
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks, public.sync_dispatch_outbox, public.remaining_metric_runs, public.remaining_metric_partitions, public.work_graph_execution_requests, public.work_graph_execution_ledger, public.daily_metrics_partitions, public.daily_metrics_runs, public.worker_job_runs TO " + authorizedDomainRole,

--- a/internal/storage/postgres/domain_authorization_test.go
+++ b/internal/storage/postgres/domain_authorization_test.go
@@ -136,6 +136,7 @@ func TestDomainPostureInventoriesEachOriginalTableExactlyOnce(t *testing.T) {
 		"integration_sources",
 		"integration_datasets",
 		"integration_credentials",
+		"provider_oauth_credentials",
 		"sync_runs",
 		"sync_dispatch_transport_routes",
 		"sync_run_units",
@@ -146,6 +147,23 @@ func TestDomainPostureInventoriesEachOriginalTableExactlyOnce(t *testing.T) {
 		if counts[table] != 1 {
 			t.Fatalf("domain posture must inventory %q exactly once, got %d", table, counts[table])
 		}
+	}
+}
+
+func TestDomainPostureInventoriesPagerDutyOAuthRotationPrivileges(t *testing.T) {
+	t.Parallel()
+	var matches []TablePrivilege
+	for _, table := range domainPosture().RequiredTables {
+		if table.TableName == "provider_oauth_credentials" {
+			matches = append(matches, table)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("provider OAuth posture entries=%d, want 1", len(matches))
+	}
+	grant := matches[0]
+	if grant.AllowInsert || !grant.AllowUpdate || grant.AllowDelete {
+		t.Fatalf("provider OAuth posture=%+v, want SELECT+UPDATE only", grant)
 	}
 }
 

--- a/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
+++ b/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
@@ -303,6 +303,7 @@ func startGrantHarness(t *testing.T, ctx context.Context) (*pgxpool.Pool, string
 			id uuid PRIMARY KEY, org_id text NOT NULL, provider text NOT NULL,
 			is_active boolean NOT NULL, config json, credentials_encrypted text
 		)`,
+		"CREATE TABLE public.provider_oauth_credentials (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id uuid PRIMARY KEY)",
 		// Carries the columns syncroute's real route-mutation statements name,
 		// so a privilege denial cannot be mistaken for an undefined column

--- a/internal/storage/postgres/runtime_authorization_integration_test.go
+++ b/internal/storage/postgres/runtime_authorization_integration_test.go
@@ -40,6 +40,7 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		"CREATE TABLE public.integration_sources (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.integration_datasets (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.integration_credentials (id bigint PRIMARY KEY)",
+		"CREATE TABLE public.provider_oauth_credentials (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id bigint PRIMARY KEY)",
 		// worker_job_routes is coordinator-exclusive under the Option B split
 		// (role-partition manifest, removed in e23ede618; see git history at
@@ -90,6 +91,7 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		"GRANT CONNECT ON DATABASE worker_test TO " + runtimeAuthorizationDomainRole + ", " + runtimeAuthorizationQueueRole,
 		"GRANT USAGE ON SCHEMA public TO " + runtimeAuthorizationDomainRole + ", " + runtimeAuthorizationQueueRole,
 		"GRANT SELECT ON TABLE public.integrations, public.integration_credentials, public.sync_dispatch_transport_routes, public.sync_configurations, public.organizations, public.billing_notifications, public.external_ingest_sources, public.feature_flags, public.org_feature_overrides, public.org_licenses, public.webhook_deliveries TO " + runtimeAuthorizationDomainRole,
+		"GRANT SELECT, UPDATE ON TABLE public.provider_oauth_credentials TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_sources, public.integration_datasets, public.sync_runs, public.sync_run_units TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, UPDATE ON TABLE public.report_runs, public.saved_reports TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks, public.sync_dispatch_outbox, public.remaining_metric_runs, public.remaining_metric_partitions, public.work_graph_execution_requests, public.work_graph_execution_ledger, public.daily_metrics_partitions, public.daily_metrics_runs, public.worker_job_runs TO " + runtimeAuthorizationDomainRole,

--- a/internal/storage/river/migrate.go
+++ b/internal/storage/river/migrate.go
@@ -385,6 +385,7 @@ func runtimeGrantStatements(options MigrationOptions) []string {
 		"DO $$ BEGIN IF to_regclass('public.integration_sources') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_sources TO " + domainRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.integration_datasets') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_datasets TO " + domainRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.integration_credentials') IS NOT NULL THEN GRANT SELECT ON TABLE public.integration_credentials TO " + domainRole + "; END IF; END $$",
+		"DO $$ BEGIN IF to_regclass('public.provider_oauth_credentials') IS NOT NULL THEN GRANT SELECT, UPDATE ON TABLE public.provider_oauth_credentials TO " + domainRole + "; END IF; END $$",
 		// worker_job_routes, scheduled_jobs, scheduled_sync_occurrences, and
 		// fixed_schedule_occurrences are coordinator-exclusive under the
 		// Option B two-role split (role-partition manifest, removed in

--- a/internal/storage/river/migrate_test.go
+++ b/internal/storage/river/migrate_test.go
@@ -406,6 +406,7 @@ func TestRuntimeGrantStatementsMatchProvisionedLeastPrivilegePolicy(t *testing.T
 		"DO $$ BEGIN IF to_regclass('public.integration_sources') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_sources TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.integration_datasets') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.integration_datasets TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.integration_credentials') IS NOT NULL THEN GRANT SELECT ON TABLE public.integration_credentials TO \"domain_runtime\"; END IF; END $$",
+		"DO $$ BEGIN IF to_regclass('public.provider_oauth_credentials') IS NOT NULL THEN GRANT SELECT, UPDATE ON TABLE public.provider_oauth_credentials TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_runs') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_runs TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_transport_routes') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO \"domain_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_run_units') IS NOT NULL THEN GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_run_units TO \"domain_runtime\"; END IF; END $$",

--- a/internal/syncreconciler/kernel_integration_test.go
+++ b/internal/syncreconciler/kernel_integration_test.go
@@ -669,6 +669,7 @@ func createKernelIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) err
 		"CREATE TABLE public.integration_sources (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.integration_datasets (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.integration_credentials (id uuid PRIMARY KEY)",
+		"CREATE TABLE public.provider_oauth_credentials (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id uuid PRIMARY KEY)",
 		// worker_job_routes is coordinator-exclusive under the Option B split
 		// (role-partition manifest, removed in e23ede618; see git history at

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -127,6 +127,9 @@ from dev_health_ops.sync.watermarks import (
     _watermark_overlap_seconds,
     get_watermark_with_overlap,
 )
+from dev_health_ops.workers.provider_family_contract import (
+    atomic_provider_family_route_enabled,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -1101,11 +1104,15 @@ def _build_work_item_family_units(
     composite_windows = _merge_family_windows([windows for _, windows in contributing])
 
     processor_flags: dict[str, bool] = dict(canonical_spec.processor_flags)
-    if provider == "github":
+    if provider == "github" or atomic_provider_family_route_enabled(
+        provider, _FAMILY_CANONICAL_DATASET_KEY
+    ):
         # CHAOS-3606: GitHub's native route has one all-five-alias writer. A
         # caught-up sibling still has no independent Python owner while this
         # canonical unit runs, so its flag records atomic route ownership rather
         # than whether that sibling contributed a window to this tick's merge.
+        # The same ownership rule applies to the other work-item providers once
+        # their native family route is enabled.
         # The merged window above remains derived only from non-empty inputs.
         family_flag_datasets = _WORK_ITEM_FAMILY_DATASET_ORDER
     else:

--- a/src/dev_health_ops/workers/provider_family_contract.py
+++ b/src/dev_health_ops/workers/provider_family_contract.py
@@ -9,6 +9,7 @@ or reject those units.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
@@ -78,6 +79,7 @@ _POLICIES = (
 )
 
 FAMILY_DATASET_FLAG_PREFIX = "family_dataset_"
+_TRUE = frozenset({"1", "true", "yes", "on"})
 
 
 def family_dataset_flag(dataset: str) -> str:
@@ -91,6 +93,37 @@ def provider_family_policy(provider: str, dataset: str) -> ProviderFamilyPolicy 
         if policy.applies_to(normalized_provider, normalized_dataset):
             return policy
     return None
+
+
+def atomic_provider_family_route_enabled(
+    provider: str,
+    dataset: str,
+    environment: Mapping[str, str] | None = None,
+) -> bool:
+    """Whether one atomic family has native ownership in this process.
+
+    Explicit per-provider switches override the local ``all`` preset. Keeping
+    this decision beside the family policy lets the planner and dispatcher
+    agree on whether processor flags describe contributing datasets or the
+    complete indivisible Go writer family.
+    """
+
+    normalized_provider = provider.strip().lower()
+    policy = provider_family_policy(normalized_provider, dataset.strip().lower())
+    if policy is None or policy.mode is not FamilyExecutionMode.ATOMIC_CANONICAL:
+        return False
+    source = os.environ if environment is None else environment
+    switch_name = (
+        policy.switch_environment_name(normalized_provider)
+        or f"WORKER_{normalized_provider.upper()}_WORK_ITEMS_ENABLED"
+    )
+    explicit = source.get(switch_name)
+    if explicit is not None:
+        return explicit.strip().lower() in _TRUE
+    return (
+        source.get("DEV_HEALTH_ENV", "").strip().lower() == "local"
+        and source.get("GO_PROVIDER_ROUTES", "").strip().lower() == "all"
+    )
 
 
 def validate_provider_family_claim(

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -35,6 +35,7 @@ from dev_health_ops.sync.planner import (
 )
 from dev_health_ops.workers.provider_family_contract import (
     FamilyExecutionMode,
+    atomic_provider_family_route_enabled,
     provider_family_policy,
     validate_provider_family_claim,
 )
@@ -268,20 +269,9 @@ def provider_family_strict_admission_enabled(
     """
 
     normalized_provider = provider.strip().lower()
-    policy = provider_family_policy(normalized_provider, dataset.strip().lower())
-    if policy is None or policy.mode is not FamilyExecutionMode.ATOMIC_CANONICAL:
-        return False
     if normalized_provider == "github":
         return True
-    switch_name = (
-        policy.switch_environment_name(normalized_provider)
-        or f"WORKER_{normalized_provider.upper()}_WORK_ITEMS_ENABLED"
-    )
-    source = os.environ if environment is None else environment
-    source = _provider_route_environment(
-        source, tuple(ProviderUnitRouteSwitches.__dataclass_fields__)
-    )
-    return _flag(source, switch_name)
+    return atomic_provider_family_route_enabled(provider, dataset, environment)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -1795,6 +1795,50 @@ def test_work_item_family_collapses_to_single_composite_unit(db_session):
         assert flags.get(flag) is True, f"{flag} must be set on the composite unit"
 
 
+def test_enabled_linear_go_family_claims_all_aliases_for_selected_backfill(
+    db_session, monkeypatch
+):
+    """A selected backfill remains one bounded crawl but claims the full Go family.
+
+    The native Linear handler owns one indivisible sixteen-destination write.
+    Once that route is enabled, the planner must encode all five family flags
+    even when the request selected only ``work-items``; otherwise dispatch
+    rejects the persisted unit before either runtime can execute it.
+    """
+    monkeypatch.setenv("DEV_HEALTH_ENV", "local")
+    monkeypatch.setenv("GO_PROVIDER_ROUTES", "all")
+
+    integration = _create_integration(db_session, provider="linear")
+    _create_source(db_session, integration, external_id="linear", provider="linear")
+    _create_dataset(db_session, integration, "work-items")
+
+    since = datetime(2026, 8, 8, tzinfo=timezone.utc)
+    before = datetime(2026, 8, 12, tzinfo=timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.BACKFILL.value,
+            triggered_by="admin-api",
+            since=since,
+            before=before,
+            dataset_keys=("work-items",),
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    unit = units[0]
+    assert unit.since_at is not None and unit.since_at.date() == since.date()
+    assert unit.before_at is not None and unit.before_at.date() == before.date()
+    flags = unit.processor_flags or {}
+    assert {
+        key: flags.get("family_dataset_" + key.replace("-", "_"))
+        for key in _FAMILY_DATASETS
+    } == {key: True for key in _FAMILY_DATASETS}
+
+
 def test_work_item_family_collapse_uses_earliest_window_across_datasets(db_session):
     """The composite unit's since_at is the EARLIEST watermark across enabled
     family datasets, so the single crawl covers every dataset (over-fetch is

--- a/tests/tooling/mutation-plans/atomic_provider_family_planning.json
+++ b/tests/tooling/mutation-plans/atomic_provider_family_planning.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "name": "atomic provider-family planning for focused backfills",
+  "$limitation": "Pins the planner-to-dispatch admission contract for a selected work-items backfill. Provider collection, derived effects, and Go handler composition remain covered by their provider mutation plans.",
+  "mutations": [
+    {
+      "id": "AFP01-enabled-native-family-claims-all-aliases",
+      "file": "src/dev_health_ops/sync/planner.py",
+      "find": "if provider == \"github\" or atomic_provider_family_route_enabled(\n        provider, _FAMILY_CANONICAL_DATASET_KEY\n    ):",
+      "replace": "if provider == \"github\":",
+      "expect_occurrences": 1,
+      "rationale": "A focused Linear/Jira/GitLab work-items request still executes through one indivisible Go family writer; omitting sibling flags makes dispatch reject the persisted unit before either runtime can execute it.",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/sync/planner.py"],
+      "proof": [["pytest", "-q", "tests/test_sync_planner.py::test_enabled_linear_go_family_claims_all_aliases_for_selected_backfill"]]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/pagerduty_oauth_binding_hydration.json
+++ b/tests/tooling/mutation-plans/pagerduty_oauth_binding_hydration.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "name": "PagerDuty OAuth binding hydration for native Go provider workers",
+  "build": ["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-run", "^$", "./internal/providerfoundation/", "./cmd/dev-health-worker/", "./internal/storage/postgres/", "./internal/storage/river/"],
+  "$limitation": "This plan covers tokenless descriptor hydration, tenant-bound OAuth binding and scope fences, renewal selection, production worker wiring, and least-privilege domain-role posture. Live PagerDuty HTTP behavior and a real PostgreSQL optimistic-rotation race remain integration evidence rather than mutation targets in this focused repair.",
+  "mutations": [
+    {
+      "id": "PD-OAUTH-1-resolver-invokes-hydrator",
+      "file": "internal/providerfoundation/types.go",
+      "find": "if r.Hydrator != nil {",
+      "replace": "if false {",
+      "rationale": "A tokenless PagerDuty descriptor cannot authenticate unless the claimed credential resolver invokes its explicit OAuth hydration boundary.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestCredentialResolverHydratesTokenlessPagerDutyOAuthBinding$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "PD-OAUTH-2-binding-fence",
+      "file": "internal/providerfoundation/pagerduty_oauth.go",
+      "find": "record.BindingID != expectedBindingID ||",
+      "replace": "false ||",
+      "rationale": "A reconnect replaces the OAuth grant. The worker must never attach a token from a different binding to a frozen integration descriptor.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestPagerDutyOAuthHydratorRejectsBindingAndScopeDrift/binding$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "PD-OAUTH-2a-embedded-token-compatibility",
+      "file": "internal/providerfoundation/pagerduty_oauth.go",
+      "find": "if token, exists := credential.Secret(\"access_token\"); exists && token.Configured() {",
+      "replace": "if false {",
+      "rationale": "An already hydrated or direct OAuth credential remains a supported shape and must not be forced through a missing binding repository reference.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestPagerDutyOAuthHydratorPreservesEmbeddedAccessTokenCompatibility$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "PD-OAUTH-3-required-read-scopes",
+      "file": "internal/providerfoundation/pagerduty_oauth.go",
+      "find": "if !hasPagerDutyOperationalReadScopes(tokens.GrantedScopes) {",
+      "replace": "if false {",
+      "rationale": "The complete operational route set must not start with a grant that cannot read every enabled PagerDuty dataset.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestPagerDutyOAuthHydratorRejectsBindingAndScopeDrift/scope$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "PD-OAUTH-4-renewal-window",
+      "file": "internal/providerfoundation/pagerduty_oauth.go",
+      "find": "if tokens.ExpiresAt.After(h.now().Add(pagerDutyOAuthRenewalWindow)) {",
+      "replace": "if true {",
+      "rationale": "A token inside the five-minute renewal window must refresh before provider work instead of being attached as if it were durable for the claim.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestPagerDutyOAuthHydratorRefreshesAndRotatesEncryptedToken$", "./internal/providerfoundation/"]]
+    },
+    {
+      "id": "PD-OAUTH-5-worker-wiring",
+      "file": "cmd/dev-health-worker/provider_sync.go",
+      "find": "Hydrator:  credentialHydrator,",
+      "replace": "Hydrator:  nil,",
+      "rationale": "Constructing a hydrator at startup is not capability evidence unless every provider-unit executor receives the same dependency.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestBuildProviderSyncHandlerWiresPagerDutyCredentialHydrator$", "./cmd/dev-health-worker/"]]
+    },
+    {
+      "id": "PD-OAUTH-6-domain-role-update",
+      "file": "internal/storage/postgres/domain_authorization.go",
+      "find": "{\"provider_oauth_credentials\", false, true, false},",
+      "replace": "{\"provider_oauth_credentials\", false, false, false},",
+      "rationale": "The domain worker needs narrowly scoped UPDATE authority to atomically rotate an expiring OAuth token; SELECT alone fails only after the first token approaches expiry.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestDomainPostureInventoriesPagerDutyOAuthRotationPrivileges$", "./internal/storage/postgres/"]]
+    }
+  ]
+}

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -213,8 +213,8 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     expected_provider_tests = _providersync_top_level_tests()
     expected_integration_tests = _providersync_integration_tagged_tests()
-    assert len(expected_provider_tests) == 882
-    assert len(expected_integration_tests) == 102
+    assert len(expected_provider_tests) == 888
+    assert len(expected_integration_tests) == 103
     assert expected_integration_tests < expected_provider_tests
 
     provider_assignments: dict[int, set[str]] = {}
@@ -230,7 +230,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     provider_flattened = [
         test_name for tests in provider_assignments.values() for test_name in tests
     ]
-    assert len(provider_flattened) == len(set(provider_flattened)) == 882
+    assert len(provider_flattened) == len(set(provider_flattened)) == 888
     assert set(provider_flattened) == expected_provider_tests
     assert {
         name
@@ -291,7 +291,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
         )
 
     expected_tests = _providersync_top_level_tests()
-    assert len(selected_tests) == len(set(selected_tests)) == 882
+    assert len(selected_tests) == len(set(selected_tests)) == 888
     assert set(selected_tests) == expected_tests
 
 


### PR DESCRIPTION
## Summary

- make Linear account-wide team discovery available to the Go work-item route
- keep focused Linear backfills atomic across the five work-item datasets while preserving the requested date window
- scan ClickHouse derivation-context numeric columns through their native widths before converting to domain integers
- hydrate PagerDuty OAuth binding credentials in the Go worker, including scope validation and safe refresh persistence
- return a comparator-valid PagerDuty on-calls result
- support both legacy and v2 PagerDuty services ordering schemas
- classify PagerDuty Teams HTTP 402 capability failures as terminal `provider_dataset_unavailable` instead of exhausting retries

## Live local proof

Fresh runs against the rebuilt API and Go worker from this head:

- Linear sync `7348678a-2a5b-48dd-8d0d-8c2ce9729b49`: success, one attempt, complete five-dataset family
- Linear focused backfill `cb149b8b-efea-40f1-82a1-bdd8023fb3b9`: success, one attempt, complete five-dataset family with the selected window retained
- PagerDuty sync `9142a372-6a53-437a-93bc-bb7dc9fa2dbb`: 10 supported datasets succeeded on their first attempt, including on-calls and services
- PagerDuty Teams terminated after one attempt as `provider_dataset_unavailable`; the live API returned HTTP 402 / provider code 2014 (`Required abilities are unavailable`) despite a credential containing `teams.read`

TEST-EVIDENCE:

- `bash ci/local_validate.sh`: 9/9 stages passed; 13,848 passed, 248 skipped, 1 expected xfail; 85/85 ClickHouse migrations; live argMax proof; scratch database dropped
- `bash ci/check_go.sh fast`: passed outside the restricted sandbox, including uncached live Python provider and planner oracles
- shared mutation harness: AFP01, D25, OC12, S12, T9, and T10 all killed; final restore verification clean
- real migrated-ClickHouse regression covers UInt8/UInt16/Int32 derivation-context scans
- focused affected Go packages, Go vet, Ruff, and mypy passed

RISK-NOTES:

- This does not fabricate PagerDuty Teams as an empty dataset. The current account lacks the required PagerDuty ability, so the overall run remains honestly `partial_failed` while all supported datasets complete.
- Unset or `1` `OPERATIONAL_ORDERING_CONTRACT` uses the live legacy services schema; explicit `2` preserves the v2 contract; invalid values fail closed.
- No deployment, production activation, or schema cutover is included.
