### PR TITLE
feat(contracts): publish pinned no-answer vocabulary artifact (CHAOS-3471)

### DIFF
--- a/contracts/ask-dev/v1/manifest.json
+++ b/contracts/ask-dev/v1/manifest.json
@@ -493,6 +493,11 @@
       "case": "source_health_labels",
       "path": "vocabulary/source_health_labels.v1.json",
       "sha256": "f141c442d84b55d59d40e5b20deba5ad810ee8d5a7c91f59c68545006d66ef7e"
+    },
+    {
+      "case": "no_answer_vocabulary",
+      "path": "vocabulary/no_answer_vocabulary.v1.json",
+      "sha256": "0fe3195b46e924bce7bf98d8d1e9372fe4a0044fa34591b19eedb00ca3e9d9c1"
     }
   ]
 }

--- a/contracts/ask-dev/v1/vocabulary/no_answer_vocabulary.v1.json
+++ b/contracts/ask-dev/v1/vocabulary/no_answer_vocabulary.v1.json
@@ -1,0 +1,53 @@
+{
+  "outcomes": {
+    "denied": {
+      "code": "forbidden",
+      "remediation": [
+        "Ask an administrator for access to this area."
+      ],
+      "retryable": false,
+      "safe_message": "You do not have access to ask about this."
+    },
+    "failed": {
+      "code": "internal_error",
+      "remediation": [
+        "Try the question again."
+      ],
+      "retryable": false,
+      "safe_message": "Something went wrong while preparing this answer."
+    },
+    "not_found": {
+      "code": "scope_not_found",
+      "remediation": [
+        "Check the name and try again."
+      ],
+      "retryable": false,
+      "safe_message": "No matching subject was found for this question."
+    },
+    "refused": {
+      "code": "refused",
+      "remediation": [
+        "Ask a read-only question about your data instead."
+      ],
+      "retryable": false,
+      "safe_message": "Ask Dev can only read and summarize your data; it can't run commands or make changes."
+    },
+    "temporarily_unavailable": {
+      "code": "source_unavailable",
+      "remediation": [
+        "Try the question again in a few minutes."
+      ],
+      "retryable": true,
+      "safe_message": "This answer is temporarily unavailable. Please try again shortly."
+    },
+    "unsupported": {
+      "code": "feature_not_enabled",
+      "remediation": [
+        "Try a status, health, or metric question instead."
+      ],
+      "retryable": false,
+      "safe_message": "This question is not supported yet."
+    }
+  },
+  "schema_version": "ask_dev_no_answer_vocabulary.v1"
+}

--- a/src/dev_health_ops/api/dev/contracts_v2/compat.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/compat.py
@@ -57,6 +57,7 @@ client can only ever see an approximation of the richer v2 frame):
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 from typing import TypeVar
 
@@ -92,7 +93,11 @@ from .frame import DevAnswerFrame, DevFrameVersions
 from .subject import DevResolutionCandidate
 from .validators import CANONICAL_NO_ANSWER_COPY, CANONICAL_NO_ANSWER_REMEDIATION
 
-__all__ = ["project_answer_v2_to_v1", "scope_resolution_from_frame"]
+__all__ = [
+    "NO_ANSWER_ERROR_CODES",
+    "project_answer_v2_to_v1",
+    "scope_resolution_from_frame",
+]
 
 _V1Model = TypeVar("_V1Model", bound=BaseModel)
 
@@ -291,6 +296,17 @@ _ERROR_OUTCOME_CODES: dict[PublicOutcome, tuple[str, bool]] = {
     # would mislabel a categorical refusal as a resolvable evidence gap on
     # replay too.
     PublicOutcome.REFUSED: ("refused", False),
+}
+
+#: CHAOS-3471: the same table as ``_ERROR_OUTCOME_CODES``, keyed by the
+#: outcome's plain string value instead of the enum member, so a consumer
+#: outside this module (the contract-artifact exporter) can pin the
+#: ``(code, retryable)`` pair a v1 client actually receives for each
+#: no-answer outcome without importing a private, enum-keyed name across a
+#: module boundary. Derived from ``_ERROR_OUTCOME_CODES``, never redeclared,
+#: so the two cannot drift apart.
+NO_ANSWER_ERROR_CODES: Mapping[str, tuple[str, bool]] = {
+    outcome.value: pair for outcome, pair in _ERROR_OUTCOME_CODES.items()
 }
 
 

--- a/src/dev_health_ops/api/dev/contracts_v2/compat.py
+++ b/src/dev_health_ops/api/dev/contracts_v2/compat.py
@@ -57,7 +57,6 @@ client can only ever see an approximation of the richer v2 frame):
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from datetime import datetime
 from typing import TypeVar
 
@@ -94,7 +93,7 @@ from .subject import DevResolutionCandidate
 from .validators import CANONICAL_NO_ANSWER_COPY, CANONICAL_NO_ANSWER_REMEDIATION
 
 __all__ = [
-    "NO_ANSWER_ERROR_CODES",
+    "no_answer_error_projection",
     "project_answer_v2_to_v1",
     "scope_resolution_from_frame",
 ]
