### PR TITLE
fix(pagerduty): serialize OAuth token refresh

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -26,7 +26,8 @@ usage() {
   test   Run go test ./... in every Go module.
   race   Run go test -race ./... in every Go module.
   live-python-oracles
-         Run the provider-sync, scheduled-planner, and sync-coverage live-Python oracle packages
+         Run the provider-sync, providerfoundation encryption,
+         scheduled-planner, and sync-coverage live-Python oracle packages
          with `go test -count=1` unconditionally
          (cache lookup disabled by -count=1 itself, not by any assumption
          about cache state). Separate from `test` because that package
@@ -209,7 +210,7 @@ check_race() {
 }
 
 check_live_python_oracles() {
-  # internal/providersync and internal/scheduler/sync execute REAL production Python files
+  # internal/providersync, internal/providerfoundation, and internal/scheduler/sync execute REAL production Python files
   # (src/dev_health_ops/**.py, via testdata/python_oracle_loader.py)
   # directly at test time -- not test fixtures, the actual functions this
   # repo ships. `//go:embed` cannot reach outside its own package
@@ -268,6 +269,27 @@ check_live_python_oracles() {
   )
   if [ "${pair_count}" -eq 0 ]; then
     printf 'ERROR: no checked-in live Python oracle pairs were discovered\n' >&2
+    rm -rf -- "${proof_dir}"
+    return 1
+  fi
+
+  printf 'go test -count=1: internal/providerfoundation (live Python encryption compatibility)\n'
+  if ! (
+    cd "${ROOT}"
+    GOWORK=off \
+      DEV_HEALTH_LIVE_PYTHON_ORACLES=1 \
+      DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR="${proof_dir}" \
+      PYTHONPATH="${ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}" \
+      go test -mod=readonly -count=1 \
+        -run '^TestFernetCipherMatchesLivePythonCustomSalt$' \
+        ./internal/providerfoundation/...
+  ); then
+    rm -rf -- "${proof_dir}"
+    return 1
+  fi
+  proof_file="${proof_dir}/providerfoundation-credentials"
+  if [ ! -f "${proof_file}" ] || [ "$(cat "${proof_file}")" != "executed" ]; then
+    printf 'ERROR: providerfoundation live Python encryption measurement did not occur\n' >&2
     rm -rf -- "${proof_dir}"
     return 1
   fi

--- a/ci/requirements-live-python-oracles.txt
+++ b/ci/requirements-live-python-oracles.txt
@@ -10,6 +10,7 @@ cffi==2.0.0
 charset-normalizer==3.4.7
 colorama==0.4.6
 croniter==6.2.2
+cryptography==50.0.0
 defusedxml==0.7.1
 fastapi==0.136.3
 gitdb==4.0.12

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -770,9 +770,7 @@ func constructProviderSyncWorkerWithDependencies(
 	if err != nil {
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}
-	decryptor, err := providerfoundation.NewFernetDecryptor(
-		cfg.SettingsEncryptionKey, "",
-	)
+	decryptor, err := newWorkerCredentialCipher(cfg)
 	if err != nil {
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}
@@ -855,6 +853,13 @@ func constructProviderSyncWorkerWithDependencies(
 		},
 		metricsSource: providerMetrics,
 	}, nil
+}
+
+func newWorkerCredentialCipher(cfg config.Config) (providerfoundation.FernetDecryptor, error) {
+	return providerfoundation.NewFernetDecryptor(
+		cfg.SettingsEncryptionKey,
+		cfg.SettingsEncryptionSalt.Reveal(),
+	)
 }
 
 func providerSyncWorkerEnabled(cfg config.Config) bool {

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/jobcontract"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 	"github.com/full-chaos/dev-health-ops/internal/providersync"
 	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
@@ -23,6 +24,34 @@ import (
 )
 
 type providerSyncEntitlementFunc func(context.Context, string) error
+
+func TestWorkerCredentialCipherUsesConfiguredSettingsEncryptionSalt(t *testing.T) {
+	t.Parallel()
+	cipher, err := newWorkerCredentialCipher(config.Config{
+		SettingsEncryptionKey:  secrets.NewValue("test-master-key"),
+		SettingsEncryptionSalt: secrets.NewValue("deployment-specific-salt"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := cipher.Encrypt([]byte("pagerduty-oauth-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultCipher, err := providerfoundation.NewFernetDecryptor(
+		secrets.NewValue("test-master-key"), "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := defaultCipher.Decrypt(ciphertext); err == nil {
+		t.Fatal("custom-salt ciphertext decrypted with the default salt")
+	}
+	plaintext, err := cipher.Decrypt(ciphertext)
+	if err != nil || string(plaintext) != "pagerduty-oauth-token" {
+		t.Fatalf("custom-salt round trip: plaintext=%q err=%v", plaintext, err)
+	}
+}
 
 func (require providerSyncEntitlementFunc) Require(ctx context.Context, orgID string) error {
 	return require(ctx, orgID)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -83,6 +83,7 @@ type Config struct {
 	ClickHouseURI          secrets.Value
 	ValkeyURI              secrets.Value
 	SettingsEncryptionKey  secrets.Value
+	SettingsEncryptionSalt secrets.Value
 	PagerDutyOAuthClientID secrets.Value
 	PagerDutyOAuthSecret   secrets.Value
 
@@ -507,6 +508,7 @@ func Load(spec Spec) (Config, error) {
 		{name: "CLICKHOUSE_URI", target: &cfg.ClickHouseURI},
 		{name: "VALKEY_URI", target: &cfg.ValkeyURI},
 		{name: "SETTINGS_ENCRYPTION_KEY", target: &cfg.SettingsEncryptionKey},
+		{name: "SETTINGS_ENCRYPTION_SALT", target: &cfg.SettingsEncryptionSalt},
 		{name: "PAGER_DUTY_CLIENT_ID", target: &cfg.PagerDutyOAuthClientID},
 		{name: "PAGER_DUTY_SECRET", target: &cfg.PagerDutyOAuthSecret},
 		{name: "WORKER_OPERATIONAL_BRIDGE_TOKEN", target: &cfg.OperationalBridgeToken},
@@ -839,6 +841,7 @@ func (c Config) SafeAttrs() []slog.Attr {
 		slog.Bool("clickhouse_configured", c.ClickHouseURI.Configured()),
 		slog.Bool("valkey_configured", c.ValkeyURI.Configured()),
 		slog.Bool("settings_encryption_key_configured", c.SettingsEncryptionKey.Configured()),
+		slog.Bool("settings_encryption_salt_configured", c.SettingsEncryptionSalt.Configured()),
 		slog.Bool("pagerduty_oauth_client_id_configured", c.PagerDutyOAuthClientID.Configured()),
 		slog.Bool("pagerduty_oauth_secret_configured", c.PagerDutyOAuthSecret.Configured()),
 	}

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -130,6 +130,36 @@ func TestLoadDefaultsAndTypedOverrides(t *testing.T) {
 	}
 }
 
+func TestLoadSettingsEncryptionSalt(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load(workerSpec(map[string]string{
+		"SETTINGS_ENCRYPTION_SALT": "deployment-specific-salt",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SettingsEncryptionSalt.Reveal() != "deployment-specific-salt" {
+		t.Fatal("SETTINGS_ENCRYPTION_SALT was not preserved in typed config")
+	}
+}
+
+func TestSafeAttrsRedactsSettingsEncryptionSalt(t *testing.T) {
+	t.Parallel()
+	cfg, err := Load(workerSpec(map[string]string{
+		"SETTINGS_ENCRYPTION_SALT": "deployment-specific-salt",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := fmt.Sprint(cfg.SafeAttrs())
+	if strings.Contains(text, "deployment-specific-salt") {
+		t.Fatal("safe attrs leaked SETTINGS_ENCRYPTION_SALT")
+	}
+	if !strings.Contains(text, "settings_encryption_salt_configured=true") {
+		t.Fatal("safe attrs omitted the SETTINGS_ENCRYPTION_SALT configured marker")
+	}
+}
+
 func TestCLIProfileOverridesEnvironmentAndMustBeAllowed(t *testing.T) {
 	t.Parallel()
 

--- a/internal/providerfoundation/credentials_python_oracle_test.go
+++ b/internal/providerfoundation/credentials_python_oracle_test.go
@@ -1,0 +1,94 @@
+package providerfoundation
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+)
+
+func TestFernetCipherMatchesLivePythonCustomSalt(t *testing.T) {
+	if os.Getenv("DEV_HEALTH_LIVE_PYTHON_ORACLES") != "1" {
+		t.Skip("live Python oracles run only through ci/check_go.sh live-python-oracles")
+	}
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve providerfoundation package path")
+	}
+	repositoryRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	python := filepath.Join(repositoryRoot, ".venv", "bin", "python")
+	if _, err := os.Stat(python); err != nil {
+		python, err = exec.LookPath("python3")
+		if err != nil {
+			t.Fatalf("live Python oracle interpreter: %v", err)
+		}
+	}
+
+	const (
+		key       = "pagerduty-cross-runtime-test-key"
+		salt      = "deployment-specific-salt"
+		plaintext = "pagerduty-oauth-token-payload"
+	)
+	cipher, err := NewFernetDecryptor(secrets.NewValue(key), salt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goCiphertext, err := cipher.Encrypt([]byte(plaintext))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pythonPlaintext := runPythonEncryptionOracle(t, python, repositoryRoot, map[string]string{
+		"SETTINGS_ENCRYPTION_KEY":  key,
+		"SETTINGS_ENCRYPTION_SALT": salt,
+		"CIPHERTEXT":               goCiphertext.Reveal(),
+	}, "from dev_health_ops.core.encryption import decrypt_value; import os; print(decrypt_value(os.environ['CIPHERTEXT']))")
+	if pythonPlaintext != plaintext {
+		t.Fatalf("Python decrypted Go ciphertext as %q", pythonPlaintext)
+	}
+
+	pythonCiphertext := runPythonEncryptionOracle(t, python, repositoryRoot, map[string]string{
+		"SETTINGS_ENCRYPTION_KEY":  key,
+		"SETTINGS_ENCRYPTION_SALT": salt,
+		"PLAINTEXT":                plaintext,
+	}, "from dev_health_ops.core.encryption import encrypt_value; import os; print(encrypt_value(os.environ['PLAINTEXT']))")
+	goPlaintext, err := cipher.Decrypt(secrets.NewValue(pythonCiphertext))
+	if err != nil || string(goPlaintext) != plaintext {
+		t.Fatalf("Go decrypt of Python ciphertext: plaintext=%q err=%v", goPlaintext, err)
+	}
+
+	proofDir := os.Getenv("DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR")
+	if proofDir == "" {
+		t.Fatal("DEV_HEALTH_LIVE_PYTHON_ORACLE_PROOF_DIR is required")
+	}
+	if err := os.WriteFile(
+		filepath.Join(proofDir, "providerfoundation-credentials"),
+		[]byte("executed"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runPythonEncryptionOracle(
+	t *testing.T,
+	python string,
+	repositoryRoot string,
+	values map[string]string,
+	program string,
+) string {
+	t.Helper()
+	command := exec.Command(python, "-c", program)
+	command.Env = append(os.Environ(), "PYTHONPATH="+filepath.Join(repositoryRoot, "src"))
+	for key, value := range values {
+		command.Env = append(command.Env, key+"="+value)
+	}
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("live Python encryption oracle: %v: %s", err, output)
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/internal/providerfoundation/pagerduty_oauth.go
+++ b/internal/providerfoundation/pagerduty_oauth.go
@@ -40,7 +40,12 @@ type PagerDutyOAuthTokenRotation struct {
 
 type PagerDutyOAuthTokenRepository interface {
 	Load(context.Context, string, string) (PagerDutyOAuthTokenRecord, error)
-	Rotate(context.Context, string, string, PagerDutyOAuthTokenRotation) (bool, error)
+	WithRefreshLock(
+		context.Context,
+		string,
+		string,
+		func(PagerDutyOAuthTokenRecord) (*PagerDutyOAuthTokenRotation, error),
+	) error
 }
 
 // PagerDutyOAuthHydrator resolves a tokenless OAuth descriptor through the
@@ -102,7 +107,7 @@ func (h PagerDutyOAuthHydrator) Hydrate(
 			"access_token", secrets.NewValue(tokens.AccessToken),
 		)
 	}
-	return h.refresh(ctx, lease, scope.OrgID, credentialName, credential, record, tokens)
+	return h.refreshLocked(ctx, lease, scope.OrgID, credentialName, bindingID, credential)
 }
 
 func (h PagerDutyOAuthHydrator) decode(
@@ -131,21 +136,60 @@ func (h PagerDutyOAuthHydrator) decode(
 	return tokens, nil
 }
 
-func (h PagerDutyOAuthHydrator) refresh(
+func (h PagerDutyOAuthHydrator) refreshLocked(
 	ctx context.Context,
 	lease LeaseGuard,
 	orgID string,
 	credentialName string,
+	bindingID string,
+	credential Credential,
+) (Credential, error) {
+	var hydrated Credential
+	err := h.Repository.WithRefreshLock(
+		ctx,
+		orgID,
+		credentialName,
+		func(record PagerDutyOAuthTokenRecord) (*PagerDutyOAuthTokenRotation, error) {
+			current, err := h.decode(ctx, lease, record, bindingID)
+			if err != nil {
+				return nil, err
+			}
+			if !hasPagerDutyOperationalReadScopes(current.GrantedScopes) {
+				return nil, ErrCredentialInvalid
+			}
+			if current.ExpiresAt.After(h.now().Add(pagerDutyOAuthRenewalWindow)) {
+				hydrated, err = credential.WithEphemeralSecret(
+					"access_token", secrets.NewValue(current.AccessToken),
+				)
+				return nil, err
+			}
+			var rotation PagerDutyOAuthTokenRotation
+			hydrated, rotation, err = h.refreshTokens(ctx, lease, credential, record, current)
+			if err != nil {
+				return nil, err
+			}
+			return &rotation, nil
+		},
+	)
+	if err != nil {
+		return Credential{}, err
+	}
+	return hydrated, nil
+}
+
+func (h PagerDutyOAuthHydrator) refreshTokens(
+	ctx context.Context,
+	lease LeaseGuard,
 	credential Credential,
 	record PagerDutyOAuthTokenRecord,
 	current pagerDutyOAuthTokens,
-) (Credential, error) {
+) (Credential, PagerDutyOAuthTokenRotation, error) {
 	if h.Doer == nil || !h.AppClientID.Configured() || current.RefreshToken == nil ||
 		strings.TrimSpace(*current.RefreshToken) == "" {
-		return Credential{}, ErrCredentialInvalid
+		return Credential{}, PagerDutyOAuthTokenRotation{}, ErrCredentialInvalid
 	}
 	if err := lease.Assert(ctx); err != nil {
-		return Credential{}, err
+		return Credential{}, PagerDutyOAuthTokenRotation{}, err
 	}
 	form := url.Values{
 		"grant_type":    {"refresh_token"},
@@ -157,16 +201,16 @@ func (h PagerDutyOAuthHydrator) refresh(
 		ctx, http.MethodPost, pagerDutyTokenURL, strings.NewReader(form.Encode()),
 	)
 	if err != nil {
-		return Credential{}, ErrCredentialInvalid
+		return Credential{}, PagerDutyOAuthTokenRotation{}, ErrCredentialInvalid
 	}
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	response, err := h.Doer.Do(request)
 	if err != nil {
-		return Credential{}, &ProviderError{Class: ErrorTransient}
+		return Credential{}, PagerDutyOAuthTokenRotation{}, &ProviderError{Class: ErrorTransient}
 	}
 	defer response.Body.Close()
 	if classification := ClassifyHTTP("pagerduty", response.StatusCode, response.Header); classification != nil {
-		return Credential{}, classification
+		return Credential{}, PagerDutyOAuthTokenRotation{}, classification
 	}
 	var payload struct {
 		AccessToken  string `json:"access_token"`
@@ -176,7 +220,7 @@ func (h PagerDutyOAuthHydrator) refresh(
 	}
 	if json.NewDecoder(io.LimitReader(response.Body, maxProviderErrorBody)).Decode(&payload) != nil ||
 		strings.TrimSpace(payload.AccessToken) == "" {
-		return Credential{}, ErrCredentialInvalid
+		return Credential{}, PagerDutyOAuthTokenRotation{}, ErrCredentialInvalid
 	}
 	expiresIn := pagerDutyExpiresIn(payload.ExpiresIn)
 	refreshed := pagerDutyOAuthTokens{
@@ -194,46 +238,31 @@ func (h PagerDutyOAuthHydrator) refresh(
 		refreshed.GrantedScopes = normalizedPagerDutyScopes(strings.Fields(payload.Scope))
 	}
 	if !hasPagerDutyOperationalReadScopes(refreshed.GrantedScopes) {
-		return Credential{}, ErrCredentialInvalid
+		return Credential{}, PagerDutyOAuthTokenRotation{}, ErrCredentialInvalid
 	}
 	encoded, err := json.Marshal(refreshed)
 	if err != nil {
-		return Credential{}, ErrCredentialInvalid
+		return Credential{}, PagerDutyOAuthTokenRotation{}, ErrCredentialInvalid
 	}
 	ciphertext, err := h.Cipher.Encrypt(encoded)
 	if err != nil {
-		return Credential{}, ErrCredentialInvalid
+		return Credential{}, PagerDutyOAuthTokenRotation{}, ErrCredentialInvalid
 	}
 	if err := lease.Assert(ctx); err != nil {
-		return Credential{}, err
+		return Credential{}, PagerDutyOAuthTokenRotation{}, err
 	}
-	rotated, err := h.Repository.Rotate(ctx, orgID, credentialName, PagerDutyOAuthTokenRotation{
+	rotation := PagerDutyOAuthTokenRotation{
 		ExpectedVersion: record.Version, ExpectedBindingID: record.BindingID,
 		Ciphertext: ciphertext, ExpiresAt: refreshed.ExpiresAt,
 		GrantedScopes: refreshed.GrantedScopes, HasRefreshToken: refreshed.RefreshToken != nil,
-	})
-	if err != nil {
-		return Credential{}, err
 	}
-	if rotated {
-		return credential.WithEphemeralSecret(
-			"access_token", secrets.NewValue(refreshed.AccessToken),
-		)
-	}
-	// A concurrent worker won the optimistic rotation. Use only its freshly
-	// persisted token and re-check the binding and scopes before proceeding.
-	latest, err := h.Repository.Load(ctx, orgID, credentialName)
-	if err != nil {
-		return Credential{}, err
-	}
-	latestTokens, err := h.decode(ctx, lease, latest, record.BindingID)
-	if err != nil || !hasPagerDutyOperationalReadScopes(latestTokens.GrantedScopes) ||
-		!latestTokens.ExpiresAt.After(h.now().Add(pagerDutyOAuthRenewalWindow)) {
-		return Credential{}, ErrCredentialInvalid
-	}
-	return credential.WithEphemeralSecret(
-		"access_token", secrets.NewValue(latestTokens.AccessToken),
+	hydrated, err := credential.WithEphemeralSecret(
+		"access_token", secrets.NewValue(refreshed.AccessToken),
 	)
+	if err != nil {
+		return Credential{}, PagerDutyOAuthTokenRotation{}, err
+	}
+	return hydrated, rotation, nil
 }
 
 func (h PagerDutyOAuthHydrator) now() time.Time {

--- a/internal/providerfoundation/pagerduty_oauth_postgres_integration_test.go
+++ b/internal/providerfoundation/pagerduty_oauth_postgres_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package providerfoundation
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestPostgresPagerDutyOAuthRefreshLockSerializesWorkers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if closeErr := instance.Close(closeCtx); closeErr != nil {
+			t.Errorf("terminate PostgreSQL test dependency: %v", closeErr)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `
+CREATE TABLE provider_oauth_credentials (
+    org_id text NOT NULL,
+    provider text NOT NULL,
+    credential_name text NOT NULL,
+    token_encrypted text NOT NULL,
+    version integer NOT NULL,
+    binding_id text,
+    expires_at timestamptz,
+    granted_scopes json,
+    has_refresh_token boolean NOT NULL DEFAULT false,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (org_id, provider, credential_name)
+);
+INSERT INTO provider_oauth_credentials (
+    org_id, provider, credential_name, token_encrypted, version, binding_id
+) VALUES ('org-1', 'pagerduty', 'operations', 'v1:ciphertext', 7, 'binding-1')`); err != nil {
+		t.Fatal(err)
+	}
+
+	repository := PostgresPagerDutyOAuthTokenRepository{Pool: pool}
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	defer release()
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- repository.WithRefreshLock(
+			ctx, "org-1", "operations",
+			func(PagerDutyOAuthTokenRecord) (*PagerDutyOAuthTokenRotation, error) {
+				close(firstEntered)
+				<-releaseFirst
+				return nil, nil
+			},
+		)
+	}()
+	<-firstEntered
+
+	secondEntered := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- repository.WithRefreshLock(
+			ctx, "org-1", "operations",
+			func(PagerDutyOAuthTokenRecord) (*PagerDutyOAuthTokenRotation, error) {
+				close(secondEntered)
+				return nil, nil
+			},
+		)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var waiting int
+		err := pool.QueryRow(ctx, `
+SELECT count(*)
+FROM pg_stat_activity
+WHERE wait_event_type = 'Lock'
+  AND query LIKE '%provider_oauth_credentials%FOR UPDATE%'`).Scan(&waiting)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if waiting > 0 {
+			break
+		}
+		select {
+		case <-secondEntered:
+			release()
+			t.Fatal("second refresh entered before the first row lock was released")
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second refresh did not become a PostgreSQL row-lock waiter")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	release()
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-secondEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second refresh did not enter after row lock release")
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/providerfoundation/pagerduty_oauth_test.go
+++ b/internal/providerfoundation/pagerduty_oauth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -188,6 +189,62 @@ func TestPagerDutyOAuthHydratorRejectsBindingAndScopeDrift(t *testing.T) {
 	}
 }
 
+func TestPagerDutyOAuthHydratorSerializesConcurrentRefresh(t *testing.T) {
+	t.Parallel()
+	key := secrets.NewValue("test-master-key")
+	cipher, err := NewFernetDecryptor(key, "salt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	refreshToken := "single-use-refresh-token"
+	stored := pagerDutyOAuthTokens{
+		AccessToken: "expiring-token", RefreshToken: &refreshToken,
+		ExpiresAt:     time.Date(2026, 8, 12, 0, 1, 0, 0, time.UTC),
+		GrantedScopes: append([]string(nil), pagerDutyOperationalReadScopes...),
+	}
+	repository := newConcurrentPagerDutyOAuthTokenRepository(PagerDutyOAuthTokenRecord{
+		Ciphertext: secrets.NewValue("v1:" + encryptForTest(t, mustJSON(t, stored), key.Reveal(), "salt")),
+		Version:    7,
+		BindingID:  "binding-1",
+	})
+	doer := &singleUsePagerDutyRefreshDoer{}
+	hydrator := PagerDutyOAuthHydrator{
+		Repository: repository, Cipher: cipher, Doer: doer,
+		AppClientID:     secrets.NewValue("client-id"),
+		AppClientSecret: secrets.NewValue("client-secret"),
+		Now:             func() time.Time { return time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC) },
+	}
+	credential := testCredential("pagerduty", map[string]string{
+		"auth_mode": "oauth", "oauth_credential_name": "operations",
+		"oauth_binding_id": "binding-1",
+	})
+	scope := TenantScope{OrgID: "org-1", Provider: "pagerduty", IntegrationID: "integration-1"}
+
+	start := make(chan struct{})
+	errors := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			_, hydrateErr := hydrator.Hydrate(
+				context.Background(),
+				LeaseGuardFunc(func(context.Context) error { return nil }),
+				scope,
+				credential,
+			)
+			errors <- hydrateErr
+		}()
+	}
+	close(start)
+	for range 2 {
+		if hydrateErr := <-errors; hydrateErr != nil {
+			t.Errorf("concurrent hydration failed: %v", hydrateErr)
+		}
+	}
+	if calls := doer.Calls(); calls != 1 {
+		t.Fatalf("remote refresh calls=%d, want one serialized rotation", calls)
+	}
+}
+
 type fakeEncryptedCredentialRepository struct{ record EncryptedCredential }
 
 func (r fakeEncryptedCredentialRepository) ResolveEncrypted(
@@ -215,15 +272,24 @@ func (r *fakePagerDutyOAuthTokenRepository) Load(
 	return r.record, nil
 }
 
-func (r *fakePagerDutyOAuthTokenRepository) Rotate(
+func (r *fakePagerDutyOAuthTokenRepository) WithRefreshLock(
 	_ context.Context,
 	_ string,
 	_ string,
-	rotation PagerDutyOAuthTokenRotation,
-) (bool, error) {
+	refresh func(PagerDutyOAuthTokenRecord) (*PagerDutyOAuthTokenRotation, error),
+) error {
+	rotation, err := refresh(r.record)
+	if err != nil {
+		return err
+	}
+	if rotation == nil {
+		return nil
+	}
 	r.rotated = true
-	r.rotation = rotation
-	return true, nil
+	r.rotation = *rotation
+	r.record.Ciphertext = rotation.Ciphertext
+	r.record.Version++
+	return nil
 }
 
 type pagerDutyRefreshDoer struct{ calls int }
@@ -247,6 +313,80 @@ func (d *pagerDutyRefreshDoer) Do(request *http.Request) (*http.Response, error)
 	}
 	return testHTTPResponse(request, http.StatusOK, nil,
 		`{"access_token":"refreshed-access-token","expires_in":3600}`), nil
+}
+
+type concurrentPagerDutyOAuthTokenRepository struct {
+	mu          sync.Mutex
+	record      PagerDutyOAuthTokenRecord
+	initialLoad sync.WaitGroup
+}
+
+func newConcurrentPagerDutyOAuthTokenRepository(
+	record PagerDutyOAuthTokenRecord,
+) *concurrentPagerDutyOAuthTokenRepository {
+	repository := &concurrentPagerDutyOAuthTokenRepository{record: record}
+	repository.initialLoad.Add(2)
+	return repository
+}
+
+func (r *concurrentPagerDutyOAuthTokenRepository) Load(
+	_ context.Context,
+	_ string,
+	_ string,
+) (PagerDutyOAuthTokenRecord, error) {
+	r.mu.Lock()
+	record := r.record
+	r.mu.Unlock()
+	r.initialLoad.Done()
+	r.initialLoad.Wait()
+	return record, nil
+}
+
+func (r *concurrentPagerDutyOAuthTokenRepository) WithRefreshLock(
+	_ context.Context,
+	_ string,
+	_ string,
+	refresh func(PagerDutyOAuthTokenRecord) (*PagerDutyOAuthTokenRotation, error),
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rotation, err := refresh(r.record)
+	if err != nil {
+		return err
+	}
+	if rotation == nil {
+		return nil
+	}
+	if r.record.Version != rotation.ExpectedVersion ||
+		r.record.BindingID != rotation.ExpectedBindingID {
+		return ErrCredentialInvalid
+	}
+	r.record.Ciphertext = rotation.Ciphertext
+	r.record.Version++
+	return nil
+}
+
+type singleUsePagerDutyRefreshDoer struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (d *singleUsePagerDutyRefreshDoer) Do(request *http.Request) (*http.Response, error) {
+	d.mu.Lock()
+	d.calls++
+	call := d.calls
+	d.mu.Unlock()
+	if call > 1 {
+		return testHTTPResponse(request, http.StatusBadRequest, nil, `{}`), nil
+	}
+	return testHTTPResponse(request, http.StatusOK, nil,
+		`{"access_token":"refreshed-access-token","refresh_token":"rotated-refresh-token","expires_in":3600}`), nil
+}
+
+func (d *singleUsePagerDutyRefreshDoer) Calls() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
 }
 
 func mustJSON(t *testing.T, value any) []byte {

--- a/internal/providerfoundation/repository_postgres.go
+++ b/internal/providerfoundation/repository_postgres.go
@@ -131,25 +131,66 @@ WHERE org_id = $1 AND provider = 'pagerduty' AND credential_name = $2`,
 	}, nil
 }
 
-func (r PostgresPagerDutyOAuthTokenRepository) Rotate(
+func (r PostgresPagerDutyOAuthTokenRepository) WithRefreshLock(
 	ctx context.Context,
 	orgID string,
 	credentialName string,
-	rotation PagerDutyOAuthTokenRotation,
-) (bool, error) {
+	refresh func(PagerDutyOAuthTokenRecord) (*PagerDutyOAuthTokenRotation, error),
+) error {
 	if r.Pool == nil || strings.TrimSpace(orgID) == "" ||
 		strings.TrimSpace(credentialName) == "" ||
-		rotation.ExpectedVersion < 1 ||
-		strings.TrimSpace(rotation.ExpectedBindingID) == "" ||
+		refresh == nil {
+		return ErrCredentialInvalid
+	}
+	tx, err := r.Pool.Begin(ctx)
+	if err != nil {
+		return &ProviderError{Class: ErrorTransient}
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	var (
+		ciphertext string
+		version    int
+		bindingID  *string
+	)
+	err = tx.QueryRow(ctx, `
+SELECT token_encrypted, version, binding_id
+FROM provider_oauth_credentials
+WHERE org_id = $1 AND provider = 'pagerduty' AND credential_name = $2
+FOR UPDATE`, orgID, credentialName).Scan(&ciphertext, &version, &bindingID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrCredentialNotFound
+	}
+	if err != nil {
+		return &ProviderError{Class: ErrorTransient}
+	}
+	if bindingID == nil || strings.TrimSpace(*bindingID) == "" ||
+		strings.TrimSpace(ciphertext) == "" || version < 1 {
+		return ErrCredentialInvalid
+	}
+	record := PagerDutyOAuthTokenRecord{
+		Ciphertext: secrets.NewValue(ciphertext), Version: version, BindingID: *bindingID,
+	}
+	rotation, err := refresh(record)
+	if err != nil {
+		return err
+	}
+	if rotation == nil {
+		if err := tx.Commit(ctx); err != nil {
+			return &ProviderError{Class: ErrorTransient}
+		}
+		return nil
+	}
+	if rotation.ExpectedVersion != record.Version ||
+		rotation.ExpectedBindingID != record.BindingID ||
 		!rotation.Ciphertext.Configured() || rotation.ExpiresAt.IsZero() {
-		return false, ErrCredentialInvalid
+		return ErrCredentialInvalid
 	}
 	scopes, err := json.Marshal(normalizedPagerDutyScopes(rotation.GrantedScopes))
 	if err != nil {
-		return false, ErrCredentialInvalid
+		return ErrCredentialInvalid
 	}
-	var version int
-	err = r.Pool.QueryRow(ctx, `
+	var nextVersion int
+	err = tx.QueryRow(ctx, `
 UPDATE provider_oauth_credentials
 SET token_encrypted = $1,
     version = version + 1,
@@ -166,14 +207,20 @@ RETURNING version`,
 		rotation.Ciphertext.Reveal(), rotation.ExpiresAt, string(scopes),
 		rotation.HasRefreshToken, time.Now().UTC(), orgID, credentialName,
 		rotation.ExpectedVersion, rotation.ExpectedBindingID,
-	).Scan(&version)
+	).Scan(&nextVersion)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return false, nil
+		return ErrCredentialInvalid
 	}
 	if err != nil {
-		return false, &ProviderError{Class: ErrorTransient}
+		return &ProviderError{Class: ErrorTransient}
 	}
-	return version == rotation.ExpectedVersion+1, nil
+	if nextVersion != rotation.ExpectedVersion+1 {
+		return ErrCredentialInvalid
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return &ProviderError{Class: ErrorTransient}
+	}
+	return nil
 }
 
 var _ CredentialRepository = PostgresCredentialRepository{}

--- a/tests/test_go_live_oracle_ci.py
+++ b/tests/test_go_live_oracle_ci.py
@@ -79,7 +79,7 @@ def test_go_quality_bootstraps_locked_live_oracle_dependencies() -> None:
         assert str(locked[package]["version"]) == version, (
             f"live-oracle pin for {package} must match uv.lock"
         )
-    for root in ("httpx", "pygithub", "croniter"):
+    for root in ("croniter", "cryptography", "httpx", "pygithub"):
         for package, version in _locked_closure(root).items():
             assert pins.get(package) == version, (
                 f"live Python oracles require locked {package}=={version}"

--- a/tests/tooling/mutation-plans/pagerduty_oauth_binding_hydration.json
+++ b/tests/tooling/mutation-plans/pagerduty_oauth_binding_hydration.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "PagerDuty OAuth binding hydration for native Go provider workers",
   "build": ["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-run", "^$", "./internal/providerfoundation/", "./cmd/dev-health-worker/", "./internal/storage/postgres/", "./internal/storage/river/"],
-  "$limitation": "This plan covers tokenless descriptor hydration, tenant-bound OAuth binding and scope fences, renewal selection, production worker wiring, and least-privilege domain-role posture. Live PagerDuty HTTP behavior and a real PostgreSQL optimistic-rotation race remain integration evidence rather than mutation targets in this focused repair.",
+  "$limitation": "This plan covers tokenless descriptor hydration, tenant-bound OAuth binding and scope fences, renewal selection and row-locked recheck, production worker and custom-salt wiring, real PostgreSQL refresh serialization, and least-privilege domain-role posture. Live PagerDuty HTTP behavior remains outside this focused local repair.",
   "mutations": [
     {
       "id": "PD-OAUTH-1-resolver-invokes-hydrator",
@@ -45,12 +45,36 @@
       "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestPagerDutyOAuthHydratorRefreshesAndRotatesEncryptedToken$", "./internal/providerfoundation/"]]
     },
     {
+      "id": "PD-OAUTH-4a-row-locked-renewal-recheck",
+      "file": "internal/providerfoundation/pagerduty_oauth.go",
+      "find": "if current.ExpiresAt.After(h.now().Add(pagerDutyOAuthRenewalWindow)) {",
+      "replace": "if false {",
+      "rationale": "A worker that waited for the refresh row lock must re-read expiry and use the winner's token instead of calling the remote refresh endpoint with the same rotating refresh token.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestPagerDutyOAuthHydratorSerializesConcurrentRefresh$", "./internal/providerfoundation/"]]
+    },
+    {
       "id": "PD-OAUTH-5-worker-wiring",
       "file": "cmd/dev-health-worker/provider_sync.go",
       "find": "Hydrator:  credentialHydrator,",
       "replace": "Hydrator:  nil,",
       "rationale": "Constructing a hydrator at startup is not capability evidence unless every provider-unit executor receives the same dependency.",
       "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestBuildProviderSyncHandlerWiresPagerDutyCredentialHydrator$", "./cmd/dev-health-worker/"]]
+    },
+    {
+      "id": "PD-OAUTH-5a-settings-encryption-salt",
+      "file": "cmd/dev-health-worker/provider_sync.go",
+      "find": "cfg.SettingsEncryptionSalt.Reveal(),",
+      "replace": "\"\",",
+      "rationale": "PagerDuty token reads and refresh writes must derive the same Fernet key as Python when a deployment configures SETTINGS_ENCRYPTION_SALT.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-count=1", "-run", "^TestWorkerCredentialCipherUsesConfiguredSettingsEncryptionSalt$", "./cmd/dev-health-worker/"]]
+    },
+    {
+      "id": "PD-OAUTH-5b-postgres-refresh-row-lock",
+      "file": "internal/providerfoundation/repository_postgres.go",
+      "find": "FOR UPDATE`, orgID, credentialName).Scan(&ciphertext, &version, &bindingID)",
+      "replace": "FOR SHARE`, orgID, credentialName).Scan(&ciphertext, &version, &bindingID)",
+      "rationale": "The real PostgreSQL repository must hold an exclusive row lock across refresh so concurrent workers cannot both use one rotating refresh token.",
+      "proof": [["env", "GOCACHE=/tmp/pagerduty-oauth-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestPostgresPagerDutyOAuthRefreshLockSerializesWorkers$", "./internal/providerfoundation/"]]
     },
     {
       "id": "PD-OAUTH-6-domain-role-update",


### PR DESCRIPTION
## Summary

- honor `SETTINGS_ENCRYPTION_SALT` in the native Go worker credential cipher
- serialize PagerDuty refresh-token rotation with a PostgreSQL row lock and recheck the locked token before remote refresh
- preserve embedded direct access-token compatibility
- add live Python/Go encryption parity and real PostgreSQL concurrency proof

## TEST-EVIDENCE

- `bash ci/local_validate.sh` — PASS, 9/9 declared stages executed
- full unit suite: 13,865 passed, 248 skipped, 1 xfailed
- live Python/Go custom-salt encryption oracle — PASS
- isolated PostgreSQL refresh serialization test — PASS
- PagerDuty OAuth mutation plan — 10/10 mutations killed; restore verified

## RISK-NOTES

- The PostgreSQL transaction intentionally remains open across PagerDuty token refresh to match the existing Python `SELECT FOR UPDATE` lifecycle and prevent reuse of rotating refresh tokens.
- The domain worker already has narrowly scoped `SELECT, UPDATE` authority for `provider_oauth_credentials`; no schema or deployment configuration change is introduced here.
- No shared Compose restart or live credential/database mutation was performed.

SCREENSHOT-WAIVER: Backend credential and concurrency repair; no rendered UI changes.