### PR TITLE
CHAOS-3805: recover post-repair contract rejections

### DIFF
--- a/internal/joboutbox/loop.go
+++ b/internal/joboutbox/loop.go
@@ -102,14 +102,15 @@ type ReconcilerLoop struct {
 	done     chan struct{}
 	ticker   reconcilerTicker
 
-	recovered uint64
-	claimed   uint64
-	delivered uint64
-	retried   uint64
-	dead      uint64
-	leaseLost uint64
-	lastOK    time.Time
-	up        bool
+	recovered                    uint64
+	postRepairContractRejections uint64
+	claimed                      uint64
+	delivered                    uint64
+	retried                      uint64
+	dead                         uint64
+	leaseLost                    uint64
+	lastOK                       time.Time
+	up                           bool
 
 	errors chan error
 }
@@ -218,6 +219,7 @@ func (loop *ReconcilerLoop) step(ctx context.Context, now time.Time) error {
 	}
 	loop.mu.Lock()
 	loop.recovered += nonNegativeUint(result.Recovered)
+	loop.postRepairContractRejections += nonNegativeUint(result.PostRepairContractRejectionsRecovered)
 	loop.claimed += nonNegativeUint(result.Claimed)
 	loop.delivered += nonNegativeUint(result.Delivered)
 	loop.retried += nonNegativeUint(result.Retried)
@@ -301,6 +303,7 @@ func (loop *ReconcilerLoop) WritePrometheus(output io.Writer) error {
 	}
 	loop.mu.Lock()
 	recovered := loop.recovered
+	postRepairContractRejections := loop.postRepairContractRejections
 	claimed := loop.claimed
 	delivered := loop.delivered
 	retried := loop.retried
@@ -317,6 +320,7 @@ func (loop *ReconcilerLoop) WritePrometheus(output io.Writer) error {
 	}
 	var text strings.Builder
 	writeReconcilerCounter(&text, "worker_outbox_reconciler_terminal_deliveries_recovered_total", "Terminal River deliveries rearmed by the reconciler.", recovered)
+	writeReconcilerCounter(&text, "worker_outbox_reconciler_post_repair_contract_rejections_recovered_total", "Post-repair provider contract rejections recovered by the reconciler.", postRepairContractRejections)
 	writeReconcilerCounter(&text, "worker_outbox_reconciler_claimed_total", "Outbox rows claimed by the reconciler.", claimed)
 	writeReconcilerCounter(&text, "worker_outbox_reconciler_delivered_total", "Outbox rows delivered to River by the reconciler.", delivered)
 	writeReconcilerCounter(&text, "worker_outbox_reconciler_retried_total", "Outbox rows scheduled for relay retry by the reconciler.", retried)