@@ -298,16 +297,36 @@ _ERROR_OUTCOME_CODES: dict[PublicOutcome, tuple[str, bool]] = {
     PublicOutcome.REFUSED: ("refused", False),
 }
 
-#: CHAOS-3471: the same table as ``_ERROR_OUTCOME_CODES``, keyed by the
-#: outcome's plain string value instead of the enum member, so a consumer
-#: outside this module (the contract-artifact exporter) can pin the
-#: ``(code, retryable)`` pair a v1 client actually receives for each
-#: no-answer outcome without importing a private, enum-keyed name across a
-#: module boundary. Derived from ``_ERROR_OUTCOME_CODES``, never redeclared,
-#: so the two cannot drift apart.
-NO_ANSWER_ERROR_CODES: Mapping[str, tuple[str, bool]] = {
-    outcome.value: pair for outcome, pair in _ERROR_OUTCOME_CODES.items()
-}
+
+def no_answer_error_projection(outcome: str) -> tuple[str, str, bool, list[str]]:
+    """``(safe_message, code, retryable, remediation)`` for one no-answer
+    outcome -- EXACTLY the composition ``_project_error`` uses to build a
+    v1 ``DevError``, factored out as the single function both the live
+    projector and the CHAOS-3471 contract-artifact exporter call.
+
+    Codex round-1 finding 1: an earlier version of the exporter published
+    ``CANONICAL_NO_ANSWER_REMEDIATION`` directly, which is only the
+    FALLBACK half of what a v1 client actually receives --
+    ``_project_error`` tries ``dev_error_remediation(code)`` first. A
+    ``dev_error_remediation`` entry added for a no-answer code (e.g.
+    ``"forbidden"``, ``denied``'s code) would silently change live output
+    while that artifact and its own content test stayed green. Composing
+    here, in the one function both sides call, makes that class of drift
+    structurally impossible rather than merely tested against.
+
+    Codex round-1 finding 2: an earlier version also published a
+    module-level snapshot (``NO_ANSWER_ERROR_CODES``) taken from
+    ``_ERROR_OUTCOME_CODES`` once at import time, while ``_project_error``
+    read ``_ERROR_OUTCOME_CODES`` directly on every call -- a runtime
+    mutation of the private table would reach the live path immediately
+    but never the stale snapshot. Reading ``_ERROR_OUTCOME_CODES`` fresh
+    on every call here closes that gap too.
+    """
+    code, retryable = _ERROR_OUTCOME_CODES[PublicOutcome(outcome)]
+    remediation = list(
+        dev_error_remediation(code) or CANONICAL_NO_ANSWER_REMEDIATION[outcome]
+    )
+    return CANONICAL_NO_ANSWER_COPY[outcome], code, retryable, remediation
 
 
 def _build_resolved_scope(
@@ -543,17 +562,16 @@ def _project_error(answer: DevAnswerV2) -> DevError:
     # channel if that constraint is ever relaxed: adversarial review's
     # `denied` counterexample reached a v1 client precisely because
     # `DevError.safe_message` was `frame.direct_answer` verbatim.
-    code, retryable = _ERROR_OUTCOME_CODES[answer.public_outcome]
+    safe_message, code, retryable, remediation = no_answer_error_projection(
+        answer.public_outcome.value
+    )
     return DevError(
         schema_version="dev_error.v1",
         request_id=answer.run_id,
         code=code,
-        safe_message=CANONICAL_NO_ANSWER_COPY[answer.public_outcome.value],
+        safe_message=safe_message,
         retryable=retryable,
-        remediation=(
-            dev_error_remediation(code)
-            or list(CANONICAL_NO_ANSWER_REMEDIATION[answer.public_outcome.value])
-        ),
+        remediation=remediation,
     )
 
 

--- a/src/dev_health_ops/api/dev/export_contracts.py
+++ b/src/dev_health_ops/api/dev/export_contracts.py
@@ -18,12 +18,8 @@ from .contract_fixtures import (
 )
 from .contracts import CONTRACT_MODELS, DevStreamEvent, ToolID, validate_stream
 from .contracts_v2.base import SourceClass
-from .contracts_v2.compat import NO_ANSWER_ERROR_CODES
-from .contracts_v2.validators import (
-    CANONICAL_NO_ANSWER_COPY,
-    CANONICAL_NO_ANSWER_REMEDIATION,
-    NO_ANSWER_OUTCOMES,
-)
+from .contracts_v2.compat import no_answer_error_projection
+from .contracts_v2.validators import NO_ANSWER_OUTCOMES
 from .no_match_terminal import INTERNAL_TOKEN_DENYLIST
 from .status_change_service import STATUS_REASON_CODES
 
@@ -272,6 +268,7 @@ def expected_artifacts() -> dict[str, str]:
         }
     )
     artifacts["vocabulary/source_health_labels.v1.json"] = source_health_labels_contents
+
     # CHAOS-3471. The entire user-visible text of a v1 DevError for a
     # dev_answer.v2 no-answer outcome comes from two server-owned Python
     # tables (contracts_v2/no_answer_policy.py's CANONICAL_NO_ANSWER_COPY /
