### PR TITLE
fix: terminalize GitLab feature-flag access denials

### DIFF
--- a/internal/jobs/providerunit/providerunit_test.go
+++ b/internal/jobs/providerunit/providerunit_test.go
@@ -257,6 +257,53 @@ func TestProviderBudgetStoreUnavailableRemainsAnAttemptFailure(t *testing.T) {
 	}
 }
 
+func TestProviderDatasetUnavailableTerminalizesOnFirstAttempt(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	unit := providerUnit()
+	unit.Provider = "gitlab"
+	unit.Dataset = "feature-flags"
+	unit.SourceExternalID = "group/project"
+	unit.SourceName = "group/project"
+	repository := newMemoryUnitRepository(unit)
+	handler := &Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			GitlabFeatureFlags: true,
+		},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: func(*providersync.LeaseSession) (providersync.CompleteRouteExecutor, error) {
+			return providersync.CompleteRouteExecutor{}, errors.Join(
+				providersync.ErrProviderDatasetUnavailable,
+				&providerfoundation.ProviderError{
+					Class: providerfoundation.ErrorAuthentication, StatusCode: http.StatusForbidden,
+				},
+			)
+		},
+	}
+	execution := providerExecution(unit, now, 1)
+	execution.Definition.MaxAttempts = 5
+
+	err := handler.Work(context.Background(), execution)
+	if !errors.Is(err, providersync.ErrProviderDatasetUnavailable) {
+		t.Fatalf("Work()=%v want unavailable dataset", err)
+	}
+	if repository.status != "failed" || repository.attempt != 1 ||
+		repository.failures != 1 ||
+		repository.lastFailCategory != ProviderDatasetUnavailableCategory {
+		t.Fatalf(
+			"status=%q attempt=%d failures=%d category=%q",
+			repository.status, repository.attempt, repository.failures,
+			repository.lastFailCategory,
+		)
+	}
+	if repository.releaseCalls != 0 {
+		t.Fatalf("unavailable dataset was released for retry %d times", repository.releaseCalls)
+	}
+}
+
 func TestProviderBudgetContentionDelayIsDeterministicAndBounded(t *testing.T) {
 	t.Parallel()
 	first := providerBudgetContentionDelay("11111111-1111-4111-8111-111111111111")

--- a/internal/providersync/gitlab_feature_flags_route.go
+++ b/internal/providersync/gitlab_feature_flags_route.go
@@ -3,6 +3,7 @@ package providersync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -38,34 +39,7 @@ type gitLabFeatureFlagsCountingDoer struct {
 
 func (doer gitLabFeatureFlagsCountingDoer) Do(request *http.Request) (*http.Response, error) {
 	*doer.attempts++
-	response, err := doer.delegate.Do(request)
-	if response != nil && gitLabFeatureFlagsQualified403(response) {
-		// providerfoundation's shared classifier intentionally gives GitLab's
-		// 403 the ordinary authentication meaning. GitLabFeatureFlagsClient has
-		// one provider-specific exception: a 403 carrying Retry-After or
-		// RateLimit-Remaining: 0 is a retryable throttle. Convert only that
-		// qualified shape to the shared 429 class at this provider boundary so
-		// the HTTP client's retry accounting remains physical and bounded.
-		response.StatusCode = http.StatusTooManyRequests
-	}
-	return response, err
-}
-
-func gitLabFeatureFlagsQualified403(response *http.Response) bool {
-	if response == nil || response.StatusCode != http.StatusForbidden {
-		return false
-	}
-	return strings.TrimSpace(gitLabFeatureFlagsHeaderValue(response.Header, "Retry-After")) != "" ||
-		strings.TrimSpace(gitLabFeatureFlagsHeaderValue(response.Header, "RateLimit-Remaining")) == "0"
-}
-
-func gitLabFeatureFlagsHeaderValue(headers http.Header, wanted string) string {
-	for key, values := range headers {
-		if strings.EqualFold(key, wanted) && len(values) > 0 {
-			return values[0]
-		}
-	}
-	return ""
+	return doer.delegate.Do(request)
 }
 
 func (handler GitLabFeatureFlagsRouteHandler) limits() (int, int, error) {
@@ -115,7 +89,7 @@ func (handler GitLabFeatureFlagsRouteHandler) Collect(
 		},
 	)
 	if err != nil {
-		return CompleteRouteBatch{}, err
+		return CompleteRouteBatch{}, gitLabFeatureFlagsCollectionError(err)
 	}
 	if flagsPage.CapReached {
 		return CompleteRouteBatch{}, ErrPaginationCapExceeded
@@ -176,6 +150,22 @@ func (handler GitLabFeatureFlagsRouteHandler) Collect(
 			Requests: requests, Pages: flagsPage.Pages, Records: len(flags) + len(events) + len(edges),
 		},
 	}, nil
+}
+
+func gitLabFeatureFlagsCollectionError(err error) error {
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) &&
+		providerErr.Class == providerfoundation.ErrorAuthentication &&
+		providerErr.StatusCode == http.StatusForbidden {
+		// GitLab requires Developer-or-higher project access for this endpoint.
+		// A plain 403 can also mean feature flags are unavailable for the project;
+		// neither condition can change on a later attempt with the same claim.
+		// Join the durable dataset verdict with the bounded provider error so the
+		// worker terminalizes immediately while parity/error telemetry can still
+		// observe the original authentication classification.
+		return errors.Join(ErrProviderDatasetUnavailable, err)
+	}
+	return err
 }
 
 func fetchGitLabFeatureFlagProjectName(

--- a/internal/providersync/gitlab_feature_flags_route_test.go
+++ b/internal/providersync/gitlab_feature_flags_route_test.go
@@ -319,3 +319,78 @@ func TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403(t *testing
 		t.Fatalf("error=%v want case-insensitive qualified rate limit", err)
 	}
 }
