### PR TITLE
fix(deps): pin openai below httpx2-requiring release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,15 @@ dependencies = [
   "radon>=6.0.1",
   # Multi-language cyclomatic complexity (TS/JS/Go/Java/...); radon stays for Python.
   "lizard>=1.17.10",
-  "openai>=2.36.0",
+  # openai 3.0.0 made the httpx2 client mandatory (httpx2<3,>=2.7.0
+  # replaces httpx<1 as a hard dependency; 2.54.0 still offers httpx2 only
+  # as an optional extra), which changed AsyncOpenAI / OpenAI's
+  # http_client parameter type away from what llm/providers/openai.py,
+  # llm/agent/openai_compatible.py, and llm/providers/local.py construct
+  # (httpx 1.x clients) -- 4 mypy arg-type errors. Migrating those call
+  # sites onto httpx2 is a follow-up, not this pin; upper-bound below the
+  # first release that requires it.
+  "openai>=2.36.0,<3",
   "anthropic>=0.101.0",
   "strawberry-graphql[fastapi]>=0.315.4",
   "celery[redis]>=5.3.0",


### PR DESCRIPTION
## Diagnosis

`main` is red: typecheck-mypy failing on `origin/main` since 2026-08-12 07:39 (runs [31574920453](https://github.com/full-chaos/dev-health-ops/actions/runs/31574920453) and [31579496291](https://github.com/full-chaos/dev-health-ops/actions/runs/31579496291)).

`pyproject.toml`'s `openai>=2.36.0` is unpinned on the upper end. CI installs via `pip install -r requirements.txt` (`-e .[dev]`), which is **not** constrained by `uv.lock` — it floats to whatever the latest matching release on PyPI is at install time. `openai==3.0.0` made the `httpx2` client mandatory (`httpx2<3,>=2.7.0` replaces `httpx<1` as a hard dependency; `2.54.0`, the prior release, still offers `httpx2` only as an optional extra — confirmed via PyPI's published `requires_dist` metadata for both versions). That changed `AsyncOpenAI`/`OpenAI`'s `http_client` parameter type away from what our code constructs (httpx 1.x clients), producing 4 mypy `arg-type` errors:

- `src/dev_health_ops/llm/providers/openai.py:564,579`
- `src/dev_health_ops/llm/agent/openai_compatible.py:412`
- `src/dev_health_ops/llm/providers/local.py:163`

Reproduced locally with the CI-literal `mypy --install-types --non-interactive .` against a fresh `pip install -r requirements.txt` (not `uv sync`, which respects the committed `uv.lock`'s older pinned `2.36.0` and doesn't reproduce the failure).

## Fix

Pin `openai>=2.36.0,<3` — resolves to `2.54.0` today, mypy green (2201 source files, no issues). `uv.lock` untouched: its existing `2.36.0` resolution already satisfies the new upper bound, so no relock was needed.

Minimal and scoped: the pin only. Migrating the three call sites onto `httpx2` is a follow-up, not this PR.

## Test evidence

- Fail-before: fresh pip venv + `mypy --install-types --non-interactive .` → 4 errors, exact 3 files/lines above.
- Pass-after: same reproduction with the pin applied → `openai==2.54.0` resolved, mypy clean.
- `ci/local_validate.sh` — GATE PASSED 8/8 (lint, mypy, full unit suite, live ClickHouse argMax proof).