@@ -287,16 +284,27 @@ def expected_artifacts() -> dict[str, str]:
     # off NO_ANSWER_OUTCOMES itself so a future outcome addition (e.g.
     # CHAOS-3541's "refused") is picked up automatically rather than
     # requiring someone to remember to extend a second, independent list.
+    #
+    # Codex round-1 findings 1+2: entries below call
+    # ``no_answer_error_projection`` -- the same function ``compat.
+    # _project_error`` calls for a real v1 request -- rather than reading
+    # ``CANONICAL_NO_ANSWER_REMEDIATION``/``_ERROR_OUTCOME_CODES`` directly,
+    # so this artifact cannot represent a composition the live path does
+    # not actually run.
+    def _no_answer_outcome_entry(outcome: str) -> dict[str, Any]:
+        safe_message, code, retryable, remediation = no_answer_error_projection(outcome)
+        return {
+            "safe_message": safe_message,
+            "remediation": remediation,
+            "code": code,
+            "retryable": retryable,
+        }
+
     no_answer_vocabulary_contents = _json(
         {
             "schema_version": "ask_dev_no_answer_vocabulary.v1",
             "outcomes": {
-                outcome: {
-                    "safe_message": CANONICAL_NO_ANSWER_COPY[outcome],
-                    "remediation": list(CANONICAL_NO_ANSWER_REMEDIATION[outcome]),
-                    "code": NO_ANSWER_ERROR_CODES[outcome][0],
-                    "retryable": NO_ANSWER_ERROR_CODES[outcome][1],
-                }
+                outcome: _no_answer_outcome_entry(outcome)
                 for outcome in sorted(NO_ANSWER_OUTCOMES)
             },
         }
@@ -347,12 +355,19 @@ def write_artifacts(artifacts: dict[str, str]) -> None:
     for relative_path, contents in artifacts.items():
         destination = ARTIFACT_ROOT / relative_path
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_text(contents, encoding="utf-8")
+        destination.write_bytes(contents.encode("utf-8"))
     for stale in _current_artifact_paths() - set(artifacts):
         (ARTIFACT_ROOT / stale).unlink()
 
 
 def check_artifacts(artifacts: dict[str, str]) -> None:
+    # Codex round-1 finding 3: ``Path.read_text()`` runs universal-newline
+    # translation on read, silently turning a checked-in file's real CRLF
+    # bytes back into "\n" in memory -- a text comparison here could never
+    # observe that corruption even though it changes the file's actual
+    # git-blob bytes (what dev-health-web's ``ask-dev-contracts.mjs``
+    # really hashes via ``git show``, and what the manifest's own declared
+    # sha256 is supposed to pin). Comparing raw bytes closes that gap.
     actual_paths = _current_artifact_paths()
     expected_paths = set(artifacts)
     if actual_paths != expected_paths:
@@ -364,7 +379,7 @@ def check_artifacts(artifacts: dict[str, str]) -> None:
     drifted = [
         relative_path
         for relative_path, expected in artifacts.items()
-        if (ARTIFACT_ROOT / relative_path).read_text(encoding="utf-8") != expected
+        if (ARTIFACT_ROOT / relative_path).read_bytes() != expected.encode("utf-8")
     ]
     if drifted:
         raise RuntimeError(f"contract artifacts drifted: {sorted(drifted)}")

--- a/src/dev_health_ops/api/dev/export_contracts.py
+++ b/src/dev_health_ops/api/dev/export_contracts.py
@@ -18,6 +18,12 @@ from .contract_fixtures import (
 )
 from .contracts import CONTRACT_MODELS, DevStreamEvent, ToolID, validate_stream
 from .contracts_v2.base import SourceClass
+from .contracts_v2.compat import NO_ANSWER_ERROR_CODES
+from .contracts_v2.validators import (
+    CANONICAL_NO_ANSWER_COPY,
+    CANONICAL_NO_ANSWER_REMEDIATION,
+    NO_ANSWER_OUTCOMES,
+)
 from .no_match_terminal import INTERNAL_TOKEN_DENYLIST
 from .status_change_service import STATUS_REASON_CODES
 
@@ -266,6 +272,36 @@ def expected_artifacts() -> dict[str, str]:
         }
     )
     artifacts["vocabulary/source_health_labels.v1.json"] = source_health_labels_contents
