### PR TITLE
chore(deps): migrate OpenAI clients to httpx2 (CHAOS-3769)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "fastapi>=0.136.1,<0.137",
   "slowapi>=0.1.9",
   "httpx>=0.28.1",
+  "httpx2>=2.7.0,<3",
   "psycopg2-binary>=2.9.12",
   "asyncpg>=0.31.0",
   "aiosqlite>=0.22.1",
@@ -48,15 +49,7 @@ dependencies = [
   "radon>=6.0.1",
   # Multi-language cyclomatic complexity (TS/JS/Go/Java/...); radon stays for Python.
   "lizard>=1.17.10",
-  # openai 3.0.0 made the httpx2 client mandatory (httpx2<3,>=2.7.0
-  # replaces httpx<1 as a hard dependency; 2.54.0 still offers httpx2 only
-  # as an optional extra), which changed AsyncOpenAI / OpenAI's
-  # http_client parameter type away from what llm/providers/openai.py,
-  # llm/agent/openai_compatible.py, and llm/providers/local.py construct
-  # (httpx 1.x clients) -- 4 mypy arg-type errors. Migrating those call
-  # sites onto httpx2 is a follow-up, not this pin; upper-bound below the
-  # first release that requires it.
-  "openai>=2.36.0,<3",
+  "openai>=3.0.0",
   "anthropic>=0.101.0",
   "strawberry-graphql[fastapi]>=0.315.4",
   "celery[redis]>=5.3.0",

--- a/src/dev_health_ops/llm/agent/openai_compatible.py
+++ b/src/dev_health_ops/llm/agent/openai_compatible.py
@@ -11,7 +11,7 @@ from enum import StrEnum
 from typing import Any, cast
 from urllib.parse import urlsplit
 
-from dev_health_ops.llm.providers._http import make_hardened_async_httpx_client
+from dev_health_ops.llm.providers._http import make_hardened_async_httpx2_client
 from dev_health_ops.llm.providers.openai_capabilities import (
     build_wire_tool_name_map,
     chat_completion_reasoning_effort,
@@ -376,7 +376,7 @@ class OpenAICompatibleAgentProvider:
             # first-ever) import (CHAOS-3258).
             pin_content_carrying_client_loggers()
 
-            self._http_client = make_hardened_async_httpx_client()
+            self._http_client = make_hardened_async_httpx2_client()
             # CHAOS-3285 round 6 (Codex HIGH): AsyncOpenAI reads
             # OPENAI_ORG_ID/OPENAI_PROJECT_ID/OPENAI_CUSTOM_HEADERS from the
             # process environment AMBIENTLY whenever organization/project

--- a/src/dev_health_ops/llm/providers/_http.py
+++ b/src/dev_health_ops/llm/providers/_http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import httpx
+import httpx2
 
 
 def make_hardened_async_httpx_client() -> httpx.AsyncClient:
@@ -13,6 +14,22 @@ def make_hardened_async_httpx_client() -> httpx.AsyncClient:
 
 def make_hardened_httpx_client() -> httpx.Client:
     return httpx.Client(
+        follow_redirects=False,
+        trust_env=False,
+        timeout=60.0,
+    )
+
+
+def make_hardened_async_httpx2_client() -> httpx2.AsyncClient:
+    return httpx2.AsyncClient(
+        follow_redirects=False,
+        trust_env=False,
+        timeout=60.0,
+    )
+
+
+def make_hardened_httpx2_client() -> httpx2.Client:
+    return httpx2.Client(
         follow_redirects=False,
         trust_env=False,
         timeout=60.0,

--- a/src/dev_health_ops/llm/providers/local.py
+++ b/src/dev_health_ops/llm/providers/local.py
@@ -19,7 +19,7 @@ from dev_health_ops.llm.errors import (
 )
 from dev_health_ops.logging_config import pin_content_carrying_client_loggers
 
-from ._http import make_hardened_async_httpx_client
+from ._http import make_hardened_async_httpx2_client
 from .base import (
     DEFAULT_MODEL_BY_PROVIDER,
     CompletionResult,
@@ -160,7 +160,7 @@ class LocalProvider(LLMProviderBase):
                 self._client = AsyncOpenAI(
                     api_key=self.api_key,
                     base_url=self.base_url,
-                    http_client=make_hardened_async_httpx_client(),
+                    http_client=make_hardened_async_httpx2_client(),
                     max_retries=0,
                 )
             except ImportError:

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -31,7 +31,7 @@ from dev_health_ops.llm.errors import (
 from dev_health_ops.llm.json_utils import validate_json_or_empty
 from dev_health_ops.logging_config import pin_content_carrying_client_loggers
 
-from ._http import make_hardened_async_httpx_client, make_hardened_httpx_client
+from ._http import make_hardened_async_httpx2_client, make_hardened_httpx2_client
 from .base import (
     DEFAULT_MODEL_BY_PROVIDER,
     CompletionResult,
@@ -561,7 +561,7 @@ class _OpenAIProviderBase(LLMProviderBase):
             self._client = AsyncOpenAI(
                 api_key=self.cfg.api_key,
                 base_url=self.cfg.base_url,
-                http_client=make_hardened_async_httpx_client(),
+                http_client=make_hardened_async_httpx2_client(),
                 max_retries=0,
             )
         return self._client
@@ -576,7 +576,7 @@ class _OpenAIProviderBase(LLMProviderBase):
         client = OpenAI(
             api_key=self.cfg.api_key,
             base_url=self.cfg.base_url,
-            http_client=make_hardened_httpx_client(),
+            http_client=make_hardened_httpx2_client(),
             max_retries=0,
         )
         try:

--- a/tests/test_byo_base_url_ssrf.py
+++ b/tests/test_byo_base_url_ssrf.py
@@ -10,6 +10,8 @@ from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+import httpx2
 import pytest
 
 from dev_health_ops.api.admin.llm_settings import (
@@ -20,7 +22,9 @@ from dev_health_ops.api.admin.schemas import LLMSettingsUpsert
 from dev_health_ops.llm import credentials as creds
 from dev_health_ops.llm.credentials import validate_llm_base_url
 from dev_health_ops.llm.providers._http import (
+    make_hardened_async_httpx2_client,
     make_hardened_async_httpx_client,
+    make_hardened_httpx2_client,
     make_hardened_httpx_client,
 )
 from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
@@ -288,7 +292,7 @@ def test_openai_compatible_providers_use_hardened_http_client(
         sys.modules, "openai", types.SimpleNamespace(AsyncOpenAI=FakeAsyncOpenAI)
     )
     monkeypatch.setattr(
-        "dev_health_ops.llm.providers.local.make_hardened_async_httpx_client",
+        "dev_health_ops.llm.providers.local.make_hardened_async_httpx2_client",
         lambda: sentinel_http_client,
     )
 
@@ -300,17 +304,33 @@ def test_openai_compatible_providers_use_hardened_http_client(
     assert captured["max_retries"] == 0
 
 
-def test_hardened_http_client_factory_disables_redirects_and_env_proxies():
-    async_client = make_hardened_async_httpx_client()
-    sync_client = make_hardened_httpx_client()
+def test_hardened_http_client_factories_preserve_transport_controls():
+    async_clients = (
+        make_hardened_async_httpx_client(),
+        make_hardened_async_httpx2_client(),
+    )
+    sync_clients = (
+        make_hardened_httpx_client(),
+        make_hardened_httpx2_client(),
+    )
     try:
-        assert async_client.follow_redirects is False
-        assert async_client.trust_env is False
-        assert sync_client.follow_redirects is False
-        assert sync_client.trust_env is False
+        assert isinstance(async_clients[0], httpx.AsyncClient)
+        assert isinstance(async_clients[1], httpx2.AsyncClient)
+        assert isinstance(sync_clients[0], httpx.Client)
+        assert isinstance(sync_clients[1], httpx2.Client)
+
+        for client in (*async_clients, *sync_clients):
+            assert client.follow_redirects is False
+            assert client.trust_env is False
+            assert client.timeout.connect == 60.0
+            assert client.timeout.read == 60.0
+            assert client.timeout.write == 60.0
+            assert client.timeout.pool == 60.0
     finally:
-        asyncio.run(async_client.aclose())
-        sync_client.close()
+        for client in async_clients:
+            asyncio.run(client.aclose())
+        for client in sync_clients:
+            client.close()
 
 
 def test_upsert_rejects_unsafe_base_url():

--- a/uv.lock
+++ b/uv.lock
@@ -627,6 +627,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "gitpython" },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "jira" },
     { name = "lizard" },
     { name = "numpy" },
@@ -701,12 +702,13 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.136.1,<0.137" },
     { name = "gitpython", specifier = ">=3.1.47" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", specifier = ">=2.7.0,<3" },
     { name = "jira", specifier = ">=3.10.5" },
     { name = "lizard", specifier = ">=1.17.10" },
     { name = "mako", marker = "extra == 'dev'", specifier = ">=1.3.12" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy", specifier = ">=2.4.4" },
-    { name = "openai", specifier = ">=2.36.0" },
+    { name = "openai", specifier = ">=3.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.41.1" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.41.1" },
     { name = "opentelemetry-instrumentation-celery", specifier = ">=0.45b0" },
@@ -959,6 +961,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -974,12 +989,37 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.15"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1392,21 +1432,21 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.36.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
 ]
 
 [[package]]
@@ -2398,6 +2438,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- remove the `openai<3` hardgate and resolve `openai==3.0.0`
- add direct HTTPX2 dependencies and hardened sync/async HTTPX2 factories
- route all four OpenAI SDK client constructions through HTTPX2 while leaving Anthropic on legacy HTTPX
- preserve `trust_env=False`, redirects disabled, and 60-second transport timeouts with regression coverage

Linear: https://linear.app/fullchaos/issue/CHAOS-3769/choredeps-migrate-to-openai-3x-httpx2-and-remove-the-3-pin

## Compatibility review

OpenAI 3.0.0 documents HTTPX2 as its only breaking change. The upstream migration guide states that parsed models, API calls, numeric timeouts, and streaming APIs remain compatible. This repository does not pass OpenAI raw response, transport, hook, or mock objects across the SDK boundary.

## TEST-EVIDENCE

- RED: focused mypy against OpenAI 3.0.0 reproduced the four expected `http_client` type errors in the three ticketed modules
- focused OpenAI and compatible-provider suite: 151 passed
- full mypy: no issues in 2,201 source files
- post-rebase `bash ci/local_validate.sh`: PASSED 8/8 stages; 12,764 passed, 615 skipped, 1 xfailed; live ClickHouse argMax proof passed

## RISK-NOTES

- HTTPX2 uses the operating-system trust store instead of HTTPX's certifi default. The hardened clients still disable ambient environment settings, as before, and no live OpenAI credential smoke was available locally.
- No migration, API schema, persistence, or web rendering behavior changes.
