### PR TITLE
CHAOS-3799: recover stranded provider-unit deliveries

### DIFF
--- a/cmd/dev-health-reconciler/dependencies.go
+++ b/cmd/dev-health-reconciler/dependencies.go
@@ -315,7 +315,7 @@ func buildReconcilerRelay(
 	riverSchema string,
 	registry *jobruntime.Registry,
 ) (joboutbox.RelayStepper, error) {
-	_ = domainPool // the relay has no domain-role component today
+	_ = domainPool // provider-unit recovery reads domain state through the queue role
 	repository, err := joboutbox.NewRepository(queuePool)
 	if err != nil {
 		return nil, err
@@ -332,7 +332,13 @@ func buildReconcilerRelay(
 	if err != nil {
 		return nil, err
 	}
-	return joboutbox.NewRelayWithRoutes(repository, inserter, routes, joboutbox.DefaultRelayConfig())
+	repair, err := joboutbox.NewTerminalDeliveryRepair(queuePool, riverSchema)
+	if err != nil {
+		return nil, err
+	}
+	return joboutbox.NewRelayWithRoutesAndRecovery(
+		repository, inserter, routes, repair, joboutbox.DefaultRelayConfig(),
+	)
 }
 
 type reconcilerDependencies struct {

--- a/cmd/dev-health-reconciler/dependencies_test.go
+++ b/cmd/dev-health-reconciler/dependencies_test.go
@@ -39,6 +39,20 @@ func TestProductionMutationPipelineConstructsTerminalDeliveryRepair(t *testing.T
 	}
 }
 
+func TestProductionGenericRelayConstructsProviderUnitTerminalDeliveryRepair(t *testing.T) {
+	source, err := os.ReadFile("dependencies.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	if strings.Count(text, "joboutbox.NewTerminalDeliveryRepair(queuePool, riverSchema)") != 1 {
+		t.Fatal("production generic relay does not construct provider-unit terminal delivery repair")
+	}
+	if strings.Count(text, "joboutbox.NewRelayWithRoutesAndRecovery(") != 1 {
+		t.Fatal("production generic relay does not run recovery before ordinary relay")
+	}
+}
+
 func TestReconcilerMissingDependenciesStayLiveAndFailReadinessWithoutValues(t *testing.T) {
 	secret := "postgresql://queue:do-not-print@database.internal/app"
 	sources := productionReconcilerDependencySources

--- a/docs/operate/configure/workers-and-schedules.md
+++ b/docs/operate/configure/workers-and-schedules.md
@@ -72,6 +72,30 @@ Before changing a route:
 6. update the deployment profile and connection budget;
 7. verify operator, health, metrics, and audit behavior.
 
+### Recover a discarded provider delivery
+
+The Go reconciler automatically repairs a provider-unit delivery only when the
+exact River job was discarded by the unhandled-kind rescue path and the
+authoritative sync run and unit are still active, due, and unleased. This can
+happen during a rolling deployment when a temporary worker set does not yet
+register the provider handler. Pausing an integration prevents new planning;
+it does not cancel work already planned for an active run.
+
+Recovery rearms the same durable outbox row and creates one replacement River
+job. It does not reset provider evidence or domain attempts, and it excludes
+canceled or terminal runs and units, ordinary provider failures, and exhausted
+River jobs. Monitor:
+
+```text
+worker_outbox_reconciler_terminal_deliveries_recovered_total
+```
+
+An increase paired with a deployment is expected recovery. Repeated increases
+without a deployment indicate workers are still starting without the complete
+checked-in handler registry. Do not rewrite queue rows manually. Cancel the
+sync run only when the user intends to abandon the remaining work; cancellation
+is not a substitute for repairing a recoverable transport delivery.
+
 ## Schedules
 
 Celery Beat remains required for current production schedules. The Go scheduler foundation can evaluate bounded schedule timing for comparison, but it does not currently own organization entitlement, mutation, lease repair, or production publication.

--- a/internal/joboperator/postgres_backend.go
+++ b/internal/joboperator/postgres_backend.go
@@ -183,7 +183,7 @@ func (backend *PostgresBackend) Retry(ctx context.Context, id int64, mutation Mu
 		return JobSummary{}, err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
-	if err := backend.lockCurrentSyncDispatchDelivery(ctx, tx, id); err != nil {
+	if err := backend.lockCurrentDelivery(ctx, tx, id); err != nil {
 		return JobSummary{}, err
 	}
 	if err := backend.compareLockedState(ctx, tx, id, mutation.ExpectedState); err != nil {
@@ -203,12 +203,12 @@ func (backend *PostgresBackend) Retry(ctx context.Context, id int64, mutation Mu
 	return summary, nil
 }
 
-// lockCurrentSyncDispatchDelivery serializes an audited retry with terminal
-// delivery recovery. Coordinator jobs are only retryable while the durable
-// outbox still names that exact River row. Locking the outbox before the River
-// row matches the reconciler's lock order and prevents an old job plus a new
+// lockCurrentDelivery serializes an audited retry with terminal delivery
+// recovery. Recoverable jobs are only retryable while their durable outbox
+// still names that exact River row. Locking the outbox before the River row
+// matches both reconcilers' lock order and prevents an old job plus a new
 // outbox attempt from becoming runnable together.
-func (backend *PostgresBackend) lockCurrentSyncDispatchDelivery(
+func (backend *PostgresBackend) lockCurrentDelivery(
 	ctx context.Context,
 	tx pgx.Tx,
 	id int64,
@@ -220,17 +220,28 @@ func (backend *PostgresBackend) lockCurrentSyncDispatchDelivery(
 		}
 		return err
 	}
-	if !isSyncDispatchKind(kind) {
+	var outboxID string
+	var err error
+	switch {
+	case isSyncDispatchKind(kind):
+		err = tx.QueryRow(ctx, `
+			SELECT id::text
+			FROM public.sync_dispatch_outbox
+			WHERE transport_job_id = ($1::bigint)::text
+				AND kind = $2
+				AND status = 'dispatched'
+			FOR UPDATE`, id, kind).Scan(&outboxID)
+	case kind == jobcontract.KindSyncProviderUnit:
+		err = tx.QueryRow(ctx, `
+			SELECT id::text
+			FROM public.worker_job_outbox
+			WHERE river_job_id = $1
+				AND job_kind = $2
+				AND status = 'delivered'
+			FOR UPDATE`, id, kind).Scan(&outboxID)
+	default:
 		return nil
 	}
-	var outboxID string
-	err := tx.QueryRow(ctx, `
-		SELECT id::text
-		FROM public.sync_dispatch_outbox
-		WHERE transport_job_id = ($1::bigint)::text
-			AND kind = $2
-			AND status = 'dispatched'
-		FOR UPDATE`, id, kind).Scan(&outboxID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ErrStateConflict
 	}

--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -162,6 +162,25 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	providerJobID := insertOperatorProviderUnitIntegrationJob(t, ctx, adminPool, registry, now)
+	if _, err := backend.Retry(ctx, providerJobID, Mutation{ExpectedState: StateDiscarded}); err != nil {
+		t.Fatalf("current provider-unit delivery retry: %v", err)
+	}
+	if _, err := adminPool.Exec(ctx, `
+		UPDATE river.river_job
+		SET state = 'discarded', finalized_at = $2
+		WHERE id = $1`, providerJobID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adminPool.Exec(ctx, `
+		UPDATE public.worker_job_outbox
+		SET status = 'pending', river_job_id = NULL
+		WHERE river_job_id = $1`, providerJobID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.Retry(ctx, providerJobID, Mutation{ExpectedState: StateDiscarded}); !errors.Is(err, ErrStateConflict) {
+		t.Fatalf("stale provider-unit delivery retry error=%v, want ErrStateConflict", err)
+	}
 	auditor, err := NewPostgresAuditor(adminPool)
 	if err != nil {
 		t.Fatal(err)
@@ -339,7 +358,8 @@ func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pg
 			id uuid PRIMARY KEY,
 			state text NOT NULL,
 			job_kind text,
-			status text
+			status text,
+			river_job_id bigint UNIQUE
 		)`,
 		"CREATE TABLE public.worker_job_delivery_abandonments (dedupe_key text PRIMARY KEY)",
 		"CREATE TABLE public.worker_job_completion_fences (completion_key text PRIMARY KEY)",
@@ -484,6 +504,74 @@ func insertOperatorIntegrationJob(
 		t.Fatal(err)
 	}
 	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return jobID
+}
+
+func insertOperatorProviderUnitIntegrationJob(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	registry joboutbox.PolicyRegistry,
+	now time.Time,
+) int64 {
+	t.Helper()
+	organizationID := "00000000-0000-4000-8000-000000000310"
+	unitID := "00000000-0000-4000-8000-000000000311"
+	envelope := jobcontract.Envelope{
+		ContractVersion: 1,
+		OrganizationID:  &organizationID,
+		CorrelationID:   "sync-run:00000000-0000-4000-8000-000000000312",
+		IdempotencyKey:  "sync.provider_unit:" + unitID,
+		Domain: jobcontract.DomainLink{
+			Type: "sync_run_unit",
+			ID:   unitID,
+		},
+		Payload: jobcontract.ProviderUnitPayload{UnitID: unitID},
+	}
+	encoded, err := jobcontract.MarshalCanonical(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(encoded)
+	inserter, err := joboutbox.NewRiverInserter(pool, "river", registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	outboxID := "00000000-0000-4000-8000-000000000313"
+	jobID, err := inserter.Insert(ctx, tx, joboutbox.Row{
+		ID:              outboxID,
+		DedupeKey:       envelope.IdempotencyKey,
+		JobKind:         jobcontract.KindSyncProviderUnit,
+		ContractVersion: 1,
+		Args:            encoded,
+		PayloadHash:     "sha256:" + hex.EncodeToString(digest[:]),
+		Queue:           "sync_provider",
+		Priority:        2,
+		MaxAttempts:     5,
+		ScheduledAt:     now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO public.worker_job_outbox (id, state, job_kind, status, river_job_id)
+		VALUES ($1, 'current', $2, 'delivered', $3)`, outboxID, jobcontract.KindSyncProviderUnit, jobID); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE river.river_job
+		SET state = 'discarded', finalized_at = $2
+		WHERE id = $1`, jobID, now); err != nil {
 		t.Fatal(err)
 	}
 	return jobID

--- a/internal/joboutbox/inserter.go
+++ b/internal/joboutbox/inserter.go
@@ -57,6 +57,7 @@ func (inserter *RiverInserter) Insert(ctx context.Context, tx pgx.Tx, row Row) (
 	if err != nil {
 		return 0, ErrContractRejected
 	}
+	uniqueStates := uniqueStatesForKind(row.JobKind)
 	result, err := inserter.client.InsertTx(ctx, tx, args, &river.InsertOpts{
 		Queue:       descriptor.Queue,
 		Priority:    descriptor.Priority,
@@ -65,7 +66,7 @@ func (inserter *RiverInserter) Insert(ctx context.Context, tx pgx.Tx, row Row) (
 		Metadata:    metadata,
 		UniqueOpts: river.UniqueOpts{
 			ByArgs:  true,
-			ByState: rivertype.JobStates(),
+			ByState: uniqueStates,
 		},
 	})
 	if err != nil {
@@ -75,6 +76,16 @@ func (inserter *RiverInserter) Insert(ctx context.Context, tx pgx.Tx, row Row) (
 		return 0, err
 	}
 	return result.Job.ID, nil
+}
+
+func uniqueStatesForKind(kind string) []rivertype.JobState {
+	if kind == jobcontract.KindSyncProviderUnit {
+		// A discarded/cancelled provider transport row is not a successful
+		// logical delivery. Excluding terminal failures lets the fenced outbox
+		// repair create a replacement while active/completed jobs still dedupe.
+		return rivertype.UniqueOptsByStateDefault()
+	}
+	return rivertype.JobStates()
 }
 
 type relayArgs struct {

--- a/internal/joboutbox/inserter_test.go
+++ b/internal/joboutbox/inserter_test.go
@@ -3,6 +3,7 @@ package joboutbox
 import (
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -239,6 +240,27 @@ func TestPrepareRowRelaysProviderUnitCanaryAsIDOnlyTenantEnvelope(t *testing.T) 
 	}
 	if canonicalHash(canonical) != row.PayloadHash {
 		t.Fatalf("provider-unit relay hash drifted: got=%s want=%s", canonicalHash(canonical), row.PayloadHash)
+	}
+}
+
+func TestProviderUnitUniquenessExcludesTerminalFailureStatesOnly(t *testing.T) {
+	providerStates := uniqueStatesForKind(jobcontract.KindSyncProviderUnit)
+	for _, excluded := range []rivertype.JobState{rivertype.JobStateDiscarded, rivertype.JobStateCancelled} {
+		if slices.Contains(providerStates, excluded) {
+			t.Fatalf("provider-unit uniqueness unexpectedly includes terminal state %q", excluded)
+		}
+	}
+	for _, required := range rivertype.UniqueOptsByStateDefault() {
+		if !slices.Contains(providerStates, required) {
+			t.Fatalf("provider-unit uniqueness missing active/completed state %q", required)
+		}
+	}
+
+	heartbeatStates := uniqueStatesForKind(jobcontract.KindHeartbeat)
+	for _, required := range rivertype.JobStates() {
+		if !slices.Contains(heartbeatStates, required) {
+			t.Fatalf("non-provider uniqueness lost state %q", required)
+		}
 	}
 }
 

--- a/internal/joboutbox/loop.go
+++ b/internal/joboutbox/loop.go
@@ -102,6 +102,7 @@ type ReconcilerLoop struct {
 	done     chan struct{}
 	ticker   reconcilerTicker
 
+	recovered uint64
 	claimed   uint64
 	delivered uint64
 	retried   uint64
@@ -216,6 +217,7 @@ func (loop *ReconcilerLoop) step(ctx context.Context, now time.Time) error {
 		return err
 	}
 	loop.mu.Lock()
+	loop.recovered += nonNegativeUint(result.Recovered)
 	loop.claimed += nonNegativeUint(result.Claimed)
 	loop.delivered += nonNegativeUint(result.Delivered)
 	loop.retried += nonNegativeUint(result.Retried)
@@ -298,6 +300,7 @@ func (loop *ReconcilerLoop) WritePrometheus(output io.Writer) error {
 		return errors.New("Prometheus output is required")
 	}
 	loop.mu.Lock()
+	recovered := loop.recovered
 	claimed := loop.claimed
 	delivered := loop.delivered
 	retried := loop.retried
@@ -313,6 +316,7 @@ func (loop *ReconcilerLoop) WritePrometheus(output io.Writer) error {
 		lastSuccessAge = now.Sub(lastOK).Seconds()
 	}
 	var text strings.Builder
+	writeReconcilerCounter(&text, "worker_outbox_reconciler_terminal_deliveries_recovered_total", "Terminal River deliveries rearmed by the reconciler.", recovered)
 	writeReconcilerCounter(&text, "worker_outbox_reconciler_claimed_total", "Outbox rows claimed by the reconciler.", claimed)
 	writeReconcilerCounter(&text, "worker_outbox_reconciler_delivered_total", "Outbox rows delivered to River by the reconciler.", delivered)
 	writeReconcilerCounter(&text, "worker_outbox_reconciler_retried_total", "Outbox rows scheduled for relay retry by the reconciler.", retried)

--- a/internal/joboutbox/loop_test.go
+++ b/internal/joboutbox/loop_test.go
@@ -108,7 +108,7 @@ func TestReconcilerLoopImmediateNoopStepOpensReadiness(t *testing.T) {
 
 func TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics(t *testing.T) {
 	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
-	results := []StepResult{{Claimed: 2, Delivered: 1, Retried: 1}, {Claimed: 3, Dead: 1, LeaseLost: 2}}
+	results := []StepResult{{Recovered: 1, Claimed: 2, Delivered: 1, Retried: 1}, {Recovered: 2, Claimed: 3, Dead: 1, LeaseLost: 2}}
 	loop, _ := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
 		result := results[0]
 		results = results[1:]
@@ -130,6 +130,7 @@ func TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics(t *test
 		t.Fatal(err)
 	}
 	for _, want := range []string{
+		"worker_outbox_reconciler_terminal_deliveries_recovered_total 3",
 		"worker_outbox_reconciler_claimed_total 5",
 		"worker_outbox_reconciler_delivered_total 1",
 		"worker_outbox_reconciler_retried_total 1",

--- a/internal/joboutbox/relay.go
+++ b/internal/joboutbox/relay.go
@@ -36,6 +36,7 @@ func (config RelayConfig) validate() error {
 }
 
 type StepResult struct {
+	Recovered int
 	Claimed   int
 	Deferred  int
 	Delivered int
@@ -52,11 +53,16 @@ type Relay struct {
 	config        RelayConfig
 	deferredKinds []string
 	routes        RouteResolver
+	repair        TerminalDeliveryRepairStepper
 }
 
 type RouteResolver interface {
 	DeferredKinds(context.Context) ([]string, error)
 	Resolve(context.Context, string) (string, error)
+}
+
+type TerminalDeliveryRepairStepper interface {
+	Step(context.Context, time.Time, int) (TerminalDeliveryRepairResult, error)
 }
 
 func NewRelay(repository *Repository, inserter *RiverInserter, config RelayConfig) (*Relay, error) {
@@ -93,6 +99,24 @@ func NewRelayWithRoutes(
 		return nil, err
 	}
 	relay.routes = routes
+	return relay, nil
+}
+
+func NewRelayWithRoutesAndRecovery(
+	repository *Repository,
+	inserter *RiverInserter,
+	routes RouteResolver,
+	repair TerminalDeliveryRepairStepper,
+	config RelayConfig,
+) (*Relay, error) {
+	if repair == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	relay, err := NewRelayWithRoutes(repository, inserter, routes, config)
+	if err != nil {
+		return nil, err
+	}
+	relay.repair = repair
 	return relay, nil
 }
 
@@ -134,15 +158,23 @@ func (relay *Relay) Step(ctx context.Context, now time.Time, limit int) (StepRes
 	if relay == nil || now.IsZero() {
 		return StepResult{}, ErrInvalidConfiguration
 	}
+	result := StepResult{}
+	if relay.repair != nil {
+		recovered, err := relay.repair.Step(ctx, now, limit)
+		if err != nil {
+			return result, err
+		}
+		result.Recovered = recovered.Recovered
+	}
 	deferred := relay.deferredKinds
 	if relay.routes != nil {
 		var err error
 		deferred, err = relay.routes.DeferredKinds(ctx)
 		if err != nil {
-			return StepResult{}, ErrUnavailable
+			return result, ErrUnavailable
 		}
 		if len(deferred) > maxRelayPolicyKinds {
-			return StepResult{}, ErrInvalidConfiguration
+			return result, ErrInvalidConfiguration
 		}
 		sort.Strings(deferred)
 	}
@@ -150,7 +182,7 @@ func (relay *Relay) Step(ctx context.Context, now time.Time, limit int) (StepRes
 	if err != nil {
 		return StepResult{}, err
 	}
-	result := StepResult{Claimed: len(claims)}
+	result.Claimed = len(claims)
 	for _, claim := range claims {
 		if relay.routes != nil {
 			transport, routeErr := relay.routes.Resolve(ctx, claim.JobKind)

--- a/internal/joboutbox/relay_integration_test.go
+++ b/internal/joboutbox/relay_integration_test.go
@@ -677,6 +677,177 @@ WHERE dedupe_key=$1`, seed.DedupeKey).Scan(
 			)
 		}
 	})
+
+	t.Run("discarded provider delivery is rearmed once for an active due unit", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		// Dispatch validates leases against PostgreSQL statement_timestamp(), so
+		// this lifecycle fixture must be anchored to the executing database day.
+		now := time.Now().UTC().Truncate(time.Second)
+		seed := providerUnitSeed(104, integrationUUID(4104), now)
+		seedProviderUnitDomain(t, ctx, adminPool, seed, "dispatching", "running", now.Add(-time.Hour))
+		seedOutbox(t, ctx, adminPool, seed.outbox)
+
+		claim := claimOne(t, ctx, repository, now, 30*time.Second)
+		firstJobID, err := repository.Dispatch(ctx, claim, now, inserter.Insert)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE river.river_job
+			SET state = 'discarded', attempt = 1, max_attempts = 5,
+				finalized_at = $2::timestamptz,
+				errors = ARRAY[jsonb_build_object(
+					'at', $2::timestamptz, 'attempt', 1,
+					'error', 'Stuck job rescued by JobRescuer', 'trace', ''
+				)]
+			WHERE id = $1`, firstJobID, now.Add(time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+
+		results := make(chan TerminalDeliveryRepairResult, 2)
+		errorsByReplica := make(chan error, 2)
+		var replicas sync.WaitGroup
+		for range 2 {
+			repair, repairErr := NewTerminalDeliveryRepair(queuePool, "river")
+			if repairErr != nil {
+				t.Fatal(repairErr)
+			}
+			replicas.Add(1)
+			go func() {
+				defer replicas.Done()
+				result, stepErr := repair.Step(ctx, now.Add(2*time.Minute), 10)
+				results <- result
+				errorsByReplica <- stepErr
+			}()
+		}
+		replicas.Wait()
+		close(results)
+		close(errorsByReplica)
+		for stepErr := range errorsByReplica {
+			if stepErr != nil {
+				t.Fatal(stepErr)
+			}
+		}
+		var recoveredTotal int
+		for result := range results {
+			recoveredTotal += result.Recovered
+		}
+		if recoveredTotal != 1 {
+			t.Fatalf("replica recovery total=%d want=1", recoveredTotal)
+		}
+
+		repair, err := NewTerminalDeliveryRepair(queuePool, "river")
+		if err != nil {
+			t.Fatal(err)
+		}
+		relay, err := NewRelayWithRoutesAndRecovery(
+			repository,
+			inserter,
+			fakeRouteResolver{route: "river"},
+			repair,
+			DefaultRelayConfig(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		delivery, err := relay.Step(ctx, now.Add(2*time.Minute), 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if delivery.Recovered != 0 || delivery.Claimed != 1 || delivery.Delivered != 1 {
+			t.Fatalf("delivery Step() = %#v", delivery)
+		}
+		var secondJobID int64
+		if err := adminPool.QueryRow(ctx, `
+			SELECT river_job_id FROM public.worker_job_outbox
+			WHERE id = $1`, seed.outbox.ID).Scan(&secondJobID); err != nil {
+			t.Fatal(err)
+		}
+		if secondJobID == firstJobID {
+			t.Fatalf("replacement reused terminal River job %d", firstJobID)
+		}
+		assertOutboxStatus(t, ctx, adminPool, seed.outbox.ID, statusDelivered, 2)
+
+		again, err := repair.Step(ctx, now.Add(3*time.Minute), 10)
+		if err != nil || again.Recovered != 0 {
+			t.Fatalf("second repair Step() = %#v, %v", again, err)
+		}
+		var jobs int
+		if err := adminPool.QueryRow(ctx, `
+			SELECT count(*) FROM river.river_job
+			WHERE kind = $1`, jobcontract.KindSyncProviderUnit).Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 2 {
+			t.Fatalf("provider River jobs=%d want=2", jobs)
+		}
+
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE river.river_job
+			SET state = 'discarded', attempt = 1, max_attempts = 5,
+				finalized_at = $2::timestamptz,
+				errors = ARRAY[jsonb_build_object(
+					'at', $2::timestamptz, 'attempt', 1,
+					'error', 'Stuck job rescued by JobRescuer', 'trace', ''
+				)]
+			WHERE id = $1`, secondJobID, now.Add(4*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.sync_run_units SET status = 'success'
+			WHERE id = $1`, seed.unitID); err != nil {
+			t.Fatal(err)
+		}
+		terminalUnit, err := repair.Step(ctx, now.Add(5*time.Minute), 10)
+		if err != nil || terminalUnit.Recovered != 0 {
+			t.Fatalf("terminal unit repair Step() = %#v, %v", terminalUnit, err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.sync_run_units SET status = 'dispatching'
+			WHERE id = $1`, seed.unitID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.sync_runs SET status = 'failed'
+			WHERE id = $1`, seed.runID); err != nil {
+			t.Fatal(err)
+		}
+		terminalRun, err := repair.Step(ctx, now.Add(6*time.Minute), 10)
+		if err != nil || terminalRun.Recovered != 0 {
+			t.Fatalf("terminal run repair Step() = %#v, %v", terminalRun, err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.sync_runs SET status = 'running' WHERE id = $1`, seed.runID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE river.river_job
+			SET errors = ARRAY[jsonb_build_object(
+				'at', $2::timestamptz, 'attempt', 1,
+				'error', 'provider request permanently rejected', 'trace', ''
+			)]
+			WHERE id = $1`, secondJobID, now.Add(7*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		ordinaryFailure, err := repair.Step(ctx, now.Add(8*time.Minute), 10)
+		if err != nil || ordinaryFailure.Recovered != 0 {
+			t.Fatalf("ordinary failure repair Step() = %#v, %v", ordinaryFailure, err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE river.river_job
+			SET attempt = max_attempts,
+				errors = ARRAY[jsonb_build_object(
+					'at', $2::timestamptz, 'attempt', max_attempts,
+					'error', 'Stuck job rescued by JobRescuer', 'trace', ''
+				)]
+			WHERE id = $1`, secondJobID, now.Add(9*time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		exhausted, err := repair.Step(ctx, now.Add(10*time.Minute), 10)
+		if err != nil || exhausted.Recovered != 0 {
+			t.Fatalf("exhausted repair Step() = %#v, %v", exhausted, err)
+		}
+	})
 }
 
 type outboxSeed struct {
@@ -690,6 +861,83 @@ type outboxSeed struct {
 	Priority    int
 	MaxAttempts int
 	ScheduledAt time.Time
+}
+
+type providerUnitIntegrationSeed struct {
+	outbox        outboxSeed
+	integrationID string
+	runID         string
+	unitID        string
+	orgID         string
+}
+
+func providerUnitSeed(index int, organizationID string, now time.Time) providerUnitIntegrationSeed {
+	runID := integrationUUID(2000 + index)
+	unitID := integrationUUID(3000 + index)
+	idempotency := "sync.provider_unit:" + unitID
+	envelope := jobcontract.Envelope{
+		ContractVersion: 1,
+		OrganizationID:  &organizationID,
+		CorrelationID:   "sync-run:" + runID,
+		IdempotencyKey:  idempotency,
+		Domain: jobcontract.DomainLink{
+			Type: "sync_run_unit",
+			ID:   unitID,
+		},
+		Payload: jobcontract.ProviderUnitPayload{UnitID: unitID},
+	}
+	args, err := jobcontract.MarshalCanonical(envelope)
+	if err != nil {
+		panic(err)
+	}
+	return providerUnitIntegrationSeed{
+		outbox: outboxSeed{
+			ID:          integrationUUID(index),
+			DedupeKey:   idempotency,
+			Kind:        jobcontract.KindSyncProviderUnit,
+			Version:     1,
+			Args:        args,
+			PayloadHash: canonicalHash(args),
+			Queue:       "sync_provider",
+			Priority:    2,
+			MaxAttempts: 5,
+			ScheduledAt: now,
+		},
+		integrationID: integrationUUID(4000 + index),
+		runID:         runID,
+		unitID:        unitID,
+		orgID:         organizationID,
+	}
+}
+
+func seedProviderUnitDomain(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	seed providerUnitIntegrationSeed,
+	unitStatus string,
+	runStatus string,
+	availableAt time.Time,
+) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.integrations (id, org_id, is_active)
+		VALUES ($1, $2, FALSE)`, seed.integrationID, seed.orgID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_runs (id, org_id, integration_id, status)
+		VALUES ($1, $2, $3, $4)`, seed.runID, seed.orgID, seed.integrationID, runStatus); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_run_units (
+			id, org_id, sync_run_id, integration_id, status, available_at,
+			lease_owner, lease_expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL)`,
+		seed.unitID, seed.orgID, seed.runID, seed.integrationID, unitStatus, availableAt); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func normalSeed(index int, now time.Time) outboxSeed {
@@ -838,7 +1086,7 @@ func injectedFault() error { return errors.New("simulated process crash") }
 
 func resetOutboxTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
 	t.Helper()
-	if _, err := pool.Exec(ctx, "TRUNCATE public.worker_job_outbox, public.worker_job_delivery_abandonments, public.worker_job_completion_fences, river.river_job RESTART IDENTITY"); err != nil {
+	if _, err := pool.Exec(ctx, "TRUNCATE public.worker_job_outbox, public.worker_job_delivery_abandonments, public.worker_job_completion_fences, public.sync_run_units, public.sync_runs, public.integrations, river.river_job RESTART IDENTITY"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -859,6 +1107,28 @@ func createOutboxRoles(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
 func createOutboxSchema(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
 	t.Helper()
 	_, err := pool.Exec(ctx, `
+		CREATE TABLE public.integrations (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			is_active boolean NOT NULL
+		);
+		CREATE TABLE public.sync_runs (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			integration_id uuid NOT NULL REFERENCES public.integrations(id),
+			status text NOT NULL
+		);
+		CREATE INDEX ix_sync_runs_status_id ON public.sync_runs (status, id);
+		CREATE TABLE public.sync_run_units (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			sync_run_id uuid NOT NULL REFERENCES public.sync_runs(id),
+			integration_id uuid NOT NULL REFERENCES public.integrations(id),
+			status text NOT NULL,
+			available_at timestamptz,
+			lease_owner text,
+			lease_expires_at timestamptz
+		);
 		CREATE TABLE public.worker_job_outbox (
 			id uuid PRIMARY KEY,
 			dedupe_key varchar(256) NOT NULL UNIQUE,

--- a/internal/joboutbox/relay_test.go
+++ b/internal/joboutbox/relay_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 )
@@ -28,6 +29,12 @@ type enumerableRegistry struct {
 }
 
 type descriptorOnlyRegistry struct{}
+
+type fakeTerminalRepair struct{}
+
+func (fakeTerminalRepair) Step(context.Context, time.Time, int) (TerminalDeliveryRepairResult, error) {
+	return TerminalDeliveryRepairResult{}, nil
+}
 
 func (descriptorOnlyRegistry) Descriptor(string) (jobruntime.Descriptor, bool) {
 	return jobruntime.Descriptor{}, false
@@ -122,11 +129,34 @@ func TestNewRelayWithRoutesRequiresDurableResolver(t *testing.T) {
 	}
 	relay, err := NewRelayWithRoutes(
 		&Repository{}, inserter,
-		fakeRouteResolver{deferred: []string{"job.alpha"}},
+		fakeRouteResolver{route: "river"},
 		DefaultRelayConfig(),
 	)
 	if err != nil || relay.routes == nil {
 		t.Fatalf("dynamic relay=%#v err=%v", relay, err)
+	}
+}
+
+func TestNewRelayWithRoutesAndRecoveryRequiresRepair(t *testing.T) {
+	descriptors := []jobruntime.Descriptor{{Kind: "job.alpha", Route: "river"}}
+	registry := enumerableRegistry{
+		descriptors: descriptors,
+		byKind: map[string]jobruntime.Descriptor{
+			"job.alpha": descriptors[0],
+		},
+	}
+	inserter := &RiverInserter{registry: registry}
+	resolver := fakeRouteResolver{route: "river"}
+	if _, err := NewRelayWithRoutesAndRecovery(
+		&Repository{}, inserter, resolver, nil, DefaultRelayConfig(),
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("nil repair error=%v", err)
+	}
+	relay, err := NewRelayWithRoutesAndRecovery(
+		&Repository{}, inserter, resolver, fakeTerminalRepair{}, DefaultRelayConfig(),
+	)
+	if err != nil || relay.repair == nil {
+		t.Fatalf("recovery relay=%#v err=%v", relay, err)
 	}
 }
 

--- a/internal/joboutbox/terminal_delivery_repair.go
+++ b/internal/joboutbox/terminal_delivery_repair.go
@@ -1,0 +1,157 @@
+package joboutbox
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	riverUnhandledRescueError      = "Stuck job rescued by JobRescuer"
+	providerTerminalRecoveryCode   = "river_unhandled_rescue"
+	providerTerminalRecoveryDetail = "terminal River delivery recovered"
+)
+
+var riverSchemaPattern = regexp.MustCompile(`^[a-z_][a-z0-9_]{0,62}$`)
+
+type TerminalDeliveryRepairResult struct {
+	Recovered int
+}
+
+// TerminalDeliveryRepair rearms a provider-unit outbox row only when its
+// exact River delivery was discarded by River's unhandled-kind rescue path
+// while the authoritative run and unit remain active and due. The outbox and
+// River rows are locked together so replicas converge on one replacement.
+type TerminalDeliveryRepair struct {
+	begin func(context.Context) (pgx.Tx, error)
+	query string
+}
+
+func NewTerminalDeliveryRepair(
+	queueControlPool *pgxpool.Pool,
+	riverSchema string,
+) (*TerminalDeliveryRepair, error) {
+	if queueControlPool == nil || !riverSchemaPattern.MatchString(riverSchema) {
+		return nil, ErrInvalidConfiguration
+	}
+	jobTable := pgx.Identifier{riverSchema, "river_job"}.Sanitize()
+	return &TerminalDeliveryRepair{
+		begin: queueControlPool.Begin,
+		query: fmt.Sprintf(repairProviderUnitTerminalDeliverySQL, jobTable),
+	}, nil
+}
+
+func (repair *TerminalDeliveryRepair) Step(
+	ctx context.Context,
+	now time.Time,
+	limit int,
+) (TerminalDeliveryRepairResult, error) {
+	if repair == nil || repair.begin == nil || ctx == nil || now.IsZero() ||
+		limit < minReconcilerLimit || limit > maxReconcilerLimit {
+		return TerminalDeliveryRepairResult{}, ErrInvalidConfiguration
+	}
+	if err := ctx.Err(); err != nil {
+		return TerminalDeliveryRepairResult{}, err
+	}
+	tx, err := repair.begin(ctx)
+	if err != nil || tx == nil {
+		return TerminalDeliveryRepairResult{}, ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	rows, err := tx.Query(
+		ctx,
+		repair.query,
+		now.UTC(),
+		limit,
+		riverUnhandledRescueError,
+		providerTerminalRecoveryCode,
+		providerTerminalRecoveryDetail,
+	)
+	if err != nil || rows == nil {
+		return TerminalDeliveryRepairResult{}, ErrUnavailable
+	}
+	defer rows.Close()
+	result := TerminalDeliveryRepairResult{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil || !uuidPattern.MatchString(id) {
+			return TerminalDeliveryRepairResult{}, ErrUnavailable
+		}
+		result.Recovered++
+	}
+	if err := rows.Err(); err != nil || result.Recovered > limit {
+		return TerminalDeliveryRepairResult{}, ErrUnavailable
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return TerminalDeliveryRepairResult{}, ErrUnavailable
+	}
+	return result, nil
+}
+
+// The queue-control role has read-only access to sync_runs/sync_run_units and
+// mutation authority over the generic outbox and River schema. The identity
+// predicates bind the immutable outbox envelope, authoritative domain row,
+// current outbox delivery, and River metadata together before any row is
+// rearmed. A paused integration is intentionally absent: pausing prevents new
+// planning, but does not cancel already-planned work in an active run.
+const repairProviderUnitTerminalDeliverySQL = `
+WITH candidates AS (
+	SELECT outbox.id
+	FROM public.worker_job_outbox AS outbox
+	JOIN public.sync_run_units AS unit
+		ON unit.id = CASE
+			WHEN (outbox.args #>> '{payload,unit_id}') ~
+				'^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+			THEN (outbox.args #>> '{payload,unit_id}')::uuid
+			ELSE NULL
+		END
+		AND unit.id::text = outbox.args #>> '{domain,id}'
+		AND unit.org_id = outbox.args ->> 'organization_id'
+	JOIN public.sync_runs AS run
+		ON run.id = unit.sync_run_id
+		AND run.org_id = unit.org_id
+	JOIN %s AS job
+		ON job.id = outbox.river_job_id
+		AND job.kind = outbox.job_kind
+		AND job.args = outbox.args::jsonb
+		AND job.metadata ->> 'worker_outbox_id' = outbox.id::text
+		AND job.metadata ->> 'payload_hash' = outbox.payload_hash
+		AND job.metadata ->> 'contract_version' = outbox.contract_version::text
+	WHERE outbox.status = 'delivered'
+		AND outbox.job_kind = 'sync.provider_unit'
+		AND outbox.dedupe_key = 'sync.provider_unit:' || unit.id::text
+		AND outbox.args #>> '{domain,type}' = 'sync_run_unit'
+		AND unit.status = 'dispatching'
+		AND (unit.available_at IS NULL OR unit.available_at <= $1)
+		AND unit.lease_owner IS NULL
+		AND unit.lease_expires_at IS NULL
+		AND run.status IN ('planned', 'dispatching', 'running')
+		AND job.state::text = 'discarded'
+		AND job.finalized_at IS NOT NULL
+		AND job.attempt < job.max_attempts
+		AND cardinality(job.errors) > 0
+		AND (job.errors[cardinality(job.errors)]->>'error') = $3
+	ORDER BY outbox.delivered_at, outbox.id
+	FOR UPDATE OF outbox, job SKIP LOCKED
+	LIMIT $2::int
+)
+UPDATE public.worker_job_outbox AS outbox
+SET status = 'pending',
+	next_attempt_at = $1,
+	last_error_code = $4,
+	last_error_detail = $5,
+	last_error_at = $1,
+	river_job_id = NULL,
+	delivered_at = NULL,
+	claim_token = NULL,
+	claimed_at = NULL,
+	claim_expires_at = NULL,
+	updated_at = $1
+FROM candidates
+WHERE outbox.id = candidates.id
+RETURNING outbox.id::text
+`

--- a/internal/storage/postgres/queue_authorization.go
+++ b/internal/storage/postgres/queue_authorization.go
@@ -8,8 +8,8 @@ import (
 
 // queueAuthorizationQuery proves the queue-control login has only the River
 // plus completion-fence capabilities it requires. Its only semantic-table
-// privilege is read-only sync_runs access for bounding terminal dispatch repair
-// to active runs. In particular, it cannot create database objects, touch
+// privileges are read-only sync_runs/sync_run_units access for bounding
+// terminal delivery repair to active work. In particular, it cannot create database objects, touch
 // arbitrary semantic tables, or insert producer-owned outbox rows. Every
 // predicate operates on effective privileges.
 const queueAuthorizationQuery = `
@@ -42,7 +42,8 @@ WITH river_tables AS (
 			'worker_job_completion_fences',
 			'sync_dispatch_outbox',
 			'sync_dispatch_transport_routes',
-			'sync_runs'
+			'sync_runs',
+			'sync_run_units'
 		)
 ), public_sequences AS (
 	SELECT class.oid
@@ -72,6 +73,29 @@ SELECT
 			AND NOT rolcreaterole
 			AND NOT rolreplication
 			AND NOT rolbypassrls
+	)
+	AND EXISTS (
+		SELECT 1
+		FROM pg_catalog.pg_class AS class
+		JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = class.relnamespace
+		WHERE namespace.nspname = 'public'
+			AND class.relname = 'sync_run_units'
+			AND class.relkind IN ('r', 'p')
+			AND has_table_privilege(current_user, class.oid, 'SELECT')
+			AND NOT has_table_privilege(current_user, class.oid, 'INSERT')
+			AND NOT has_table_privilege(current_user, class.oid, 'UPDATE')
+			AND NOT has_any_column_privilege(
+				current_user, class.oid, 'INSERT, UPDATE, REFERENCES'
+			)
+			AND NOT has_table_privilege(current_user, class.oid, 'DELETE')
+			AND NOT has_table_privilege(current_user, class.oid, 'TRUNCATE')
+			AND NOT has_table_privilege(current_user, class.oid, 'REFERENCES')
+			AND NOT has_table_privilege(current_user, class.oid, 'TRIGGER')
+			AND NOT CASE
+				WHEN current_setting('server_version_num')::integer >= 170000
+				THEN has_table_privilege(current_user, class.oid, 'MAINTAIN')
+				ELSE false
+			END
 	)
 	AND EXISTS (
 		SELECT 1

--- a/internal/storage/postgres/queue_authorization_integration_test.go
+++ b/internal/storage/postgres/queue_authorization_integration_test.go
@@ -39,6 +39,7 @@ func TestQueueAuthorizationRequiresExactCompletionFenceGrants(t *testing.T) {
 		"CREATE TABLE public.sync_dispatch_outbox (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_dispatch_transport_routes (kind text PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id uuid PRIMARY KEY)",
+		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY)",
 		"CREATE SCHEMA river",
 		"CREATE TABLE river.river_job (id bigserial PRIMARY KEY)",
 		"CREATE FUNCTION river.queue_authorization_probe() RETURNS integer LANGUAGE sql AS 'SELECT 1'",
@@ -51,6 +52,7 @@ func TestQueueAuthorizationRequiresExactCompletionFenceGrants(t *testing.T) {
 		"GRANT SELECT, UPDATE ON TABLE public.sync_dispatch_outbox TO " + queueAuthorizationFenceRole,
 		"GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO " + queueAuthorizationFenceRole,
 		"GRANT SELECT ON TABLE public.sync_runs TO " + queueAuthorizationFenceRole,
+		"GRANT SELECT ON TABLE public.sync_run_units TO " + queueAuthorizationFenceRole,
 		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA river TO " + queueAuthorizationFenceRole,
 		"GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA river TO " + queueAuthorizationFenceRole,
 		"GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA river TO " + queueAuthorizationFenceRole,
@@ -116,6 +118,8 @@ func TestQueueAuthorizationRequiresExactCompletionFenceGrants(t *testing.T) {
 		{name: "maintain", grant: "GRANT MAINTAIN ON TABLE public.worker_job_completion_fences TO " + queueAuthorizationFenceRole, revoke: "REVOKE MAINTAIN ON TABLE public.worker_job_completion_fences FROM " + queueAuthorizationFenceRole},
 		{name: "missing sync runs select", revoke: "REVOKE SELECT ON TABLE public.sync_runs FROM " + queueAuthorizationFenceRole, grant: "GRANT SELECT ON TABLE public.sync_runs TO " + queueAuthorizationFenceRole, missing: true},
 		{name: "sync runs update", grant: "GRANT UPDATE ON TABLE public.sync_runs TO " + queueAuthorizationFenceRole, revoke: "REVOKE UPDATE ON TABLE public.sync_runs FROM " + queueAuthorizationFenceRole},
+		{name: "missing sync run units select", revoke: "REVOKE SELECT ON TABLE public.sync_run_units FROM " + queueAuthorizationFenceRole, grant: "GRANT SELECT ON TABLE public.sync_run_units TO " + queueAuthorizationFenceRole, missing: true},
+		{name: "sync run units update", grant: "GRANT UPDATE ON TABLE public.sync_run_units TO " + queueAuthorizationFenceRole, revoke: "REVOKE UPDATE ON TABLE public.sync_run_units FROM " + queueAuthorizationFenceRole},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			statement := test.grant

--- a/internal/storage/postgres/runtime_authorization_integration_test.go
+++ b/internal/storage/postgres/runtime_authorization_integration_test.go
@@ -118,6 +118,7 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		"GRANT SELECT, UPDATE ON TABLE public.sync_dispatch_outbox TO " + runtimeAuthorizationQueueRole,
 		"GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO " + runtimeAuthorizationQueueRole,
 		"GRANT SELECT ON TABLE public.sync_runs TO " + runtimeAuthorizationQueueRole,
+		"GRANT SELECT ON TABLE public.sync_run_units TO " + runtimeAuthorizationQueueRole,
 		"GRANT USAGE ON SCHEMA river TO " + runtimeAuthorizationQueueRole,
 		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA river TO " + runtimeAuthorizationQueueRole,
 		"GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA river TO " + runtimeAuthorizationQueueRole,
@@ -155,6 +156,12 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) || pgErr.Code != "42501" {
 		t.Fatalf("queue domain materializer write-boundary error = %v, want 42501 insufficient_privilege", err)
+	}
+	if _, err := queue.Exec(ctx, "SELECT id FROM public.sync_run_units LIMIT 1"); err != nil {
+		t.Fatalf("queue cannot read sync-run-unit recovery state: %v", err)
+	}
+	if _, err := queue.Exec(ctx, "UPDATE public.sync_run_units SET state = state"); err == nil {
+		t.Fatal("queue unexpectedly mutates sync-run-unit recovery state")
 	}
 	if _, err := admin.Exec(ctx, "GRANT TEMPORARY ON DATABASE worker_test TO PUBLIC"); err != nil {
 		t.Fatal(err)

--- a/internal/storage/river/migrate.go
+++ b/internal/storage/river/migrate.go
@@ -465,6 +465,7 @@ func runtimeGrantStatements(options MigrationOptions) []string {
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_outbox') IS NOT NULL THEN GRANT SELECT, UPDATE ON TABLE public.sync_dispatch_outbox TO " + queueRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_transport_routes') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO " + queueRole + "; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_runs') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_runs TO " + queueRole + "; END IF; END $$",
+		"DO $$ BEGIN IF to_regclass('public.sync_run_units') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_run_units TO " + queueRole + "; END IF; END $$",
 		"REVOKE ALL PRIVILEGES ON SCHEMA " + schema + " FROM PUBLIC",
 		"REVOKE ALL PRIVILEGES ON SCHEMA " + schema + " FROM " + domainRole,
 		"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA " + schema + " FROM PUBLIC, " + domainRole,

--- a/internal/storage/river/migrate_test.go
+++ b/internal/storage/river/migrate_test.go
@@ -454,6 +454,7 @@ func TestRuntimeGrantStatementsMatchProvisionedLeastPrivilegePolicy(t *testing.T
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_outbox') IS NOT NULL THEN GRANT SELECT, UPDATE ON TABLE public.sync_dispatch_outbox TO \"queue_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_transport_routes') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO \"queue_runtime\"; END IF; END $$",
 		"DO $$ BEGIN IF to_regclass('public.sync_runs') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_runs TO \"queue_runtime\"; END IF; END $$",
+		"DO $$ BEGIN IF to_regclass('public.sync_run_units') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_run_units TO \"queue_runtime\"; END IF; END $$",
 		"REVOKE ALL PRIVILEGES ON SCHEMA \"river\" FROM PUBLIC",
 		"REVOKE ALL PRIVILEGES ON SCHEMA \"river\" FROM \"domain_runtime\"",
 		"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA \"river\" FROM PUBLIC, \"domain_runtime\"",

--- a/scripts/worker/provision_river_roles.sql
+++ b/scripts/worker/provision_river_roles.sql
@@ -190,3 +190,9 @@ SELECT format(
        )
  WHERE to_regclass('public.sync_runs') IS NOT NULL
 \gexec
+SELECT format(
+         'GRANT SELECT ON TABLE public.sync_run_units TO %I',
+         :'queue_role'
+       )
+ WHERE to_regclass('public.sync_run_units') IS NOT NULL
+\gexec

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -457,8 +457,11 @@ def test_local_postgres_bootstraps_distinct_go_runtime_roles() -> None:
     )
     queue_section = upgrade_script.split("-- The queue role", maxsplit=1)[1]
     assert "GRANT SELECT ON TABLE public.sync_runs TO %I" in queue_section
+    assert "GRANT SELECT ON TABLE public.sync_run_units TO %I" in queue_section
     assert "GRANT SELECT, UPDATE ON TABLE public.sync_runs" not in queue_section
     assert "GRANT SELECT, INSERT ON TABLE public.sync_runs" not in queue_section
+    assert "GRANT SELECT, UPDATE ON TABLE public.sync_run_units" not in queue_section
+    assert "GRANT SELECT, INSERT ON TABLE public.sync_run_units" not in queue_section
     _assert_least_privilege_domain_grants(
         upgrade_script.split("-- The queue role", maxsplit=1)[0]
     )

--- a/tests/tooling/mutation-plans/provider_unit_terminal_delivery_recovery.json
+++ b/tests/tooling/mutation-plans/provider_unit_terminal_delivery_recovery.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": 1,
+  "name": "provider-unit terminal River delivery recovery",
+  "$limitation": "Pins the validated unhandled-JobRescuer discard recovery path for active provider units. It does not reopen ordinary provider failures, terminal domain work, exhausted River jobs, cancelled jobs, or operator-paused job routes.",
+  "mutations": [
+    {
+      "id": "PUTR01-exact-rescuer-error",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\tAND (job.errors[cardinality(job.errors)]->>'error') = $3\n",
+      "replace": "\t\tAND (job.errors[cardinality(job.errors)]->>'error') <> $3\n",
+      "expect_occurrences": 1,
+      "rationale": "Only the exact River unhandled-kind rescuer discard is recoverable; an ordinary provider failure remains terminal.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "TestGenericOutboxLiveFailureInjectionMatrix/discarded_provider_delivery", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUTR02-remaining-attempt-fence",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\tAND job.attempt < job.max_attempts\n",
+      "replace": "\t\tAND job.attempt <= job.max_attempts\n",
+      "expect_occurrences": 1,
+      "rationale": "An exhausted River job remains terminal even if its last error names JobRescuer.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "TestGenericOutboxLiveFailureInjectionMatrix/discarded_provider_delivery", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUTR03-active-unit-fence",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\tAND unit.status = 'dispatching'\n",
+      "replace": "\t\tAND unit.status <> 'dispatching'\n",
+      "expect_occurrences": 1,
+      "rationale": "Recovery is limited to a still-dispatching unit and must not reopen a successful or failed unit.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "TestGenericOutboxLiveFailureInjectionMatrix/discarded_provider_delivery", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUTR04-active-run-fence",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\tAND run.status IN ('planned', 'dispatching', 'running')\n",
+      "replace": "",
+      "expect_occurrences": 1,
+      "rationale": "A terminal or cancelled sync run must not regain provider work.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "TestGenericOutboxLiveFailureInjectionMatrix/discarded_provider_delivery", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUTR05-exact-outbox-identity",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\tAND job.metadata ->> 'worker_outbox_id' = outbox.id::text\n",
+      "replace": "\t\tAND job.metadata ->> 'worker_outbox_id' <> outbox.id::text\n",
+      "expect_occurrences": 1,
+      "rationale": "Recovery must bind the discarded River row to the exact durable outbox delivery.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "TestGenericOutboxLiveFailureInjectionMatrix/discarded_provider_delivery", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUTR06-provider-replacement-uniqueness",
+      "file": "internal/joboutbox/inserter.go",
+      "find": "\tif kind == jobcontract.KindSyncProviderUnit {\n",
+      "replace": "\tif kind == jobcontract.KindHeartbeat {\n",
+      "expect_occurrences": 1,
+      "rationale": "Only provider units exclude discarded/cancelled River rows from uniqueness so one replacement can be created.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-count=1", "-run", "^TestProviderUnitUniquenessExcludesTerminalFailureStatesOnly$", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUTR07-production-reconciler-wiring",
+      "file": "cmd/dev-health-reconciler/dependencies.go",
+      "find": "\trepair, err := joboutbox.NewTerminalDeliveryRepair(queuePool, riverSchema)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n",
+      "replace": "\trepair := (*joboutbox.TerminalDeliveryRepair)(nil)\n",
+      "expect_occurrences": 1,
+      "rationale": "The production generic relay must construct the provider-unit repair stage.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-run", "^$", "./cmd/dev-health-reconciler/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-count=1", "-run", "^TestProductionGenericRelayConstructsProviderUnitTerminalDeliveryRepair$", "./cmd/dev-health-reconciler/"]]
+    },
+    {
+      "id": "PUTR08-stale-operator-retry-fence",
+      "file": "internal/joboperator/postgres_backend.go",
+      "find": "\tcase kind == jobcontract.KindSyncProviderUnit:\n",
+      "replace": "\tcase kind == \"disabled.sync.provider_unit\":\n",
+      "expect_occurrences": 1,
+      "rationale": "An operator retry cannot resurrect the discarded River row after recovery detaches it from the outbox.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboperator/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestPostgresOperatorAuthenticationBackendAndAudit$", "./internal/joboperator/"]]
+    },
+    {
+      "id": "PUTR09-queue-unit-read-grant",
+      "file": "internal/storage/river/migrate.go",
+      "find": "\t\t\"DO $$ BEGIN IF to_regclass('public.sync_run_units') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_run_units TO \" + queueRole + \"; END IF; END $$\",\n",
+      "replace": "",
+      "expect_occurrences": 1,
+      "rationale": "The queue role needs read-only unit state to apply the active-domain recovery fence.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-run", "^$", "./internal/storage/river/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-count=1", "-run", "^TestRuntimeGrantStatementsMatchProvisionedLeastPrivilegePolicy$", "./internal/storage/river/"]]
+    },
+    {
+      "id": "PUTR10-deployed-unit-read-grant",
+      "file": "scripts/worker/provision_river_roles.sql",
+      "find": "SELECT format(\n         'GRANT SELECT ON TABLE public.sync_run_units TO %I',\n         :'queue_role'\n       )\n WHERE to_regclass('public.sync_run_units') IS NOT NULL\n\\gexec\n",
+      "replace": "",
+      "expect_occurrences": 1,
+      "rationale": "Deployed role provisioning must match the migrator's read-only unit-state grant.",
+      "build": ["python3", "-m", "py_compile", "tests/test_compose_config.py"],
+      "proof": [[".venv/bin/pytest", "--noconftest", "-q", "tests/test_compose_config.py::test_local_postgres_bootstraps_distinct_go_runtime_roles"]]
+    },
+    {
+      "id": "PUTR11-recovery-telemetry",
+      "file": "internal/joboutbox/loop.go",
+      "find": "\tloop.recovered += nonNegativeUint(result.Recovered)\n",
+      "replace": "\tloop.recovered += 0 * nonNegativeUint(result.Recovered)\n",
+      "expect_occurrences": 1,
+      "rationale": "Operators need a durable low-cardinality signal that terminal provider deliveries were repaired.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3799-mutation-cache", "go", "test", "-count=1", "-run", "^TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics$", "./internal/joboutbox/"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- recover an active, due `sync.provider_unit` whose exact River delivery was discarded by the unhandled-kind `JobRescuer` path during a rolling or out-of-sync worker deployment
- rearm the same durable worker outbox row under exact envelope, tenant, unit, run, River-job, attempt, and error fences; two reconciler replicas converge on one replacement
- exclude canceled or terminal work, ordinary provider failures, exhausted River jobs, and operator-paused routes
- prevent an audited operator retry from reviving the stale discarded River job after recovery
- add read-only queue-role access to `sync_run_units`, recovery telemetry, operator guidance, and mutation coverage

Linear: https://linear.app/fullchaos/issue/CHAOS-3799/recover-stranded-provider-unit-jobs-after-terminal-river-delivery

## TEST-EVIDENCE

- Baseline live diagnosis: active `dispatching` provider units had delivered worker-outbox rows whose exact River jobs were terminal `discarded` with `Stuck job rescued by JobRescuer`; no provider budget key remained and integration pause was not the blocker.
- Real PostgreSQL/River recovery test: exact discarded delivery is recovered once across two replicas, delivered as one replacement, and stays excluded for terminal units/runs, ordinary failures, and exhausted jobs.
- Real PostgreSQL operator test: current provider retry succeeds; stale retry after recovery loses the exact durable mapping and returns a state conflict.
- Shared mutation harness: PUTR01-PUTR11 all KILLED; restore verified clean.
- `bash ci/check_go.sh fast`: PASS, including live Python oracles, contracts, integration-tag vet, and sharding discovery.
- `bash ci/local_validate.sh`: PASS 9/9; 13,139 passed, 639 skipped, 1 expected xfail; 86 ClickHouse migrations and live argMax proof passed.
- Focused Go tests/vet, Compose contract tests, docs publication validation, and `git diff --check`: PASS.

## RISK-NOTES

- Recovery is intentionally narrow: only `sync.provider_unit`, only the exact current durable outbox/River identity, only the checked-in unhandled-kind rescue error, only below `max_attempts`, and only while the authoritative run/unit remain active, due, and unleased.
- Provider-unit River uniqueness now excludes discarded/cancelled rows so the fenced replacement can be inserted; every other job kind retains the existing all-state uniqueness behavior.
- The queue role gains SELECT only on `sync_run_units`; tests reject write privileges.
- Pausing an integration prevents new planning but does not cancel already-planned work. Operator-paused job routes remain deferred by the existing route resolver.
- No migration, deployment, activation, runtime restart, or live database mutation is included.

SCREENSHOT-WAIVER: backend recovery, authorization, telemetry, and operator documentation only; no rendered web surface changes.
