### PR TITLE
fix: rearm stale dispatch wakeups

### DIFF
--- a/internal/syncreconciler/materializer.go
+++ b/internal/syncreconciler/materializer.go
@@ -221,9 +221,22 @@ SET available_at = CASE
 	END,
 	updated_at = $1
 WHERE sync_dispatch_outbox.status <> 'pending'
-	AND NOT (
-		sync_dispatch_outbox.status = 'dispatched'
-		AND sync_dispatch_outbox.dispatched_transport = 'river'
+	AND sync_dispatch_outbox.last_error IS DISTINCT FROM 'feature_disabled'
+	AND (
+		sync_dispatch_outbox.dispatched_transport IS DISTINCT FROM 'river'
+		OR EXISTS (
+			SELECT 1
+			FROM public.sync_run_units AS unit
+			WHERE unit.sync_run_id = sync_dispatch_outbox.sync_run_id
+				AND (
+					(unit.status = 'dispatching' AND unit.updated_at <= $2)
+					OR (
+						unit.status = 'retrying'
+						AND unit.available_at IS NOT NULL
+						AND unit.available_at <= $1
+					)
+				)
+		)
 	)
 `
 

--- a/internal/syncreconciler/materializer_integration_test.go
+++ b/internal/syncreconciler/materializer_integration_test.go
@@ -15,16 +15,143 @@ import (
 )
 
 const (
-	materializerDispatchMissing = "00000000-0000-4000-8000-000000004101"
-	materializerExpiredClaim    = "00000000-0000-4000-8000-000000004102"
-	materializerLiveClaim       = "00000000-0000-4000-8000-000000004103"
-	materializerTerminalDenial  = "00000000-0000-4000-8000-000000004104"
-	materializerFinalize        = "00000000-0000-4000-8000-000000004105"
-	materializerDiscovery       = "00000000-0000-4000-8000-000000004106"
-	materializerPostSyncMissing = "00000000-0000-4000-8000-000000004107"
-	materializerPostSyncExists  = "00000000-0000-4000-8000-000000004108"
-	materializerRiverQueued     = "00000000-0000-4000-8000-000000004109"
+	materializerDispatchMissing  = "00000000-0000-4000-8000-000000004101"
+	materializerExpiredClaim     = "00000000-0000-4000-8000-000000004102"
+	materializerLiveClaim        = "00000000-0000-4000-8000-000000004103"
+	materializerTerminalDenial   = "00000000-0000-4000-8000-000000004104"
+	materializerFinalize         = "00000000-0000-4000-8000-000000004105"
+	materializerDiscovery        = "00000000-0000-4000-8000-000000004106"
+	materializerPostSyncMissing  = "00000000-0000-4000-8000-000000004107"
+	materializerPostSyncExists   = "00000000-0000-4000-8000-000000004108"
+	materializerRiverQueued      = "00000000-0000-4000-8000-000000004109"
+	materializerStaleDispatch    = "00000000-0000-4000-8000-00000000410a"
+	materializerFreshDispatch    = "00000000-0000-4000-8000-00000000410b"
+	materializerRetryingDispatch = "00000000-0000-4000-8000-00000000410c"
+	materializerFeatureDisabled  = "00000000-0000-4000-8000-00000000410d"
 )
+
+func TestMaterializerRedispatchesStaleUnitsExactlyOnce(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createMaterializerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	materializer, err := NewMaterializer(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("stale dispatching River row re-arms once", func(t *testing.T) {
+		resetMaterializerIntegrationTables(t, ctx, pool)
+		now := time.Date(2026, time.July, 24, 1, 0, 0, 0, time.UTC)
+		cutoff := now.Add(-15 * time.Minute)
+		seedRun(t, ctx, pool, materializerStaleDispatch, "running", now.Add(-2*time.Hour))
+		seedUnit(t, ctx, pool, "00000000-0000-4000-8000-000000004301",
+			materializerStaleDispatch, "dispatching", nil, now.Add(-time.Hour))
+		seedMaterializerDispatchedOutbox(t, ctx, pool, materializerStaleDispatch, "river-stale-job", now.Add(-2*time.Hour))
+
+		result, err := materializer.Step(ctx, now, cutoff, 20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Dispatch != 1 {
+			t.Fatalf("stale dispatching graph did not rearm exactly once: %#v", result)
+		}
+		assertMaterializerDispatchState(t, ctx, pool, materializerStaleDispatch, "pending", nil, 1)
+
+		result, err = materializer.Step(ctx, now, cutoff, 20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Dispatch != 0 {
+			t.Fatalf("stale dispatching graph amplified on second pass: %#v", result)
+		}
+		assertMaterializerDispatchState(t, ctx, pool, materializerStaleDispatch, "pending", nil, 1)
+	})
+
+	t.Run("fresh dispatching River row stays protected", func(t *testing.T) {
+		resetMaterializerIntegrationTables(t, ctx, pool)
+		now := time.Date(2026, time.July, 24, 2, 0, 0, 0, time.UTC)
+		cutoff := now.Add(-15 * time.Minute)
+		seedRun(t, ctx, pool, materializerFreshDispatch, "running", now.Add(-2*time.Hour))
+		seedUnit(t, ctx, pool, "00000000-0000-4000-8000-000000004302",
+			materializerFreshDispatch, "dispatching", nil, now.Add(-5*time.Minute))
+		seedMaterializerDispatchedOutbox(t, ctx, pool, materializerFreshDispatch, "river-fresh-job", now.Add(-2*time.Hour))
+
+		result, err := materializer.Step(ctx, now, cutoff, 20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Dispatch != 0 {
+			t.Fatalf("fresh dispatching graph rearmed unexpectedly: %#v", result)
+		}
+		assertMaterializerDispatchState(t, ctx, pool, materializerFreshDispatch, "dispatched", ptrString("river"), 1)
+	})
+
+	t.Run("retrying River row re-arms once when due", func(t *testing.T) {
+		resetMaterializerIntegrationTables(t, ctx, pool)
+		now := time.Date(2026, time.July, 24, 3, 0, 0, 0, time.UTC)
+		cutoff := now.Add(-15 * time.Minute)
+		seedRun(t, ctx, pool, materializerRetryingDispatch, "running", now.Add(-2*time.Hour))
+		seedUnit(t, ctx, pool, "00000000-0000-4000-8000-000000004303",
+			materializerRetryingDispatch, "retrying", ptrTime(now.Add(-time.Minute)), now.Add(-5*time.Minute))
+		seedMaterializerDispatchedOutbox(t, ctx, pool, materializerRetryingDispatch, "river-retry-job", now.Add(-2*time.Hour))
+
+		result, err := materializer.Step(ctx, now, cutoff, 20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Dispatch != 1 {
+			t.Fatalf("retrying graph did not rearm exactly once: %#v", result)
+		}
+		assertMaterializerDispatchState(t, ctx, pool, materializerRetryingDispatch, "pending", nil, 1)
+
+		result, err = materializer.Step(ctx, now, cutoff, 20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Dispatch != 0 {
+			t.Fatalf("retrying graph amplified on second pass: %#v", result)
+		}
+		assertMaterializerDispatchState(t, ctx, pool, materializerRetryingDispatch, "pending", nil, 1)
+	})
+
+	t.Run("feature-disabled River row stays protected", func(t *testing.T) {
+		resetMaterializerIntegrationTables(t, ctx, pool)
+		now := time.Date(2026, time.July, 24, 4, 0, 0, 0, time.UTC)
+		cutoff := now.Add(-15 * time.Minute)
+		seedRun(t, ctx, pool, materializerFeatureDisabled, "running", now.Add(-2*time.Hour))
+		seedUnit(t, ctx, pool, "00000000-0000-4000-8000-000000004304",
+			materializerFeatureDisabled, "dispatching", nil, now.Add(-time.Hour))
+		seedMaterializerFeatureDisabledOutbox(t, ctx, pool, materializerFeatureDisabled, now.Add(-2*time.Hour))
+
+		result, err := materializer.Step(ctx, now, cutoff, 20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Dispatch != 0 {
+			t.Fatalf("feature-disabled row rearmed unexpectedly: %#v", result)
+		}
+		assertMaterializerDispatchState(t, ctx, pool, materializerFeatureDisabled, "dispatched", ptrString("river"), 1)
+	})
+}
 
 func TestMaterializerPostgresConcurrencyAndRollback(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
@@ -611,6 +738,97 @@ func seedUnit(
 		id, runID, status, availableAt, updatedAt); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func seedMaterializerDispatchedOutbox(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	runID, jobID string,
+	dispatchedAt time.Time,
+) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_dispatch_outbox (
+			id, org_id, sync_run_id, kind, status, available_at, attempts,
+			dispatched_at, dispatched_transport, dispatched_route_generation,
+			transport_job_id, created_at, updated_at
+		) VALUES (
+			gen_random_uuid(), 'org-materializer', $1, 'dispatch_sync_run',
+			'dispatched', $2, 1, $2, 'river', 2, $3, $2, $2
+		)`,
+		runID, dispatchedAt, jobID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedMaterializerFeatureDisabledOutbox(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	runID string,
+	dispatchedAt time.Time,
+) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_dispatch_outbox (
+			id, org_id, sync_run_id, kind, status, available_at, attempts,
+			last_error, dispatched_at, dispatched_transport,
+			dispatched_route_generation, transport_job_id,
+			created_at, updated_at
+		) VALUES (
+			gen_random_uuid(), 'org-materializer', $1, 'dispatch_sync_run',
+			'dispatched', $2, 1, 'feature_disabled', $2, 'river', 2, 'feature-disabled-job', $2, $2
+		)`,
+		runID, dispatchedAt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertMaterializerDispatchState(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	runID, wantStatus string,
+	wantTransport *string,
+	wantAttempts int,
+) {
+	t.Helper()
+	var (
+		status    string
+		transport *string
+		attempts  int
+	)
+	if err := pool.QueryRow(ctx, `
+		SELECT status, dispatched_transport, attempts
+		FROM public.sync_dispatch_outbox
+		WHERE sync_run_id = $1 AND kind = 'dispatch_sync_run'`,
+		runID,
+	).Scan(&status, &transport, &attempts); err != nil {
+		t.Fatal(err)
+	}
+	if status != wantStatus || attempts != wantAttempts {
+		t.Fatalf("dispatch state for %s = %s/%v/%d, want %s/%v/%d",
+			runID, status, transport, attempts, wantStatus, wantTransport, wantAttempts)
+	}
+	if wantTransport == nil {
+		if transport != nil {
+			t.Fatalf("dispatch state for %s transport = %v, want nil", runID, transport)
+		}
+		return
+	}
+	if transport == nil || *transport != *wantTransport {
+		t.Fatalf("dispatch state for %s transport = %v, want %s",
+			runID, transport, *wantTransport)
+	}
+}
+
+func ptrTime(value time.Time) *time.Time {
+	return &value
+}
+
+func ptrString(value string) *string {
+	return &value
 }
 
 func assertMaterializerOutboxCount(

--- a/internal/syncreconciler/materializer_test.go
+++ b/internal/syncreconciler/materializer_test.go
@@ -97,24 +97,20 @@ func TestMaterializerRunsOneBoundedTransportNeutralTransaction(t *testing.T) {
 			t.Fatalf("statement %d is not bounded/idempotent:\n%s", index, execution.sql)
 		}
 	}
-	for _, rearmSQL := range []string{
-		tx.execs[0].sql,
-		tx.execs[1].sql,
-		tx.execs[2].sql,
+	rearmSQL := strings.ToUpper(tx.execs[0].sql)
+	for _, required := range []string{
+		"EXCLUDED.AVAILABLE_AT < SYNC_DISPATCH_OUTBOX.AVAILABLE_AT",
+		"SYNC_DISPATCH_OUTBOX.CLAIM_EXPIRES_AT > $1",
+		"LAST_ERROR IS DISTINCT FROM 'FEATURE_DISABLED'",
+		"DISPATCHED_TRANSPORT IS DISTINCT FROM 'RIVER'",
+		"UNIT.STATUS = 'DISPATCHING'",
+		"UNIT.STATUS = 'RETRYING'",
+		"CLAIM_ROUTE_GENERATION = CASE",
+		"DISPATCHED_ROUTE_GENERATION = CASE",
+		"WHERE SYNC_DISPATCH_OUTBOX.STATUS <> 'PENDING'",
 	} {
-		upper := strings.ToUpper(rearmSQL)
-		for _, required := range []string{
-			"EXCLUDED.AVAILABLE_AT < SYNC_DISPATCH_OUTBOX.AVAILABLE_AT",
-			"SYNC_DISPATCH_OUTBOX.CLAIM_EXPIRES_AT > $1",
-			"LAST_ERROR = 'FEATURE_DISABLED'",
-			"DISPATCHED_TRANSPORT = 'RIVER'",
-			"CLAIM_ROUTE_GENERATION = CASE",
-			"DISPATCHED_ROUTE_GENERATION = CASE",
-			"WHERE SYNC_DISPATCH_OUTBOX.STATUS <> 'PENDING'",
-		} {
-			if !strings.Contains(upper, required) {
-				t.Fatalf("rearm SQL missing %q:\n%s", required, rearmSQL)
-			}
+		if !strings.Contains(rearmSQL, required) {
+			t.Fatalf("rearm SQL missing %q:\n%s", required, tx.execs[0].sql)
 		}
 	}
 	postSyncUpper := strings.ToUpper(tx.execs[3].sql)

--- a/tests/tooling/mutation-plans/stale-dispatch-rearm.json
+++ b/tests/tooling/mutation-plans/stale-dispatch-rearm.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "name": "stale dispatch rearm",
+  "$limitation": "Pins the new Go reconciler guard that re-arms stale dispatching and due retrying sync runs exactly once, while keeping fresh River rows and feature-disabled rows protected.",
+  "mutations": [
+    {
+      "id": "SDR01-stale-dispatching-clause",
+      "file": "internal/syncreconciler/materializer.go",
+      "find": "\t\t\tOR (unit.status = 'dispatching' AND unit.updated_at <= $2)",
+      "replace": "\t\t\tOR false",
+      "expect_occurrences": 1,
+      "rationale": "A stale dispatching unit must be able to re-arm an already-dispatched River wakeup.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/syncreconciler/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestMaterializerRedispatchesStaleUnitsExactlyOnce$", "./internal/syncreconciler/"]]
+    },
+    {
+      "id": "SDR02-retrying-due-clause",
+      "file": "internal/syncreconciler/materializer.go",
+      "find": "\t\t\tOR (\n\t\t\t\tunit.status = 'retrying'\n\t\t\t\tAND unit.available_at IS NOT NULL\n\t\t\t\tAND unit.available_at <= $1\n\t\t\t)",
+      "replace": "\t\t\tOR false",
+      "expect_occurrences": 1,
+      "rationale": "A due retrying unit must be able to re-arm an already-dispatched River wakeup.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/syncreconciler/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestMaterializerRedispatchesStaleUnitsExactlyOnce$", "./internal/syncreconciler/"]]
+    },
+    {
+      "id": "SDR03-no-amplification-status-guard",
+      "file": "internal/syncreconciler/materializer.go",
+      "find": "WHERE sync_dispatch_outbox.status <> 'pending'\n\tAND sync_dispatch_outbox.last_error IS DISTINCT FROM 'feature_disabled'\n\tAND (\n\t\tsync_dispatch_outbox.dispatched_transport IS DISTINCT FROM 'river'\n\t\tOR EXISTS (",
+      "replace": "WHERE true",
+      "expect_occurrences": 1,
+      "rationale": "A pending River wakeup must not be re-armed again on the next reconciler pass.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/syncreconciler/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestMaterializerRedispatchesStaleUnitsExactlyOnce$", "./internal/syncreconciler/"]]
+    },
+    {
+      "id": "SDR04-feature-disabled-protection",
+      "file": "internal/syncreconciler/materializer.go",
+      "find": "AND sync_dispatch_outbox.last_error IS DISTINCT FROM 'feature_disabled'",
+      "replace": "AND sync_dispatch_outbox.last_error IS NOT DISTINCT FROM 'feature_disabled'",
+      "expect_occurrences": 1,
+      "rationale": "A River dispatch denied by the feature flag must stay protected from re-arm.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/syncreconciler/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/go-stale-dispatch-rearm-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestMaterializerRedispatchesStaleUnitsExactlyOnce$", "./internal/syncreconciler/"]]
+    }
+  ]
+}


### PR DESCRIPTION
Fix stale River-dispatched sync wakeups when alias units are still dispatching or due retrying.

Validation:
- Pre-rebase full local gate: 9/9 passed
- Post-rebase focused materializer PostgreSQL test: passed
- Post-rebase race test: passed
- Mutation plan: 4/4 killed

Boundary:
- One unrelated package run failed on TestMutationReconcilerActiveActive because port 5432/tcp was not found. I did not treat that as a regression in this fix.

Base:
- feat/go-worker-runtime-migration at ae814374289076fb536350ddc3b689894e2c81e4

Head:
- fix/stale-dispatch-rearm at b039fc5c12c1e2238d9c0d98350bbb196733bc3f