+
+func TestGitLabFeatureFlagsRouteClassifiesPlain403AsUnavailableDataset(t *testing.T) {
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{status: http.StatusForbidden, body: `{"message":"403 Forbidden"}`},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	_, err := (GitLabFeatureFlagsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 5, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if !errors.Is(err, ErrProviderDatasetUnavailable) ||
+		!errors.As(err, &providerErr) ||
+		providerErr.Class != providerfoundation.ErrorAuthentication ||
+		providerErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("error=%v want unavailable dataset retaining forbidden provider evidence", err)
+	}
+	if len(doer.requests) != 1 {
+		t.Fatalf("plain forbidden requests=%d want=1", len(doer.requests))
+	}
+}
+
+func TestGitLabFeatureFlagsRouteKeepsProjectLookup403AsAuthentication(t *testing.T) {
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{body: `[]`},
+		{status: http.StatusForbidden, body: `{"message":"403 Forbidden"}`},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	claim.SourceExternalID = "group/project"
+	_, err := (GitLabFeatureFlagsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+	var providerErr *providerfoundation.ProviderError
+	if errors.Is(err, ErrProviderDatasetUnavailable) ||
+		!errors.As(err, &providerErr) ||
+		providerErr.Class != providerfoundation.ErrorAuthentication ||
+		providerErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("error=%v want unwrapped project lookup authentication error", err)
+	}
+	if len(doer.requests) != 2 {
+		t.Fatalf("project forbidden requests=%d want=2", len(doer.requests))
+	}
+}
+
+func TestGitLabFeatureFlagsRouteAcceptsEmptyInventory(t *testing.T) {
+	doer := &gitLabFeatureFlagsDoer{t: t, responses: []gitLabFeatureFlagsResponse{
+		{body: `[]`},
+		{body: `{"path_with_namespace":"acme/api"}`},
+	}}
+	claim := nativeTestClaim("gitlab", "feature-flags")
+	claim.SourceExternalID = "group/project"
+	batch, err := (GitLabFeatureFlagsRouteHandler{}).Collect(
+		context.Background(), claim, providerfoundation.Credential{},
+		gitLabFeatureFlagsClient(t, doer, providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		}), time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("empty inventory error=%v", err)
+	}
+	if batch.Result["flags_synced"] != 0 || batch.Result["events_synced"] != 0 ||
+		batch.Watermark == nil || len(doer.requests) != 2 {
+		t.Fatalf("empty inventory batch=%+v requests=%d", batch, len(doer.requests))
+	}
+	for _, effect := range batch.Effects {
+		if len(effect.Rows) != 0 {
+			t.Fatalf("empty inventory effect %q rows=%d", effect.Destination, len(effect.Rows))
+		}
+	}
+}

