### PR TITLE
fix(worker): pool River control connections

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -306,6 +306,7 @@ jobs:
         run: >-
           python -m pip install
           asyncpg==0.31.0
+          greenlet==3.5.0
           riverqueue==0.7.0
           SQLAlchemy==2.0.49
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -317,7 +317,8 @@ jobs:
           jq -e '
             .status == "complete_with_architecture_blocker"
             and .nested_n_minus_1.status == "pass"
-            and (.profiles | length) == 2
+            and [.profiles[].mode] == ["direct", "poll-only", "session"]
+            and (.gate_truth_table | keys) == ["direct", "poll_only", "session"]
           ' "${RUNNER_TEMP}/river-compatibility.json" >/dev/null
 
       - name: Upload sanitized compatibility evidence

--- a/ci/check_river_compat_static.sh
+++ b/ci/check_river_compat_static.sh
@@ -8,6 +8,7 @@ HARNESS="${ROOT}/tests/compatibility/river/run.sh"
 RECORDER="${ROOT}/tests/compatibility/river/record.sh"
 COMPOSE_FILE="${ROOT}/tests/compatibility/river/compose.compatibility.yml"
 RESULTS="${ROOT}/ci/evidence/go-worker-migration/v1-river-spike/local-harness-results.json"
+GO_WORKFLOW="${ROOT}/.github/workflows/go.yml"
 
 for command_name in bash docker jq shellcheck; do
   command -v "${command_name}" >/dev/null 2>&1 || {
@@ -23,6 +24,23 @@ docker compose version >/dev/null 2>&1 || {
 bash -n "${HARNESS}"
 bash -n "${RECORDER}"
 shellcheck "${HARNESS}" "${RECORDER}" "${ROOT}/ci/check_go.sh" "${BASH_SOURCE[0]}"
+# shellcheck disable=SC2016 # This is a literal source-contract assertion.
+grep -F 'if $mode == "direct" or $mode == "session" then' "${HARNESS}" >/dev/null || {
+  printf 'ERROR: direct and session cancellation contracts must remain identical\n' >&2
+  exit 1
+}
+grep -F 'pgbouncer-session-helm-smoke' "${HARNESS}" >/dev/null || {
+  printf 'ERROR: the Helm PgBouncer startup smoke must run in the isolated harness\n' >&2
+  exit 1
+}
+grep -F 'GREENLET_VERSION="3.5.0"' "${HARNESS}" >/dev/null || {
+  printf 'ERROR: the Python async SQLAlchemy greenlet pin must remain preflight-validated\n' >&2
+  exit 1
+}
+grep -F 'greenlet==3.5.0' "${GO_WORKFLOW}" >/dev/null || {
+  printf 'ERROR: the hosted River compatibility job must install the greenlet pin explicitly\n' >&2
+  exit 1
+}
 docker compose \
   --project-name rivercompat-static-check \
   --file "${COMPOSE_FILE}" \
@@ -52,10 +70,28 @@ jq -e '
   and .versions.riverqueue_python == "0.7.0"
   and .versions.sqlalchemy == "2.0.49"
   and .versions.asyncpg == "0.31.0"
-  and (.gate_truth_table.direct | all(. == true))
-  and (.gate_truth_table.session | all(. == true))
+  and .versions.greenlet == "3.5.0"
+  and .gate_truth_table.direct.backend_connection_delta_at_most_six == true
+  and .gate_truth_table.direct.canceled_acquires_zero == true
+  and .gate_truth_table.direct.enqueue_p95_within_limit == true
+  and .gate_truth_table.direct.new_connections_at_most_six == true
+  and .gate_truth_table.direct.cross_client_running_cancel == true
+  and .gate_truth_table.direct.same_client_running_cancel == null
+  and .gate_truth_table.session.backend_connection_delta_at_most_six == true
+  and .gate_truth_table.session.canceled_acquires_zero == true
+  and .gate_truth_table.session.enqueue_p95_within_limit == true
+  and .gate_truth_table.session.new_connections_at_most_six == true
+  and .gate_truth_table.session.cross_client_running_cancel == true
+  and .gate_truth_table.session.same_client_running_cancel == null
   and .gate_truth_table.poll_only.cross_client_running_cancel == false
   and .gate_truth_table.poll_only.same_client_running_cancel == false
+  and .helm_pgbouncer_startup == {
+    status: "pass",
+    mode: "session",
+    container_identity: "postgres_uid_gid_70",
+    root_filesystem: "read_only",
+    writable_config_path: "/etc/pgbouncer"
+  }
   and all(.profiles[]; .python_transactions.scheduled_commit.job_contract.state == "scheduled")
   and .nested_n_minus_1.phases[1].current_insert.outcome == "inserted"
   and .nested_n_minus_1.phases[1].n_minus_one_consume.outcome == "completed"

--- a/ci/check_river_compat_static.sh
+++ b/ci/check_river_compat_static.sh
@@ -37,7 +37,8 @@ jq -e '
   and .status == "complete_with_architecture_blocker"
   and .architecture_blocker == "poll_only_running_cancel_not_propagated"
   and (.profiles | type) == "array"
-  and (.profiles | length) == 2
+  and [.profiles[].mode] == ["direct", "poll-only", "session"]
+  and (.gate_truth_table | keys) == ["direct", "poll_only", "session"]
   and .nested_n_minus_1.status == "pass"
   and (.nested_n_minus_1.phases | length) == 2
   and .versions.go == "go1.25.9"
@@ -51,6 +52,10 @@ jq -e '
   and .versions.riverqueue_python == "0.7.0"
   and .versions.sqlalchemy == "2.0.49"
   and .versions.asyncpg == "0.31.0"
+  and (.gate_truth_table.direct | all(. == true))
+  and (.gate_truth_table.session | all(. == true))
+  and .gate_truth_table.poll_only.cross_client_running_cancel == false
+  and .gate_truth_table.poll_only.same_client_running_cancel == false
   and all(.profiles[]; .python_transactions.scheduled_commit.job_contract.state == "scheduled")
   and .nested_n_minus_1.phases[1].current_insert.outcome == "inserted"
   and .nested_n_minus_1.phases[1].n_minus_one_consume.outcome == "completed"

--- a/ci/evidence/go-worker-migration/v1-river-spike/local-harness-results.json
+++ b/ci/evidence/go-worker-migration/v1-river-spike/local-harness-results.json
@@ -15,7 +15,8 @@
     "python": "3.13.14",
     "riverqueue_python": "0.7.0",
     "sqlalchemy": "2.0.49",
-    "asyncpg": "0.31.0"
+    "asyncpg": "0.31.0",
+    "greenlet": "3.5.0"
   },
   "samples_per_mode": 20,
   "gate_truth_table": {
@@ -34,7 +35,22 @@
       "new_connections_at_most_six": true,
       "cross_client_running_cancel": false,
       "same_client_running_cancel": false
+    },
+    "session": {
+      "backend_connection_delta_at_most_six": true,
+      "canceled_acquires_zero": true,
+      "enqueue_p95_within_limit": true,
+      "new_connections_at_most_six": true,
+      "cross_client_running_cancel": true,
+      "same_client_running_cancel": null
     }
+  },
+  "helm_pgbouncer_startup": {
+    "status": "pass",
+    "mode": "session",
+    "container_identity": "postgres_uid_gid_70",
+    "root_filesystem": "read_only",
+    "writable_config_path": "/etc/pgbouncer"
   },
   "profiles": [
     {
@@ -53,63 +69,63 @@
           "applied_versions": [
             7
           ],
-          "duration_ms": 21.595,
+          "duration_ms": 15.803,
           "latest_version": 7,
           "version_count": 7
         },
         "workload": {
           "execute": {
             "attempt": 1,
-            "enqueue_to_start_ms": 10.167,
+            "enqueue_to_start_ms": 11.061,
             "error_count": 0,
             "max_attempts": 3,
             "outcome": "completed",
             "priority": 2,
             "queue": "chaos3034-direct",
-            "run_duration_ms": 0.101,
+            "run_duration_ms": 0.087,
             "scheduled": false,
             "source": "go",
             "state": "completed"
           },
           "execute_latency_ms": {
             "count": 20,
-            "max": 232.265,
-            "min": 2.974,
-            "p50": 4.12,
-            "p95": 21.995,
+            "max": 214.841,
+            "min": 1.873,
+            "p50": 2.449,
+            "p95": 24.604,
             "limit": 250,
             "within_limit": true
           },
           "cancel": {
             "attempt": 1,
-            "enqueue_to_start_ms": 5.453,
+            "enqueue_to_start_ms": 2.012,
             "error_count": 1,
             "max_attempts": 3,
             "outcome": "running_context_cancelled_cross_client",
             "priority": 2,
             "queue": "chaos3034-direct",
-            "run_duration_ms": 1.243,
+            "run_duration_ms": 1.329,
             "scheduled": false,
             "source": "go",
             "state": "cancelled"
           },
           "running_cancellation": {
             "cross_client_context_cancelled": true,
-            "cross_client_observation_ms": 0.043,
+            "cross_client_observation_ms": 0.005,
             "same_client_attempted": false,
             "same_client_context_cancelled": false,
             "probe_release_used": false
           },
           "recovery": {
             "attempt": 2,
-            "enqueue_to_start_ms": 23.233,
+            "enqueue_to_start_ms": 2.239,
             "error_count": 1,
             "max_attempts": 3,
             "outcome": "completed_after_retry",
             "priority": 2,
             "queue": "chaos3034-direct",
-            "recovery_first_to_last_ms": 228.553,
-            "run_duration_ms": 0.03,
+            "recovery_first_to_last_ms": 486.023,
+            "run_duration_ms": 0.023,
             "scheduled": true,
             "source": "go",
             "state": "completed"
@@ -128,43 +144,43 @@
         },
         "postgres": {
           "before": {
-            "backend_connections": 2,
-            "blocks_hit": 15437,
+            "backend_connections": 4,
+            "blocks_hit": 15942,
             "blocks_read": 376,
-            "sessions": 9,
+            "sessions": 11,
             "tuples_deleted": 79,
             "tuples_inserted": 578,
             "tuples_updated": 59,
-            "xact_commit": 50,
+            "xact_commit": 52,
             "xact_rollback": 0
           },
           "after": {
-            "backend_connections": 8,
-            "blocks_hit": 24361,
+            "backend_connections": 10,
+            "blocks_hit": 24935,
             "blocks_read": 385,
-            "sessions": 15,
+            "sessions": 17,
             "tuples_deleted": 226,
             "tuples_inserted": 683,
-            "tuples_updated": 120,
-            "xact_commit": 231,
+            "tuples_updated": 121,
+            "xact_commit": 236,
             "xact_rollback": 0
           },
           "delta": {
             "backend_connections": 6,
-            "blocks_hit": 8924,
+            "blocks_hit": 8993,
             "blocks_read": 9,
             "sessions": 6,
             "tuples_deleted": 147,
             "tuples_inserted": 105,
-            "tuples_updated": 61,
-            "xact_commit": 181,
+            "tuples_updated": 62,
+            "xact_commit": 184,
             "xact_rollback": 0
           }
         },
         "pool": {
           "before": {
             "acquire_count": 9,
-            "acquire_duration_ms": 5.05,
+            "acquire_duration_ms": 4.238,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 1,
@@ -173,8 +189,8 @@
             "total_connections": 1
           },
           "after": {
-            "acquire_count": 151,
-            "acquire_duration_ms": 38.601,
+            "acquire_count": 153,
+            "acquire_duration_ms": 43.2,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 7,
@@ -183,8 +199,8 @@
             "total_connections": 6
           },
           "delta": {
-            "acquire_count": 142,
-            "acquire_duration_ms": 33.551,
+            "acquire_count": 144,
+            "acquire_duration_ms": 38.962,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 6,
@@ -262,20 +278,20 @@
         "fetch_poll_interval_ms": 250,
         "migration": {
           "applied_versions": [],
-          "duration_ms": 17.359,
+          "duration_ms": 12.461,
           "latest_version": 7,
           "version_count": 7
         },
         "workload": {
           "external": {
             "attempt": 1,
-            "enqueue_to_start_ms": 134.937,
+            "enqueue_to_start_ms": 91.935,
             "error_count": 0,
             "max_attempts": 7,
             "outcome": "external_completed",
             "priority": 2,
             "queue": "chaos3034-direct",
-            "run_duration_ms": 0.046,
+            "run_duration_ms": 0.04,
             "scheduled": false,
             "source": "python",
             "state": "completed"
@@ -283,25 +299,25 @@
         },
         "postgres": {
           "before": {
-            "backend_connections": 3,
-            "blocks_hit": 51834,
+            "backend_connections": 10,
+            "blocks_hit": 62421,
             "blocks_read": 404,
-            "sessions": 31,
-            "tuples_deleted": 229,
-            "tuples_inserted": 756,
-            "tuples_updated": 174,
-            "xact_commit": 471,
+            "sessions": 39,
+            "tuples_deleted": 230,
+            "tuples_inserted": 785,
+            "tuples_updated": 232,
+            "xact_commit": 720,
             "xact_rollback": 2
           },
           "after": {
-            "backend_connections": 8,
-            "blocks_hit": 51989,
+            "backend_connections": 15,
+            "blocks_hit": 62576,
             "blocks_read": 404,
-            "sessions": 36,
-            "tuples_deleted": 229,
-            "tuples_inserted": 756,
-            "tuples_updated": 174,
-            "xact_commit": 476,
+            "sessions": 44,
+            "tuples_deleted": 230,
+            "tuples_inserted": 785,
+            "tuples_updated": 232,
+            "xact_commit": 725,
             "xact_rollback": 2
           },
           "delta": {
@@ -319,7 +335,7 @@
         "pool": {
           "before": {
             "acquire_count": 8,
-            "acquire_duration_ms": 9.776,
+            "acquire_duration_ms": 7.199,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 1,
@@ -329,7 +345,7 @@
           },
           "after": {
             "acquire_count": 21,
-            "acquire_duration_ms": 63.298,
+            "acquire_duration_ms": 50.119,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 6,
@@ -339,7 +355,7 @@
           },
           "delta": {
             "acquire_count": 13,
-            "acquire_duration_ms": 53.522000000000006,
+            "acquire_duration_ms": 42.92,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 5,
@@ -375,20 +391,20 @@
           "fetch_poll_interval_ms": 250,
           "migration": {
             "applied_versions": [],
-            "duration_ms": 15.259,
+            "duration_ms": 8.188,
             "latest_version": 7,
             "version_count": 7
           },
           "workload": {
             "external": {
               "attempt": 2,
-              "enqueue_to_start_ms": 23108.403,
+              "enqueue_to_start_ms": 22223.039,
               "error_count": 1,
               "max_attempts": 3,
               "outcome": "external_completed",
               "priority": 2,
               "queue": "chaos3034-direct",
-              "run_duration_ms": 0.045,
+              "run_duration_ms": 0.093,
               "scheduled": true,
               "source": "go",
               "state": "completed"
@@ -396,43 +412,43 @@
           },
           "postgres": {
             "before": {
-              "backend_connections": 3,
-              "blocks_hit": 71893,
+              "backend_connections": 10,
+              "blocks_hit": 82443,
               "blocks_read": 404,
-              "sessions": 47,
-              "tuples_deleted": 230,
-              "tuples_inserted": 763,
-              "tuples_updated": 179,
-              "xact_commit": 566,
+              "sessions": 55,
+              "tuples_deleted": 231,
+              "tuples_inserted": 792,
+              "tuples_updated": 237,
+              "xact_commit": 813,
               "xact_rollback": 9
             },
             "after": {
-              "backend_connections": 7,
-              "blocks_hit": 77557,
+              "backend_connections": 14,
+              "blocks_hit": 88461,
               "blocks_read": 404,
-              "sessions": 52,
-              "tuples_deleted": 231,
-              "tuples_inserted": 767,
-              "tuples_updated": 190,
-              "xact_commit": 715,
+              "sessions": 59,
+              "tuples_deleted": 232,
+              "tuples_inserted": 792,
+              "tuples_updated": 242,
+              "xact_commit": 949,
               "xact_rollback": 9
             },
             "delta": {
               "backend_connections": 4,
-              "blocks_hit": 5664,
+              "blocks_hit": 6018,
               "blocks_read": 0,
-              "sessions": 5,
+              "sessions": 4,
               "tuples_deleted": 1,
-              "tuples_inserted": 4,
-              "tuples_updated": 11,
-              "xact_commit": 149,
+              "tuples_inserted": 0,
+              "tuples_updated": 5,
+              "xact_commit": 136,
               "xact_rollback": 0
             }
           },
           "pool": {
             "before": {
               "acquire_count": 8,
-              "acquire_duration_ms": 8.151,
+              "acquire_duration_ms": 3.956,
               "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 1,
@@ -441,8 +457,8 @@
               "total_connections": 1
             },
             "after": {
-              "acquire_count": 111,
-              "acquire_duration_ms": 40.66,
+              "acquire_count": 108,
+              "acquire_duration_ms": 28.232,
               "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 5,
@@ -451,8 +467,8 @@
               "total_connections": 4
             },
             "delta": {
-              "acquire_count": 103,
-              "acquire_duration_ms": 32.509,
+              "acquire_count": 100,
+              "acquire_duration_ms": 24.276,
               "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 4,
@@ -484,64 +500,64 @@
         "fetch_poll_interval_ms": 250,
         "migration": {
           "applied_versions": [],
-          "duration_ms": 13.853,
+          "duration_ms": 8.43,
           "latest_version": 7,
           "version_count": 7
         },
         "workload": {
           "execute": {
             "attempt": 1,
-            "enqueue_to_start_ms": 15.251,
+            "enqueue_to_start_ms": 9.784,
             "error_count": 0,
             "max_attempts": 3,
             "outcome": "completed",
             "priority": 2,
             "queue": "chaos3034-poll-only",
-            "run_duration_ms": 0.054,
+            "run_duration_ms": 0.034,
             "scheduled": false,
             "source": "go",
             "state": "completed"
           },
           "execute_latency_ms": {
             "count": 20,
-            "max": 271.024,
-            "min": 5.634,
-            "p50": 133.507,
-            "p95": 231.58,
+            "max": 252.739,
+            "min": 2.947,
+            "p50": 70.124,
+            "p95": 237.787,
             "limit": 600,
             "within_limit": true
           },
           "cancel": {
             "attempt": 1,
-            "enqueue_to_start_ms": 240.699,
+            "enqueue_to_start_ms": 158.142,
             "error_count": 1,
             "max_attempts": 3,
             "outcome": "running_cancel_not_propagated_probe_released",
             "priority": 2,
             "queue": "chaos3034-poll-only",
-            "run_duration_ms": 1504.576,
+            "run_duration_ms": 1504.641,
             "scheduled": false,
             "source": "go",
             "state": "cancelled"
           },
           "running_cancellation": {
             "cross_client_context_cancelled": false,
-            "cross_client_observation_ms": 750.943,
+            "cross_client_observation_ms": 750.867,
             "same_client_attempted": true,
             "same_client_context_cancelled": false,
-            "same_client_observation_ms": 750.271,
+            "same_client_observation_ms": 751.029,
             "probe_release_used": true
           },
           "recovery": {
             "attempt": 2,
-            "enqueue_to_start_ms": 104.082,
+            "enqueue_to_start_ms": 268.74,
             "error_count": 1,
             "max_attempts": 3,
             "outcome": "completed_after_retry",
             "priority": 2,
             "queue": "chaos3034-poll-only",
-            "recovery_first_to_last_ms": 264.491,
-            "run_duration_ms": 0.037,
+            "recovery_first_to_last_ms": 265.743,
+            "run_duration_ms": 0.018,
             "scheduled": true,
             "source": "go",
             "state": "completed"
@@ -560,43 +576,43 @@
         },
         "postgres": {
           "before": {
-            "backend_connections": 1,
-            "blocks_hit": 42726,
+            "backend_connections": 3,
+            "blocks_hit": 43420,
             "blocks_read": 385,
-            "sessions": 28,
+            "sessions": 30,
             "tuples_deleted": 229,
             "tuples_inserted": 690,
             "tuples_updated": 132,
-            "xact_commit": 354,
+            "xact_commit": 357,
             "xact_rollback": 0
           },
           "after": {
-            "backend_connections": 2,
-            "blocks_hit": 49154,
+            "backend_connections": 5,
+            "blocks_hit": 47239,
             "blocks_read": 385,
-            "sessions": 29,
+            "sessions": 32,
             "tuples_deleted": 229,
             "tuples_inserted": 711,
-            "tuples_updated": 172,
-            "xact_commit": 467,
+            "tuples_updated": 176,
+            "xact_commit": 476,
             "xact_rollback": 0
           },
           "delta": {
-            "backend_connections": 1,
-            "blocks_hit": 6428,
+            "backend_connections": 2,
+            "blocks_hit": 3819,
             "blocks_read": 0,
-            "sessions": 1,
+            "sessions": 2,
             "tuples_deleted": 0,
             "tuples_inserted": 21,
-            "tuples_updated": 40,
-            "xact_commit": 113,
+            "tuples_updated": 44,
+            "xact_commit": 119,
             "xact_rollback": 0
           }
         },
         "pool": {
           "before": {
             "acquire_count": 8,
-            "acquire_duration_ms": 7.474,
+            "acquire_duration_ms": 2.505,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 1,
@@ -606,7 +622,7 @@
           },
           "after": {
             "acquire_count": 139,
-            "acquire_duration_ms": 29.299,
+            "acquire_duration_ms": 21.025,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 5,
@@ -616,7 +632,7 @@
           },
           "delta": {
             "acquire_count": 131,
-            "acquire_duration_ms": 21.825,
+            "acquire_duration_ms": 18.52,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 4,
@@ -695,20 +711,20 @@
         "fetch_poll_interval_ms": 250,
         "migration": {
           "applied_versions": [],
-          "duration_ms": 7.12,
+          "duration_ms": 6.514,
           "latest_version": 7,
           "version_count": 7
         },
         "workload": {
           "external": {
             "attempt": 1,
-            "enqueue_to_start_ms": 133.205,
+            "enqueue_to_start_ms": 79.563,
             "error_count": 0,
             "max_attempts": 7,
             "outcome": "external_completed",
             "priority": 2,
             "queue": "chaos3034-poll-only",
-            "run_duration_ms": 0.067,
+            "run_duration_ms": 0.04,
             "scheduled": false,
             "source": "python",
             "state": "completed"
@@ -716,43 +732,43 @@
         },
         "postgres": {
           "before": {
-            "backend_connections": 2,
-            "blocks_hit": 78955,
+            "backend_connections": 9,
+            "blocks_hit": 89394,
             "blocks_read": 404,
-            "sessions": 52,
-            "tuples_deleted": 233,
-            "tuples_inserted": 768,
-            "tuples_updated": 195,
-            "xact_commit": 740,
+            "sessions": 59,
+            "tuples_deleted": 234,
+            "tuples_inserted": 793,
+            "tuples_updated": 246,
+            "xact_commit": 976,
             "xact_rollback": 10
           },
           "after": {
-            "backend_connections": 2,
-            "blocks_hit": 79055,
+            "backend_connections": 10,
+            "blocks_hit": 89442,
             "blocks_read": 404,
-            "sessions": 52,
-            "tuples_deleted": 233,
-            "tuples_inserted": 768,
-            "tuples_updated": 195,
-            "xact_commit": 741,
+            "sessions": 60,
+            "tuples_deleted": 234,
+            "tuples_inserted": 793,
+            "tuples_updated": 247,
+            "xact_commit": 981,
             "xact_rollback": 10
           },
           "delta": {
-            "backend_connections": 0,
-            "blocks_hit": 100,
+            "backend_connections": 1,
+            "blocks_hit": 48,
             "blocks_read": 0,
-            "sessions": 0,
+            "sessions": 1,
             "tuples_deleted": 0,
             "tuples_inserted": 0,
-            "tuples_updated": 0,
-            "xact_commit": 1,
+            "tuples_updated": 1,
+            "xact_commit": 5,
             "xact_rollback": 0
           }
         },
         "pool": {
           "before": {
             "acquire_count": 8,
-            "acquire_duration_ms": 4.544,
+            "acquire_duration_ms": 2.346,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 1,
@@ -762,23 +778,23 @@
           },
           "after": {
             "acquire_count": 20,
-            "acquire_duration_ms": 18.059,
+            "acquire_duration_ms": 13.047,
+            "acquired_connections": 0,
+            "canceled_acquire_count": 0,
+            "empty_acquire_count": 5,
+            "idle_connections": 5,
+            "new_connections": 5,
+            "total_connections": 5
+          },
+          "delta": {
+            "acquire_count": 12,
+            "acquire_duration_ms": 10.701,
             "acquired_connections": 0,
             "canceled_acquire_count": 0,
             "empty_acquire_count": 4,
             "idle_connections": 4,
             "new_connections": 4,
             "total_connections": 4
-          },
-          "delta": {
-            "acquire_count": 12,
-            "acquire_duration_ms": 13.515,
-            "acquired_connections": 0,
-            "canceled_acquire_count": 0,
-            "empty_acquire_count": 3,
-            "idle_connections": 3,
-            "new_connections": 3,
-            "total_connections": 3
           }
         },
         "gates": {
@@ -808,20 +824,20 @@
           "fetch_poll_interval_ms": 250,
           "migration": {
             "applied_versions": [],
-            "duration_ms": 9.594,
+            "duration_ms": 4.478,
             "latest_version": 7,
             "version_count": 7
           },
           "workload": {
             "external": {
               "attempt": 2,
-              "enqueue_to_start_ms": 22609.576,
+              "enqueue_to_start_ms": 22629.425,
               "error_count": 1,
               "max_attempts": 3,
               "outcome": "external_completed",
               "priority": 2,
               "queue": "chaos3034-poll-only",
-              "run_duration_ms": 0.049,
+              "run_duration_ms": 0.027,
               "scheduled": true,
               "source": "go",
               "state": "completed"
@@ -829,43 +845,43 @@
           },
           "postgres": {
             "before": {
-              "backend_connections": 3,
-              "blocks_hit": 82750,
+              "backend_connections": 10,
+              "blocks_hit": 89833,
               "blocks_read": 404,
-              "sessions": 53,
+              "sessions": 60,
               "tuples_deleted": 234,
-              "tuples_inserted": 776,
-              "tuples_updated": 199,
-              "xact_commit": 782,
-              "xact_rollback": 16
+              "tuples_inserted": 794,
+              "tuples_updated": 247,
+              "xact_commit": 986,
+              "xact_rollback": 10
             },
             "after": {
-              "backend_connections": 3,
-              "blocks_hit": 91380,
-              "blocks_read": 425,
-              "sessions": 54,
-              "tuples_deleted": 235,
-              "tuples_inserted": 796,
-              "tuples_updated": 238,
-              "xact_commit": 919,
+              "backend_connections": 10,
+              "blocks_hit": 103277,
+              "blocks_read": 424,
+              "sessions": 61,
+              "tuples_deleted": 236,
+              "tuples_inserted": 821,
+              "tuples_updated": 290,
+              "xact_commit": 1159,
               "xact_rollback": 18
             },
             "delta": {
               "backend_connections": 0,
-              "blocks_hit": 8630,
-              "blocks_read": 21,
+              "blocks_hit": 13444,
+              "blocks_read": 20,
               "sessions": 1,
-              "tuples_deleted": 1,
-              "tuples_inserted": 20,
-              "tuples_updated": 39,
-              "xact_commit": 137,
-              "xact_rollback": 2
+              "tuples_deleted": 2,
+              "tuples_inserted": 27,
+              "tuples_updated": 43,
+              "xact_commit": 173,
+              "xact_rollback": 8
             }
           },
           "pool": {
             "before": {
               "acquire_count": 8,
-              "acquire_duration_ms": 3.489,
+              "acquire_duration_ms": 3.443,
               "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 1,
@@ -874,23 +890,454 @@
               "total_connections": 1
             },
             "after": {
-              "acquire_count": 117,
-              "acquire_duration_ms": 14.832,
-              "acquired_connections": 1,
+              "acquire_count": 118,
+              "acquire_duration_ms": 11.911,
+              "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 4,
-              "idle_connections": 3,
+              "idle_connections": 4,
               "new_connections": 4,
               "total_connections": 4
             },
             "delta": {
-              "acquire_count": 109,
-              "acquire_duration_ms": 11.343,
-              "acquired_connections": 1,
+              "acquire_count": 110,
+              "acquire_duration_ms": 8.468,
+              "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 3,
-              "idle_connections": 2,
+              "idle_connections": 3,
               "new_connections": 3,
+              "total_connections": 3
+            }
+          },
+          "gates": {
+            "backend_connection_delta_at_most_six": true,
+            "canceled_acquires_zero": true,
+            "enqueue_p95_within_limit": true,
+            "new_connections_at_most_six": true
+          }
+        }
+      }
+    },
+    {
+      "mode": "session",
+      "transport": "pgbouncer_session",
+      "matrix": {
+        "status": "ok",
+        "mode": "session",
+        "go_version": "go1.25.9",
+        "pgx_version": "v5.10.0",
+        "river_driver_version": "v0.40.0",
+        "river_version": "v0.40.0",
+        "poll_only": false,
+        "fetch_poll_interval_ms": 250,
+        "migration": {
+          "applied_versions": [],
+          "duration_ms": 8.657,
+          "latest_version": 7,
+          "version_count": 7
+        },
+        "workload": {
+          "execute": {
+            "attempt": 1,
+            "enqueue_to_start_ms": 10003.826,
+            "error_count": 0,
+            "max_attempts": 3,
+            "outcome": "completed",
+            "priority": 2,
+            "queue": "chaos3034-session",
+            "run_duration_ms": 0.05,
+            "scheduled": false,
+            "source": "go",
+            "state": "completed"
+          },
+          "execute_latency_ms": {
+            "count": 20,
+            "max": 10003.826,
+            "min": 1.97,
+            "p50": 2.524,
+            "p95": 19.258,
+            "limit": 250,
+            "within_limit": true
+          },
+          "cancel": {
+            "attempt": 1,
+            "enqueue_to_start_ms": 1.906,
+            "error_count": 1,
+            "max_attempts": 3,
+            "outcome": "running_context_cancelled_cross_client",
+            "priority": 2,
+            "queue": "chaos3034-session",
+            "run_duration_ms": 0.739,
+            "scheduled": false,
+            "source": "go",
+            "state": "cancelled"
+          },
+          "running_cancellation": {
+            "cross_client_context_cancelled": true,
+            "cross_client_observation_ms": 0.029,
+            "same_client_attempted": false,
+            "same_client_context_cancelled": false,
+            "probe_release_used": false
+          },
+          "recovery": {
+            "attempt": 2,
+            "enqueue_to_start_ms": 1.997,
+            "error_count": 1,
+            "max_attempts": 3,
+            "outcome": "completed_after_retry",
+            "priority": 2,
+            "queue": "chaos3034-session",
+            "recovery_first_to_last_ms": 322.277,
+            "run_duration_ms": 0.058,
+            "scheduled": true,
+            "source": "go",
+            "state": "completed"
+          },
+          "scheduled": {
+            "attempt": 0,
+            "error_count": 0,
+            "max_attempts": 3,
+            "outcome": "scheduled_state_observed",
+            "priority": 2,
+            "queue": "chaos3034-session",
+            "scheduled": true,
+            "source": "go",
+            "state": "cancelled"
+          }
+        },
+        "postgres": {
+          "before": {
+            "backend_connections": 5,
+            "blocks_hit": 47269,
+            "blocks_read": 385,
+            "sessions": 32,
+            "tuples_deleted": 229,
+            "tuples_inserted": 711,
+            "tuples_updated": 176,
+            "xact_commit": 479,
+            "xact_rollback": 0
+          },
+          "after": {
+            "backend_connections": 9,
+            "blocks_hit": 58737,
+            "blocks_read": 385,
+            "sessions": 37,
+            "tuples_deleted": 230,
+            "tuples_inserted": 738,
+            "tuples_updated": 224,
+            "xact_commit": 692,
+            "xact_rollback": 0
+          },
+          "delta": {
+            "backend_connections": 4,
+            "blocks_hit": 11468,
+            "blocks_read": 0,
+            "sessions": 5,
+            "tuples_deleted": 1,
+            "tuples_inserted": 27,
+            "tuples_updated": 48,
+            "xact_commit": 213,
+            "xact_rollback": 0
+          }
+        },
+        "pool": {
+          "before": {
+            "acquire_count": 8,
+            "acquire_duration_ms": 2.521,
+            "acquired_connections": 0,
+            "canceled_acquire_count": 0,
+            "empty_acquire_count": 1,
+            "idle_connections": 1,
+            "new_connections": 1,
+            "total_connections": 1
+          },
+          "after": {
+            "acquire_count": 157,
+            "acquire_duration_ms": 20.351,
+            "acquired_connections": 1,
+            "canceled_acquire_count": 0,
+            "empty_acquire_count": 7,
+            "idle_connections": 4,
+            "new_connections": 7,
+            "total_connections": 5
+          },
+          "delta": {
+            "acquire_count": 149,
+            "acquire_duration_ms": 17.83,
+            "acquired_connections": 1,
+            "canceled_acquire_count": 0,
+            "empty_acquire_count": 6,
+            "idle_connections": 3,
+            "new_connections": 6,
+            "total_connections": 4
+          }
+        },
+        "gates": {
+          "backend_connection_delta_at_most_six": true,
+          "canceled_acquires_zero": true,
+          "enqueue_p95_within_limit": true,
+          "new_connections_at_most_six": true,
+          "cross_client_running_cancel": true
+        }
+      },
+      "python_transactions": {
+        "commit": {
+          "mode": "commit",
+          "domain_count": 1,
+          "job_count": 1,
+          "job_contract": {
+            "contract_version": 1,
+            "max_attempts": 7,
+            "priority": 2,
+            "queue": "chaos3034-session",
+            "scheduled_after_create": false,
+            "source": "python",
+            "state": "available",
+            "tags": [
+              "phase0",
+              "python"
+            ]
+          }
+        },
+        "scheduled_commit": {
+          "mode": "commit",
+          "domain_count": 1,
+          "job_count": 1,
+          "job_contract": {
+            "contract_version": 1,
+            "max_attempts": 7,
+            "priority": 2,
+            "queue": "chaos3034-session",
+            "scheduled_after_create": true,
+            "source": "python",
+            "state": "scheduled",
+            "tags": [
+              "phase0",
+              "python"
+            ]
+          }
+        },
+        "rollback": {
+          "mode": "rollback",
+          "domain_count": 0,
+          "job_count": 0,
+          "job_contract": null
+        },
+        "unique": {
+          "mode": "unique",
+          "status": "unsupported",
+          "reason_code": "river_0_40_unique_index_contract_missing",
+          "sqlstate": "42P10"
+        }
+      },
+      "cross_language_consume": {
+        "status": "ok",
+        "mode": "session",
+        "go_version": "go1.25.9",
+        "pgx_version": "v5.10.0",
+        "river_driver_version": "v0.40.0",
+        "river_version": "v0.40.0",
+        "poll_only": false,
+        "fetch_poll_interval_ms": 250,
+        "migration": {
+          "applied_versions": [],
+          "duration_ms": 9.388,
+          "latest_version": 7,
+          "version_count": 7
+        },
+        "workload": {
+          "external": {
+            "attempt": 1,
+            "enqueue_to_start_ms": 84.745,
+            "error_count": 0,
+            "max_attempts": 7,
+            "outcome": "external_completed",
+            "priority": 2,
+            "queue": "chaos3034-session",
+            "run_duration_ms": 0.044,
+            "scheduled": false,
+            "source": "python",
+            "state": "completed"
+          }
+        },
+        "postgres": {
+          "before": {
+            "backend_connections": 10,
+            "blocks_hit": 103292,
+            "blocks_read": 424,
+            "sessions": 61,
+            "tuples_deleted": 236,
+            "tuples_inserted": 821,
+            "tuples_updated": 290,
+            "xact_commit": 1161,
+            "xact_rollback": 19
+          },
+          "after": {
+            "backend_connections": 10,
+            "blocks_hit": 103454,
+            "blocks_read": 424,
+            "sessions": 61,
+            "tuples_deleted": 236,
+            "tuples_inserted": 822,
+            "tuples_updated": 291,
+            "xact_commit": 1174,
+            "xact_rollback": 19
+          },
+          "delta": {
+            "backend_connections": 0,
+            "blocks_hit": 162,
+            "blocks_read": 0,
+            "sessions": 0,
+            "tuples_deleted": 0,
+            "tuples_inserted": 1,
+            "tuples_updated": 1,
+            "xact_commit": 13,
+            "xact_rollback": 0
+          }
+        },
+        "pool": {
+          "before": {
+            "acquire_count": 8,
+            "acquire_duration_ms": 3.321,
+            "acquired_connections": 0,
+            "canceled_acquire_count": 0,
+            "empty_acquire_count": 1,
+            "idle_connections": 1,
+            "new_connections": 1,
+            "total_connections": 1
+          },
+          "after": {
+            "acquire_count": 21,
+            "acquire_duration_ms": 19.671,
+            "acquired_connections": 1,
+            "canceled_acquire_count": 0,
+            "empty_acquire_count": 6,
+            "idle_connections": 4,
+            "new_connections": 6,
+            "total_connections": 5
+          },
+          "delta": {
+            "acquire_count": 13,
+            "acquire_duration_ms": 16.349999999999998,
+            "acquired_connections": 1,
+            "canceled_acquire_count": 0,
+            "empty_acquire_count": 5,
+            "idle_connections": 3,
+            "new_connections": 5,
+            "total_connections": 4
+          }
+        },
+        "gates": {
+          "backend_connection_delta_at_most_six": true,
+          "canceled_acquires_zero": true,
+          "enqueue_p95_within_limit": true,
+          "new_connections_at_most_six": true
+        }
+      },
+      "crash_recovery": {
+        "first_attempt": {
+          "event": "started",
+          "attempt": 1
+        },
+        "termination": {
+          "signal": "SIGKILL",
+          "exit_code": 137
+        },
+        "rescue": {
+          "status": "ok",
+          "mode": "session",
+          "go_version": "go1.25.9",
+          "pgx_version": "v5.10.0",
+          "river_driver_version": "v0.40.0",
+          "river_version": "v0.40.0",
+          "poll_only": false,
+          "fetch_poll_interval_ms": 250,
+          "migration": {
+            "applied_versions": [],
+            "duration_ms": 8.883,
+            "latest_version": 7,
+            "version_count": 7
+          },
+          "workload": {
+            "external": {
+              "attempt": 2,
+              "enqueue_to_start_ms": 32874.267,
+              "error_count": 1,
+              "max_attempts": 3,
+              "outcome": "external_completed",
+              "priority": 2,
+              "queue": "chaos3034-session",
+              "run_duration_ms": 0.028,
+              "scheduled": true,
+              "source": "go",
+              "state": "completed"
+            }
+          },
+          "postgres": {
+            "before": {
+              "backend_connections": 10,
+              "blocks_hit": 109074,
+              "blocks_read": 424,
+              "sessions": 62,
+              "tuples_deleted": 238,
+              "tuples_inserted": 830,
+              "tuples_updated": 298,
+              "xact_commit": 1286,
+              "xact_rollback": 27
+            },
+            "after": {
+              "backend_connections": 10,
+              "blocks_hit": 111194,
+              "blocks_read": 424,
+              "sessions": 62,
+              "tuples_deleted": 239,
+              "tuples_inserted": 831,
+              "tuples_updated": 300,
+              "xact_commit": 1417,
+              "xact_rollback": 27
+            },
+            "delta": {
+              "backend_connections": 0,
+              "blocks_hit": 2120,
+              "blocks_read": 0,
+              "sessions": 0,
+              "tuples_deleted": 1,
+              "tuples_inserted": 1,
+              "tuples_updated": 2,
+              "xact_commit": 131,
+              "xact_rollback": 0
+            }
+          },
+          "pool": {
+            "before": {
+              "acquire_count": 8,
+              "acquire_duration_ms": 3.805,
+              "acquired_connections": 0,
+              "canceled_acquire_count": 0,
+              "empty_acquire_count": 1,
+              "idle_connections": 1,
+              "new_connections": 1,
+              "total_connections": 1
+            },
+            "after": {
+              "acquire_count": 111,
+              "acquire_duration_ms": 15.4,
+              "acquired_connections": 0,
+              "canceled_acquire_count": 0,
+              "empty_acquire_count": 5,
+              "idle_connections": 4,
+              "new_connections": 5,
+              "total_connections": 4
+            },
+            "delta": {
+              "acquire_count": 103,
+              "acquire_duration_ms": 11.595,
+              "acquired_connections": 0,
+              "canceled_acquire_count": 0,
+              "empty_acquire_count": 4,
+              "idle_connections": 3,
+              "new_connections": 4,
               "total_connections": 3
             }
           },
@@ -960,20 +1407,20 @@
           "fetch_poll_interval_ms": 250,
           "migration": {
             "applied_versions": [],
-            "duration_ms": 14.049,
+            "duration_ms": 9.754,
             "latest_version": 7,
             "version_count": 7
           },
           "workload": {
             "external": {
               "attempt": 1,
-              "enqueue_to_start_ms": 74.575,
+              "enqueue_to_start_ms": 47.269,
               "error_count": 0,
               "max_attempts": 25,
               "outcome": "external_completed",
               "priority": 1,
               "queue": "chaos3034-n-minus-1",
-              "run_duration_ms": 0.055,
+              "run_duration_ms": 0.042,
               "scheduled": false,
               "source": "go",
               "state": "completed"
@@ -981,25 +1428,25 @@
           },
           "postgres": {
             "before": {
-              "backend_connections": 2,
-              "blocks_hit": 28994,
+              "backend_connections": 4,
+              "blocks_hit": 29951,
               "blocks_read": 385,
-              "sessions": 17,
+              "sessions": 19,
               "tuples_deleted": 227,
               "tuples_inserted": 687,
               "tuples_updated": 126,
-              "xact_commit": 258,
+              "xact_commit": 262,
               "xact_rollback": 0
             },
             "after": {
-              "backend_connections": 7,
-              "blocks_hit": 29149,
+              "backend_connections": 9,
+              "blocks_hit": 30106,
               "blocks_read": 385,
-              "sessions": 22,
+              "sessions": 24,
               "tuples_deleted": 227,
               "tuples_inserted": 687,
               "tuples_updated": 126,
-              "xact_commit": 263,
+              "xact_commit": 267,
               "xact_rollback": 0
             },
             "delta": {
@@ -1017,7 +1464,7 @@
           "pool": {
             "before": {
               "acquire_count": 8,
-              "acquire_duration_ms": 6.328,
+              "acquire_duration_ms": 5.066,
               "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 1,
@@ -1027,7 +1474,7 @@
             },
             "after": {
               "acquire_count": 21,
-              "acquire_duration_ms": 38.307,
+              "acquire_duration_ms": 31.334,
               "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 6,
@@ -1037,7 +1484,7 @@
             },
             "delta": {
               "acquire_count": 13,
-              "acquire_duration_ms": 31.979000000000003,
+              "acquire_duration_ms": 26.268,
               "acquired_connections": 0,
               "canceled_acquire_count": 0,
               "empty_acquire_count": 5,

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -929,7 +929,6 @@ func (dependencies *workerDependencies) queueControlConfigReady(context.Context)
 	for _, configurationError := range []error{
 		postgres.ErrQueueControlRequired,
 		postgres.ErrQueueControlTransactionMode,
-		postgres.ErrQueueControlSessionUnverified,
 		postgres.ErrRuntimeRolesNotSeparated,
 		postgres.ErrRuntimeRoleConfiguration,
 	} {

--- a/cmd/dev-health-workerctl/main.go
+++ b/cmd/dev-health-workerctl/main.go
@@ -52,6 +52,7 @@ type operatorRuntime struct {
 	lockTx                pgx.Tx
 	streamDeploymentState string
 	streams               []streamProfileStatus
+	queueControlMode      platformconfig.QueueControlMode
 }
 
 type streamProfileStatus struct {
@@ -126,12 +127,13 @@ func configureRuntime(ctx context.Context, lookup platformsecrets.LookupEnv, std
 	if !ok {
 		return nil, writeError(stderr, "authentication_failed")
 	}
-	mode := platformconfig.QueueControlDirect
-	if raw, configured := lookup("WORKER_DATABASE_MODE"); configured && raw != "" {
-		mode = platformconfig.QueueControlMode(strings.ToLower(raw))
-	}
-	if mode != platformconfig.QueueControlDirect {
+	mode := databaseMode(lookup, "WORKER_DATABASE_MODE")
+	if !sessionSafeMode(mode) {
 		return nil, writeError(stderr, "queue_control_mode_unsupported")
+	}
+	coordinatorMode := databaseMode(lookup, "COORDINATOR_DATABASE_MODE")
+	if !sessionSafeMode(coordinatorMode) {
+		return nil, writeError(stderr, "coordinator_database_mode_unsupported")
 	}
 	domainRole := resolveName("RIVER_DOMAIN_DATABASE_ROLE", defaultDomainRole, lookup)
 	queueRole := resolveName("RIVER_QUEUE_DATABASE_ROLE", defaultQueueRole, lookup)
@@ -150,6 +152,7 @@ func configureRuntime(ctx context.Context, lookup platformsecrets.LookupEnv, std
 		domainURI.Reveal(), queueURI.Reveal(), domainRole, queueRole,
 	).WithCoordinator()
 	runtimeConfig.QueueControlMode = mode
+	runtimeConfig.CoordinatorMode = coordinatorMode
 	runtimeConfig.RiverSchema = schema
 	runtimeConfig.DomainTransactionPooler = domainTransactionPooler
 	runtimeConfig.DomainMaxConns = 2
@@ -293,8 +296,19 @@ func configureRuntime(ctx context.Context, lookup platformsecrets.LookupEnv, std
 	lockHeld = false
 	return &operatorRuntime{
 		service: service, principal: authentication.Principal(), pools: pools, lockTx: lockTx,
-		streamDeploymentState: manifest.DeploymentState, streams: streams,
+		streamDeploymentState: manifest.DeploymentState, streams: streams, queueControlMode: mode,
 	}, 0
+}
+
+func databaseMode(lookup platformsecrets.LookupEnv, key string) platformconfig.QueueControlMode {
+	if raw, configured := lookup(key); configured && raw != "" {
+		return platformconfig.QueueControlMode(strings.ToLower(raw))
+	}
+	return platformconfig.QueueControlDirect
+}
+
+func sessionSafeMode(mode platformconfig.QueueControlMode) bool {
+	return mode == platformconfig.QueueControlDirect || mode == platformconfig.QueueControlSession
 }
 
 // newJobRouteController composes the only currently approved forward cutover:
@@ -353,7 +367,7 @@ func dispatch(ctx context.Context, runtime *operatorRuntime, args []string, stdo
 			return writeServiceError(stderr, err)
 		}
 		return writeResult(stdout, stderr, map[string]any{
-			"queue_control_mode":   "direct",
+			"queue_control_mode":   runtime.queueControlMode,
 			"river_schema_version": riverstore.PinnedSchemaVersion,
 			"status":               "ready",
 		})

--- a/cmd/dev-health-workerctl/main_test.go
+++ b/cmd/dev-health-workerctl/main_test.go
@@ -264,10 +264,28 @@ func commandRuntime(t *testing.T, authorizer joboperator.Authorizer) *operatorRu
 		t.Fatal(err)
 	}
 	return &operatorRuntime{
-		service: service,
+		service:          service,
+		queueControlMode: "direct",
 		principal: joboperator.Principal{
 			Type: "service_credential",
 			ID:   "00000000-0000-4000-8000-000000000303",
 		},
+	}
+}
+
+func TestSessionSafeModeRejectsTransactionAndUnknownModes(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		mode string
+		want bool
+	}{
+		{mode: "direct", want: true},
+		{mode: "session", want: true},
+		{mode: "transaction", want: false},
+		{mode: "invalid", want: false},
+	} {
+		if got := sessionSafeMode(databaseMode(func(key string) (string, bool) { return test.mode, true }, "ignored")); got != test.want {
+			t.Fatalf("mode %q allowed=%t, want %t", test.mode, got, test.want)
+		}
 	}
 }

--- a/cmd/worker-contractcheck/main.go
+++ b/cmd/worker-contractcheck/main.go
@@ -72,9 +72,10 @@ func runValidate(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintln(stdout, "worker contracts valid")
 	fmt.Fprintf(
 		stdout,
-		"deployment profiles valid: direct=%d domain_clients=%d server_footprint=%d\n",
-		budget.DirectQueueControlConnections,
-		budget.DomainClientConnections,
+		"deployment profiles valid: queue_session_clients=%d coordinator_session_clients=%d domain_transaction_clients=%d server_footprint=%d\n",
+		budget.QueueSessionClientConnections,
+		budget.CoordinatorSessionClientConnections,
+		budget.DomainTransactionClientConnections,
 		budget.ServerConnectionFootprint,
 	)
 	return 0

--- a/deploy/docker-compose/compose.go-workers.yml
+++ b/deploy/docker-compose/compose.go-workers.yml
@@ -114,14 +114,15 @@ services:
     environment: &go-worker-env
       DEV_HEALTH_HTTP_ADDR: ":8080"
       DEV_HEALTH_PROFILE: heavy
-      POSTGRES_URI: ${POSTGRES_URI:?direct domain PostgreSQL URI is required}
-      WORKER_DATABASE_URI: ${WORKER_DATABASE_URI:?queue-control PostgreSQL URI is required}
+      POSTGRES_URI: ${POSTGRES_URI:?transaction-pooler domain PostgreSQL URI is required}
+      WORKER_DATABASE_URI: ${WORKER_DATABASE_URI:?session-pooler queue-control PostgreSQL URI is required}
       CLICKHOUSE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:8123/${CLICKHOUSE_DB:-default}
       VALKEY_URI: redis://valkey:6379/1
       RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
       RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
       RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
-      WORKER_DATABASE_MODE: ${WORKER_DATABASE_MODE:-direct}
+      WORKER_DATABASE_MODE: ${WORKER_DATABASE_MODE:-session}
+      COORDINATOR_DATABASE_MODE: ${COORDINATOR_DATABASE_MODE:-session}
       # The PagerDuty stream runner forwards reconciliation to the Python
       # worker bridge until the locked-graph port lands (CUT-20), so it
       # cannot open readiness without both values.
@@ -167,6 +168,7 @@ services:
     environment:
       <<: *go-worker-env
       DEV_HEALTH_PROFILE: ""
+      COORDINATOR_DATABASE_URI: ${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}
 
   go-scheduler:
     <<: *go-worker
@@ -174,6 +176,7 @@ services:
     environment:
       <<: *go-worker-env
       DEV_HEALTH_PROFILE: ""
+      COORDINATOR_DATABASE_URI: ${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}
 
   go-stream-external:
     <<: *go-worker

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -411,7 +411,7 @@ services:
       POOL_MODE: transaction
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_MAX_CLIENT_CONN:-1000}
-      DEFAULT_POOL_SIZE: ${PGBOUNCER_DEFAULT_POOL_SIZE:-25}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
     ports:
       - "${PGBOUNCER_PORT:-6432}:6432"
     networks:
@@ -421,6 +421,49 @@ services:
         limits:
           memory: 256M
           cpus: "0.5"
+
+  # River listener/cancellation uses a session pool, never the transaction
+  # endpoint above. DB_USER and DB_NAME are fixed, so DEFAULT_POOL_SIZE caps
+  # the one relevant PgBouncer (database,user) backend pool.
+  pgbouncer-river-queue:
+    profiles: ["pooler"]
+    image: edoburu/pgbouncer:latest
+    restart: unless-stopped
+    environment:
+      DB_HOST: ${POSTGRES_HOST:?set POSTGRES_HOST}
+      DB_PORT: ${POSTGRES_PORT:-5432}
+      DB_USER: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      DB_PASSWORD: ${RIVER_QUEUE_DATABASE_PASSWORD:?set RIVER_QUEUE_DATABASE_PASSWORD}
+      DB_NAME: ${POSTGRES_DB:?set POSTGRES_DB}
+      LISTEN_PORT: "6433"
+      POOL_MODE: session
+      AUTH_TYPE: scram-sha-256
+      MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_QUEUE_MAX_CLIENT_CONN:-128}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-18}
+    ports:
+      - "${PGBOUNCER_RIVER_QUEUE_PORT:-6433}:6433"
+    networks: [dev-health]
+
+  # Coordinator locks also need one stable session. This endpoint is separate
+  # from queue control so each role has an independently auditable hard cap.
+  pgbouncer-river-coordinator:
+    profiles: ["pooler"]
+    image: edoburu/pgbouncer:latest
+    restart: unless-stopped
+    environment:
+      DB_HOST: ${POSTGRES_HOST:?set POSTGRES_HOST}
+      DB_PORT: ${POSTGRES_PORT:-5432}
+      DB_USER: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+      DB_PASSWORD: ${RIVER_COORDINATOR_DATABASE_PASSWORD:?set RIVER_COORDINATOR_DATABASE_PASSWORD}
+      DB_NAME: ${POSTGRES_DB:?set POSTGRES_DB}
+      LISTEN_PORT: "6434"
+      POOL_MODE: session
+      AUTH_TYPE: scram-sha-256
+      MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_COORDINATOR_MAX_CLIENT_CONN:-32}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-10}
+    ports:
+      - "${PGBOUNCER_RIVER_COORDINATOR_PORT:-6434}:6434"
+    networks: [dev-health]
 
 volumes:
   clickhouse_data:

--- a/deploy/docker-swarm/stack.go-workers.yml
+++ b/deploy/docker-swarm/stack.go-workers.yml
@@ -9,8 +9,8 @@ x-go-worker: &go-worker
   tmpfs: [/tmp]
   environment: &go-worker-env
     DEV_HEALTH_HTTP_ADDR: ":8080"
-    POSTGRES_URI: ${POSTGRES_URI:?direct domain PostgreSQL URI is required}
-    WORKER_DATABASE_URI: ${WORKER_DATABASE_URI:?queue-control PostgreSQL URI is required}
+    POSTGRES_URI: ${POSTGRES_URI:?transaction-pooler domain PostgreSQL URI is required}
+    WORKER_DATABASE_URI: ${WORKER_DATABASE_URI:?session-pooler queue-control PostgreSQL URI is required}
     CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:8123/default
     VALKEY_URI: redis://valkey:6379/1
     RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
@@ -29,7 +29,8 @@ x-go-worker: &go-worker
     # Exactly one runtime owns the PagerDuty webhook stream. Celery keeps
     # it until the route flips at cutover (CUT-14/18).
     PAGERDUTY_WEBHOOK_TRANSPORT: ${PAGERDUTY_WEBHOOK_TRANSPORT:-celery}
-    WORKER_DATABASE_MODE: ${WORKER_DATABASE_MODE:-direct}
+    WORKER_DATABASE_MODE: ${WORKER_DATABASE_MODE:-session}
+    COORDINATOR_DATABASE_MODE: ${COORDINATOR_DATABASE_MODE:-session}
     DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
     AUTO_RUN_MIGRATIONS: "false"
   networks: [dev-health-internal]
@@ -56,9 +57,15 @@ services:
   go-reconciler:
     <<: *go-worker
     image: ${DEV_HEALTH_GO_RECONCILER_IMAGE:-ghcr.io/full-chaos/dev-health-go-reconciler:latest}
+    environment:
+      <<: *go-worker-env
+      COORDINATOR_DATABASE_URI: "${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}"
   go-scheduler:
     <<: *go-worker
     image: ${DEV_HEALTH_GO_SCHEDULER_IMAGE:-ghcr.io/full-chaos/dev-health-go-scheduler:latest}
+    environment:
+      <<: *go-worker-env
+      COORDINATOR_DATABASE_URI: "${COORDINATOR_DATABASE_URI:?session-pooler coordinator PostgreSQL URI is required}"
   go-stream-external:
     <<: *go-worker
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -6,7 +6,7 @@ during coexistence: a checked-in process or queue does not route production
 work away from Celery.
 
 The manifest also budgets one concurrent `dev-health-workerctl` invocation
-with two domain and two direct queue-control connections. The operator is a
+with two domain and two queue-control session connections. The operator is a
 one-shot authenticated CLI, not a replica-bearing process, and its dedicated
 image target receives the operator token only when an operator invokes it.
 `runtime_role_env` is the shared non-secret identity contract for every future
@@ -35,7 +35,7 @@ The contract gate validates that:
 - the one-shot operator has an exact token/DSN/config surface and is included
   in both direct and PgBouncer client connection budgets;
 - every River/control process receives separate domain and queue-control DSNs;
-- maximum direct queue-control connections plus the PgBouncer server pool and
+- maximum River session-pool connections plus the transaction PgBouncer server pool and
   server reserve stay below PostgreSQL `max_connections`; the PgBouncer term
   multiplies `default_pool_size` by the declared `(database,user)` pool count;
   and
@@ -260,22 +260,22 @@ Two consequences worth knowing:
   it does mean "rename the project" is not the same as "the two stacks now
   coexist". Run one at a time, or drop the fixed names.
 
-### The coordinator DSN must be direct Postgres, never PgBouncer
+### River control DSNs must use session semantics
 
-`COORDINATOR_DATABASE_URI` (read by `go-reconciler` and by
+`COORDINATOR_DATABASE_URI` (read by `go-reconciler`, `go-scheduler`, and `dev-health-workerctl`) and
 `dev-health-worker-migrate`'s `MIGRATION_DATABASE_URI`, which is a distinct,
 more-privileged DSN — never reused as a coordinator runtime identity) must
-point at Postgres's own port (`5432` locally), never through PgBouncer's
-transaction-mode pool (`6432` locally). The coordinator holds
+point at the dedicated PgBouncer session endpoint (`6434` locally) or direct
+Postgres (`5432` locally), never the transaction-mode pool (`6432` locally). The coordinator holds
 cross-statement row and table locks (`FOR UPDATE`, `LOCK TABLE ... IN SHARE
 ROW EXCLUSIVE MODE`) that a transaction-mode pooler can hand to a different
 server session mid-transaction, silently breaking the lock. Startup rejects
 this explicitly: `internal/storage/postgres/runtime.go`'s
 `ErrCoordinatorTransactionMode` fires when the domain endpoint is
 PgBouncer-pooled and the coordinator DSN resolves to that same endpoint. The
-domain DSN (`POSTGRES_URI`) may continue through PgBouncer, as the Python
-API/Celery processes' `DATABASE_URI` already does; the queue-control DSN
-(`WORKER_DATABASE_URI`) must also be direct, for the same reason.
+domain DSN (`POSTGRES_URI`) continues through transaction-mode PgBouncer. The
+queue-control DSN (`WORKER_DATABASE_URI`) uses the dedicated session endpoint
+(`6433` locally) or direct PostgreSQL for the same session-semantics reason.
 
 ### ClickHouse: the Go worker needs the native port, not the HTTP port
 

--- a/deploy/go-workers/compose-go-profile.yml
+++ b/deploy/go-workers/compose-go-profile.yml
@@ -229,7 +229,8 @@ services:
       DEV_HEALTH_PROFILE: sync
       POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-devhealth}
       PGBOUNCER_TRANSACTION_MODE: "true"
-      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-devhealth}
+      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@pgbouncer-river-queue:6433/${POSTGRES_DB:-devhealth}
+      WORKER_DATABASE_MODE: session
       # Native protocol port 9000, NOT the HTTP port 8123 every Python service
       # in this file uses. internal/storage/clickhouse opens with
       # ClickHouse/clickhouse-go/v2, which speaks the native wire protocol and
@@ -310,7 +311,7 @@ services:
 
   # Relays worker_job_outbox rows into River and observes the sync-dispatch
   # outbox. This is a coordinator-role binary, so COORDINATOR_DATABASE_URI is
-  # required and MUST be direct postgres:5432 — transaction-mode pooling cannot
+  # required and MUST use the dedicated session pool — transaction-mode pooling cannot
   # hold the cross-statement row and table locks the coordinator takes, and the
   # process rejects a pooled coordinator DSN at startup rather than risking
   # them silently spanning connections. It declares no deployment profile, so
@@ -331,8 +332,10 @@ services:
     environment:
       POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-devhealth}
       PGBOUNCER_TRANSACTION_MODE: "true"
-      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-devhealth}
-      COORDINATOR_DATABASE_URI: postgresql://${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}:${RIVER_COORDINATOR_DATABASE_PASSWORD:-devhealth_coordinator}@postgres:5432/${POSTGRES_DB:-devhealth}
+      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@pgbouncer-river-queue:6433/${POSTGRES_DB:-devhealth}
+      WORKER_DATABASE_MODE: session
+      COORDINATOR_DATABASE_URI: postgresql://${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}:${RIVER_COORDINATOR_DATABASE_PASSWORD:-devhealth_coordinator}@pgbouncer-river-coordinator:6434/${POSTGRES_DB:-devhealth}
+      COORDINATOR_DATABASE_MODE: session
       RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
       RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
       RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}

--- a/deploy/go-workers/profiles.json
+++ b/deploy/go-workers/profiles.json
@@ -10,9 +10,13 @@
   "postgres_budget": {
     "server_max_connections": 100,
     "server_reserved_connections": 15,
-    "pgbouncer_default_pool_size": 25,
-    "pgbouncer_server_pool_count": 2,
-    "pgbouncer_max_client_connections": 1000
+    "pgbouncer_transaction_pool_size": 20,
+    "pgbouncer_transaction_server_pool_count": 2,
+    "pgbouncer_transaction_max_client_connections": 1000,
+    "pgbouncer_queue_session_pool_size": 18,
+    "pgbouncer_queue_session_max_client_connections": 128,
+    "pgbouncer_coordinator_session_pool_size": 10,
+    "pgbouncer_coordinator_session_max_client_connections": 32
   },
   "migration_job": {
     "name": "go-worker-migrations",
@@ -36,6 +40,7 @@
     "domain_max_connections": 2,
     "coordinator_max_connections": 2,
     "config_env": [
+      "COORDINATOR_DATABASE_MODE",
       "PGBOUNCER_TRANSACTION_MODE",
       "RIVER_COORDINATOR_DATABASE_ROLE",
       "RIVER_DATABASE_SCHEMA",

--- a/deploy/helm/dev-health/templates/_helpers.tpl
+++ b/deploy/helm/dev-health/templates/_helpers.tpl
@@ -136,6 +136,36 @@ PostgreSQL URI — auto-computed when postgresql.enabled
 {{- end }}
 {{- end }}
 
+{{/* Go PgBouncer topology helpers. The poolers have stable in-cluster Service
+names; role credentials and runtime DSNs remain Secret values. */}}
+{{- define "dev-health.goPgbouncerSecretName" -}}
+{{- if .Values.goWorkers.pgbouncer.secret.create }}
+{{- printf "%s-go-pgbouncer" (include "dev-health.fullname" .) }}
+{{- else }}
+{{- required "goWorkers.pgbouncer.secret.externalSecretName is required when goWorkers.pgbouncer.secret.create=false" .Values.goWorkers.pgbouncer.secret.externalSecretName }}
+{{- end }}
+{{- end }}
+
+{{- define "dev-health.goPgbouncerPostgresHost" -}}
+{{- if .Values.postgresql.enabled }}
+{{- printf "%s-postgresql" (include "dev-health.fullname" .) }}
+{{- else }}
+{{- required "goWorkers.pgbouncer.postgres.host is required for external PostgreSQL" .Values.goWorkers.pgbouncer.postgres.host }}
+{{- end }}
+{{- end }}
+
+{{- define "dev-health.goPgbouncerPostgresPort" -}}
+{{- if .Values.postgresql.enabled }}5432{{- else }}{{ required "goWorkers.pgbouncer.postgres.port is required for external PostgreSQL" .Values.goWorkers.pgbouncer.postgres.port }}{{- end }}
+{{- end }}
+
+{{- define "dev-health.goPgbouncerPostgresDatabase" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.credentials.database }}
+{{- else }}
+{{- required "goWorkers.pgbouncer.postgres.database is required for external PostgreSQL" .Values.goWorkers.pgbouncer.postgres.database }}
+{{- end }}
+{{- end }}
+
 {{/*
 Worker operational bridge URL — the in-cluster API Service that serves the
 bridge the Go PagerDuty stream runner forwards reconciliation to. Auto-computed

--- a/deploy/helm/dev-health/templates/go-pgbouncer.yaml
+++ b/deploy/helm/dev-health/templates/go-pgbouncer.yaml
@@ -1,0 +1,137 @@
+{{- /*
+Go runtime PostgreSQL topology. Domain state can use transaction pooling, but
+River queue control (LISTEN/cancel) and coordinator locks require stable
+sessions. These are separate services so each backend cap is auditable.
+*/ -}}
+{{- if and .Values.goWorkers.enabled .Values.goWorkers.pgbouncer.enabled }}
+{{- if not (contains "@sha256:" .Values.goWorkers.pgbouncer.image) }}
+{{- fail "goWorkers.pgbouncer.image must be pinned by immutable sha256 digest" }}
+{{- end }}
+{{- $secretName := include "dev-health.goPgbouncerSecretName" . }}
+{{- $postgresHost := include "dev-health.goPgbouncerPostgresHost" . }}
+{{- $postgresPort := include "dev-health.goPgbouncerPostgresPort" . }}
+{{- $postgresDatabase := include "dev-health.goPgbouncerPostgresDatabase" . }}
+{{- if .Values.goWorkers.pgbouncer.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ include "dev-health.namespace" . }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" "go-pgbouncer" "context" $) | nindent 4 }}
+type: Opaque
+stringData:
+  RIVER_DOMAIN_DATABASE_PASSWORD: {{ required "goWorkers.pgbouncer.secret.data.RIVER_DOMAIN_DATABASE_PASSWORD is required when PgBouncer is enabled" .Values.goWorkers.pgbouncer.secret.data.RIVER_DOMAIN_DATABASE_PASSWORD | quote }}
+  RIVER_QUEUE_DATABASE_PASSWORD: {{ required "goWorkers.pgbouncer.secret.data.RIVER_QUEUE_DATABASE_PASSWORD is required when PgBouncer is enabled" .Values.goWorkers.pgbouncer.secret.data.RIVER_QUEUE_DATABASE_PASSWORD | quote }}
+  RIVER_COORDINATOR_DATABASE_PASSWORD: {{ required "goWorkers.pgbouncer.secret.data.RIVER_COORDINATOR_DATABASE_PASSWORD is required when PgBouncer is enabled" .Values.goWorkers.pgbouncer.secret.data.RIVER_COORDINATOR_DATABASE_PASSWORD | quote }}
+  POSTGRES_URI: {{ printf "postgresql://%s:%s@%s:%v/%s" .Values.config.RIVER_DOMAIN_DATABASE_ROLE .Values.goWorkers.pgbouncer.secret.data.RIVER_DOMAIN_DATABASE_PASSWORD (include "dev-health.fullname" . | printf "%s-go-pgbouncer-transaction") .Values.goWorkers.pgbouncer.transaction.port $postgresDatabase | quote }}
+  WORKER_DATABASE_URI: {{ printf "postgresql://%s:%s@%s:%v/%s" .Values.config.RIVER_QUEUE_DATABASE_ROLE .Values.goWorkers.pgbouncer.secret.data.RIVER_QUEUE_DATABASE_PASSWORD (include "dev-health.fullname" . | printf "%s-go-pgbouncer-queue-session") .Values.goWorkers.pgbouncer.queueSession.port $postgresDatabase | quote }}
+  COORDINATOR_DATABASE_URI: {{ printf "postgresql://%s:%s@%s:%v/%s" .Values.config.RIVER_COORDINATOR_DATABASE_ROLE .Values.goWorkers.pgbouncer.secret.data.RIVER_COORDINATOR_DATABASE_PASSWORD (include "dev-health.fullname" . | printf "%s-go-pgbouncer-coordinator-session") .Values.goWorkers.pgbouncer.coordinatorSession.port $postgresDatabase | quote }}
+---
+{{- end }}
+{{- $poolers := list
+  (dict "name" "transaction" "component" "go-pgbouncer-transaction" "port" .Values.goWorkers.pgbouncer.transaction.port "poolMode" "transaction" "poolSize" .Values.goWorkers.pgbouncer.transaction.poolSize "maxClientConnections" .Values.goWorkers.pgbouncer.transaction.maxClientConnections "role" .Values.config.RIVER_DOMAIN_DATABASE_ROLE "passwordKey" "RIVER_DOMAIN_DATABASE_PASSWORD")
+  (dict "name" "queue-session" "component" "go-pgbouncer-queue-session" "port" .Values.goWorkers.pgbouncer.queueSession.port "poolMode" "session" "poolSize" .Values.goWorkers.pgbouncer.queueSession.poolSize "maxClientConnections" .Values.goWorkers.pgbouncer.queueSession.maxClientConnections "role" .Values.config.RIVER_QUEUE_DATABASE_ROLE "passwordKey" "RIVER_QUEUE_DATABASE_PASSWORD")
+  (dict "name" "coordinator-session" "component" "go-pgbouncer-coordinator-session" "port" .Values.goWorkers.pgbouncer.coordinatorSession.port "poolMode" "session" "poolSize" .Values.goWorkers.pgbouncer.coordinatorSession.poolSize "maxClientConnections" .Values.goWorkers.pgbouncer.coordinatorSession.maxClientConnections "role" .Values.config.RIVER_COORDINATOR_DATABASE_ROLE "passwordKey" "RIVER_COORDINATOR_DATABASE_PASSWORD")
+}}
+{{- range $pooler := $poolers }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dev-health.fullname" $ }}-go-pgbouncer-{{ $pooler.name }}
+  namespace: {{ include "dev-health.namespace" $ }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" $pooler.component "context" $) | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "dev-health.componentSelectorLabels" (dict "component" $pooler.component "context" $) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dev-health.componentSelectorLabels" (dict "component" $pooler.component "context" $) | nindent 8 }}
+    spec:
+      {{- include "dev-health.imagePullSecrets" $ | nindent 6 }}
+      # edoburu/pgbouncer runs as postgres (UID/GID 70) and writes its generated
+      # pgbouncer.ini and userlist.txt below /etc/pgbouncer at startup. Keep the
+      # root filesystem read-only, but give that exact path an fsGroup-owned
+      # ephemeral volume. The isolated compatibility harness starts this shape.
+      securityContext: {runAsNonRoot: true, runAsUser: 70, runAsGroup: 70, fsGroup: 70, seccompProfile: {type: RuntimeDefault}}
+      containers:
+        - name: pgbouncer
+          image: {{ $.Values.goWorkers.pgbouncer.image | quote }}
+          imagePullPolicy: {{ $.Values.goWorkers.pgbouncer.pullPolicy }}
+          ports: [{name: pgbouncer, containerPort: {{ $pooler.port }}}]
+          env:
+            - {name: DB_HOST, value: {{ $postgresHost | quote }}}
+            - {name: DB_PORT, value: {{ $postgresPort | quote }}}
+            - {name: DB_NAME, value: {{ $postgresDatabase | quote }}}
+            - {name: DB_USER, value: {{ $pooler.role | quote }}}
+            - name: DB_PASSWORD
+              valueFrom: {secretKeyRef: {name: {{ $secretName }}, key: {{ $pooler.passwordKey }}}}
+            - {name: LISTEN_PORT, value: {{ $pooler.port | quote }}}
+            - {name: POOL_MODE, value: {{ $pooler.poolMode | quote }}}
+            - {name: AUTH_TYPE, value: scram-sha-256}
+            - {name: DEFAULT_POOL_SIZE, value: {{ $pooler.poolSize | quote }}}
+            - {name: MAX_CLIENT_CONN, value: {{ $pooler.maxClientConnections | quote }}}
+          readinessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 2, periodSeconds: 5}
+          livenessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 10, periodSeconds: 10}
+          securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: generated-config, mountPath: /etc/pgbouncer}
+          resources:
+            {{- toYaml $.Values.goWorkers.pgbouncer.resources | nindent 12 }}
+      volumes:
+        - name: generated-config
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dev-health.fullname" $ }}-go-pgbouncer-{{ $pooler.name }}
+  namespace: {{ include "dev-health.namespace" $ }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" $pooler.component "context" $) | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "dev-health.componentSelectorLabels" (dict "component" $pooler.component "context" $) | nindent 4 }}
+  ports:
+    - {name: pgbouncer, port: {{ $pooler.port }}, targetPort: pgbouncer}
+{{- if $.Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "dev-health.fullname" $ }}-go-pgbouncer-{{ $pooler.name }}
+  namespace: {{ include "dev-health.namespace" $ }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" $pooler.component "context" $) | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "dev-health.componentSelectorLabels" (dict "component" $pooler.component "context" $) | nindent 6 }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "dev-health.componentSelectorLabels" (dict "component" "go-worker" "context" $) | nindent 14 }}
+      ports: [{protocol: TCP, port: {{ $pooler.port }}}]
+  egress:
+    {{- if $.Values.postgresql.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "dev-health.componentSelectorLabels" (dict "component" "postgresql" "context" $) | nindent 14 }}
+      ports: [{protocol: TCP, port: 5432}]
+    {{- else }}
+    - to:
+        - ipBlock: {cidr: {{ required "goWorkers.pgbouncer.postgres.networkPolicyCIDR is required for external PostgreSQL when networkPolicy.enabled" $.Values.goWorkers.pgbouncer.postgres.networkPolicyCIDR | quote }}}
+      ports: [{protocol: TCP, port: {{ $postgresPort }}}]
+    {{- end }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/deploy/helm/dev-health/templates/go-workers.yaml
+++ b/deploy/helm/dev-health/templates/go-workers.yaml
@@ -1,6 +1,7 @@
 {{- /* Additive Go/River topology. `goWorkers.enabled` is false by default. */ -}}
 {{- if .Values.goWorkers.enabled }}
 {{- range $profile := .Values.goWorkers.profiles }}
+{{- $coordinator := has $profile.name (list "reconciler" "scheduler") }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -39,11 +40,27 @@ spec:
         - name: {{ $profile.name }}
           image: {{ $profile.image }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
-          {{- if $profile.runtimeProfile }}
-          env: [{name: DEV_HEALTH_PROFILE, value: {{ $profile.runtimeProfile | quote }}}, {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
-          {{- else }}
-          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
-          {{- end }}
+          env:
+            {{- if $profile.runtimeProfile }}
+            - {name: DEV_HEALTH_PROFILE, value: {{ $profile.runtimeProfile | quote }}}
+            {{- end }}
+            - {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}
+            {{- if $.Values.goWorkers.pgbouncer.enabled }}
+            # Every Go profile uses the bounded domain transaction pool plus
+            # the River queue session pool. Only coordinator binaries receive
+            # the separate coordinator lock session endpoint.
+            - name: POSTGRES_URI
+              valueFrom: {secretKeyRef: {name: {{ include "dev-health.goPgbouncerSecretName" $ }}, key: POSTGRES_URI}}
+            - {name: PGBOUNCER_TRANSACTION_MODE, value: "true"}
+            - name: WORKER_DATABASE_URI
+              valueFrom: {secretKeyRef: {name: {{ include "dev-health.goPgbouncerSecretName" $ }}, key: WORKER_DATABASE_URI}}
+            - {name: WORKER_DATABASE_MODE, value: session}
+            {{- if $coordinator }}
+            - name: COORDINATOR_DATABASE_URI
+              valueFrom: {secretKeyRef: {name: {{ include "dev-health.goPgbouncerSecretName" $ }}, key: COORDINATOR_DATABASE_URI}}
+            - {name: COORDINATOR_DATABASE_MODE, value: session}
+            {{- end }}
+            {{- end }}
           envFrom:
             - configMapRef: {name: {{ include "dev-health.configMapName" $ }}}
             - secretRef: {name: {{ include "dev-health.secretName" $ }}}

--- a/deploy/helm/dev-health/values-go-workers-coexistence.yaml
+++ b/deploy/helm/dev-health/values-go-workers-coexistence.yaml
@@ -2,3 +2,5 @@
 # Celery fleet. Scale only a reviewed profile after it is healthy and observed.
 goWorkers:
   enabled: true
+  pgbouncer:
+    enabled: true

--- a/deploy/helm/dev-health/values-go-workers-only.yaml
+++ b/deploy/helm/dev-health/values-go-workers-only.yaml
@@ -3,6 +3,8 @@
 # zero. Go profiles remain zero until an operator deliberately scales them.
 goWorkers:
   enabled: true
+  pgbouncer:
+    enabled: true
 worker: {enabled: false}
 workerIngest: {enabled: false}
 workerExternalIngest: {enabled: false}

--- a/deploy/helm/dev-health/values.schema.json
+++ b/deploy/helm/dev-health/values.schema.json
@@ -38,9 +38,72 @@
           }
         }
       }
+    },
+    "goWorkers": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "pgbouncer": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "type": "string" },
+            "postgres": {
+              "type": "object",
+              "properties": {
+                "host": { "type": "string" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "database": { "type": "string" },
+                "networkPolicyCIDR": { "type": "string" }
+              }
+            },
+            "secret": {
+              "type": "object",
+              "properties": {
+                "create": { "type": "boolean" },
+                "externalSecretName": { "type": "string" },
+                "data": {
+                  "type": "object",
+                  "description": "Go PgBouncer secrets contain only role passwords and endpoint DSNs; migration DSNs are prohibited.",
+                  "not": {
+                    "anyOf": [
+                      { "required": ["MIGRATION_DATABASE_URI"] },
+                      { "required": ["MIGRATION_DATABASE_URI_FILE"] }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "allOf": [
+    {
+      "if": {
+        "properties": {
+          "goWorkers": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          }
+        },
+        "required": ["goWorkers"]
+      },
+      "then": {
+        "properties": {
+          "goWorkers": {
+            "properties": {
+              "pgbouncer": {
+                "properties": { "enabled": { "const": true } },
+                "required": ["enabled"]
+              }
+            },
+            "required": ["pgbouncer"]
+          }
+        }
+      }
+    },
     {
       "if": {
         "properties": {

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -207,6 +207,51 @@ workerHeavy:
 # to zero but retains their definitions and Valkey DB 0.
 goWorkers:
   enabled: false
+  # The production Go topology has three distinct PostgreSQL endpoints.
+  # Domain traffic uses a bounded transaction pool. River queue control and
+  # coordinator locks use independent session pools: those connections cannot
+  # switch backends between statements. The role passwords stay in the
+  # dedicated goWorkers.pgbouncer secret and are projected to each Go profile
+  # by individual secretKeyRef entries, never envFrom.
+  pgbouncer:
+    enabled: false
+    # Pinned to the compatibility-matrix image. Do not replace this with a
+    # mutable tag: the pooler controls the runtime's database semantics.
+    image: "edoburu/pgbouncer:1.25.2@sha256:4c1ca296ef525f108f5d3552cc337c0c09587cf8dae7f0067fd93349e47dc1cd"
+    pullPolicy: IfNotPresent
+    postgres:
+      # These values are required for an external PostgreSQL service. When the
+      # bundled StatefulSet is enabled, host/database/port are derived from it.
+      host: ""
+      port: 5432
+      database: ""
+      # Required for an external PostgreSQL service with networkPolicy.enabled.
+      # Use a narrowly-scoped CIDR, never a broad public range.
+      networkPolicyCIDR: ""
+    transaction:
+      port: 6432
+      poolSize: 20
+      maxClientConnections: 1000
+    queueSession:
+      port: 6433
+      poolSize: 18
+      maxClientConnections: 128
+    coordinatorSession:
+      port: 6434
+      poolSize: 10
+      maxClientConnections: 32
+    resources:
+      requests: {cpu: 50m, memory: 64Mi}
+      limits: {cpu: 250m, memory: 256Mi}
+    secret:
+      # Set create=false and provide a pre-created Secret with the same six
+      # keys for externally managed credentials and DSNs.
+      create: true
+      externalSecretName: ""
+      data:
+        RIVER_DOMAIN_DATABASE_PASSWORD: ""
+        RIVER_QUEUE_DATABASE_PASSWORD: ""
+        RIVER_COORDINATOR_DATABASE_PASSWORD: ""
   profiles:
     - name: heavy
       image: ghcr.io/full-chaos/dev-health-go-worker:latest
@@ -485,6 +530,7 @@ config:
   RIVER_DATABASE_SCHEMA: "river"
   RIVER_DOMAIN_DATABASE_ROLE: "devhealth_domain"
   RIVER_QUEUE_DATABASE_ROLE: "devhealth_queue"
+  RIVER_COORDINATOR_DATABASE_ROLE: "devhealth_coordinator"
   # -- Worker operational bridge (CUT-04). The Go PagerDuty stream runner
   #    forwards reconciliation to the API bridge, so it cannot open readiness
   #    without a reachable endpoint. Empty auto-computes the in-cluster API

--- a/docs/operate/configure/databases-and-storage.md
+++ b/docs/operate/configure/databases-and-storage.md
@@ -54,6 +54,23 @@ The Go foundation uses three distinct responsibilities:
 
 Do not give long-running workers the migration DSN. Do not reuse the migration role for domain or queue-control access.
 
+### Helm Go-worker poolers
+
+The component chart keeps this topology disabled until `goWorkers.enabled` and
+`goWorkers.pgbouncer.enabled` are both set. It renders three in-cluster
+Services: a transaction endpoint for domain state, a queue session endpoint,
+and a coordinator session endpoint. The chart creates or references one
+dedicated PgBouncer Secret, but projects only the required DSN key to each Go
+pod: all profiles receive domain and queue endpoints; only `reconciler` and
+`scheduler` receive the coordinator endpoint. The migration hook never reads
+that Secret and continues to use direct PostgreSQL.
+
+For external PostgreSQL, set `goWorkers.pgbouncer.postgres.host`, `database`,
+and role-password Secret values. With `networkPolicy.enabled`, also set a
+narrow `goWorkers.pgbouncer.postgres.networkPolicyCIDR`; the chart fails to
+render rather than silently blocking PgBouncer egress. The chart requires a
+digest-pinned PgBouncer image and adds TCP readiness probes for each endpoint.
+
 ## Runtime roles
 
 Provision distinct unprivileged login roles for:

--- a/docs/operate/configure/databases-and-storage.md
+++ b/docs/operate/configure/databases-and-storage.md
@@ -1,6 +1,6 @@
 ---
 page_id: op-db
-summary: Configure Postgres semantic state, direct River queue control, ClickHouse analytics, Valkey coordination, migrations, retention, and recovery boundaries.
+summary: Configure Postgres semantic state, session-pooled River control, ClickHouse analytics, Valkey coordination, migrations, retention, and recovery boundaries.
 content_type: task-guide
 owner: platform-operations
 source_of_truth:
@@ -46,10 +46,11 @@ The Go foundation uses three distinct responsibilities:
 | Purpose | Setting | Default maximum | Required endpoint |
 | --- | --- | ---: | --- |
 | Domain state | `POSTGRES_URI` | `WORKER_DOMAIN_DATABASE_MAX_CONNS=4` | Transaction-mode PgBouncer is supported |
-| River queue control | `WORKER_DATABASE_URI` | `WORKER_DATABASE_MAX_CONNS=2` | Direct PostgreSQL |
+| River queue control | `WORKER_DATABASE_URI` | `WORKER_DATABASE_MAX_CONNS=2` | Dedicated PgBouncer session endpoint or direct PostgreSQL |
+| Coordinator control | `COORDINATOR_DATABASE_URI` | `WORKER_COORDINATOR_DATABASE_MAX_CONNS=2` | Dedicated PgBouncer session endpoint or direct PostgreSQL |
 | One-shot migrations | `MIGRATION_DATABASE_URI` | 2 migration connections | Direct PostgreSQL with the migration role |
 
-`WORKER_DATABASE_MODE` defaults to `direct`. Transaction mode is rejected for River queue control because cancellation and listener behavior are not compatible with that pooling model. Session mode remains unsupported until it passes the same compatibility evidence.
+`WORKER_DATABASE_MODE` and `COORDINATOR_DATABASE_MODE` default to `direct`. Use `session` for the dedicated River endpoints. Transaction mode is rejected because River listener/cancellation and coordinator locks require session semantics. PgBouncer pools are per `(database, user)` pair, so dedicate one fixed role to each session endpoint and size its pool for every declared client connection. Go pools use `MinConns=0` and a bounded idle timeout; idle clients do not permanently pin all session backends.
 
 Do not give long-running workers the migration DSN. Do not reuse the migration role for domain or queue-control access.
 
@@ -95,7 +96,7 @@ Size pools against the maximum deployment topology, not current replicas. Accoun
 
 - SQLAlchemy pools across API and Celery processes;
 - PgBouncer server pools per database/user pair;
-- direct River queue-control connections;
+- River queue-control and coordinator session pools;
 - operator CLI invocations;
 - migration and administrative reserve.
 

--- a/docs/reference/configuration/environment.md
+++ b/docs/reference/configuration/environment.md
@@ -29,7 +29,8 @@ Document these as distinct responsibilities:
 | Family | Representative settings | Boundary |
 | --- | --- | --- |
 | Semantic PostgreSQL | `POSTGRES_URI`, pool settings, `PGBOUNCER_TRANSACTION_MODE` | API, Celery, and Go domain state; transaction-mode pooler is supported where configured |
-| River queue control | `WORKER_DATABASE_URI`, `WORKER_DATABASE_MODE`, `WORKER_DATABASE_MAX_CONNS` | Direct PostgreSQL for Go queue state; transaction mode is rejected |
+| River queue control | `WORKER_DATABASE_URI`, `WORKER_DATABASE_MODE`, `WORKER_DATABASE_MAX_CONNS` | Dedicated PgBouncer session endpoint or direct PostgreSQL; transaction mode is rejected |
+| River coordinator control | `COORDINATOR_DATABASE_URI`, `COORDINATOR_DATABASE_MODE`, `WORKER_COORDINATOR_DATABASE_MAX_CONNS` | Dedicated PgBouncer session endpoint or direct PostgreSQL; transaction mode is rejected |
 | Worker domain pool | `WORKER_DOMAIN_DATABASE_MAX_CONNS` | Bounds the Go domain-state pool using `POSTGRES_URI` |
 | One-shot migrations | `MIGRATION_DATABASE_URI`, role-name settings | Direct elevated connection; never injected into long-running workers |
 | ClickHouse | `CLICKHOUSE_URI` and connection/query settings | Provider facts, analytics, and materializations |

--- a/internal/deploymentcontract/manifest.go
+++ b/internal/deploymentcontract/manifest.go
@@ -26,11 +26,15 @@ var (
 )
 
 type PostgresBudget struct {
-	ServerMaxConnections          int `json:"server_max_connections"`
-	ServerReservedConnections     int `json:"server_reserved_connections"`
-	PgBouncerDefaultPoolSize      int `json:"pgbouncer_default_pool_size"`
-	PgBouncerServerPoolCount      int `json:"pgbouncer_server_pool_count"`
-	PgBouncerMaxClientConnections int `json:"pgbouncer_max_client_connections"`
+	ServerMaxConnections                            int `json:"server_max_connections"`
+	ServerReservedConnections                       int `json:"server_reserved_connections"`
+	PgBouncerTransactionPoolSize                    int `json:"pgbouncer_transaction_pool_size"`
+	PgBouncerTransactionServerPoolCount             int `json:"pgbouncer_transaction_server_pool_count"`
+	PgBouncerTransactionMaxClientConnections        int `json:"pgbouncer_transaction_max_client_connections"`
+	PgBouncerQueueSessionPoolSize                   int `json:"pgbouncer_queue_session_pool_size"`
+	PgBouncerQueueSessionMaxClientConnections       int `json:"pgbouncer_queue_session_max_client_connections"`
+	PgBouncerCoordinatorSessionPoolSize             int `json:"pgbouncer_coordinator_session_pool_size"`
+	PgBouncerCoordinatorSessionMaxClientConnections int `json:"pgbouncer_coordinator_session_max_client_connections"`
 }
 
 type MigrationJob struct {
@@ -88,10 +92,10 @@ type Manifest struct {
 }
 
 type BudgetSummary struct {
-	DirectQueueControlConnections int
-	DirectCoordinatorConnections  int
-	DomainClientConnections       int
-	ServerConnectionFootprint     int
+	QueueSessionClientConnections       int
+	CoordinatorSessionClientConnections int
+	DomainTransactionClientConnections  int
+	ServerConnectionFootprint           int
 }
 
 func Load(path string, registry jobcontract.Registry) (Manifest, BudgetSummary, error) {
@@ -157,11 +161,11 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 	queueOwners := make(map[string]string)
 	previousName := ""
 	summary := BudgetSummary{
-		DirectQueueControlConnections: manifest.OperatorCLI.MaxConcurrentInvocations *
+		QueueSessionClientConnections: manifest.OperatorCLI.MaxConcurrentInvocations *
 			manifest.OperatorCLI.QueueControlMaxConnections,
-		DirectCoordinatorConnections: manifest.OperatorCLI.MaxConcurrentInvocations *
+		CoordinatorSessionClientConnections: manifest.OperatorCLI.MaxConcurrentInvocations *
 			manifest.OperatorCLI.CoordinatorMaxConnections,
-		DomainClientConnections: manifest.OperatorCLI.MaxConcurrentInvocations *
+		DomainTransactionClientConnections: manifest.OperatorCLI.MaxConcurrentInvocations *
 			manifest.OperatorCLI.DomainMaxConnections,
 	}
 
@@ -178,9 +182,9 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 			return BudgetSummary{}, fmt.Errorf("deployment process %s: %w", process.Name, err)
 		}
 
-		summary.DirectQueueControlConnections += process.MaxReplicas * process.QueueControlMaxConnections
-		summary.DirectCoordinatorConnections += process.MaxReplicas * process.CoordinatorMaxConnections
-		summary.DomainClientConnections += process.MaxReplicas * process.DomainMaxConnections
+		summary.QueueSessionClientConnections += process.MaxReplicas * process.QueueControlMaxConnections
+		summary.CoordinatorSessionClientConnections += process.MaxReplicas * process.CoordinatorMaxConnections
+		summary.DomainTransactionClientConnections += process.MaxReplicas * process.DomainMaxConnections
 
 		if process.Runtime != "river" {
 			continue
@@ -211,9 +215,9 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 		}
 	}
 	summary.ServerConnectionFootprint = manifest.PostgresBudget.ServerReservedConnections +
-		manifest.PostgresBudget.PgBouncerDefaultPoolSize*manifest.PostgresBudget.PgBouncerServerPoolCount +
-		summary.DirectQueueControlConnections +
-		summary.DirectCoordinatorConnections
+		manifest.PostgresBudget.PgBouncerTransactionPoolSize*manifest.PostgresBudget.PgBouncerTransactionServerPoolCount +
+		manifest.PostgresBudget.PgBouncerQueueSessionPoolSize +
+		manifest.PostgresBudget.PgBouncerCoordinatorSessionPoolSize
 	if summary.ServerConnectionFootprint > manifest.PostgresBudget.ServerMaxConnections {
 		return BudgetSummary{}, fmt.Errorf(
 			"PostgreSQL server connection budget exceeded: %d > %d",
@@ -221,12 +225,20 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 			manifest.PostgresBudget.ServerMaxConnections,
 		)
 	}
-	if summary.DomainClientConnections > manifest.PostgresBudget.PgBouncerMaxClientConnections {
+	if summary.DomainTransactionClientConnections > manifest.PostgresBudget.PgBouncerTransactionMaxClientConnections {
 		return BudgetSummary{}, fmt.Errorf(
-			"PgBouncer client connection budget exceeded: %d > %d",
-			summary.DomainClientConnections,
-			manifest.PostgresBudget.PgBouncerMaxClientConnections,
+			"transaction PgBouncer client connection budget exceeded: %d > %d",
+			summary.DomainTransactionClientConnections,
+			manifest.PostgresBudget.PgBouncerTransactionMaxClientConnections,
 		)
+	}
+	if summary.QueueSessionClientConnections > manifest.PostgresBudget.PgBouncerQueueSessionMaxClientConnections ||
+		summary.QueueSessionClientConnections > manifest.PostgresBudget.PgBouncerQueueSessionPoolSize {
+		return BudgetSummary{}, errors.New("queue session PgBouncer budget cannot serve every declared River queue connection")
+	}
+	if summary.CoordinatorSessionClientConnections > manifest.PostgresBudget.PgBouncerCoordinatorSessionMaxClientConnections ||
+		summary.CoordinatorSessionClientConnections > manifest.PostgresBudget.PgBouncerCoordinatorSessionPoolSize {
+		return BudgetSummary{}, errors.New("coordinator session PgBouncer budget cannot serve every declared coordinator connection")
 	}
 	return summary, nil
 }
@@ -260,14 +272,18 @@ func expectedCoverage(registry jobcontract.Registry) map[string]profileCoverage 
 func validatePostgresBudget(budget PostgresBudget) error {
 	if budget.ServerMaxConnections < 1 || budget.ServerMaxConnections > 10000 ||
 		budget.ServerReservedConnections < 1 ||
-		budget.PgBouncerDefaultPoolSize < 1 ||
-		budget.PgBouncerServerPoolCount < 1 || budget.PgBouncerServerPoolCount > 128 ||
-		budget.PgBouncerMaxClientConnections < 1 {
+		budget.PgBouncerTransactionPoolSize < 1 ||
+		budget.PgBouncerTransactionServerPoolCount < 1 || budget.PgBouncerTransactionServerPoolCount > 128 ||
+		budget.PgBouncerTransactionMaxClientConnections < 1 ||
+		budget.PgBouncerQueueSessionPoolSize < 1 || budget.PgBouncerQueueSessionMaxClientConnections < 1 ||
+		budget.PgBouncerCoordinatorSessionPoolSize < 1 || budget.PgBouncerCoordinatorSessionMaxClientConnections < 1 {
 		return errors.New("deployment PostgreSQL budget has invalid bounds")
 	}
 	if budget.ServerReservedConnections+
-		budget.PgBouncerDefaultPoolSize*budget.PgBouncerServerPoolCount >= budget.ServerMaxConnections {
-		return errors.New("deployment PostgreSQL budget leaves no direct queue-control capacity")
+		budget.PgBouncerTransactionPoolSize*budget.PgBouncerTransactionServerPoolCount+
+		budget.PgBouncerQueueSessionPoolSize+
+		budget.PgBouncerCoordinatorSessionPoolSize > budget.ServerMaxConnections {
+		return errors.New("deployment PostgreSQL budget exceeds the server connection limit")
 	}
 	return nil
 }
@@ -295,9 +311,8 @@ func validateOperatorCLI(operator OperatorCLI) error {
 		operator.QueueControlMaxConnections > 4 || operator.DomainMaxConnections < 1 ||
 		operator.DomainMaxConnections > 16 ||
 		// workerctl is one of the three coordinator profiles (with reconciler
-		// and scheduler) under the Option B split — see the "control" runtime
-		// case in validateProcess for why this is a direct, server-counted
-		// connection rather than a PgBouncer-pooled one.
+		// and scheduler) under the Option B split. Their dedicated PgBouncer
+		// session endpoint is server-counted, while preserving River semantics.
 		operator.CoordinatorMaxConnections < 1 || operator.CoordinatorMaxConnections > 4 {
 		return errors.New("worker operator deployment identity or connection budget is invalid")
 	}
@@ -308,6 +323,7 @@ func validateOperatorCLI(operator OperatorCLI) error {
 	// anything at all, so the deployment contract refuses to describe it as
 	// deployable without one.
 	if !equalStrings(operator.ConfigEnv, []string{
+		"COORDINATOR_DATABASE_MODE",
 		"PGBOUNCER_TRANSACTION_MODE",
 		"RIVER_COORDINATOR_DATABASE_ROLE",
 		"RIVER_DATABASE_SCHEMA",
@@ -383,10 +399,8 @@ func validateProcess(process Process) error {
 			len(process.QueueWorkers) != 0 ||
 			// Control-runtime processes are the coordinator role's own worker
 			// pool under the Option B split — their control-plane database
-			// access is direct (server-counted), the same shape
-			// QueueControlMaxConnections already models for River's own
-			// queue-control access, not PgBouncer-pooled like
-			// DomainMaxConnections. See BudgetSummary.DirectCoordinatorConnections.
+			// access uses a dedicated PgBouncer session pool. It is server-counted
+			// in the shared budget but preserves control-plane session semantics.
 			process.CoordinatorMaxConnections < 1 ||
 			// A coordinator budget without the coordinator DSN would describe a
 			// process that reserves connections it cannot open: the binary calls

--- a/internal/deploymentcontract/manifest_test.go
+++ b/internal/deploymentcontract/manifest_test.go
@@ -30,21 +30,21 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.DirectQueueControlConnections != 18 {
-		t.Fatalf("direct queue-control connections = %d", summary.DirectQueueControlConnections)
+	if summary.QueueSessionClientConnections != 18 {
+		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
 	// The three coordinator profiles under the Option B split — reconciler
 	// and scheduler at two replicas each (2×2 + 2×2 = 8), plus workerctl's
-	// single invocation (1×2) — contribute 10 direct, server-counted
+	// single invocation (1×2) — contribute 10 session-pool client
 	// connections alongside (not instead of) their existing domain pools.
-	if summary.DirectCoordinatorConnections != 10 {
-		t.Fatalf("direct coordinator connections = %d", summary.DirectCoordinatorConnections)
+	if summary.CoordinatorSessionClientConnections != 10 {
+		t.Fatalf("coordinator session clients = %d", summary.CoordinatorSessionClientConnections)
 	}
 	// stream-pagerduty adds two replicas of a four-connection domain pool.
-	if summary.DomainClientConnections != 50 {
-		t.Fatalf("domain client connections = %d", summary.DomainClientConnections)
+	if summary.DomainTransactionClientConnections != 50 {
+		t.Fatalf("domain transaction clients = %d", summary.DomainTransactionClientConnections)
 	}
-	if summary.ServerConnectionFootprint != 93 {
+	if summary.ServerConnectionFootprint != 83 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
 }
@@ -78,7 +78,7 @@ func TestManifestRejectsQueueWorkerCoverageDrift(t *testing.T) {
 func TestManifestRejectsConnectionBudgetOverflow(t *testing.T) {
 	t.Parallel()
 	manifest, registry := loadFixture(t)
-	manifest.PostgresBudget.ServerMaxConnections = 92
+	manifest.PostgresBudget.ServerMaxConnections = 82
 	if _, err := manifest.Validate(registry); err == nil {
 		t.Fatal("expected server connection budget overflow")
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -47,9 +47,9 @@ const (
 )
 
 // QueueControlMode describes the endpoint semantics promised by the operator.
-// Phase 0 proved direct PostgreSQL. Session mode remains unavailable until it
-// passes the same compatibility matrix, and transaction mode cannot propagate
-// cancellation to a running River worker.
+// Direct PostgreSQL and PgBouncer session pooling preserve River's required
+// session semantics. Transaction pooling cannot propagate cancellation to a
+// running River worker.
 type QueueControlMode string
 
 const (
@@ -88,6 +88,7 @@ type Config struct {
 	PagerDutyOAuthSecret   secrets.Value
 
 	QueueDatabaseMode              QueueControlMode
+	CoordinatorDatabaseMode        QueueControlMode
 	RiverDatabaseSchema            string
 	DomainDatabaseRole             string
 	QueueDatabaseRole              string
@@ -562,6 +563,10 @@ func Load(spec Spec) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	cfg.CoordinatorDatabaseMode, err = coordinatorDatabaseModeEnv(lookup)
+	if err != nil {
+		return Config{}, err
+	}
 	cfg.PagerDutyWebhookTransport = strings.ToLower(strings.TrimSpace(envOrDefault(
 		lookup, "PAGERDUTY_WEBHOOK_TRANSPORT", PagerDutyTransportCelery,
 	)))
@@ -777,6 +782,7 @@ func (c Config) SafeAttrs() []slog.Attr {
 		slog.Bool("coordinator_database_configured", c.CoordinatorDatabaseURI.Configured()),
 		slog.Bool("queue_database_configured", c.QueueDatabaseURI.Configured()),
 		slog.String("queue_database_mode", string(c.QueueDatabaseMode)),
+		slog.String("coordinator_database_mode", string(c.CoordinatorDatabaseMode)),
 		slog.String("river_database_schema", c.RiverDatabaseSchema),
 		slog.String("river_domain_database_role", c.DomainDatabaseRole),
 		slog.String("river_queue_database_role", c.QueueDatabaseRole),
@@ -877,12 +883,20 @@ func validateIdentifier(key, value string) error {
 }
 
 func queueControlModeEnv(lookup secrets.LookupEnv) (QueueControlMode, error) {
-	mode := QueueControlMode(strings.ToLower(envOrDefault(lookup, "WORKER_DATABASE_MODE", string(QueueControlDirect))))
+	return databaseModeEnv(lookup, "WORKER_DATABASE_MODE", QueueControlDirect)
+}
+
+func coordinatorDatabaseModeEnv(lookup secrets.LookupEnv) (QueueControlMode, error) {
+	return databaseModeEnv(lookup, "COORDINATOR_DATABASE_MODE", QueueControlDirect)
+}
+
+func databaseModeEnv(lookup secrets.LookupEnv, key string, fallback QueueControlMode) (QueueControlMode, error) {
+	mode := QueueControlMode(strings.ToLower(envOrDefault(lookup, key, string(fallback))))
 	switch mode {
 	case QueueControlDirect, QueueControlSession, QueueControlTransaction:
 		return mode, nil
 	default:
-		return "", fmt.Errorf("WORKER_DATABASE_MODE must be direct, session, or transaction")
+		return "", fmt.Errorf("%s must be direct, session, or transaction", key)
 	}
 }
 

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -228,6 +228,9 @@ func TestQueueControlAndRetentionDefaults(t *testing.T) {
 	if cfg.QueueDatabaseMode != QueueControlDirect {
 		t.Fatalf("queue mode = %q, want direct", cfg.QueueDatabaseMode)
 	}
+	if cfg.CoordinatorDatabaseMode != QueueControlDirect {
+		t.Fatalf("coordinator mode = %q, want direct", cfg.CoordinatorDatabaseMode)
+	}
 	if cfg.RiverDatabaseSchema != "river" {
 		t.Fatalf("River schema = %q, want river", cfg.RiverDatabaseSchema)
 	}

--- a/internal/storage/postgres/factory_test.go
+++ b/internal/storage/postgres/factory_test.go
@@ -36,6 +36,18 @@ func TestSafeSurfaceRedactsURI(t *testing.T) {
 	}
 }
 
+func TestDefaultConfigDoesNotPinIdleSessionPoolBackends(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultConfig("postgres://queue:secret@pgbouncer-river-queue:6433/app")
+	if config.MinConns != 0 {
+		t.Fatalf("MinConns = %d, want 0 so idle clients release session-pool backends", config.MinConns)
+	}
+	if config.MaxConnIdleTime <= 0 {
+		t.Fatalf("MaxConnIdleTime = %s, want bounded idle release", config.MaxConnIdleTime)
+	}
+}
+
 func TestOpenReturnsSanitizedUnavailableError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/postgres/runtime.go
+++ b/internal/storage/postgres/runtime.go
@@ -10,12 +10,11 @@ import (
 )
 
 var (
-	ErrDomainDatabaseRequired        = errors.New("domain PostgreSQL configuration is required")
-	ErrQueueControlRequired          = errors.New("WORKER_DATABASE_URI is required for queue control")
-	ErrQueueControlTransactionMode   = errors.New("transaction-mode PgBouncer cannot be used for River queue control")
-	ErrQueueControlSessionUnverified = errors.New("session-mode queue control is unavailable until its compatibility matrix passes")
-	ErrRuntimeRolesNotSeparated      = errors.New("queue-control, coordinator, and domain PostgreSQL roles must be distinct")
-	ErrRuntimeRoleConfiguration      = errors.New("runtime PostgreSQL role configuration is invalid")
+	ErrDomainDatabaseRequired      = errors.New("domain PostgreSQL configuration is required")
+	ErrQueueControlRequired        = errors.New("WORKER_DATABASE_URI is required for queue control")
+	ErrQueueControlTransactionMode = errors.New("transaction-mode PgBouncer cannot be used for River queue control")
+	ErrRuntimeRolesNotSeparated    = errors.New("queue-control, coordinator, and domain PostgreSQL roles must be distinct")
+	ErrRuntimeRoleConfiguration    = errors.New("runtime PostgreSQL role configuration is invalid")
 	// ErrCoordinatorDatabaseRequired is deliberately its own sentinel rather
 	// than a reuse of ErrDomainDatabaseRequired: a coordinator binary that
 	// silently fell back to the domain pool would re-introduce CHAOS-3113
@@ -28,17 +27,18 @@ var (
 
 // RuntimeConfig describes the PostgreSQL trust boundaries used by River
 // processes. Domain traffic may traverse transaction-mode PgBouncer. Queue
-// control must use the bounded direct endpoint proved by the compatibility
-// matrix; session mode remains fail-closed until equivalent evidence exists.
+// control must use either a bounded direct PostgreSQL endpoint or a bounded
+// PgBouncer session endpoint. Transaction mode cannot preserve River's session
+// semantics and always fails closed.
 //
 // The coordinator boundary is the third role of the CHAOS-3033 Option B split
 // and is OPT-IN per binary via RequireCoordinator: binaries that do only domain
 // work (dev-health-worker, dev-health-stream-runner) must not be forced to
 // carry a coordinator DSN, while binaries that do coordinator work must fail
 // closed without one rather than fall back to the domain pool. Like queue
-// control — and unlike domain traffic — the coordinator connection is modeled
-// as a DIRECT, server-counted connection, never PgBouncer-pooled; see
-// deploymentcontract.BudgetSummary.DirectCoordinatorConnections.
+// control — and unlike domain traffic — the coordinator connection must retain
+// session semantics. It can use a bounded direct endpoint or the dedicated
+// PgBouncer session endpoint; see deploymentcontract.BudgetSummary.
 type RuntimeConfig struct {
 	DomainURI               string
 	QueueControlURI         string
@@ -48,6 +48,7 @@ type RuntimeConfig struct {
 	CoordinatorRole         string
 	RiverSchema             string
 	QueueControlMode        config.QueueControlMode
+	CoordinatorMode         config.QueueControlMode
 	DomainTransactionPooler bool
 	DomainMaxConns          int32
 	QueueMaxConns           int32
@@ -67,6 +68,7 @@ func DefaultRuntimeConfig(domainURI, queueControlURI, domainRole, queueRole stri
 		QueueRole:        queueRole,
 		RiverSchema:      "river",
 		QueueControlMode: config.QueueControlDirect,
+		CoordinatorMode:  config.QueueControlDirect,
 		DomainMaxConns:   4,
 		QueueMaxConns:    2,
 	}
@@ -82,6 +84,7 @@ func RuntimeConfigFromPlatform(configValue config.Config) RuntimeConfig {
 		CoordinatorRole:         configValue.CoordinatorDatabaseRole,
 		RiverSchema:             configValue.RiverDatabaseSchema,
 		QueueControlMode:        configValue.QueueDatabaseMode,
+		CoordinatorMode:         configValue.CoordinatorDatabaseMode,
 		DomainTransactionPooler: configValue.DomainTransactionPooler,
 		DomainMaxConns:          configValue.DomainDatabaseMaxConns,
 		QueueMaxConns:           configValue.QueueDatabaseMaxConns,
@@ -127,11 +130,9 @@ func (c RuntimeConfig) Validate() error {
 		}
 	}
 	switch c.QueueControlMode {
-	case config.QueueControlDirect:
+	case config.QueueControlDirect, config.QueueControlSession:
 	case config.QueueControlTransaction:
 		return ErrQueueControlTransactionMode
-	case config.QueueControlSession:
-		return ErrQueueControlSessionUnverified
 	default:
 		return ErrInvalidConfig
 	}
@@ -144,6 +145,15 @@ func (c RuntimeConfig) Validate() error {
 	// ceiling, not the PgBouncer-pooled domain ceiling of 16.
 	if c.RequireCoordinator && (c.CoordinatorMaxConns < 1 || c.CoordinatorMaxConns > 4) {
 		return ErrInvalidConfig
+	}
+	if c.RequireCoordinator {
+		switch c.CoordinatorMode {
+		case config.QueueControlDirect, config.QueueControlSession:
+		case config.QueueControlTransaction:
+			return ErrCoordinatorTransactionMode
+		default:
+			return ErrInvalidConfig
+		}
 	}
 	domainConfig, err := parseConfig(c.DomainURI)
 	if err != nil {
@@ -197,6 +207,7 @@ func (c RuntimeConfig) SafeAttributes() map[string]any {
 		"queue_database_role":           c.QueueRole,
 		"river_database_schema":         c.RiverSchema,
 		"queue_control_mode":            c.QueueControlMode,
+		"coordinator_mode":              c.CoordinatorMode,
 		"domain_transaction_pooler":     c.DomainTransactionPooler,
 		"domain_max_connections":        c.DomainMaxConns,
 		"queue_control_max_connections": c.QueueMaxConns,

--- a/internal/storage/postgres/runtime_test.go
+++ b/internal/storage/postgres/runtime_test.go
@@ -9,7 +9,7 @@ import (
 	platformconfig "github.com/full-chaos/dev-health-ops/internal/platform/config"
 )
 
-func TestRuntimeConfigRequiresDirectSeparatedPools(t *testing.T) {
+func TestRuntimeConfigRequiresSeparatedSessionSafePools(t *testing.T) {
 	t.Parallel()
 
 	valid := DefaultRuntimeConfig(
@@ -30,7 +30,7 @@ func TestRuntimeConfigRequiresDirectSeparatedPools(t *testing.T) {
 		{name: "domain missing", mutate: func(c *RuntimeConfig) { c.DomainURI = "" }, want: ErrDomainDatabaseRequired},
 		{name: "queue missing", mutate: func(c *RuntimeConfig) { c.QueueControlURI = "" }, want: ErrQueueControlRequired},
 		{name: "transaction queue", mutate: func(c *RuntimeConfig) { c.QueueControlMode = platformconfig.QueueControlTransaction }, want: ErrQueueControlTransactionMode},
-		{name: "unverified session queue", mutate: func(c *RuntimeConfig) { c.QueueControlMode = platformconfig.QueueControlSession }, want: ErrQueueControlSessionUnverified},
+		{name: "session queue", mutate: func(c *RuntimeConfig) { c.QueueControlMode = platformconfig.QueueControlSession }, want: nil},
 		{name: "shared configured role", mutate: func(c *RuntimeConfig) { c.QueueRole = "domain_role" }, want: ErrRuntimeRolesNotSeparated},
 		{name: "domain DSN role mismatch", mutate: func(c *RuntimeConfig) { c.DomainRole = "other_role" }, want: ErrRuntimeRoleConfiguration},
 		{name: "queue DSN role mismatch", mutate: func(c *RuntimeConfig) { c.QueueControlURI = "postgres://other_role:other@postgres.internal/app" }, want: ErrRuntimeRoleConfiguration},
@@ -170,6 +170,16 @@ func TestRuntimeConfigValidatesTheCoordinatorBoundaryWhenRequired(t *testing.T) 
 			name:   "coordinator DSN unparseable",
 			mutate: func(c *RuntimeConfig) { c.CoordinatorURI = "postgres://coordinator_role:x@:notaport/app" },
 			want:   ErrInvalidConfig,
+		},
+		{
+			name:   "coordinator uses session endpoint",
+			mutate: func(c *RuntimeConfig) { c.CoordinatorMode = platformconfig.QueueControlSession },
+			want:   nil,
+		},
+		{
+			name:   "coordinator transaction mode",
+			mutate: func(c *RuntimeConfig) { c.CoordinatorMode = platformconfig.QueueControlTransaction },
+			want:   ErrCoordinatorTransactionMode,
 		},
 		{
 			// The coordinator holds SHARE ROW EXCLUSIVE table locks and FOR

--- a/tests/compatibility/river/README.md
+++ b/tests/compatibility/river/README.md
@@ -1,8 +1,8 @@
 # River compatibility harness
 
 This directory contains the isolated Phase 0 compatibility proof for River
-v0.40.0. It exercises River against direct PostgreSQL and against PgBouncer in
-transaction mode with River `PollOnly`. The Python path is a compatibility
+v0.40.0. It exercises River against direct PostgreSQL, PgBouncer in session
+mode, and PgBouncer in transaction mode with River `PollOnly`. The Python path is a compatibility
 probe for the rejected `riverqueue` production option; it is not a production
 enqueue adapter.
 
@@ -82,7 +82,7 @@ startup, ahead of the next steady-state Compose health check where possible so
 `pg_isready` sessions do not contaminate the load deltas. The required N/N-1
 migration-prefix steps remain ordered around the direct v0.40 matrix.
 
-For each of `direct` and `poll-only`, it:
+For each of `direct`, `session`, and `poll-only`, it:
 
 1. runs a 20-sample execute/cancel/retry/scheduled-job matrix;
 2. asserts every Boolean emitted under `gates` against the mode-specific truth
@@ -130,7 +130,8 @@ The combined document has this shape:
   "samples_per_mode": 20,
   "profiles": [
     {"mode": "direct"},
-    {"mode": "poll-only"}
+    {"mode": "poll-only"},
+    {"mode": "session"}
   ],
   "nested_n_minus_1": {"status": "pass"},
   "redaction": {

--- a/tests/compatibility/river/README.md
+++ b/tests/compatibility/river/README.md
@@ -19,8 +19,8 @@ touch the repository's development PostgreSQL or ClickHouse data.
 - a Go installation with automatic toolchain selection enabled; the runner
   builds both CLIs with and asserts the exact candidate runtime Go 1.25.9;
 - `jq`;
-- a standalone Python 3.13.14 environment with `riverqueue`, SQLAlchemy, and
-  `asyncpg` installed at the exact versions below. This is intentionally
+- a standalone Python 3.13.14 environment with `riverqueue`, SQLAlchemy,
+  `asyncpg`, and `greenlet` installed at the exact versions below. This is intentionally
   independent of the repository's own virtual environment: the main project
   now requires Python >=3.14 (CHAOS-3419), so `.venv` at the repo root is a
   3.14 interpreter and `uv sync` against the repository lock can no longer
@@ -34,12 +34,13 @@ Prepare that exact interpreter and environment with:
 uv python install 3.13.14
 uv venv --python 3.13.14 .venv-river-compat
 uv pip install --python .venv-river-compat/bin/python \
-  asyncpg==0.31.0 riverqueue==0.7.0 SQLAlchemy==2.0.49
+  asyncpg==0.31.0 greenlet==3.5.0 riverqueue==0.7.0 SQLAlchemy==2.0.49
 ```
 
 (matches the pinned dependency install in `.github/workflows/go.yml`'s
 `river-compatibility` job). The runner fails closed if the Python patch
-version or the pinned `riverqueue`, SQLAlchemy, or `asyncpg` versions drift.
+version or the pinned `riverqueue`, SQLAlchemy, `asyncpg`, or `greenlet`
+versions drift.
 
 The default Python executable is `.venv/bin/python` at the repo root, which
 is now a 3.14 interpreter and will fail the runner's version check. Set
@@ -154,6 +155,12 @@ connection strings, remain in a mode-`0700` temporary directory and are
 deleted by the exit trap. The runner writes no raw logs or evidence files into
 the repository. Review the combined JSON before copying it into any committed
 evidence artifact.
+
+The same isolated run also starts a PgBouncer service that mirrors the Helm
+security contract: PostgreSQL UID/GID 70, read-only root filesystem, and only
+the generated `/etc/pgbouncer` configuration path writable. Its successful
+health check is recorded as `helm_pgbouncer_startup`; the Helm render test
+separately pins the equivalent Kubernetes `emptyDir` mount and `fsGroup`.
 
 ## Static validation
 

--- a/tests/compatibility/river/cmd/river-compat/main.go
+++ b/tests/compatibility/river/cmd/river-compat/main.go
@@ -45,7 +45,7 @@ func run(args []string, getenv func(string) string, stdout, stderr io.Writer) in
 		getenv("RIVER_COMPAT_DATABASE_URL"),
 		"PostgreSQL DSN (or set RIVER_COMPAT_DATABASE_URL)",
 	)
-	mode := flags.String("mode", string(rivercompat.ModeDirect), "direct or poll-only")
+	mode := flags.String("mode", string(rivercompat.ModeDirect), "direct, session, or poll-only")
 	operation := flags.String(
 		"operation",
 		operationMatrix,

--- a/tests/compatibility/river/compose.compatibility.yml
+++ b/tests/compatibility/river/compose.compatibility.yml
@@ -82,3 +82,42 @@ services:
       retries: 3
     ports:
       - "127.0.0.1::6433"
+
+  # Mirrors the Helm security context: the image is postgres UID/GID 70, its
+  # root filesystem is read-only, and only its generated config path is
+  # writable and ephemeral. The harness waits for this service to become
+  # healthy, so it is a startup proof rather than a render-only assertion.
+  pgbouncer-session-helm-smoke:
+    image: edoburu/pgbouncer:1.25.2@sha256:4c1ca296ef525f108f5d3552cc337c0c09587cf8dae7f0067fd93349e47dc1cd
+    user: "70:70"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    tmpfs:
+      - /etc/pgbouncer:uid=70,gid=70,mode=0755
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ADMIN_USERS: river_compat
+      AUTH_TYPE: scram-sha-256
+      DB_HOST: postgres
+      DB_NAME: river_compat
+      DB_PASSWORD: river_compat
+      DB_PORT: 5432
+      DB_USER: river_compat
+      DEFAULT_POOL_SIZE: 5
+      LISTEN_PORT: 6434
+      MAX_CLIENT_CONN: 50
+      POOL_MODE: session
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          PGPASSWORD=$$DB_PASSWORD pg_isready -h 127.0.0.1 -p 6434
+          -U $$DB_USER -d $$DB_NAME
+      interval: 30s
+      start_interval: 1s
+      start_period: 30s
+      timeout: 3s
+      retries: 3

--- a/tests/compatibility/river/compose.compatibility.yml
+++ b/tests/compatibility/river/compose.compatibility.yml
@@ -51,3 +51,34 @@ services:
       retries: 3
     ports:
       - "127.0.0.1::6432"
+
+  pgbouncer-session:
+    image: edoburu/pgbouncer:1.25.2@sha256:4c1ca296ef525f108f5d3552cc337c0c09587cf8dae7f0067fd93349e47dc1cd
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ADMIN_USERS: river_compat
+      AUTH_TYPE: scram-sha-256
+      DB_HOST: postgres
+      DB_NAME: river_compat
+      DB_PASSWORD: river_compat
+      DB_PORT: 5432
+      DB_USER: river_compat
+      DEFAULT_POOL_SIZE: 5
+      LISTEN_PORT: 6433
+      MAX_CLIENT_CONN: 50
+      POOL_MODE: session
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          PGPASSWORD=$$DB_PASSWORD pg_isready -h 127.0.0.1 -p 6433
+          -U $$DB_USER -d $$DB_NAME
+      interval: 30s
+      start_interval: 1s
+      start_period: 30s
+      timeout: 3s
+      retries: 3
+    ports:
+      - "127.0.0.1::6433"

--- a/tests/compatibility/river/go/probe.go
+++ b/tests/compatibility/river/go/probe.go
@@ -30,6 +30,7 @@ type Mode string
 
 const (
 	ModeDirect   Mode = "direct"
+	ModeSession  Mode = "session"
 	ModePollOnly Mode = "poll-only"
 )
 
@@ -796,8 +797,8 @@ func normalizedOptions(opts Options) (Options, error) {
 	if opts.Mode == "" {
 		opts.Mode = ModeDirect
 	}
-	if opts.Mode != ModeDirect && opts.Mode != ModePollOnly {
-		return Options{}, fmt.Errorf("mode must be %q or %q", ModeDirect, ModePollOnly)
+	if opts.Mode != ModeDirect && opts.Mode != ModeSession && opts.Mode != ModePollOnly {
+		return Options{}, fmt.Errorf("mode must be %q, %q, or %q", ModeDirect, ModeSession, ModePollOnly)
 	}
 	if opts.FetchPollInterval == 0 {
 		opts.FetchPollInterval = 250 * time.Millisecond

--- a/tests/compatibility/river/go/probe_integration_test.go
+++ b/tests/compatibility/river/go/probe_integration_test.go
@@ -55,7 +55,7 @@ func runIntegrationProbe(t *testing.T, databaseURL string, mode Mode) {
 	if result.Workload.RunningCancellation == nil {
 		t.Fatal("running cancellation evidence is missing")
 	}
-	if mode == ModeDirect {
+	if mode == ModeDirect || mode == ModeSession {
 		if !result.Workload.RunningCancellation.CrossClientContextCancelled || result.Workload.RunningCancellation.ProbeReleaseUsed {
 			t.Fatalf("direct cancellation result = %#v", result.Workload.RunningCancellation)
 		}

--- a/tests/compatibility/river/run.sh
+++ b/tests/compatibility/river/run.sh
@@ -18,6 +18,7 @@ PYTHON_VERSION="3.13.14"
 RIVERQUEUE_PYTHON_VERSION="0.7.0"
 SQLALCHEMY_VERSION="2.0.49"
 ASYNCPG_VERSION="0.31.0"
+GREENLET_VERSION="3.5.0"
 FETCH_POLL_INTERVAL="250ms"
 CRASH_CANDIDATE_JOB_TIMEOUT="30s"
 CRASH_CANDIDATE_RESCUE_AFTER="31s"
@@ -167,6 +168,8 @@ dump_bootstrap_diagnostics() {
     "${compose[@]}" logs --no-color --tail=40 postgres 2>&1
     printf -- '\n-- pgbouncer logs (tail 40) --\n'
     "${compose[@]}" logs --no-color --tail=40 pgbouncer 2>&1
+    printf -- '\n-- Helm PgBouncer security smoke logs (tail 40) --\n'
+    "${compose[@]}" logs --no-color --tail=40 pgbouncer-session-helm-smoke 2>&1
   } 2>&1 | redact_diagnostic_stream >"${status_file}" || true
 
   printf 'river compatibility harness: bootstrap diagnostics (sanitized) ----------\n' >&2
@@ -257,7 +260,9 @@ run_go_checked() {
 
   if ! RIVER_COMPAT_DATABASE_URL="${database_url}" "${GO_BINARY}" "$@" \
     >"${output_file}" 2>"${TEMP_DIR}/${label}.stderr"; then
-    die "${label} failed; captured details were discarded"
+    progress "${label} failed; sanitized diagnostic follows"
+    redact_diagnostic_stream <"${TEMP_DIR}/${label}.stderr" | tail -n 40 >&2 || true
+    die "${label} failed"
   fi
   assert_single_json_object "${output_file}" || die "${label} emitted invalid JSON"
   if ! assert_all_emitted_gates "${output_file}"; then
@@ -306,7 +311,7 @@ assert_matrix() {
       and .workload.execute_latency_ms.within_limit == true
       and .workload.cancel.state == "cancelled"
       and (
-        if $mode == "direct" then
+        if $mode == "direct" or $mode == "session" then
           .workload.cancel.outcome == "running_context_cancelled_cross_client"
           and .workload.running_cancellation.cross_client_context_cancelled == true
           and .workload.running_cancellation.same_client_attempted == false
@@ -327,7 +332,10 @@ assert_matrix() {
       and .workload.scheduled.state == "cancelled"
       and .workload.scheduled.scheduled == true
       and .workload.scheduled.outcome == "scheduled_state_observed"
-    ' "${output_file}" >/dev/null 2>&1 || die "${mode} matrix contract assertion failed"
+    ' "${output_file}" >/dev/null 2>&1 || {
+      report_gate_failure "${output_file}"
+      die "${mode} matrix contract assertion failed"
+    }
 }
 
 run_python_case() {
@@ -358,7 +366,9 @@ run_python_case() {
 
   if ! "${PYTHON_BIN}" "${PYTHON_CLI}" "${args[@]}" \
     >"${output_file}" 2>"${TEMP_DIR}/${label}.stderr"; then
-    die "${label} failed; captured details were discarded"
+    progress "${label} failed; sanitized diagnostic follows"
+    redact_diagnostic_stream <"${TEMP_DIR}/${label}.stderr" | tail -n 40 >&2 || true
+    die "${label} failed"
   fi
   assert_single_json_object "${output_file}" || die "${label} emitted invalid JSON"
 }
@@ -1015,6 +1025,7 @@ from importlib.metadata import version
 
 print(json.dumps({
     "asyncpg": version("asyncpg"),
+    "greenlet": version("greenlet"),
     "python": platform.python_version(),
     "riverqueue": version("riverqueue"),
     "sqlalchemy": version("SQLAlchemy"),
@@ -1028,11 +1039,13 @@ if ! jq -e \
   --arg python "${PYTHON_VERSION}" \
   --arg riverqueue "${RIVERQUEUE_PYTHON_VERSION}" \
   --arg sqlalchemy "${SQLALCHEMY_VERSION}" \
-  --arg asyncpg "${ASYNCPG_VERSION}" '
+  --arg asyncpg "${ASYNCPG_VERSION}" \
+  --arg greenlet "${GREENLET_VERSION}" '
     .python == $python
     and .riverqueue == $riverqueue
     and .sqlalchemy == $sqlalchemy
     and .asyncpg == $asyncpg
+    and .greenlet == $greenlet
   ' "${python_versions}" \
   >"${TEMP_DIR}/python-import.stdout" \
   2>"${TEMP_DIR}/python-version-check.stderr"; then
@@ -1060,7 +1073,7 @@ fi
 
 progress "starting the isolated pinned PostgreSQL and PgBouncer services"
 COMPOSE_ATTEMPTED=1
-if ! "${compose[@]}" up -d --wait postgres pgbouncer pgbouncer-session \
+if ! "${compose[@]}" up -d --wait postgres pgbouncer pgbouncer-session pgbouncer-session-helm-smoke \
   >"${TEMP_DIR}/compose-up.stdout" \
   2>"${TEMP_DIR}/compose-up.stderr"; then
   dump_bootstrap_diagnostics
@@ -1125,7 +1138,8 @@ jq -n \
       python: $python_versions[0].python,
       riverqueue_python: $python_versions[0].riverqueue,
       sqlalchemy: $python_versions[0].sqlalchemy,
-      asyncpg: $python_versions[0].asyncpg
+      asyncpg: $python_versions[0].asyncpg,
+      greenlet: $python_versions[0].greenlet
     },
     samples_per_mode: $samples,
     gate_truth_table: {
@@ -1153,6 +1167,13 @@ jq -n \
         cross_client_running_cancel: $session[0].matrix.gates.cross_client_running_cancel,
         same_client_running_cancel: $session[0].matrix.gates.same_client_running_cancel
       }
+    },
+    helm_pgbouncer_startup: {
+      status: "pass",
+      mode: "session",
+      container_identity: "postgres_uid_gid_70",
+      root_filesystem: "read_only",
+      writable_config_path: "/etc/pgbouncer"
     },
     profiles: [$direct[0], $poll[0], $session[0]],
     nested_n_minus_1: $n_minus_one[0],

--- a/tests/compatibility/river/run.sh
+++ b/tests/compatibility/river/run.sh
@@ -209,7 +209,7 @@ assert_all_emitted_gates() {
     and (
       if ($cancel_gates | length) == 0 then
         all($gates[]; .value == true)
-      elif .mode == "direct" then
+      elif .mode == "direct" or .mode == "session" then
         all($gates[]; .value == true)
       elif .mode == "poll-only" then
         all(
@@ -1060,7 +1060,7 @@ fi
 
 progress "starting the isolated pinned PostgreSQL and PgBouncer services"
 COMPOSE_ATTEMPTED=1
-if ! "${compose[@]}" up -d --wait postgres pgbouncer \
+if ! "${compose[@]}" up -d --wait postgres pgbouncer pgbouncer-session \
   >"${TEMP_DIR}/compose-up.stdout" \
   2>"${TEMP_DIR}/compose-up.stderr"; then
   dump_bootstrap_diagnostics
@@ -1069,13 +1069,17 @@ fi
 
 postgres_port="$(resolve_local_port postgres 5432)"
 pgbouncer_port="$(resolve_local_port pgbouncer 6432)"
+pgbouncer_session_port="$(resolve_local_port pgbouncer-session 6433)"
 direct_database_url="postgresql://river_compat:river_compat@127.0.0.1:${postgres_port}/river_compat"
 poll_database_url="postgresql://river_compat:river_compat@127.0.0.1:${pgbouncer_port}/river_compat"
+session_database_url="postgresql://river_compat:river_compat@127.0.0.1:${pgbouncer_session_port}/river_compat"
 
 direct_profile="${TEMP_DIR}/direct-profile.json"
 poll_profile="${TEMP_DIR}/poll-only-profile.json"
+session_profile="${TEMP_DIR}/session-profile.json"
 direct_matrix="${TEMP_DIR}/direct-matrix.stdout"
 poll_matrix="${TEMP_DIR}/poll-only-matrix.stdout"
+session_matrix="${TEMP_DIR}/session-matrix.stdout"
 n_minus_one_before="${TEMP_DIR}/n-minus-one-before-upgrade.json"
 n_minus_one_after="${TEMP_DIR}/n-minus-one-after-upgrade.json"
 n_minus_one="${TEMP_DIR}/n-minus-one.json"
@@ -1091,15 +1095,18 @@ run_nested_n_minus_one after-v0.40-upgrade "${direct_database_url}" "${n_minus_o
 # Keep the second measured matrix as close to service startup as the required
 # N/N-1 migration-prefix order permits, minimizing pg_isready contamination.
 run_mode_matrix poll-only "${poll_database_url}" true chaos3034-poll-only "${poll_matrix}"
+run_mode_matrix session "${session_database_url}" false chaos3034-session "${session_matrix}"
 
 run_profile direct "${direct_database_url}" false direct_postgresql "${direct_matrix}" "${direct_profile}"
 run_profile poll-only "${poll_database_url}" true pgbouncer_transaction_poll_only "${poll_matrix}" "${poll_profile}"
+run_profile session "${session_database_url}" false pgbouncer_session "${session_matrix}" "${session_profile}"
 combine_nested_n_minus_one "${n_minus_one_before}" "${n_minus_one_after}" "${n_minus_one}"
 
 jq -n \
   --argjson samples "${SAMPLES}" \
   --slurpfile direct "${direct_profile}" \
   --slurpfile poll "${poll_profile}" \
+  --slurpfile session "${session_profile}" \
   --slurpfile n_minus_one "${n_minus_one}" \
   --slurpfile python_versions "${python_versions}" '{
     schema_version: 1,
@@ -1137,9 +1144,17 @@ jq -n \
         new_connections_at_most_six: $poll[0].matrix.gates.new_connections_at_most_six,
         cross_client_running_cancel: $poll[0].matrix.gates.cross_client_running_cancel,
         same_client_running_cancel: $poll[0].matrix.gates.same_client_running_cancel
+      },
+      session: {
+        backend_connection_delta_at_most_six: $session[0].matrix.gates.backend_connection_delta_at_most_six,
+        canceled_acquires_zero: $session[0].matrix.gates.canceled_acquires_zero,
+        enqueue_p95_within_limit: $session[0].matrix.gates.enqueue_p95_within_limit,
+        new_connections_at_most_six: $session[0].matrix.gates.new_connections_at_most_six,
+        cross_client_running_cancel: $session[0].matrix.gates.cross_client_running_cancel,
+        same_client_running_cancel: $session[0].matrix.gates.same_client_running_cancel
       }
     },
-    profiles: [$direct[0], $poll[0]],
+    profiles: [$direct[0], $poll[0], $session[0]],
     nested_n_minus_1: $n_minus_one[0],
     redaction: {
       contains_raw_logs: false,

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -933,7 +933,6 @@ def test_platform_compose_workers_and_beat_import_mounted_source() -> None:
         pytest.skip("platform compose.yml is only present in the monorepo checkout")
 
     services = _load_yaml(compose_path).get("services") or {}
-
     service_names = ["worker", "worker-ingest", "worker-heavy", "beat"]
     if "worker-wi" in services:
         service_names.append("worker-wi")
@@ -1404,3 +1403,44 @@ def test_go_profile_overlay_services_are_all_profile_gated() -> None:
         assert spec.get("profiles") == ["go"], (
             f'{name} must declare profiles: ["go"] so a default `up` never starts it'
         )
+
+
+def test_platform_go_runtime_uses_bounded_session_poolers() -> None:
+    compose_path = _platform_go_compose_path()
+    if compose_path is None:
+        pytest.skip("platform compose.yml is only present in the monorepo checkout")
+
+    services = _load_yaml(compose_path).get("services") or {}
+    transaction_pool = services["pgbouncer"]
+    queue_pool = services["pgbouncer-river-queue"]
+    coordinator_pool = services["pgbouncer-river-coordinator"]
+    assert queue_pool["environment"].get("POOL_MODE") == "session"
+    assert coordinator_pool["environment"].get("POOL_MODE") == "session"
+    # PgBouncer budgets are per (database, user) pool. Each endpoint has one
+    # fixed River role and one database, so these are true backend ceilings.
+    assert (
+        queue_pool["environment"].get("DB_USER")
+        == "${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}"
+    )
+    assert (
+        coordinator_pool["environment"].get("DB_USER")
+        == "${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}"
+    )
+    assert queue_pool["environment"].get("DEFAULT_POOL_SIZE") == "18"
+    assert coordinator_pool["environment"].get("DEFAULT_POOL_SIZE") == "10"
+    assert transaction_pool["environment"].get("DEFAULT_POOL_SIZE") == "20"
+    assert "RESERVE_POOL_SIZE" not in transaction_pool["environment"]
+
+    for service_name in ("go-worker", "go-worker-heavy", "go-worker-ops"):
+        environment = services[service_name]["environment"]
+        assert "@pgbouncer-river-queue:6433/" in environment["WORKER_DATABASE_URI"]
+        assert environment["WORKER_DATABASE_MODE"] == "session"
+        assert "COORDINATOR_DATABASE_URI" not in environment
+    for service_name in ("go-reconciler", "go-scheduler", "go-worker-route-activate"):
+        environment = services[service_name]["environment"]
+        assert "@pgbouncer-river-queue:6433/" in environment["WORKER_DATABASE_URI"]
+        assert (
+            "@pgbouncer-river-coordinator:6434/"
+            in environment["COORDINATOR_DATABASE_URI"]
+        )
+        assert environment["COORDINATOR_DATABASE_MODE"] == "session"

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -272,6 +272,7 @@ def test_go_profiles_are_disabled_future_topology() -> None:
         # carries a coordinator budget and requires the coordinator DSN.
         "coordinator_max_connections": 2,
         "config_env": [
+            "COORDINATOR_DATABASE_MODE",
             "PGBOUNCER_TRANSACTION_MODE",
             "RIVER_COORDINATOR_DATABASE_ROLE",
             "RIVER_DATABASE_SCHEMA",
@@ -598,17 +599,17 @@ def test_profile_pgbouncer_budget_matches_production_compose_defaults() -> None:
 
     assert pgbouncer["profiles"] == ["pooler"]
     environment = pgbouncer["environment"]
-    assert manifest["postgres_budget"]["pgbouncer_max_client_connections"] == (
-        _compose_default(environment["MAX_CLIENT_CONN"], "PGBOUNCER_MAX_CLIENT_CONN")
-    )
-    assert manifest["postgres_budget"]["pgbouncer_default_pool_size"] == (
+    assert manifest["postgres_budget"][
+        "pgbouncer_transaction_max_client_connections"
+    ] == (_compose_default(environment["MAX_CLIENT_CONN"], "PGBOUNCER_MAX_CLIENT_CONN"))
+    assert manifest["postgres_budget"]["pgbouncer_transaction_pool_size"] == (
         _compose_default(
             environment["DEFAULT_POOL_SIZE"], "PGBOUNCER_DEFAULT_POOL_SIZE"
         )
     )
     # Existing Celery/application traffic and the new Go domain role create
     # distinct (database,user) server pools in PgBouncer.
-    assert manifest["postgres_budget"]["pgbouncer_server_pool_count"] == 2
+    assert manifest["postgres_budget"]["pgbouncer_transaction_server_pool_count"] == 2
 
 
 @pytest.mark.parametrize("path", [_PRODUCTION_COMPOSE, _SWARM_STACK])

--- a/tests/workers/test_helm_go_pgbouncer.py
+++ b/tests/workers/test_helm_go_pgbouncer.py
@@ -1,0 +1,249 @@
+"""Rendered Helm contract for the Go PgBouncer topology.
+
+This is intentionally a chart-level oracle: values alone cannot prove which
+pool endpoint a long-running binary receives, and a template-only assertion
+cannot prove the rendered Secret references stay role-scoped.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_CHART = Path(__file__).resolve().parents[2] / "deploy" / "helm" / "dev-health"
+_RELEASE = "pool-contract"
+_PROFILE_NAMES = {
+    "heavy",
+    "ops",
+    "sync",
+    "reconciler",
+    "scheduler",
+    "stream-external",
+    "stream-ingest",
+    "stream-pagerduty",
+}
+_COORDINATOR_PROFILES = {"reconciler", "scheduler"}
+_POOLERS = {
+    "transaction": (6432, "transaction", 20, 1000, "devhealth_domain"),
+    "queue-session": (6433, "session", 18, 128, "devhealth_queue"),
+    "coordinator-session": (6434, "session", 10, 32, "devhealth_coordinator"),
+}
+_ROLE_SECRET_KEYS = {
+    "RIVER_DOMAIN_DATABASE_PASSWORD",
+    "RIVER_QUEUE_DATABASE_PASSWORD",
+    "RIVER_COORDINATOR_DATABASE_PASSWORD",
+    "POSTGRES_URI",
+    "WORKER_DATABASE_URI",
+    "COORDINATOR_DATABASE_URI",
+}
+
+
+def _render(*args: str) -> list[dict]:
+    completed = subprocess.run(
+        ["helm", "template", _RELEASE, _CHART, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [document for document in yaml.safe_load_all(completed.stdout) if document]
+
+
+def _go_values(*extra: str) -> list[str]:
+    return [
+        "--set",
+        "goWorkers.enabled=true",
+        "--set",
+        "goWorkers.pgbouncer.enabled=true",
+        "--set",
+        "goWorkers.pgbouncer.postgres.host=postgres.internal",
+        "--set",
+        "goWorkers.pgbouncer.postgres.database=devhealth",
+        "--set-string",
+        "goWorkers.pgbouncer.secret.data.RIVER_DOMAIN_DATABASE_PASSWORD=domain-password",
+        "--set-string",
+        "goWorkers.pgbouncer.secret.data.RIVER_QUEUE_DATABASE_PASSWORD=queue-password",
+        "--set-string",
+        "goWorkers.pgbouncer.secret.data.RIVER_COORDINATOR_DATABASE_PASSWORD=coordinator-password",
+        *extra,
+    ]
+
+
+def _env(container: dict) -> dict[str, dict]:
+    return {item["name"]: item for item in container["env"]}
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+def test_go_workers_require_the_pgbouncer_topology() -> None:
+    rejected = subprocess.run(
+        ["helm", "template", _RELEASE, _CHART, "--set", "goWorkers.enabled=true"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert rejected.returncode != 0
+    assert "values don't meet the specifications" in rejected.stderr
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+def test_go_pgbouncer_render_scopes_role_dsns_and_preserves_direct_migrations() -> None:
+    documents = _render(*_go_values())
+    secrets = {
+        doc["metadata"]["name"]: doc for doc in documents if doc["kind"] == "Secret"
+    }
+    runtime_secret = secrets[f"{_RELEASE}-dev-health-go-pgbouncer"]
+    assert set(runtime_secret["stringData"]) == _ROLE_SECRET_KEYS
+    assert "MIGRATION_DATABASE_URI" not in runtime_secret["stringData"]
+    assert "MIGRATION_DATABASE_URI_FILE" not in runtime_secret["stringData"]
+    assert runtime_secret["stringData"]["POSTGRES_URI"].endswith(
+        "-go-pgbouncer-transaction:6432/devhealth"
+    )
+    assert runtime_secret["stringData"]["WORKER_DATABASE_URI"].endswith(
+        "-go-pgbouncer-queue-session:6433/devhealth"
+    )
+    assert runtime_secret["stringData"]["COORDINATOR_DATABASE_URI"].endswith(
+        "-go-pgbouncer-coordinator-session:6434/devhealth"
+    )
+
+    pooler_deployments = {
+        doc["metadata"]["labels"]["app.kubernetes.io/component"]: doc
+        for doc in documents
+        if doc["kind"] == "Deployment"
+        and doc["metadata"]["labels"]["app.kubernetes.io/component"].startswith(
+            "go-pgbouncer-"
+        )
+    }
+    assert set(pooler_deployments) == {f"go-pgbouncer-{name}" for name in _POOLERS}
+    for name, (port, mode, pool_size, max_clients, role) in _POOLERS.items():
+        container = pooler_deployments[f"go-pgbouncer-{name}"]["spec"]["template"][
+            "spec"
+        ]["containers"][0]
+        environment = _env(container)
+        assert "@sha256:" in container["image"]
+        assert environment["DB_USER"]["value"] == role
+        assert environment["POOL_MODE"]["value"] == mode
+        assert environment["DEFAULT_POOL_SIZE"]["value"] == str(pool_size)
+        assert environment["MAX_CLIENT_CONN"]["value"] == str(max_clients)
+        assert container["readinessProbe"]["tcpSocket"]["port"] == "pgbouncer"
+        pod_spec = pooler_deployments[f"go-pgbouncer-{name}"]["spec"]["template"][
+            "spec"
+        ]
+        assert pod_spec["securityContext"] == {
+            "runAsNonRoot": True,
+            "runAsUser": 70,
+            "runAsGroup": 70,
+            "fsGroup": 70,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+        assert container["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "readOnlyRootFilesystem": True,
+            "capabilities": {"drop": ["ALL"]},
+        }
+        assert container["volumeMounts"] == [
+            {"name": "generated-config", "mountPath": "/etc/pgbouncer"}
+        ]
+        assert pod_spec["volumes"] == [{"name": "generated-config", "emptyDir": {}}]
+
+    services = {
+        doc["metadata"]["labels"]["app.kubernetes.io/component"]: doc
+        for doc in documents
+        if doc["kind"] == "Service"
+        and doc["metadata"]["labels"]
+        .get("app.kubernetes.io/component", "")
+        .startswith("go-pgbouncer-")
+    }
+    for name, (port, *_rest) in _POOLERS.items():
+        service_port = services[f"go-pgbouncer-{name}"]["spec"]["ports"][0]
+        assert service_port == {
+            "name": "pgbouncer",
+            "port": port,
+            "targetPort": "pgbouncer",
+        }
+
+    workers = {
+        doc["metadata"]["labels"]["dev-health.io/profile"]: doc
+        for doc in documents
+        if doc["kind"] == "Deployment"
+        and doc["metadata"]["labels"].get("app.kubernetes.io/component") == "go-worker"
+    }
+    assert set(workers) == _PROFILE_NAMES
+    for profile, deployment in workers.items():
+        container = deployment["spec"]["template"]["spec"]["containers"][0]
+        environment = _env(container)
+        assert (
+            environment["POSTGRES_URI"]["valueFrom"]["secretKeyRef"]["key"]
+            == "POSTGRES_URI"
+        )
+        assert (
+            environment["WORKER_DATABASE_URI"]["valueFrom"]["secretKeyRef"]["key"]
+            == "WORKER_DATABASE_URI"
+        )
+        assert environment["WORKER_DATABASE_MODE"]["value"] == "session"
+        assert environment["PGBOUNCER_TRANSACTION_MODE"]["value"] == "true"
+        assert "MIGRATION_DATABASE_URI" not in environment
+        assert "MIGRATION_DATABASE_URI_FILE" not in environment
+        if profile in _COORDINATOR_PROFILES:
+            assert (
+                environment["COORDINATOR_DATABASE_URI"]["valueFrom"]["secretKeyRef"][
+                    "key"
+                ]
+                == "COORDINATOR_DATABASE_URI"
+            )
+            assert environment["COORDINATOR_DATABASE_MODE"]["value"] == "session"
+        else:
+            assert "COORDINATOR_DATABASE_URI" not in environment
+            assert "COORDINATOR_DATABASE_MODE" not in environment
+
+    migration = next(doc for doc in documents if doc["kind"] == "Job")
+    migration_env_from = migration["spec"]["template"]["spec"]["containers"][0][
+        "envFrom"
+    ]
+    assert all(
+        source["secretRef"]["name"] != runtime_secret["metadata"]["name"]
+        for source in migration_env_from
+        if "secretRef" in source
+    )
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+def test_go_pgbouncer_network_policy_pins_bundled_and_external_postgres_paths() -> None:
+    bundled_documents = _render(
+        *_go_values(
+            "--set",
+            "networkPolicy.enabled=true",
+            "--set",
+            "postgresql.enabled=true",
+        )
+    )
+    policies = [doc for doc in bundled_documents if doc["kind"] == "NetworkPolicy"]
+    pooler_policies = [
+        policy
+        for policy in policies
+        if policy["metadata"]["name"].startswith(f"{_RELEASE}-dev-health-go-pgbouncer-")
+    ]
+    assert len(pooler_policies) == 3
+    for policy in pooler_policies:
+        egress_selector = policy["spec"]["egress"][0]["to"][0]["podSelector"][
+            "matchLabels"
+        ]
+        assert egress_selector["app.kubernetes.io/component"] == "postgresql"
+
+    rejected = subprocess.run(
+        [
+            "helm",
+            "template",
+            _RELEASE,
+            _CHART,
+            *_go_values("--set", "networkPolicy.enabled=true"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert rejected.returncode != 0
+    assert "networkPolicyCIDR" in rejected.stderr


### PR DESCRIPTION
## Summary

- Route Go domain traffic through transaction-mode PgBouncer.
- Route River queue-control and coordinator traffic through distinct session-mode PgBouncer endpoints.
- Keep migration traffic on the direct PostgreSQL endpoint.
- Add runtime guards, deployment-contract checks, supported Compose/Swarm/Helm topology, and River compatibility coverage.

## Validated problem

Long-running Go workers used direct PostgreSQL connections for River queue-control and coordinator pools. Those pools multiplied with worker replicas and could pressure PostgreSQL. River control traffic cannot use transaction-mode PgBouncer because it requires session semantics.

## Tested revision

`017f4b652e1d75e70b0052566aa99b83521b86ef`

## TEST-EVIDENCE

- Canonical local gate: `bash ci/local_validate.sh`
  - 9/9 declared stages executed and passed.
  - 13,144 passed, 639 skipped, 1 xfailed.
  - mypy checked 2,401 source files.
  - 86 ClickHouse migrations validated.
  - Live ClickHouse argMax proof passed.
- Isolated River compatibility:
  - direct mode passed.
  - polling mode passed.
  - session-mode PgBouncer passed.
  - the disposable test topology was cleaned up.
- Hardened Helm PgBouncer startup passed with the rendered security and writable-volume shape.
- Hosted GitHub checks are green for this revision. Conditional deploy, rollback, coverage, and image-merge jobs are skipped as designed; no check is pending or failed.

## RISK-NOTES

- Session pooling bounds the configured PostgreSQL backend capacity. It does not provide transaction-style multiplexing for River clients.
- Pool sizes still require production capacity planning against the PostgreSQL connection limit and non-worker connection reserve.
- The compatibility proof used an isolated disposable topology. It did not exercise the user development stack or a production traffic load.
- Helm rendering and startup tests prove configuration and container startup shape. They do not prove a live production-cluster rollout.
- Direct PostgreSQL remains required for migrations and is not injected into long-running Go worker processes.

Linear: [CHAOS-3816](https://linear.app/fullchaos/issue/CHAOS-3816/pool-go-river-control-connections-through-a-session-pgbouncer-endpoint)