--- a/internal/joboutbox/loop_test.go
+++ b/internal/joboutbox/loop_test.go
@@ -108,7 +108,7 @@ func TestReconcilerLoopImmediateNoopStepOpensReadiness(t *testing.T) {
 
 func TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics(t *testing.T) {
 	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
-	results := []StepResult{{Recovered: 1, Claimed: 2, Delivered: 1, Retried: 1}, {Recovered: 2, Claimed: 3, Dead: 1, LeaseLost: 2}}
+	results := []StepResult{{Recovered: 1, PostRepairContractRejectionsRecovered: 1, Claimed: 2, Delivered: 1, Retried: 1}, {Recovered: 2, Claimed: 3, Dead: 1, LeaseLost: 2}}
 	loop, _ := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
 		result := results[0]
 		results = results[1:]
@@ -131,6 +131,7 @@ func TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics(t *test
 	}
 	for _, want := range []string{
 		"worker_outbox_reconciler_terminal_deliveries_recovered_total 3",
+		"worker_outbox_reconciler_post_repair_contract_rejections_recovered_total 1",
 		"worker_outbox_reconciler_claimed_total 5",
 		"worker_outbox_reconciler_delivered_total 1",
 		"worker_outbox_reconciler_retried_total 1",

--- a/internal/joboutbox/relay.go
+++ b/internal/joboutbox/relay.go
@@ -36,13 +36,14 @@ func (config RelayConfig) validate() error {
 }
 
 type StepResult struct {
-	Recovered int
-	Claimed   int
-	Deferred  int
-	Delivered int
-	Retried   int
-	Dead      int
-	LeaseLost int
+	Recovered                             int
+	PostRepairContractRejectionsRecovered int
+	Claimed                               int
+	Deferred                              int
+	Delivered                             int
+	Retried                               int
+	Dead                                  int
+	LeaseLost                             int
 }
 
 // Relay is a single bounded reconciliation step. Process lifecycle and polling
@@ -165,6 +166,7 @@ func (relay *Relay) Step(ctx context.Context, now time.Time, limit int) (StepRes
 			return result, err
 		}
 		result.Recovered = recovered.Recovered
+		result.PostRepairContractRejectionsRecovered = recovered.PostRepairContractRejectionsRecovered
 	}
 	deferred := relay.deferredKinds
 	if relay.routes != nil {

--- a/internal/joboutbox/relay_integration_test.go
+++ b/internal/joboutbox/relay_integration_test.go
@@ -695,6 +695,7 @@ WHERE dedupe_key=$1`, seed.DedupeKey).Scan(
 		if _, err := adminPool.Exec(ctx, `
 			UPDATE river.river_job
 			SET state = 'discarded', attempt = 1, max_attempts = 5,
+				unique_states = B'11111111',
 				finalized_at = $2::timestamptz,
 				errors = ARRAY[jsonb_build_object(
 					'at', $2::timestamptz, 'attempt', 1,
@@ -778,8 +779,8 @@ WHERE dedupe_key=$1`, seed.DedupeKey).Scan(
 			WHERE kind = $1`, jobcontract.KindSyncProviderUnit).Scan(&jobs); err != nil {
 			t.Fatal(err)
 		}
-		if jobs != 2 {
-			t.Fatalf("provider River jobs=%d want=2", jobs)
+		if jobs != 1 {
+			t.Fatalf("provider River jobs=%d want=1", jobs)
 		}
 
 		if _, err := adminPool.Exec(ctx, `
@@ -847,6 +848,248 @@ WHERE dedupe_key=$1`, seed.DedupeKey).Scan(
 		if err != nil || exhausted.Recovered != 0 {
 			t.Fatalf("exhausted repair Step() = %#v, %v", exhausted, err)
 		}
+	})
+
+	t.Run("post-repair contract rejection releases its retained discarded transport", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		now := time.Now().UTC().Truncate(time.Second)
+		seed := providerUnitSeed(105, integrationUUID(4105), now)
+		seedProviderUnitDomain(t, ctx, adminPool, seed, "dispatching", "running", now.Add(-time.Hour))
+		seedOutbox(t, ctx, adminPool, seed.outbox)
+		claim := claimOne(t, ctx, repository, now, 30*time.Second)
+		firstJobID, err := repository.Dispatch(ctx, claim, now, inserter.Insert)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE river.river_job
+			SET state = 'discarded', attempt = 1, max_attempts = 5,
+				unique_states = B'11111111', finalized_at = $2::timestamptz,
+				errors = ARRAY[jsonb_build_object(
+					'at', $2::timestamptz, 'attempt', 1,
+					'error', 'Stuck job rescued by JobRescuer', 'trace', ''
+				)]
+			WHERE id = $1`, firstJobID, now); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.worker_job_outbox
+			SET status = 'dead', river_job_id = NULL, delivered_at = NULL, attempt_count = 2,
+				first_attempt_at = $2, last_attempt_at = $2,
+				last_error_code = 'contract_rejected',
+				last_error_detail = 'stored job contract was rejected',
+				last_error_at = $2, updated_at = $2
+			WHERE id = $1`, seed.outbox.ID, now); err != nil {
+			t.Fatal(err)
+		}
+
+		results := make(chan TerminalDeliveryRepairResult, 2)
+		errorsByReplica := make(chan error, 2)
+		var replicas sync.WaitGroup
+		for range 2 {
+			repair, repairErr := NewTerminalDeliveryRepair(queuePool, "river")
+			if repairErr != nil {
+				t.Fatal(repairErr)
+			}
+			replicas.Add(1)
+			go func() {
+				defer replicas.Done()
+				result, stepErr := repair.Step(ctx, now.Add(time.Minute), 10)
+				results <- result
+				errorsByReplica <- stepErr
+			}()
+		}
+		replicas.Wait()
+		close(results)
+		close(errorsByReplica)
+		var recovered, postRepairRecovered int
+		for stepErr := range errorsByReplica {
+			if stepErr != nil {
+				t.Fatal(stepErr)
+			}
+		}
+		for result := range results {
+			recovered += result.Recovered
+			postRepairRecovered += result.PostRepairContractRejectionsRecovered
+		}
+		if recovered != 1 || postRepairRecovered != 1 {
+			t.Fatalf("post-repair contract replica recovery = %d/%d, want 1/1", recovered, postRepairRecovered)
+		}
+		var staleJobs int
+		if err := adminPool.QueryRow(ctx, `SELECT count(*) FROM river.river_job WHERE id=$1`, firstJobID).Scan(&staleJobs); err != nil {
+			t.Fatal(err)
+		}
+		if staleJobs != 0 {
+			t.Fatal("terminal stale transport was not deleted")
+		}
+		repair, err := NewTerminalDeliveryRepair(queuePool, "river")
+		if err != nil {
+			t.Fatal(err)
+		}
+		relay, err := NewRelayWithRoutesAndRecovery(
+			repository,
+			inserter,
+			fakeRouteResolver{route: "river"},
+			repair,
+			DefaultRelayConfig(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		delivery, err := relay.Step(ctx, now.Add(2*time.Minute), 10)
+		if err != nil || delivery.Claimed != 1 || delivery.Delivered != 1 {
+			t.Fatalf("post-repair contract relay Step() = %#v, %v", delivery, err)
+		}
+		var secondJobID int64
+		if err := adminPool.QueryRow(ctx, `SELECT river_job_id FROM public.worker_job_outbox WHERE id=$1`, seed.outbox.ID).Scan(&secondJobID); err != nil {
+			t.Fatal(err)
+		}
+		if secondJobID == firstJobID {
+			t.Fatal("relay reattached the terminal duplicate instead of inserting a new job")
+		}
+		var secondState string
+		if err := adminPool.QueryRow(ctx, `SELECT state::text FROM river.river_job WHERE id=$1`, secondJobID).Scan(&secondState); err != nil {
+			t.Fatal(err)
+		}
+		if secondState != "available" && secondState != "scheduled" {
+			t.Fatalf("fresh River job state=%s, want schedulable", secondState)
+		}
+		assertOutboxStatus(t, ctx, adminPool, seed.outbox.ID, statusDelivered, 3)
+	})
+
+	t.Run("mismatched terminal transport is never deleted or rearmed", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		now := time.Now().UTC().Truncate(time.Second)
+		seed := providerUnitSeed(106, integrationUUID(4106), now)
+		seedProviderUnitDomain(t, ctx, adminPool, seed, "dispatching", "running", now.Add(-time.Hour))
+		seedOutbox(t, ctx, adminPool, seed.outbox)
+		claim := claimOne(t, ctx, repository, now, 30*time.Second)
+		jobID, err := repository.Dispatch(ctx, claim, now, inserter.Insert)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE river.river_job
+			SET state = 'discarded', attempt = 1, max_attempts = 5,
+				unique_states = B'11111111', finalized_at = $2::timestamptz,
+				errors = ARRAY[jsonb_build_object(
+					'at', $2::timestamptz, 'attempt', 1,
+					'error', 'Stuck job rescued by JobRescuer', 'trace', ''
+				)],
+				metadata = jsonb_set(metadata, '{worker_outbox_id}', '"00000000-0000-4000-8000-000000009999"')
+			WHERE id = $1`, jobID, now); err != nil {
+			t.Fatal(err)
+		}
+		repair, err := NewTerminalDeliveryRepair(queuePool, "river")
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := repair.Step(ctx, now.Add(time.Minute), 10)
+		if err != nil || result != (TerminalDeliveryRepairResult{}) {
+			t.Fatalf("mismatched transport repair Step() = %#v, %v", result, err)
+		}
+		assertOutboxStatus(t, ctx, adminPool, seed.outbox.ID, statusDelivered, 1)
+		var jobs int
+		if err := adminPool.QueryRow(ctx, `SELECT count(*) FROM river.river_job WHERE id=$1`, jobID).Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 1 {
+			t.Fatal("mismatched terminal transport was deleted")
+		}
+	})
+
+	t.Run("post-repair recovery deletes only the latest exact stale transport", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		now := time.Now().UTC().Truncate(time.Second)
+		seed := providerUnitSeed(107, integrationUUID(4107), now)
+		seedProviderUnitDomain(t, ctx, adminPool, seed, "dispatching", "running", now.Add(-time.Hour))
+		seedOutbox(t, ctx, adminPool, seed.outbox)
+		claim := claimOne(t, ctx, repository, now, 30*time.Second)
+		firstJobID, err := repository.Dispatch(ctx, claim, now, inserter.Insert)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE river.river_job
+			SET state = 'discarded', attempt = 1, max_attempts = 5,
+				unique_states = B'11111111', finalized_at = $2::timestamptz,
+				errors = ARRAY[jsonb_build_object(
+					'at', $2::timestamptz, 'attempt', 1,
+					'error', 'Stuck job rescued by JobRescuer', 'trace', ''
+				)]
+			WHERE id = $1`, firstJobID, now); err != nil {
+			t.Fatal(err)
+		}
+		var secondStaleJobID int64
+		if err := adminPool.QueryRow(ctx, `
+			INSERT INTO river.river_job (
+				args, attempt, created_at, errors, finalized_at, kind, max_attempts,
+				metadata, priority, queue, state, scheduled_at, unique_key, unique_states
+			)
+			SELECT args, 1, $2::timestamptz, errors, $2::timestamptz, kind, max_attempts,
+				metadata, priority, queue, 'discarded', scheduled_at,
+				decode(repeat('ab', 32), 'hex'), B'11110101'
+			FROM river.river_job WHERE id=$1
+			RETURNING id`, firstJobID, now.Add(time.Second)).Scan(&secondStaleJobID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.worker_job_outbox
+			SET status = 'dead', river_job_id = NULL, delivered_at = NULL, attempt_count = 2,
+				first_attempt_at = $2, last_attempt_at = $2,
+				last_error_code = 'contract_rejected',
+				last_error_detail = 'stored job contract was rejected', last_error_at = $2, updated_at = $2
+			WHERE id=$1`, seed.outbox.ID, now); err != nil {
+			t.Fatal(err)
+		}
+		repair, err := NewTerminalDeliveryRepair(queuePool, "river")
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := repair.Step(ctx, now.Add(2*time.Minute), 10)
+		if err != nil || result != (TerminalDeliveryRepairResult{Recovered: 1, PostRepairContractRejectionsRecovered: 1}) {
+			t.Fatalf("multi-stale repair Step() = %#v, %v", result, err)
+		}
+		var firstJobs, secondJobs int
+		if err := adminPool.QueryRow(ctx, `SELECT count(*) FROM river.river_job WHERE id=$1`, firstJobID).Scan(&firstJobs); err != nil {
+			t.Fatal(err)
+		}
+		if err := adminPool.QueryRow(ctx, `SELECT count(*) FROM river.river_job WHERE id=$1`, secondStaleJobID).Scan(&secondJobs); err != nil {
+			t.Fatal(err)
+		}
+		if firstJobs != 0 || secondJobs != 1 {
+			t.Fatalf("multi-stale deletion first/second=%d/%d, want 0/1", firstJobs, secondJobs)
+		}
+		relay, err := NewRelayWithRoutesAndRecovery(
+			repository,
+			inserter,
+			fakeRouteResolver{route: "river"},
+			repair,
+			DefaultRelayConfig(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		delivery, err := relay.Step(ctx, now.Add(3*time.Minute), 10)
+		if err != nil || delivery.Claimed != 1 || delivery.Delivered != 1 {
+			t.Fatalf("multi-stale relay Step() = %#v, %v", delivery, err)
+		}
+		var freshJobID int64
+		var freshState string
+		if err := adminPool.QueryRow(ctx, `
+			SELECT river_job_id FROM public.worker_job_outbox WHERE id=$1`, seed.outbox.ID).Scan(&freshJobID); err != nil {
+			t.Fatal(err)
+		}
+		if freshJobID == firstJobID || freshJobID == secondStaleJobID {
+			t.Fatalf("multi-stale relay reused terminal job %d", freshJobID)
+		}
+		if err := adminPool.QueryRow(ctx, `SELECT state::text FROM river.river_job WHERE id=$1`, freshJobID).Scan(&freshState); err != nil {
+			t.Fatal(err)
+		}
+		if freshState != "available" && freshState != "scheduled" {
+			t.Fatalf("multi-stale fresh River job state=%s, want schedulable", freshState)
+		}
+		assertOutboxStatus(t, ctx, adminPool, seed.outbox.ID, statusDelivered, 3)
 	})
 }
 

--- a/internal/joboutbox/terminal_delivery_repair.go
+++ b/internal/joboutbox/terminal_delivery_repair.go
@@ -8,18 +8,26 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
 )
 
 const (
-	riverUnhandledRescueError      = "Stuck job rescued by JobRescuer"
-	providerTerminalRecoveryCode   = "river_unhandled_rescue"
-	providerTerminalRecoveryDetail = "terminal River delivery recovered"
+	riverUnhandledRescueError                = "Stuck job rescued by JobRescuer"
+	providerTerminalRecoveryCode             = "river_unhandled_rescue"
+	providerTerminalRecoveryDetail           = "terminal River delivery recovered"
+	providerPostRepairContractRecoveryCode   = "post_repair_contract_rejection_recovered"
+	providerPostRepairContractRecoveryDetail = "post-repair contract rejection recovered"
+	providerContractRejectedCode             = "contract_rejected"
+	providerContractRejectedDetail           = "stored job contract was rejected"
 )
 
 var riverSchemaPattern = regexp.MustCompile(`^[a-z_][a-z0-9_]{0,62}$`)
 
 type TerminalDeliveryRepairResult struct {
-	Recovered int
+	Recovered                             int
+	PostRepairContractRejectionsRecovered int
 }
 
 // TerminalDeliveryRepair rearms a provider-unit outbox row only when its
@@ -27,7 +35,10 @@ type TerminalDeliveryRepairResult struct {
 // while the authoritative run and unit remain active and due. The outbox and
 // River rows are locked together so replicas converge on one replacement.
 type TerminalDeliveryRepair struct {
-	begin func(context.Context) (pgx.Tx, error)
+	begin  func(context.Context) (pgx.Tx, error)
+	client interface {
+		JobDeleteTx(context.Context, pgx.Tx, int64) (*rivertype.JobRow, error)
+	}
 	query string
 }
 
@@ -39,10 +50,22 @@ func NewTerminalDeliveryRepair(
 		return nil, ErrInvalidConfiguration
 	}
 	jobTable := pgx.Identifier{riverSchema, "river_job"}.Sanitize()
+	stateInMask := pgx.Identifier{riverSchema, "river_job_state_in_bitmask"}.Sanitize()
+	client, err := river.NewClient(riverpgxv5.New(queueControlPool), &river.Config{Schema: riverSchema})
+	if err != nil {
+		return nil, ErrInvalidConfiguration
+	}
 	return &TerminalDeliveryRepair{
-		begin: queueControlPool.Begin,
-		query: fmt.Sprintf(repairProviderUnitTerminalDeliverySQL, jobTable),
+		begin:  queueControlPool.Begin,
+		client: riverDeleteAdapter{client: client},
+		query:  fmt.Sprintf(repairProviderUnitTerminalDeliverySQL, jobTable, stateInMask),
 	}, nil
+}
+
+type riverDeleteAdapter struct{ client *river.Client[pgx.Tx] }
+
+func (adapter riverDeleteAdapter) JobDeleteTx(ctx context.Context, tx pgx.Tx, id int64) (*rivertype.JobRow, error) {
+	return adapter.client.JobDeleteTx(ctx, tx, id)
 }
 
 func (repair *TerminalDeliveryRepair) Step(
@@ -50,7 +73,7 @@ func (repair *TerminalDeliveryRepair) Step(
 	now time.Time,
 	limit int,
 ) (TerminalDeliveryRepairResult, error) {
-	if repair == nil || repair.begin == nil || ctx == nil || now.IsZero() ||
+	if repair == nil || repair.begin == nil || repair.client == nil || ctx == nil || now.IsZero() ||
 		limit < minReconcilerLimit || limit > maxReconcilerLimit {
 		return TerminalDeliveryRepairResult{}, ErrInvalidConfiguration
 	}
@@ -70,21 +93,52 @@ func (repair *TerminalDeliveryRepair) Step(
 		riverUnhandledRescueError,
 		providerTerminalRecoveryCode,
 		providerTerminalRecoveryDetail,
+		providerPostRepairContractRecoveryCode,
+		providerPostRepairContractRecoveryDetail,
+		providerContractRejectedCode,
+		providerContractRejectedDetail,
 	)
 	if err != nil || rows == nil {
 		return TerminalDeliveryRepairResult{}, ErrUnavailable
 	}
 	defer rows.Close()
-	result := TerminalDeliveryRepairResult{}
+	type candidate struct {
+		outboxID, recoveryCode, recoveryDetail string
+		riverJobID                             int64
+	}
+	candidates := make([]candidate, 0, limit)
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil || !uuidPattern.MatchString(id) {
+		var candidate candidate
+		if err := rows.Scan(&candidate.outboxID, &candidate.riverJobID, &candidate.recoveryCode, &candidate.recoveryDetail); err != nil ||
+			!uuidPattern.MatchString(candidate.outboxID) || candidate.riverJobID <= 0 {
+			return TerminalDeliveryRepairResult{}, ErrUnavailable
+		}
+		candidates = append(candidates, candidate)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil || len(candidates) > limit {
+		return TerminalDeliveryRepairResult{}, ErrUnavailable
+	}
+	result := TerminalDeliveryRepairResult{}
+	for _, candidate := range candidates {
+		deleted, err := repair.client.JobDeleteTx(ctx, tx, candidate.riverJobID)
+		if err != nil || deleted == nil || deleted.ID != candidate.riverJobID || deleted.State != rivertype.JobStateDiscarded {
+			return TerminalDeliveryRepairResult{}, ErrUnavailable
+		}
+		command, err := tx.Exec(ctx, `
+			UPDATE public.worker_job_outbox
+			SET status = 'pending', next_attempt_at = $2,
+				last_error_code = $3, last_error_detail = $4, last_error_at = $2,
+				river_job_id = NULL, delivered_at = NULL,
+				claim_token = NULL, claimed_at = NULL, claim_expires_at = NULL, updated_at = $2
+			WHERE id = $1`, candidate.outboxID, now.UTC(), candidate.recoveryCode, candidate.recoveryDetail)
+		if err != nil || command.RowsAffected() != 1 {
 			return TerminalDeliveryRepairResult{}, ErrUnavailable
 		}
 		result.Recovered++
-	}
-	if err := rows.Err(); err != nil || result.Recovered > limit {
-		return TerminalDeliveryRepairResult{}, ErrUnavailable
+		if candidate.recoveryCode == providerPostRepairContractRecoveryCode {
+			result.PostRepairContractRejectionsRecovered++
+		}
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return TerminalDeliveryRepairResult{}, ErrUnavailable
@@ -96,11 +150,20 @@ func (repair *TerminalDeliveryRepair) Step(
 // mutation authority over the generic outbox and River schema. The identity
 // predicates bind the immutable outbox envelope, authoritative domain row,
 // current outbox delivery, and River metadata together before any row is
-// rearmed. A paused integration is intentionally absent: pausing prevents new
-// planning, but does not cancel already-planned work in an active run.
+// rearmed. The supported River delete runs in this same transaction after the
+// exact terminal row is locked; a new relay step then creates fresh strict
+// metadata. A paused integration is intentionally absent: pausing prevents
+// new planning, but does not cancel already-planned work in an active run.
 const repairProviderUnitTerminalDeliverySQL = `
-WITH candidates AS (
-	SELECT outbox.id
+	SELECT outbox.id::text, job.id,
+		CASE
+			WHEN outbox.status = 'delivered' THEN $4::text
+			ELSE $6::text
+		END AS recovery_code,
+		CASE
+			WHEN outbox.status = 'delivered' THEN $5::text
+			ELSE $7::text
+		END AS recovery_detail
 	FROM public.worker_job_outbox AS outbox
 	JOIN public.sync_run_units AS unit
 		ON unit.id = CASE
@@ -114,15 +177,25 @@ WITH candidates AS (
 	JOIN public.sync_runs AS run
 		ON run.id = unit.sync_run_id
 		AND run.org_id = unit.org_id
-	JOIN %s AS job
-		ON job.id = outbox.river_job_id
-		AND job.kind = outbox.job_kind
-		AND job.args = outbox.args::jsonb
-		AND job.metadata ->> 'worker_outbox_id' = outbox.id::text
-		AND job.metadata ->> 'payload_hash' = outbox.payload_hash
-		AND job.metadata ->> 'contract_version' = outbox.contract_version::text
-	WHERE outbox.status = 'delivered'
-		AND outbox.job_kind = 'sync.provider_unit'
+	JOIN LATERAL (
+		SELECT candidate_job.*
+		FROM %s AS candidate_job
+		WHERE candidate_job.kind = outbox.job_kind
+			AND candidate_job.args = outbox.args::jsonb
+			AND candidate_job.metadata ->> 'worker_outbox_id' = outbox.id::text
+			AND candidate_job.metadata ->> 'payload_hash' = outbox.payload_hash
+			AND candidate_job.metadata ->> 'contract_version' = outbox.contract_version::text
+			AND candidate_job.state::text = 'discarded'
+			AND candidate_job.finalized_at IS NOT NULL
+			AND candidate_job.attempt < candidate_job.max_attempts
+			AND candidate_job.unique_key IS NOT NULL
+			AND %s(candidate_job.unique_states, candidate_job.state)
+			AND cardinality(candidate_job.errors) > 0
+			AND (candidate_job.errors[cardinality(candidate_job.errors)]->>'error') = $3
+		ORDER BY candidate_job.id DESC
+		LIMIT 1
+	) AS job ON TRUE
+	WHERE outbox.job_kind = 'sync.provider_unit'
 		AND outbox.dedupe_key = 'sync.provider_unit:' || unit.id::text
 		AND outbox.args #>> '{domain,type}' = 'sync_run_unit'
 		AND unit.status = 'dispatching'
@@ -130,28 +203,24 @@ WITH candidates AS (
 		AND unit.lease_owner IS NULL
 		AND unit.lease_expires_at IS NULL
 		AND run.status IN ('planned', 'dispatching', 'running')
-		AND job.state::text = 'discarded'
-		AND job.finalized_at IS NOT NULL
-		AND job.attempt < job.max_attempts
-		AND cardinality(job.errors) > 0
-		AND (job.errors[cardinality(job.errors)]->>'error') = $3
+		AND (
+			(
+				outbox.status = 'delivered'
+				AND outbox.river_job_id = job.id
+			)
+			OR (
+				outbox.status = 'dead'
+				AND outbox.river_job_id IS NULL
+				AND outbox.delivered_at IS NULL
+				AND outbox.contract_version = 1
+				AND outbox.queue = 'sync_provider'
+				AND outbox.priority = 2
+				AND outbox.max_attempts = 5
+				AND outbox.last_error_code = $8
+				AND outbox.last_error_detail = $9
+			)
+		)
 	ORDER BY outbox.delivered_at, outbox.id
 	FOR UPDATE OF outbox, job SKIP LOCKED
 	LIMIT $2::int
-)
-UPDATE public.worker_job_outbox AS outbox
-SET status = 'pending',
-	next_attempt_at = $1,
-	last_error_code = $4,
-	last_error_detail = $5,
-	last_error_at = $1,
-	river_job_id = NULL,
-	delivered_at = NULL,
-	claim_token = NULL,
-	claimed_at = NULL,
-	claim_expires_at = NULL,
-	updated_at = $1
-FROM candidates
-WHERE outbox.id = candidates.id
-RETURNING outbox.id::text
 `

--- a/tests/tooling/mutation-plans/provider_unit_post_repair_contract_rejection.json
+++ b/tests/tooling/mutation-plans/provider_unit_post_repair_contract_rejection.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "name": "provider-unit post-repair contract rejection recovery",
+  "$limitation": "Pins recovery only for active provider units with an exact discarded, finalized River transport. It does not reopen mismatched, running, cancelled, or terminal work.",
+  "mutations": [
+    {
+      "id": "PUPR01-dead-contract-evidence",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\t\t\tAND outbox.last_error_code = $8\n",
+      "replace": "\t\t\t\tAND outbox.last_error_code <> $8\n",
+      "expect_occurrences": 1,
+      "rationale": "Only the recorded post-repair contract rejection can rearm a dead outbox row.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestGenericOutboxLiveFailureInjectionMatrix$/^post-repair_contract_rejection_releases_its_retained_discarded_transport$", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUPR02-outbox-identity",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\t\tAND candidate_job.metadata ->> 'worker_outbox_id' = outbox.id::text\n",
+      "replace": "\t\t\tAND candidate_job.metadata ->> 'worker_outbox_id' <> outbox.id::text\n",
+      "expect_occurrences": 1,
+      "rationale": "A mismatched terminal River job must neither be deleted nor rearm another outbox delivery.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestGenericOutboxLiveFailureInjectionMatrix$/^mismatched_terminal_transport_is_never_deleted_or_rearmed$", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUPR03-supported-terminal-delete",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\tdeleted, err := repair.client.JobDeleteTx(ctx, tx, candidate.riverJobID)\n",
+      "replace": "\t\tdeleted, err := &rivertype.JobRow{ID: candidate.riverJobID, State: rivertype.JobStateDiscarded}, error(nil)\n",
+      "expect_occurrences": 1,
+      "rationale": "The stale terminal job must be removed before the ordinary relay can insert a fresh, schedulable delivery.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestGenericOutboxLiveFailureInjectionMatrix$/^post-repair_contract_rejection_releases_its_retained_discarded_transport$", "./internal/joboutbox/"]]
+    },
+    {
+      "id": "PUPR04-legacy-unique-blocker",
+      "file": "internal/joboutbox/terminal_delivery_repair.go",
+      "find": "\t\t\tAND %s(candidate_job.unique_states, candidate_job.state)\n",
+      "replace": "\t\t\tAND NOT %s(candidate_job.unique_states, candidate_job.state)\n",
+      "expect_occurrences": 1,
+      "rationale": "A dead outbox is recovered only when the selected discarded job still owns the legacy uniqueness key that blocks a fresh relay insert.",
+      "build": ["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-run", "^$", "./internal/joboutbox/"],
+      "proof": [["env", "GOTOOLCHAIN=go1.25.9", "GOCACHE=/tmp/chaos3805-mutation-cache", "go", "test", "-tags=integration", "-count=1", "-run", "^TestGenericOutboxLiveFailureInjectionMatrix$/^post-repair_contract_rejection_releases_its_retained_discarded_transport$", "./internal/joboutbox/"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- What changed: recover narrowly fenced provider outbox rows stranded after a legacy discarded River job blocks replacement delivery; atomically remove that stale terminal transport and rearm the immutable outbox for normal strict relay.
- Why: River could return a discarded legacy job as a unique duplicate, then strict metadata verification terminalized the outbox and left the active unit permanently dispatching.

## Checklist

- [x] I added/updated tests, or provided required governance evidence below.
- [x] I ran relevant local validation.
- [x] I documented risk and rollback considerations.
- [x] Breaking changes, migrations, and config impacts: none.

## Test Evidence

TEST-EVIDENCE: Full internal/joboutbox unit and integration suites passed; exact disposable PostgreSQL/River recovery matrix passed for delivered and dead/no-pointer branches plus mismatch negatives; go vet passed; shared mutation plan PUPR01-PUPR04 all killed with restore verified; canonical ci/local_validate.sh passed all 9 declared stages including full unit suite, 86 ClickHouse migrations, and live argMax proof.

## Risk Notes

RISK-NOTES: Narrow to sync.provider_unit contract v1 rows with exact outbox identity, immutable payload hash/version, discarded finalized rescue evidence, active due domain state, remaining attempts, and a legacy uniqueness mask that includes discarded. Recovery and stale-job deletion occur in one transaction; normal relay still performs strict contract validation. Rollback is this commit. No live stack mutation, restart, cancellation, migration, or config change was performed.

## Optional Context

- Linked issues: CHAOS-3805
- Additional notes: The affected run should recover automatically after this change is merged and the reconciler is rebuilt; no manual SQL or cancellation is required.