### PR TITLE
feat(worker): add provider-unit lifecycle identity logs

### DIFF
--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -152,6 +153,42 @@ type Handler struct {
 	LeaseMetrics jobruntime.SyncLeaseObserver
 }
 
+// logLifecycle records the safe, authoritative identity of one provider-unit
+// attempt. River arguments deliberately carry only the unit ID, so provider,
+// dataset, mode, and run identity become available only after Claim. Keep this
+// record out of generic queue metrics: provider/dataset would make that scrape
+// surface unbounded as the configured provider matrix grows.
+func (handler *Handler) logLifecycle(
+	ctx context.Context,
+	execution *jobruntime.Execution[jobruntime.ProviderUnitArgs],
+	claim providersync.Claim,
+	event string,
+	result string,
+) {
+	if execution == nil {
+		return
+	}
+	logger := execution.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	attributes := []any{
+		"provider", claim.Provider,
+		"dataset", claim.Dataset,
+		"mode", claim.Mode,
+		"kind", execution.Definition.Kind,
+		"queue", execution.Definition.Queue,
+		"job_id", execution.JobID,
+		"attempt", execution.Attempt,
+		"sync_run_id", claim.SyncRunID,
+		"sync_unit_id", claim.ID,
+	}
+	if result != "" {
+		attributes = append(attributes, "result", result)
+	}
+	logger.InfoContext(ctx, event, attributes...)
+}
+
 func (handler *Handler) observeRouteFault(fault RouteFault) {
 	if handler == nil || handler.OnRouteFault == nil {
 		return
@@ -223,6 +260,7 @@ func (handler *Handler) reconcileRouteFault(
 			return jobruntime.Retryable(failErr)
 		}
 		handler.observeLeaseRecovery(claim, jobruntime.SyncLeaseResultFailed)
+		handler.logLifecycle(ctx, execution, claim, "sync_provider_unit_finished", "failed")
 		return jobruntime.Retryable(routeReconciliationError(configurationErr))
 	}
 	releaseErr := handler.Repository.ReleaseForRetry(
@@ -234,6 +272,7 @@ func (handler *Handler) reconcileRouteFault(
 		return jobruntime.Retryable(releaseErr)
 	}
 	handler.observeLeaseRecovery(claim, jobruntime.SyncLeaseResultRetrying)
+	handler.logLifecycle(ctx, execution, claim, "sync_provider_unit_finished", "retrying")
 	return jobruntime.Retryable(routeReconciliationError(configurationErr))
 }
 
@@ -301,6 +340,7 @@ func (handler *Handler) Work(
 		}
 		return jobruntime.Permanent(err)
 	}
+	handler.logLifecycle(ctx, execution, claim, "sync_provider_unit_started", "")
 	descriptor, descriptorPresent := handler.Switches.Descriptor(claim.Provider, claim.Dataset)
 	// This admission boundary is intentionally before LeaseSession and
 	// BuildExecutor. A stale River unit can otherwise fetch credentials and
@@ -338,6 +378,7 @@ func (handler *Handler) Work(
 			); completeErr != nil {
 				err = completeErr
 			} else {
+				handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "succeeded")
 				return nil
 			}
 		}
@@ -358,6 +399,7 @@ func (handler *Handler) Work(
 			return jobruntime.Retryable(failErr)
 		}
 		handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultFailed)
+		handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "failed")
 		return jobruntime.Permanent(err)
 	}
 	if execution.Attempt >= execution.Definition.MaxAttempts {
@@ -371,6 +413,7 @@ func (handler *Handler) Work(
 		)
 		if failErr == nil {
 			handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultFailed)
+			handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "failed")
 		}
 		return jobruntime.Retryable(err)
 	}
@@ -380,6 +423,7 @@ func (handler *Handler) Work(
 		return jobruntime.Retryable(releaseErr)
 	}
 	handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultRetrying)
+	handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "retrying")
 	return jobruntime.Retryable(err)
 }
 

