### PR TITLE
fix(ci): synchronize live-oracle idna pin

### DIFF
--- a/ci/requirements-live-python-oracles.txt
+++ b/ci/requirements-live-python-oracles.txt
@@ -20,7 +20,7 @@ greenlet==3.5.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
-idna==3.15
+idna==3.18
 iniconfig==2.3.0
 mando==0.7.1
 packaging==26.2

--- a/uv.lock
+++ b/uv.lock
@@ -975,11 +975,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
- update the no-deps live Python oracle requirement from idna 3.15 to 3.18
- update only the indirect idna block in uv.lock to the same resolved release
- preserve all other feature-branch dependency versions

TEST-EVIDENCE:
- exact PR 1738 synthetic merge af5e4771f: guard RED before fix with live-oracle pin mismatch 3.18 versus 3.15
- exact synthetic merge guard GREEN after the pin change
- focused feature test: 2 passed
- bash ci/local_validate.sh: 9/9 stages green; 13,870 passed, 248 skipped, 1 xfailed
- pre-push Ruff and mypy hooks green

RISK-NOTES:
- lock-only convergence with current main; no runtime source or API behavior changes
- uv lock upgrade changed only idna 3.15 to 3.18 and its source hashes