--- a/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_route.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_route.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "GitLab feature-flags provider-local route (CHAOS-3702)",
   "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
-  "$limitation": "Provider-local mutation coverage only. The focused route suite proves the valid multi-page request sequence, physical request accounting, scope rows, three destinations, cap/no-watermark, non-list fail-closed behavior, qualified 403 classification, invalid configuration guards, project fallback, recovery policies, result identity, and evidence identity. The fresh live proof executes the pinned Python client, normalizers, worker edge block, and real WorkGraphBuilder methods with a capturing sink. Frozen tests do not contain malformed nested scope shapes, project HTTP/decode failures, duplicate scopes with different timestamps, or sub-millisecond timestamp precision cases; those unmeasurable mutations are intentionally excluded rather than overstating coverage. This plan intentionally excludes registry, matrix, scheduler, transport wiring, ClickHouse implementation, and the mutation harness itself.",
+  "$limitation": "Provider-local mutation coverage only. The focused route suite proves the valid multi-page request sequence, physical request accounting, scope rows, three destinations, cap/no-watermark, non-list fail-closed behavior, qualified 403 classification, plain-403 terminal dataset classification, invalid configuration guards, project fallback, recovery policies, result identity, and evidence identity. The fresh live proof executes the pinned Python client, normalizers, worker edge block, and real WorkGraphBuilder methods with a capturing sink. Frozen tests do not contain malformed nested scope shapes, project HTTP/decode failures, duplicate scopes with different timestamps, or sub-millisecond timestamp precision cases; those unmeasurable mutations are intentionally excluded rather than overstating coverage. This plan intentionally excludes registry, matrix, scheduler, transport wiring, ClickHouse implementation, and the mutation harness itself.",
   "mutations": [
     {
       "id": "R1-context-guard",
@@ -115,30 +115,6 @@
       "replace": "func (doer gitLabFeatureFlagsCountingDoer) Do(request *http.Request) (*http.Response, error) {\n\t*doer.attempts = *doer.attempts",
       "rationale": "accepted fetch evidence must count every physical page and project request",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
-    },
-    {
-      "id": "R17-qualified-403-conversion",
-      "file": "internal/providersync/gitlab_feature_flags_route.go",
-      "find": "if response != nil && gitLabFeatureFlagsQualified403(response) {",
-      "replace": "if false {",
-      "rationale": "only GitLab's qualified 403 shape may enter shared retry accounting as a throttle",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403$", "./internal/providersync/"]]
-    },
-    {
-      "id": "R18-rate-limit-header-clause",
-      "file": "internal/providersync/gitlab_feature_flags_route.go",
-      "find": "strings.TrimSpace(gitLabFeatureFlagsHeaderValue(response.Header, \"RateLimit-Remaining\")) == \"0\"",
-      "replace": "false",
-      "rationale": "RateLimit-Remaining: 0 is an explicit GitLab throttle signal",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403$", "./internal/providersync/"]]
-    },
-    {
-      "id": "R19-case-insensitive-rate-header",
-      "file": "internal/providersync/gitlab_feature_flags_route.go",
-      "find": "if strings.EqualFold(key, wanted) && len(values) > 0 {",
-      "replace": "if key == wanted && len(values) > 0 {",
-      "rationale": "HTTP header names are case-insensitive and the Python client accepts GitLab's casing variants",
-      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesCaseInsensitiveQualified403$", "./internal/providersync/"]]
     },
     {
       "id": "R20-feature-flags-endpoint",
@@ -491,6 +467,39 @@
       "replace": "Dataset: \"\",",
       "rationale": "fetch evidence must retain the canonical feature-flags dataset identity",
       "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteMirrorsPythonOrderScopesAndEffects$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R80-plain-403-dataset-fence",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "providerErr.StatusCode == http.StatusForbidden {",
+      "replace": "providerErr.StatusCode == http.StatusOK {",
+      "rationale": "a plain GitLab feature-flags 403 is an unavailable project dataset, while 401 and unrelated status classes must retain their credential or provider meaning",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesPlain403AsUnavailableDataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R81-plain-403-durable-verdict",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "return errors.Join(ErrProviderDatasetUnavailable, err)",
+      "replace": "return err",
+      "rationale": "the endpoint-specific 403 must reach the provider-unit state machine as a durable unavailable-dataset verdict instead of consuming every River attempt as generic exhaustion",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteClassifiesPlain403AsUnavailableDataset$", "./internal/providersync/"]]
+    },
+    {
+      "id": "R82-dataset-unavailable-first-attempt",
+      "file": "internal/jobs/providerunit/providerunit.go",
+      "find": "if errors.Is(err, providersync.ErrProviderDatasetUnavailable) {\n\t\treturn ProviderDatasetUnavailableCategory, true",
+      "replace": "if errors.Is(err, providersync.ErrProviderDatasetUnavailable) {\n\t\treturn \"\", false",
+      "rationale": "a deterministic feature-flags access denial must fail with provider_dataset_unavailable on the first attempt rather than re-entering dispatch and ending as provider_unit_exhausted",
+      "build": ["go", "test", "-run", "^$", "./internal/jobs/providerunit/"],
+      "proof": [["go", "test", "-count=1", "-run", "^TestProviderDatasetUnavailableTerminalizesOnFirstAttempt$", "./internal/jobs/providerunit/"]]
+    },
+    {
+      "id": "R83-project-lookup-scope-fence",
+      "file": "internal/providersync/gitlab_feature_flags_route.go",
+      "find": "projectKey, err := fetchGitLabFeatureFlagProjectName(\n\t\tctx, &counted, projectPath, projectIDOrPath,\n\t)\n\tif err != nil {\n\t\treturn CompleteRouteBatch{}, err\n\t}",
+      "replace": "projectKey, err := fetchGitLabFeatureFlagProjectName(\n\t\tctx, &counted, projectPath, projectIDOrPath,\n\t)\n\tif err != nil {\n\t\treturn CompleteRouteBatch{}, gitLabFeatureFlagsCollectionError(err)\n\t}",
+      "rationale": "only the feature-flags inventory endpoint may translate a plain 403 into unavailable-dataset; the project-name lookup must retain ordinary authentication semantics",
+      "proof": [["go", "test", "-count=1", "-run", "^TestGitLabFeatureFlagsRouteKeepsProjectLookup403AsAuthentication$", "./internal/providersync/"]]
     }
   ]
 }

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -243,7 +243,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     expected_provider_tests = _providersync_top_level_tests()
     expected_integration_tests = _providersync_integration_tagged_tests()