+    # CHAOS-3471. The entire user-visible text of a v1 DevError for a
+    # dev_answer.v2 no-answer outcome comes from two server-owned Python
+    # tables (contracts_v2/no_answer_policy.py's CANONICAL_NO_ANSWER_COPY /
+    # CANONICAL_NO_ANSWER_REMEDIATION) plus the (code, retryable) pair
+    # compat.py's projector attaches -- see compat._project_error. Before
+    # this, web hand-mirrored all three as tests/mocks/devScenario.ts's
+    # NO_ANSWER_OUTCOMES, which proves the UI renders the server's
+    # safe_message verbatim but cannot detect an ops-side reword: the mock
+    # and the Python constants could drift and both sides would stay green.
+    # Publishing the live tables closes that gap the same way
+    # internal_prose_denylist.v1.json already does for the completion-
+    # assessment vocabulary -- derived here, never hand-authored, and keyed
+    # off NO_ANSWER_OUTCOMES itself so a future outcome addition (e.g.
+    # CHAOS-3541's "refused") is picked up automatically rather than
+    # requiring someone to remember to extend a second, independent list.
+    no_answer_vocabulary_contents = _json(
+        {
+            "schema_version": "ask_dev_no_answer_vocabulary.v1",
+            "outcomes": {
+                outcome: {
+                    "safe_message": CANONICAL_NO_ANSWER_COPY[outcome],
+                    "remediation": list(CANONICAL_NO_ANSWER_REMEDIATION[outcome]),
+                    "code": NO_ANSWER_ERROR_CODES[outcome][0],
+                    "retryable": NO_ANSWER_ERROR_CODES[outcome][1],
+                }
+                for outcome in sorted(NO_ANSWER_OUTCOMES)
+            },
+        }
+    )
+    artifacts["vocabulary/no_answer_vocabulary.v1.json"] = no_answer_vocabulary_contents
     manifest = {
         "schema_version": "ask_dev_contract_manifest.v1",
         "compatibility": "additive-within-v1",
@@ -284,6 +320,11 @@ def expected_artifacts() -> dict[str, str]:
                 "case": "source_health_labels",
                 "path": "vocabulary/source_health_labels.v1.json",
                 "sha256": _sha256(source_health_labels_contents),
+            },
+            {
+                "case": "no_answer_vocabulary",
+                "path": "vocabulary/no_answer_vocabulary.v1.json",
+                "sha256": _sha256(no_answer_vocabulary_contents),
             },
         ],
     }

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -4,10 +4,12 @@ import hashlib
 import json
 from copy import deepcopy
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
+from dev_health_ops.api.dev import export_contracts
 from dev_health_ops.api.dev.contract_fixtures import (
     TEAM_ID,
     TEAM_LABEL,
@@ -31,16 +33,14 @@ from dev_health_ops.api.dev.contracts import (
     validate_stream,
 )
 from dev_health_ops.api.dev.contracts_v2.base import SourceClass
-from dev_health_ops.api.dev.contracts_v2.compat import NO_ANSWER_ERROR_CODES
-from dev_health_ops.api.dev.contracts_v2.validators import (
-    CANONICAL_NO_ANSWER_COPY,
-    CANONICAL_NO_ANSWER_REMEDIATION,
-    NO_ANSWER_OUTCOMES,
-)
+from dev_health_ops.api.dev.contracts_v2.compat import no_answer_error_projection
+from dev_health_ops.api.dev.contracts_v2.validators import NO_ANSWER_OUTCOMES
 from dev_health_ops.api.dev.export_contracts import (
+    ARTIFACT_ROOT,
     SOURCE_HEALTH_LABELS,
     check_artifacts,
     expected_artifacts,
+    write_artifacts,
 )
 from dev_health_ops.api.dev.no_match_terminal import INTERNAL_TOKEN_DENYLIST
 from dev_health_ops.api.dev.scope_service import (
@@ -602,17 +602,21 @@ def test_source_health_labels_cover_every_known_required_source_producer() -> No
 
 def test_published_no_answer_vocabulary_matches_the_live_policy_tables() -> None:
     """CHAOS-3471. The entire user-visible text of a v1 ``DevError`` for a
-    ``dev_answer.v2`` no-answer outcome is the server-owned
-    ``CANONICAL_NO_ANSWER_COPY`` / ``CANONICAL_NO_ANSWER_REMEDIATION``
-    tables plus the ``(code, retryable)`` pair
-    ``compat.NO_ANSWER_ERROR_CODES`` attaches (``compat._project_error``).
-    Before this artifact, web hand-mirrored all three in
+    ``dev_answer.v2`` no-answer outcome comes from
+    ``compat.no_answer_error_projection`` -- the single function
+    ``compat._project_error`` (the live path) and this exporter both call,
+    per codex round-1 findings 1+2 (see that function's docstring). Before
+    this artifact, web hand-mirrored the underlying tables in
     ``tests/mocks/devScenario.ts``'s ``NO_ANSWER_OUTCOMES`` -- a copy that
     proves the UI renders ``safe_message`` verbatim but cannot detect an
     ops-side reword. This test pins that the published artifact is exactly
-    the live tables, keyed by every member of ``NO_ANSWER_OUTCOMES`` (not a
-    hand-picked subset), so a future outcome addition or a copy/remediation
-    edit either lands in the artifact automatically or fails this test.
+    what that shared function returns, keyed by every member of
+    ``NO_ANSWER_OUTCOMES`` (not a hand-picked subset), so a future outcome
+    addition or a copy/remediation edit either lands in the artifact
+    automatically or fails this test. The stronger, end-to-end guard --
+    that this also matches a REAL ``project_answer_v2_to_v1`` call, not
+    just the function the exporter happens to call too -- lives in
+    ``test_contracts_v2.py``.
     """
     published = json.loads(
         expected_artifacts()["vocabulary/no_answer_vocabulary.v1.json"]
@@ -620,10 +624,10 @@ def test_published_no_answer_vocabulary_matches_the_live_policy_tables() -> None
     assert published["schema_version"] == "ask_dev_no_answer_vocabulary.v1"
     assert set(published["outcomes"]) == NO_ANSWER_OUTCOMES
     for outcome in NO_ANSWER_OUTCOMES:
-        code, retryable = NO_ANSWER_ERROR_CODES[outcome]
+        safe_message, code, retryable, remediation = no_answer_error_projection(outcome)
         assert published["outcomes"][outcome] == {
-            "safe_message": CANONICAL_NO_ANSWER_COPY[outcome],
-            "remediation": list(CANONICAL_NO_ANSWER_REMEDIATION[outcome]),
+            "safe_message": safe_message,
+            "remediation": remediation,
             "code": code,
             "retryable": retryable,
         }
@@ -644,6 +648,61 @@ def test_no_answer_vocabulary_is_listed_in_the_manifest() -> None:
             artifacts["vocabulary/no_answer_vocabulary.v1.json"].encode("utf-8")
         ).hexdigest()
     )
+
+
+def test_no_answer_vocabulary_manifest_sha_matches_the_bytes_on_disk() -> None:
+    """CHAOS-3471 / codex round-1 finding 3. Hashes the RAW ON-DISK BYTES
+    of the checked-in artifact (not the in-memory string ``expected_
+    artifacts()`` built) and pins that against both the manifest's
+    declared sha256 and the generator output -- so a byte-level corruption
+    a text read would silently normalize away (see
+    ``test_check_artifacts_detects_byte_level_corruption_read_text_would_
+    hide`` below for the direct reproduction of that gap) is still caught
+    here, on the actual shipped file.
+    """
+    artifacts = expected_artifacts()
+    manifest = json.loads(artifacts["manifest.json"])
+    entry = next(
+        item
+        for item in manifest["vocabulary"]
+        if item["case"] == "no_answer_vocabulary"
+    )
+    on_disk_bytes = (ARTIFACT_ROOT / entry["path"]).read_bytes()
+    assert hashlib.sha256(on_disk_bytes).hexdigest() == entry["sha256"]
+    assert on_disk_bytes == artifacts[entry["path"]].encode("utf-8")
+
+
+def test_check_artifacts_detects_byte_level_corruption_read_text_would_hide(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CHAOS-3471 / codex round-1 finding 3 (probe). ``Path.read_text()``
+    performs universal-newline translation on read, so a checked-in
+    file's real CRLF bytes decode back to plain "\\n" in memory --
+    a text-based ``check_artifacts`` could never observe that corruption,
+    even though it changes the file's actual git-blob bytes (what
+    dev-health-web's ``ask-dev-contracts.mjs`` really hashes via
+    ``git show``, and what a manifest sha256 is supposed to pin).
+    ``check_artifacts`` now compares raw bytes, so this corruption is
+    caught.
+    """
+    monkeypatch.setattr(export_contracts, "ARTIFACT_ROOT", tmp_path)
+    artifacts = {"vocabulary/probe.v1.json": '{"a": 1}\n'}
+    write_artifacts(artifacts)
+    check_artifacts(artifacts)  # uncorrupted: passes
+
+    on_disk_path = tmp_path / "vocabulary" / "probe.v1.json"
+    corrupted_bytes = (
+        artifacts["vocabulary/probe.v1.json"].replace("\n", "\r\n").encode("utf-8")
+    )
+    on_disk_path.write_bytes(corrupted_bytes)
+    # A text read would normalize \r\n back to \n and see no difference;
+    # confirm that decoy first, so this test documents the exact gap.
+    assert (
+        on_disk_path.read_text(encoding="utf-8")
+        == artifacts["vocabulary/probe.v1.json"]
+    )
+    with pytest.raises(RuntimeError, match="contract artifacts drifted"):
+        check_artifacts(artifacts)
 
 
 @pytest.mark.parametrize("schema_version", CONTRACT_MODELS)

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -600,6 +600,83 @@ def test_source_health_labels_cover_every_known_required_source_producer() -> No
         assert label, f"{source_id} has an empty label"
 
 
+#: CHAOS-3471 / codex round-2 finding. HARDCODED LITERALS -- deliberately
+#: not derived from ``CANONICAL_NO_ANSWER_COPY``, ``CANONICAL_NO_ANSWER_
+#: REMEDIATION``, or ``compat.no_answer_error_projection`` -- because both
+#: of the tests below it compute their own "expected" value by calling
+#: ``no_answer_error_projection`` (directly, or transitively through a real
+#: ``project_answer_v2_to_v1`` call), and the published artifact is built
+#: from that SAME function. A mutation inside that one shared composition
+#: (codex round-2 repro: hardcode every outcome's remediation to
+#: ``["WRONG-REMEDIATION"]``) changes the exporter's output, the live
+#: projector's output, and both tests' own "expected" value together --
+#: so both tests keep passing. Only a genuinely independent ground truth,
+#: typed out here by hand, can catch that class of bug.
+_NO_ANSWER_VOCABULARY_GOLDEN: dict[str, dict[str, object]] = {
+    "not_found": {
+        "safe_message": "No matching subject was found for this question.",
+        "remediation": ["Check the name and try again."],
+        "code": "scope_not_found",
+        "retryable": False,
+    },
+    "temporarily_unavailable": {
+        "safe_message": (
+            "This answer is temporarily unavailable. Please try again shortly."
+        ),
+        "remediation": ["Try the question again in a few minutes."],
+        "code": "source_unavailable",
+        "retryable": True,
+    },
+    "unsupported": {
+        "safe_message": "This question is not supported yet.",
+        "remediation": ["Try a status, health, or metric question instead."],
+        "code": "feature_not_enabled",
+        "retryable": False,
+    },
+    "denied": {
+        "safe_message": "You do not have access to ask about this.",
+        "remediation": ["Ask an administrator for access to this area."],
+        "code": "forbidden",
+        "retryable": False,
+    },
+    "failed": {
+        "safe_message": "Something went wrong while preparing this answer.",
+        "remediation": ["Try the question again."],
+        "code": "internal_error",
+        "retryable": False,
+    },
+    "refused": {
+        "safe_message": (
+            "Ask Dev can only read and summarize your data; it can't run "
+            "commands or make changes."
+        ),
+        "remediation": ["Ask a read-only question about your data instead."],
+        "code": "refused",
+        "retryable": False,
+    },
+}
+
+
+def test_no_answer_vocabulary_matches_an_independent_golden_expectation() -> None:
+    """CHAOS-3471 / codex round-2 finding (probe). Verified fail-to-catch
+    gap in the pre-existing tests: monkeypatching ``no_answer_error_
+    projection`` (both this module's and ``compat``'s bound name, so it
+    reaches the exporter AND the live projector) to return
+    ``remediation=["WRONG-REMEDIATION"]`` for every outcome left
+    ``test_published_no_answer_vocabulary_matches_the_live_policy_tables``
+    and ``test_contracts_v2.py``'s
+    ``test_no_answer_vocabulary_artifact_matches_the_real_v1_projection``
+    both green, because each computes its own "expected" value through
+    the very function that was mutated. This test's expectation is typed
+    out by hand instead, so that exact mutation fails it.
+    """
+    assert set(_NO_ANSWER_VOCABULARY_GOLDEN) == NO_ANSWER_OUTCOMES
+    published = json.loads(
+        expected_artifacts()["vocabulary/no_answer_vocabulary.v1.json"]
+    )["outcomes"]
+    assert published == _NO_ANSWER_VOCABULARY_GOLDEN
+
+
 def test_published_no_answer_vocabulary_matches_the_live_policy_tables() -> None:
     """CHAOS-3471. The entire user-visible text of a v1 ``DevError`` for a
     ``dev_answer.v2`` no-answer outcome comes from

--- a/tests/api/dev/test_contracts.py
+++ b/tests/api/dev/test_contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from copy import deepcopy
 from datetime import datetime
@@ -30,6 +31,12 @@ from dev_health_ops.api.dev.contracts import (
     validate_stream,
 )
 from dev_health_ops.api.dev.contracts_v2.base import SourceClass
+from dev_health_ops.api.dev.contracts_v2.compat import NO_ANSWER_ERROR_CODES
+from dev_health_ops.api.dev.contracts_v2.validators import (
+    CANONICAL_NO_ANSWER_COPY,
+    CANONICAL_NO_ANSWER_REMEDIATION,
+    NO_ANSWER_OUTCOMES,
+)
 from dev_health_ops.api.dev.export_contracts import (
     SOURCE_HEALTH_LABELS,
     check_artifacts,
@@ -591,6 +598,52 @@ def test_source_health_labels_cover_every_known_required_source_producer() -> No
     assert set(published["labels"]) == expected
     for source_id, label in SOURCE_HEALTH_LABELS.items():
         assert label, f"{source_id} has an empty label"
+
+
+def test_published_no_answer_vocabulary_matches_the_live_policy_tables() -> None:
+    """CHAOS-3471. The entire user-visible text of a v1 ``DevError`` for a
+    ``dev_answer.v2`` no-answer outcome is the server-owned
+    ``CANONICAL_NO_ANSWER_COPY`` / ``CANONICAL_NO_ANSWER_REMEDIATION``
+    tables plus the ``(code, retryable)`` pair
+    ``compat.NO_ANSWER_ERROR_CODES`` attaches (``compat._project_error``).
+    Before this artifact, web hand-mirrored all three in
+    ``tests/mocks/devScenario.ts``'s ``NO_ANSWER_OUTCOMES`` -- a copy that
+    proves the UI renders ``safe_message`` verbatim but cannot detect an
+    ops-side reword. This test pins that the published artifact is exactly
+    the live tables, keyed by every member of ``NO_ANSWER_OUTCOMES`` (not a
+    hand-picked subset), so a future outcome addition or a copy/remediation
+    edit either lands in the artifact automatically or fails this test.
+    """
+    published = json.loads(
+        expected_artifacts()["vocabulary/no_answer_vocabulary.v1.json"]
+    )
+    assert published["schema_version"] == "ask_dev_no_answer_vocabulary.v1"
+    assert set(published["outcomes"]) == NO_ANSWER_OUTCOMES
+    for outcome in NO_ANSWER_OUTCOMES:
+        code, retryable = NO_ANSWER_ERROR_CODES[outcome]
+        assert published["outcomes"][outcome] == {
+            "safe_message": CANONICAL_NO_ANSWER_COPY[outcome],
+            "remediation": list(CANONICAL_NO_ANSWER_REMEDIATION[outcome]),
+            "code": code,
+            "retryable": retryable,
+        }
+
+
+def test_no_answer_vocabulary_is_listed_in_the_manifest() -> None:
+    artifacts = expected_artifacts()
+    manifest = json.loads(artifacts["manifest.json"])
+    entry = next(
+        item
+        for item in manifest["vocabulary"]
+        if item["case"] == "no_answer_vocabulary"
+    )
+    assert entry["path"] == "vocabulary/no_answer_vocabulary.v1.json"
+    assert (
+        entry["sha256"]
+        == hashlib.sha256(
+            artifacts["vocabulary/no_answer_vocabulary.v1.json"].encode("utf-8")
+        ).hexdigest()
+    )
 
 
 @pytest.mark.parametrize("schema_version", CONTRACT_MODELS)

--- a/tests/api/dev/test_contracts_v2.py
+++ b/tests/api/dev/test_contracts_v2.py
@@ -26,6 +26,7 @@ from typing import Any, get_args, get_origin
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from dev_health_ops.api.dev import contracts as contracts_module
 from dev_health_ops.api.dev import contracts_v2 as v2
 from dev_health_ops.api.dev.contract_fixtures import (
     TEAM_ID,
@@ -1200,6 +1201,102 @@ def test_compat_error_outcome_codes_is_total_over_no_answer_outcomes() -> None:
         f"missing: {sorted(o.value for o in expected - actual)}, "
         f"unexpected: {sorted(o.value for o in actual - expected)}"
     )
+
+
+def test_no_answer_vocabulary_artifact_matches_the_real_v1_projection() -> None:
+    """CHAOS-3471 / codex round-1 finding 1. The published
+    ``no_answer_vocabulary.v1.json`` must equal what a v1 client actually
+    receives -- a REAL ``project_answer_v2_to_v1`` call for every
+    no-answer outcome, not merely a value the artifact-exporter's own
+    ``no_answer_error_projection`` call happens to agree with (the
+    self-consistency version of this lives in ``test_contracts.py``).
+    Drives the real projector end to end so a future change to either side
+    of the ``compat.py``/``export_contracts.py`` boundary is caught here.
+    """
+    published = json.loads(
+        expected_artifacts_v1()["vocabulary/no_answer_vocabulary.v1.json"]
+    )["outcomes"]
+    for outcome in v2.NO_ANSWER_OUTCOMES:
+        answer = v2.DevAnswerV2.model_validate(no_answer_payload(outcome))
+        projected = v2.project_answer_v2_to_v1(
+            answer, organization_id="org_fullchaos", time_range=_time_range_for_scope()
+        )
+        assert isinstance(projected, DevErrorV1)
+        assert published[outcome] == {
+            "safe_message": projected.safe_message,
+            "remediation": projected.remediation,
+            "code": projected.code,
+            "retryable": projected.retryable,
+        }
+
+
+def test_no_answer_vocabulary_composes_effective_remediation_not_just_the_canonical_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3471 / codex round-1 finding 1 (probe). ``_project_error``
+    composes ``dev_error_remediation(code) or CANONICAL_NO_ANSWER_
+    REMEDIATION[outcome]`` -- ``dev_error_remediation`` wins when it has
+    an entry for the code (``compat.no_answer_error_projection``).
+
+    Fail-before verified: with the exporter reading
+    ``CANONICAL_NO_ANSWER_REMEDIATION`` directly (the pre-fix shape),
+    registering a ``dev_error_remediation`` entry for ``denied``'s code
+    ("forbidden") changes what a real v1 client receives
+    (``projected.remediation`` below) while the published artifact stayed
+    on the old canonical text -- both the artifact and its own content
+    test stayed green. Composing through the shared
+    ``no_answer_error_projection`` function makes that divergence
+    impossible; this test pins it by registering exactly that entry and
+    asserting the live projection and the published artifact still agree.
+    """
+    patched_remediation = ("Patched: contact your org administrator.",)
+    monkeypatch.setitem(
+        contracts_module._DEV_ERROR_REMEDIATION, "forbidden", patched_remediation
+    )
+
+    answer = v2.DevAnswerV2.model_validate(no_answer_payload("denied"))
+    projected = v2.project_answer_v2_to_v1(
+        answer, organization_id="org_fullchaos", time_range=_time_range_for_scope()
+    )
+    assert isinstance(projected, DevErrorV1)
+    assert projected.remediation == list(patched_remediation)
+
+    published = json.loads(
+        expected_artifacts_v1()["vocabulary/no_answer_vocabulary.v1.json"]
+    )["outcomes"]
+    assert published["denied"]["remediation"] == list(patched_remediation)
+
+
+def test_no_answer_vocabulary_reflects_a_runtime_mutation_of_error_outcome_codes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-3471 / codex round-1 finding 2 (probe). Before this fix, the
+    exporter read a MODULE-LEVEL SNAPSHOT (``NO_ANSWER_ERROR_CODES``)
+    derived from ``compat._ERROR_OUTCOME_CODES`` once at import time,
+    while the live projector reads ``_ERROR_OUTCOME_CODES`` directly on
+    every call -- a runtime mutation of the private table would reach the
+    live path immediately but never that stale snapshot. Both now read
+    ``_ERROR_OUTCOME_CODES`` fresh (``compat.no_answer_error_projection``
+    is a function, not a precomputed table), so mutating it here reaches
+    both the live projection and the published artifact identically.
+    """
+    monkeypatch.setitem(
+        compat_module._ERROR_OUTCOME_CODES,
+        v2.PublicOutcome.DENIED,
+        ("forbidden", True),
+    )
+
+    answer = v2.DevAnswerV2.model_validate(no_answer_payload("denied"))
+    projected = v2.project_answer_v2_to_v1(
+        answer, organization_id="org_fullchaos", time_range=_time_range_for_scope()
+    )
+    assert isinstance(projected, DevErrorV1)
+    assert projected.retryable is True
+
+    published = json.loads(
+        expected_artifacts_v1()["vocabulary/no_answer_vocabulary.v1.json"]
+    )["outcomes"]
+    assert published["denied"]["retryable"] is True
 
 
 def test_compat_never_mislabels_a_team_subject_answer() -> None:


### PR DESCRIPTION
## Gap

Five of `dev_answer.v2`'s eight public outcomes (`not_found`, `temporarily_unavailable`, `unsupported`, `denied`, `failed` — plus `refused`, added later by CHAOS-3541, six total) never become an answer: the v1 compat projector turns each into a `DevError` whose entire user-visible text comes from two server-owned Python tables (`contracts_v2/no_answer_policy.py`'s `CANONICAL_NO_ANSWER_COPY` / `CANONICAL_NO_ANSWER_REMEDIATION`) plus a `(code, retryable)` pair. `dev-health-web`'s no-answer e2e coverage hand-mirrors all three in `tests/mocks/devScenario.ts`'s `NO_ANSWER_OUTCOMES`. That mirror proves the UI renders the server's `safe_message` verbatim, but it cannot detect ops-side drift: if ops rewords a sentence, web keeps asserting the old one against its own mock and stays green.

## What shipped

- `contracts/ask-dev/v1/vocabulary/no_answer_vocabulary.v1.json` — a generated (never hand-authored) artifact, one entry per outcome (`safe_message`, `remediation`, `code`, `retryable`), covering all six live `NO_ANSWER_OUTCOMES` members, listed in `manifest.json` alongside `internal_prose_denylist.v1.json` / `source_health_labels.v1.json`.
- `compat.no_answer_error_projection(outcome)` — the single function both the live v1 projector (`compat._project_error`) and the artifact exporter call, so the artifact cannot represent a composition the live path doesn't actually run.
- Drift enforcement rides the existing `test_checked_in_contract_artifacts_have_no_drift` gate, now comparing raw bytes (`write_bytes`/`read_bytes`) instead of text, so a checked-in CRLF corruption can no longer pass silently (`read_text()` would normalize it away).
- An independent, hand-typed golden expectation for all six outcomes, alongside the composed-projection and end-to-end tests — closes the gap where a mutation inside the shared composition function could otherwise pass every test that derives its own expectation from that same function.

## Codex rounds

- Round 1 (3 mediums, all fixed, probe-first): remediation-composition drift (artifact ignored `dev_error_remediation(code)`'s precedence), a public/private code-table pairing that could go stale under runtime mutation (fixed by elimination — one shared function, not two tables), and a text-based drift gate blind to CRLF corruption.
- Round 2 (1 medium, fixed, probe-first): both round-1 regression tests computed their own "expected" value through the same function under test, so a mutation inside that function's body passed both. Closed with an independent golden.

Every fix's regression test was verified fail-before / pass-after against the exact mutation it targets (documented in each test's docstring).

## Recorded follow-ups (not silent drops)

- `CLARIFICATION_COPY` (`api/dev/preflight_outcomes.py`) — a third server-owned copy table, also hand-mirrored in web, named in scope by a later Linear comment on CHAOS-3471 but not built here.
- The 2026-08-11 "Reset disposition" comment on CHAOS-3471 asks for this to eventually generate from "the ACR contract bundle" rather than these ops Python constants directly — not actionable yet: ACR's contract bundle has no ask-dev vocabulary surface today.
- `export_contracts_v2.py`'s `check_artifacts`/`write_artifacts` have the identical text-vs-bytes pattern this PR fixed in `export_contracts.py` (v1) — untouched here since v2 has no consumer yet.

## Part 1 of CHAOS-3471 — do not auto-close

Web's `ask-dev:contracts:check` still needs to pin and consume this artifact (replacing the hand mirror in `tests/mocks/devScenario.ts`); that's the second PR, in `dev-health-web`, sequenced after this one merges.

## Test evidence

- `pytest tests/api/dev/test_contracts.py tests/api/dev/test_contracts_v2.py` — 395 passed.
- `ci/local_validate.sh` — GATE PASSED 8/8 (lint, mypy, full unit suite, live ClickHouse argMax proof) — run 3x across the review rounds.
