### PR TITLE
CHAOS-3717: complete Linear AI-attribution destination

### DIFF
--- a/internal/providersync/linear_work_items_ai_attribution_oracle_test.go
+++ b/internal/providersync/linear_work_items_ai_attribution_oracle_test.go
@@ -1,0 +1,70 @@
+package providersync
+
+import (
+	"reflect"
+	"testing"
+)
+
+func linearAIAttributionOracleInput() map[string]any {
+	return map[string]any{
+		"org_id":        "77777777-7777-4777-8777-777777777777",
+		"signal_source": "issue_label",
+		"history":       []any{},
+		"raw_issue": map[string]any{
+			"id": "lin-issue-3717", "identifier": "ENG-3717",
+			"title":       "Codex is discussed, but only the label is attribution",
+			"description": "Generated with Codex is ordinary issue text.",
+			"priority":    2, "createdAt": "2026-08-01T08:00:00Z",
+			"updatedAt": "2026-08-03T09:30:00Z",
+			"state":     map[string]any{"name": "In Progress", "type": "started"},
+			"labels": map[string]any{"nodes": []any{
+				map[string]any{"name": "codex"}, map[string]any{"name": "bug"},
+			}},
+			"assignee": nil, "creator": nil,
+			"team":    map[string]any{"id": "team-eng", "key": "ENG", "name": "Engineering"},
+			"project": nil, "cycle": nil, "parent": nil,
+		},
+	}
+}
+
+func TestLinearAIAttributionMatchesLivePythonProductionRow(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "linear/work-items/ai-attribution",
+		[]oracleCase{{ID: "explicit_codex_issue_label", Input: linearAIAttributionOracleInput()}},
+		buildLinearAIAttributionOracleRow, nil,
+	)
+}
+
+func TestLinearAIAttributionIsRetryStable(t *testing.T) {
+	input := linearAIAttributionOracleInput()
+	first := buildLinearAIAttributionOracleRow(t, input)
+	second := buildLinearAIAttributionOracleRow(t, input)
+	if !reflect.DeepEqual(first, second) || first.RecordID == [16]byte{} {
+		t.Fatalf("attribution changed across retry:\nfirst=%+v\nsecond=%+v", first, second)
+	}
+}
+
+func buildLinearAIAttributionOracleRow(
+	t *testing.T,
+	input map[string]any,
+) githubAIAttributionRow {
+	t.Helper()
+	claim := linearOracleClaim(input)
+	item, _, err := normalizeLinearWorkItem(
+		claim, linearOraclePayload(t, input), linearWorkItemOracleNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := normalizeLinearWorkItemAIAttributions(
+		claim, linearWorkItemRows{WorkItems: []linearWorkItemRow{item}},
+		linearWorkItemOracleNormalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("attribution rows=%d want 1: %+v", len(rows), rows)
+	}
+	return rows[0]
+}

--- a/internal/providersync/linear_work_items_composition_test.go
+++ b/internal/providersync/linear_work_items_composition_test.go
@@ -61,6 +61,7 @@ func (linearFamilyEngine) Derive(
 
 func linearFamilyClaim() Claim {
 	claim := nativeTestClaim("linear", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
 	claim.SourceExternalID = "ENG"
 	since := time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC)
 	before := since.AddDate(0, 0, 1)

--- a/internal/providersync/linear_work_items_derived.go
+++ b/internal/providersync/linear_work_items_derived.go
@@ -13,14 +13,11 @@ import (
 )
 
 // LinearWorkItemDerivedEffectRows is the provider-owned, typed projection for
-// the nine destinations that the real Linear work-item producer can emit from
-// its six normalized facts. AI attribution is an evaluated, explicit empty
-// destination for Linear: the Python work-item job has no Linear
-// AI-attribution producer. It is therefore not represented as an arbitrary
-// row/blob field here; BuildLinearWorkItemDerivedEffects always emits its
-// readback-required empty effect so recovery cannot mistake "not produced" for
-// "not evaluated".
+// the ten destinations that the real Linear work-item producer can emit from
+// its six normalized facts. AI attribution is derived only from explicit issue
+// labels; title and description text are not attribution inputs.
 type LinearWorkItemDerivedEffectRows struct {
+	AIAttributions                 []LinearAIAttributionRow
 	EstimateCoverageMetricsDaily   []LinearEstimateCoverageMetricsDailyRow
 	InvestmentClassificationsDaily []LinearInvestmentClassificationDailyRow
 	InvestmentMetricsDaily         []LinearInvestmentMetricsDailyRow
@@ -48,10 +45,12 @@ var linearWorkItemDerivedEffectDestinations = []string{
 func BuildLinearWorkItemDerivedEffects(
 	rows LinearWorkItemDerivedEffectRows,
 ) ([]EffectBatch, error) {
-	projections := map[string][]json.RawMessage{
-		"ai_attribution": {},
-	}
+	projections := map[string][]json.RawMessage{}
 	var err error
+	projections["ai_attribution"], err = effectRowsFromValues(rows.AIAttributions)
+	if err != nil {
+		return nil, err
+	}
 	projections["estimate_coverage_metrics_daily"], err = effectRowsFromValues(rows.EstimateCoverageMetricsDaily)
 	if err != nil {
 		return nil, err
@@ -119,6 +118,7 @@ func buildLinearWorkItemDerivedEffectsFromMap(
 // builders without copying a second schema that could drift from the real
 // Python dataclasses or ClickHouse migrations.
 type LinearEstimateCoverageMetricsDailyRow = githubEstimateCoverageMetricsDailyRow
+type LinearAIAttributionRow = githubAIAttributionRow
 type LinearInvestmentClassificationDailyRow = githubInvestmentClassificationDailyRow
 type LinearInvestmentMetricsDailyRow = githubInvestmentMetricsDailyRow
 type LinearIssueTypeMetricsDailyRow = githubIssueTypeMetricsDailyRow
@@ -259,9 +259,15 @@ func (deriver LinearWorkItemDeriver) Derive(
 	if err != nil {
 		return nil, err
 	}
-	derived := map[string][]json.RawMessage{
-		"ai_attribution": {},
+	aiAttributions, err := normalizeLinearWorkItemAIAttributions(claim, rows, normalizedAt)
+	if err != nil {
+		return nil, err
 	}
+	aiRows, err := effectRowsFromValues(aiAttributions)
+	if err != nil {
+		return nil, err
+	}
+	derived := map[string][]json.RawMessage{"ai_attribution": aiRows}
 	for _, destination := range githubWorkItemDerivedOwnedDestinations {
 		derived[destination] = []json.RawMessage{}
 	}
@@ -319,6 +325,57 @@ func (deriver LinearWorkItemDeriver) Derive(
 	return derived, nil
 }
 
+var linearAIAttributionLabelKinds = map[string]string{
+	"ai-assisted": "ai_assisted", "agent-created": "agent_created",
+	"ai-review": "ai_review", "copilot": "ai_assisted",
+	"claude-code": "ai_assisted", "codex": "ai_assisted",
+	"cursor": "ai_assisted", "windsurf": "ai_assisted",
+}
+
+func normalizeLinearWorkItemAIAttributions(
+	claim Claim,
+	rows linearWorkItemRows,
+	normalizedAt time.Time,
+) ([]githubAIAttributionRow, error) {
+	if claim.Validate() != nil || claim.Provider != "linear" ||
+		claim.Dataset != "work-items" || normalizedAt.IsZero() {
+		return nil, ErrInvalidConfiguration
+	}
+	tenant, err := uuid.Parse(claim.OrgID)
+	if err != nil {
+		return nil, providerfoundation.ErrInvalidScope
+	}
+	result := make([]githubAIAttributionRow, 0)
+	for _, item := range rows.WorkItems {
+		if item.Provider != "linear" || item.OrgID != claim.OrgID ||
+			item.WorkItemID == "" || item.CreatedAt.IsZero() || item.Labels == nil {
+			return nil, providerfoundation.ErrInvalidScope
+		}
+		for index, label := range item.Labels {
+			kind, matched := linearAIAttributionLabelKinds[strings.ToLower(strings.TrimSpace(label))]
+			if !matched {
+				continue
+			}
+			evidence := map[string]any{"label": label}
+			encodedEvidence, marshalErr := json.Marshal(evidence)
+			if marshalErr != nil {
+				return nil, providerfoundation.ErrNormalizationInvalid
+			}
+			identity := strings.Join([]string{
+				claim.OrgID, item.WorkItemID, "issue_label", fmt.Sprint(index), string(encodedEvidence),
+			}, "|")
+			result = append(result, githubAIAttributionRow{
+				RecordID: uuid.NewSHA1(uuid.NameSpaceURL, []byte(identity)),
+				OrgID:    tenant, Provider: "linear", SubjectType: "issue",
+				SubjectID: item.WorkItemID, RepoID: nil, Kind: kind,
+				Source: "issue_label", Confidence: 0.95, Evidence: evidence,
+				ObservedAt: item.CreatedAt.UTC(), IngestedAt: normalizedAt.UTC(),
+			})
+		}
+	}
+	return result, nil
+}
+
 // linearDerivedGitHubAdapter is a narrow provider adapter around the existing
 // ClickHouse implementations. The underlying adapters retain their exact SQL,
 // coercion, readback, and lease behavior; this wrapper supplies the Linear
@@ -343,10 +400,22 @@ func (adapter linearDerivedGitHubAdapter) validate(
 		return ErrInvalidConfiguration
 	}
 	if adapter.destination == "ai_attribution" {
-		// Linear has no Python AI attribution producer in this work-item job. A
-		// non-empty UUID-based row would not have a valid Linear tenant key.
-		if len(effect.Rows) != 0 {
+		if len(effect.Rows) == 0 {
+			return nil
+		}
+		tenant, parseErr := uuid.Parse(identity.OrgID)
+		if parseErr != nil {
 			return ErrInvalidConfiguration
+		}
+		for _, raw := range effect.Rows {
+			var row githubAIAttributionRow
+			if json.Unmarshal(raw, &row) != nil || row.RecordID == uuid.Nil ||
+				row.OrgID != tenant || row.Provider != "linear" ||
+				row.SubjectType != "issue" || row.SubjectID == "" || row.RepoID != nil ||
+				row.Kind == "" || row.Source != "issue_label" || row.Confidence != 0.95 ||
+				row.Evidence == nil || row.ObservedAt.IsZero() || row.IngestedAt.IsZero() {
+				return ErrInvalidConfiguration
+			}
 		}
 		return nil
 	}

--- a/internal/providersync/linear_work_items_derived_effects_integration_test.go
+++ b/internal/providersync/linear_work_items_derived_effects_integration_test.go
@@ -20,6 +20,7 @@ import (
 func TestLinearDerivedClickHouseEffectsPersistReadBackAndFenceTenants(t *testing.T) {
 	ctx, conn := newWorkItemEffectsConn(t)
 	claim := nativeTestClaim("linear", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
 	now := time.Date(2026, 8, 4, 12, 34, 56, 123456000, time.UTC)
 	effects := linearDerivedIntegrationEffects(t, claim, now)
 	lease := &linearDerivedCountingLease{}
@@ -36,8 +37,7 @@ func TestLinearDerivedClickHouseEffectsPersistReadBackAndFenceTenants(t *testing
 			t.Fatalf("write %s: %v", effect.Destination, err)
 		}
 		inspection, err := sink.InspectEffect(ctx, claim, effect)
-		if err != nil || (effect.Destination != "ai_attribution" && inspection != EffectExact) ||
-			(effect.Destination == "ai_attribution" && inspection != EffectAbsent) {
+		if err != nil || inspection != EffectExact {
 			t.Fatalf("readback %s: inspection=%s error=%v", effect.Destination, inspection, err)
 		}
 	}
@@ -87,46 +87,46 @@ func TestLinearDerivedClickHouseEffectsPersistReadBackAndFenceTenants(t *testing
 func TestLinearDerivedClickHouseEffectsRecoverAfterLeaseLoss(t *testing.T) {
 	ctx, conn := newWorkItemEffectsConn(t)
 	claim := nativeTestClaim("linear", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
 	now := time.Date(2026, 8, 5, 12, 34, 56, 123456000, time.UTC)
 	effects := linearDerivedIntegrationEffects(t, claim, now)
-	var target EffectBatch
-	for _, effect := range effects {
-		if effect.Destination == "work_item_metrics_daily" {
-			target = effect
-			break
-		}
-	}
-	if target.Destination == "" {
-		t.Fatal("fixture omitted work_item_metrics_daily")
-	}
+	byDestination := effectsByDestination(effects)
+	for _, testCase := range []struct {
+		destination string
+		failAt      int
+	}{{"ai_attribution", 2}, {"work_item_metrics_daily", 4}} {
+		t.Run(testCase.destination, func(t *testing.T) {
+			target, ok := byDestination[testCase.destination]
+			if !ok {
+				t.Fatalf("fixture omitted %s", testCase.destination)
+			}
+			// The dispatcher checks before and after its adapter. Losing the lease
+			// on the post-write assertion leaves a durable row but returns an error.
+			lostLease := &linearDerivedCountingLease{failAt: testCase.failAt}
+			lostSink, err := NewLinearWorkItemDerivedClickHouseEffects(conn, lostLease)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := lostSink.WriteEffect(ctx, claim, target); !errors.Is(err, providerfoundation.ErrLeaseLost) {
+				t.Fatalf("lease-loss write error=%v, want ErrLeaseLost", err)
+			}
 
-	// The dispatcher checks before and after its adapter. The adapter checks
-	// before preparing the batch and again before Send. Losing the lease at the
-	// fourth assertion leaves a durable row but returns an error, exactly the
-	// crash window the effect ledger must recover by readback.
-	lostLease := &linearDerivedCountingLease{failAt: 4}
-	lostSink, err := NewLinearWorkItemDerivedClickHouseEffects(conn, lostLease)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := lostSink.WriteEffect(ctx, claim, target); !errors.Is(err, providerfoundation.ErrLeaseLost) {
-		t.Fatalf("lease-loss write error=%v, want ErrLeaseLost", err)
-	}
-
-	recoveredLease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
-	recoveredSink, err := NewLinearWorkItemDerivedClickHouseEffects(conn, recoveredLease)
-	if err != nil {
-		t.Fatal(err)
-	}
-	inspection, err := recoveredSink.InspectEffect(ctx, claim, target)
-	if err != nil || inspection != EffectExact {
-		t.Fatalf("recovery readback: inspection=%s error=%v", inspection, err)
-	}
-	if err := recoveredSink.WriteEffect(ctx, claim, target); err != nil {
-		t.Fatalf("idempotent recovery replay: %v", err)
-	}
-	if inspection, err := recoveredSink.InspectEffect(ctx, claim, target); err != nil || inspection != EffectExact {
-		t.Fatalf("post-replay readback: inspection=%s error=%v", inspection, err)
+			recoveredLease := providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil })
+			recoveredSink, err := NewLinearWorkItemDerivedClickHouseEffects(conn, recoveredLease)
+			if err != nil {
+				t.Fatal(err)
+			}
+			inspection, err := recoveredSink.InspectEffect(ctx, claim, target)
+			if err != nil || inspection != EffectExact {
+				t.Fatalf("recovery readback: inspection=%s error=%v", inspection, err)
+			}
+			if err := recoveredSink.WriteEffect(ctx, claim, target); err != nil {
+				t.Fatalf("idempotent recovery replay: %v", err)
+			}
+			if inspection, err := recoveredSink.InspectEffect(ctx, claim, target); err != nil || inspection != EffectExact {
+				t.Fatalf("post-replay readback: inspection=%s error=%v", inspection, err)
+			}
+		})
 	}
 }
 
@@ -180,6 +180,13 @@ func linearDerivedIntegrationEffects(t *testing.T, claim Claim, now time.Time) [
 	investment.ComputedAt, investment.InvestmentArea = now, &area
 
 	rows := LinearWorkItemDerivedEffectRows{}
+	rows.AIAttributions = []LinearAIAttributionRow{{
+		RecordID: uuid.MustParse("22222222-2222-4222-8222-222222222222"),
+		OrgID:    uuid.MustParse(claim.OrgID), Provider: "linear", SubjectType: "issue",
+		SubjectID: "linear:ENG-100", RepoID: nil, Kind: "ai_assisted",
+		Source: "issue_label", Confidence: 0.95, Evidence: map[string]any{"label": "codex"},
+		ObservedAt: now.Add(-time.Hour), IngestedAt: now,
+	}}
 	rows.EstimateCoverageMetricsDaily = []LinearEstimateCoverageMetricsDailyRow{estimate}
 	rows.WorkItemTeamAttributions = []LinearWorkItemTeamAttributionRow{teamAttribution}
 	rows.WorkItemStateDurationsDaily = []LinearWorkItemStateDurationDailyRow{stateDuration}

--- a/internal/providersync/linear_work_items_derived_test.go
+++ b/internal/providersync/linear_work_items_derived_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/google/uuid"
 )
 
 type linearDerivedEngineStub struct{}
@@ -30,6 +31,7 @@ func (linearDerivedEngineStub) Derive(
 
 func linearDerivedTestClaim() Claim {
 	claim := nativeTestClaim("linear", "work-items")
+	claim.OrgID = "77777777-7777-4777-8777-777777777777"
 	day := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
 	before := day.AddDate(0, 0, 1)
 	claim.SinceAt = &day
@@ -61,7 +63,7 @@ func TestLinearWorkItemDeriverUsesLinearRowsAndEvaluatesAllTenDestinations(t *te
 	row := linearWorkItemRow{
 		WorkItemID: "LIN-1", Provider: "linear", Title: "Repair delivery path",
 		Type: "issue", Status: "todo", CreatedAt: day.Add(time.Hour),
-		UpdatedAt: day.Add(2 * time.Hour), OrgID: claim.OrgID,
+		UpdatedAt: day.Add(2 * time.Hour), Labels: []string{"codex"}, OrgID: claim.OrgID,
 	}
 	source := &fakeGitHubWorkItemDerivationContextSource{}
 	deriver := LinearWorkItemDeriver{
@@ -89,8 +91,17 @@ func TestLinearWorkItemDeriverUsesLinearRowsAndEvaluatesAllTenDestinations(t *te
 			t.Fatalf("destination %q was not evaluated", destination)
 		}
 	}
-	if len(derived["ai_attribution"]) != 0 {
-		t.Fatal("Linear AI attribution is not an implemented producer and must stay explicitly empty")
+	if len(derived["ai_attribution"]) != 1 {
+		t.Fatalf("Linear explicit issue label attribution rows=%d want 1", len(derived["ai_attribution"]))
+	}
+	var attribution LinearAIAttributionRow
+	if err := json.Unmarshal(derived["ai_attribution"][0], &attribution); err != nil {
+		t.Fatal(err)
+	}
+	if attribution.Provider != "linear" || attribution.SubjectType != "issue" ||
+		attribution.SubjectID != "LIN-1" || attribution.RepoID != nil ||
+		attribution.Source != "issue_label" || attribution.OrgID.String() != claim.OrgID {
+		t.Fatalf("Linear attribution lost semantic fence: %+v", attribution)
 	}
 	if len(derived["work_item_metrics_daily"]) == 0 ||
 		len(derived["estimate_coverage_metrics_daily"]) == 0 ||
@@ -243,23 +254,61 @@ func TestLinearDerivedAdapterRequiresProviderAndTenantColumns(t *testing.T) {
 	}
 }
 
-func TestLinearDerivedAdapterRejectsNonEmptyAIEffect(t *testing.T) {
+func TestLinearDerivedAdapterRejectsCrossProviderAIEffect(t *testing.T) {
 	claim := linearDerivedTestClaim()
-	effect, err := BuildEffectBatch(
-		"ai_attribution", EffectReadbackRequired, []json.RawMessage{json.RawMessage(`{"unexpected":true}`)},
-	)
+	base := githubAIAttributionRow{
+		RecordID: uuid.MustParse("11111111-1111-4111-8111-111111111111"),
+		OrgID:    uuid.MustParse(claim.OrgID), Provider: "linear", SubjectType: "issue",
+		SubjectID: "LIN-1", Kind: "ai_assisted", Source: "issue_label", Confidence: 0.95,
+		Evidence: map[string]any{"label": "codex"}, ObservedAt: *claim.SinceAt,
+		IngestedAt: claim.SinceAt.Add(time.Hour),
+	}
+	for _, testCase := range []struct {
+		name   string
+		mutate func(*githubAIAttributionRow)
+	}{
+		{"provider", func(row *githubAIAttributionRow) { row.Provider = "github" }},
+		{"source", func(row *githubAIAttributionRow) { row.Source = "pr_label" }},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			row := base
+			testCase.mutate(&row)
+			raw, err := effectRowsFromValues([]githubAIAttributionRow{row})
+			if err != nil {
+				t.Fatal(err)
+			}
+			effect, err := BuildEffectBatch("ai_attribution", EffectReadbackRequired, raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			identity, err := newLinearWorkItemDerivedEffectIdentity(claim, effect)
+			if err != nil {
+				t.Fatal(err)
+			}
+			adapter := linearDerivedGitHubAdapter{
+				destination: "ai_attribution", delegate: &linearDerivedRecordingAdapter{},
+			}
+			if err := adapter.WriteLinearWorkItemEffect(context.Background(), identity, effect); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("false-provenance AI error=%v want ErrInvalidConfiguration", err)
+			}
+		})
+	}
+}
+
+func TestLinearAIAttributionDoesNotInferFromIssueText(t *testing.T) {
+	claim := linearDerivedTestClaim()
+	rows, err := normalizeLinearWorkItemAIAttributions(claim, linearWorkItemRows{
+		WorkItems: []linearWorkItemRow{{
+			WorkItemID: "linear:ENG-2", Provider: "linear", Title: "Generated with Codex",
+			Description: stringPointer("AI-assisted issue text"), Labels: []string{"bug"},
+			CreatedAt: *claim.SinceAt, UpdatedAt: *claim.SinceAt, OrgID: claim.OrgID,
+		}},
+	}, *claim.BeforeAt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	identity, err := newLinearWorkItemDerivedEffectIdentity(claim, effect)
-	if err != nil {
-		t.Fatal(err)
-	}
-	adapter := linearDerivedGitHubAdapter{
-		destination: "ai_attribution", delegate: &linearDerivedRecordingAdapter{},
-	}
-	if err := adapter.WriteLinearWorkItemEffect(context.Background(), identity, effect); !errors.Is(err, ErrInvalidConfiguration) {
-		t.Fatalf("non-empty AI error=%v want ErrInvalidConfiguration", err)
+	if len(rows) != 0 {
+		t.Fatalf("text-only attribution rows=%+v", rows)
 	}
 }
 

--- a/internal/providersync/testdata/mutation-plans/linear_work_items_derived.json
+++ b/internal/providersync/testdata/mutation-plans/linear_work_items_derived.json
@@ -16,7 +16,7 @@
       "file": "internal/providersync/linear_work_items_derived.go",
       "find": "var linearWorkItemDerivedEffectDestinations = []string{\n\t\"ai_attribution\",",
       "replace": "var linearWorkItemDerivedEffectDestinations = []string{\n\t\"ai_attribution_omitted\",",
-      "rationale": "The recovery manifest must enumerate all ten derived destinations, including the explicit empty AI result; a missing key makes a complete Linear computation appear partial.",
+      "rationale": "The recovery manifest must enumerate all ten derived destinations, including explicit Linear issue-label AI attribution; a missing key makes a complete Linear computation appear partial.",
       "proof": [
         [
           "go",
@@ -114,19 +114,67 @@
       ]
     },
     {
-      "id": "LD7-ai-empty-destination-rejects-rows",
+      "id": "LD7-ai-source-provenance-is-enforced",
       "file": "internal/providersync/linear_work_items_derived.go",
-      "find": "\t\tif len(effect.Rows) != 0 {",
-      "replace": "\t\tif false {",
-      "rationale": "Linear's real Python work-item producer emits no AI attribution rows; a non-empty AI effect must fail closed instead of writing an invented schema row.",
+      "find": "\t\t\t\trow.Kind == \"\" || row.Source != \"issue_label\" || row.Confidence != 0.95 ||",
+      "replace": "\t\t\t\trow.Kind == \"\" || false || row.Confidence != 0.95 ||",
+      "rationale": "A Linear issue-label effect must carry truthful issue_label provenance; accepting another source would authorize a semantically false attribution row under the Linear claim.",
       "proof": [
         [
           "go",
           "test",
           "-count=1",
           "-run",
-          "^TestLinearDerivedAdapterRejectsNonEmptyAIEffect$",
+          "^TestLinearDerivedAdapterRejectsCrossProviderAIEffect$|^TestLinearAIAttributionMatchesLivePythonProductionRow$",
           "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "LD14-ai-producer-reaches-derived-effect",
+      "file": "internal/providersync/linear_work_items_derived.go",
+      "find": "\tderived := map[string][]json.RawMessage{\"ai_attribution\": aiRows}",
+      "replace": "\tderived := map[string][]json.RawMessage{\"ai_attribution\": aiRows[:0]}",
+      "rationale": "An explicit Linear AI issue label must reach the durable derived effect; evaluating the destination as empty would preserve the old false-complete behavior.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestLinearWorkItemDeriverUsesLinearRowsAndEvaluatesAllTenDestinations$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "LD15-non-ai-labels-do-not-become-attribution",
+      "file": "internal/providersync/linear_work_items_derived.go",
+      "find": "\t\t\tif !matched {\n\t\t\t\tcontinue\n\t\t\t}",
+      "replace": "\t\t\tif !matched {\n\t\t\t\tkind = \"ai_assisted\"\n\t\t\t}",
+      "rationale": "Only labels in the fixed canonical AI registry may create attribution; ordinary issue labels and issue text must remain non-signals.",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestLinearAIAttributionDoesNotInferFromIssueText$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "LD16-issue-label-source-is-ranked-by-the-live-view",
+      "file": "src/dev_health_ops/migrations/clickhouse/076_ai_attribution_issue_label.sql",
+      "find": "            source = 'issue_label',     2,",
+      "replace": "            source = 'issue_label',     9,",
+      "rationale": "The authoritative resolved view must recognize issue_label with explicit-label precedence rather than falling through as an unknown source.",
+      "proof": [
+        [
+          "pytest",
+          "-q",
+          "tests/test_migration_076_ai_issue_label.py"
         ]
       ]
     },

--- a/internal/providersync/testdata/oracle_pairs/linear_work-items_ai-attribution.py
+++ b/internal/providersync/testdata/oracle_pairs/linear_work-items_ai-attribution.py
@@ -1,0 +1,57 @@
+"""Live Python oracle for explicit Linear issue-label AI attribution."""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Any
+from uuid import UUID
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dataclass_field_names
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_SOURCE = REPO_ROOT / "src/dev_health_ops/models/ai_attribution.py"
+_NORMALIZE_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/linear/normalize.py"
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    module = load_live_module(_NORMALIZE_SOURCE)
+    from dev_health_ops.providers.identity import IdentityResolver
+    from dev_health_ops.providers.status_mapping import StatusMapping
+
+    item, _ = module.linear_issue_to_work_item(
+        issue=case["raw_issue"],
+        status_mapping=StatusMapping({}, {}, {}, {}),
+        identity=IdentityResolver({}),
+        history=case.get("history", []),
+    )
+    rows = module.linear_work_item_ai_attributions(
+        work_item=item,
+        org_id=UUID(case["org_id"]),
+    )
+    source = case["signal_source"]
+    row = next(candidate for candidate in rows if candidate.source.value == source)
+    return dataclasses.asdict(row)
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="linear/work-items/ai-attribution",
+        build_row=_build_row,
+        reflected_fields=lambda: dataclass_field_names(
+            _MODELS_SOURCE.read_text(), "AIAttributionRecord"
+        ),
+        excluded_fields={
+            "ingested_at": (
+                "the Python record constructor stamps wall-clock now; Go stamps the "
+                "complete unit normalizedAt and tests its retry stability"
+            ),
+            "record_id": (
+                "the Python record constructor assigns uuid4; Go derives a stable "
+                "retry identifier and tests that stability separately"
+            ),
+        },
+    )
+)

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -112,6 +112,7 @@ _NORMALIZE_HELPERS_SOURCE = _source("dev_health_ops/providers/normalize_helpers.
 _DATETIME_SOURCE = _source("dev_health_ops/utils/datetime.py")
 _LINEAR_NORMALIZE_SOURCE = _source("dev_health_ops/providers/linear/normalize.py")
 _LINEAR_PROVIDER_SOURCE = _source("dev_health_ops/providers/linear/provider.py")
+_AI_DETECTION_SOURCE = _source("dev_health_ops/providers/_ai_detection.py")
 _TEAM_AUTOIMPORT_LINEAR_SOURCE = _source(
     "dev_health_ops/workers/team_autoimport_linear.py"
 )
@@ -908,6 +909,10 @@ def _target_linear_normalize() -> None:
     dependency with a hand-authored copy.
     """
     _load_source_module("dev_health_ops.models.work_items", _WORK_ITEMS_MODEL_SOURCE)
+    _load_source_module(
+        "dev_health_ops.models.ai_attribution", _AI_ATTRIBUTION_MODELS_SOURCE
+    )
+    _load_source_module("dev_health_ops.providers._ai_detection", _AI_DETECTION_SOURCE)
     _load_source_module("dev_health_ops.utils.datetime", _DATETIME_SOURCE)
     _load_source_module(
         "dev_health_ops.providers.normalize_helpers", _NORMALIZE_HELPERS_SOURCE

--- a/src/dev_health_ops/migrations/clickhouse/076_ai_attribution_issue_label.sql
+++ b/src/dev_health_ops/migrations/clickhouse/076_ai_attribution_issue_label.sql
@@ -1,0 +1,46 @@
+-- Migration 076: add truthful Linear issue-label AI attribution provenance.
+--
+-- Linear work items can carry the same fixed explicit AI label registry as
+-- pull requests, but persisting that signal as `pr_label` would corrupt its
+-- provenance. `issue_label` is therefore a distinct source. It has the same
+-- explicit-declaration strength as a PR label and sits directly below manual
+-- attribution. Existing source order is otherwise unchanged.
+
+CREATE OR REPLACE VIEW ai_attribution_resolved AS
+SELECT
+    record_id,
+    org_id,
+    provider,
+    subject_type,
+    subject_id,
+    repo_id,
+    kind,
+    source,
+    confidence,
+    actor,
+    evidence,
+    observed_at,
+    ingested_at,
+    superseded_by,
+    computed_at
+FROM (
+    SELECT
+        *,
+        multiIf(
+            source = 'manual',          1,
+            source = 'issue_label',     2,
+            source = 'pr_label',        3,
+            source = 'bot_author',      4,
+            source = 'commit_trailer',  5,
+            source = 'ci_annotation',   6,
+            source = 'branch_name',     7,
+            source = 'pr_body',         8,
+            9
+        ) AS _source_priority
+    FROM ai_attribution FINAL
+    WHERE superseded_by IS NULL
+)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY org_id, subject_type, repo_id, subject_id
+    ORDER BY _source_priority ASC, confidence DESC
+) = 1;

--- a/src/dev_health_ops/models/ai_attribution.py
+++ b/src/dev_health_ops/models/ai_attribution.py
@@ -5,7 +5,7 @@ These types represent both the lightweight *signal* detected at normalization ti
 and the full *record* persisted to ClickHouse.
 
 Source precedence (highest → lowest):
-    MANUAL > PR_LABEL > BOT_AUTHOR > COMMIT_TRAILER > CI_ANNOTATION > BRANCH_NAME > PR_BODY
+    MANUAL > ISSUE_LABEL > PR_LABEL > BOT_AUTHOR > COMMIT_TRAILER > CI_ANNOTATION > BRANCH_NAME > PR_BODY
 
 Write-time: persist every detected signal, deduped on (repo, subject, source).
 Read-time:  the ``ai_attribution_resolved`` view resolves the effective attribution.
@@ -28,7 +28,8 @@ from uuid import UUID, uuid4
 class AIAttributionSource(StrEnum):
     """Where the AI attribution signal came from (ordered by precedence, high→low)."""
 
-    PR_LABEL = "pr_label"  # explicit label on the PR — highest signal
+    ISSUE_LABEL = "issue_label"  # explicit label on an issue/work item
+    PR_LABEL = "pr_label"  # explicit label on a PR
     BOT_AUTHOR = "bot_author"  # GitHub App / known bot user
     COMMIT_TRAILER = "commit_trailer"  # AI-Assisted-By / Co-authored-by AI bot
     BRANCH_NAME = "branch_name"  # weak heuristic signal
@@ -54,12 +55,13 @@ class AIAttributionKind(StrEnum):
 #: Lower integer = higher precedence.  MANUAL wins all others.
 SOURCE_PRECEDENCE: dict[AIAttributionSource, int] = {
     AIAttributionSource.MANUAL: 1,
-    AIAttributionSource.PR_LABEL: 2,
-    AIAttributionSource.BOT_AUTHOR: 3,
-    AIAttributionSource.COMMIT_TRAILER: 4,
-    AIAttributionSource.CI_ANNOTATION: 5,
-    AIAttributionSource.BRANCH_NAME: 6,
-    AIAttributionSource.PR_BODY: 7,
+    AIAttributionSource.ISSUE_LABEL: 2,
+    AIAttributionSource.PR_LABEL: 3,
+    AIAttributionSource.BOT_AUTHOR: 4,
+    AIAttributionSource.COMMIT_TRAILER: 5,
+    AIAttributionSource.CI_ANNOTATION: 6,
+    AIAttributionSource.BRANCH_NAME: 7,
+    AIAttributionSource.PR_BODY: 8,
 }
 
 SubjectType = Literal["pull_request", "commit", "issue", "workflow_run", "review"]
@@ -116,7 +118,7 @@ class AIAttributionRecord:
     """
 
     org_id: UUID
-    provider: str  # github | gitlab | jira | local
+    provider: str  # github | gitlab | jira | linear | local
     subject_type: SubjectType
     subject_id: str  # provider-native id
     repo_id: UUID | None

--- a/src/dev_health_ops/providers/_ai_detection.py
+++ b/src/dev_health_ops/providers/_ai_detection.py
@@ -6,7 +6,7 @@ Each function is a pure parser — no I/O, no side effects.
 
 Signal precedence (resolved at READ time, persisted raw at WRITE time)::
 
-    MANUAL > PR_LABEL > BOT_AUTHOR > COMMIT_TRAILER > CI_ANNOTATION > BRANCH_NAME > PR_BODY
+    MANUAL > ISSUE_LABEL > PR_LABEL > BOT_AUTHOR > COMMIT_TRAILER > CI_ANNOTATION > BRANCH_NAME > PR_BODY
 """
 
 from __future__ import annotations
@@ -37,6 +37,7 @@ __all__ = [
     "AI_TRAILER_KEYS",
     # detection functions
     "detect_from_pr_labels",
+    "detect_from_issue_labels",
     "detect_from_author",
     "detect_from_commit_trailers",
     "detect_from_branch_name",
@@ -49,7 +50,7 @@ __all__ = [
 # Extensible in code only — NOT user-configurable per AGENTS.md.
 # --------------------------------------------------------------------------
 
-# Known AI attribution PR label names (lowercase for comparison).
+# Known explicit AI attribution label names for PRs and issues.
 AI_LABELS: frozenset[str] = frozenset(
     {
         "ai-assisted",
@@ -248,6 +249,22 @@ def detect_from_pr_labels(labels: list[str]) -> list[AIAttributionSignal]:
         List of signals, one per AI-related label found.
         Empty list if no AI labels present.
     """
+    return _detect_from_labels(labels, source=AIAttributionSource.PR_LABEL)
+
+
+def detect_from_issue_labels(labels: list[str]) -> list[AIAttributionSignal]:
+    """Detect AI attribution only from explicit issue label names.
+
+    This deliberately does not inspect issue title or description text. The
+    registry is fixed in code and shared with PR labels, while the distinct
+    source preserves truthful provider provenance.
+    """
+    return _detect_from_labels(labels, source=AIAttributionSource.ISSUE_LABEL)
+
+
+def _detect_from_labels(
+    labels: list[str], *, source: AIAttributionSource
+) -> list[AIAttributionSignal]:
     signals: list[AIAttributionSignal] = []
     for label in labels:
         normalized = label.strip().lower()
@@ -255,7 +272,7 @@ def detect_from_pr_labels(labels: list[str]) -> list[AIAttributionSignal]:
             kind = _LABEL_KIND_MAP.get(normalized, AIAttributionKind.AI_ASSISTED)
             signals.append(
                 AIAttributionSignal(
-                    source=AIAttributionSource.PR_LABEL,
+                    source=source,
                     kind=kind,
                     confidence=0.95,
                     actor=None,

--- a/src/dev_health_ops/providers/base.py
+++ b/src/dev_health_ops/providers/base.py
@@ -122,7 +122,7 @@ class ProviderBatch:
     reopen_events: list[WorkItemReopenEvent] = field(default_factory=list)
     worklogs: list[Worklog] = field(default_factory=list)
     # AI attribution signals detected during provider normalization.
-    # Populated by providers that support AI detection (currently GitHub).
+    # Populated by providers that support AI detection (GitHub and Linear).
     # Records are passed to the ClickHouse sink by the sync orchestrator.
     # NOTE: storage-worker (CHAOS-1579) may add this field too — trivial merge.
     ai_attributions: list[AIAttributionRecord] = field(default_factory=list)

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -6,7 +6,9 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import urlsplit
+from uuid import UUID
 
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
@@ -17,6 +19,7 @@ from dev_health_ops.models.work_items import (
     WorkItemStatusTransition,
     WorkItemType,
 )
+from dev_health_ops.providers._ai_detection import detect_from_issue_labels
 from dev_health_ops.providers.identity import IdentityResolver
 from dev_health_ops.providers.normalize_common import to_utc as _to_utc
 from dev_health_ops.providers.normalize_helpers import get_nested as _get
@@ -243,6 +246,34 @@ def _type_from_labels(labels: list[str]) -> WorkItemType:
     if "chore" in label_lower or "maintenance" in label_lower:
         return "chore"
     return "task"
+
+
+def linear_work_item_ai_attributions(
+    *, work_item: WorkItem, org_id: UUID | str | None
+) -> list[AIAttributionRecord]:
+    """Promote explicit Linear issue labels to persisted AI attribution.
+
+    Labels are the only accepted signal. Title and description text are not
+    inspected, so a discussion of an AI tool cannot become attribution.
+    """
+    signals = detect_from_issue_labels(list(work_item.labels))
+    if not signals:
+        return []
+    if org_id is None:
+        raise ValueError("Linear AI attribution requires org_id")
+    tenant = org_id if isinstance(org_id, UUID) else UUID(org_id)
+    return [
+        AIAttributionRecord.from_signal(
+            signal,
+            org_id=tenant,
+            provider="linear",
+            subject_type="issue",
+            subject_id=work_item.work_item_id,
+            repo_id=None,
+            observed_at=work_item.created_at,
+        )
+        for signal in signals
+    ]
 
 
 def linear_issue_to_work_item(

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -12,6 +12,7 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
@@ -116,6 +117,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
             merged.interactions.extend(batch.interactions)
             merged.sprints.extend(batch.sprints)
             merged.dependencies.extend(batch.dependencies)
+            merged.ai_attributions.extend(batch.ai_attributions)
         return merged
 
     def iter_ingest(self, ctx: IngestionContext) -> Iterable[ProviderBatch]:
@@ -131,6 +133,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
             linear_comment_to_interaction_event,
             linear_cycle_to_sprint,
             linear_issue_to_work_item,
+            linear_work_item_ai_attributions,
         )
 
         client = self._make_client()
@@ -308,6 +311,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                     page_reopen_events: list[WorkItemReopenEvent] = []
                     page_interactions: list[WorkItemInteractionEvent] = []
                     page_dependencies: list[WorkItemDependency] = []
+                    page_ai_attributions: list[AIAttributionRecord] = []
 
                     for issue in issues_page:
                         if ctx.limit is not None and fetched_count >= ctx.limit:
@@ -327,6 +331,11 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                         )
 
                         page_items.append(wi)
+                        page_ai_attributions.extend(
+                            linear_work_item_ai_attributions(
+                                work_item=wi, org_id=ctx.org_id
+                            )
+                        )
                         page_transitions.extend(wi_transitions)
                         page_dependencies.extend(
                             _issue_dependencies(issue, wi.work_item_id)
@@ -360,6 +369,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                         or page_reopen_events
                         or page_interactions
                         or page_dependencies
+                        or page_ai_attributions
                     ):
                         yield ProviderBatch(
                             work_items=page_items,
@@ -367,6 +377,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                             interactions=page_interactions,
                             reopen_events=page_reopen_events,
                             dependencies=page_dependencies,
+                            ai_attributions=page_ai_attributions,
                         )
                         yielded_batch = True
                         fetched_transitions += len(page_transitions)
@@ -390,6 +401,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                         page_reopen_events = []
                         page_interactions = []
                         page_dependencies = []
+                        page_ai_attributions = []
                         for issue in fallback_issues:
                             if ctx.limit is not None and fetched_count >= ctx.limit:
                                 break
@@ -408,6 +420,11 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                                 history=history,
                             )
                             page_items.append(wi)
+                            page_ai_attributions.extend(
+                                linear_work_item_ai_attributions(
+                                    work_item=wi, org_id=ctx.org_id
+                                )
+                            )
                             page_transitions.extend(wi_transitions)
                             page_dependencies.extend(
                                 _issue_dependencies(issue, wi.work_item_id)
@@ -439,6 +456,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                             or page_reopen_events
                             or page_interactions
                             or page_dependencies
+                            or page_ai_attributions
                         ):
                             yield ProviderBatch(
                                 work_items=page_items,
@@ -446,6 +464,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                                 interactions=page_interactions,
                                 reopen_events=page_reopen_events,
                                 dependencies=page_dependencies,
+                                ai_attributions=page_ai_attributions,
                             )
                             yielded_batch = True
                             fetched_transitions += len(page_transitions)

--- a/tests/storage/test_ai_attribution.py
+++ b/tests/storage/test_ai_attribution.py
@@ -521,7 +521,7 @@ class TestResolvedViewPrecedence:
             _resolve_effective([rec])
 
     def test_full_precedence_chain_manual_wins(self) -> None:
-        """All 7 sources present — MANUAL always wins."""
+        """All 8 sources present — MANUAL always wins."""
         sources = list(AIAttributionSource)
         records = [_make_record(source=s, confidence=0.5) for s in sources]
         winner = _resolve_effective(records)

--- a/tests/test_linear_provider.py
+++ b/tests/test_linear_provider.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 from typing import Any
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
 
@@ -24,6 +25,7 @@ from dev_health_ops.providers.linear.normalize import (
     linear_comment_to_interaction_event,
     linear_cycle_to_sprint,
     linear_issue_to_work_item,
+    linear_work_item_ai_attributions,
 )
 from dev_health_ops.providers.linear.provider import LinearProvider
 from dev_health_ops.providers.registry import get_provider, is_registered
@@ -781,6 +783,88 @@ class TestLinearClientWindowFilter:
 
 
 class TestLinearProviderIngest:
+    def test_explicit_issue_labels_emit_ai_attribution_without_text_inference(
+        self,
+        mock_identity: IdentityResolver,
+        mock_status_mapping: StatusMapping,
+    ) -> None:
+        issue = _mock_linear_issue(
+            identifier="ENG-3717",
+            title="Codex is discussed here but is not attribution",
+            description="Generated with Codex is ordinary issue text.",
+            labels=["codex", "bug"],
+        )
+        work_item, _ = linear_issue_to_work_item(
+            issue=issue,
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+        )
+
+        rows = linear_work_item_ai_attributions(
+            work_item=work_item,
+            org_id="77777777-7777-4777-8777-777777777777",
+        )
+
+        assert len(rows) == 1
+        assert rows[0].provider == "linear"
+        assert rows[0].subject_type == "issue"
+        assert rows[0].subject_id == "linear:ENG-3717"
+        assert rows[0].repo_id is None
+        assert str(rows[0].source) == "issue_label"
+        assert rows[0].evidence == {"label": "codex"}
+
+        without_label = _mock_linear_issue(
+            identifier="ENG-3718",
+            title="Codex is discussed here but is not attribution",
+            description="Generated with Codex is ordinary issue text.",
+            labels=["bug"],
+        )
+        plain, _ = linear_issue_to_work_item(
+            issue=without_label,
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+        )
+        assert (
+            linear_work_item_ai_attributions(
+                work_item=plain,
+                org_id="77777777-7777-4777-8777-777777777777",
+            )
+            == []
+        )
+
+    @patch.dict(os.environ, {"LINEAR_API_KEY": "test-api-key"}, clear=False)
+    @patch("dev_health_ops.providers.linear.client.LinearClient.from_env")
+    def test_ingest_carries_issue_label_attribution_in_provider_batch(
+        self,
+        mock_from_env: MagicMock,
+        mock_identity: IdentityResolver,
+        mock_status_mapping: StatusMapping,
+    ) -> None:
+        mock_client = MagicMock()
+        mock_from_env.return_value = mock_client
+        mock_client.iter_teams.return_value = [
+            {"id": "team-1", "key": "ENG", "name": "Engineering"}
+        ]
+        mock_client.iter_cycles.return_value = []
+        mock_client.iter_issues_pages.return_value = [
+            [_mock_linear_issue(identifier="ENG-3717", labels=["codex"])]
+        ]
+        provider = LinearProvider(
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+        )
+
+        batch = provider.ingest(
+            IngestionContext(
+                window=IngestionWindow(),
+                org_id=UUID("77777777-7777-4777-8777-777777777777"),
+            )
+        )
+
+        assert len(batch.ai_attributions) == 1
+        assert batch.ai_attributions[0].subject_id == "linear:ENG-3717"
+        assert str(batch.ai_attributions[0].source) == "issue_label"
+
     @patch.dict(os.environ, {"LINEAR_API_KEY": "test-api-key"}, clear=False)
     @patch("dev_health_ops.providers.linear.client.LinearClient.from_env")
     def test_ingest_all_teams(

--- a/tests/test_migration_076_ai_issue_label.py
+++ b/tests/test_migration_076_ai_issue_label.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from dev_health_ops.models.ai_attribution import (
+    SOURCE_PRECEDENCE,
+    AIAttributionSource,
+)
+
+MIGRATION = Path(
+    "src/dev_health_ops/migrations/clickhouse/076_ai_attribution_issue_label.sql"
+)
+
+
+def test_issue_label_source_has_distinct_typed_precedence() -> None:
+    assert AIAttributionSource.ISSUE_LABEL.value == "issue_label"
+    assert SOURCE_PRECEDENCE[AIAttributionSource.MANUAL] == 1
+    assert SOURCE_PRECEDENCE[AIAttributionSource.ISSUE_LABEL] == 2
+    assert SOURCE_PRECEDENCE[AIAttributionSource.PR_LABEL] == 3
+    assert len(SOURCE_PRECEDENCE.values()) == len(set(SOURCE_PRECEDENCE.values()))
+
+
+def test_migration_076_keeps_repo_scoped_resolution_and_issue_label_priority() -> None:
+    sql = MIGRATION.read_text()
+    assert "source = 'issue_label',     2" in sql
+    assert "source = 'pr_label',        3" in sql
+    assert "PARTITION BY org_id, subject_type, repo_id, subject_id" in sql
+    assert "WHERE superseded_by IS NULL" in sql

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -214,7 +214,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     expected_provider_tests = _providersync_top_level_tests()
     expected_integration_tests = _providersync_integration_tagged_tests()
-    assert len(expected_provider_tests) == 888
+    assert len(expected_provider_tests) == 891
     assert len(expected_integration_tests) == 103
     assert expected_integration_tests < expected_provider_tests
 
@@ -231,7 +231,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     provider_flattened = [
         test_name for tests in provider_assignments.values() for test_name in tests
     ]
-    assert len(provider_flattened) == len(set(provider_flattened)) == 888
+    assert len(provider_flattened) == len(set(provider_flattened)) == 891
     assert set(provider_flattened) == expected_provider_tests
     assert {
         name
@@ -292,7 +292,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
         )
 
     expected_tests = _providersync_top_level_tests()
-    assert len(selected_tests) == len(set(selected_tests)) == 888
+    assert len(selected_tests) == len(set(selected_tests)) == 891
     assert set(selected_tests) == expected_tests
 
 


### PR DESCRIPTION
## Summary

Completes the remaining CHAOS-3717 / CHAOS-3728 Linear derived-destination gap.

- emits typed AI-attribution facts from explicit Linear issue labels only
- introduces semantically accurate `issue_label` provenance rather than mislabeling issue evidence as `pr_label`
- wires the facts through Python provider batches and the Go Linear work-item composition/effect path
- adds ClickHouse migration 076 precedence for issue-label attribution
- keeps taxonomy fixed and explicit; no title/description scanning and no user-configurable categories

TEST-EVIDENCE:
- canonical `bash ci/local_validate.sh`: PASS 9/9; 13,110 passed, 621 skipped, 1 xfailed
- focused Python provider/storage tests: 193 passed
- full `go test ./internal/providersync`: PASS
- `bash ci/check_go.sh live-python-oracles`: PASS, including production Python↔Go Linear AI-attribution parity
- real ClickHouse all-10 destination readback/tenant fence and AI lease-loss recovery: PASS
- shared mutation harness: LD7, LD14, LD15, LD16 all KILLED; restore verified

RISK-NOTES:
- attribution is derived only from explicit Linear issue labels in the fixed canonical registry
- migration changes precedence by adding the new typed `issue_label` source; existing source behavior remains otherwise unchanged
- no deployment, route activation, Compose restart, or live data mutation was performed

Linear: CHAOS-3717, CHAOS-3728