### PR TITLE
fix(sync): recover local all-route aliases

### DIFF
--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -508,6 +508,7 @@ func composeWorkerFamily(existing, additional workerFamily) (workerFamily, error
 // handler used to permit (CHAOS-3123).
 func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 	return providersync.CompleteRouteSwitches{
+		LocalAllRoutes:              cfg.LocalAllProviderRoutes,
 		LinearWorkItems:             cfg.WorkerLinearWorkItemsEnabled,
 		JiraWorkItems:               cfg.WorkerJiraWorkItemsEnabled,
 		JiraIncidents:               cfg.WorkerJiraIncidentsEnabled,
@@ -554,16 +555,15 @@ func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 	}
 }
 
-func providerRouteSwitchesReady(
-	cfg config.Config,
-	runtimeConstructed *bool,
-) health.CheckFunc {
+type providerRouteSwitch struct {
+	provider   string
+	dataset    string
+	configured bool
+}
+
+func effectiveProviderRouteSwitches(cfg config.Config) []providerRouteSwitch {
 	switches := workerRouteSwitches(cfg)
-	routes := []struct {
-		provider string
-		dataset  string
-		enabled  bool
-	}{
+	routes := []providerRouteSwitch{
 		{"linear", "work-items", cfg.WorkerLinearWorkItemsEnabled},
 		{"jira", "work-items", cfg.WorkerJiraWorkItemsEnabled},
 		{"jira", "incidents", cfg.WorkerJiraIncidentsEnabled},
@@ -608,6 +608,22 @@ func providerRouteSwitchesReady(
 		{"github", "tests", cfg.WorkerGithubTestsEnabled},
 		{"github", "work-items", cfg.WorkerGithubWorkItemsEnabled},
 	}
+	effective := make([]providerRouteSwitch, 0, len(routes))
+	for _, route := range routes {
+		descriptor, ok := switches.Descriptor(route.provider, route.dataset)
+		if route.configured || (ok && descriptor.RouteEnabled) {
+			effective = append(effective, route)
+		}
+	}
+	return effective
+}
+
+func providerRouteSwitchesReady(
+	cfg config.Config,
+	runtimeConstructed *bool,
+) health.CheckFunc {
+	switches := workerRouteSwitches(cfg)
+	routes := effectiveProviderRouteSwitches(cfg)
 	return func(context.Context) error {
 		// The same helper feeds the production BuildExecutor closure below.
 		// A route cannot report ready for one pair of config files and construct
@@ -617,9 +633,6 @@ func providerRouteSwitchesReady(
 			return errWorkerDependencyUnavailable
 		}
 		for _, route := range routes {
-			if !route.enabled {
-				continue
-			}
 			descriptor, ok := switches.Descriptor(route.provider, route.dataset)
 			if !ok || !descriptor.RouteReady || !descriptor.RouteEnabled {
 				return errWorkerDependencyUnavailable

--- a/cmd/dev-health-worker/dependencies_test.go
+++ b/cmd/dev-health-worker/dependencies_test.go
@@ -249,6 +249,36 @@ func TestProviderRouteSwitchesAreIndependentAndRejectIncompleteRoutes(t *testing
 	}
 }
 
+func TestLocalAllStartupReadinessProjectsEveryCompleteWriterAlias(t *testing.T) {
+	values := map[string]string{
+		"DEV_HEALTH_ENV":     "local",
+		"GO_PROVIDER_ROUTES": "all",
+		"DEV_HEALTH_PROFILE": "sync",
+	}
+	cfg, err := config.Load(config.Spec{
+		Service: "dev-health-worker", Profiles: []string{"sync"}, DefaultProfile: "sync",
+		LookupEnv: func(key string) (string, bool) {
+			value, ok := values[key]
+			return value, ok
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	effective := map[string]bool{}
+	for _, route := range effectiveProviderRouteSwitches(cfg) {
+		effective[route.provider+"/"+route.dataset] = true
+	}
+	for _, identity := range []string{
+		"github/pr-reviews", "github/pr-comments", "github/tests",
+		"gitlab/pr-reviews", "gitlab/pr-comments", "gitlab/tests",
+	} {
+		if !effective[identity] {
+			t.Fatalf("startup readiness omitted inherited route %s", identity)
+		}
+	}
+}
+
 func TestGitHubWorkItemsRouteReadinessUsesTheProductionRuntimeConfig(t *testing.T) {
 	t.Setenv("STATUS_MAPPING_PATH", "")
 	valid := validGitHubWorkItemsRuntimeConfig(t)

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -994,6 +994,59 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 	}
 }
 
+func TestLocalAllProviderRoutesMakeCompleteWriterAliasesExecutable(t *testing.T) {
+	t.Parallel()
+	values := map[string]string{
+		"DEV_HEALTH_ENV":     "local",
+		"GO_PROVIDER_ROUTES": "all",
+		"DEV_HEALTH_PROFILE": "sync",
+	}
+	cfg, err := config.Load(config.Spec{
+		Service: "dev-health-worker", Profiles: []string{"sync"}, DefaultProfile: "sync",
+		LookupEnv: func(key string) (string, bool) {
+			value, ok := values[key]
+			return value, ok
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	switches := workerRouteSwitches(cfg)
+	handler, _ := buildProviderSyncHandler(
+		nil, switches, nil, nil, nil, nil, nil, nil, slog.Default(),
+	)
+	for _, route := range []struct {
+		provider string
+		dataset  string
+	}{
+		{"github", "pr-reviews"}, {"github", "pr-comments"}, {"github", "tests"},
+		{"gitlab", "pr-reviews"}, {"gitlab", "pr-comments"}, {"gitlab", "tests"},
+	} {
+		descriptor, ok := switches.Descriptor(route.provider, route.dataset)
+		if !ok || !descriptor.RouteReady || !descriptor.RouteEnabled {
+			t.Fatalf("%s/%s descriptor=%+v ok=%v", route.provider, route.dataset, descriptor, ok)
+		}
+		executor, err := handler.BuildExecutor(&providersync.LeaseSession{
+			Claim: providersync.Claim{Unit: providersync.Unit{
+				Provider: route.provider, Dataset: route.dataset,
+			}},
+		})
+		if err != nil {
+			t.Fatalf("%s/%s executor: %v", route.provider, route.dataset, err)
+		}
+		if executor.Handler == nil {
+			t.Fatalf("%s/%s executor has no complete handler", route.provider, route.dataset)
+		}
+	}
+	explicit := workerRouteSwitches(config.Config{WorkerGithubPRsEnabled: true})
+	for _, dataset := range []string{"pr-reviews", "pr-comments"} {
+		descriptor, _ := explicit.Descriptor("github", dataset)
+		if descriptor.RouteEnabled {
+			t.Fatalf("explicit github/prs switch widened to github/%s", dataset)
+		}
+	}
+}
+
 func TestBuildProviderSyncHandlerConstructsGitHubCommitStatsCapability(t *testing.T) {
 	handler, _ := buildProviderSyncHandler(
 		nil,

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	OperationalBridgeTimeout       time.Duration
 	OperationalBridgeAllowInsecure bool
 	StreamConfiguredReplicas       int
+	LocalAllProviderRoutes         bool
 
 	WorkerLinearWorkItemsEnabled          bool
 	WorkerJiraWorkItemsEnabled            bool
@@ -252,6 +253,7 @@ func Load(spec Spec) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	cfg.LocalAllProviderRoutes = allProviderRoutes
 	for _, item := range []struct {
 		name   string
 		target *bool

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -248,6 +248,7 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 	// The literal below must name every field of CompleteRouteSwitches: a new
 	// switch left out of it would leave its pair unexercised here.
 	all := CompleteRouteSwitches{
+		LocalAllRoutes:  true,
 		LinearWorkItems: true, JiraWorkItems: true, JiraIncidents: true,
 		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
 		GitlabRepoMetadata:          true,
@@ -284,7 +285,7 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 		GithubTests:       true,
 		GithubWorkItems:   true,
 	}
-	if reflect.TypeOf(all).NumField() != 43 {
+	if reflect.TypeOf(all).NumField() != 44 {
 		t.Fatalf(
 			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
 				"pair is exercised, then update this count",

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -173,6 +173,10 @@ func (descriptor CompleteRouteDescriptor) Shadow(write bool) (ShadowDescriptor, 
 // why adding github, gitlab, and pagerduty descriptors in CUT-08 cannot widen
 // the live route surface.
 type CompleteRouteSwitches struct {
+	// LocalAllRoutes is set only by the validated local GO_PROVIDER_ROUTES=all
+	// preset. Equivalent persisted aliases inherit its selected complete writer;
+	// explicit deployment switches remain identity-scoped.
+	LocalAllRoutes           bool
 	LinearWorkItems          bool
 	JiraWorkItems            bool
 	JiraIncidents            bool
@@ -365,7 +369,8 @@ func (switches CompleteRouteSwitches) Descriptor(
 			"test_suite_results", "test_case_results", "coverage_snapshots",
 		}
 		descriptor.RouteReady = true
-		descriptor.RouteEnabled = switches.GitlabTests
+		descriptor.RouteEnabled = switches.GitlabTests ||
+			(switches.LocalAllRoutes && switches.GitlabCICD)
 	case provider == "gitlab" && dataset == "incidents":
 		descriptor.Destinations = []string{
 			"operational_services", "operational_service_repository_mappings",
@@ -396,11 +401,13 @@ func (switches CompleteRouteSwitches) Descriptor(
 	case provider == "gitlab" && dataset == "pr-reviews":
 		descriptor.Destinations = githubPRSocialRouteDestinations()
 		descriptor.RouteReady = true
-		descriptor.RouteEnabled = switches.GitlabPRReviews
+		descriptor.RouteEnabled = switches.GitlabPRReviews ||
+			(switches.LocalAllRoutes && switches.GitlabPRs)
 	case provider == "gitlab" && dataset == "pr-comments":
 		descriptor.Destinations = githubPRSocialRouteDestinations()
 		descriptor.RouteReady = true
-		descriptor.RouteEnabled = switches.GitlabPRComments
+		descriptor.RouteEnabled = switches.GitlabPRComments ||
+			(switches.LocalAllRoutes && switches.GitlabPRs)
 	case provider == "gitlab" && dataset == "security":
 		descriptor.Destinations = []string{"security_alerts"}
 		descriptor.RouteReady = true
@@ -463,11 +470,13 @@ func (switches CompleteRouteSwitches) Descriptor(
 	case provider == "github" && dataset == "pr-reviews":
 		descriptor.Destinations = githubPRSocialRouteDestinations()
 		descriptor.RouteReady = true
-		descriptor.RouteEnabled = switches.GithubPRReviews
+		descriptor.RouteEnabled = switches.GithubPRReviews ||
+			(switches.LocalAllRoutes && switches.GithubPRs)
 	case provider == "github" && dataset == "pr-comments":
 		descriptor.Destinations = githubPRSocialRouteDestinations()
 		descriptor.RouteReady = true
-		descriptor.RouteEnabled = switches.GithubPRComments
+		descriptor.RouteEnabled = switches.GithubPRComments ||
+			(switches.LocalAllRoutes && switches.GithubPRs)
 	case provider == "github" && dataset == "cicd":
 		// cicd and tests delegate to one complete-row unit. Startup rejects both
 		// switches enabled together, so ci_pipeline_runs has one active writer.
@@ -510,7 +519,8 @@ func (switches CompleteRouteSwitches) Descriptor(
 			"test_suite_results", "test_case_results", "coverage_snapshots",
 		}
 		descriptor.RouteReady = true
-		descriptor.RouteEnabled = switches.GithubTests
+		descriptor.RouteEnabled = switches.GithubTests ||
+			(switches.LocalAllRoutes && switches.GithubCICD)
 	}
 	return descriptor, true
 }

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -61,6 +61,11 @@ _LOCAL_ALL_CANONICAL_ALTERNATIVES = {
     "gitlab_prs": ("gitlab_pr_reviews", "gitlab_pr_comments"),
     "gitlab_cicd": ("gitlab_tests",),
 }
+_LOCAL_ALL_ALIAS_CANONICAL = {
+    alternative: canonical
+    for canonical, alternatives in _LOCAL_ALL_CANONICAL_ALTERNATIVES.items()
+    for alternative in alternatives
+}
 
 # src/dev_health_ops/workers/provider_unit_route.py -> repo root is 3 parents up.
 _DEFAULT_MATRIX_CONTRACT_PATH = (
@@ -338,6 +343,11 @@ class ProviderUnitRouteSwitches:
     # route-ready for matrix/audit/watermark truth but never become partial
     # producer routes.
     github_work_items: bool = False
+    # Internal marker for the validated local-only preset. It is not a direct
+    # environment switch. It lets equivalent persisted alias identities use
+    # the preset's one selected complete writer without widening explicit
+    # deployment switches.
+    local_all_routes: bool = False
 
     @classmethod
     def from_environment(
@@ -392,6 +402,10 @@ class ProviderUnitRouteSwitches:
             github_blame=_flag(source, "WORKER_GITHUB_BLAME_ENABLED"),
             github_tests=_flag(source, "WORKER_GITHUB_TESTS_ENABLED"),
             github_work_items=_flag(source, "WORKER_GITHUB_WORK_ITEMS_ENABLED"),
+            local_all_routes=(
+                source.get(_PROVIDER_ROUTES_PRESET_ENV, "").strip().lower() == "all"
+                and source.get(_DEV_HEALTH_ENV, "").strip().lower() == "local"
+            ),
         )
         switches.require_complete_routes()
         return switches
@@ -430,7 +444,12 @@ class ProviderUnitRouteSwitches:
             # execute the composite Go handler, so keep it at reconciliation
             # before any River enqueue rather than widening a partial writer.
             return False
-        return bool(getattr(self, _switch_field_name(provider, dataset), False))
+        field_name = _switch_field_name(provider, dataset)
+        if bool(getattr(self, field_name, False)):
+            return True
+        if self.local_all_routes:
+            field_name = _LOCAL_ALL_ALIAS_CANONICAL.get(field_name, field_name)
+        return bool(getattr(self, field_name, False))
 
     @staticmethod
     def is_route_ready(provider: str, dataset: str) -> bool:

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -3795,6 +3795,123 @@ def test_dispatch_sync_run_reclaims_stale_units_of_both_transports_and_redecides
     assert unit_publish_calls[0][0] == str(celery_unit.id)
 
 
+@pytest.mark.parametrize(
+    ("provider", "dataset_key"),
+    (
+        ("github", "pr-reviews"),
+        ("github", "pr-comments"),
+        ("github", "tests"),
+        ("gitlab", "pr-reviews"),
+        ("gitlab", "pr-comments"),
+        ("gitlab", "tests"),
+    ),
+)
+def test_local_all_reclaims_stale_complete_writer_alias_to_river_without_celery(
+    db_session, monkeypatch, provider: str, dataset_key: str
+) -> None:
+    """A local Go-only redispatch must durably recover every alias identity."""
+
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(
+        db_session,
+        provider=provider,
+        dataset_key=dataset_key,
+        processor_flags={"sync_prs": True}
+        if dataset_key.startswith("pr-")
+        else {"sync_tests": True},
+    )
+    unit.status = SyncRunUnitStatus.DISPATCHING.value
+    unit.updated_at = datetime.now(timezone.utc) - timedelta(minutes=30)
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: "river_canary"})
+    db_session.commit()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("DEV_HEALTH_ENV", "local")
+    monkeypatch.setenv("GO_PROVIDER_ROUTES", "all")
+    monkeypatch.setenv("SYNC_UNIT_DISPATCH_STALE_SECONDS", "1")
+
+    assert sync_units.dispatch_sync_run(str(run.id)) == {
+        "status": "dispatched",
+        "queued_units": 1,
+    }
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit_publish_calls == []
+    outbox = db_session.query(WorkerJobOutbox).all()
+    assert len(outbox) == 1
+    assert outbox[0].dedupe_key == f"sync.provider_unit:{unit.id}"
+    assert outbox[0].args["payload"] == {"unit_id": str(unit.id)}
+
+
+@pytest.mark.parametrize("provider", ("github", "gitlab"))
+def test_local_all_routes_complete_writer_identity_set_only_to_river(
+    db_session, monkeypatch, provider: str
+) -> None:
+    """One Go-only pass must stage every persisted complete-writer identity."""
+
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(
+        db_session,
+        provider=provider,
+        dataset_key="prs",
+        processor_flags={"sync_prs": True},
+    )
+    units = [first]
+    for dataset_key, processor_flags in (
+        ("pr-reviews", {"sync_prs": True}),
+        ("pr-comments", {"sync_prs": True}),
+        ("cicd", {"sync_cicd": True}),
+        ("tests", {"sync_tests": True}),
+    ):
+        units.append(
+            SyncRunUnit(
+                org_id=run.org_id,
+                sync_run_id=run.id,
+                integration_id=first.integration_id,
+                source_id=first.source_id,
+                provider=provider,
+                dataset_key=dataset_key,
+                cost_class="medium",
+                mode=SyncRunMode.INCREMENTAL.value,
+                status=SyncRunUnitStatus.DISPATCHING.value,
+                attempts=0,
+                processor_flags=processor_flags,
+            )
+        )
+    stale = datetime.now(timezone.utc) - timedelta(minutes=30)
+    for unit in units:
+        unit.status = SyncRunUnitStatus.DISPATCHING.value
+        unit.updated_at = stale
+    run.total_units = len(units)
+    db_session.add_all(units[1:])
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: "river_canary"})
+    db_session.commit()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("DEV_HEALTH_ENV", "local")
+    monkeypatch.setenv("GO_PROVIDER_ROUTES", "all")
+    monkeypatch.setenv("SYNC_UNIT_DISPATCH_STALE_SECONDS", "1")
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "20")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "20")
+
+    assert sync_units.dispatch_sync_run(str(run.id)) == {
+        "status": "dispatched",
+        "queued_units": len(units),
+    }
+
+    assert unit_publish_calls == []
+    assert {row.dedupe_key for row in db_session.query(WorkerJobOutbox).all()} == {
+        f"sync.provider_unit:{unit.id}" for unit in units
+    }
+
+
 def test_dispatch_sync_run_continues_accepted_run_after_planner_config_pause(
     db_session, monkeypatch
 ):

--- a/tests/tooling/mutation-plans/local_all_alias_recovery.json
+++ b/tests/tooling/mutation-plans/local_all_alias_recovery.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": 1,
+  "name": "local all-route complete-writer alias recovery",
+  "$limitation": "Pins only the local-all inheritance seam that lets already-persisted PR-social and TestOps aliases recover to River. Explicit non-local switches remain identity-scoped and are covered by the same focused tests.",
+  "mutations": [
+    {
+      "id": "LAA01-python-local-all-marker",
+      "file": "src/dev_health_ops/workers/provider_unit_route.py",
+      "find": "            local_all_routes=(\n                source.get(_PROVIDER_ROUTES_PRESET_ENV, \"\").strip().lower() == \"all\"\n                and source.get(_DEV_HEALTH_ENV, \"\").strip().lower() == \"local\"\n            ),",
+      "replace": "            local_all_routes=False,",
+      "expect_occurrences": 1,
+      "rationale": "Alias inheritance must be reachable only through the validated local all-routes preset.",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/workers/provider_unit_route.py"],
+      "proof": [["pytest", "-q", "tests/workers/test_provider_unit_route.py::test_local_all_routes_selected_complete_writer_accepts_equivalent_aliases", "tests/workers/test_provider_unit_route.py::test_explicit_nonlocal_complete_writer_switch_stays_identity_scoped"]]
+    },
+    {
+      "id": "LAA02-python-alias-canonical-lookup",
+      "file": "src/dev_health_ops/workers/provider_unit_route.py",
+      "find": "            field_name = _LOCAL_ALL_ALIAS_CANONICAL.get(field_name, field_name)",
+      "replace": "            field_name = field_name",
+      "expect_occurrences": 1,
+      "rationale": "The local preset's disabled alias identities must inherit the one selected complete writer before producer transport selection.",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/workers/provider_unit_route.py"],
+      "proof": [["pytest", "-q", "tests/test_sync_units.py::test_local_all_routes_complete_writer_identity_set_only_to_river"]]
+    },
+    {
+      "id": "LAA03-python-explicit-alias-precedence",
+      "file": "src/dev_health_ops/workers/provider_unit_route.py",
+      "find": "        if bool(getattr(self, field_name, False)):\n            return True",
+      "replace": "        if False and bool(getattr(self, field_name, False)):\n            return True",
+      "expect_occurrences": 1,
+      "rationale": "An explicitly selected alias must retain its own true switch before local-all canonical fallback is considered.",
+      "build": ["python3", "-m", "py_compile", "src/dev_health_ops/workers/provider_unit_route.py"],
+      "proof": [["pytest", "-q", "tests/workers/test_provider_unit_route.py::test_local_all_explicit_alias_wins_over_canonical_inheritance"]]
+    },
+    {
+      "id": "LAA04-go-local-all-marker-wiring",
+      "file": "cmd/dev-health-worker/dependencies.go",
+      "find": "\t\tLocalAllRoutes:              cfg.LocalAllProviderRoutes,",
+      "replace": "\t\tLocalAllRoutes:              false,",
+      "expect_occurrences": 1,
+      "rationale": "The executor descriptor must receive the same validated local-all marker as Python producer admission.",
+      "build": ["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-run", "^$", "./cmd/dev-health-worker"],
+      "proof": [["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-count=1", "-run", "^TestLocalAllProviderRoutesMakeCompleteWriterAliasesExecutable$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "LAA05-go-gitlab-tests-canonical-clause",
+      "file": "internal/providersync/execution_registry.go",
+      "find": "(switches.LocalAllRoutes && switches.GitlabCICD)",
+      "replace": "(switches.LocalAllRoutes && false)",
+      "expect_occurrences": 1,
+      "rationale": "GitLab tests must inherit the selected complete CICD writer in local-all mode.",
+      "build": ["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-run", "^$", "./internal/providersync"],
+      "proof": [["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-count=1", "-run", "^TestLocalAllProviderRoutesMakeCompleteWriterAliasesExecutable$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "LAA06-go-gitlab-reviews-canonical-clause",
+      "file": "internal/providersync/execution_registry.go",
+      "find": "\t\t\t(switches.LocalAllRoutes && switches.GitlabPRs)",
+      "replace": "\t\t\t(switches.LocalAllRoutes && false)",
+      "expect_occurrences": 2,
+      "rationale": "Both GitLab PR-social sibling claims must inherit the selected complete PR writer in local-all mode.",
+      "build": ["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-run", "^$", "./internal/providersync"],
+      "proof": [["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-count=1", "-run", "^TestLocalAllProviderRoutesMakeCompleteWriterAliasesExecutable$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "LAA07-go-github-reviews-canonical-clause",
+      "file": "internal/providersync/execution_registry.go",
+      "find": "\t\t\t(switches.LocalAllRoutes && switches.GithubPRs)",
+      "replace": "\t\t\t(switches.LocalAllRoutes && false)",
+      "expect_occurrences": 2,
+      "rationale": "Both GitHub PR-social sibling claims must inherit the selected complete PR writer in local-all mode.",
+      "build": ["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-run", "^$", "./internal/providersync"],
+      "proof": [["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-count=1", "-run", "^TestLocalAllProviderRoutesMakeCompleteWriterAliasesExecutable$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "LAA08-go-github-tests-canonical-clause",
+      "file": "internal/providersync/execution_registry.go",
+      "find": "(switches.LocalAllRoutes && switches.GithubCICD)",
+      "replace": "(switches.LocalAllRoutes && false)",
+      "expect_occurrences": 1,
+      "rationale": "GitHub tests must inherit the selected complete CICD writer in local-all mode.",
+      "build": ["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-run", "^$", "./internal/providersync"],
+      "proof": [["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-count=1", "-run", "^TestLocalAllProviderRoutesMakeCompleteWriterAliasesExecutable$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "LAA09-go-startup-effective-alias-projection",
+      "file": "cmd/dev-health-worker/dependencies.go",
+      "find": "\t\tif route.configured || (ok && descriptor.RouteEnabled) {",
+      "replace": "\t\tif route.configured || (ok && descriptor.RouteEnabled && false) {",
+      "expect_occurrences": 1,
+      "rationale": "Startup readiness must inspect inherited local-all aliases, not only the canonical switches that were directly true in Config.",
+      "build": ["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-run", "^$", "./cmd/dev-health-worker"],
+      "proof": [["env", "GOCACHE=/tmp/no-celery-alias-go-cache", "go", "test", "-count=1", "-run", "^TestLocalAllStartupReadinessProjectsEveryCompleteWriterAlias$", "./cmd/dev-health-worker"]]
+    }
+  ]
+}

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -70,6 +70,64 @@ def test_local_all_routes_preset_preserves_explicit_switch_override() -> None:
 
 
 @pytest.mark.parametrize(
+    ("provider", "canonical", "aliases"),
+    (
+        ("github", "prs", ("pr-reviews", "pr-comments")),
+        ("github", "cicd", ("tests",)),
+        ("gitlab", "prs", ("pr-reviews", "pr-comments")),
+        ("gitlab", "cicd", ("tests",)),
+    ),
+)
+def test_local_all_routes_selected_complete_writer_accepts_equivalent_aliases(
+    provider: str, canonical: str, aliases: tuple[str, ...]
+) -> None:
+    """Local Go-only mode cannot leave complete-writer aliases on Celery."""
+
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"DEV_HEALTH_ENV": "local", "GO_PROVIDER_ROUTES": "all"}
+    )
+
+    assert switches.routes_to_river(provider, canonical)
+    for alias in aliases:
+        assert switches.routes_to_river(provider, alias)
+
+
+def test_explicit_nonlocal_complete_writer_switch_stays_identity_scoped() -> None:
+    """The local convenience preset must not widen an explicit deployment switch."""
+
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_PRS_ENABLED": "true"}
+    )
+
+    assert switches.routes_to_river("github", "prs")
+    assert not switches.routes_to_river("github", "pr-reviews")
+    assert not switches.routes_to_river("github", "pr-comments")
+
+
+@pytest.mark.parametrize(
+    ("provider", "dataset", "switch"),
+    [
+        ("github", "pr-reviews", "WORKER_GITHUB_PR_REVIEWS_ENABLED"),
+        ("github", "tests", "WORKER_GITHUB_TESTS_ENABLED"),
+        ("gitlab", "pr-comments", "WORKER_GITLAB_PR_COMMENTS_ENABLED"),
+        ("gitlab", "tests", "WORKER_GITLAB_TESTS_ENABLED"),
+    ],
+)
+def test_local_all_explicit_alias_wins_over_canonical_inheritance(
+    provider: str, dataset: str, switch: str
+) -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {
+            "DEV_HEALTH_ENV": "local",
+            "GO_PROVIDER_ROUTES": "all",
+            switch: "true",
+        }
+    )
+
+    assert switches.routes_to_river(provider, dataset)
+
+
+@pytest.mark.parametrize(
     "environment",
     (
         {"GO_PROVIDER_ROUTES": "all"},


### PR DESCRIPTION
## Summary
- route persisted PR-social and TestOps aliases to River when the validated local `GO_PROVIDER_ROUTES=all` preset selects their complete canonical writer
- preserve explicit alias precedence and keep non-local explicit switches identity-scoped
- include inherited aliases in worker startup readiness
- recover stale `dispatching` alias units through normal redispatch, with one durable River outbox row per unit and no Celery publication

## Live defect and recovery
GitHub run `517d6477-5f11-4aa6-9d4b-11d9e8abe92b` and GitLab run `f7ff0c23-3265-410e-b2a4-b4af2880dac5` contain persisted alias units that were claimed while local all-route mode selected only `prs` and `cicd`. Before this change, alias admission fell through to Celery while the Go descriptor rejected the same aliases.

After rebuilding the API/worker from this branch, the existing stale-unit redispatch path reclaims those rows and writes `sync.provider_unit:<unit_id>` to `worker_job_outbox`. No manual SQL or other database writes are needed.

## TEST-EVIDENCE
- baseline RED: 6 stale alias recovery cases and the combined five-identity GitHub/GitLab cases produced no River outbox; 6 Go alias descriptors were disabled
- affected Python suites: 349 passed
- affected Go suites: `internal/platform/config`, `internal/providersync`, and `cmd/dev-health-worker` passed
- shared mutation harness: 9/9 mutations killed
- live Python oracle: `internal/providersync` and `internal/scheduler/sync` passed with `-count=1`
- `bash ci/local_validate.sh`: GATE PASSED, 9/9 stages; 13,865 passed, 248 skipped, 1 expected xfail

## RISK-NOTES
Local all-route mode deliberately lets the persisted aliases execute the same complete idempotent effect writers as their selected canonical identities, while each alias keeps its independent claim/effect ledger. This is limited to the validated local preset. Explicit non-local switches keep their previous mutual-exclusion and identity boundaries.

SCREENSHOT-WAIVER: backend routing and recovery change; no rendered UI changed.