--- a/internal/jobs/providerunit/providerunit_test.go
+++ b/internal/jobs/providerunit/providerunit_test.go
@@ -1,10 +1,12 @@
 package providerunit
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -59,6 +61,126 @@ func TestEnabledProviderUnitExecutesCompleteRouteAndTerminalizes(t *testing.T) {
 	if !ok || len(observations) != 1 || !observations[0].RESTFallbackUsed {
 		t.Fatalf("persisted worklog observations=%#v", repository.result["go_worklog_observations"])
 	}
+}
+
+// TestProviderUnitLifecycleLogsIdentifyTheClaimedScope proves the operator log
+// seam uses the authoritative claim, not River's ID-only arguments. A mixed
+// sync_provider queue otherwise exposes only the shared kind and queue, which
+// cannot tell an operator which provider/dataset is draining or retrying.
+func TestProviderUnitLifecycleLogsIdentifyTheClaimedScope(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	unit := providerUnit()
+	unit.Mode = "backfill"
+	repository := newMemoryUnitRepository(unit)
+	var output bytes.Buffer
+	handler := &Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			LaunchDarklyFeatureFlags: true,
+		},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: successfulExecutor(t, now),
+	}
+	execution := providerExecution(unit, now, 1)
+	execution.JobID = 42
+	execution.Definition.Kind = jobcontract.KindSyncProviderUnit
+	execution.Definition.Queue = "sync_provider"
+	execution.Logger = slog.New(slog.NewJSONHandler(&output, nil))
+
+	if err := handler.Work(context.Background(), execution); err != nil {
+		t.Fatalf("Work() error = %v", err)
+	}
+
+	records := providerUnitLifecycleRecords(t, output.Bytes())
+	if len(records) != 2 {
+		t.Fatalf("lifecycle logs=%d want start and terminal records: %s", len(records), output.String())
+	}
+	for _, record := range records {
+		for key, want := range map[string]any{
+			"provider":     unit.Provider,
+			"dataset":      unit.Dataset,
+			"mode":         unit.Mode,
+			"kind":         jobcontract.KindSyncProviderUnit,
+			"queue":        "sync_provider",
+			"job_id":       float64(42),
+			"sync_run_id":  unit.SyncRunID,
+			"sync_unit_id": unit.ID,
+		} {
+			if record[key] != want {
+				t.Fatalf("record[%q]=%#v want %#v; record=%#v", key, record[key], want, record)
+			}
+		}
+	}
+	if records[0]["msg"] != "sync_provider_unit_started" || records[1]["msg"] != "sync_provider_unit_finished" || records[1]["result"] != "succeeded" {
+		t.Fatalf("lifecycle records=%#v", records)
+	}
+}
+
+func TestProviderUnitLifecycleLogsRetryAndFailureResults(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name, wantStatus, wantResult string
+		attempt, maxAttempts         int
+	}{
+		{name: "retryable attempt", attempt: 1, maxAttempts: 5, wantStatus: "dispatching", wantResult: "retrying"},
+		{name: "exhausted attempt", attempt: 5, maxAttempts: 5, wantStatus: "failed", wantResult: "failed"},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			unit := providerUnit()
+			unit.Mode = "backfill"
+			repository := newMemoryUnitRepository(unit)
+			var output bytes.Buffer
+			handler := &Handler{
+				Repository: repository,
+				Switches: providersync.CompleteRouteSwitches{
+					LaunchDarklyFeatureFlags: true,
+				},
+				LeaseDuration: time.Minute,
+				Heartbeat:     10 * time.Second,
+				Now:           func() time.Time { return now },
+				BuildExecutor: func(*providersync.LeaseSession) (providersync.CompleteRouteExecutor, error) {
+					return providersync.CompleteRouteExecutor{}, errors.New("transient")
+				},
+			}
+			execution := providerExecution(unit, now, test.attempt)
+			execution.JobID = 42
+			execution.Definition.Kind = jobcontract.KindSyncProviderUnit
+			execution.Definition.Queue = "sync_provider"
+			execution.Definition.MaxAttempts = test.maxAttempts
+			execution.Logger = slog.New(slog.NewJSONHandler(&output, nil))
+
+			if err := handler.Work(context.Background(), execution); err == nil {
+				t.Fatal("Work() error = nil, want retryable transport result")
+			}
+			if repository.status != test.wantStatus {
+				t.Fatalf("unit status=%q want %q", repository.status, test.wantStatus)
+			}
+			records := providerUnitLifecycleRecords(t, output.Bytes())
+			if len(records) != 2 || records[1]["msg"] != "sync_provider_unit_finished" || records[1]["result"] != test.wantResult {
+				t.Fatalf("lifecycle records=%#v", records)
+			}
+		})
+	}
+}
+
+func providerUnitLifecycleRecords(t *testing.T, output []byte) []map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(output), []byte{'\n'})
+	records := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		var record map[string]any
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatalf("decode lifecycle log %q: %v", line, err)
+		}
+		records = append(records, record)
+	}
+	return records
 }
 
 func TestProviderUnitPersistsCanonicalProviderUsageObservations(t *testing.T) {

--- a/tests/tooling/mutation-plans/provider_unit_lifecycle_logging.json
+++ b/tests/tooling/mutation-plans/provider_unit_lifecycle_logging.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "name": "provider-unit lifecycle log identity",
+  "$limitation": "Pins only the safe claimed identity and per-attempt result in provider-unit lifecycle logs. River queue telemetry remains intentionally aggregate and low-cardinality; it cannot identify a mixed provider queue. The operator API remains payload-redacted and is not extended by this plan.",
+  "mutations": [
+    {
+      "id": "PULL01-provider-identity",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\"provider\", claim.Provider,",
+      "replace": "\"provider\", \"\",",
+      "expect_occurrences": 1,
+      "rationale": "An operator must be able to distinguish a GitHub, GitLab, Linear, or PagerDuty unit on the shared provider queue after the authoritative claim resolves its provider.",
+      "build": ["go", "test", "./internal/jobs/providerunit", "-run", "^$"],
+      "proof": [["go", "test", "./internal/jobs/providerunit", "-run", "^TestProviderUnitLifecycleLogsIdentifyTheClaimedScope$", "-count=1"]]
+    },
+    {
+      "id": "PULL02-dataset-identity",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\"dataset\", claim.Dataset,",
+      "replace": "\"dataset\", \"\",",
+      "expect_occurrences": 1,
+      "rationale": "A provider alone is insufficient on a provider's mixed queue; the dataset identifies which route is draining or failing.",
+      "build": ["go", "test", "./internal/jobs/providerunit", "-run", "^$"],
+      "proof": [["go", "test", "./internal/jobs/providerunit", "-run", "^TestProviderUnitLifecycleLogsIdentifyTheClaimedScope$", "-count=1"]]
+    },
+    {
+      "id": "PULL03-run-identity",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\"sync_run_id\", claim.SyncRunID,",
+      "replace": "\"sync_run_id\", \"\",",
+      "expect_occurrences": 1,
+      "rationale": "A provider-unit record must identify the durable sync run that owns the claimed unit, not only an opaque River job row.",
+      "build": ["go", "test", "./internal/jobs/providerunit", "-run", "^$"],
+      "proof": [["go", "test", "./internal/jobs/providerunit", "-run", "^TestProviderUnitLifecycleLogsIdentifyTheClaimedScope$", "-count=1"]]
+    },
+    {
+      "id": "PULL04-success-result",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "handler.logLifecycle(ctx, execution, session.Claim, \"sync_provider_unit_finished\", \"succeeded\")",
+      "replace": "handler.logLifecycle(ctx, execution, session.Claim, \"sync_provider_unit_finished\", \"retrying\")",
+      "expect_occurrences": 1,
+      "rationale": "A completed provider unit must not be logged as retrying, because that sends an operator to chase a queue that has already reached its terminal success state.",
+      "build": ["go", "test", "./internal/jobs/providerunit", "-run", "^$"],
+      "proof": [["go", "test", "./internal/jobs/providerunit", "-run", "^TestProviderUnitLifecycleLogsIdentifyTheClaimedScope$", "-count=1"]]
+    },
+    {
+      "id": "PULL05-exhausted-result",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "handler.logLifecycle(ctx, execution, session.Claim, \"sync_provider_unit_finished\", \"failed\")",
+      "replace": "handler.logLifecycle(ctx, execution, session.Claim, \"sync_provider_unit_finished\", \"retrying\")",
+      "expect_occurrences": 2,
+      "rationale": "An exhausted provider unit must be logged as failed rather than retrying, so a terminal backfill failure is distinguishable from a live retry.",
+      "build": ["go", "test", "./internal/jobs/providerunit", "-run", "^$"],
+      "proof": [["go", "test", "./internal/jobs/providerunit", "-run", "^TestProviderUnitLifecycleLogsRetryAndFailureResults/exhausted_attempt$", "-count=1"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add safe start and terminal lifecycle logs after a provider unit is authoritatively claimed.
- Identify provider, dataset, mode, kind, queue, River job/attempt, sync run, and sync unit without logging provider payloads or credentials.
- Add focused tests and a mutation plan for identity and terminal-result fields.

## Authority
- CHAOS-3760, Partial backfill operator surface: progress, retry, cancel, and evidence. This is the small lifecycle-log visibility seam; it does not expand the payload-redacted operator API.

## TEST-EVIDENCE
- RED baseline: TestProviderUnitLifecycleLogsIdentifyTheClaimedScope failed because no lifecycle records existed.
- Focused Go tests passed.
- Mutation harness: 5/5 targeted mutations killed and restored.
- bash ci/local_validate.sh passed all 9 declared stages, including 13,848 tests and the live ClickHouse scratch proof.

## RISK-NOTES
- Queue depth/age metrics remain intentionally aggregate and cannot give provider/dataset totals before a unit is claimed.
- No queue split, capacity tuning, database mutation, Compose restart, or operator API expansion is included.