-    assert len(expected_provider_tests) == 899
+    assert len(expected_provider_tests) == 902
     assert len(expected_integration_tests) == 105
     assert expected_integration_tests < expected_provider_tests
 
@@ -260,7 +260,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     provider_flattened = [
         test_name for tests in provider_assignments.values() for test_name in tests
     ]
-    assert len(provider_flattened) == len(set(provider_flattened)) == 899
+    assert len(provider_flattened) == len(set(provider_flattened)) == 902
     assert set(provider_flattened) == expected_provider_tests
     assert {
         name
@@ -321,7 +321,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
         )
 
     expected_tests = _providersync_top_level_tests()
-    assert len(selected_tests) == len(set(selected_tests)) == 899
+    assert len(selected_tests) == len(set(selected_tests)) == 902
     assert set(selected_tests) == expected_tests
 
 


### PR DESCRIPTION
## Summary

- Map a plain GitLab feature-flags inventory 403 to the durable provider-dataset-unavailable result.
- Keep rate-limit-qualified 403 responses retryable through the shared GitLab classifier.
- Keep project-name lookup 403 responses as ordinary authentication errors.
- Accept an empty feature-flags inventory and update the Go shard-count contract.

## TEST-EVIDENCE

- Full local gate passed: 9/9 stages; 13,140 passed, 639 skipped, 1 xfailed.
- Live Python-oracle stage passed for providersync and related oracle packages.
- Mutation plan: 61 effective mutations killed, including the list-403, first-attempt terminalization, and project-lookup scope fences.
- Focused Go regressions and Python GitLab feature-flags client tests passed.

## RISK-NOTES

- Only the feature-flags inventory endpoint translates a plain 403. The separate project lookup preserves its existing authentication semantics.
- A GitLab feature-flags 403 with throttle evidence continues to use the shared retry path.

Refs CHAOS-3806