### PR TITLE
fix(sync): make coverage backfills exact and scoped

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol, cast
 
 from croniter import croniter as Croniter
@@ -2531,6 +2531,20 @@ async def trigger_sync_config_backfill(
 
     selector = payload.resolved_selector()
     structured_selector = payload.selector
+    if structured_selector is None:
+        # BackfillRequest validates the legacy pair. Preserve the explicit
+        # local narrowing so the route cannot accidentally reintroduce a
+        # date-only fallback for structured half-open selectors.
+        legacy_since = payload.since
+        legacy_before = payload.before
+        if legacy_since is None or legacy_before is None:
+            raise HTTPException(status_code=422, detail="Backfill dates are required")
+    else:
+        # These values are used only by the legacy response/history branches
+        # below. Keeping them concrete also makes the branch distinction
+        # explicit to static checking.
+        legacy_since = selector.since.date()
+        legacy_before = (selector.before - timedelta(microseconds=1)).date()
     requested_days = (selector.before - selector.since).days
 
     def _check_backfill_limit(sync_session) -> tuple[bool, str | None]:
@@ -2560,12 +2574,8 @@ async def trigger_sync_config_backfill(
                     triggered_by="backfill",
                     mode="backfill",
                     backfill_selector=SyncBackfillSelector(
-                        since=datetime.combine(
-                            selector.since, datetime.min.time(), tzinfo=timezone.utc
-                        ),
-                        before=datetime.combine(
-                            selector.before, datetime.max.time(), tzinfo=timezone.utc
-                        ),
+                        since=selector.since,
+                        before=selector.before,
                         source_ids=tuple(selector.source_ids)
                         if selector.source_ids is not None
                         else None,
@@ -2576,12 +2586,12 @@ async def trigger_sync_config_backfill(
                     if structured_selector is not None
                     else None,
                     since=datetime.combine(
-                        selector.since, datetime.min.time(), tzinfo=timezone.utc
+                        legacy_since, datetime.min.time(), tzinfo=timezone.utc
                     )
                     if structured_selector is None
                     else None,
                     before=datetime.combine(
-                        selector.before, datetime.max.time(), tzinfo=timezone.utc
+                        legacy_before, datetime.max.time(), tzinfo=timezone.utc
                     )
                     if structured_selector is None
                     else None,
@@ -2618,8 +2628,13 @@ async def trigger_sync_config_backfill(
             org_id=org_id,
             sync_config_id=uuid.UUID(config_id),
             status="pending",
-            since_date=selector.since,
-            before_date=selector.before,
+            # BackfillJob is the legacy, inclusive calendar-date history
+            # anchor. The linked SyncRunUnit rows retain the authoritative
+            # exact structured-selector boundaries used for coverage.
+            since_date=selector.since.date(),
+            before_date=(selector.before - timedelta(microseconds=1)).date()
+            if structured_selector is not None
+            else legacy_before,
             total_chunks=0,
         )
         session.add(backfill_job)
@@ -2637,8 +2652,12 @@ async def trigger_sync_config_backfill(
             "backfill_job_id": backfill_job_id,
             "sync_run_id": trigger.sync_run_id,
             "mode": "fanout",
-            "since": selector.since.isoformat(),
-            "before": selector.before.isoformat(),
+            "since": selector.since.isoformat()
+            if structured_selector is not None
+            else legacy_since.isoformat(),
+            "before": selector.before.isoformat()
+            if structured_selector is not None
+            else legacy_before.isoformat(),
         }
     except HTTPException:
         raise

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, time, timezone
 from typing import Any, Literal
 
 from pydantic import (
@@ -281,10 +281,25 @@ class DiscoveredReposResponse(BaseModel):
 
 
 class BackfillSelectorRequest(BaseModel):
-    since: date
-    before: date
+    """An exact, half-open focused-backfill selector.
+
+    The legacy top-level ``since`` and ``before`` fields remain calendar dates
+    with their established inclusive semantics. A structured selector is the
+    authoritative form used by coverage actions: ``since`` is inclusive and
+    ``before`` is exclusive so an advertised coverage interval can be submitted
+    without expanding it by a day.
+    """
+
+    since: AwareDatetime
+    before: AwareDatetime
     source_ids: list[str] | None = None
     dataset_keys: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _validate_half_open_interval(self) -> BackfillSelectorRequest:
+        if self.since >= self.before:
+            raise ValueError("backfill selector before must be after since")
+        return self
 
 
 class BackfillRequest(BaseModel):
@@ -311,7 +326,13 @@ class BackfillRequest(BaseModel):
             return self.selector
         assert self.since is not None
         assert self.before is not None
-        return BackfillSelectorRequest(since=self.since, before=self.before)
+        # Legacy flat dates retain their inclusive calendar-date semantics.
+        # Construct the equivalent UTC datetimes without routing them through
+        # the exact half-open structured-selector validator.
+        return BackfillSelectorRequest.model_construct(
+            since=datetime.combine(self.since, time.min, tzinfo=timezone.utc),
+            before=datetime.combine(self.before, time.max, tzinfo=timezone.utc),
+        )
 
 
 JOB_RUN_STATUS_LABELS: dict[int, str] = {
@@ -392,8 +413,17 @@ class SyncCoverageSource(BaseModel):
 
 
 class SyncCoverageBackfillWindow(BaseModel):
-    since: date
-    before: date
+    """A server-authorized exact selector for a coverage gap or failure.
+
+    These are deliberately source and dataset scoped. Callers must not merge
+    adjacent windows, because the adjacent range can belong to another source
+    or dataset.
+    """
+
+    since: datetime
+    before: datetime
+    source_ids: list[str] = Field(default_factory=list)
+    dataset_keys: list[str] = Field(default_factory=list)
     reasons: list[Literal["gap", "failed"]] = Field(default_factory=list)
 
 

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -9,7 +9,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
 from time import monotonic
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from croniter import croniter as Croniter
 from fastapi.encoders import jsonable_encoder
@@ -366,6 +366,34 @@ def merge_intervals(
             continue
         merged.append(interval)
     return merged
+
+
+def merge_intervals_by_source_scope(
+    intervals: Iterable[CoverageInterval],
+    *,
+    tolerance: timedelta = INTERVAL_ADJACENCY_TOLERANCE,
+) -> list[CoverageInterval]:
+    """Merge intervals only when their source scopes match exactly.
+
+    Dataset coverage is displayed as a union across sources. That remains
+    useful for reporting, but a row-level backfill action must keep the source
+    scope that produced the gap. Otherwise adjacent gaps from two sources turn
+    into one broad actionable range.
+    """
+
+    by_source_scope: dict[tuple[str, ...], list[CoverageInterval]] = defaultdict(list)
+    for interval in intervals:
+        source_scope = tuple(sorted(set(interval.source_ids)))
+        by_source_scope[source_scope].append(interval)
+
+    return sorted(
+        (
+            merged
+            for scoped_intervals in by_source_scope.values()
+            for merged in merge_intervals(scoped_intervals, tolerance=tolerance)
+        ),
+        key=lambda interval: (interval.since, interval.before, interval.source_ids),
+    )
 
 
 def subtract_intervals(
@@ -1514,44 +1542,62 @@ def _data_basis_for_config(config: SyncConfiguration, scope: EffectiveScope) -> 
 
 
 def _canonical_backfill_windows(
-    datasets: Sequence[_DatasetCoverage],
+    pair_coverages: Sequence[_PairCoverage],
 ) -> list[dict[str, Any]]:
-    """Return inclusive date windows the existing backfill action can submit.
+    """Return exact, source/dataset-scoped actionable coverage windows.
 
-    Coverage intervals are half-open datetimes while the backfill endpoint is
-    inclusive by calendar date. An exclusive midnight boundary therefore maps
-    to the preceding date; any later time maps to its own calendar date.
+    The focused-backfill form only accepts day boundaries. We therefore emit a
+    suggestion only when the half-open coverage range has exact UTC-midnight
+    boundaries. This keeps the server authoritative: an explicit empty list
+    means a displayed row is not safely representable by that selector.
     """
 
-    candidates: list[dict[str, Any]] = []
-    for dataset in datasets:
-        for interval, reason in (
-            *((interval, "gap") for interval in dataset.gaps),
-            *((interval, "failed") for interval in dataset.failed_ranges),
-        ):
-            inclusive_before = (
-                interval.before - timedelta(microseconds=1)
-                if interval.before.time() == time.min
-                else interval.before
+    candidates_by_scope: dict[
+        tuple[datetime, datetime, str, str], set[Literal["gap", "failed"]]
+    ] = defaultdict(set)
+    for pair in pair_coverages:
+        for interval in pair.gaps:
+            since = ensure_utc(interval.since)
+            before = ensure_utc(interval.before)
+            if since.time() != time.min or before.time() != time.min:
+                continue
+            candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(
+                "gap"
             )
-            candidates.append(
-                {
-                    "since": interval.since.date(),
-                    "before": inclusive_before.date(),
-                    "reasons": [reason],
-                }
+        for interval in pair.failed_ranges:
+            since = ensure_utc(interval.since)
+            before = ensure_utc(interval.before)
+            if since.time() != time.min or before.time() != time.min:
+                continue
+            candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(
+                "failed"
             )
-    candidates.sort(key=lambda item: (item["since"], item["before"]))
-    merged: list[dict[str, Any]] = []
-    for candidate in candidates:
-        if merged and candidate["since"] <= merged[-1]["before"] + timedelta(days=1):
-            merged[-1]["before"] = max(merged[-1]["before"], candidate["before"])
-            merged[-1]["reasons"] = sorted(
-                set(merged[-1]["reasons"]).union(candidate["reasons"])
-            )
-            continue
-        merged.append(candidate)
-    return merged
+
+    candidates = [
+        {
+            "since": since,
+            "before": before,
+            "source_ids": [source_id],
+            "dataset_keys": [dataset_key],
+            "reasons": sorted(reasons),
+        }
+        for (
+            since,
+            before,
+            source_id,
+            dataset_key,
+        ), reasons in candidates_by_scope.items()
+    ]
+    return sorted(
+        candidates,
+        key=lambda item: (
+            item["since"],
+            item["before"],
+            item["dataset_keys"],
+            item["source_ids"],
+            item["reasons"],
+        ),
+    )
 
 
 def _sync_coverage_lock_name(org_id: str, sync_config_id: uuid.UUID) -> str:
@@ -1842,7 +1888,9 @@ def build_coverage_summary_payload(
         covered = merge_intervals(
             interval for pair in pairs for interval in pair.covered
         )
-        gaps = merge_intervals(interval for pair in pairs for interval in pair.gaps)
+        gaps = merge_intervals_by_source_scope(
+            interval for pair in pairs for interval in pair.gaps
+        )
         failed_ranges = merge_intervals(
             interval for pair in pairs for interval in pair.failed_ranges
         )
@@ -1992,7 +2040,7 @@ def build_coverage_summary_payload(
             for dataset_key in sorted(not_enabled_dataset_keys)
         ],
         "sources": source_payloads,
-        "backfill_windows": _canonical_backfill_windows(datasets),
+        "backfill_windows": _canonical_backfill_windows(pair_coverages),
     }
 
 

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -1304,8 +1304,8 @@ def _backfill_windows(
 
     since = _as_utc(request.since)
     before = _as_utc(request.before)
-    if since > before:
-        raise ValueError("Backfill since must be before or equal to before")
+    if since >= before:
+        raise ValueError("Backfill since must be before")
 
     if _is_linear_work_item_family(provider, dataset_key):
         chunk_days = _linear_backfill_max_window_days()

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -329,8 +329,8 @@ async def test_sync_config_backfill_accepts_nested_selector_and_resolves_integra
             f"/api/v1/admin/sync-configs/{config_id}/backfill",
             json={
                 "selector": {
-                    "since": "2026-01-01",
-                    "before": "2026-01-08",
+                    "since": "2026-01-01T00:00:00Z",
+                    "before": "2026-01-08T00:00:00Z",
                     "source_ids": [source_id],
                     "dataset_keys": ["commits"],
                 }
@@ -341,6 +341,8 @@ async def test_sync_config_backfill_accepts_nested_selector_and_resolves_integra
     assert captured["integration_id"] == integration_id
     selector = captured["backfill_selector"]
     assert selector is not None
+    assert getattr(selector, "since") == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert getattr(selector, "before") == datetime(2026, 1, 8, tzinfo=timezone.utc)
     assert getattr(selector, "source_ids") == (source_id,)
     assert getattr(selector, "dataset_keys") == ("commits",)
 

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 import uuid
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -792,33 +792,66 @@ async def test_sync_config_update_invalidates_coverage_projection(
     assert coverage.json()["projection_refreshing"] is True
 
 
-def test_canonical_backfill_windows_merge_after_inclusive_date_conversion():
-    dataset = sync_coverage_module._DatasetCoverage(
-        dataset_key="commits",
-        gaps=[
-            sync_coverage_module.CoverageInterval(
-                since=datetime(2026, 1, 2, 10, tzinfo=timezone.utc),
-                before=datetime(2026, 1, 2, 11, tzinfo=timezone.utc),
-            )
-        ],
-        failed_ranges=[
-            sync_coverage_module.CoverageInterval(
-                since=datetime(2026, 1, 2, 13, tzinfo=timezone.utc),
-                before=datetime(2026, 1, 2, 14, tzinfo=timezone.utc),
-            ),
-            sync_coverage_module.CoverageInterval(
-                since=datetime(2026, 1, 3, tzinfo=timezone.utc),
-                before=datetime(2026, 1, 4, tzinfo=timezone.utc),
-            ),
-        ],
-    )
+def test_canonical_backfill_windows_preserve_pair_scope_and_half_open_bounds():
+    """Coverage actions must not join adjacent gaps from different sources.
 
-    assert sync_coverage_module._canonical_backfill_windows([dataset]) == [
+    The focused-backfill dialog sends source and dataset scope back to the
+    planner. Joining these pair windows would quietly schedule a source over a
+    time period that coverage never marked as missing.
+    """
+    source_one = "11111111-1111-1111-1111-111111111111"
+    source_two = "22222222-2222-2222-2222-222222222222"
+    pair_coverages = [
+        sync_coverage_module._PairCoverage(
+            source_id=source_one,
+            dataset_key="commits",
+            gaps=[
+                sync_coverage_module.CoverageInterval(
+                    since=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                    before=datetime(2026, 1, 3, tzinfo=timezone.utc),
+                    source_ids=(source_one,),
+                )
+            ],
+        ),
+        sync_coverage_module._PairCoverage(
+            source_id=source_two,
+            dataset_key="commits",
+            failed_ranges=[
+                sync_coverage_module.CoverageInterval(
+                    since=datetime(2026, 1, 3, tzinfo=timezone.utc),
+                    before=datetime(2026, 1, 4, tzinfo=timezone.utc),
+                    source_ids=(source_two,),
+                )
+            ],
+        ),
+        sync_coverage_module._PairCoverage(
+            source_id=source_one,
+            dataset_key="deployments",
+            gaps=[
+                sync_coverage_module.CoverageInterval(
+                    since=datetime(2026, 1, 2, 10, tzinfo=timezone.utc),
+                    before=datetime(2026, 1, 2, 11, tzinfo=timezone.utc),
+                    source_ids=(source_one,),
+                )
+            ],
+        ),
+    ]
+
+    assert sync_coverage_module._canonical_backfill_windows(pair_coverages) == [
         {
-            "since": date(2026, 1, 2),
-            "before": date(2026, 1, 3),
-            "reasons": ["failed", "gap"],
-        }
+            "since": datetime(2026, 1, 2, tzinfo=timezone.utc),
+            "before": datetime(2026, 1, 3, tzinfo=timezone.utc),
+            "source_ids": [source_one],
+            "dataset_keys": ["commits"],
+            "reasons": ["gap"],
+        },
+        {
+            "since": datetime(2026, 1, 3, tzinfo=timezone.utc),
+            "before": datetime(2026, 1, 4, tzinfo=timezone.utc),
+            "source_ids": [source_two],
+            "dataset_keys": ["commits"],
+            "reasons": ["failed"],
+        },
     ]
 
 
@@ -933,7 +966,13 @@ async def test_sync_coverage_api_planned_units_create_requested_gap(
     assert data["coverage_since"] is None
     assert data["coverage_through"] is None
     assert data["backfill_windows"] == [
-        {"since": "2026-01-01", "before": "2026-01-01", "reasons": ["gap"]}
+        {
+            "since": "2026-01-01T00:00:00Z",
+            "before": "2026-01-02T00:00:00Z",
+            "source_ids": [scope["source_id"]],
+            "dataset_keys": ["commits"],
+            "reasons": ["gap"],
+        }
     ]
     assert data["overall"]["health"] == "gaps"
 


### PR DESCRIPTION
## Summary

- Emit only exact UTC-midnight, source-and-dataset-scoped coverage backfill suggestions.
- Preserve structured selectors as half-open bounds while retaining legacy inclusive date behavior.
- Keep pair gaps separate so a focused action cannot broaden a disjoint gap.

## Validation

- Targeted Ruff, mypy, and 5 API/planner tests passed.
- `ci/local_validate.sh`: mutation, lint, full mypy, ClickHouse migration checks, and 13,143 tests passed.
- The final gate has one unrelated Compose expectation failure: concurrent PgBouncer work changed the expected `pgbouncer` condition from `service_started` to `service_healthy`.

Refs CHAOS-3819