### PR TITLE
CHAOS-3777: preserve valid GitHub test reports

### DIFF
--- a/internal/providersync/complete_route_comparator.go
+++ b/internal/providersync/complete_route_comparator.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"time"
 )
 
 // ProductionContractComparator enforces the runtime invariants whose output
@@ -19,6 +20,11 @@ func (ProductionContractComparator) CompareCompleteRoute(
 	if ctx == nil || claim.Validate() != nil || batch.Result == nil {
 		return ShadowComparison{}, ErrInvalidConfiguration
 	}
+	if claim.Provider == "github" && (claim.Dataset == "tests" || claim.Dataset == "cicd") {
+		if err := validateGitHubTestsCompletion(claim, batch); err != nil {
+			return ShadowComparison{}, err
+		}
+	}
 	records := 0
 	for _, effect := range batch.Effects {
 		for _, row := range effect.Rows {
@@ -34,6 +40,46 @@ func (ProductionContractComparator) CompareCompleteRoute(
 		NativeRecords: records,
 		PythonRecords: records,
 	}, nil
+}
+
+func validateGitHubTestsCompletion(claim Claim, batch CompleteRouteBatch) error {
+	complete, completeOK := batch.Result["reports_complete"].(bool)
+	skipped, skippedOK := batch.Result["reports_skipped"].(int)
+	incomplete, incompleteOK := batch.Result["incomplete"].([]GitHubTestsIncomplete)
+	if !completeOK || !skippedOK || !incompleteOK || skipped < 0 ||
+		githubTestsIncompleteCount(incomplete) != skipped {
+		return ErrInvalidConfiguration
+	}
+	seen := map[string]bool{}
+	for _, observation := range incomplete {
+		key := observation.Component + "\x00" + observation.Cause
+		if observation.Component != "report_member" ||
+			(observation.Cause != "malformed" && observation.Cause != "unreadable") ||
+			observation.Count < 1 || seen[key] {
+			return ErrInvalidConfiguration
+		}
+		seen[key] = true
+	}
+	if complete != (skipped == 0) || complete != (len(incomplete) == 0) {
+		return ErrInvalidConfiguration
+	}
+	if !complete {
+		if batch.Watermark != nil {
+			return ErrInvalidConfiguration
+		}
+		return nil
+	}
+	if !sameOptionalTime(batch.Watermark, claim.BeforeAt) {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
+func sameOptionalTime(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
 }
 
 var _ CompleteRouteComparator = ProductionContractComparator{}

--- a/internal/providersync/github_tests_effects_integration_test.go
+++ b/internal/providersync/github_tests_effects_integration_test.go
@@ -13,7 +13,84 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
 )
+
+func TestGitHubTestsIncompleteBatchCommitsOnceAndRemainsTenantScoped(t *testing.T) {
+	ctx, sink := newGitHubTestsIntegrationSink(t)
+	now := time.Date(2026, 8, 12, 12, 30, 0, 0, time.UTC)
+	claimA := nativeTestClaim("github", "tests")
+	claimB := claimA
+	claimB.OrgID = "other-org"
+	claimB.ID = uuid.NewString()
+	claimB.SyncRunID = uuid.NewString()
+
+	archive := githubTestsZip(t, map[string]string{
+		"reports/good.xml":  githubTestsJUnitFixture,
+		"reports/good.info": githubTestsLCOVFixture,
+		"reports/bad.xml":   `<!DOCTYPE x [<!ENTITY x "boom">]><testsuite>&x;</testsuite>`,
+	})
+	collect := func(claim Claim) CompleteRouteBatch {
+		t.Helper()
+		doer := &githubTestsRouteDoer{t: t, archive: archive}
+		batch, err := (GitHubTestsRouteHandler{}).Collect(
+			ctx, claim, providerfoundation.Credential{}, githubTestsClient(t, doer), now,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		comparison, err := (ProductionContractComparator{}).CompareCompleteRoute(ctx, claim, batch)
+		if err != nil || !comparison.Match || comparison.NativeRecords != 7 {
+			t.Fatalf("comparison=%+v error=%v", comparison, err)
+		}
+		if batch.Watermark != nil || batch.Result["reports_complete"] != false ||
+			batch.Result["reports_skipped"] != 1 {
+			t.Fatalf("incomplete batch was reported complete: %+v", batch)
+		}
+		return batch
+	}
+
+	batchA, batchB := collect(claimA), collect(claimB)
+	if err := sink.WriteEffect(ctx, claimB, batchA.Effects[0]); !errors.Is(err, providerfoundation.ErrInvalidScope) {
+		t.Fatalf("foreign tenant row error=%v", err)
+	}
+	for _, item := range []struct {
+		claim Claim
+		batch CompleteRouteBatch
+	}{
+		{claim: claimA, batch: batchA},
+		{claim: claimB, batch: batchB},
+	} {
+		ledger := &memoryEffectLedger{}
+		committer := EffectCommitter{
+			Ledger: ledger, Sink: sink, Readback: sink,
+			Now: func() time.Time { return now },
+		}
+		first, err := committer.Commit(ctx, item.claim, item.batch.Effects, now)
+		if err != nil || first.Written != 6 {
+			t.Fatalf("first commit=%+v error=%v", first, err)
+		}
+		second, err := committer.Commit(ctx, item.claim, item.batch.Effects, now)
+		if err != nil || second.Written != 0 || second.Skipped != 6 {
+			t.Fatalf("retry commit=%+v error=%v", second, err)
+		}
+		for _, effect := range item.batch.Effects {
+			inspection, inspectErr := sink.InspectEffect(ctx, item.claim, effect)
+			if inspectErr != nil || inspection != EffectExact {
+				t.Fatalf("%s inspection=%s error=%v", effect.Destination, inspection, inspectErr)
+			}
+			var count uint64
+			if err := sink.Conn.QueryRow(
+				ctx, "SELECT count() FROM "+effect.Destination+" WHERE org_id = ?", item.claim.OrgID,
+			).Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != uint64(len(effect.Rows)) {
+				t.Fatalf("%s raw rows=%d want=%d", effect.Destination, count, len(effect.Rows))
+			}
+		}
+	}
+}
 
 func TestGitHubTestsMultiRowEffectsAreAtomicAndRejectDuplicateNaturalKeys(t *testing.T) {
 	ctx, sink := newGitHubTestsIntegrationSink(t)

--- a/internal/providersync/github_tests_generic_oracle_test.go
+++ b/internal/providersync/github_tests_generic_oracle_test.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -120,33 +121,80 @@ func githubTestsOracleTimes(t *testing.T, input map[string]any) (*time.Time, *ti
 	return parse("started_at"), parse("finished_at"), time.Date(2026, 7, 23, 12, 10, 0, 0, time.UTC)
 }
 
+func githubTestsOracleReportRows(t *testing.T, input map[string]any) githubTestsReportRows {
+	t.Helper()
+	members := map[string]string{"reports/junit.xml": githubTestsJUnitFixture}
+	body := githubTestsLCOVFixture
+	path := "reports/lcov.info"
+	if value, ok := input["lcov"].(string); ok {
+		body = value
+	}
+	if value, ok := input["coverage"].(string); ok {
+		body = value
+	}
+	if value, ok := input["coverage_name"].(string); ok {
+		path = value
+	}
+	members[path] = body
+	malformed, _ := input["malformed_report"].(bool)
+	if malformed {
+		members["reports/malformed.xml"] = `<!DOCTYPE x [<!ENTITY x "boom">]><testsuite>&x;</testsuite>`
+	}
+	started, finished, normalizedAt := githubTestsOracleTimes(t, input)
+	rows, err := parseGitHubTestsArtifact(
+		githubTestsZip(t, members), input["repo_id"].(string),
+		input["run_id"].(string), input["org_id"].(string),
+		started, finished, normalizedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSkipped := 0
+	wantIncomplete := []GitHubTestsIncomplete{}
+	if malformed {
+		wantSkipped = 1
+		wantIncomplete = []GitHubTestsIncomplete{{
+			Component: "report_member", Cause: "malformed", Count: 1,
+		}}
+	}
+	incomplete, optional := rows.optionalIncomplete()
+	if !optional || rows.Skipped != wantSkipped ||
+		!reflect.DeepEqual(incomplete, wantIncomplete) {
+		t.Fatalf("skipped=%d incomplete=%+v optional=%t", rows.Skipped, incomplete, optional)
+	}
+	return rows
+}
+
+func githubTestsMalformedReportOracleCase() oracleCase {
+	testCase := githubTestsOracleCase()
+	testCase.ID = "malformed_report_preserves_valid_members"
+	testCase.Input["malformed_report"] = true
+	return testCase
+}
+
 func TestGenericOracleMatchesLivePythonForGitHubTestsSuiteRow(t *testing.T) {
-	compareRowsAgainstPythonOracle(t, "github/tests/suite", []oracleCase{githubTestsOracleCase()},
+	compareRowsAgainstPythonOracle(t, "github/tests/suite", []oracleCase{
+		githubTestsOracleCase(), githubTestsMalformedReportOracleCase(),
+	},
 		func(t *testing.T, input map[string]any) testSuiteResultRow {
-			started, finished, normalizedAt := githubTestsOracleTimes(t, input)
-			suites, _, err := parseJUnitRows(
-				[]byte(githubTestsJUnitFixture), input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string),
-				started, finished, normalizedAt,
-			)
-			if err != nil || len(suites) != 1 {
-				t.Fatalf("suites=%+v error=%v", suites, err)
+			rows := githubTestsOracleReportRows(t, input)
+			if len(rows.Suites) != 1 {
+				t.Fatalf("suites=%+v", rows.Suites)
 			}
-			return suites[0]
+			return rows.Suites[0]
 		}, githubTestsOracleGoOnlyFields)
 }
 
 func TestGenericOracleMatchesLivePythonForGitHubTestsCaseRow(t *testing.T) {
-	compareRowsAgainstPythonOracle(t, "github/tests/case", []oracleCase{githubTestsOracleCase()},
+	compareRowsAgainstPythonOracle(t, "github/tests/case", []oracleCase{
+		githubTestsOracleCase(), githubTestsMalformedReportOracleCase(),
+	},
 		func(t *testing.T, input map[string]any) testCaseResultRow {
-			started, finished, normalizedAt := githubTestsOracleTimes(t, input)
-			_, cases, err := parseJUnitRows(
-				[]byte(githubTestsJUnitFixture), input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string),
-				started, finished, normalizedAt,
-			)
-			if err != nil || len(cases) != 2 {
-				t.Fatalf("cases=%+v error=%v", cases, err)
+			rows := githubTestsOracleReportRows(t, input)
+			if len(rows.Cases) != 2 {
+				t.Fatalf("cases=%+v", rows.Cases)
 			}
-			return cases[1]
+			return rows.Cases[1]
 		}, githubTestsOracleGoOnlyFields)
 }
 
@@ -164,27 +212,14 @@ func TestGenericOracleMatchesLivePythonForGitHubTestsCoverageRow(t *testing.T) {
 	cobertura.Input["coverage_name"] = "reports/coverage.xml"
 	cobertura.Input["coverage"] = `<coverage lines-valid="2" lines-covered="1" branches-valid="2" branches-covered="1"><packages><package><classes><class filename="services/api/main.go"><lines><line number="1" hits="1" branch="true" condition-coverage="50% (1/2)"/><line number="2" hits="0"/></lines></class></classes></package></packages></coverage>`
 	compareRowsAgainstPythonOracle(t, "github/tests/coverage", []oracleCase{
-		githubTestsOracleCase(), fallback, majority, cobertura,
+		githubTestsOracleCase(), githubTestsMalformedReportOracleCase(),
+		fallback, majority, cobertura,
 	},
 		func(t *testing.T, input map[string]any) coverageSnapshotRow {
-			_, _, normalizedAt := githubTestsOracleTimes(t, input)
-			body := githubTestsLCOVFixture
-			path := "reports/lcov.info"
-			if value, ok := input["lcov"].(string); ok {
-				body = value
+			rows := githubTestsOracleReportRows(t, input)
+			if len(rows.Coverage) != 1 {
+				t.Fatalf("coverage=%+v", rows.Coverage)
 			}
-			if value, ok := input["coverage"].(string); ok {
-				body = value
-			}
-			if value, ok := input["coverage_name"].(string); ok {
-				path = value
-			}
-			row, err := parseGitHubCoverageRow(
-				[]byte(body), path, input["repo_id"].(string), input["run_id"].(string), input["org_id"].(string), normalizedAt,
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			return row
+			return rows.Coverage[0]
 		}, githubTestsOracleGoOnlyFields)
 }

--- a/internal/providersync/github_tests_reports.go
+++ b/internal/providersync/github_tests_reports.go
@@ -93,6 +93,50 @@ type githubTestsReportRows struct {
 	Cases    []testCaseResultRow
 	Coverage []coverageSnapshotRow
 	Skipped  int
+	issues   []githubTestsReportIssue
+}
+
+// GitHubTestsIncomplete is the bounded, provider-specific evidence retained
+// when one report member cannot be parsed but other members remain valid. It
+// deliberately records a stable local cause and count, never the untrusted
+// archive member name or parser text.
+type GitHubTestsIncomplete struct {
+	Component string `json:"component"`
+	Cause     string `json:"cause"`
+	Count     int    `json:"count"`
+}
+
+type githubTestsReportIssue struct {
+	evidence GitHubTestsIncomplete
+	blocking bool
+}
+
+func (rows *githubTestsReportRows) recordSkipped(cause string, blocking bool) {
+	rows.Skipped++
+	for index := range rows.issues {
+		issue := &rows.issues[index]
+		if issue.evidence.Cause == cause && issue.blocking == blocking {
+			issue.evidence.Count++
+			return
+		}
+	}
+	rows.issues = append(rows.issues, githubTestsReportIssue{
+		evidence: GitHubTestsIncomplete{
+			Component: "report_member", Cause: cause, Count: 1,
+		},
+		blocking: blocking,
+	})
+}
+
+func (rows githubTestsReportRows) optionalIncomplete() ([]GitHubTestsIncomplete, bool) {
+	result := make([]GitHubTestsIncomplete, 0, len(rows.issues))
+	for _, issue := range rows.issues {
+		if issue.blocking {
+			return nil, false
+		}
+		result = append(result, issue.evidence)
+	}
+	return result, true
 }
 
 type lcovFileMetrics struct {
@@ -174,11 +218,11 @@ func parseGitHubTestsArtifact(
 			continue
 		}
 		if processed >= githubTestsMaxReportsPerRun {
-			result.Skipped++
+			result.recordSkipped("report_cap", true)
 			continue
 		}
 		if member.UncompressedSize64 > githubTestsMaxReportBytes || expanded+member.UncompressedSize64 > githubTestsMaxArchiveBytes {
-			result.Skipped++
+			result.recordSkipped("archive_bounds", true)
 			continue
 		}
 		compressed := member.CompressedSize64
@@ -190,7 +234,7 @@ func parseGitHubTestsArtifact(
 		}
 		body, err := readZipReport(member)
 		if err != nil {
-			result.Skipped++
+			result.recordSkipped("unreadable", false)
 			continue
 		}
 		expanded += uint64(len(body))
@@ -203,7 +247,7 @@ func parseGitHubTestsArtifact(
 		case "junit":
 			suites, cases, err := parseJUnitRows(body, repoID, runID, orgID, startedAt, finishedAt, normalizedAt)
 			if err != nil {
-				result.Skipped++
+				result.recordSkipped("malformed", false)
 				continue
 			}
 			result.Suites = append(result.Suites, suites...)
@@ -211,7 +255,7 @@ func parseGitHubTestsArtifact(
 		case "coverage":
 			coverage, err := parseGitHubCoverageRow(body, name, repoID, runID, orgID, normalizedAt)
 			if err != nil {
-				result.Skipped++
+				result.recordSkipped("malformed", false)
 				continue
 			}
 			result.Coverage = append(result.Coverage, coverage)

--- a/internal/providersync/github_tests_reports_test.go
+++ b/internal/providersync/github_tests_reports_test.go
@@ -83,6 +83,55 @@ func TestGitHubTestsArtifactSkipsMalformedMemberWithoutDroppingValidReports(t *t
 	if rows.Skipped != 1 || len(rows.Coverage) != 1 || len(rows.Suites) != 0 {
 		t.Fatalf("rows=%+v", rows)
 	}
+	incomplete, optional := rows.optionalIncomplete()
+	if !optional || len(incomplete) != 1 || incomplete[0] != (GitHubTestsIncomplete{
+		Component: "report_member", Cause: "malformed", Count: 1,
+	}) {
+		t.Fatalf("incomplete=%+v optional=%t", incomplete, optional)
+	}
+}
+
+func TestGitHubTestsArtifactSkipsUnreadableMemberWithoutDroppingValidReports(t *testing.T) {
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for name, body := range map[string]string{
+		"reports/good.info": githubTestsLCOVFixture,
+		"reports/bad.xml":   `<testsuite name="corrupt"><testcase name="lost"/></testsuite>`,
+	} {
+		header := &zip.FileHeader{Name: name, Method: zip.Store}
+		member, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := member.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	archive := buffer.Bytes()
+	marker := []byte(`<testsuite name="corrupt">`)
+	index := bytes.Index(archive, marker)
+	if index < 0 {
+		t.Fatal("corrupt member payload not found")
+	}
+	archive[index] ^= 0x01
+
+	rows, err := parseGitHubTestsArtifact(
+		archive, "c7198fbc-1945-3717-05d8-eb78866b4e79", "9001", "org-a",
+		nil, nil, time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	incomplete, optional := rows.optionalIncomplete()
+	if rows.Skipped != 1 || len(rows.Coverage) != 1 || len(rows.Suites) != 0 ||
+		!optional || len(incomplete) != 1 || incomplete[0] != (GitHubTestsIncomplete{
+		Component: "report_member", Cause: "unreadable", Count: 1,
+	}) {
+		t.Fatalf("rows=%+v incomplete=%+v optional=%t", rows, incomplete, optional)
+	}
 }
 
 func TestGitHubTestsArchiveMemberNameMatchesPythonSafetyContract(t *testing.T) {

--- a/internal/providersync/github_tests_route.go
+++ b/internal/providersync/github_tests_route.go
@@ -203,6 +203,7 @@ func (handler GitHubTestsRouteHandler) Collect(
 	suites := make([]testSuiteResultRow, 0)
 	cases := make([]testCaseResultRow, 0)
 	coverage := make([]coverageSnapshotRow, 0)
+	incomplete := make([]GitHubTestsIncomplete, 0)
 	requests, pages := 1+runsPage.Pages+artifactRunsPage.Pages, runsPage.Pages+artifactRunsPage.Pages
 	policyCache := map[string]githubTestsPolicy{}
 	for _, raw := range runsPage.Items {
@@ -302,8 +303,15 @@ func (handler GitHubTestsRouteHandler) Collect(
 				continue
 			}
 			rows, parseErr := parseGitHubTestsArtifact(archive, repoID, pipeline.RunID, claim.OrgID, pipeline.StartedAtPtr(), pipeline.FinishedAt, normalizedAt)
-			if parseErr != nil || rows.Skipped != 0 {
+			if parseErr != nil {
 				return CompleteRouteBatch{}, fmt.Errorf("%w: reports skipped=%d: %v", ErrGitHubTestsIncomplete, rows.Skipped, parseErr)
+			}
+			reportIncomplete, optional := rows.optionalIncomplete()
+			if !optional {
+				return CompleteRouteBatch{}, fmt.Errorf("%w: reports skipped=%d: unsafe archive bounds", ErrGitHubTestsIncomplete, rows.Skipped)
+			}
+			for _, observation := range reportIncomplete {
+				incomplete = mergeGitHubTestsIncomplete(incomplete, observation)
 			}
 			suites = append(suites, rows.Suites...)
 			cases = append(cases, rows.Cases...)
@@ -314,10 +322,38 @@ func (handler GitHubTestsRouteHandler) Collect(
 	if err != nil {
 		return CompleteRouteBatch{}, err
 	}
-	return CompleteRouteBatch{Effects: effects, Watermark: claim.BeforeAt, Result: map[string]any{
+	watermark := claim.BeforeAt
+	if len(incomplete) > 0 {
+		watermark = nil
+	}
+	return CompleteRouteBatch{Effects: effects, Watermark: watermark, Result: map[string]any{
 		"pipeline_runs_synced": len(pipelines), "job_runs_synced": len(jobs), "acceptance_checks_synced": len(acceptance),
 		"test_suites_synced": len(suites), "test_cases_synced": len(cases), "coverage_snapshots_synced": len(coverage), "repo": repo.FullName,
+		"reports_complete": len(incomplete) == 0,
+		"reports_skipped":  githubTestsIncompleteCount(incomplete),
+		"incomplete":       incomplete,
 	}, Evidence: FetchEvidence{Provider: claim.Provider, Dataset: claim.Dataset, Requests: requests, Pages: pages, Records: len(pipelines) + len(jobs) + len(acceptance) + len(suites) + len(cases) + len(coverage)}}, nil
+}
+
+func mergeGitHubTestsIncomplete(
+	current []GitHubTestsIncomplete,
+	observation GitHubTestsIncomplete,
+) []GitHubTestsIncomplete {
+	for index := range current {
+		if current[index].Component == observation.Component && current[index].Cause == observation.Cause {
+			current[index].Count += observation.Count
+			return current
+		}
+	}
+	return append(current, observation)
+}
+
+func githubTestsIncompleteCount(incomplete []GitHubTestsIncomplete) int {
+	total := 0
+	for _, observation := range incomplete {
+		total += observation.Count
+	}
+	return total
 }
 
 func (row githubTestsPipelineRow) StartedAtPtr() *time.Time { value := row.StartedAt; return &value }

--- a/internal/providersync/github_tests_route_test.go
+++ b/internal/providersync/github_tests_route_test.go
@@ -2,6 +2,7 @@ package providersync
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -188,6 +189,107 @@ func TestGitHubTestsRouteFetchFailureCannotCommitEffectsOrWatermark(t *testing.T
 	}
 	if len(batch.Effects) != 0 || batch.Watermark != nil {
 		t.Fatalf("partial batch=%+v", batch)
+	}
+}
+
+func TestGitHubTestsRoutePreservesValidReportsAndRecordsSkippedMember(t *testing.T) {
+	now := time.Date(2026, 8, 12, 12, 30, 0, 0, time.UTC)
+	doer := &githubTestsRouteDoer{t: t, archive: githubTestsZip(t, map[string]string{
+		"reports/good.xml":  githubTestsJUnitFixture,
+		"reports/good.info": githubTestsLCOVFixture,
+		"reports/bad.xml":   `<!DOCTYPE x [<!ENTITY x "boom">]><testsuite>&x;</testsuite>`,
+	})}
+	claim := nativeTestClaim("github", "tests")
+	batch, err := (GitHubTestsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		githubTestsClient(t, doer), now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[string]int{}
+	for _, effect := range batch.Effects {
+		counts[effect.Destination] = len(effect.Rows)
+	}
+	if counts["test_suite_results"] != 1 || counts["test_case_results"] != 2 ||
+		counts["coverage_snapshots"] != 1 {
+		t.Fatalf("valid report rows were lost: %v", counts)
+	}
+	if batch.Watermark != nil {
+		t.Fatalf("incomplete report inventory advanced watermark=%v", batch.Watermark)
+	}
+	encoded, marshalErr := json.Marshal(batch.Result)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	var durable struct {
+		ReportsComplete bool                    `json:"reports_complete"`
+		ReportsSkipped  int                     `json:"reports_skipped"`
+		Incomplete      []GitHubTestsIncomplete `json:"incomplete"`
+	}
+	if err := json.Unmarshal(encoded, &durable); err != nil {
+		t.Fatal(err)
+	}
+	wantIncomplete := []GitHubTestsIncomplete{{
+		Component: "report_member", Cause: "malformed", Count: 1,
+	}}
+	if durable.ReportsComplete || durable.ReportsSkipped != 1 ||
+		!reflect.DeepEqual(durable.Incomplete, wantIncomplete) {
+		t.Fatalf("durable result=%+v", durable)
+	}
+	if batch.Result["reports_complete"] != false || batch.Result["reports_skipped"] != 1 {
+		t.Fatalf("result=%+v", batch.Result)
+	}
+	comparison, compareErr := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, batch,
+	)
+	if compareErr != nil || !comparison.Match || comparison.NativeRecords != 7 ||
+		comparison.PythonRecords != 7 {
+		t.Fatalf("comparison=%+v error=%v", comparison, compareErr)
+	}
+	invalidWatermark := batch
+	invalidWatermark.Watermark = claim.BeforeAt
+	if _, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, invalidWatermark,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("incomplete watermark comparison error=%v", err)
+	}
+	invalidCount := batch
+	invalidCount.Result = make(map[string]any, len(batch.Result))
+	for key, value := range batch.Result {
+		invalidCount.Result[key] = value
+	}
+	invalidCount.Result["reports_skipped"] = 2
+	if _, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, invalidCount,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("inconsistent skipped count comparison error=%v", err)
+	}
+	invalidComplete := batch
+	invalidComplete.Result = make(map[string]any, len(batch.Result))
+	for key, value := range batch.Result {
+		invalidComplete.Result[key] = value
+	}
+	invalidComplete.Result["reports_complete"] = true
+	if _, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, invalidComplete,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("false complete comparison error=%v", err)
+	}
+}
+
+func TestGitHubTestsRouteUnsafeArchiveFailureRemainsFailClosed(t *testing.T) {
+	doer := &githubTestsRouteDoer{t: t, archive: []byte("not a zip archive")}
+	claim := nativeTestClaim("github", "tests")
+	batch, err := (GitHubTestsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		githubTestsClient(t, doer), time.Now(),
+	)
+	if !errors.Is(err, ErrGitHubTestsIncomplete) {
+		t.Fatalf("error=%v", err)
+	}
+	if len(batch.Effects) != 0 || batch.Watermark != nil || batch.Result != nil {
+		t.Fatalf("unsafe archive returned partial batch=%+v", batch)
 	}
 }
 

--- a/internal/providersync/testdata/mutation-plans/github_tests_reports.json
+++ b/internal/providersync/testdata/mutation-plans/github_tests_reports.json
@@ -506,6 +506,160 @@
           "producer_actuals_share_tests_estimator_admission_identity"
         ]
       ]
+    },
+    {
+      "id": "T31-optional-report-member-preserved",
+      "file": "internal/providersync/github_tests_route.go",
+      "find": "if !optional {",
+      "replace": "if optional && len(reportIncomplete) > 0 {",
+      "rationale": "a bounded malformed or unreadable member must record incompleteness while valid rows in the same archive remain committable",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsRoutePreservesValidReportsAndRecordsSkippedMember$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T32-unsafe-archive-parse-fails-closed",
+      "file": "internal/providersync/github_tests_route.go",
+      "find": "if parseErr != nil {",
+      "replace": "if false {",
+      "rationale": "a globally unreadable archive is not one bounded report-member omission and must return no effects or watermark",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsRouteUnsafeArchiveFailureRemainsFailClosed$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T33-incomplete-report-withholds-watermark",
+      "file": "internal/providersync/github_tests_route.go",
+      "find": "if len(incomplete) > 0 {",
+      "replace": "if false {",
+      "rationale": "partial report effects may land, but the unit watermark must remain retryable until every report member is readable",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsRoutePreservesValidReportsAndRecordsSkippedMember$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T34-comparator-rejects-incomplete-watermark",
+      "file": "internal/providersync/complete_route_comparator.go",
+      "find": "if batch.Watermark != nil {",
+      "replace": "if false {",
+      "rationale": "the production comparator must reject an incomplete batch that claims durable progress",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsRoutePreservesValidReportsAndRecordsSkippedMember$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T35-comparator-counts-incomplete-evidence",
+      "file": "internal/providersync/complete_route_comparator.go",
+      "find": "githubTestsIncompleteCount(incomplete) != skipped {",
+      "replace": "false {",
+      "rationale": "the reported skipped count must equal the bounded typed evidence that explains why coverage is incomplete",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsRoutePreservesValidReportsAndRecordsSkippedMember$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T36-incomplete-effects-reject-foreign-tenant",
+      "file": "internal/providersync/github_tests_effects_clickhouse.go",
+      "find": "orgID != claim.OrgID",
+      "replace": "false",
+      "rationale": "preserved partial effects must retain the same tenant boundary and cannot be written under another claim",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-tags=integration",
+          "-run",
+          "^TestGitHubTestsIncompleteBatchCommitsOnceAndRemainsTenantScoped$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T37-incomplete-evidence-reaches-durable-result",
+      "file": "internal/providersync/github_tests_route.go",
+      "find": "\"incomplete\":       incomplete,",
+      "replace": "\"incomplete\":       []GitHubTestsIncomplete{},",
+      "rationale": "best-effort continuation is safe only when the typed omission evidence survives the JSON encoding written to the durable unit result",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsRoutePreservesValidReportsAndRecordsSkippedMember$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T38-incomplete-result-cannot-claim-complete",
+      "file": "internal/providersync/github_tests_route.go",
+      "find": "\"reports_complete\": len(incomplete) == 0,",
+      "replace": "\"reports_complete\": true,",
+      "rationale": "a skipped report member must remain explicitly incomplete in the durable unit result",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsRoutePreservesValidReportsAndRecordsSkippedMember$",
+          "./internal/providersync/"
+        ]
+      ]
+    },
+    {
+      "id": "T39-unreadable-member-has-typed-evidence",
+      "file": "internal/providersync/github_tests_reports.go",
+      "find": "result.recordSkipped(\"unreadable\", false)",
+      "replace": "result.recordSkipped(\"malformed\", false)",
+      "rationale": "a bounded member read failure must preserve other rows and remain distinguishable from report parse failure in durable evidence",
+      "proof": [
+        [
+          "go",
+          "test",
+          "-count=1",
+          "-run",
+          "^TestGitHubTestsArtifactSkipsUnreadableMemberWithoutDroppingValidReports$",
+          "./internal/providersync/"
+        ]
+      ]
     }
   ]
 }

--- a/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
+++ b/internal/providersync/testdata/oracle_pairs/_github_tests_common.py
@@ -66,22 +66,41 @@ def build_rows(
 ]:
     started = datetime.fromisoformat(case["started_at"].replace("Z", "+00:00"))
     finished = datetime.fromisoformat(case["finished_at"].replace("Z", "+00:00"))
-    return asyncio.run(
-        ingest_report_members(
-            [
-                ("reports/junit.xml", JUNIT.encode()),
-                (
-                    case.get("coverage_name", "reports/lcov.info"),
-                    case.get("coverage", case.get("lcov", LCOV)).encode(),
-                ),
-            ],
-            repo_id=uuid.UUID(case["repo_id"]),
-            run_id=case["run_id"],
-            org_id=case["org_id"],
-            started_at=started.astimezone(timezone.utc),
-            finished_at=finished.astimezone(timezone.utc),
+    members = [("reports/junit.xml", JUNIT.encode())]
+    if case.get("malformed_report"):
+        members.append(
+            (
+                "reports/malformed.xml",
+                b'<!DOCTYPE x [<!ENTITY x "boom">]><testsuite>&x;</testsuite>',
+            )
+        )
+    members.append(
+        (
+            case.get("coverage_name", "reports/lcov.info"),
+            case.get("coverage", case.get("lcov", LCOV)).encode(),
         )
     )
+    # The generic oracle protocol owns stdout and stderr. The active producer
+    # logs each best-effort parse failure, so suppress only that output while
+    # still executing the production function and comparing its returned rows.
+    captured = io.StringIO()
+    logger = _ingest_module.logger
+    was_disabled = logger.disabled
+    logger.disabled = True
+    try:
+        with contextlib.redirect_stdout(captured), contextlib.redirect_stderr(captured):
+            return asyncio.run(
+                ingest_report_members(
+                    members,
+                    repo_id=uuid.UUID(case["repo_id"]),
+                    run_id=case["run_id"],
+                    org_id=case["org_id"],
+                    started_at=started.astimezone(timezone.utc),
+                    finished_at=finished.astimezone(timezone.utc),
+                )
+            )
+    finally:
+        logger.disabled = was_disabled
 
 
 def build_pipeline_rows(case: dict[str, Any]):

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -214,8 +214,8 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     expected_provider_tests = _providersync_top_level_tests()
     expected_integration_tests = _providersync_integration_tagged_tests()
-    assert len(expected_provider_tests) == 894
-    assert len(expected_integration_tests) == 104
+    assert len(expected_provider_tests) == 898
+    assert len(expected_integration_tests) == 105
     assert expected_integration_tests < expected_provider_tests
 
     provider_assignments: dict[int, set[str]] = {}
@@ -231,7 +231,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     provider_flattened = [
         test_name for tests in provider_assignments.values() for test_name in tests
     ]
-    assert len(provider_flattened) == len(set(provider_flattened)) == 894
+    assert len(provider_flattened) == len(set(provider_flattened)) == 898
     assert set(provider_flattened) == expected_provider_tests
     assert {
         name
@@ -292,7 +292,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
         )
 
     expected_tests = _providersync_top_level_tests()
-    assert len(selected_tests) == len(set(selected_tests)) == 894
+    assert len(selected_tests) == len(set(selected_tests)) == 898
     assert set(selected_tests) == expected_tests
 
 


### PR DESCRIPTION
## Summary

Fixes the reproduced Go tests-route failure where one malformed or unreadable report member discarded an otherwise-valid unit.

- preserves valid suite, case, coverage, pipeline, job, and acceptance-check effects around a bounded bad member
- records typed incomplete evidence (`report_member` + `malformed`/`unreadable` count)
- sets `reports_complete=false` and withholds the coverage watermark so partial evidence cannot advance completeness
- keeps archive bounds, report caps, global parse errors, and pagination truncation fail-closed
- leaves all page caps unchanged

TEST-EVIDENCE:
- exact baseline RED on commit c971f2392: route failed `github tests inventory incomplete: reports skipped=1: <nil>`
- production Python live differential oracle: Go matches Python best-effort valid-row preservation around malformed members
- production comparator rejects forged completeness, count, and watermark claims
- real ClickHouse: all six effects commit once, retry is 0 written/6 skipped, same natural keys remain tenant-scoped, and foreign-tenant write is rejected
- shared mutation harness T31–T39 all KILLED; restore verified
- canonical `bash ci/local_validate.sh`: PASS 9/9; 13,110 passed, 621 skipped, 1 xfailed; 86 ClickHouse migrations
- live sharding discovery: 898 top-level / 105 integration-tagged; all six sharding contracts PASS

RISK-NOTES:
- partial report evidence is intentionally non-watermarking and observable, not silently complete
- no page-cap increase, broad error suppression, restart, deployment, route activation, or live database mutation

Linear: CHAOS-3777