### PR TITLE
CHAOS-3776: defer provider budget contention without attempts

### DIFF
--- a/internal/jobruntime/adapter_test.go
+++ b/internal/jobruntime/adapter_test.go
@@ -48,6 +48,14 @@ func TestAdapterMiddlewareOutcomesAreSafeAndDeterministic(t *testing.T) {
 			wantResult: ResultRetry, wantCategory: CategoryRetryable,
 		},
 		{
+			name: "budget contention snooze at attempt ceiling", attempt: 3,
+			claimState: ClaimProceed,
+			handler: func(context.Context, *Execution[RetentionCleanupArgs]) error {
+				return BudgetContention(errors.New("provider budget contended"), 1500*time.Millisecond)
+			},
+			wantResult: ResultRetry, wantCategory: CategoryBudget,
+		},
+		{
 			name: "discard", attempt: 3, claimState: ClaimProceed,
 			handler: func(context.Context, *Execution[RetentionCleanupArgs]) error {
 				return Retryable(errors.New("credential=do-not-log"))
@@ -136,6 +144,14 @@ func TestAdapterMiddlewareOutcomesAreSafeAndDeterministic(t *testing.T) {
 			var cancelErr *river.JobCancelError
 			if errors.As(err, &cancelErr) != test.wantCancelError {
 				t.Fatalf("cancel wrapper = %v, want %v (err=%v)", errors.As(err, &cancelErr), test.wantCancelError, err)
+			}
+			var snoozeErr *rivertype.JobSnoozeError
+			if test.name == "budget contention snooze at attempt ceiling" {
+				if !errors.As(err, &snoozeErr) || snoozeErr.Duration != 1500*time.Millisecond {
+					t.Fatalf("snooze error = %#v, want 1.5s River snooze", err)
+				}
+			} else if errors.As(err, &snoozeErr) {
+				t.Fatalf("unexpected River snooze: %v", err)
 			}
 			if observer.result != test.wantResult || observer.category != test.wantCategory {
 				t.Fatalf("observed %s/%s, want %s/%s", observer.result, observer.category, test.wantResult, test.wantCategory)

--- a/internal/jobruntime/budget_contention_river_integration_test.go
+++ b/internal/jobruntime/budget_contention_river_integration_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package jobruntime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// TestBudgetContentionSnoozeIsAttemptNeutralInRiver executes the production
+// adapter through a real River client and PostgreSQL row. Unit classification
+// alone cannot prove River applies JobSnoozeError's attempt-neutral database
+// transition.
+func TestBudgetContentionSnoozeIsAttemptNeutralInRiver(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if _, err := pool.Exec(ctx, "CREATE SCHEMA river"); err != nil {
+		t.Fatal(err)
+	}
+	migrator, err := rivermigrate.New(
+		riverpgxv5.New(pool),
+		&rivermigrate.Config{Logger: logger, Schema: "river"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := migrator.Migrate(ctx, rivermigrate.DirectionUp, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	claim := &recordingClaim{state: ClaimProceed}
+	adapter := newRetentionAdapter(
+		t,
+		HandlerFunc[RetentionCleanupArgs](func(context.Context, *Execution[RetentionCleanupArgs]) error {
+			return BudgetContention(errors.New("provider budget contended"), 1500*time.Millisecond)
+		}),
+		&recordingObserver{}, claim, &recordingLease{}, &bytes.Buffer{},
+	)
+	workers := river.NewWorkers()
+	if err := river.AddWorkerSafely(workers, adapter); err != nil {
+		t.Fatal(err)
+	}
+	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
+		FetchCooldown:     500 * time.Millisecond,
+		FetchPollInterval: 500 * time.Millisecond,
+		ID:                "provider-budget-contention-integration",
+		Logger:            logger,
+		Queues: map[string]river.QueueConfig{
+			"retention": {MaxWorkers: 1},
+		},
+		Schema:   "river",
+		TestOnly: true,
+		Workers:  workers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, unsubscribe := client.Subscribe(river.EventKindJobFailed, river.EventKindJobSnoozed)
+	defer unsubscribe()
+	if err := client.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		if err := client.StopAndCancel(stopCtx); err != nil {
+			t.Errorf("stop River client: %v", err)
+		}
+	})
+
+	inserted, err := client.Insert(ctx, retentionJob(t, 1).Args, &river.InsertOpts{
+		MaxAttempts: 3,
+		Priority:    3,
+		Queue:       "retention",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var event *river.Event
+	select {
+	case event = <-events:
+	case <-time.After(15 * time.Second):
+		t.Fatal("River did not publish the snoozed event")
+	}
+	if event == nil || event.Job == nil || event.Job.ID != inserted.Job.ID {
+		t.Fatalf("snooze event does not identify inserted job: %#v", event)
+	}
+	if event.Kind != river.EventKindJobSnoozed {
+		t.Fatalf("River emitted %s instead of an attempt-neutral snooze", event.Kind)
+	}
+	if event.Job.Attempt != 0 || !riverSnoozeStateIsSchedulable(event.Job.State) {
+		t.Fatalf("snooze event attempt/state=%d/%s, want 0 and scheduled or available",
+			event.Job.Attempt, event.Job.State)
+	}
+
+	var storedAttempt int
+	var storedState string
+	var scheduledAt time.Time
+	if err := pool.QueryRow(ctx, `
+SELECT attempt, state::text, scheduled_at
+FROM river.river_job WHERE id = $1`, inserted.Job.ID).Scan(
+		&storedAttempt, &storedState, &scheduledAt,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if storedAttempt != 0 || !riverSnoozeStateIsSchedulable(rivertype.JobState(storedState)) {
+		t.Fatalf("stored attempt/state=%d/%s, want 0 and scheduled or available", storedAttempt, storedState)
+	}
+	if scheduledAt.IsZero() {
+		t.Fatal("snoozed row has no scheduled_at")
+	}
+	if len(claim.completions) != 1 || claim.completions[0] != (Completion{
+		Result: ResultRetry, Category: CategoryBudget,
+	}) {
+		t.Fatalf("domain completion=%#v, want one budget retry", claim.completions)
+	}
+}
+
+func riverSnoozeStateIsSchedulable(state rivertype.JobState) bool {
+	return state == rivertype.JobStateScheduled || state == rivertype.JobStateAvailable
+}

--- a/internal/jobruntime/errors.go
+++ b/internal/jobruntime/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/riverqueue/river"
 )
@@ -42,6 +43,7 @@ type markedError struct {
 	category ErrorCategory
 	cause    error
 	cancel   bool
+	snooze   time.Duration
 }
 
 func (err *markedError) Error() string { return "job error category: " + string(err.category) }
@@ -49,6 +51,26 @@ func (err *markedError) Unwrap() error { return err.cause }
 
 // Retryable marks an expected transient handler failure.
 func Retryable(err error) error { return mark(CategoryRetryable, err, false) }
+
+// BudgetContention marks a short-lived shared-request reservation collision.
+// River snoozes do not count as attempts, so this is distinct from Retryable:
+// healthy sibling work cannot consume a job's bounded failure budget.
+func BudgetContention(err error, delay time.Duration) error {
+	if delay <= 0 {
+		delay = time.Second
+	}
+	return &markedError{category: CategoryBudget, cause: nonNilError(err), snooze: delay}
+}
+
+// SnoozeDelay exposes the typed decision to domain handlers and tests without
+// exposing the internal runtime error representation.
+func SnoozeDelay(err error) (time.Duration, bool) {
+	var marked *markedError
+	if !errors.As(err, &marked) || marked.snooze <= 0 {
+		return 0, false
+	}
+	return marked.snooze, true
+}
 
 // Permanent marks an invalid request or deterministic handler failure that
 // must not be retried.
@@ -64,16 +86,21 @@ func Cancel(err error) error { return mark(CategoryCancelled, err, true) }
 func DomainMismatch(err error) error { return mark(CategoryTenant, err, true) }
 
 func mark(category ErrorCategory, err error, cancel bool) error {
+	return &markedError{category: category, cause: nonNilError(err), cancel: cancel}
+}
+
+func nonNilError(err error) error {
 	if err == nil {
-		err = errors.New("unspecified")
+		return errors.New("unspecified")
 	}
-	return &markedError{category: category, cause: err, cancel: cancel}
+	return err
 }
 
 type decision struct {
 	result   Result
 	category ErrorCategory
 	cancel   bool
+	snooze   time.Duration
 }
 
 func classify(ctx context.Context, err error, attempt, maxAttempts int) decision {
@@ -90,6 +117,9 @@ func classify(ctx context.Context, err error, attempt, maxAttempts int) decision
 	}
 	var marked *markedError
 	if errors.As(err, &marked) {
+		if marked.snooze > 0 {
+			return decision{result: ResultRetry, category: marked.category, snooze: marked.snooze}
+		}
 		if marked.cancel {
 			return decision{result: ResultCancel, category: marked.category, cancel: true}
 		}
@@ -114,6 +144,9 @@ func (err *safeError) Error() string {
 }
 
 func transportError(choice decision) error {
+	if choice.snooze > 0 {
+		return river.JobSnooze(choice.snooze)
+	}
 	safe := &safeError{category: choice.category}
 	if choice.cancel {
 		return river.JobCancel(safe)

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -4,6 +4,8 @@ package providerunit
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,6 +16,7 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 	"github.com/full-chaos/dev-health-ops/internal/platform/logging"
 	"github.com/full-chaos/dev-health-ops/internal/providerfamilycontract"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 	"github.com/full-chaos/dev-health-ops/internal/providersync"
 	"github.com/google/uuid"
 )
@@ -125,6 +128,7 @@ type UnitRepository interface {
 		time.Time,
 	) error
 	ReleaseForRetry(context.Context, providersync.Claim, time.Time) error
+	DeferForBudgetContention(context.Context, providersync.Claim, time.Time, time.Time) error
 	Fail(
 		context.Context,
 		providersync.Claim,
@@ -400,6 +404,22 @@ func (handler *Handler) Work(
 		}
 	}
 	completedAt := handler.now()
+	// A healthy shared request bucket can be full when sibling provider units
+	// overlap. That is scheduling contention, not an execution failure. Persist
+	// the domain deferral before returning River's attempt-neutral snooze so a
+	// process restart keeps the same not-before fence and operator evidence.
+	if errors.Is(err, providerfoundation.ErrBudgetContended) {
+		delay := providerBudgetContentionDelay(session.Claim.ID)
+		availableAt := completedAt.Add(delay)
+		if deferErr := handler.Repository.DeferForBudgetContention(
+			context.WithoutCancel(ctx), session.Claim, availableAt, completedAt,
+		); deferErr != nil {
+			return jobruntime.Retryable(deferErr)
+		}
+		handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultRetrying)
+		handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "deferred", err)
+		return jobruntime.BudgetContention(err, delay)
+	}
 	// A deterministic fault cannot succeed on a later attempt. Burning the
 	// remaining attempts would only delay the outcome and then bury the real
 	// cause under the generic provider_unit_exhausted category.
@@ -441,6 +461,12 @@ func (handler *Handler) Work(
 	handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultRetrying)
 	handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "retrying", err)
 	return jobruntime.Retryable(err)
+}
+
+func providerBudgetContentionDelay(unitID string) time.Duration {
+	digest := sha256.Sum256([]byte(unitID))
+	jitter := time.Duration(binary.BigEndian.Uint64(digest[:8])%1000) * time.Millisecond
+	return time.Second + jitter
 }
 
 func cloneResult(input map[string]any) map[string]any {

--- a/internal/jobs/providerunit/providerunit_test.go
+++ b/internal/jobs/providerunit/providerunit_test.go
@@ -187,6 +187,94 @@ func TestProviderUnitLifecycleLogsRetryAndFailureResults(t *testing.T) {
 	}
 }
 
+func TestProviderBudgetContentionDefersWithoutConsumingTheRiverAttempt(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	unit := providerUnit()
+	repository := newMemoryUnitRepository(unit)
+	handler := &Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			LaunchDarklyFeatureFlags: true,
+		},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: func(*providersync.LeaseSession) (providersync.CompleteRouteExecutor, error) {
+			return providersync.CompleteRouteExecutor{}, providerfoundation.ErrBudgetContended
+		},
+	}
+	execution := providerExecution(unit, now, 5)
+	execution.Definition.MaxAttempts = 5
+
+	err := handler.Work(context.Background(), execution)
+	delay, snoozed := jobruntime.SnoozeDelay(err)
+	if !snoozed || delay < time.Second || delay >= 2*time.Second {
+		t.Fatalf("Work() = %v, delay=%v; want typed 1s <= snooze < 2s", err, delay)
+	}
+	if repository.status != "dispatching" || repository.failures != 0 {
+		t.Fatalf("contention status=%q failures=%d; must defer, not exhaust", repository.status, repository.failures)
+	}
+	if repository.releaseCalls != 0 || repository.contentionDeferrals != 1 {
+		t.Fatalf("ordinary releases=%d contention deferrals=%d; want 0/1",
+			repository.releaseCalls, repository.contentionDeferrals)
+	}
+	if !repository.availableAt.Equal(now.Add(delay)) {
+		t.Fatalf("durable available_at=%v want %v", repository.availableAt, now.Add(delay))
+	}
+}
+
+func TestProviderBudgetStoreUnavailableRemainsAnAttemptFailure(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	unit := providerUnit()
+	repository := newMemoryUnitRepository(unit)
+	handler := &Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			LaunchDarklyFeatureFlags: true,
+		},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: func(*providersync.LeaseSession) (providersync.CompleteRouteExecutor, error) {
+			return providersync.CompleteRouteExecutor{}, providerfoundation.ErrBudgetUnavailable
+		},
+	}
+	execution := providerExecution(unit, now, 5)
+	execution.Definition.MaxAttempts = 5
+
+	err := handler.Work(context.Background(), execution)
+	if _, snoozed := jobruntime.SnoozeDelay(err); snoozed {
+		t.Fatalf("budget-store outage was incorrectly treated as contention: %v", err)
+	}
+	if repository.status != "failed" || repository.lastFailCategory != "provider_unit_exhausted" {
+		t.Fatalf("store outage status=%q category=%q; want bounded failure",
+			repository.status, repository.lastFailCategory)
+	}
+	if repository.contentionDeferrals != 0 {
+		t.Fatalf("store outage wrote %d contention deferrals", repository.contentionDeferrals)
+	}
+}
+
+func TestProviderBudgetContentionDelayIsDeterministicAndBounded(t *testing.T) {
+	t.Parallel()
+	first := providerBudgetContentionDelay("11111111-1111-4111-8111-111111111111")
+	repeated := providerBudgetContentionDelay("11111111-1111-4111-8111-111111111111")
+	sibling := providerBudgetContentionDelay("22222222-2222-4222-8222-222222222222")
+	if first != repeated {
+		t.Fatalf("same unit jitter changed: %v != %v", first, repeated)
+	}
+	for name, delay := range map[string]time.Duration{"first": first, "sibling": sibling} {
+		if delay < time.Second || delay >= 2*time.Second {
+			t.Fatalf("%s delay=%v; want 1s <= delay < 2s", name, delay)
+		}
+	}
+	if first == sibling {
+		t.Fatalf("known sibling units collided at %v; the regression fixture no longer proves spreading", first)
+	}
+}
+
 func TestProviderUnitLifecycleLogsCaptureTraversalFailureDetail(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
@@ -585,16 +673,19 @@ func githubFilesTraversalExecutor(now time.Time) ExecutorFactory {
 }
 
 type memoryUnitRepository struct {
-	mu               sync.Mutex
-	unit             providersync.Unit
-	status           string
-	attempt          int
-	lastClaim        providersync.Claim
-	result           map[string]any
-	watermark        *time.Time
-	failures         int
-	lastFailCategory string
-	releaseErr       error
+	mu                  sync.Mutex
+	unit                providersync.Unit
+	status              string
+	attempt             int
+	lastClaim           providersync.Claim
+	result              map[string]any
+	watermark           *time.Time
+	failures            int
+	lastFailCategory    string
+	releaseErr          error
+	releaseCalls        int
+	contentionDeferrals int
+	availableAt         time.Time
 }
 
 func newMemoryUnitRepository(unit providersync.Unit) *memoryUnitRepository {
@@ -679,12 +770,30 @@ func (repository *memoryUnitRepository) ReleaseForRetry(
 ) error {
 	repository.mu.Lock()
 	defer repository.mu.Unlock()
+	repository.releaseCalls++
 	if repository.releaseErr != nil {
 		return repository.releaseErr
 	}
 	if repository.status != "running" || repository.lastClaim.Owner != claim.Owner {
 		return providersync.ErrLeaseLost
 	}
+	repository.status = "dispatching"
+	return nil
+}
+
+func (repository *memoryUnitRepository) DeferForBudgetContention(
+	_ context.Context,
+	claim providersync.Claim,
+	availableAt time.Time,
+	_ time.Time,
+) error {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	if repository.status != "running" || repository.lastClaim.Owner != claim.Owner {
+		return providersync.ErrLeaseLost
+	}
+	repository.contentionDeferrals++
+	repository.availableAt = availableAt
 	repository.status = "dispatching"
 	return nil
 }

--- a/internal/providerfoundation/budget.go
+++ b/internal/providerfoundation/budget.go
@@ -109,7 +109,7 @@ type ValkeyBudgetStore struct {
 	// Observer records how long Acquire spent asking the shared Valkey store
 	// for a reservation — round-trip and lock-contention latency, not a
 	// client-side backoff sleep (this store never sleeps; a denial is
-	// returned immediately as ErrBudgetUnavailable). It is observed on both
+	// returned immediately as ErrBudgetContended). It is observed on both
 	// the granted and the denied path, since both represent real time this
 	// call spent waiting on the budget subsystem.
 	Observer BudgetWaitObserver
@@ -130,7 +130,7 @@ func (s ValkeyBudgetStore) Acquire(ctx context.Context, key BudgetKey) (Reservat
 		return nil, ErrBudgetUnavailable
 	}
 	if allowed != 1 {
-		return nil, ErrBudgetUnavailable
+		return nil, ErrBudgetContended
 	}
 	return &valkeyReservation{client: s.Client, key: key.String()}, nil
 }

--- a/internal/providerfoundation/budget_wait_integration_test.go
+++ b/internal/providerfoundation/budget_wait_integration_test.go
@@ -4,6 +4,7 @@ package providerfoundation_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -61,6 +62,19 @@ func TestValkeyBudgetStoreAndBackoffGateObserveRealWait(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = reservation.Release(context.Background()) })
 
+	// A full, healthy reservation bucket is contention, not a store outage.
+	// The distinction is what lets the provider-unit worker snooze without
+	// consuming its bounded River attempt budget. Before this regression fix,
+	// both cases returned ErrBudgetUnavailable and five sibling collisions
+	// terminalized a healthy sync unit as provider_unit_exhausted.
+	blocked, err := store.Acquire(ctx, key)
+	if blocked != nil || !errors.Is(err, providerfoundation.ErrBudgetContended) {
+		t.Fatalf("contended Acquire() = %v, %v; want nil, ErrBudgetContended", blocked, err)
+	}
+	if errors.Is(err, providerfoundation.ErrBudgetUnavailable) {
+		t.Fatalf("healthy contention was classified as a budget-store outage: %v", err)
+	}
+
 	gate := providerfoundation.ValkeyBackoffGate{
 		Client: client, Provider: "github", OrgID: "org-1", Host: "api.github.com",
 		MaxBackoff: time.Minute, CostClass: "medium",
@@ -82,8 +96,8 @@ func TestValkeyBudgetStoreAndBackoffGateObserveRealWait(t *testing.T) {
 	}
 
 	text := collector.PrometheusText()
-	if !strings.Contains(text, `worker_budget_wait_seconds_count{provider="github",cost_class="medium"} 2`) {
-		t.Fatalf("expected two non-zero worker_budget_wait_seconds observations (Acquire + Wait), got:\n%s", text)
+	if !strings.Contains(text, `worker_budget_wait_seconds_count{provider="github",cost_class="medium"} 3`) {
+		t.Fatalf("expected three worker_budget_wait_seconds observations (grant + contention + backoff), got:\n%s", text)
 	}
 	if strings.Contains(text, `worker_budget_wait_seconds_sum{provider="github",cost_class="medium"} 0`) {
 		t.Fatalf("expected a non-zero wait sum from the real Penalize/Wait round trip, got:\n%s", text)

--- a/internal/providerfoundation/http.go
+++ b/internal/providerfoundation/http.go
@@ -224,7 +224,13 @@ func (c *HTTPClient) DoUnauthenticated(
 	var reservation Reservation
 	if c.Budget != nil {
 		reservation, err = c.Budget.Acquire(ctx, c.BudgetKey)
-		if err != nil || reservation == nil {
+		if err != nil {
+			if c.Metrics != nil {
+				c.Metrics.RecordBudgetDenied(c.Provider)
+			}
+			return nil, err // Preserve ErrBudgetContended for attempt-neutral snooze.
+		}
+		if reservation == nil {
 			if c.Metrics != nil {
 				c.Metrics.RecordBudgetDenied(c.Provider)
 			}

--- a/internal/providerfoundation/http_regression_test.go
+++ b/internal/providerfoundation/http_regression_test.go
@@ -209,6 +209,28 @@ func TestHTTPClientPreservesRequestAndReleaseFailures(t *testing.T) {
 	}
 }
 
+func TestHTTPClientUnauthenticatedPreservesBudgetContention(t *testing.T) {
+	t.Parallel()
+	client := newTestHTTPClient(t, HTTPDoerFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("contended request reached transport")
+		return nil, nil
+	}), RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond})
+	client.Budget = staticBudgetStore{err: ErrBudgetContended}
+	client.BudgetKey = BudgetKey{
+		Provider: "github", OrgID: "org", CostClass: "rest", Limit: 1, TTL: time.Minute,
+	}
+
+	response, err := client.DoUnauthenticated(
+		context.Background(), http.MethodGet, "https://objects.example.test/artifact",
+	)
+	if response != nil || !errors.Is(err, ErrBudgetContended) {
+		t.Fatalf("response=%v error=%v; want preserved contention", response, err)
+	}
+	if errors.Is(err, ErrBudgetUnavailable) {
+		t.Fatalf("unauthenticated request converted contention into store outage: %v", err)
+	}
+}
+
 func newTestHTTPClient(t *testing.T, doer HTTPDoer, retry RetryPolicy) *HTTPClient {
 	t.Helper()
 	client, err := NewHTTPClient(

--- a/internal/providerfoundation/types.go
+++ b/internal/providerfoundation/types.go
@@ -18,11 +18,15 @@ import (
 )
 
 var (
-	ErrInvalidScope         = errors.New("invalid provider tenant scope")
-	ErrCredentialNotFound   = errors.New("provider credential not found")
-	ErrCredentialInactive   = errors.New("provider credential inactive")
-	ErrCredentialInvalid    = errors.New("provider credential is invalid")
-	ErrLeaseLost            = errors.New("provider lease is no longer valid")
+	ErrInvalidScope       = errors.New("invalid provider tenant scope")
+	ErrCredentialNotFound = errors.New("provider credential not found")
+	ErrCredentialInactive = errors.New("provider credential inactive")
+	ErrCredentialInvalid  = errors.New("provider credential is invalid")
+	ErrLeaseLost          = errors.New("provider lease is no longer valid")
+	// ErrBudgetContended means the shared request reservation store is healthy,
+	// but every slot in this provider/org/host/cost bucket is in use. Callers
+	// must defer without spending their failure-attempt budget.
+	ErrBudgetContended      = errors.New("provider budget contended")
 	ErrBudgetUnavailable    = errors.New("provider budget unavailable")
 	ErrSinkDuplicate        = errors.New("provider sink duplicate has different content")
 	ErrSinkGenerationUnsafe = errors.New("provider sink generation is not safely deduplicated")

--- a/internal/providersync/provider_budget_contention_integration_test.go
+++ b/internal/providersync/provider_budget_contention_integration_test.go
@@ -1,0 +1,139 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestProviderBudgetContentionSurvivesRestartWithoutArmingFinalization proves
+// the reached PostgreSQL state, not only the SQL text. The first repository
+// writes the deferral; a newly constructed repository cannot claim it before
+// available_at, can claim it after, and no finalize row appears while the unit
+// remains nonterminal.
+func TestProviderBudgetContentionSurvivesRestartWithoutArmingFinalization(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	priorEpisodeAt := now.Add(-10 * time.Minute)
+	const priorAttempts = 3
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_units
+SET attempts = $2,
+    result = '{"error_category":"budget_deferred","sentinel":{"kept":true},"provider_budget_contention_deferrals":2}'::json,
+    rate_limit_deferrals = 4,
+    rate_limit_first_seen_at = $3,
+    budget_deferrals = 5,
+    budget_first_deferred_at = $3,
+    first_blocked_at = $3
+WHERE id = $1`, firstUnitID, priorAttempts, priorEpisodeAt); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	availableAt := now.Add(1500 * time.Millisecond)
+	if err := repository.DeferForBudgetContention(ctx, claim, availableAt, now); err != nil {
+		t.Fatal(err)
+	}
+
+	var status, category, retryReason string
+	var storedAvailable time.Time
+	var attempts, contentionDeferrals, rateLimitDeferrals, intrinsicDeferrals, finalizeRows int
+	var rateLimitFirstSeen, intrinsicFirstDeferred, firstBlocked *time.Time
+	var sentinelKept bool
+	if err := pool.QueryRow(ctx, `
+SELECT status, available_at, result::jsonb ->> 'error_category',
+       (result::jsonb ->> 'provider_budget_contention_deferrals')::integer,
+       COALESCE((result::jsonb #>> '{sentinel,kept}')::boolean, false),
+       attempts, rate_limit_deferrals, rate_limit_first_seen_at,
+       budget_deferrals, budget_first_deferred_at, first_blocked_at,
+       COALESCE(last_retry_reason, '')
+FROM public.sync_run_units WHERE id = $1`, firstUnitID).Scan(
+		&status, &storedAvailable, &category, &contentionDeferrals,
+		&sentinelKept, &attempts, &rateLimitDeferrals, &rateLimitFirstSeen,
+		&intrinsicDeferrals, &intrinsicFirstDeferred, &firstBlocked, &retryReason,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if status != "dispatching" || !storedAvailable.Equal(availableAt) ||
+		category != "provider_budget_contention" || contentionDeferrals != 3 ||
+		retryReason != "provider_budget_contention" {
+		t.Fatalf("durable contention state=%q %v %q %d %q",
+			status, storedAvailable, category, contentionDeferrals, retryReason)
+	}
+	if !sentinelKept || attempts != priorAttempts || rateLimitDeferrals != 4 ||
+		rateLimitFirstSeen == nil || !rateLimitFirstSeen.Equal(priorEpisodeAt) ||
+		intrinsicDeferrals != 5 || intrinsicFirstDeferred == nil ||
+		!intrinsicFirstDeferred.Equal(priorEpisodeAt) || firstBlocked == nil ||
+		!firstBlocked.Equal(priorEpisodeAt) {
+		t.Fatalf("preserved state=sentinel:%t attempts:%d rate:%d/%v budget:%d/%v blocked:%v",
+			sentinelKept, attempts, rateLimitDeferrals, rateLimitFirstSeen,
+			intrinsicDeferrals, intrinsicFirstDeferred, firstBlocked)
+	}
+	if err := pool.QueryRow(ctx, `
+SELECT count(*) FROM public.sync_dispatch_outbox
+WHERE sync_run_id = $1::uuid AND kind = 'finalize_sync_run'`, claim.SyncRunID).Scan(&finalizeRows); err != nil {
+		t.Fatal(err)
+	}
+	if finalizeRows != 0 {
+		t.Fatalf("contention armed %d finalize rows while work remains", finalizeRows)
+	}
+
+	restarted, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = restarted.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(),
+		Now: availableAt.Add(-time.Millisecond), LeaseDuration: time.Minute,
+		AllowExpiredRecovery: true,
+	})
+	if !errors.Is(err, ErrUnitNotClaimable) {
+		t.Fatalf("restart claimed before durable available_at: %v", err)
+	}
+	reclaimed, err := restarted.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(),
+		Now: availableAt, LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatalf("restart could not claim at durable available_at: %v", err)
+	}
+	if reclaimed.Attempt != priorAttempts+1 {
+		t.Fatalf("post-deferral attempts=%d, want %d", reclaimed.Attempt, priorAttempts+1)
+	}
+}

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -260,6 +260,31 @@ func (repository *PostgresRepository) ReleaseForRetry(
 	return nil
 }
 
+// DeferForBudgetContention records a healthy request-reservation collision.
+// It is intentionally separate from the Python planner's intrinsic
+// budget_deferred episode: a sibling holding a short-lived HTTP slot says
+// nothing about whether this unit can fit the configured sync budget.
+func (repository *PostgresRepository) DeferForBudgetContention(
+	ctx context.Context,
+	claim Claim,
+	availableAt time.Time,
+	now time.Time,
+) error {
+	if repository == nil || repository.Pool == nil || ctx == nil ||
+		claim.Validate() != nil || now.IsZero() || !availableAt.After(now) ||
+		availableAt.Sub(now) > 5*time.Minute {
+		return ErrInvalidConfiguration
+	}
+	command, err := repository.Pool.Exec(
+		ctx, deferForBudgetContentionSQL,
+		claim.ID, claim.Owner, now.UTC(), availableAt.UTC(),
+	)
+	if err != nil || command.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	return nil
+}
+
 // Fail terminalizes an exhausted unit and arms run finalization.
 func (repository *PostgresRepository) Fail(
 	ctx context.Context,
@@ -347,7 +372,10 @@ WITH candidate AS (
     WHERE unit.id = $1::uuid
       AND run.status NOT IN ('success', 'partial_failed', 'failed')
       AND (
-        unit.status = 'dispatching'
+        (
+          unit.status = 'dispatching'
+          AND (unit.available_at IS NULL OR unit.available_at <= $3)
+        )
         OR (
           $5::boolean
           AND unit.status = 'running'
@@ -536,6 +564,53 @@ SET status = 'dispatching',
     last_heartbeat_at = $3,
     updated_at = $3
 WHERE unit.id = $1::uuid
+  AND unit.status = 'running'
+  AND unit.lease_owner = $2
+  AND unit.lease_expires_at IS NOT NULL
+  AND unit.lease_expires_at > $3`
+
+// deferForBudgetContentionSQL keeps the unit claimable by the SAME snoozed
+// River job after $4, while stale-dispatch repair remains a much later safety
+// net. The distinct result counter survives process restarts and does not
+// increment or clear either existing Python deferral episode. The claim's
+// domain attempt is restored under the same lease CAS because healthy sibling
+// contention is neutral in both River and sync_run_units. The aggregate
+// first_blocked_at clock remains set until SUCCESS.
+const deferForBudgetContentionSQL = `
+WITH contention AS (
+    SELECT unit.id,
+           COALESCE(
+             CASE
+               WHEN jsonb_typeof(unit.result::jsonb) = 'object'
+               THEN (unit.result::jsonb -> 'provider_budget_contention_deferrals')::integer
+               ELSE 0
+             END,
+             0
+           ) + 1 AS next_deferrals
+    FROM public.sync_run_units AS unit
+    WHERE unit.id = $1::uuid
+)
+UPDATE public.sync_run_units AS unit
+SET status = 'dispatching',
+    attempts = GREATEST(unit.attempts - 1, 0),
+    available_at = $4,
+    error = 'provider_budget_contention',
+    result = (
+      COALESCE(unit.result::jsonb, jsonb_build_object()) ||
+      jsonb_build_object(
+        'error_category', 'provider_budget_contention',
+        'not_before', to_jsonb($4::timestamptz),
+        'provider_budget_contention_deferrals', contention.next_deferrals
+      )
+    ),
+    first_blocked_at = COALESCE(unit.first_blocked_at, $3),
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_heartbeat_at = $3,
+    last_retry_reason = 'provider_budget_contention',
+    updated_at = $3
+FROM contention
+WHERE unit.id = contention.id
   AND unit.status = 'running'
   AND unit.lease_owner = $2
   AND unit.lease_expires_at IS NOT NULL

--- a/internal/providersync/repository_postgres_sql_test.go
+++ b/internal/providersync/repository_postgres_sql_test.go
@@ -69,6 +69,50 @@ func TestReleaseForRetrySQLDoesNotClearEpisodeState(t *testing.T) {
 	}
 }
 
+func TestProviderBudgetContentionStampIsDistinctAndDurable(t *testing.T) {
+	for _, required := range []string{
+		"status = 'dispatching'",
+		"attempts = GREATEST(unit.attempts - 1, 0)",
+		"available_at = $4",
+		"COALESCE(unit.result::jsonb, jsonb_build_object()) ||",
+		"'error_category', 'provider_budget_contention'",
+		"'provider_budget_contention_deferrals'",
+		"first_blocked_at = COALESCE(unit.first_blocked_at, $3)",
+		"last_retry_reason = 'provider_budget_contention'",
+	} {
+		if !strings.Contains(deferForBudgetContentionSQL, required) {
+			t.Errorf("deferForBudgetContentionSQL missing %q:\n%s", required, deferForBudgetContentionSQL)
+		}
+	}
+	if strings.Contains(deferForBudgetContentionSQL, "budget_deferrals = unit.budget_deferrals + 1") {
+		t.Fatalf("request-slot contention was charged to the intrinsic planner budget episode:\n%s",
+			deferForBudgetContentionSQL)
+	}
+	for _, column := range episodeClearColumns {
+		name := strings.SplitN(column, " ", 2)[0]
+		if strings.Contains(deferForBudgetContentionSQL, name+" =") {
+			t.Fatalf("contention stamp changes existing %q episode state:\n%s",
+				name, deferForBudgetContentionSQL)
+		}
+	}
+	if preservingErrorCategory(deferForBudgetContentionSQL) {
+		t.Fatalf("contention stamp preserves a prior category; Python could treat it as intrinsic unfitness:\n%s",
+			deferForBudgetContentionSQL)
+	}
+}
+
+func TestClaimHonorsDurableProviderBudgetContentionFence(t *testing.T) {
+	for _, required := range []string{
+		"unit.status = 'dispatching'",
+		"unit.available_at IS NULL OR unit.available_at <= $3",
+	} {
+		if !strings.Contains(claimUnitSQL, required) {
+			t.Errorf("claimUnitSQL missing %q; a restarted worker could bypass available_at:\n%s",
+				required, claimUnitSQL)
+		}
+	}
+}
+
 // preservingErrorCategory reports whether a jsonb result stamp could leave a
 // PRIOR result document's 'error_category' in place. See
 // sqlshape.PreservesPriorResultCategory for the two forbidden shapes and why
@@ -109,9 +153,10 @@ func preservingErrorCategory(sql string) bool {
 // a merge.
 func TestNoUnitStampPreservesAPriorErrorCategory(t *testing.T) {
 	stamps := map[string]string{
-		"completeUnitSQL":    completeUnitSQL,
-		"releaseForRetrySQL": releaseForRetrySQL,
-		"failUnitSQL":        failUnitSQL,
+		"completeUnitSQL":             completeUnitSQL,
+		"releaseForRetrySQL":          releaseForRetrySQL,
+		"deferForBudgetContentionSQL": deferForBudgetContentionSQL,
+		"failUnitSQL":                 failUnitSQL,
 	}
 	measured := 0
 	for name, sql := range stamps {

--- a/internal/providersync/syncunit_budget_exhaustion_oracle_test.go
+++ b/internal/providersync/syncunit_budget_exhaustion_oracle_test.go
@@ -45,11 +45,11 @@ type budgetEpisodeSnapshot struct {
 //
 // It is NOT a production function driven under test, and calling it one would
 // be the inaccurate coverage claim. Go owns no budget-admission decision
-// today: the only budget references in this repository's non-test Go source
-// are the two SQL clears (repository_postgres.go's completeUnitSQL and
-// syncreconciler's markExpiredLeaseRetryingSQL), so there is no production Go
-// producer to drive here instead of this mirror. Adding one would be unwired
-// code pretending to be a second implementation.
+// today. Go now owns short-lived HTTP reservation contention, but that is a
+// distinct provider_budget_contention episode: it clears the intrinsic pair
+// and River snoozes the job. It still does not estimate a unit or decide
+// whether it fits the planner budget, so there is no production Go intrinsic-
+// budget producer to drive here instead of this mirror.
 //
 // "No admission" is too broad and is narrowed here deliberately: Go owns no
 // unit-DISPATCH admission. It does own PLAN-TIME validation of the same
@@ -231,6 +231,16 @@ func budgetExhaustionOracleCases(t *testing.T) []oracleCase {
 			),
 		})
 	}
+	// Request-reservation contention is a real Go budget-related stamp, but it
+	// starts a distinct episode and clears the intrinsic pair. Build the exact
+	// post-stamp field shape, with its category derived from production SQL, so
+	// live Python proves it can never call that state intrinsic unfitness.
+	cases = append(cases, oracleCase{
+		ID: "go_stamp_provider_budget_contention_is_not_intrinsic_exhaustion",
+		Input: snapshot(
+			0, nil, stampedErrorCategory(t, deferForBudgetContentionSQL),
+		),
+	})
 	return cases
 }
 
@@ -287,7 +297,8 @@ func TestBudgetExhaustionPredicateMatchesLivePython(t *testing.T) {
 // while the behaviour was wrong).
 func TestGoStampCategoriesAreNotBudgetDeferred(t *testing.T) {
 	stamps := map[string]string{
-		"releaseForRetrySQL": releaseForRetrySQL,
+		"releaseForRetrySQL":          releaseForRetrySQL,
+		"deferForBudgetContentionSQL": deferForBudgetContentionSQL,
 	}
 	for name, sql := range stamps {
 		if !strings.Contains(sql, "error_category") {

--- a/internal/providersync/testdata/mutation-plans/provider_budget_contention_deferral.json
+++ b/internal/providersync/testdata/mutation-plans/provider_budget_contention_deferral.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 1,
+  "name": "provider request-budget contention deferral",
+  "build": [
+    "env",
+    "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+    "GOWORK=off",
+    "go",
+    "test",
+    "-run",
+    "^$",
+    "-tags",
+    "integration",
+    "./internal/jobruntime",
+    "./internal/jobs/providerunit",
+    "./internal/providerfoundation",
+    "./internal/providersync"
+  ],
+  "mutations": [
+    {
+      "id": "M1-full-bucket-is-store-outage",
+      "file": "internal/providerfoundation/budget.go",
+      "find": "\t\treturn nil, ErrBudgetContended\n",
+      "replace": "\t\treturn nil, ErrBudgetUnavailable\n",
+      "expect_occurrences": 1,
+      "rationale": "A healthy full request bucket must be distinguishable from a Valkey/store failure so the worker can snooze instead of consuming attempts.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-tags",
+          "integration",
+          "-run",
+          "^TestValkeyBudgetStoreAndBackoffGateObserveRealWait$",
+          "./internal/providerfoundation"
+        ]
+      ]
+    },
+    {
+      "id": "M2-handler-skips-contention-deferral",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\tif errors.Is(err, providerfoundation.ErrBudgetContended) {\n",
+      "replace": "\tif false && errors.Is(err, providerfoundation.ErrBudgetContended) {\n",
+      "expect_occurrences": 1,
+      "rationale": "The provider-unit handler must durably defer request contention even on the final River attempt.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestProviderBudgetContentionDefersWithoutConsumingTheRiverAttempt$",
+          "./internal/jobs/providerunit"
+        ]
+      ]
+    },
+    {
+      "id": "M3-snooze-becomes-bounded-retry",
+      "file": "internal/jobruntime/errors.go",
+      "find": "\t\treturn river.JobSnooze(choice.snooze)\n",
+      "replace": "\t\treturn &safeError{category: choice.category}\n",
+      "expect_occurrences": 1,
+      "rationale": "The transport must return River JobSnooze so contention decrements the attempt rather than reaching bounded retry exhaustion.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestAdapterMiddlewareOutcomesAreSafeAndDeterministic$/budget_contention_snooze_at_attempt_ceiling$",
+          "./internal/jobruntime"
+        ]
+      ]
+    },
+    {
+      "id": "M4-contention-masquerades-as-intrinsic-budget-unfitness",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "        'error_category', 'provider_budget_contention',\n",
+      "replace": "        'error_category', 'budget_deferred',\n",
+      "expect_occurrences": 1,
+      "rationale": "Request-slot contention must use a distinct category so Python intrinsic budget exhaustion cannot terminalize it as an oversized unit.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestProviderBudgetContentionStampIsDistinctAndDurable$",
+          "./internal/providersync"
+        ]
+      ]
+    },
+    {
+      "id": "M5-restart-bypasses-not-before-fence",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "          AND (unit.available_at IS NULL OR unit.available_at <= $3)\n",
+      "replace": "          AND TRUE\n",
+      "expect_occurrences": 1,
+      "rationale": "The authoritative claim must honor the durable not-before fence after a worker restart.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-tags",
+          "integration",
+          "-run",
+          "^TestProviderBudgetContentionSurvivesRestartWithoutArmingFinalization$",
+          "./internal/providersync"
+        ]
+      ]
+    },
+    {
+      "id": "M6-contention-charged-to-intrinsic-counter",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "    first_blocked_at = COALESCE(unit.first_blocked_at, $3),\n",
+      "replace": "    budget_deferrals = unit.budget_deferrals + 1,\n    first_blocked_at = COALESCE(unit.first_blocked_at, $3),\n",
+      "expect_occurrences": 1,
+      "rationale": "Short-lived HTTP slot contention must not advance the Python planner's intrinsic budget episode.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-tags",
+          "integration",
+          "-run",
+          "^TestProviderBudgetContentionSurvivesRestartWithoutArmingFinalization$",
+          "./internal/providersync"
+        ]
+      ]
+    },
+    {
+      "id": "M7-deterministic-jitter-collapses",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\tjitter := time.Duration(binary.BigEndian.Uint64(digest[:8])%1000) * time.Millisecond\n",
+      "replace": "\tjitter := time.Duration(binary.BigEndian.Uint64(digest[:8])%1) * time.Millisecond\n",
+      "expect_occurrences": 1,
+      "rationale": "Sibling units must receive deterministic bounded spreading instead of all waking at the same instant.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestProviderBudgetContentionDelayIsDeterministicAndBounded$",
+          "./internal/jobs/providerunit"
+        ]
+      ]
+    },
+    {
+      "id": "M8-store-outage-is-snoozed-as-contention",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "\tif errors.Is(err, providerfoundation.ErrBudgetContended) {\n",
+      "replace": "\tif errors.Is(err, providerfoundation.ErrBudgetContended) || errors.Is(err, providerfoundation.ErrBudgetUnavailable) {\n",
+      "expect_occurrences": 1,
+      "rationale": "A real Valkey/store outage must stay on the bounded retry/error path and must not masquerade as healthy slot contention.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestProviderBudgetStoreUnavailableRemainsAnAttemptFailure$",
+          "./internal/jobs/providerunit"
+        ]
+      ]
+    },
+    {
+      "id": "M9-artifact-request-erases-contention-type",
+      "file": "internal/providerfoundation/http.go",
+      "find": "\t\t\treturn nil, err // Preserve ErrBudgetContended for attempt-neutral snooze.\n",
+      "replace": "\t\t\treturn nil, ErrBudgetUnavailable // Incorrectly erases typed contention.\n",
+      "expect_occurrences": 1,
+      "rationale": "Unauthenticated artifact downloads use the same reservation store and must preserve the typed contention signal instead of converting it to a store outage.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestHTTPClientUnauthenticatedPreservesBudgetContention$",
+          "./internal/providerfoundation"
+        ]
+      ]
+    },
+    {
+      "id": "M10-domain-attempt-remains-consumed",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "    attempts = GREATEST(unit.attempts - 1, 0),\n",
+      "replace": "    attempts = unit.attempts,\n",
+      "expect_occurrences": 1,
+      "rationale": "Healthy sibling contention must restore the SyncRunUnit attempt claimed for this execution, as well as River's transport attempt.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestProviderBudgetContentionStampIsDistinctAndDurable$",
+          "./internal/providersync"
+        ]
+      ]
+    },
+    {
+      "id": "M11-contention-overwrites-durable-result-evidence",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "      COALESCE(unit.result::jsonb, jsonb_build_object()) ||\n      jsonb_build_object(\n        'error_category', 'provider_budget_contention',\n",
+      "replace": "      '{}'::jsonb ||\n      jsonb_build_object(\n        'error_category', 'provider_budget_contention',\n",
+      "expect_occurrences": 1,
+      "rationale": "A contention stamp must preserve prior durable result evidence while its right-hand object replaces only the contention fields.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestProviderBudgetContentionStampIsDistinctAndDurable$",
+          "./internal/providersync"
+        ]
+      ]
+    },
+    {
+      "id": "M12-live-river-snooze-consumes-attempt",
+      "file": "internal/jobruntime/errors.go",
+      "find": "\t\treturn river.JobSnooze(choice.snooze)\n",
+      "replace": "\t\treturn &safeError{category: choice.category}\n",
+      "expect_occurrences": 1,
+      "rationale": "The actual River/PostgreSQL row must return to attempt zero and a schedulable state after the production adapter transports contention.",
+      "proof": [
+        [
+          "env",
+          "GOCACHE=/tmp/provider-budget-contention-mutation-cache",
+          "GOWORK=off",
+          "go",
+          "test",
+          "-count=1",
+          "-tags",
+          "integration",
+          "-run",
+          "^TestBudgetContentionSnoozeIsAttemptNeutralInRiver$",
+          "./internal/jobruntime"
+        ]
+      ]
+    }
+  ]
+}

--- a/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
+++ b/internal/providersync/testdata/oracle_pairs/syncunit_budget_exhaustion.py
@@ -50,12 +50,11 @@ WHAT THIS PAIR IS NOT. It is a PREDICATE-parity check, not a state-machine
 oracle. The Go side of the comparison is a hand-written mirror of this
 predicate (``budgetDeferralExhausted`` in
 internal/providersync/syncunit_budget_exhaustion_oracle_test.go), because Go
-owns no budget-admission decision to drive -- its only budget references in
-non-test source are the two SQL clears. (More precisely, no unit-DISPATCH
-admission: internal/scheduler/sync/materializer.go does validate max_sync_units
-at PLAN time, and providerfoundation/budget.go prepares an advisory-lock key
-that nothing outside tests calls. Neither reads a column this predicate
-reads.) Nothing here executes a Go producer
+owns no intrinsic planner-budget admission decision to drive. Go does own
+short-lived HTTP reservation contention, but records it under the distinct
+``provider_budget_contention`` category and clears the intrinsic episode pair;
+the ``go_stamp_*`` input binds that production stamp to this live predicate.
+Nothing here executes a Go producer
 or reaches a database. The Go stamps' effect on the columns this predicate
 reads is covered by the SQL-string guards and, against real PostgreSQL, by
 internal/providersync/budget_episode_integration_test.go and

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -214,8 +214,8 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     expected_provider_tests = _providersync_top_level_tests()
     expected_integration_tests = _providersync_integration_tagged_tests()
-    assert len(expected_provider_tests) == 891
-    assert len(expected_integration_tests) == 103
+    assert len(expected_provider_tests) == 894
+    assert len(expected_integration_tests) == 104
     assert expected_integration_tests < expected_provider_tests
 
     provider_assignments: dict[int, set[str]] = {}
@@ -231,7 +231,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     provider_flattened = [
         test_name for tests in provider_assignments.values() for test_name in tests
     ]
-    assert len(provider_flattened) == len(set(provider_flattened)) == 891
+    assert len(provider_flattened) == len(set(provider_flattened)) == 894
     assert set(provider_flattened) == expected_provider_tests
     assert {
         name
@@ -292,7 +292,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
         )
 
     expected_tests = _providersync_top_level_tests()
-    assert len(selected_tests) == len(set(selected_tests)) == 891
+    assert len(selected_tests) == len(set(selected_tests)) == 894
     assert set(selected_tests) == expected_tests
 
 


### PR DESCRIPTION
## Summary

Fixes the reproduced local Go-worker failure where healthy sibling request-budget contention consumed all five River and domain attempts in milliseconds.

- distinguishes a healthy full Valkey reservation bucket from a budget-store outage
- persists a bounded `provider_budget_contention` not-before fence without altering intrinsic Python budget/rate-limit episodes
- restores the claimed domain attempt under the same lease CAS
- returns a real River snooze so transport attempts remain neutral
- preserves prior result/effect-ledger evidence and prevents premature finalization
- uses deterministic 1–2s spreading; no provider-limit or retry-count increase

TEST-EVIDENCE:
- exact run mechanism: `9fcfb40f-6f73-4a92-8b7c-4b5a3d94d719`; 7 heavy and 2 medium units exhausted after five sub-200ms contention failures; 77 GitHub budget denials; zero budget/rate-limit deferrals
- real PostgreSQL + Valkey: contention state, prior episode/result preservation, attempt neutrality, restart not-before fence, and no finalize outbox PASS
- real River v0.40 + PostgreSQL: snoozed job stored at attempt 0 and remains schedulable PASS
- live Python-Go intrinsic-budget predicate oracle PASS
- shared mutation harness M1–M12 all KILLED; restore verified
- canonical `bash ci/local_validate.sh`: PASS 9/9; 13,110 passed, 621 skipped, 1 xfailed; 86 ClickHouse migrations
- live sharding discovery: 894 top-level / 104 integration-tagged; focused sharding contracts PASS

RISK-NOTES:
- Valkey/store faults remain ordinary retryable failures
- provider request limits remain unchanged
- no Compose restart, deployment, route activation, or live database write was performed

Linear: CHAOS-3776