### PR TITLE
fix(sync): preserve coverage during projection refresh

### DIFF
--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -421,6 +421,13 @@ class SyncCoverageSummaryResponse(BaseModel):
     truncation_reason: Literal["lookback_limit"] | None = None
     projection_version: int
     projection_complete: bool
+    projection_refreshing: bool = Field(
+        default=False,
+        description=(
+            "True when this response is the last completed projection while a newer "
+            "projection is being built."
+        ),
+    )
     overall: SyncCoverageOverall
     datasets: list[SyncCoverageDataset]
     sources: list[SyncCoverageSource]

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -2181,7 +2181,14 @@ async def build_sync_coverage_summary(
     lookback_days: int = HISTORY_LOOKBACK_DAYS,
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Return an O(1) read of the background-built durable projection."""
+    """Return the latest O(1) durable projection, including during refresh.
+
+    Invalidation marks the existing payload as needing replacement; it does not
+    erase the last completed coverage state. Serving that payload with an
+    explicit refresh marker keeps navigation and reloads truthful while the
+    background builder prepares its successor. A genuinely cold config still
+    raises ``SyncCoveragePendingError``.
+    """
 
     started_at = monotonic()
     log_context = {
@@ -2198,7 +2205,6 @@ async def build_sync_coverage_summary(
                 SyncCoverageProjection.history_lookback_days == lookback_days,
                 SyncCoverageProjection.projection_version
                 == SYNC_COVERAGE_PROJECTION_VERSION,
-                SyncCoverageProjection.invalidated_at.is_(None),
             )
         )
     ).scalar_one_or_none()
@@ -2206,6 +2212,7 @@ async def build_sync_coverage_summary(
         logger.info("sync_coverage_projection_pending", extra=log_context)
         raise SyncCoveragePendingError("Coverage is being prepared. Retry shortly.")
     payload = dict(projection.payload)
+    payload["projection_refreshing"] = projection.invalidated_at is not None
     logger.info(
         "sync_coverage_summary_completed",
         extra={
@@ -2214,6 +2221,7 @@ async def build_sync_coverage_summary(
             "gap_count": payload["overall"]["gap_count"],
             "failed_range_count": payload["overall"]["failed_range_count"],
             "projection_version": payload["projection_version"],
+            "projection_refreshing": payload["projection_refreshing"],
         },
     )
     return payload

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -741,12 +741,16 @@ async def test_sync_coverage_missing_projection_is_pending_without_building(
 
 
 @pytest.mark.asyncio
-async def test_sync_coverage_invalidated_projection_is_pending_until_rebuilt(
+async def test_sync_coverage_invalidated_projection_stays_visible_until_rebuilt(
     client, session_maker
 ):
     ac, seeded_state = client
     scope = await _seed_scope(session_maker, seeded_state["org_id"])
     await _warm_projection(session_maker, scope)
+    url = f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage"
+    current = await ac.get(url)
+    assert current.status_code == 200, current.text
+    assert current.json()["projection_refreshing"] is False
 
     async with session_maker() as session:
         await invalidate_sync_coverage_projection(
@@ -756,13 +760,17 @@ async def test_sync_coverage_invalidated_projection_is_pending_until_rebuilt(
         )
         await session.commit()
 
-    url = f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage"
-    pending = await ac.get(url)
-    assert pending.status_code == 503
+    refreshing = await ac.get(url)
+    assert refreshing.status_code == 200, refreshing.text
+    assert refreshing.json() == {
+        **current.json(),
+        "projection_refreshing": True,
+    }
 
     await _warm_projection(session_maker, scope)
     rebuilt = await ac.get(url)
     assert rebuilt.status_code == 200, rebuilt.text
+    assert rebuilt.json()["projection_refreshing"] is False
 
 
 @pytest.mark.asyncio
@@ -780,7 +788,8 @@ async def test_sync_config_update_invalidates_coverage_projection(
     assert updated.status_code == 200, updated.text
 
     coverage = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
-    assert coverage.status_code == 503
+    assert coverage.status_code == 200, coverage.text
+    assert coverage.json()["projection_refreshing"] is True
 
 
 def test_canonical_backfill_windows_merge_after_inclusive_date_conversion():


### PR DESCRIPTION
Closes CHAOS-3766\n\n## Summary\n- keep the last completed sync coverage projection readable while its replacement is invalidated/rebuilding\n- expose projection_refreshing so clients can distinguish stale-but-usable coverage from a cold projection\n- preserve 503 pending behavior when no projection has ever been built\n\nTEST-EVIDENCE:\n- red: invalidated projection endpoint returned 503 and omitted the refresh marker\n- focused: 29 passed, 1 PostgreSQL-only skip\n- full: bash ci/local_validate.sh passed 9/9; 13,848 passed, 248 skipped, 1 expected xfail; live ClickHouse argMax proof passed\n\nRISK-NOTES:\n- no migration or storage move; sync_coverage_projections remains PostgreSQL-backed\n- this is a response-contract addition with a default false field\n- web rendering/polling follows in a linked dev-health-web PR\n