### PR TITLE
CHAOS-3807: add durable sharded mutation harness runs

### DIFF
--- a/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_route.json
+++ b/internal/providersync/testdata/mutation-plans/gitlab_feature_flags_route.json
@@ -2,6 +2,15 @@
   "schema_version": 1,
   "name": "GitLab feature-flags provider-local route (CHAOS-3702)",
   "build": ["go", "test", "-run", "^$", "./internal/providersync/"],
+  "sharding": {
+    "max_shards": 2,
+    "workspace_inputs": [".venv"],
+    "external_resources": "none",
+    "shared_mutable_resource_exclusions": [
+      "go-build-cache",
+      "go-module-cache"
+    ]
+  },
   "$limitation": "Provider-local mutation coverage only. The focused route suite proves the valid multi-page request sequence, physical request accounting, scope rows, three destinations, cap/no-watermark, non-list fail-closed behavior, qualified 403 classification, plain-403 terminal dataset classification, invalid configuration guards, project fallback, recovery policies, result identity, and evidence identity. The fresh live proof executes the pinned Python client, normalizers, worker edge block, and real WorkGraphBuilder methods with a capturing sink. Frozen tests do not contain malformed nested scope shapes, project HTTP/decode failures, duplicate scopes with different timestamps, or sub-millisecond timestamp precision cases; those unmeasurable mutations are intentionally excluded rather than overstating coverage. This plan intentionally excludes registry, matrix, scheduler, transport wiring, ClickHouse implementation, and the mutation harness itself.",
   "mutations": [
     {

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -1033,12 +1033,18 @@ def coordinator_run(
     def source_manifest_reader() -> str:
         return execution_tree.build_source_manifest(root).digest
 
-    def child_factory(assignment: Any, run_id: str) -> Any:
+    def temporary_root_factory(run_id: str) -> Path:
         nonlocal temporary_root
+        if temporary_root is not None:
+            raise HarnessError("coordinator requested more than one temporary root")
+        temporary_root = execution_tree.create_private_temp_root(
+            prefix=f"mutation-harness-{run_id}-"
+        )
+        return temporary_root
+
+    def child_factory(assignment: Any, run_id: str) -> Any:
         if temporary_root is None:
-            temporary_root = execution_tree.create_private_temp_root(
-                prefix=f"mutation-harness-{run_id}-"
-            )
+            raise HarnessError("coordinator did not create the recorded temporary root")
         staged = stage_execution_tree(
             root,
             temporary_root / f"shard-{assignment.shard_index}",
@@ -1124,6 +1130,7 @@ def coordinator_run(
         source_manifest_digest=source_manifest.digest,
         plan_digest=plan_digest,
         source_manifest_reader=source_manifest_reader,
+        temporary_root_factory=temporary_root_factory,
         child_factory=child_factory,
     )
     return list(outcome.results), outcome.exit_code

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -1067,6 +1067,7 @@ def coordinator_run(
         environment = external_resource_environment(
             sharding, run_id, assignment.shard_index
         )
+        environment["PYTHONDONTWRITEBYTECODE"] = "1"
         environment["MUTATION_HARNESS_PLAN_ORDINALS"] = json.dumps(
             plan_ordinals, sort_keys=True, separators=(",", ":")
         )

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -146,6 +146,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO
 
 if TYPE_CHECKING:
+    from scripts.mutation_harness_coordinator import TemporaryRootClaim
     from scripts.mutation_harness_execution_tree import (
         StagedExecutionTree as ExecutionStagedTree,
     )
@@ -1033,14 +1034,14 @@ def coordinator_run(
     def source_manifest_reader() -> str:
         return execution_tree.build_source_manifest(root).digest
 
-    def temporary_root_factory(run_id: str) -> Path:
+    def temporary_root_factory(run_id: str) -> TemporaryRootClaim:
         nonlocal temporary_root
         if temporary_root is not None:
             raise HarnessError("coordinator requested more than one temporary root")
         temporary_root = execution_tree.create_private_temp_root(
             prefix=f"mutation-harness-{run_id}-"
         )
-        return temporary_root
+        return coordinator.TemporaryRootClaim.created(temporary_root)
 
     def child_factory(assignment: Any, run_id: str) -> Any:
         if temporary_root is None:

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -143,7 +143,18 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
+
+if TYPE_CHECKING:
+    from scripts.mutation_harness_execution_tree import (
+        StagedExecutionTree as ExecutionStagedTree,
+    )
+
+# Keep ``python scripts/mutation_harness.py`` compatible with package imports.
+# Direct script execution otherwise puts only ``scripts/`` on ``sys.path``.
+_REPOSITORY_IMPORT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPOSITORY_IMPORT_ROOT not in sys.path:
+    sys.path.insert(0, _REPOSITORY_IMPORT_ROOT)
 
 STATE_DIRNAME = ".mutation-harness"
 STATE_FILENAME = "state.json"
@@ -233,6 +244,43 @@ class StagedExecutionTree:
     root: Path
     ownership_marker: Path
     shard_index: int
+
+
+@dataclass(frozen=True)
+class _ChildProtocol:
+    """Coordinator-owned metadata for one internal shard child."""
+
+    run_id: str
+    shard_index: int
+    plan_digest: str
+    result_stream: Path
+    plan_ordinals: dict[str, int]
+    stream: TextIO
+
+    def emit(
+        self,
+        event: str,
+        mutation: Mutation,
+        *,
+        phase: str | None = None,
+        verdict: str | None = None,
+        started_ns: int,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "event": event,
+            "shard_index": self.shard_index,
+            "plan_ordinal": self.plan_ordinals[mutation.identifier],
+            "mutation_id": mutation.identifier,
+            "elapsed_ms": (time.monotonic_ns() - started_ns) // 1_000_000,
+        }
+        if phase is not None:
+            payload["phase"] = phase
+        if verdict is not None:
+            payload["verdict"] = verdict
+        self.stream.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        self.stream.flush()
 
 
 class _ProgressEmitter:
@@ -455,6 +503,83 @@ def _write_result_record(
     _append_jsonl(
         result_stream,
         json.dumps(durable_result, separators=(",", ":")).encode("utf-8") + b"\n",
+    )
+
+
+def _write_child_result_record(
+    protocol: _ChildProtocol, mutation: Mutation, result: Result
+) -> None:
+    """Write the coordinator child schema before the terminal child event."""
+
+    try:
+        from scripts.mutation_harness_coordinator import append_durable_jsonl
+    except ImportError as exc:
+        raise HarnessError("coordinator result-stream backend is unavailable") from exc
+    append_durable_jsonl(
+        protocol.result_stream,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": protocol.run_id,
+            "shard_index": protocol.shard_index,
+            "plan_digest": protocol.plan_digest,
+            "plan_ordinal": protocol.plan_ordinals[mutation.identifier],
+            "mutation_id": mutation.identifier,
+            "result": _result_fields(result),
+        },
+    )
+
+
+def _child_protocol_from_environment(root: Path) -> _ChildProtocol:
+    """Load the hidden coordinator-child contract and reject direct invocation."""
+
+    required = {
+        "run_id": os.environ.get("MUTATION_HARNESS_RUN_ID"),
+        "shard_index": os.environ.get("MUTATION_HARNESS_SHARD_INDEX"),
+        "plan_digest": os.environ.get("MUTATION_HARNESS_PLAN_DIGEST"),
+        "result_stream": os.environ.get("MUTATION_HARNESS_RESULT_STREAM"),
+        "plan_ordinals": os.environ.get("MUTATION_HARNESS_PLAN_ORDINALS"),
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        raise HarnessError(
+            "--internal-child requires coordinator-owned environment fields: "
+            + ", ".join(sorted(missing))
+        )
+    assert all(value is not None for value in required.values())
+    try:
+        shard_index = int(str(required["shard_index"]))
+    except ValueError as exc:
+        raise HarnessError("internal child shard index must be an integer") from exc
+    if shard_index < 0:
+        raise HarnessError("internal child shard index must be non-negative")
+    try:
+        loaded_ordinals = json.loads(str(required["plan_ordinals"]))
+    except json.JSONDecodeError as exc:
+        raise HarnessError("internal child plan ordinals are invalid JSON") from exc
+    if not isinstance(loaded_ordinals, dict) or not all(
+        isinstance(identifier, str)
+        and isinstance(ordinal, int)
+        and not isinstance(ordinal, bool)
+        and ordinal >= 0
+        for identifier, ordinal in loaded_ordinals.items()
+    ):
+        raise HarnessError(
+            "internal child plan ordinals must map mutation ids to non-negative integers"
+        )
+    result_stream = Path(str(required["result_stream"]))
+    if not result_stream.is_absolute():
+        raise HarnessError("internal child result stream must be an absolute path")
+    resolved_root = root.resolve()
+    resolved_stream = result_stream.resolve()
+    if not resolved_stream.is_relative_to(resolved_root / STATE_DIRNAME):
+        raise HarnessError("internal child result stream escapes shard state")
+    return _ChildProtocol(
+        run_id=str(required["run_id"]),
+        shard_index=shard_index,
+        plan_digest=str(required["plan_digest"]),
+        result_stream=resolved_stream,
+        plan_ordinals=dict(loaded_ordinals),
+        stream=sys.stdout,
     )
 
 
@@ -681,11 +806,23 @@ def _self_referential_warning(root: Path, mutation: Mutation) -> str | None:
 
 def _load_plan(path: Path) -> tuple[str, list[Mutation]]:
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise HarnessError(f"could not read plan {path}: {exc}") from exc
-    if not isinstance(raw, dict):
-        raise HarnessError(f"{path} must be a JSON object")
+        from scripts.mutation_harness_optin import (
+            PlanContractError,
+            load_plan_contract,
+        )
+
+        raw, _sharding = load_plan_contract(path)
+    except ImportError as exc:
+        raise HarnessError("sharding plan validation backend is unavailable") from exc
+    except PlanContractError as exc:
+        raise HarnessError(str(exc)) from exc
+
+    return _parse_plan(path, raw)
+
+
+def _parse_plan(path: Path, raw: dict[str, Any]) -> tuple[str, list[Mutation]]:
+    """Parse mutations after the closed plan vocabulary has been validated."""
+
     if raw.get("schema_version") != SCHEMA_VERSION:
         raise HarnessError(
             f"{path} has schema_version {raw.get('schema_version')!r}, "
@@ -792,7 +929,25 @@ def _load_plan(path: Path) -> tuple[str, list[Mutation]]:
 def _load_sharding_plan(path: Path, raw: dict[str, Any]) -> ShardingPlan | None:
     """Load and validate the optional sharding plan contract."""
 
-    raise NotImplementedError
+    del raw  # The authoritative loader reads and validates the complete file.
+    try:
+        from scripts.mutation_harness_optin import (
+            PlanContractError,
+            load_plan_contract,
+        )
+
+        _loaded, contract = load_plan_contract(path)
+    except ImportError as exc:
+        raise HarnessError("sharding plan validation backend is unavailable") from exc
+    except PlanContractError as exc:
+        raise HarnessError(str(exc)) from exc
+    if contract is None:
+        return None
+    return ShardingPlan(
+        max_shards=contract.max_shards,
+        workspace_inputs=contract.workspace_inputs,
+        external_resources=contract.external_resources,
+    )
 
 
 def stage_execution_tree(
@@ -804,10 +959,28 @@ def stage_execution_tree(
     source_manifest_digest: str,
     plan_digest: str,
     workspace_inputs: tuple[str, ...],
-) -> StagedExecutionTree:
+    source_manifest: Any | None = None,
+) -> ExecutionStagedTree:
     """Create one isolated, owned execution tree for a mutation shard."""
 
-    raise NotImplementedError
+    try:
+        from scripts import mutation_harness_execution_tree as execution_tree
+    except ImportError as exc:
+        raise HarnessError("execution-tree backend is unavailable") from exc
+    frozen = source_manifest or execution_tree.build_source_manifest(source_root)
+    if frozen.digest != source_manifest_digest:
+        raise HarnessError(
+            "source manifest digest does not match the frozen execution-tree manifest"
+        )
+    return execution_tree.stage_execution_tree(
+        source_root,
+        destination,
+        run_id=run_id,
+        shard_index=shard_index,
+        source_manifest=frozen,
+        plan_digest=plan_digest,
+        workspace_inputs=workspace_inputs,
+    )
 
 
 def coordinator_run(
@@ -821,13 +994,153 @@ def coordinator_run(
 ) -> tuple[list[Result], int]:
     """Coordinate an opted-in sharded mutation run."""
 
-    raise NotImplementedError
+    try:
+        from scripts import mutation_harness_coordinator as coordinator
+        from scripts import mutation_harness_execution_tree as execution_tree
+        from scripts.mutation_harness_optin import (
+            PlanContractError,
+            external_resource_environment,
+            load_plan_contract,
+            validate_requested_shards,
+        )
+    except ImportError as exc:
+        raise HarnessError("sharded execution backend is unavailable") from exc
+
+    root = root.resolve()
+    plan_path = plan_path.resolve()
+    try:
+        raw, sharding = load_plan_contract(plan_path)
+        validate_requested_shards(sharding, requested_shards)
+    except PlanContractError as exc:
+        raise HarnessError(str(exc)) from exc
+    if sharding is None:
+        raise HarnessError("the plan does not opt in to sharding")
+    try:
+        relative_plan = plan_path.relative_to(root)
+    except ValueError as exc:
+        raise HarnessError(
+            "sharded plan must be inside the repository so every frozen execution "
+            "tree runs the same plan bytes"
+        ) from exc
+
+    plan_name, mutations = _parse_plan(plan_path, raw)
+    source_manifest = execution_tree.build_source_manifest(root)
+    source_manifest_mapping = execution_tree.source_manifest_to_dict(source_manifest)
+    plan_digest = _digest(plan_path.read_bytes())
+    temporary_root: Path | None = None
+    owned_roots: set[Path] = set()
+
+    def source_manifest_reader() -> str:
+        return execution_tree.build_source_manifest(root).digest
+
+    def child_factory(assignment: Any, run_id: str) -> Any:
+        nonlocal temporary_root
+        if temporary_root is None:
+            temporary_root = execution_tree.create_private_temp_root(
+                prefix=f"mutation-harness-{run_id}-"
+            )
+        staged = stage_execution_tree(
+            root,
+            temporary_root / f"shard-{assignment.shard_index}",
+            run_id=run_id,
+            shard_index=assignment.shard_index,
+            source_manifest_digest=source_manifest.digest,
+            plan_digest=plan_digest,
+            workspace_inputs=sharding.workspace_inputs,
+            source_manifest=source_manifest,
+        )
+        owned_roots.add(staged.root.resolve())
+        staged_plan = staged.root / relative_plan
+        if _digest(staged_plan.read_bytes()) != plan_digest:
+            raise HarnessError("staged plan bytes do not match the frozen plan digest")
+        selected_ids = [item.identifier for item in assignment.mutations]
+        plan_ordinals = {
+            item.identifier: item.selected_ordinal for item in assignment.mutations
+        }
+        environment = external_resource_environment(
+            sharding, run_id, assignment.shard_index
+        )
+        environment["MUTATION_HARNESS_PLAN_ORDINALS"] = json.dumps(
+            plan_ordinals, sort_keys=True, separators=(",", ":")
+        )
+        result_stream = (
+            staged.root / STATE_DIRNAME / RUNS_DIRNAME / run_id / RESULT_STREAM_FILENAME
+        )
+
+        def cleanup() -> None:
+            assert temporary_root is not None
+            execution_tree.cleanup_execution_tree(
+                staged,
+                temporary_root=temporary_root,
+                child_liveness_proven=True,
+            )
+            owned_roots.remove(staged.root.resolve())
+            if not owned_roots:
+                temporary_root.rmdir()
+
+        argv = [
+            sys.executable,
+            "-m",
+            "scripts.mutation_harness",
+            "--root",
+            ".",
+            "run",
+            "--plan",
+            str(relative_plan),
+            "--only",
+            ",".join(selected_ids),
+            "--shards",
+            "1",
+            "--progress",
+            "none",
+            "--internal-child",
+        ]
+        if assert_all_killed:
+            argv.append("--assert-all-killed")
+        return coordinator.ChildSpec(
+            assignment=assignment,
+            root=staged.root,
+            source_root=root,
+            temporary_root=temporary_root,
+            argv=tuple(argv),
+            result_stream=result_stream,
+            ownership_marker=staged.ownership_marker,
+            liveness_lock=staged.root / STATE_DIRNAME / "child.liveness",
+            environment=environment,
+            cleanup=cleanup,
+        )
+
+    outcome = coordinator.coordinator_run(
+        root,
+        plan_path,
+        plan_name,
+        [mutation.identifier for mutation in mutations],
+        only,
+        assert_all_killed,
+        requested_shards=requested_shards,
+        progress=progress,
+        source_head=source_manifest.head,
+        source_manifest=source_manifest_mapping,
+        source_manifest_digest=source_manifest.digest,
+        plan_digest=plan_digest,
+        source_manifest_reader=source_manifest_reader,
+        child_factory=child_factory,
+    )
+    return list(outcome.results), outcome.exit_code
 
 
 def recover_run(root: Path, run_id: str, *, force: bool = False) -> str:
     """Recover or retain the recorded execution trees for an aborted run."""
 
-    raise NotImplementedError
+    try:
+        from scripts.mutation_harness_recovery import RecoveryError
+        from scripts.mutation_harness_recovery import recover_run as recover_backend
+    except ImportError as exc:
+        raise HarnessError("recovery backend is unavailable") from exc
+    try:
+        return recover_backend(root, run_id, force=force)
+    except RecoveryError as exc:
+        raise HarnessError(str(exc)) from exc
 
 
 def acquire_lock(root: Path) -> Path:
@@ -1628,6 +1941,7 @@ def run_plan(
     progress: str = "none",
     run_id: str | None = None,
     shard_index: int | None = None,
+    child_protocol: _ChildProtocol | None = None,
 ) -> tuple[list[Result], int]:
     blockers = verify(root)
     if blockers:
@@ -1639,6 +1953,15 @@ def run_plan(
         if unknown:
             raise HarnessError(f"--only names unknown mutations: {sorted(unknown)}")
         mutations = [mutation for mutation in mutations if mutation.identifier in only]
+
+    if child_protocol is not None:
+        selected_ids = {mutation.identifier for mutation in mutations}
+        if set(child_protocol.plan_ordinals) != selected_ids:
+            raise HarnessError(
+                "internal child ordinal bindings do not exactly match selected mutations"
+            )
+        if run_id != child_protocol.run_id or shard_index != child_protocol.shard_index:
+            raise HarnessError("internal child run identity is inconsistent")
 
     snapshot_dir = _snapshot_dir(root)
     snapshot_dir.mkdir(parents=True, exist_ok=True)
@@ -1669,29 +1992,54 @@ def run_plan(
             )
         try:
             for ordinal, mutation in enumerate(mutations):
+                event_ordinal = (
+                    child_protocol.plan_ordinals[mutation.identifier]
+                    if child_protocol is not None
+                    else ordinal
+                )
+                child_started_ns = time.monotonic_ns()
                 emitter.emit(
                     "mutation_started",
                     completed=len(results),
                     active=1,
                     total=total,
                     shard_index=shard_index,
-                    plan_ordinal=ordinal,
+                    plan_ordinal=event_ordinal,
                     mutation_id=mutation.identifier,
                     phase="baseline",
                 )
+                if child_protocol is not None:
+                    child_protocol.emit(
+                        "mutation_started",
+                        mutation,
+                        phase="baseline",
+                        started_ns=child_started_ns,
+                    )
                 result = _run_one(root, mutation, snapshot_dir)
                 results.append(result)
-                _write_result_record(result_stream, selected_run_id, ordinal, result)
+                if child_protocol is None:
+                    _write_result_record(
+                        result_stream, selected_run_id, ordinal, result
+                    )
+                else:
+                    _write_child_result_record(child_protocol, mutation, result)
                 emitter.emit(
                     "mutation_finished",
                     completed=len(results),
                     active=0,
                     total=total,
                     shard_index=shard_index,
-                    plan_ordinal=ordinal,
+                    plan_ordinal=event_ordinal,
                     mutation_id=mutation.identifier,
                     verdict=result.verdict,
                 )
+                if child_protocol is not None:
+                    child_protocol.emit(
+                        "mutation_finished",
+                        mutation,
+                        verdict=result.verdict,
+                        started_ns=child_started_ns,
+                    )
         except BaseException:
             emitter.emit(
                 "run_stopping",
@@ -2157,6 +2505,15 @@ def main(argv: list[str] | None = None) -> int:
         "the content you inspected",
     )
     sub.add_parser("report", help="print the last run's report")
+    recover_parser = sub.add_parser(
+        "recover-run", help="recover an incomplete sharded coordinator run"
+    )
+    recover_parser.add_argument("--run-id", required=True)
+    recover_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="continue safe cleanup of other owned shards after a recovery refusal",
+    )
     run_parser = sub.add_parser("run", help="execute a mutation plan")
     run_parser.add_argument("--plan", required=True)
     run_parser.add_argument("--only", default="")
@@ -2170,6 +2527,17 @@ def main(argv: list[str] | None = None) -> int:
         choices=("human", "jsonl", "none"),
         default="human",
         help="stream progress to stderr (durable JSONL is always recorded)",
+    )
+    run_parser.add_argument(
+        "--shards",
+        type=int,
+        default=1,
+        help="number of isolated shards (requires plan opt-in above 1)",
+    )
+    run_parser.add_argument(
+        "--internal-child",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
 
     args = parser.parse_args(argv)
@@ -2197,15 +2565,60 @@ def main(argv: list[str] | None = None) -> int:
                 return 1
             print(path.read_text(encoding="utf-8"), end="")
             return 0
+        if args.command == "recover-run":
+            print(recover_run(root, str(args.run_id), force=bool(args.force)))
+            return 0
 
         only = {item.strip() for item in args.only.split(",") if item.strip()}
-        results, exit_code = run_plan(
-            root,
-            Path(args.plan),
-            only or None,
-            args.assert_all_killed,
-            progress=str(args.progress),
-        )
+        plan_path = Path(args.plan)
+        try:
+            from scripts.mutation_harness_optin import (
+                PlanContractError,
+                load_plan_contract,
+                validate_requested_shards,
+            )
+
+            _raw, sharding = load_plan_contract(plan_path)
+            validate_requested_shards(sharding, int(args.shards))
+        except ImportError as exc:
+            raise HarnessError(
+                "sharding plan validation backend is unavailable"
+            ) from exc
+        except PlanContractError as exc:
+            raise HarnessError(str(exc)) from exc
+
+        if args.internal_child:
+            if int(args.shards) != 1:
+                raise HarnessError("internal children must execute exactly one shard")
+            child_protocol = _child_protocol_from_environment(root)
+            results, exit_code = run_plan(
+                root,
+                plan_path,
+                only or None,
+                args.assert_all_killed,
+                progress="none",
+                run_id=child_protocol.run_id,
+                shard_index=child_protocol.shard_index,
+                child_protocol=child_protocol,
+            )
+            return exit_code
+        if int(args.shards) == 1:
+            results, exit_code = run_plan(
+                root,
+                plan_path,
+                only or None,
+                args.assert_all_killed,
+                progress=str(args.progress),
+            )
+        else:
+            results, exit_code = coordinator_run(
+                root,
+                plan_path,
+                only or None,
+                args.assert_all_killed,
+                requested_shards=int(args.shards),
+                progress=str(args.progress),
+            )
         print(_render(results))
         for result in results:
             if result.verdict in {

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -72,6 +72,7 @@ Usage:
     python3 scripts/mutation_harness.py accept --digest SHA256 [--root PATH]
     python3 scripts/mutation_harness.py run --plan PATH [--only M1,M2]
                                             [--assert-all-killed]
+                                            [--progress human|jsonl|none]
     python3 scripts/mutation_harness.py report [--root PATH]
 
 ``accept`` is the exit from a safe refusal. Several of ``restore``'s refusals
@@ -138,15 +139,20 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 STATE_DIRNAME = ".mutation-harness"
 STATE_FILENAME = "state.json"
 REPORT_FILENAME = "report.json"
 SNAPSHOT_DIRNAME = "snapshots"
 LOCK_DIRNAME = "lock"
+RUNS_DIRNAME = "runs"
+EVENT_LOG_FILENAME = "events.jsonl"
+RESULT_STREAM_FILENAME = "results.jsonl"
 SCHEMA_VERSION = 1
 
 # Test sources, for the self-referential-assertion warning. Deliberately broad:
@@ -229,6 +235,75 @@ class StagedExecutionTree:
     shard_index: int
 
 
+class _ProgressEmitter:
+    """Write one ordered progress stream to durable storage and stderr."""
+
+    def __init__(
+        self,
+        root: Path,
+        run_id: str,
+        progress: str,
+        *,
+        stream: TextIO | None = None,
+    ) -> None:
+        if progress not in {"human", "jsonl", "none"}:
+            raise HarnessError(f"unknown progress mode: {progress!r}")
+        self.run_id = run_id
+        self.progress = progress
+        self._stream = stream if stream is not None else sys.stderr
+        self._sequence = 0
+        self._started_ns = time.monotonic_ns()
+        self.run_directory = _run_directory(root, run_id)
+        self.event_log = self.run_directory / EVENT_LOG_FILENAME
+
+    def emit(
+        self,
+        event: str,
+        *,
+        completed: int,
+        active: int,
+        total: int,
+        shard_index: int | None = None,
+        plan_ordinal: int | None = None,
+        mutation_id: str | None = None,
+        phase: str | None = None,
+        verdict: str | None = None,
+    ) -> None:
+        self._sequence += 1
+        payload: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "sequence": self._sequence,
+            "run_id": self.run_id,
+            "event": event,
+        }
+        if shard_index is not None:
+            payload["shard_index"] = shard_index
+        if plan_ordinal is not None:
+            payload["plan_ordinal"] = plan_ordinal
+        if mutation_id is not None:
+            payload["mutation_id"] = mutation_id
+        if phase is not None:
+            payload["phase"] = phase
+        if verdict is not None:
+            payload["verdict"] = verdict
+        payload.update(
+            {
+                "completed": completed,
+                "active": active,
+                "total": total,
+                "elapsed_ms": (time.monotonic_ns() - self._started_ns) // 1_000_000,
+            }
+        )
+
+        encoded = json.dumps(payload, separators=(",", ":"))
+        _append_jsonl(self.event_log, encoded.encode("utf-8") + b"\n")
+        if self.progress == "none":
+            return
+        rendered = encoded if self.progress == "jsonl" else _human_progress(payload)
+        self._stream.write(rendered + "\n")
+        self._stream.flush()
+
+
 VERDICT_KILLED = "KILLED"
 VERDICT_SURVIVED = "SURVIVED"
 VERDICT_SURVIVED_DECLARED = "SURVIVED_DECLARED"
@@ -302,6 +377,85 @@ def _atomic_write(target: Path, data: bytes) -> None:
     finally:
         if temporary.exists():
             temporary.unlink(missing_ok=True)
+
+
+def _run_directory(root: Path, run_id: str) -> Path:
+    """Create a private run directory without following predictable links."""
+
+    if _sanitised_identifier(run_id) is None:
+        raise HarnessError(f"run id {run_id!r} is not a plain name")
+    runs = _state_dir(root) / RUNS_DIRNAME
+    if runs.is_symlink():
+        raise HarnessError(f"run directory parent {runs} is a symlink")
+    runs.mkdir(parents=True, exist_ok=True)
+    run_directory = runs / run_id
+    if run_directory.is_symlink():
+        raise HarnessError(f"run directory {run_directory} is a symlink")
+    try:
+        run_directory.mkdir(mode=0o700)
+    except FileExistsError as exc:
+        raise HarnessError(f"run directory already exists: {run_directory}") from exc
+    return run_directory
+
+
+def _append_jsonl(target: Path, line: bytes) -> None:
+    """Atomically add one complete JSON line and make it durable before return."""
+
+    if not line.endswith(b"\n") or line.count(b"\n") != 1:
+        raise HarnessError("a JSONL record must be exactly one complete line")
+    try:
+        existing = target.read_bytes()
+    except FileNotFoundError:
+        existing = b""
+    except OSError as exc:
+        raise HarnessError(f"could not read durable stream {target}: {exc}") from exc
+    if existing and not existing.endswith(b"\n"):
+        raise HarnessError(f"durable stream {target} ends with a partial JSON line")
+    _atomic_write(target, existing + line)
+
+
+def _human_progress(payload: dict[str, Any]) -> str:
+    """Render stable progress fields without proof output or command tails."""
+
+    subject = str(payload["event"])
+    if "mutation_id" in payload:
+        subject += f" {payload['mutation_id']}"
+    elif "shard_index" in payload:
+        subject += f" shard={payload['shard_index']}"
+    return (
+        f"mutation harness: {subject} "
+        f"({payload['completed']}/{payload['total']} complete, "
+        f"{payload['active']} active)"
+    )
+
+
+def _result_fields(result: Result) -> dict[str, Any]:
+    """The stable result contract shared by reports and durable streams."""
+
+    return {
+        "id": result.identifier,
+        "verdict": result.verdict,
+        "detail": result.detail,
+        "failing_proof": result.failing_proof,
+        "warnings": result.warnings,
+    }
+
+
+def _write_result_record(
+    result_stream: Path, run_id: str, plan_ordinal: int, result: Result
+) -> None:
+    """Persist one measured result before another mutation may start."""
+
+    durable_result = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "plan_ordinal": plan_ordinal,
+        **_result_fields(result),
+    }
+    _append_jsonl(
+        result_stream,
+        json.dumps(durable_result, separators=(",", ":")).encode("utf-8") + b"\n",
+    )
 
 
 def _sanitised_identifier(candidate: str) -> str | None:
@@ -1470,6 +1624,10 @@ def run_plan(
     plan_path: Path,
     only: set[str] | None,
     assert_all_killed: bool,
+    *,
+    progress: str = "none",
+    run_id: str | None = None,
+    shard_index: int | None = None,
 ) -> tuple[list[Result], int]:
     blockers = verify(root)
     if blockers:
@@ -1485,58 +1643,142 @@ def run_plan(
     snapshot_dir = _snapshot_dir(root)
     snapshot_dir.mkdir(parents=True, exist_ok=True)
 
+    selected_run_id = run_id or f"run-{uuid.uuid4().hex}"
+    emitter = _ProgressEmitter(root, selected_run_id, progress)
+    result_stream = emitter.run_directory / RESULT_STREAM_FILENAME
     results: list[Result] = []
     lock = acquire_lock(root)
     try:
-        for mutation in mutations:
-            results.append(_run_one(root, mutation, snapshot_dir))
-    finally:
-        release_lock(lock)
+        total = len(mutations)
+        emitter.emit(
+            "run_started",
+            completed=0,
+            active=0,
+            total=total,
+            shard_index=shard_index,
+            phase="running",
+        )
+        if shard_index is not None:
+            emitter.emit(
+                "shard_started",
+                completed=0,
+                active=0,
+                total=total,
+                shard_index=shard_index,
+                phase="running",
+            )
+        try:
+            for ordinal, mutation in enumerate(mutations):
+                emitter.emit(
+                    "mutation_started",
+                    completed=len(results),
+                    active=1,
+                    total=total,
+                    shard_index=shard_index,
+                    plan_ordinal=ordinal,
+                    mutation_id=mutation.identifier,
+                    phase="baseline",
+                )
+                result = _run_one(root, mutation, snapshot_dir)
+                results.append(result)
+                _write_result_record(result_stream, selected_run_id, ordinal, result)
+                emitter.emit(
+                    "mutation_finished",
+                    completed=len(results),
+                    active=0,
+                    total=total,
+                    shard_index=shard_index,
+                    plan_ordinal=ordinal,
+                    mutation_id=mutation.identifier,
+                    verdict=result.verdict,
+                )
+        except BaseException:
+            emitter.emit(
+                "run_stopping",
+                completed=len(results),
+                active=0,
+                total=total,
+                shard_index=shard_index,
+                phase="aborted",
+            )
+            if shard_index is not None:
+                emitter.emit(
+                    "shard_finished",
+                    completed=len(results),
+                    active=0,
+                    total=total,
+                    shard_index=shard_index,
+                    phase="aborted",
+                )
+            emitter.emit(
+                "run_finished",
+                completed=len(results),
+                active=0,
+                total=total,
+                shard_index=shard_index,
+                phase="aborted",
+            )
+            raise
 
-    report = {
-        "schema_version": SCHEMA_VERSION,
-        "plan": plan_name,
-        "plan_path": str(plan_path),
-        "results": [
-            {
-                "id": result.identifier,
-                "verdict": result.verdict,
-                "detail": result.detail,
-                "failing_proof": result.failing_proof,
-                "warnings": result.warnings,
+        if shard_index is not None:
+            emitter.emit(
+                "shard_finished",
+                completed=len(results),
+                active=0,
+                total=total,
+                shard_index=shard_index,
+                phase="complete",
+            )
+
+        report = {
+            "schema_version": SCHEMA_VERSION,
+            "plan": plan_name,
+            "plan_path": str(plan_path),
+            "results": [_result_fields(result) for result in results],
+            "run_id": selected_run_id,
+            "mode": "serial",
+            "event_log": str(emitter.event_log.relative_to(root)),
+            "result_stream": str(result_stream.relative_to(root)),
+        }
+        _state_dir(root).mkdir(parents=True, exist_ok=True)
+        _atomic_write(
+            _state_dir(root) / REPORT_FILENAME,
+            (json.dumps(report, indent=2) + "\n").encode("utf-8"),
+        )
+
+        exit_code = 0
+        # BASELINE_FAILED, INVALID, STALE_DECLARATION and PROOF_VACUOUS all mean a
+        # mutation was never measured. A drifted anchor, a doubled match, a
+        # comment-line anchor, or a proof selecting no test silently measures
+        # nothing, so exiting 0 would report a plan as verified while part of it did
+        # not run -- the same false pass this tool exists to catch.
+        if any(
+            result.verdict
+            in {
+                VERDICT_BASELINE_FAILED,
+                VERDICT_INVALID,
+                VERDICT_STALE_DECLARATION,
+                VERDICT_PROOF_VACUOUS,
+                VERDICT_PROOF_SKIPPED,
             }
             for result in results
-        ],
-    }
-    _state_dir(root).mkdir(parents=True, exist_ok=True)
-    _atomic_write(
-        _state_dir(root) / REPORT_FILENAME,
-        (json.dumps(report, indent=2) + "\n").encode("utf-8"),
-    )
-
-    exit_code = 0
-    # BASELINE_FAILED, INVALID, STALE_DECLARATION and PROOF_VACUOUS all mean a
-    # mutation was never measured. A drifted anchor, a doubled match, a
-    # comment-line anchor, or a proof selecting no test silently measures
-    # nothing, so exiting 0 would report a plan as verified while part of it did
-    # not run -- the same false pass this tool exists to catch.
-    if any(
-        result.verdict
-        in {
-            VERDICT_BASELINE_FAILED,
-            VERDICT_INVALID,
-            VERDICT_STALE_DECLARATION,
-            VERDICT_PROOF_VACUOUS,
-            VERDICT_PROOF_SKIPPED,
-        }
-        for result in results
-    ):
-        exit_code = 1
-    if assert_all_killed and any(
-        result.verdict == VERDICT_SURVIVED for result in results
-    ):
-        exit_code = 1
-    return results, exit_code
+        ):
+            exit_code = 1
+        if assert_all_killed and any(
+            result.verdict == VERDICT_SURVIVED for result in results
+        ):
+            exit_code = 1
+        emitter.emit(
+            "run_finished",
+            completed=len(results),
+            active=0,
+            total=total,
+            shard_index=shard_index,
+            phase="accepted" if exit_code == 0 else "unacceptable",
+        )
+        return results, exit_code
+    finally:
+        release_lock(lock)
 
 
 def _run_one(root: Path, mutation: Mutation, snapshot_dir: Path) -> Result:
@@ -1923,6 +2165,12 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="exit non-zero on any survivor lacking expected_survivor_reason",
     )
+    run_parser.add_argument(
+        "--progress",
+        choices=("human", "jsonl", "none"),
+        default="human",
+        help="stream progress to stderr (durable JSONL is always recorded)",
+    )
 
     args = parser.parse_args(argv)
     root = Path(args.root).resolve()
@@ -1952,7 +2200,11 @@ def main(argv: list[str] | None = None) -> int:
 
         only = {item.strip() for item in args.only.split(",") if item.strip()}
         results, exit_code = run_plan(
-            root, Path(args.plan), only or None, args.assert_all_killed
+            root,
+            Path(args.plan),
+            only or None,
+            args.assert_all_killed,
+            progress=str(args.progress),
         )
         print(_render(results))
         for result in results:

--- a/scripts/mutation_harness.py
+++ b/scripts/mutation_harness.py
@@ -211,6 +211,24 @@ class Result:
     failing_proof: str | None = None
 
 
+@dataclass(frozen=True)
+class ShardingPlan:
+    """Validated plan opt-in consumed by the sharded coordinator."""
+
+    max_shards: int
+    workspace_inputs: tuple[str, ...]
+    external_resources: str
+
+
+@dataclass(frozen=True)
+class StagedExecutionTree:
+    """One owned execution tree prepared for a mutation shard."""
+
+    root: Path
+    ownership_marker: Path
+    shard_index: int
+
+
 VERDICT_KILLED = "KILLED"
 VERDICT_SURVIVED = "SURVIVED"
 VERDICT_SURVIVED_DECLARED = "SURVIVED_DECLARED"
@@ -617,6 +635,47 @@ def _load_plan(path: Path) -> tuple[str, list[Mutation]]:
     return str(raw.get("name") or path.name), mutations
 
 
+def _load_sharding_plan(path: Path, raw: dict[str, Any]) -> ShardingPlan | None:
+    """Load and validate the optional sharding plan contract."""
+
+    raise NotImplementedError
+
+
+def stage_execution_tree(
+    source_root: Path,
+    destination: Path,
+    *,
+    run_id: str,
+    shard_index: int,
+    source_manifest_digest: str,
+    plan_digest: str,
+    workspace_inputs: tuple[str, ...],
+) -> StagedExecutionTree:
+    """Create one isolated, owned execution tree for a mutation shard."""
+
+    raise NotImplementedError
+
+
+def coordinator_run(
+    root: Path,
+    plan_path: Path,
+    only: set[str] | None,
+    assert_all_killed: bool,
+    *,
+    requested_shards: int,
+    progress: str,
+) -> tuple[list[Result], int]:
+    """Coordinate an opted-in sharded mutation run."""
+
+    raise NotImplementedError
+
+
+def recover_run(root: Path, run_id: str, *, force: bool = False) -> str:
+    """Recover or retain the recorded execution trees for an aborted run."""
+
+    raise NotImplementedError
+
+
 def acquire_lock(root: Path) -> Path:
     """Take an exclusive lock, or explain precisely how to break a stale one."""
 
@@ -717,6 +776,18 @@ def verify(root: Path) -> list[str]:
     """
 
     state = _read_state(root)
+    coordinator = (state or {}).get("coordinator_run")
+    if coordinator is not None:
+        if not isinstance(coordinator, dict):
+            raise HarnessError("coordinator_run state is not a JSON object")
+        run_id = coordinator.get("run_id", "unknown")
+        lifecycle = coordinator.get("lifecycle", "unknown")
+        return [
+            f"coordinator run {run_id} remains in lifecycle {lifecycle}. "
+            "No result from this tree is trustworthy until it is recovered. "
+            "Recover it with: python3 scripts/mutation_harness.py recover-run "
+            f"--run-id {shlex.quote(str(run_id))}"
+        ]
     applied = (state or {}).get("applied")
     live = _live_run(root)
 

--- a/scripts/mutation_harness_coordinator.py
+++ b/scripts/mutation_harness_coordinator.py
@@ -547,6 +547,7 @@ def normalize_detail(
 
     normalized = detail
     replacements: list[tuple[str, str]] = []
+    resolved_go_root: Path | None = None
     for path in shard_roots:
         replacements.append((str(path.resolve()), "<SHARD_ROOT>"))
     for path in temporary_roots:
@@ -562,11 +563,14 @@ def normalize_detail(
             raise DetailNormalizationError(
                 f"go_root is not a canonical, existing toolchain directory: {go_root}"
             )
-        replacements.append((str(resolved_go_root), "<GOROOT>"))
     for original, marker in sorted(
         replacements, key=lambda item: len(item[0]), reverse=True
     ):
         normalized = normalized.replace(original, marker)
+    if resolved_go_root is not None:
+        normalized = _replace_bound_absolute_root(
+            normalized, resolved_go_root, "<GOROOT>"
+        )
     normalized = _DURATION_RE.sub("<DURATION>", normalized)
     normalized = _GO_TEST_PACKAGE_DURATION_RE.sub(r"\g<prefix><DURATION>", normalized)
     request_target_spans = _contextual_request_target_spans(normalized)
@@ -592,6 +596,19 @@ def normalize_detail(
             f"unrecognised absolute path in result detail: {match.group(0)!r}"
         )
     return normalized
+
+
+def _replace_bound_absolute_root(detail: str, root: Path, marker: str) -> str:
+    pattern = re.compile(
+        r"(?<![A-Za-z0-9_.>:/\\-])"
+        + re.escape(str(root))
+        + _absolute_root_right_boundary()
+    )
+    return pattern.sub(marker, detail)
+
+
+def _absolute_root_right_boundary() -> str:
+    return r"(?=$|" + re.escape(os.sep) + r"|[\s\]\[(){}<>:'\"`,;])"
 
 
 def _contextual_request_target_spans(detail: str) -> tuple[tuple[int, int], ...]:

--- a/scripts/mutation_harness_coordinator.py
+++ b/scripts/mutation_harness_coordinator.py
@@ -183,6 +183,7 @@ class ChildRuntime:
     spec: ChildSpec
     process: subprocess.Popen[str]
     stderr_handle: IO[str]
+    lifecycle_events: dict[str, str] = field(default_factory=dict)
     finished_events: set[str] = field(default_factory=set)
 
 
@@ -253,29 +254,33 @@ def append_durable_jsonl(path: Path, payload: Mapping[str, Any]) -> None:
         os.close(descriptor)
 
 
-def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+def _load_jsonl(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Load every complete durable record and report malformed residue."""
+
     try:
         raw = path.read_bytes()
     except FileNotFoundError:
-        return []
+        return [], []
     except OSError as exc:
-        raise HarnessError(f"cannot read child result stream {path}: {exc}") from exc
-    if raw and not raw.endswith(b"\n"):
-        raise HarnessError(f"child result stream {path} ends with a partial JSON line")
+        return [], [f"cannot read child result stream {path}: {exc}"]
     records: list[dict[str, Any]] = []
-    for number, line in enumerate(raw.splitlines(), 1):
+    errors: list[str] = []
+    for number, line in enumerate(raw.splitlines(keepends=True), 1):
+        if not line.endswith(b"\n"):
+            errors.append(f"child result stream {path} ends with a partial JSON line")
+            continue
         try:
             item = json.loads(line)
         except json.JSONDecodeError as exc:
-            raise HarnessError(
+            errors.append(
                 f"child result stream {path} line {number} is not JSON: {exc}"
-            ) from exc
-        if not isinstance(item, dict):
-            raise HarnessError(
-                f"child result stream {path} line {number} is not an object"
             )
+            continue
+        if not isinstance(item, dict):
+            errors.append(f"child result stream {path} line {number} is not an object")
+            continue
         records.append(item)
-    return records
+    return records, errors
 
 
 def parse_child_result(raw: Mapping[str, Any]) -> ChildResultRecord:
@@ -635,7 +640,12 @@ class EventWriter:
             self.stream.flush()
         return payload
 
-    def ingest_child(self, shard: ShardAssignment, raw: Mapping[str, Any]) -> None:
+    def ingest_child(
+        self,
+        shard: ShardAssignment,
+        raw: Mapping[str, Any],
+        lifecycle: dict[str, str],
+    ) -> None:
         allowed = {
             "schema_version",
             "run_id",
@@ -665,6 +675,21 @@ class EventWriter:
             raise HarnessError(f"child event names unassigned mutation {mutation_id!r}")
         if raw.get("plan_ordinal") != binding[mutation_id]:
             raise HarnessError(f"child event ordinal mismatch for {mutation_id}")
+        previous = lifecycle.get(mutation_id)
+        if event == "mutation_started":
+            if previous is not None:
+                raise HarnessError(
+                    f"shard {shard.shard_index} duplicate or late "
+                    f"mutation_started event for {mutation_id}"
+                )
+            lifecycle[mutation_id] = "started"
+        elif previous != "started":
+            raise HarnessError(
+                f"shard {shard.shard_index} mutation_finished event without "
+                f"one prior mutation_started event for {mutation_id}"
+            )
+        else:
+            lifecycle[mutation_id] = "finished"
         forwarded = {
             key: value
             for key, value in raw.items()
@@ -721,6 +746,10 @@ def _record_child(lease: CoordinatorLease, spec: ChildSpec) -> None:
     lease.persist()
 
 
+def _paths_overlap(left: Path, right: Path) -> bool:
+    return left == right or left.is_relative_to(right) or right.is_relative_to(left)
+
+
 def _validate_child_spec(
     source_root: Path,
     spec: ChildSpec,
@@ -733,8 +762,16 @@ def _validate_child_spec(
     resolved_temporary = spec.temporary_root.resolve()
     if spec.source_root.resolve() != resolved_source:
         raise HarnessError("child spec source_root does not match the coordinator root")
-    if resolved_root == resolved_source:
-        raise HarnessError("a mutation shard cannot use the invoking source worktree")
+    if _paths_overlap(resolved_source, resolved_temporary):
+        raise HarnessError(
+            f"child temporary_root {resolved_temporary} overlaps the invoking "
+            f"source root {resolved_source}"
+        )
+    if _paths_overlap(resolved_source, resolved_root):
+        raise HarnessError(
+            f"child shard root {resolved_root} overlaps the invoking source root "
+            f"{resolved_source}"
+        )
     if resolved_root in prior_roots:
         raise HarnessError(
             f"two mutation shards resolved to the same root: {resolved_root}"
@@ -809,6 +846,21 @@ def _parse_child_event_line(runtime: ChildRuntime, line: str) -> dict[str, Any]:
     return raw
 
 
+def _append_missing_lifecycle_errors(runtime: ChildRuntime, errors: list[str]) -> None:
+    for item in runtime.spec.assignment.mutations:
+        lifecycle = runtime.lifecycle_events.get(item.identifier)
+        if lifecycle is None:
+            errors.append(
+                f"shard {runtime.spec.assignment.shard_index} missing "
+                f"mutation_started event for {item.identifier}"
+            )
+        if lifecycle != "finished":
+            errors.append(
+                f"shard {runtime.spec.assignment.shard_index} missing "
+                f"mutation_finished event for {item.identifier}"
+            )
+
+
 def _tail_children(
     runtimes: Sequence[ChildRuntime], writer: EventWriter
 ) -> tuple[dict[int, int], list[str]]:
@@ -832,7 +884,9 @@ def _tail_children(
                     continue
                 try:
                     raw = _parse_child_event_line(runtime, line)
-                    writer.ingest_child(runtime.spec.assignment, raw)
+                    writer.ingest_child(
+                        runtime.spec.assignment, raw, runtime.lifecycle_events
+                    )
                     if raw.get("event") == "mutation_finished":
                         mutation_id = raw.get("mutation_id")
                         if isinstance(mutation_id, str):
@@ -845,6 +899,7 @@ def _tail_children(
     for runtime in runtimes:
         exits[runtime.spec.assignment.shard_index] = runtime.process.wait()
         runtime.stderr_handle.close()
+        _append_missing_lifecycle_errors(runtime, errors)
         writer.emit(
             "shard_finished",
             shard_index=runtime.spec.assignment.shard_index,
@@ -992,9 +1047,11 @@ def coordinator_run(
                 "complete" if exits[spec.assignment.shard_index] == 0 else "aborted"
             )
         lease.persist()
-        raw_records = [
-            record for spec in children for record in _load_jsonl(spec.result_stream)
-        ]
+        raw_records: list[dict[str, Any]] = []
+        for spec in children:
+            stream_records, stream_errors = _load_jsonl(spec.result_stream)
+            raw_records.extend(stream_records)
+            protocol_errors.extend(stream_errors)
         try:
             aggregated = aggregate_child_results(
                 raw_records,

--- a/scripts/mutation_harness_coordinator.py
+++ b/scripts/mutation_harness_coordinator.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import json
 import os
 import re
 import selectors
 import signal
+import stat
 import subprocess
 import sys
 import time
@@ -111,6 +113,56 @@ class AggregateRefusal(HarnessError):
 
 class DetailNormalizationError(HarnessError):
     """A detail contains run-varying bytes the normalizer does not understand."""
+
+
+_CREATED_TEMPORARY_ROOT_AUTHORITY = object()
+
+
+@dataclass(frozen=True)
+class TemporaryRootClaim:
+    """Captured directory identity and explicit startup-cleanup authority."""
+
+    path: Path
+    device: int
+    inode: int
+    _cleanup_authority: object | None = field(repr=False, compare=False)
+
+    @classmethod
+    def created(cls, path: Path) -> TemporaryRootClaim:
+        """Claim a directory that the current factory call just created."""
+
+        return cls._capture(path, authority=_CREATED_TEMPORARY_ROOT_AUTHORITY)
+
+    @classmethod
+    def borrowed(cls, path: Path) -> TemporaryRootClaim:
+        """Capture a pre-existing directory without cleanup authority."""
+
+        return cls._capture(path, authority=None)
+
+    @classmethod
+    def _capture(cls, path: Path, *, authority: object | None) -> TemporaryRootClaim:
+        canonical = path.resolve()
+        if not path.is_absolute() or path != canonical:
+            raise HarnessError(
+                f"run temporary_root claim is not canonical and absolute: {path}"
+            )
+        metadata = path.lstat()
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise HarnessError(f"run temporary_root is not a directory: {canonical}")
+        return cls(
+            path=canonical,
+            device=metadata.st_dev,
+            inode=metadata.st_ino,
+            _cleanup_authority=authority,
+        )
+
+
+@dataclass(frozen=True)
+class _RegularFileClaim:
+    path: Path
+    device: int
+    inode: int
+    digest: str
 
 
 @dataclass(frozen=True)
@@ -549,35 +601,72 @@ def _validate_run_temporary_root(source_root: Path, temporary_root: Path) -> Pat
     return resolved_temporary
 
 
+def _remove_claimed_empty_directory(claim: TemporaryRootClaim | None) -> None:
+    if (
+        claim is None
+        or claim._cleanup_authority is not _CREATED_TEMPORARY_ROOT_AUTHORITY
+    ):
+        return
+    try:
+        metadata = claim.path.lstat()
+    except OSError:
+        return
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_dev != claim.device
+        or metadata.st_ino != claim.inode
+    ):
+        return
+    try:
+        claim.path.rmdir()
+    except OSError:
+        pass
+
+
+def _remove_claimed_regular_file(claim: _RegularFileClaim | None) -> None:
+    if claim is None:
+        return
+    try:
+        before = claim.path.lstat()
+    except OSError:
+        return
+    if not stat.S_ISREG(before.st_mode) or (before.st_dev, before.st_ino) != (
+        claim.device,
+        claim.inode,
+    ):
+        return
+    try:
+        content = claim.path.read_bytes()
+        after = claim.path.lstat()
+    except OSError:
+        return
+    if (after.st_dev, after.st_ino) != (
+        claim.device,
+        claim.inode,
+    ) or hashlib.sha256(content).hexdigest() != claim.digest:
+        return
+    try:
+        claim.path.unlink()
+    except OSError:
+        pass
+
+
 def _cleanup_pre_authority_startup(
-    temporary_root: Path | None,
+    temporary_root_claim: TemporaryRootClaim | None,
     run_dir: Path,
     *,
     run_dir_created: bool,
-    manifest_written: bool,
+    manifest_claim: _RegularFileClaim | None,
 ) -> None:
     """Remove only empty artifacts created by this startup attempt."""
 
     if run_dir_created:
-        manifest_path = run_dir / MANIFEST_FILENAME
-        if (
-            manifest_written
-            and manifest_path.is_file()
-            and not manifest_path.is_symlink()
-        ):
-            try:
-                manifest_path.unlink()
-            except OSError:
-                pass
+        _remove_claimed_regular_file(manifest_claim)
         try:
             run_dir.rmdir()
         except OSError:
             pass
-    if temporary_root is not None:
-        try:
-            temporary_root.rmdir()
-        except OSError:
-            pass
+    _remove_claimed_empty_directory(temporary_root_claim)
 
 
 def begin_coordinator_run(
@@ -591,7 +680,7 @@ def begin_coordinator_run(
     plan_digest: str,
     requested_shards: int,
     effective_shards: int,
-    temporary_root_factory: Callable[[str], Path],
+    temporary_root_factory: Callable[[str], TemporaryRootClaim],
 ) -> CoordinatorLease:
     """Atomically claim the root, then write state before any staging callback."""
 
@@ -604,9 +693,9 @@ def begin_coordinator_run(
     lock = acquire_lock(root)
     run_dir = (_state_dir(root) / RUNS_DIRNAME / run_id).resolve()
     state_root = _state_dir(root).resolve()
-    temporary_root: Path | None = None
+    temporary_root_claim: TemporaryRootClaim | None = None
     run_dir_created = False
-    manifest_written = False
+    manifest_claim: _RegularFileClaim | None = None
     authority_persisted = False
     try:
         existing = _read_state(root)
@@ -621,9 +710,8 @@ def begin_coordinator_run(
             raise FileExistsError(
                 f"coordinator run directory already exists: {run_dir}"
             )
-        temporary_root = _validate_run_temporary_root(
-            root, temporary_root_factory(run_id)
-        )
+        temporary_root_claim = temporary_root_factory(run_id)
+        temporary_root = _validate_run_temporary_root(root, temporary_root_claim.path)
         run_dir.mkdir(parents=True, exist_ok=False)
         run_dir_created = True
         manifest_path = (run_dir / MANIFEST_FILENAME).resolve()
@@ -645,18 +733,17 @@ def begin_coordinator_run(
             "shards": [],
         }
         lease = CoordinatorLease(root, lock, state)
-        _write_manifest(lease)
-        manifest_written = True
+        manifest_claim = _write_manifest(lease)
         lease.persist()
         authority_persisted = True
         return lease
     except BaseException:
         if not authority_persisted:
             _cleanup_pre_authority_startup(
-                temporary_root,
+                temporary_root_claim,
                 run_dir,
                 run_dir_created=run_dir_created,
-                manifest_written=manifest_written,
+                manifest_claim=manifest_claim,
             )
         release_lock(lock)
         raise
@@ -813,11 +900,27 @@ def _manifest_payload(lease: CoordinatorLease) -> dict[str, Any]:
     }
 
 
-def _write_manifest(lease: CoordinatorLease) -> None:
+def _write_manifest(lease: CoordinatorLease) -> _RegularFileClaim:
     target = Path(lease.state["manifest_path"])
-    _atomic_write(
-        target,
-        (json.dumps(_manifest_payload(lease), indent=2) + "\n").encode("utf-8"),
+    content = (json.dumps(_manifest_payload(lease), indent=2) + "\n").encode("utf-8")
+    _atomic_write(target, content)
+    metadata = target.lstat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise HarnessError(f"coordinator manifest is not a regular file: {target}")
+    written_content = target.read_bytes()
+    after = target.lstat()
+    if (after.st_dev, after.st_ino) != (
+        metadata.st_dev,
+        metadata.st_ino,
+    ) or written_content != content:
+        raise HarnessError(
+            "coordinator manifest changed while claiming startup ownership"
+        )
+    return _RegularFileClaim(
+        path=target,
+        device=metadata.st_dev,
+        inode=metadata.st_ino,
+        digest=hashlib.sha256(written_content).hexdigest(),
     )
 
 
@@ -1063,7 +1166,7 @@ def coordinator_run(
     source_manifest_digest: str,
     plan_digest: str,
     source_manifest_reader: Callable[[], str],
-    temporary_root_factory: Callable[[str], Path],
+    temporary_root_factory: Callable[[str], TemporaryRootClaim],
     child_factory: Callable[[ShardAssignment, str], ChildSpec],
     run_id: str | None = None,
     progress_stream: IO[str] | None = None,

--- a/scripts/mutation_harness_coordinator.py
+++ b/scripts/mutation_harness_coordinator.py
@@ -532,6 +532,23 @@ class CoordinatorLease:
         self.closed = True
 
 
+def _paths_overlap(left: Path, right: Path) -> bool:
+    return left == right or left.is_relative_to(right) or right.is_relative_to(left)
+
+
+def _validate_run_temporary_root(source_root: Path, temporary_root: Path) -> Path:
+    """Return one canonical run root that cannot contain or be under the source."""
+
+    resolved_source = source_root.resolve()
+    resolved_temporary = temporary_root.resolve()
+    if _paths_overlap(resolved_source, resolved_temporary):
+        raise HarnessError(
+            f"run temporary_root {resolved_temporary} overlaps the invoking "
+            f"source root {resolved_source}"
+        )
+    return resolved_temporary
+
+
 def begin_coordinator_run(
     root: Path,
     *,
@@ -543,6 +560,7 @@ def begin_coordinator_run(
     plan_digest: str,
     requested_shards: int,
     effective_shards: int,
+    temporary_root_factory: Callable[[str], Path],
 ) -> CoordinatorLease:
     """Atomically claim the root, then write state before any staging callback."""
 
@@ -560,6 +578,9 @@ def begin_coordinator_run(
                 "root state exists after the coordinator acquired the lock; "
                 "recover it before staging"
             )
+        temporary_root = _validate_run_temporary_root(
+            root, temporary_root_factory(run_id)
+        )
         run_dir = (_state_dir(root) / RUNS_DIRNAME / run_id).resolve()
         state_root = _state_dir(root).resolve()
         if not run_dir.is_relative_to(state_root):
@@ -572,6 +593,7 @@ def begin_coordinator_run(
             "process_start_time": time.time_ns(),
             "lifecycle": "staging",
             "source_root": str(root.resolve()),
+            "temporary_root": str(temporary_root),
             "source_head": source_head,
             "source_manifest": json.loads(json.dumps(dict(source_manifest))),
             "source_manifest_digest": source_manifest_digest,
@@ -705,10 +727,31 @@ class EventWriter:
 
 def _manifest_payload(lease: CoordinatorLease) -> dict[str, Any]:
     state = lease.state
+    source_manifest = state["source_manifest"]
+    if (
+        not isinstance(source_manifest, Mapping)
+        or source_manifest.get("digest") != state["source_manifest_digest"]
+    ):
+        raise HarnessError(
+            "source manifest mapping digest does not match source_manifest_digest"
+        )
+    recorded_temporary = state.get("temporary_root")
+    if not isinstance(recorded_temporary, str):
+        raise HarnessError("coordinator state has no temporary_root")
+    temporary_root = Path(recorded_temporary)
+    if not temporary_root.is_absolute() or temporary_root.resolve() != temporary_root:
+        raise HarnessError("coordinator temporary_root is not canonical and absolute")
+    _validate_run_temporary_root(Path(state["source_root"]), temporary_root)
+    for shard in state["shards"]:
+        if shard.get("temporary_root") != recorded_temporary:
+            raise HarnessError(
+                "recorded shard temporary_root does not match the coordinator run"
+            )
     return {
         "schema_version": COORDINATOR_SCHEMA_VERSION,
         "run_id": state["run_id"],
         "source_root": state["source_root"],
+        "temporary_root": recorded_temporary,
         "source_head": state["source_head"],
         "source_manifest": state["source_manifest"],
         "source_manifest_digest": state["source_manifest_digest"],
@@ -746,22 +789,24 @@ def _record_child(lease: CoordinatorLease, spec: ChildSpec) -> None:
     lease.persist()
 
 
-def _paths_overlap(left: Path, right: Path) -> bool:
-    return left == right or left.is_relative_to(right) or right.is_relative_to(left)
-
-
 def _validate_child_spec(
     source_root: Path,
+    temporary_root: Path,
     spec: ChildSpec,
     prior_roots: set[Path],
 ) -> None:
     """Keep every child-owned write and liveness token inside one unique shard."""
 
     resolved_source = source_root.resolve()
+    resolved_run_temporary = temporary_root.resolve()
     resolved_root = spec.root.resolve()
     resolved_temporary = spec.temporary_root.resolve()
     if spec.source_root.resolve() != resolved_source:
         raise HarnessError("child spec source_root does not match the coordinator root")
+    if resolved_temporary != resolved_run_temporary:
+        raise HarnessError(
+            "child temporary_root does not match the coordinator run temporary_root"
+        )
     if _paths_overlap(resolved_source, resolved_temporary):
         raise HarnessError(
             f"child temporary_root {resolved_temporary} overlaps the invoking "
@@ -968,6 +1013,7 @@ def coordinator_run(
     source_manifest_digest: str,
     plan_digest: str,
     source_manifest_reader: Callable[[], str],
+    temporary_root_factory: Callable[[str], Path],
     child_factory: Callable[[ShardAssignment, str], ChildSpec],
     run_id: str | None = None,
     progress_stream: IO[str] | None = None,
@@ -990,8 +1036,10 @@ def coordinator_run(
         plan_digest=plan_digest,
         requested_shards=requested_shards,
         effective_shards=effective_shards,
+        temporary_root_factory=temporary_root_factory,
     )
     run_dir = Path(lease.state["manifest_path"]).parent
+    temporary_root = Path(lease.state["temporary_root"])
     event_log = run_dir / EVENT_LOG_FILENAME
     report_path = _state_dir(root) / REPORT_FILENAME
     writer = EventWriter(
@@ -1024,7 +1072,7 @@ def coordinator_run(
                     f"child factory returned the wrong assignment for shard "
                     f"{assignment.shard_index}"
                 )
-            _validate_child_spec(root, spec, resolved_child_roots)
+            _validate_child_spec(root, temporary_root, spec, resolved_child_roots)
             children.append(spec)
             _record_child(lease, spec)
         if source_manifest_reader() != source_manifest_digest:

--- a/scripts/mutation_harness_coordinator.py
+++ b/scripts/mutation_harness_coordinator.py
@@ -25,6 +25,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Any, Protocol, cast
+from urllib.parse import unquote
 
 try:
     from scripts.mutation_harness import (
@@ -78,10 +79,62 @@ AGGREGATE_CLEANUP_FAILED = "CLEANUP_FAILED"
 
 _SAFE_RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
 _DURATION_RE = re.compile(r"\((?:\d+(?:\.\d+)?)(?:ns|us|µs|ms|s|m|h)\)")
+_GO_TEST_PACKAGE_DURATION_RE = re.compile(
+    r"(?m)(?P<prefix>^[ \t]*(?:ok|FAIL)\t[^\t\r\n]+\t)\d+(?:\.\d+)?s(?=\r?$)"
+)
 _POSIX_ABSOLUTE_PATH_RE = re.compile(
-    r"(?<![A-Za-z0-9_.>:/\-])/(?:[^\s\]\[(){}<>:'\"]+/)*[^\s\]\[(){}<>:'\",;]*"
+    r"(?<![A-Za-z0-9_.>:/\-])/(?:[^\s\]\[(){}<>:'\"`]+/)*"
+    r"[^\s\]\[(){}<>:'\"`,;]*"
 )
 _WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"\b[A-Za-z]:\\[^\s\]\[(){}<>:'\",;]+")
+_REQUEST_TARGET_CONTEXT_RE = re.compile(
+    r"""
+    (?<![A-Za-z0-9_-])
+    (?:request(?:[ -]target)?|url|get|head|post|put|patch|delete|options|trace)
+    (?![A-Za-z0-9_-])
+    (?:[ \t]+|[ \t]*[:=][ \t]*)
+    (?:
+        "(?P<double>/[^"\r\n]*)"
+        |'(?P<single>/[^'\r\n]*)'
+        |`(?P<backtick>/[^`\r\n]*)`
+        |(?P<bare>/[^\s<>"'`]+)
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_INDEXED_REQUEST_ASSERTION_RE = re.compile(
+    r"""
+    (?<![A-Za-z0-9_-])request\[(?:0|[1-9][0-9]*)\][ \t]*=[ \t]*
+    (?:(?P<actual_double>"/[^"\r\n]*")|(?P<actual_single>'/[^'\r\n]*'))
+    [ \t]+want[ \t]*=[ \t]*
+    (?:(?P<want_double>"/[^"\r\n]*")|(?P<want_single>'/[^'\r\n]*'))
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_STRUCTURED_REQUEST_FIELD_RE = re.compile(
+    r"""
+    (?<![A-Za-z0-9_-])field[ \t]+["']requests["'][ \t]*:
+    [^\r\n]{0,512}?["']v["'][ \t]*:[ \t]*
+    (?:(?P<value_double>"/[^"\r\n]*"?)|(?P<value_single>'/[^'\r\n]*'?))
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_SHELL_TEMP_TEMPLATE_RE = re.compile(
+    r"""
+    (?<![A-Za-z0-9_-])mktemp[ \t]+-d[ \t]+
+    (?P<quote>["'])\$\{TMPDIR:-/tmp\}/[A-Za-z0-9._-]*XXXXXX(?P=quote)
+    """,
+    re.VERBOSE,
+)
+_ORIGIN_FORM_REQUEST_TARGET_RE = re.compile(
+    r"""
+    /(?!/)
+    (?:[A-Za-z0-9._~!$&'()*+,;=:@-]|%[0-9A-Fa-f]{2}|/)*
+    (?:\?(?:[A-Za-z0-9._~!$&'()*+,;=:@/?-]|%[0-9A-Fa-f]{2})*)?
+    """,
+    re.VERBOSE,
+)
+_TRAVERSAL_SEGMENT_RE = re.compile(r"(?:^|[/?&=])\.{1,2}(?=$|[/?&#=])")
 
 _CHILD_EVENTS = frozenset({"mutation_started", "mutation_finished"})
 _RESULT_FIELDS = frozenset({"id", "verdict", "detail", "failing_proof", "warnings"})
@@ -488,8 +541,9 @@ def normalize_detail(
     *,
     shard_roots: Sequence[Path],
     temporary_roots: Sequence[Path],
+    go_root: Path | None = None,
 ) -> str:
-    """Normalize only named shard roots, named temporary roots, and durations."""
+    """Normalize explicitly bound roots and known run-varying duration forms."""
 
     normalized = detail
     replacements: list[tuple[str, str]] = []
@@ -497,12 +551,39 @@ def normalize_detail(
         replacements.append((str(path.resolve()), "<SHARD_ROOT>"))
     for path in temporary_roots:
         replacements.append((str(path.resolve()), "<TMP>"))
+    if go_root is not None:
+        resolved_go_root = go_root.resolve()
+        if (
+            not go_root.is_absolute()
+            or go_root != resolved_go_root
+            or resolved_go_root == Path(resolved_go_root.anchor)
+            or not resolved_go_root.is_dir()
+        ):
+            raise DetailNormalizationError(
+                f"go_root is not a canonical, existing toolchain directory: {go_root}"
+            )
+        replacements.append((str(resolved_go_root), "<GOROOT>"))
     for original, marker in sorted(
         replacements, key=lambda item: len(item[0]), reverse=True
     ):
         normalized = normalized.replace(original, marker)
     normalized = _DURATION_RE.sub("<DURATION>", normalized)
-    absolute = _POSIX_ABSOLUTE_PATH_RE.search(normalized)
+    normalized = _GO_TEST_PACKAGE_DURATION_RE.sub(r"\g<prefix><DURATION>", normalized)
+    request_target_spans = _contextual_request_target_spans(normalized)
+    allowed_absolute_spans = request_target_spans + _shell_temp_template_spans(
+        normalized
+    )
+    absolute = next(
+        (
+            match
+            for match in _POSIX_ABSOLUTE_PATH_RE.finditer(normalized)
+            if not any(
+                start <= match.start() and match.end() <= end
+                for start, end in allowed_absolute_spans
+            )
+        ),
+        None,
+    )
     windows = _WINDOWS_ABSOLUTE_PATH_RE.search(normalized)
     if absolute is not None or windows is not None:
         match = absolute if absolute is not None else windows
@@ -513,11 +594,87 @@ def normalize_detail(
     return normalized
 
 
+def _contextual_request_target_spans(detail: str) -> tuple[tuple[int, int], ...]:
+    spans: list[tuple[int, int]] = []
+    for match in _REQUEST_TARGET_CONTEXT_RE.finditer(detail):
+        group = next(
+            name
+            for name in ("double", "single", "backtick", "bare")
+            if match.group(name) is not None
+        )
+        target = match.group(group)
+        if _is_origin_form_request_target(target):
+            spans.append(match.span(group))
+    spans.extend(_indexed_request_assertion_spans(detail))
+    spans.extend(_structured_request_field_spans(detail))
+    return tuple(spans)
+
+
+def _indexed_request_assertion_spans(detail: str) -> tuple[tuple[int, int], ...]:
+    spans: list[tuple[int, int]] = []
+    for match in _INDEXED_REQUEST_ASSERTION_RE.finditer(detail):
+        candidates = (
+            ("actual_double", '"'),
+            ("actual_single", "'"),
+            ("want_double", '"'),
+            ("want_single", "'"),
+        )
+        targets = [
+            (name, quote) for name, quote in candidates if match.group(name) is not None
+        ]
+        if len(targets) != 2:
+            continue
+        for name, quote in targets:
+            target = match.group(name).removeprefix(quote).removesuffix(quote)
+            if not _is_origin_form_request_target(target):
+                break
+        else:
+            spans.extend(
+                (match.start(name) + 1, match.end(name) - 1) for name, _quote in targets
+            )
+    return tuple(spans)
+
+
+def _structured_request_field_spans(detail: str) -> tuple[tuple[int, int], ...]:
+    spans: list[tuple[int, int]] = []
+    for match in _STRUCTURED_REQUEST_FIELD_RE.finditer(detail):
+        name = (
+            "value_double"
+            if match.group("value_double") is not None
+            else "value_single"
+        )
+        quoted = match.group(name)
+        quote = quoted[0]
+        target = quoted.removeprefix(quote).removesuffix(quote)
+        if _is_origin_form_request_target(target):
+            spans.append((match.start(name) + 1, match.start(name) + 1 + len(target)))
+    return tuple(spans)
+
+
+def _shell_temp_template_spans(detail: str) -> tuple[tuple[int, int], ...]:
+    return tuple(match.span() for match in _SHELL_TEMP_TEMPLATE_RE.finditer(detail))
+
+
+def _is_origin_form_request_target(target: str) -> bool:
+    if _ORIGIN_FORM_REQUEST_TARGET_RE.fullmatch(target) is None:
+        return False
+    decoded = target
+    for _ in range(len(target) + 1):
+        expanded = unquote(decoded)
+        if expanded == decoded:
+            break
+        decoded = expanded
+    if "\\" in decoded:
+        return False
+    return _TRAVERSAL_SEGMENT_RE.search(decoded) is None
+
+
 def canonical_result_projection(
     results: Sequence[Result | Mapping[str, Any]],
     *,
     shard_roots: Sequence[Path],
     temporary_roots: Sequence[Path],
+    go_root: Path | None = None,
 ) -> tuple[dict[str, Any], ...]:
     """Return the normative serial/sharded differential projection."""
 
@@ -543,6 +700,7 @@ def canonical_result_projection(
                     str(detail),
                     shard_roots=shard_roots,
                     temporary_roots=temporary_roots,
+                    go_root=go_root,
                 ),
                 "failing_proof": failing_proof,
                 "warnings": list(warnings),

--- a/scripts/mutation_harness_coordinator.py
+++ b/scripts/mutation_harness_coordinator.py
@@ -1,0 +1,1163 @@
+#!/usr/bin/env python3
+"""Fail-closed coordinator for isolated mutation-harness shards.
+
+The coordinator owns the source-root lock, recovery state, aggregate event log,
+and final report.  Children receive only shard-local paths.  They stream events
+on stdout and durably append results to their shard-local result stream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import re
+import selectors
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO, Any, Protocol, cast
+
+try:
+    from scripts.mutation_harness import (
+        REPORT_FILENAME,
+        SCHEMA_VERSION,
+        VERDICT_BASELINE_FAILED,
+        VERDICT_INVALID,
+        VERDICT_PROOF_SKIPPED,
+        VERDICT_PROOF_VACUOUS,
+        VERDICT_STALE_DECLARATION,
+        VERDICT_SURVIVED,
+        HarnessError,
+        Result,
+        _atomic_write,
+        _read_state,
+        _state_dir,
+        _write_state,
+        acquire_lock,
+        release_lock,
+    )
+except ModuleNotFoundError:  # Direct internal liveness-wrapper execution.
+    from mutation_harness import (  # type: ignore[import-not-found,no-redef]
+        REPORT_FILENAME,
+        SCHEMA_VERSION,
+        VERDICT_BASELINE_FAILED,
+        VERDICT_INVALID,
+        VERDICT_PROOF_SKIPPED,
+        VERDICT_PROOF_VACUOUS,
+        VERDICT_STALE_DECLARATION,
+        VERDICT_SURVIVED,
+        HarnessError,
+        Result,
+        _atomic_write,
+        _read_state,
+        _state_dir,
+        _write_state,
+        acquire_lock,
+        release_lock,
+    )
+
+RUNS_DIRNAME = "runs"
+MANIFEST_FILENAME = "manifest.json"
+EVENT_LOG_FILENAME = "events.jsonl"
+COORDINATOR_SCHEMA_VERSION = 1
+
+AGGREGATE_COMPLETE = "COMPLETE"
+AGGREGATE_INVALID = "AGGREGATE_INVALID"
+AGGREGATE_CHILD_FAILED = "CHILD_FAILED"
+AGGREGATE_SOURCE_DRIFTED = "SOURCE_DRIFTED"
+AGGREGATE_CLEANUP_FAILED = "CLEANUP_FAILED"
+
+_SAFE_RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+_DURATION_RE = re.compile(r"\((?:\d+(?:\.\d+)?)(?:ns|us|µs|ms|s|m|h)\)")
+_POSIX_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_.>:/\-])/(?:[^\s\]\[(){}<>:'\"]+/)*[^\s\]\[(){}<>:'\",;]*"
+)
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"\b[A-Za-z]:\\[^\s\]\[(){}<>:'\",;]+")
+
+_CHILD_EVENTS = frozenset({"mutation_started", "mutation_finished"})
+_RESULT_FIELDS = frozenset({"id", "verdict", "detail", "failing_proof", "warnings"})
+CANONICAL_EXCLUDED_FIELDS = (
+    "run_id",
+    "shard_index",
+    "pid",
+    "timestamp",
+    "elapsed_ms",
+    "event_log_path",
+)
+
+
+class AggregateRefusal(HarnessError):
+    """A child result set is not an exact projection of the selected plan."""
+
+    def __init__(
+        self,
+        reasons: Sequence[str],
+        *,
+        partial_results: Sequence[Result] = (),
+        missing_ids: Sequence[str] = (),
+    ) -> None:
+        super().__init__("; ".join(reasons))
+        self.reasons = tuple(reasons)
+        self.partial_results = tuple(partial_results)
+        self.missing_ids = tuple(missing_ids)
+
+
+class DetailNormalizationError(HarnessError):
+    """A detail contains run-varying bytes the normalizer does not understand."""
+
+
+@dataclass(frozen=True)
+class SelectedMutation:
+    """A plan entry after ``--only`` selection, with both useful ordinals."""
+
+    identifier: str
+    plan_ordinal: int
+    selected_ordinal: int
+
+
+@dataclass(frozen=True)
+class ShardAssignment:
+    """Stable selected-plan ordinals owned by one shard."""
+
+    shard_index: int
+    mutations: tuple[SelectedMutation, ...]
+
+    @property
+    def assigned_ordinals(self) -> tuple[int, ...]:
+        return tuple(item.selected_ordinal for item in self.mutations)
+
+
+class Cleanup(Protocol):
+    """Ownership-checked cleanup supplied by the execution-tree lane."""
+
+    def __call__(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class ChildSpec:
+    """Shard-local process contract returned by the staging callback."""
+
+    assignment: ShardAssignment
+    root: Path
+    source_root: Path
+    temporary_root: Path
+    argv: tuple[str, ...]
+    result_stream: Path
+    ownership_marker: Path
+    liveness_lock: Path
+    environment: Mapping[str, str] = field(default_factory=dict)
+    cleanup: Cleanup | None = None
+
+
+@dataclass(frozen=True)
+class ChildResultRecord:
+    """One durable child result with coordinator validation metadata."""
+
+    run_id: str
+    shard_index: int
+    plan_digest: str
+    plan_ordinal: int
+    mutation_id: str
+    result: Result
+
+
+@dataclass(frozen=True)
+class AggregatedResults:
+    """Exact, selected-plan-ordered child results."""
+
+    results: tuple[Result, ...]
+    records: tuple[ChildResultRecord, ...]
+
+
+@dataclass
+class ChildRuntime:
+    """Coordinator-owned live process state."""
+
+    spec: ChildSpec
+    process: subprocess.Popen[str]
+    stderr_handle: IO[str]
+    finished_events: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class CoordinatorOutcome:
+    """Complete aggregate outcome returned to the harness CLI seam."""
+
+    results: tuple[Result, ...]
+    exit_code: int
+    aggregate_status: str
+    report_path: Path
+    event_log_path: Path
+    unmeasured_ids: tuple[str, ...]
+    measured_lost_ids: tuple[str, ...]
+
+
+def select_and_assign(
+    plan_mutation_ids: Sequence[str],
+    only: set[str] | None,
+    requested_shards: int,
+) -> tuple[ShardAssignment, ...]:
+    """Apply ``--only`` first, then assign selected ordinal modulo shard count."""
+
+    if requested_shards < 1:
+        raise HarnessError("requested shard count must be greater than zero")
+    if len(set(plan_mutation_ids)) != len(plan_mutation_ids):
+        raise HarnessError("plan mutation identifiers must be unique before assignment")
+    known = set(plan_mutation_ids)
+    if only is not None:
+        unknown = only - known
+        if unknown:
+            raise HarnessError(f"--only names unknown mutations: {sorted(unknown)}")
+    selected = [
+        SelectedMutation(identifier, plan_ordinal, selected_ordinal)
+        for selected_ordinal, (plan_ordinal, identifier) in enumerate(
+            pair
+            for pair in enumerate(plan_mutation_ids)
+            if only is None or pair[1] in only
+        )
+    ]
+    if not selected:
+        raise HarnessError("the selected mutation set is empty")
+    effective = min(requested_shards, len(selected))
+    buckets: list[list[SelectedMutation]] = [[] for _ in range(effective)]
+    for item in selected:
+        buckets[item.selected_ordinal % effective].append(item)
+    return tuple(
+        ShardAssignment(shard_index=index, mutations=tuple(items))
+        for index, items in enumerate(buckets)
+    )
+
+
+def append_durable_jsonl(path: Path, payload: Mapping[str, Any]) -> None:
+    """Append one flushed and fsynced JSON line without following a symlink."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    line = (json.dumps(dict(payload), sort_keys=True) + "\n").encode("utf-8")
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        written = os.write(descriptor, line)
+        if written != len(line):
+            raise HarnessError(f"short JSONL write to {path}: {written}/{len(line)}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        raise HarnessError(f"cannot read child result stream {path}: {exc}") from exc
+    if raw and not raw.endswith(b"\n"):
+        raise HarnessError(f"child result stream {path} ends with a partial JSON line")
+    records: list[dict[str, Any]] = []
+    for number, line in enumerate(raw.splitlines(), 1):
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise HarnessError(
+                f"child result stream {path} line {number} is not JSON: {exc}"
+            ) from exc
+        if not isinstance(item, dict):
+            raise HarnessError(
+                f"child result stream {path} line {number} is not an object"
+            )
+        records.append(item)
+    return records
+
+
+def parse_child_result(raw: Mapping[str, Any]) -> ChildResultRecord:
+    """Parse the closed durable child-result protocol."""
+
+    required = {
+        "schema_version",
+        "run_id",
+        "shard_index",
+        "plan_digest",
+        "plan_ordinal",
+        "mutation_id",
+        "result",
+    }
+    unknown = set(raw) - required
+    missing = required - set(raw)
+    if unknown or missing:
+        raise HarnessError(
+            f"child result keys differ: missing={sorted(missing)}, unknown={sorted(unknown)}"
+        )
+    if raw["schema_version"] != COORDINATOR_SCHEMA_VERSION:
+        raise HarnessError(
+            f"unsupported child result schema_version {raw['schema_version']!r}"
+        )
+    result_raw = raw["result"]
+    if not isinstance(result_raw, dict):
+        raise HarnessError("child result field 'result' must be an object")
+    result_unknown = set(result_raw) - _RESULT_FIELDS
+    result_missing = _RESULT_FIELDS - set(result_raw)
+    if result_unknown or result_missing:
+        raise HarnessError(
+            "child mutation result keys differ: "
+            f"missing={sorted(result_missing)}, unknown={sorted(result_unknown)}"
+        )
+    mutation_id = raw["mutation_id"]
+    if not isinstance(mutation_id, str) or not mutation_id:
+        raise HarnessError("child result mutation_id must be a non-empty string")
+    if result_raw["id"] != mutation_id:
+        raise HarnessError(
+            f"child result id {result_raw['id']!r} does not match {mutation_id!r}"
+        )
+    warnings = result_raw["warnings"]
+    if not isinstance(warnings, list) or not all(isinstance(x, str) for x in warnings):
+        raise HarnessError("child result warnings must be a string array")
+    failing_proof = result_raw["failing_proof"]
+    if failing_proof is not None and not isinstance(failing_proof, str):
+        raise HarnessError("child result failing_proof must be null or a string")
+    if not isinstance(raw["shard_index"], int) or isinstance(raw["shard_index"], bool):
+        raise HarnessError("child result shard_index must be an integer")
+    if not isinstance(raw["plan_ordinal"], int) or isinstance(
+        raw["plan_ordinal"], bool
+    ):
+        raise HarnessError("child result plan_ordinal must be an integer")
+    for field_name in ("run_id", "plan_digest"):
+        if not isinstance(raw[field_name], str) or not raw[field_name]:
+            raise HarnessError(f"child result {field_name} must be a non-empty string")
+    for field_name in ("verdict", "detail"):
+        if not isinstance(result_raw[field_name], str):
+            raise HarnessError(f"child mutation result {field_name} must be a string")
+    return ChildResultRecord(
+        run_id=raw["run_id"],
+        shard_index=raw["shard_index"],
+        plan_digest=raw["plan_digest"],
+        plan_ordinal=raw["plan_ordinal"],
+        mutation_id=mutation_id,
+        result=Result(
+            identifier=mutation_id,
+            verdict=result_raw["verdict"],
+            detail=result_raw["detail"],
+            failing_proof=failing_proof,
+            warnings=list(warnings),
+        ),
+    )
+
+
+def aggregate_child_results(
+    raw_records: Iterable[Mapping[str, Any]],
+    assignments: Sequence[ShardAssignment],
+    *,
+    run_id: str,
+    plan_digest: str,
+) -> AggregatedResults:
+    """Require exactly one correctly bound result for each selected mutation."""
+
+    expected = {
+        item.identifier: (assignment.shard_index, item.selected_ordinal)
+        for assignment in assignments
+        for item in assignment.mutations
+    }
+    seen: dict[str, ChildResultRecord] = {}
+    duplicates: set[str] = set()
+    unknown: set[str] = set()
+    reasons: list[str] = []
+    for raw in raw_records:
+        try:
+            record = parse_child_result(raw)
+        except HarnessError as exc:
+            reasons.append(str(exc))
+            continue
+        if record.run_id != run_id:
+            reasons.append(
+                f"result {record.mutation_id} run_id mismatch: "
+                f"{record.run_id!r} != {run_id!r}"
+            )
+        if record.plan_digest != plan_digest:
+            reasons.append(
+                f"result {record.mutation_id} plan digest mismatch: "
+                f"{record.plan_digest!r} != {plan_digest!r}"
+            )
+        binding = expected.get(record.mutation_id)
+        if binding is None:
+            unknown.add(record.mutation_id)
+            continue
+        expected_shard, expected_ordinal = binding
+        if record.shard_index != expected_shard:
+            reasons.append(
+                f"result {record.mutation_id} came from shard {record.shard_index}, "
+                f"expected {expected_shard}"
+            )
+        if record.plan_ordinal != expected_ordinal:
+            reasons.append(
+                f"result {record.mutation_id} ordinal {record.plan_ordinal}, "
+                f"expected {expected_ordinal}"
+            )
+        if record.mutation_id in seen:
+            duplicates.add(record.mutation_id)
+        else:
+            seen[record.mutation_id] = record
+    missing = sorted(set(expected) - set(seen))
+    if unknown:
+        reasons.append(f"unknown mutation results: {sorted(unknown)}")
+    if duplicates:
+        reasons.append(f"duplicate mutation results: {sorted(duplicates)}")
+    if missing:
+        reasons.append(f"missing mutation results: {missing}")
+    ordered_ids = [
+        item.identifier for assignment in assignments for item in assignment.mutations
+    ]
+    ordered_ids.sort(key=lambda identifier: expected[identifier][1])
+    partial = [
+        seen[identifier].result for identifier in ordered_ids if identifier in seen
+    ]
+    if reasons:
+        raise AggregateRefusal(reasons, partial_results=partial, missing_ids=missing)
+    records = tuple(seen[identifier] for identifier in ordered_ids)
+    return AggregatedResults(
+        results=tuple(record.result for record in records), records=records
+    )
+
+
+def normalize_detail(
+    detail: str,
+    *,
+    shard_roots: Sequence[Path],
+    temporary_roots: Sequence[Path],
+) -> str:
+    """Normalize only named shard roots, named temporary roots, and durations."""
+
+    normalized = detail
+    replacements: list[tuple[str, str]] = []
+    for path in shard_roots:
+        replacements.append((str(path.resolve()), "<SHARD_ROOT>"))
+    for path in temporary_roots:
+        replacements.append((str(path.resolve()), "<TMP>"))
+    for original, marker in sorted(
+        replacements, key=lambda item: len(item[0]), reverse=True
+    ):
+        normalized = normalized.replace(original, marker)
+    normalized = _DURATION_RE.sub("<DURATION>", normalized)
+    absolute = _POSIX_ABSOLUTE_PATH_RE.search(normalized)
+    windows = _WINDOWS_ABSOLUTE_PATH_RE.search(normalized)
+    if absolute is not None or windows is not None:
+        match = absolute if absolute is not None else windows
+        assert match is not None
+        raise DetailNormalizationError(
+            f"unrecognised absolute path in result detail: {match.group(0)!r}"
+        )
+    return normalized
+
+
+def canonical_result_projection(
+    results: Sequence[Result | Mapping[str, Any]],
+    *,
+    shard_roots: Sequence[Path],
+    temporary_roots: Sequence[Path],
+) -> tuple[dict[str, Any], ...]:
+    """Return the normative serial/sharded differential projection."""
+
+    projected: list[dict[str, Any]] = []
+    for item in results:
+        if isinstance(item, Result):
+            identifier = item.identifier
+            verdict = item.verdict
+            detail = item.detail
+            failing_proof = item.failing_proof
+            warnings = item.warnings
+        else:
+            identifier = item["id"]
+            verdict = item["verdict"]
+            detail = item["detail"]
+            failing_proof = item["failing_proof"]
+            warnings = item["warnings"]
+        projected.append(
+            {
+                "id": identifier,
+                "verdict": verdict,
+                "detail": normalize_detail(
+                    str(detail),
+                    shard_roots=shard_roots,
+                    temporary_roots=temporary_roots,
+                ),
+                "failing_proof": failing_proof,
+                "warnings": list(warnings),
+            }
+        )
+    return tuple(projected)
+
+
+class CoordinatorLease:
+    """Root-lock owner and durable coordinator state lifecycle."""
+
+    def __init__(self, root: Path, lock: Path, state: dict[str, Any]) -> None:
+        self.root = root
+        self.lock = lock
+        self.state = state
+        self.closed = False
+
+    def persist(self) -> None:
+        _write_state(
+            self.root,
+            {"schema_version": SCHEMA_VERSION, "coordinator_run": self.state},
+        )
+
+    def transition(self, lifecycle: str) -> None:
+        self.state["lifecycle"] = lifecycle
+        self.persist()
+
+    def clear_and_release(self) -> None:
+        if self.closed:
+            return
+        _write_state(self.root, None)
+        release_lock(self.lock)
+        self.closed = True
+
+    def retain_and_release(self) -> None:
+        if self.closed:
+            return
+        release_lock(self.lock)
+        self.closed = True
+
+
+def begin_coordinator_run(
+    root: Path,
+    *,
+    run_id: str,
+    source_head: str,
+    source_manifest: Mapping[str, Any],
+    source_manifest_digest: str,
+    plan_path: Path,
+    plan_digest: str,
+    requested_shards: int,
+    effective_shards: int,
+) -> CoordinatorLease:
+    """Atomically claim the root, then write state before any staging callback."""
+
+    if _SAFE_RUN_ID.fullmatch(run_id) is None:
+        raise HarnessError(f"unsafe coordinator run id: {run_id!r}")
+    if source_manifest.get("digest") != source_manifest_digest:
+        raise HarnessError(
+            "source manifest mapping digest does not match source_manifest_digest"
+        )
+    lock = acquire_lock(root)
+    try:
+        existing = _read_state(root)
+        if existing:
+            raise HarnessError(
+                "root state exists after the coordinator acquired the lock; "
+                "recover it before staging"
+            )
+        run_dir = (_state_dir(root) / RUNS_DIRNAME / run_id).resolve()
+        state_root = _state_dir(root).resolve()
+        if not run_dir.is_relative_to(state_root):
+            raise HarnessError("coordinator run directory escapes the state root")
+        run_dir.mkdir(parents=True, exist_ok=False)
+        manifest_path = (run_dir / MANIFEST_FILENAME).resolve()
+        state: dict[str, Any] = {
+            "run_id": run_id,
+            "pid": os.getpid(),
+            "process_start_time": time.time_ns(),
+            "lifecycle": "staging",
+            "source_root": str(root.resolve()),
+            "source_head": source_head,
+            "source_manifest": json.loads(json.dumps(dict(source_manifest))),
+            "source_manifest_digest": source_manifest_digest,
+            "plan_path": str(plan_path.resolve()),
+            "plan_digest": plan_digest,
+            "requested_shards": requested_shards,
+            "effective_shards": effective_shards,
+            "manifest_path": str(manifest_path),
+            "shards": [],
+        }
+        lease = CoordinatorLease(root, lock, state)
+        lease.persist()
+        return lease
+    except BaseException:
+        release_lock(lock)
+        raise
+
+
+class EventWriter:
+    """The only writer of the root event log and its monotonic sequence."""
+
+    def __init__(
+        self,
+        path: Path,
+        run_id: str,
+        total: int,
+        progress: str,
+        stream: IO[str],
+    ) -> None:
+        self.path = path
+        self.run_id = run_id
+        self.total = total
+        self.progress = progress
+        self.stream = stream
+        self.sequence = 0
+        self.active: set[str] = set()
+        self.completed: set[str] = set()
+
+    def emit(self, event: str, **fields: Any) -> dict[str, Any]:
+        mutation_id = fields.get("mutation_id")
+        if event == "mutation_started" and isinstance(mutation_id, str):
+            self.active.add(mutation_id)
+        if event == "mutation_finished" and isinstance(mutation_id, str):
+            self.active.discard(mutation_id)
+            self.completed.add(mutation_id)
+        self.sequence += 1
+        payload = {
+            "schema_version": COORDINATOR_SCHEMA_VERSION,
+            "sequence": self.sequence,
+            "run_id": self.run_id,
+            "event": event,
+            "completed": len(self.completed),
+            "active": len(self.active),
+            "total": self.total,
+            **fields,
+        }
+        append_durable_jsonl(self.path, payload)
+        if self.progress == "jsonl":
+            self.stream.write(json.dumps(payload, sort_keys=True) + "\n")
+            self.stream.flush()
+        elif self.progress == "human":
+            subject = mutation_id or fields.get("shard_index", "")
+            self.stream.write(
+                f"[{payload['completed']}/{self.total}] {event} {subject}\n"
+            )
+            self.stream.flush()
+        return payload
+
+    def ingest_child(self, shard: ShardAssignment, raw: Mapping[str, Any]) -> None:
+        allowed = {
+            "schema_version",
+            "run_id",
+            "event",
+            "shard_index",
+            "plan_ordinal",
+            "mutation_id",
+            "phase",
+            "verdict",
+            "elapsed_ms",
+        }
+        unknown = set(raw) - allowed
+        if unknown:
+            raise HarnessError(f"unknown child event keys: {sorted(unknown)}")
+        if raw.get("schema_version") != COORDINATOR_SCHEMA_VERSION:
+            raise HarnessError("child event schema_version mismatch")
+        if raw.get("run_id") != self.run_id:
+            raise HarnessError("child event run_id mismatch")
+        if raw.get("shard_index") != shard.shard_index:
+            raise HarnessError("child event shard_index mismatch")
+        event = raw.get("event")
+        if event not in _CHILD_EVENTS:
+            raise HarnessError(f"child event is not permitted: {event!r}")
+        mutation_id = raw.get("mutation_id")
+        binding = {item.identifier: item.selected_ordinal for item in shard.mutations}
+        if mutation_id not in binding:
+            raise HarnessError(f"child event names unassigned mutation {mutation_id!r}")
+        if raw.get("plan_ordinal") != binding[mutation_id]:
+            raise HarnessError(f"child event ordinal mismatch for {mutation_id}")
+        forwarded = {
+            key: value
+            for key, value in raw.items()
+            if key
+            not in {
+                "schema_version",
+                "run_id",
+                "event",
+            }
+        }
+        self.emit(str(event), **forwarded)
+
+
+def _manifest_payload(lease: CoordinatorLease) -> dict[str, Any]:
+    state = lease.state
+    return {
+        "schema_version": COORDINATOR_SCHEMA_VERSION,
+        "run_id": state["run_id"],
+        "source_root": state["source_root"],
+        "source_head": state["source_head"],
+        "source_manifest": state["source_manifest"],
+        "source_manifest_digest": state["source_manifest_digest"],
+        "plan_path": state["plan_path"],
+        "plan_digest": state["plan_digest"],
+        "requested_shards": state["requested_shards"],
+        "effective_shards": state["effective_shards"],
+        "shards": state["shards"],
+    }
+
+
+def _write_manifest(lease: CoordinatorLease) -> None:
+    target = Path(lease.state["manifest_path"])
+    _atomic_write(
+        target,
+        (json.dumps(_manifest_payload(lease), indent=2) + "\n").encode("utf-8"),
+    )
+
+
+def _record_child(lease: CoordinatorLease, spec: ChildSpec) -> None:
+    shard = {
+        "shard_index": spec.assignment.shard_index,
+        "root": str(spec.root.resolve()),
+        "source_root": str(spec.source_root.resolve()),
+        "temporary_root": str(spec.temporary_root.resolve()),
+        "ownership_marker": str(spec.ownership_marker.resolve()),
+        "liveness_lock": str(spec.liveness_lock.resolve()),
+        "assigned_ordinals": list(spec.assignment.assigned_ordinals),
+        "lifecycle": "staged",
+        "pid": None,
+        "process_start_time": None,
+    }
+    lease.state["shards"].append(shard)
+    _write_manifest(lease)
+    lease.persist()
+
+
+def _validate_child_spec(
+    source_root: Path,
+    spec: ChildSpec,
+    prior_roots: set[Path],
+) -> None:
+    """Keep every child-owned write and liveness token inside one unique shard."""
+
+    resolved_source = source_root.resolve()
+    resolved_root = spec.root.resolve()
+    resolved_temporary = spec.temporary_root.resolve()
+    if spec.source_root.resolve() != resolved_source:
+        raise HarnessError("child spec source_root does not match the coordinator root")
+    if resolved_root == resolved_source:
+        raise HarnessError("a mutation shard cannot use the invoking source worktree")
+    if resolved_root in prior_roots:
+        raise HarnessError(
+            f"two mutation shards resolved to the same root: {resolved_root}"
+        )
+    if not resolved_root.is_relative_to(resolved_temporary):
+        raise HarnessError("child shard root escapes its recorded temporary_root")
+    for label, path in (
+        ("result_stream", spec.result_stream),
+        ("ownership_marker", spec.ownership_marker),
+        ("liveness_lock", spec.liveness_lock),
+    ):
+        if not path.resolve().is_relative_to(resolved_root):
+            raise HarnessError(f"child {label} escapes shard root {resolved_root}")
+    if not spec.argv or not all(spec.argv):
+        raise HarnessError("child argv must contain non-empty strings")
+    prior_roots.add(resolved_root)
+
+
+def _launch_child(spec: ChildSpec, run_id: str, plan_digest: str) -> ChildRuntime:
+    stderr_path = spec.root / ".mutation-harness" / "child.stderr.log"
+    stderr_path.parent.mkdir(parents=True, exist_ok=True)
+    stderr_handle = stderr_path.open("w", encoding="utf-8")
+    argv = (
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "_hold-liveness",
+        str(spec.liveness_lock),
+        "--",
+        *spec.argv,
+    )
+    environment = os.environ.copy()
+    environment.update(spec.environment)
+    environment.update(
+        {
+            "MUTATION_HARNESS_RUN_ID": run_id,
+            "MUTATION_HARNESS_SHARD_INDEX": str(spec.assignment.shard_index),
+            "MUTATION_HARNESS_PLAN_DIGEST": plan_digest,
+            "MUTATION_HARNESS_RESULT_STREAM": str(spec.result_stream),
+        }
+    )
+    try:
+        process = subprocess.Popen(  # noqa: S603 - reviewed argv, shell=False
+            list(argv),
+            cwd=spec.root,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=stderr_handle,
+            text=True,
+            bufsize=1,
+        )
+    except BaseException:
+        stderr_handle.close()
+        raise
+    if process.stdout is None:
+        process.terminate()
+        process.wait()
+        stderr_handle.close()
+        raise HarnessError("child stdout pipe was not created")
+    return ChildRuntime(spec=spec, process=process, stderr_handle=stderr_handle)
+
+
+def _parse_child_event_line(runtime: ChildRuntime, line: str) -> dict[str, Any]:
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise HarnessError(
+            f"shard {runtime.spec.assignment.shard_index} emitted invalid JSON: {exc}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise HarnessError("child event must be a JSON object")
+    return raw
+
+
+def _tail_children(
+    runtimes: Sequence[ChildRuntime], writer: EventWriter
+) -> tuple[dict[int, int], list[str]]:
+    selector = selectors.DefaultSelector()
+    by_stream: dict[IO[str], ChildRuntime] = {}
+    errors: list[str] = []
+    for runtime in runtimes:
+        assert runtime.process.stdout is not None
+        selector.register(runtime.process.stdout, selectors.EVENT_READ)
+        by_stream[runtime.process.stdout] = runtime
+    try:
+        while by_stream:
+            for key, _mask in selector.select():
+                stream = cast(IO[str], key.fileobj)
+                assert hasattr(stream, "readline")
+                line = stream.readline()
+                runtime = by_stream[stream]
+                if line == "":
+                    selector.unregister(stream)
+                    del by_stream[stream]
+                    continue
+                try:
+                    raw = _parse_child_event_line(runtime, line)
+                    writer.ingest_child(runtime.spec.assignment, raw)
+                    if raw.get("event") == "mutation_finished":
+                        mutation_id = raw.get("mutation_id")
+                        if isinstance(mutation_id, str):
+                            runtime.finished_events.add(mutation_id)
+                except HarnessError as exc:
+                    errors.append(str(exc))
+    finally:
+        selector.close()
+    exits: dict[int, int] = {}
+    for runtime in runtimes:
+        exits[runtime.spec.assignment.shard_index] = runtime.process.wait()
+        runtime.stderr_handle.close()
+        writer.emit(
+            "shard_finished",
+            shard_index=runtime.spec.assignment.shard_index,
+            phase="complete" if runtime.process.returncode == 0 else "aborted",
+        )
+    return exits, errors
+
+
+def _result_payload(result: Result) -> dict[str, Any]:
+    return {
+        "id": result.identifier,
+        "verdict": result.verdict,
+        "detail": result.detail,
+        "failing_proof": result.failing_proof,
+        "warnings": result.warnings,
+    }
+
+
+def _result_exit_policy(results: Sequence[Result], assert_all_killed: bool) -> int:
+    unmeasured_verdicts = {
+        VERDICT_BASELINE_FAILED,
+        VERDICT_INVALID,
+        VERDICT_STALE_DECLARATION,
+        VERDICT_PROOF_VACUOUS,
+        VERDICT_PROOF_SKIPPED,
+    }
+    if any(result.verdict in unmeasured_verdicts for result in results):
+        return 1
+    if assert_all_killed and any(
+        result.verdict == VERDICT_SURVIVED for result in results
+    ):
+        return 1
+    return 0
+
+
+def write_aggregate_report(
+    report_path: Path,
+    report: Mapping[str, Any],
+    *,
+    all_children_complete: bool,
+) -> None:
+    """Write the final report only after every launched child has terminated."""
+
+    if not all_children_complete:
+        raise HarnessError(
+            "refusing to write an aggregate before all children complete"
+        )
+    _atomic_write(
+        report_path,
+        (json.dumps(dict(report), indent=2) + "\n").encode("utf-8"),
+    )
+
+
+def coordinator_run(
+    root: Path,
+    plan_path: Path,
+    plan_name: str,
+    plan_mutation_ids: Sequence[str],
+    only: set[str] | None,
+    assert_all_killed: bool,
+    *,
+    requested_shards: int,
+    progress: str,
+    source_head: str,
+    source_manifest: Mapping[str, Any],
+    source_manifest_digest: str,
+    plan_digest: str,
+    source_manifest_reader: Callable[[], str],
+    child_factory: Callable[[ShardAssignment, str], ChildSpec],
+    run_id: str | None = None,
+    progress_stream: IO[str] | None = None,
+    before_report: Callable[[], None] | None = None,
+) -> CoordinatorOutcome:
+    """Run isolated children while the coordinator owns every root artifact."""
+
+    if progress not in {"human", "jsonl", "none"}:
+        raise HarnessError(f"unknown progress mode: {progress!r}")
+    assignments = select_and_assign(plan_mutation_ids, only, requested_shards)
+    effective_shards = len(assignments)
+    actual_run_id = run_id or f"run-{uuid.uuid4().hex}"
+    lease = begin_coordinator_run(
+        root,
+        run_id=actual_run_id,
+        source_head=source_head,
+        source_manifest=source_manifest,
+        source_manifest_digest=source_manifest_digest,
+        plan_path=plan_path,
+        plan_digest=plan_digest,
+        requested_shards=requested_shards,
+        effective_shards=effective_shards,
+    )
+    run_dir = Path(lease.state["manifest_path"]).parent
+    event_log = run_dir / EVENT_LOG_FILENAME
+    report_path = _state_dir(root) / REPORT_FILENAME
+    writer = EventWriter(
+        event_log,
+        actual_run_id,
+        sum(len(item.mutations) for item in assignments),
+        progress,
+        progress_stream or sys.stderr,
+    )
+    children: list[ChildSpec] = []
+    runtimes: list[ChildRuntime] = []
+    aggregate_status = AGGREGATE_COMPLETE
+    results: tuple[Result, ...] = ()
+    unmeasured: tuple[str, ...] = ()
+    measured_lost: tuple[str, ...] = ()
+    protocol_errors: list[str] = []
+    cleanup_errors: list[str] = []
+    state_retained = False
+    try:
+        _write_manifest(lease)
+        writer.emit("run_started")
+        if source_manifest_reader() != source_manifest_digest:
+            aggregate_status = AGGREGATE_SOURCE_DRIFTED
+            raise AggregateRefusal(["source manifest changed before staging"])
+        resolved_child_roots: set[Path] = set()
+        for assignment in assignments:
+            spec = child_factory(assignment, actual_run_id)
+            if spec.assignment != assignment:
+                raise HarnessError(
+                    f"child factory returned the wrong assignment for shard "
+                    f"{assignment.shard_index}"
+                )
+            _validate_child_spec(root, spec, resolved_child_roots)
+            children.append(spec)
+            _record_child(lease, spec)
+        if source_manifest_reader() != source_manifest_digest:
+            aggregate_status = AGGREGATE_SOURCE_DRIFTED
+            raise AggregateRefusal(["source manifest changed during staging"])
+        lease.transition("running")
+        for spec in children:
+            runtime = _launch_child(spec, actual_run_id, plan_digest)
+            runtimes.append(runtime)
+            state_shard = lease.state["shards"][spec.assignment.shard_index]
+            state_shard["pid"] = runtime.process.pid
+            state_shard["process_start_time"] = time.time_ns()
+            state_shard["lifecycle"] = "running"
+            lease.persist()
+            writer.emit("shard_started", shard_index=spec.assignment.shard_index)
+        exits, protocol_errors = _tail_children(runtimes, writer)
+        for spec in children:
+            state_shard = lease.state["shards"][spec.assignment.shard_index]
+            state_shard["lifecycle"] = (
+                "complete" if exits[spec.assignment.shard_index] == 0 else "aborted"
+            )
+        lease.persist()
+        raw_records = [
+            record for spec in children for record in _load_jsonl(spec.result_stream)
+        ]
+        try:
+            aggregated = aggregate_child_results(
+                raw_records,
+                assignments,
+                run_id=actual_run_id,
+                plan_digest=plan_digest,
+            )
+            results = aggregated.results
+        except AggregateRefusal as exc:
+            results = exc.partial_results
+            unmeasured = exc.missing_ids
+            protocol_errors.extend(exc.reasons)
+            aggregate_status = AGGREGATE_INVALID
+        finished_ids = {
+            identifier for runtime in runtimes for identifier in runtime.finished_events
+        }
+        measured_lost = tuple(sorted(set(unmeasured) & finished_ids))
+        unmeasured = tuple(sorted(set(unmeasured) - finished_ids))
+        if any(code != 0 for code in exits.values()):
+            aggregate_status = AGGREGATE_CHILD_FAILED
+            expected_ids = {
+                item.identifier
+                for assignment in assignments
+                for item in assignment.mutations
+            }
+            present_ids = {result.identifier for result in results}
+            measured_lost_set = set(measured_lost)
+            unmeasured = tuple(sorted(expected_ids - present_ids - measured_lost_set))
+        if protocol_errors and aggregate_status == AGGREGATE_COMPLETE:
+            aggregate_status = AGGREGATE_INVALID
+        if source_manifest_reader() != source_manifest_digest:
+            aggregate_status = AGGREGATE_SOURCE_DRIFTED
+            protocol_errors.append("source manifest changed before aggregation")
+        for spec in children:
+            if spec.cleanup is None:
+                continue
+            try:
+                spec.cleanup()
+            except Exception as exc:  # noqa: BLE001 - retain state for operator recovery
+                cleanup_errors.append(
+                    f"shard {spec.assignment.shard_index} cleanup failed: {exc}"
+                )
+        if cleanup_errors:
+            aggregate_status = AGGREGATE_CLEANUP_FAILED
+            state_retained = True
+        if before_report is not None:
+            before_report()
+        report = {
+            "schema_version": SCHEMA_VERSION,
+            "plan": plan_name,
+            "plan_path": str(plan_path),
+            "results": [_result_payload(result) for result in results],
+            "run_id": actual_run_id,
+            "mode": "sharded",
+            "aggregate_status": aggregate_status,
+            "source_head": source_head,
+            "source_manifest_digest": source_manifest_digest,
+            "plan_digest": plan_digest,
+            "requested_shards": requested_shards,
+            "effective_shards": effective_shards,
+            "shards": lease.state["shards"],
+            "event_log_path": str(event_log),
+            "unmeasured_mutation_ids": list(unmeasured),
+            "measured_lost_mutation_ids": list(measured_lost),
+            "aggregate_errors": protocol_errors + cleanup_errors,
+            "canonical_projection": {
+                "compared_verbatim": [
+                    "id",
+                    "verdict",
+                    "failing_proof",
+                    "warnings",
+                    "ordered ids",
+                ],
+                "normalized": ["detail"],
+                "excluded": list(CANONICAL_EXCLUDED_FIELDS),
+            },
+        }
+        write_aggregate_report(
+            report_path,
+            report,
+            all_children_complete=all(
+                runtime.process.poll() is not None for runtime in runtimes
+            ),
+        )
+        writer.emit("run_finished", phase=aggregate_status)
+        lease.transition(
+            "complete" if aggregate_status == AGGREGATE_COMPLETE else "aborted"
+        )
+        exit_code = _result_exit_policy(results, assert_all_killed)
+        if aggregate_status != AGGREGATE_COMPLETE:
+            exit_code = 1
+        if state_retained:
+            lease.retain_and_release()
+        else:
+            lease.clear_and_release()
+        return CoordinatorOutcome(
+            results=results,
+            exit_code=exit_code,
+            aggregate_status=aggregate_status,
+            report_path=report_path,
+            event_log_path=event_log,
+            unmeasured_ids=unmeasured,
+            measured_lost_ids=measured_lost,
+        )
+    except KeyboardInterrupt:
+        lease.transition("stopping")
+        writer.emit("run_stopping", phase="interrupted")
+        for runtime in runtimes:
+            if runtime.process.poll() is None:
+                runtime.process.terminate()
+        for runtime in runtimes:
+            runtime.process.wait()
+            runtime.stderr_handle.close()
+        lease.transition("aborted")
+        lease.retain_and_release()
+        raise
+    except BaseException:
+        lease.transition("aborted")
+        lease.retain_and_release()
+        raise
+
+
+def _hold_liveness(lock_path: Path, argv: Sequence[str]) -> int:
+    """Hold the advisory child-liveness lock for the exact child lifetime."""
+
+    if not argv:
+        raise HarnessError("the liveness wrapper needs a child argv")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        child = subprocess.Popen(list(argv))  # noqa: S603
+        previous_handlers: dict[signal.Signals, Any] = {}
+
+        def forward(signum: int, _frame: Any) -> None:
+            if child.poll() is None:
+                child.send_signal(signum)
+
+        for signal_number in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signal_number] = signal.signal(signal_number, forward)
+        try:
+            return child.wait()
+        finally:
+            for signal_number, previous in previous_handlers.items():
+                signal.signal(signal_number, previous)
+
+
+def _main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("mode")
+    parser.add_argument("lock", nargs="?")
+    parser.add_argument("child", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args(argv)
+    if arguments.mode != "_hold-liveness" or arguments.lock is None:
+        raise HarnessError("this module is an internal child-liveness wrapper")
+    child = arguments.child
+    if child and child[0] == "--":
+        child = child[1:]
+    return _hold_liveness(Path(arguments.lock), child)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(_main())
+    except HarnessError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/scripts/mutation_harness_coordinator.py
+++ b/scripts/mutation_harness_coordinator.py
@@ -549,6 +549,37 @@ def _validate_run_temporary_root(source_root: Path, temporary_root: Path) -> Pat
     return resolved_temporary
 
 
+def _cleanup_pre_authority_startup(
+    temporary_root: Path | None,
+    run_dir: Path,
+    *,
+    run_dir_created: bool,
+    manifest_written: bool,
+) -> None:
+    """Remove only empty artifacts created by this startup attempt."""
+
+    if run_dir_created:
+        manifest_path = run_dir / MANIFEST_FILENAME
+        if (
+            manifest_written
+            and manifest_path.is_file()
+            and not manifest_path.is_symlink()
+        ):
+            try:
+                manifest_path.unlink()
+            except OSError:
+                pass
+        try:
+            run_dir.rmdir()
+        except OSError:
+            pass
+    if temporary_root is not None:
+        try:
+            temporary_root.rmdir()
+        except OSError:
+            pass
+
+
 def begin_coordinator_run(
     root: Path,
     *,
@@ -571,6 +602,12 @@ def begin_coordinator_run(
             "source manifest mapping digest does not match source_manifest_digest"
         )
     lock = acquire_lock(root)
+    run_dir = (_state_dir(root) / RUNS_DIRNAME / run_id).resolve()
+    state_root = _state_dir(root).resolve()
+    temporary_root: Path | None = None
+    run_dir_created = False
+    manifest_written = False
+    authority_persisted = False
     try:
         existing = _read_state(root)
         if existing:
@@ -578,14 +615,17 @@ def begin_coordinator_run(
                 "root state exists after the coordinator acquired the lock; "
                 "recover it before staging"
             )
+        if not run_dir.is_relative_to(state_root):
+            raise HarnessError("coordinator run directory escapes the state root")
+        if run_dir.exists() or run_dir.is_symlink():
+            raise FileExistsError(
+                f"coordinator run directory already exists: {run_dir}"
+            )
         temporary_root = _validate_run_temporary_root(
             root, temporary_root_factory(run_id)
         )
-        run_dir = (_state_dir(root) / RUNS_DIRNAME / run_id).resolve()
-        state_root = _state_dir(root).resolve()
-        if not run_dir.is_relative_to(state_root):
-            raise HarnessError("coordinator run directory escapes the state root")
         run_dir.mkdir(parents=True, exist_ok=False)
+        run_dir_created = True
         manifest_path = (run_dir / MANIFEST_FILENAME).resolve()
         state: dict[str, Any] = {
             "run_id": run_id,
@@ -605,9 +645,19 @@ def begin_coordinator_run(
             "shards": [],
         }
         lease = CoordinatorLease(root, lock, state)
+        _write_manifest(lease)
+        manifest_written = True
         lease.persist()
+        authority_persisted = True
         return lease
     except BaseException:
+        if not authority_persisted:
+            _cleanup_pre_authority_startup(
+                temporary_root,
+                run_dir,
+                run_dir_created=run_dir_created,
+                manifest_written=manifest_written,
+            )
         release_lock(lock)
         raise
 

--- a/scripts/mutation_harness_execution_tree.py
+++ b/scripts/mutation_harness_execution_tree.py
@@ -111,7 +111,7 @@ def _assert_harness_state_is_ignored(root: Path) -> None:
         "check-ignore",
         "--no-index",
         "--quiet",
-        ".mutation-harness/execution-tree-probe",
+        ".mutation-harness",
         check=False,
     )
     if check.returncode == 1:
@@ -122,6 +122,10 @@ def _assert_harness_state_is_ignored(root: Path) -> None:
     if check.returncode != 0:
         detail = check.stderr.decode(errors="replace").strip()
         raise HarnessError(f"could not verify .mutation-harness exclusion: {detail}")
+
+
+def _is_harness_state_path(relative: str) -> bool:
+    return PurePosixPath(relative).parts[0] == ".mutation-harness"
 
 
 def _entry_for_path(root: Path, relative: str, *, tracked: bool) -> SourceManifestEntry:
@@ -295,12 +299,23 @@ def build_source_manifest(source_root: Path) -> SourceManifest:
     )
     index_paths = _nul_paths(_git(root, "ls-files", "-z", "--cached").stdout)
     tracked_paths = head_paths | index_paths
+    tracked_harness_state = sorted(
+        relative for relative in tracked_paths if _is_harness_state_path(relative)
+    )
+    if tracked_harness_state:
+        raise HarnessError(
+            ".mutation-harness state is tracked and cannot be staged safely: "
+            + ", ".join(tracked_harness_state)
+        )
     untracked_paths = (
         _nul_paths(
             _git(root, "ls-files", "-z", "--others", "--exclude-standard").stdout
         )
         - tracked_paths
     )
+    untracked_paths = {
+        relative for relative in untracked_paths if not _is_harness_state_path(relative)
+    }
 
     entries = tuple(
         _entry_for_path(
@@ -726,6 +741,20 @@ def cleanup_execution_tree(
     if stat.S_IMODE(private_root.stat().st_mode) != 0o700:
         raise HarnessError("execution-tree run root no longer has mode 0700")
 
+    state_directory = tree_root / ".mutation-harness"
+    try:
+        state_directory_metadata = state_directory.lstat()
+    except OSError as exc:
+        raise HarnessError(
+            f"execution-tree state directory is unreadable: {state_directory}"
+        ) from exc
+    if stat.S_ISLNK(state_directory_metadata.st_mode) or not stat.S_ISDIR(
+        state_directory_metadata.st_mode
+    ):
+        raise HarnessError(
+            f"execution-tree state directory is not a real directory: {state_directory}"
+        )
+
     canonical_marker = tree_root / OWNERSHIP_MARKER
     try:
         recorded_marker = staged.ownership_marker.resolve(strict=True)
@@ -754,10 +783,18 @@ def cleanup_execution_tree(
             f"shard {staged.shard_index} death is not proved; retaining {tree_root}"
         )
 
-    state_path = tree_root / ".mutation-harness/state.json"
-    if state_path.exists():
-        if state_path.is_symlink():
+    state_path = state_directory / "state.json"
+    try:
+        state_metadata = state_path.lstat()
+    except FileNotFoundError:
+        state_metadata = None
+    except OSError as exc:
+        raise HarnessError(f"shard state is unreadable: {state_path}") from exc
+    if state_metadata is not None:
+        if stat.S_ISLNK(state_metadata.st_mode):
             raise HarnessError(f"shard state is a symlink: {state_path}")
+        if not stat.S_ISREG(state_metadata.st_mode):
+            raise HarnessError(f"shard state is not a regular file: {state_path}")
         try:
             state = json.loads(state_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:

--- a/scripts/mutation_harness_execution_tree.py
+++ b/scripts/mutation_harness_execution_tree.py
@@ -976,6 +976,11 @@ def probe_python_toolchain_independence(*, shard_root: Path, environment: Path) 
         sentinel.unlink(missing_ok=True)
         raise HarnessError(f"Python workspace input has no interpreter: {interpreter}")
     environment_variables = os.environ.copy()
+    # The probe intentionally exercises the failure path where the copied
+    # interpreter still resolves imports from the invoking workspace.  Keep that
+    # path read-only so a failing probe cannot leave bytecode behind in the
+    # source tree and poison the cleanup manifest check.
+    environment_variables["PYTHONDONTWRITEBYTECODE"] = "1"
     environment_variables.pop("PYTHONPATH", None)
     try:
         completed = subprocess.run(

--- a/scripts/mutation_harness_execution_tree.py
+++ b/scripts/mutation_harness_execution_tree.py
@@ -20,6 +20,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Literal, cast
+from urllib.parse import unquote, urlsplit
 
 from scripts.mutation_harness import HarnessError
 
@@ -452,6 +453,126 @@ def _copy_manifest_entry(
     destination.chmod(entry.mode)
 
 
+def cleanup_partial_execution_tree(
+    source_root: Path,
+    destination: Path,
+    *,
+    temporary_root: Path,
+    run_id: str,
+    shard_index: int,
+    source_manifest: SourceManifest,
+    plan_digest: str,
+    child_liveness_proven: bool,
+) -> None:
+    """Remove a staging-only worktree after proving its narrow ownership."""
+
+    source = _assert_repository_root(source_root)
+    private_root = temporary_root.resolve(strict=True)
+    if stat.S_IMODE(private_root.stat().st_mode) != 0o700:
+        raise HarnessError("partial execution-tree run root no longer has mode 0700")
+    lexical_root = destination.absolute()
+    try:
+        root_metadata = lexical_root.lstat()
+    except OSError as exc:
+        raise HarnessError(
+            f"partial execution-tree path is unreadable: {lexical_root}"
+        ) from exc
+    if stat.S_ISLNK(root_metadata.st_mode) or not stat.S_ISDIR(root_metadata.st_mode):
+        raise HarnessError(
+            f"partial execution-tree path is not a real directory: {lexical_root}"
+        )
+    tree_root = lexical_root.resolve(strict=True)
+    if tree_root.parent != private_root:
+        raise HarnessError(
+            f"partial execution-tree cleanup path escapes its run root: {tree_root}"
+        )
+
+    state_directory = tree_root / ".mutation-harness"
+    try:
+        state_directory_metadata = state_directory.lstat()
+    except OSError as exc:
+        raise HarnessError(
+            f"partial execution-tree state directory is unreadable: {state_directory}"
+        ) from exc
+    if stat.S_ISLNK(state_directory_metadata.st_mode) or not stat.S_ISDIR(
+        state_directory_metadata.st_mode
+    ):
+        raise HarnessError(
+            "partial execution-tree state directory is not a real directory: "
+            f"{state_directory}"
+        )
+
+    marker = tree_root / OWNERSHIP_MARKER
+    try:
+        marker_metadata = marker.lstat()
+    except OSError as exc:
+        raise HarnessError(
+            f"partial execution-tree ownership marker is unreadable: {marker}"
+        ) from exc
+    if stat.S_ISLNK(marker_metadata.st_mode) or not stat.S_ISREG(
+        marker_metadata.st_mode
+    ):
+        raise HarnessError(
+            f"partial execution-tree ownership marker is not a regular file: {marker}"
+        )
+    expected_marker = _marker_document(
+        run_id=run_id,
+        shard_index=shard_index,
+        source_manifest_digest=source_manifest.digest,
+        plan_digest=plan_digest,
+    )
+    try:
+        observed_marker = json.loads(marker.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise HarnessError(
+            f"partial execution-tree ownership marker is unreadable: {marker}"
+        ) from exc
+    if observed_marker != expected_marker:
+        raise HarnessError(
+            f"partial execution-tree ownership marker does not match shard {shard_index}"
+        )
+    if not child_liveness_proven:
+        raise HarnessError(
+            f"partial shard {shard_index} death is not proved; retaining {tree_root}"
+        )
+
+    state_path = state_directory / "state.json"
+    try:
+        state_metadata = state_path.lstat()
+    except FileNotFoundError:
+        state_metadata = None
+    except OSError as exc:
+        raise HarnessError(f"partial shard state is unreadable: {state_path}") from exc
+    if state_metadata is not None:
+        if stat.S_ISLNK(state_metadata.st_mode) or not stat.S_ISREG(
+            state_metadata.st_mode
+        ):
+            raise HarnessError(
+                f"partial shard state is not a regular file: {state_path}"
+            )
+        try:
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise HarnessError(
+                f"partial shard state is unreadable: {state_path}"
+            ) from exc
+        if not isinstance(state, dict):
+            raise HarnessError(
+                f"partial shard state is not a JSON object: {state_path}"
+            )
+        if state.get("applied") is not None:
+            raise HarnessError(
+                f"partial shard {shard_index} has an applied mutation; retaining {tree_root}"
+            )
+
+    verify_source_manifest(source, source_manifest)
+    _git(source, "worktree", "remove", "--force", str(tree_root))
+    if lexical_root.exists() or lexical_root.is_symlink():
+        raise HarnessError(
+            f"partial execution tree still exists after removal: {tree_root}"
+        )
+
+
 def stage_execution_tree(
     source_root: Path,
     destination: Path,
@@ -466,41 +587,71 @@ def stage_execution_tree(
 
     source = _assert_repository_root(source_root)
     destination = destination.absolute()
-    _assert_private_parent(destination)
+    private_root = _assert_private_parent(destination)
     verify_source_manifest(source, source_manifest)
-
-    _git(source, "worktree", "add", "--detach", str(destination), source_manifest.head)
-    destination.chmod(0o700)
-    marker = _write_marker(
-        destination,
-        run_id=run_id,
-        shard_index=shard_index,
-        source_manifest_digest=source_manifest.digest,
-        plan_digest=plan_digest,
-    )
-
-    detached_head = os.fsdecode(_git(destination, "rev-parse", "HEAD").stdout).strip()
-    symbolic = _git(destination, "symbolic-ref", "-q", "HEAD", check=False)
-    if detached_head != source_manifest.head or symbolic.returncode == 0:
-        raise HarnessError(
-            f"execution tree is not detached at validated HEAD {source_manifest.head}"
+    created_by_call = False
+    try:
+        _git(
+            source,
+            "worktree",
+            "add",
+            "--detach",
+            str(destination),
+            source_manifest.head,
         )
+        created_by_call = True
+        marker = _write_marker(
+            destination,
+            run_id=run_id,
+            shard_index=shard_index,
+            source_manifest_digest=source_manifest.digest,
+            plan_digest=plan_digest,
+        )
+        destination.chmod(0o700)
 
-    for entry in source_manifest.entries:
-        _copy_manifest_entry(source, destination, entry)
+        detached_head = os.fsdecode(
+            _git(destination, "rev-parse", "HEAD").stdout
+        ).strip()
+        symbolic = _git(destination, "symbolic-ref", "-q", "HEAD", check=False)
+        if detached_head != source_manifest.head or symbolic.returncode == 0:
+            raise HarnessError(
+                f"execution tree is not detached at validated HEAD {source_manifest.head}"
+            )
 
-    if workspace_inputs:
-        _materialize_workspace_inputs(source, destination, workspace_inputs)
-    verify_source_manifest(source, source_manifest)
-    return StagedExecutionTree(
-        root=destination,
-        ownership_marker=marker,
-        shard_index=shard_index,
-        run_id=run_id,
-        source_root=source,
-        source_manifest=source_manifest,
-        plan_digest=plan_digest,
-    )
+        for entry in source_manifest.entries:
+            _copy_manifest_entry(source, destination, entry)
+
+        if workspace_inputs:
+            _materialize_workspace_inputs(source, destination, workspace_inputs)
+        verify_source_manifest(source, source_manifest)
+        return StagedExecutionTree(
+            root=destination,
+            ownership_marker=marker,
+            shard_index=shard_index,
+            run_id=run_id,
+            source_root=source,
+            source_manifest=source_manifest,
+            plan_digest=plan_digest,
+        )
+    except BaseException as staging_error:
+        if created_by_call:
+            try:
+                cleanup_partial_execution_tree(
+                    source,
+                    destination,
+                    temporary_root=private_root,
+                    run_id=run_id,
+                    shard_index=shard_index,
+                    source_manifest=source_manifest,
+                    plan_digest=plan_digest,
+                    child_liveness_proven=True,
+                )
+            except BaseException as cleanup_error:
+                raise HarnessError(
+                    f"execution-tree staging failed and owned partial cleanup "
+                    f"refused for {destination}: {cleanup_error}"
+                ) from staging_error
+        raise
 
 
 def _materialize_workspace_inputs(
@@ -609,6 +760,34 @@ def _replace_invoking_root(path: Path, invoking: bytes, shard: bytes) -> None:
     path.write_bytes(data.replace(invoking, shard))
 
 
+def _relocate_direct_url_metadata(
+    path: Path, *, source_root: Path, shard_root: Path
+) -> None:
+    """Relocate a PEP 610 editable-install file URI under the invoking root."""
+
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise HarnessError(f"editable direct_url.json is unreadable: {path}") from exc
+    if not isinstance(document, dict) or not isinstance(document.get("url"), str):
+        raise HarnessError(f"editable direct_url.json has no string URL: {path}")
+    url = cast(str, document["url"])
+    parsed = urlsplit(url)
+    if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
+        return
+    referenced = Path(unquote(parsed.path)).resolve(strict=False)
+    invoking = source_root.resolve(strict=True)
+    try:
+        relative = referenced.relative_to(invoking)
+    except ValueError:
+        return
+    document["url"] = (shard_root.resolve(strict=True) / relative).as_uri()
+    path.write_text(
+        json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+
 def relocate_python_environment(
     *, source_root: Path, shard_root: Path, environment: Path
 ) -> None:
@@ -642,6 +821,14 @@ def relocate_python_environment(
     for editable in sorted(editable_files):
         if editable.is_file() and not editable.is_symlink():
             _replace_invoking_root(editable, invoking, shard)
+
+    for direct_url in sorted(environment.rglob("direct_url.json")):
+        if direct_url.parent.name.endswith(".dist-info") and direct_url.is_file():
+            _relocate_direct_url_metadata(
+                direct_url,
+                source_root=source_root,
+                shard_root=shard_root,
+            )
 
     # Bytecode embeds source filenames and can retain the invoking environment
     # path. It is a derived cache, so remove it and let the shard interpreter

--- a/scripts/mutation_harness_execution_tree.py
+++ b/scripts/mutation_harness_execution_tree.py
@@ -704,13 +704,18 @@ def _copy_workspace_path(source: Path, destination: Path) -> None:
     metadata = source.lstat()
     if stat.S_ISLNK(metadata.st_mode):
         resolved = source.resolve(strict=True)
+        resolved_mode = resolved.stat().st_mode
+        if stat.S_ISREG(resolved_mode):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(resolved, destination, follow_symlinks=True)
+            return
+        if stat.S_ISDIR(resolved_mode):
+            _copy_workspace_path(resolved, destination)
+            return
         if not resolved.is_file():
             raise HarnessError(
-                f"workspace input link must resolve to a regular file: {source}"
+                f"workspace input link must resolve to a regular file or directory: {source}"
             )
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(resolved, destination, follow_symlinks=True)
-        return
     if stat.S_ISREG(metadata.st_mode):
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, destination, follow_symlinks=True)
@@ -729,8 +734,11 @@ def _assert_independent_copy(source: Path, destination: Path) -> None:
     destination_metadata = destination.lstat()
     if stat.S_ISLNK(destination_metadata.st_mode):
         raise HarnessError(f"workspace input copy contains a symlink: {destination}")
+    source_target = (
+        source.resolve(strict=True) if stat.S_ISLNK(source_metadata.st_mode) else source
+    )
+    source_target_metadata = source_target.stat()
     if stat.S_ISREG(destination_metadata.st_mode):
-        source_target = source.resolve(strict=True) if source.is_symlink() else source
         source_identity = (source_target.stat().st_dev, source_target.stat().st_ino)
         destination_identity = (
             destination_metadata.st_dev,
@@ -741,11 +749,11 @@ def _assert_independent_copy(source: Path, destination: Path) -> None:
         return
     if not stat.S_ISDIR(destination_metadata.st_mode):
         raise HarnessError(f"workspace input copy has unsupported type: {destination}")
-    if not stat.S_ISDIR(source_metadata.st_mode):
+    if not stat.S_ISDIR(source_target_metadata.st_mode):
         raise HarnessError(
             f"workspace input copy changed filesystem type: {destination}"
         )
-    source_children = {child.name: child for child in source.iterdir()}
+    source_children = {child.name: child for child in source_target.iterdir()}
     destination_children = {child.name: child for child in destination.iterdir()}
     if source_children.keys() != destination_children.keys():
         raise HarnessError(f"workspace input copy is incomplete: {destination}")

--- a/scripts/mutation_harness_execution_tree.py
+++ b/scripts/mutation_harness_execution_tree.py
@@ -1,0 +1,785 @@
+"""Build isolated execution trees for sharded mutation plans.
+
+This module owns only the filesystem boundary.  It snapshots the invoking
+workspace, creates a detached disposable worktree, overlays the invoking bytes,
+relocates declared workspace inputs, proves Python execution resolves inside the
+shard, and removes only a tree whose ownership and restored state are proved.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import stat
+import subprocess
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal, cast
+
+from scripts.mutation_harness import HarnessError
+
+OWNERSHIP_MARKER = ".mutation-harness/execution-tree-owner.json"
+OWNERSHIP_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class SourceManifestEntry:
+    """One path in the invoking workspace snapshot."""
+
+    path: str
+    kind: Literal["file", "symlink", "deleted"]
+    mode: int
+    digest: str | None
+    link_target: str | None
+    tracked: bool
+
+
+@dataclass(frozen=True)
+class SourceManifest:
+    """Canonical workspace identity used before and after shard execution."""
+
+    head: str
+    entries: tuple[SourceManifestEntry, ...]
+    digest: str
+
+
+@dataclass(frozen=True)
+class StagedExecutionTree:
+    """One detached, owned worktree prepared for a mutation shard."""
+
+    root: Path
+    ownership_marker: Path
+    shard_index: int
+    run_id: str
+    source_root: Path
+    source_manifest: SourceManifest
+    plan_digest: str
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _git(
+    root: Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess[bytes]:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if check and completed.returncode != 0:
+        detail = completed.stderr.decode(errors="replace").strip()
+        raise HarnessError(f"git {' '.join(args)} failed: {detail}")
+    return completed
+
+
+def _nul_paths(output: bytes) -> set[str]:
+    return {os.fsdecode(item) for item in output.split(b"\0") if item}
+
+
+def _validated_relative_path(raw: str) -> str:
+    path = PurePosixPath(raw)
+    if not raw or path.is_absolute() or ".." in path.parts or "." in path.parts:
+        raise HarnessError(f"workspace path is not repository-relative: {raw!r}")
+    if path.parts[0] == ".git":
+        raise HarnessError(f"workspace manifest must not include Git metadata: {raw}")
+    return path.as_posix()
+
+
+def _assert_repository_root(root: Path) -> Path:
+    resolved = root.resolve(strict=True)
+    top_level = Path(
+        os.fsdecode(_git(resolved, "rev-parse", "--show-toplevel").stdout).strip()
+    ).resolve(strict=True)
+    if top_level != resolved:
+        raise HarnessError(
+            f"execution-tree source must be the repository root: {resolved} != {top_level}"
+        )
+    return resolved
+
+
+def _assert_harness_state_is_ignored(root: Path) -> None:
+    check = _git(
+        root,
+        "check-ignore",
+        "--no-index",
+        "--quiet",
+        ".mutation-harness/execution-tree-probe",
+        check=False,
+    )
+    if check.returncode == 1:
+        raise HarnessError(
+            ".mutation-harness is not excluded by gitignore; staging could copy "
+            "live mutation state into a shard"
+        )
+    if check.returncode != 0:
+        detail = check.stderr.decode(errors="replace").strip()
+        raise HarnessError(f"could not verify .mutation-harness exclusion: {detail}")
+
+
+def _entry_for_path(root: Path, relative: str, *, tracked: bool) -> SourceManifestEntry:
+    target = root / relative
+    try:
+        metadata = target.lstat()
+    except FileNotFoundError:
+        if not tracked:
+            raise HarnessError(
+                f"untracked manifest path disappeared: {relative}"
+            ) from None
+        return SourceManifestEntry(relative, "deleted", 0, None, None, True)
+
+    mode = stat.S_IMODE(metadata.st_mode)
+    if stat.S_ISLNK(metadata.st_mode):
+        link_target = os.readlink(target)
+        return SourceManifestEntry(
+            relative,
+            "symlink",
+            mode,
+            _sha256(os.fsencode(link_target)),
+            link_target,
+            tracked,
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        raise HarnessError(
+            f"workspace path has unsupported filesystem type: {relative}"
+        )
+    return SourceManifestEntry(
+        relative,
+        "file",
+        mode,
+        _sha256(target.read_bytes()),
+        None,
+        tracked,
+    )
+
+
+def _manifest_digest(head: str, entries: tuple[SourceManifestEntry, ...]) -> str:
+    document = {
+        "schema_version": 1,
+        "head": head,
+        "entries": [
+            {
+                "path": entry.path,
+                "kind": entry.kind,
+                "mode": entry.mode,
+                "digest": entry.digest,
+                "link_target": entry.link_target,
+                "tracked": entry.tracked,
+            }
+            for entry in entries
+        ],
+    }
+    encoded = json.dumps(
+        document, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+    return _sha256(encoded)
+
+
+def source_manifest_to_dict(manifest: SourceManifest) -> dict[str, object]:
+    """Serialize the full recovery authority, not only its digest."""
+
+    return {
+        "schema_version": 1,
+        "head": manifest.head,
+        "entries": [
+            {
+                "path": entry.path,
+                "kind": entry.kind,
+                "mode": entry.mode,
+                "digest": entry.digest,
+                "link_target": entry.link_target,
+                "tracked": entry.tracked,
+            }
+            for entry in manifest.entries
+        ],
+        "digest": manifest.digest,
+    }
+
+
+def source_manifest_from_dict(raw: Mapping[str, object]) -> SourceManifest:
+    """Load a durable source manifest and reject a damaged recovery record."""
+
+    if raw.get("schema_version") != 1:
+        raise HarnessError("source manifest schema_version must be 1")
+    head = raw.get("head")
+    recorded_digest = raw.get("digest")
+    entries_raw = raw.get("entries")
+    if not isinstance(head, str) or not head:
+        raise HarnessError("source manifest head must be a non-empty string")
+    if not isinstance(recorded_digest, str) or not recorded_digest:
+        raise HarnessError("source manifest digest must be a non-empty string")
+    if not isinstance(entries_raw, list):
+        raise HarnessError("source manifest entries must be a list")
+
+    entries: list[SourceManifestEntry] = []
+    seen: set[str] = set()
+    for item in entries_raw:
+        if not isinstance(item, dict):
+            raise HarnessError("source manifest entry must be a JSON object")
+        path_raw = item.get("path")
+        kind_raw = item.get("kind")
+        mode_raw = item.get("mode")
+        digest_raw = item.get("digest")
+        link_target_raw = item.get("link_target")
+        tracked_raw = item.get("tracked")
+        if not isinstance(path_raw, str):
+            raise HarnessError("source manifest entry path must be a string")
+        path = _validated_relative_path(path_raw)
+        if path in seen:
+            raise HarnessError(f"source manifest repeats path: {path}")
+        seen.add(path)
+        if kind_raw not in {"file", "symlink", "deleted"}:
+            raise HarnessError(f"source manifest entry has invalid kind: {path}")
+        if (
+            not isinstance(mode_raw, int)
+            or isinstance(mode_raw, bool)
+            or mode_raw < 0
+            or mode_raw > 0o7777
+        ):
+            raise HarnessError(f"source manifest entry has invalid mode: {path}")
+        if digest_raw is not None and not isinstance(digest_raw, str):
+            raise HarnessError(f"source manifest entry has invalid digest: {path}")
+        if link_target_raw is not None and not isinstance(link_target_raw, str):
+            raise HarnessError(f"source manifest entry has invalid link target: {path}")
+        if not isinstance(tracked_raw, bool):
+            raise HarnessError(
+                f"source manifest entry has invalid tracked flag: {path}"
+            )
+        kind = cast(Literal["file", "symlink", "deleted"], kind_raw)
+        if kind == "deleted" and (
+            mode_raw != 0 or digest_raw is not None or link_target_raw is not None
+        ):
+            raise HarnessError(f"deleted source manifest entry has content: {path}")
+        if kind == "file" and (digest_raw is None or link_target_raw is not None):
+            raise HarnessError(f"file source manifest entry is incomplete: {path}")
+        if kind == "symlink" and (digest_raw is None or link_target_raw is None):
+            raise HarnessError(f"symlink source manifest entry is incomplete: {path}")
+        entries.append(
+            SourceManifestEntry(
+                path,
+                kind,
+                mode_raw,
+                digest_raw,
+                link_target_raw,
+                tracked_raw,
+            )
+        )
+    if [entry.path for entry in entries] != sorted(entry.path for entry in entries):
+        raise HarnessError("source manifest entries are not in canonical path order")
+    frozen_entries = tuple(entries)
+    observed_digest = _manifest_digest(head, frozen_entries)
+    if observed_digest != recorded_digest:
+        raise HarnessError(
+            "source manifest recovery record digest mismatch: "
+            f"expected {recorded_digest}, observed {observed_digest}"
+        )
+    return SourceManifest(head, frozen_entries, recorded_digest)
+
+
+def build_source_manifest(source_root: Path) -> SourceManifest:
+    """Hash all relevant workspace paths without writing the Git index."""
+
+    root = _assert_repository_root(source_root)
+    _assert_harness_state_is_ignored(root)
+    head = os.fsdecode(_git(root, "rev-parse", "HEAD").stdout).strip()
+
+    head_paths = _nul_paths(
+        _git(root, "ls-tree", "-r", "-z", "--name-only", head).stdout
+    )
+    index_paths = _nul_paths(_git(root, "ls-files", "-z", "--cached").stdout)
+    tracked_paths = head_paths | index_paths
+    untracked_paths = (
+        _nul_paths(
+            _git(root, "ls-files", "-z", "--others", "--exclude-standard").stdout
+        )
+        - tracked_paths
+    )
+
+    entries = tuple(
+        _entry_for_path(
+            root,
+            _validated_relative_path(relative),
+            tracked=relative in tracked_paths,
+        )
+        for relative in sorted(tracked_paths | untracked_paths)
+    )
+    return SourceManifest(head, entries, _manifest_digest(head, entries))
+
+
+def verify_source_manifest(source_root: Path, expected: SourceManifest) -> None:
+    """Fail if the invoking workspace differs from its frozen manifest."""
+
+    observed = build_source_manifest(source_root)
+    if observed != expected:
+        raise HarnessError(
+            "invoking workspace changed while execution trees were active: "
+            f"expected {expected.digest}, observed {observed.digest}"
+        )
+
+
+def create_private_temp_root(*, prefix: str = "mutation-harness-") -> Path:
+    """Create the operating-system run root with owner-only permissions."""
+
+    root = Path(tempfile.mkdtemp(prefix=prefix)).resolve()
+    root.chmod(0o700)
+    return root
+
+
+def _assert_private_parent(destination: Path) -> Path:
+    parent = destination.parent.resolve(strict=True)
+    mode = stat.S_IMODE(parent.stat().st_mode)
+    if mode != 0o700:
+        raise HarnessError(
+            f"execution-tree temporary root must have mode 0700: {parent} has {mode:04o}"
+        )
+    if destination.exists() or destination.is_symlink():
+        raise HarnessError(f"execution-tree destination already exists: {destination}")
+    return parent
+
+
+def _marker_document(
+    *,
+    run_id: str,
+    shard_index: int,
+    source_manifest_digest: str,
+    plan_digest: str,
+) -> dict[str, object]:
+    return {
+        "schema_version": OWNERSHIP_SCHEMA_VERSION,
+        "run_id": run_id,
+        "shard_index": shard_index,
+        "source_manifest_digest": source_manifest_digest,
+        "plan_digest": plan_digest,
+    }
+
+
+def _write_marker(
+    destination: Path,
+    *,
+    run_id: str,
+    shard_index: int,
+    source_manifest_digest: str,
+    plan_digest: str,
+) -> Path:
+    marker = destination / OWNERSHIP_MARKER
+    marker.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    marker.write_text(
+        json.dumps(
+            _marker_document(
+                run_id=run_id,
+                shard_index=shard_index,
+                source_manifest_digest=source_manifest_digest,
+                plan_digest=plan_digest,
+            ),
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return marker
+
+
+def _remove_existing(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _copy_manifest_entry(
+    source_root: Path, destination_root: Path, entry: SourceManifestEntry
+) -> None:
+    source = source_root / entry.path
+    destination = destination_root / entry.path
+    if entry.kind == "deleted":
+        _remove_existing(destination)
+        return
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _remove_existing(destination)
+    if entry.kind == "symlink":
+        current_target = os.readlink(source)
+        if current_target != entry.link_target:
+            raise HarnessError(f"source symlink changed during staging: {entry.path}")
+        os.symlink(current_target, destination)
+        return
+
+    data = source.read_bytes()
+    if _sha256(data) != entry.digest:
+        raise HarnessError(f"source file changed during staging: {entry.path}")
+    destination.write_bytes(data)
+    destination.chmod(entry.mode)
+
+
+def stage_execution_tree(
+    source_root: Path,
+    destination: Path,
+    *,
+    run_id: str,
+    shard_index: int,
+    source_manifest: SourceManifest,
+    plan_digest: str,
+    workspace_inputs: tuple[str, ...],
+) -> StagedExecutionTree:
+    """Create one detached worktree with the exact invoking workspace overlay."""
+
+    source = _assert_repository_root(source_root)
+    destination = destination.absolute()
+    _assert_private_parent(destination)
+    verify_source_manifest(source, source_manifest)
+
+    _git(source, "worktree", "add", "--detach", str(destination), source_manifest.head)
+    destination.chmod(0o700)
+    marker = _write_marker(
+        destination,
+        run_id=run_id,
+        shard_index=shard_index,
+        source_manifest_digest=source_manifest.digest,
+        plan_digest=plan_digest,
+    )
+
+    detached_head = os.fsdecode(_git(destination, "rev-parse", "HEAD").stdout).strip()
+    symbolic = _git(destination, "symbolic-ref", "-q", "HEAD", check=False)
+    if detached_head != source_manifest.head or symbolic.returncode == 0:
+        raise HarnessError(
+            f"execution tree is not detached at validated HEAD {source_manifest.head}"
+        )
+
+    for entry in source_manifest.entries:
+        _copy_manifest_entry(source, destination, entry)
+
+    if workspace_inputs:
+        _materialize_workspace_inputs(source, destination, workspace_inputs)
+    verify_source_manifest(source, source_manifest)
+    return StagedExecutionTree(
+        root=destination,
+        ownership_marker=marker,
+        shard_index=shard_index,
+        run_id=run_id,
+        source_root=source,
+        source_manifest=source_manifest,
+        plan_digest=plan_digest,
+    )
+
+
+def _materialize_workspace_inputs(
+    source_root: Path, destination_root: Path, workspace_inputs: tuple[str, ...]
+) -> None:
+    """Copy ignored inputs without links, relocate them, and probe Python bytes."""
+
+    for raw in workspace_inputs:
+        relative = _validated_workspace_input(source_root, raw)
+        source = source_root / relative
+        destination = destination_root / relative
+        if not source.exists() and not source.is_symlink():
+            raise HarnessError(f"workspace input does not exist: {relative}")
+        _copy_workspace_path(source, destination)
+        _assert_independent_copy(source, destination)
+        if destination.is_dir() and (destination / "pyvenv.cfg").is_file():
+            relocate_python_environment(
+                source_root=source_root,
+                shard_root=destination_root,
+                environment=destination,
+            )
+            probe_python_toolchain_independence(
+                shard_root=destination_root,
+                environment=destination,
+            )
+
+
+def _validated_workspace_input(source_root: Path, raw: str) -> str:
+    relative = _validated_relative_path(raw)
+    first = PurePosixPath(relative).parts[0]
+    if first in {".git", ".mutation-harness"}:
+        raise HarnessError(f"workspace input is forbidden: {raw}")
+    ignored = _git(
+        source_root,
+        "check-ignore",
+        "--no-index",
+        "--quiet",
+        relative,
+        check=False,
+    )
+    if ignored.returncode == 1:
+        raise HarnessError(f"workspace input must be ignored by Git: {relative}")
+    if ignored.returncode != 0:
+        detail = ignored.stderr.decode(errors="replace").strip()
+        raise HarnessError(f"could not validate workspace input {relative}: {detail}")
+    return relative
+
+
+def _copy_workspace_path(source: Path, destination: Path) -> None:
+    metadata = source.lstat()
+    if stat.S_ISLNK(metadata.st_mode):
+        resolved = source.resolve(strict=True)
+        if not resolved.is_file():
+            raise HarnessError(
+                f"workspace input link must resolve to a regular file: {source}"
+            )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(resolved, destination, follow_symlinks=True)
+        return
+    if stat.S_ISREG(metadata.st_mode):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination, follow_symlinks=True)
+        return
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise HarnessError(f"workspace input has unsupported type: {source}")
+
+    destination.mkdir(parents=True)
+    shutil.copystat(source, destination, follow_symlinks=True)
+    for child in sorted(source.iterdir(), key=lambda path: path.name):
+        _copy_workspace_path(child, destination / child.name)
+
+
+def _assert_independent_copy(source: Path, destination: Path) -> None:
+    source_metadata = source.lstat()
+    destination_metadata = destination.lstat()
+    if stat.S_ISLNK(destination_metadata.st_mode):
+        raise HarnessError(f"workspace input copy contains a symlink: {destination}")
+    if stat.S_ISREG(destination_metadata.st_mode):
+        source_target = source.resolve(strict=True) if source.is_symlink() else source
+        source_identity = (source_target.stat().st_dev, source_target.stat().st_ino)
+        destination_identity = (
+            destination_metadata.st_dev,
+            destination_metadata.st_ino,
+        )
+        if source_identity == destination_identity:
+            raise HarnessError(f"workspace input copy is hard-linked: {destination}")
+        return
+    if not stat.S_ISDIR(destination_metadata.st_mode):
+        raise HarnessError(f"workspace input copy has unsupported type: {destination}")
+    if not stat.S_ISDIR(source_metadata.st_mode):
+        raise HarnessError(
+            f"workspace input copy changed filesystem type: {destination}"
+        )
+    source_children = {child.name: child for child in source.iterdir()}
+    destination_children = {child.name: child for child in destination.iterdir()}
+    if source_children.keys() != destination_children.keys():
+        raise HarnessError(f"workspace input copy is incomplete: {destination}")
+    for name, source_child in source_children.items():
+        _assert_independent_copy(source_child, destination_children[name])
+
+
+def _replace_invoking_root(path: Path, invoking: bytes, shard: bytes) -> None:
+    data = path.read_bytes()
+    if invoking not in data:
+        return
+    path.write_bytes(data.replace(invoking, shard))
+
+
+def relocate_python_environment(
+    *, source_root: Path, shard_root: Path, environment: Path
+) -> None:
+    """Rewrite install-time paths in a copied Python environment."""
+
+    invoking = os.fsencode(str(source_root.resolve(strict=True)))
+    shard = os.fsencode(str(shard_root.resolve(strict=True)))
+    pyvenv = environment / "pyvenv.cfg"
+    if not pyvenv.is_file():
+        raise HarnessError(f"Python workspace input has no pyvenv.cfg: {environment}")
+    _replace_invoking_root(pyvenv, invoking, shard)
+
+    bin_dir = environment / "bin"
+    if not bin_dir.is_dir():
+        raise HarnessError(
+            f"Python workspace input has no bin directory: {environment}"
+        )
+    for launcher in sorted(bin_dir.iterdir(), key=lambda path: path.name):
+        if not launcher.is_file() or launcher.is_symlink():
+            continue
+        # Console-script shebangs and activation scripts both record the
+        # environment's installation path. Replacing the invoking root covers
+        # both forms and leaves system-rooted launchers unchanged.
+        _replace_invoking_root(launcher, invoking, shard)
+
+    editable_files = {
+        *environment.rglob("__editable__*.pth"),
+        *environment.rglob("__editable__*.py"),
+        *environment.rglob("__editable__*_finder.py"),
+    }
+    for editable in sorted(editable_files):
+        if editable.is_file() and not editable.is_symlink():
+            _replace_invoking_root(editable, invoking, shard)
+
+    # Bytecode embeds source filenames and can retain the invoking environment
+    # path. It is a derived cache, so remove it and let the shard interpreter
+    # regenerate it with shard-rooted filenames when needed.
+    for bytecode in sorted(environment.rglob("*.pyc")):
+        bytecode.unlink()
+    for cache_directory in sorted(
+        environment.rglob("__pycache__"), key=lambda path: len(path.parts), reverse=True
+    ):
+        if cache_directory.is_dir():
+            cache_directory.rmdir()
+
+    residue: list[str] = []
+    for path in sorted(environment.rglob("*")):
+        if path.is_symlink():
+            residue.append(f"{path}: symlink")
+            continue
+        if path.is_file() and invoking in path.read_bytes():
+            residue.append(f"{path}: invoking-root bytes")
+    if residue:
+        joined = "\n".join(residue[:20])
+        raise HarnessError(
+            "Python workspace input still resolves to the invoking root after "
+            f"relocation:\n{joined}"
+        )
+
+
+def _probe_package(shard_root: Path) -> tuple[Path, str]:
+    source = shard_root / "src"
+    candidates = sorted(
+        path.parent for path in source.rglob("__init__.py") if path.parent.is_dir()
+    )
+    if not candidates:
+        raise HarnessError(
+            "toolchain-independence probe requires an importable package under src"
+        )
+    package = candidates[0]
+    relative = package.relative_to(source)
+    return package, ".".join(relative.parts)
+
+
+def probe_python_toolchain_independence(*, shard_root: Path, environment: Path) -> None:
+    """Observe the copied interpreter importing bytes that exist only in the shard."""
+
+    package, package_name = _probe_package(shard_root)
+    token = secrets.token_hex(16)
+    module_name = f"_mutation_harness_probe_{token}"
+    sentinel = package / f"{module_name}.py"
+    sentinel.write_text(f"VALUE = {token!r}\n", encoding="utf-8")
+    interpreter = environment / "bin" / "python"
+    if not interpreter.is_file():
+        sentinel.unlink(missing_ok=True)
+        raise HarnessError(f"Python workspace input has no interpreter: {interpreter}")
+    environment_variables = os.environ.copy()
+    environment_variables.pop("PYTHONPATH", None)
+    try:
+        completed = subprocess.run(
+            [
+                str(interpreter),
+                "-c",
+                (
+                    f"from {package_name} import {module_name} as probe; "
+                    f"print(probe.VALUE, end='')"
+                ),
+            ],
+            cwd=shard_root,
+            check=False,
+            capture_output=True,
+            env=environment_variables,
+            text=True,
+        )
+    finally:
+        sentinel.unlink(missing_ok=True)
+    if completed.returncode != 0 or completed.stdout != token:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise HarnessError(
+            "toolchain-independence probe did not read shard-only bytes: "
+            f"{detail or 'no sentinel value returned'}"
+        )
+
+
+def _read_marker(staged: StagedExecutionTree) -> dict[str, object]:
+    try:
+        raw = json.loads(staged.ownership_marker.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        raise HarnessError(
+            f"execution-tree ownership marker is unreadable: {staged.ownership_marker}"
+        ) from exc
+    if not isinstance(raw, dict):
+        raise HarnessError("execution-tree ownership marker is not a JSON object")
+    return raw
+
+
+def cleanup_execution_tree(
+    staged: StagedExecutionTree,
+    *,
+    temporary_root: Path,
+    child_liveness_proven: bool,
+) -> None:
+    """Remove a disposable tree only after every cleanup guard is proved."""
+
+    private_root = temporary_root.resolve(strict=True)
+    tree_root = staged.root.resolve(strict=True)
+    try:
+        tree_root.relative_to(private_root)
+    except ValueError as exc:
+        raise HarnessError(
+            f"execution-tree cleanup path escapes the run root: {tree_root}"
+        ) from exc
+    if tree_root == private_root:
+        raise HarnessError("execution-tree cleanup path is the whole run root")
+    if stat.S_IMODE(private_root.stat().st_mode) != 0o700:
+        raise HarnessError("execution-tree run root no longer has mode 0700")
+
+    canonical_marker = tree_root / OWNERSHIP_MARKER
+    try:
+        recorded_marker = staged.ownership_marker.resolve(strict=True)
+    except OSError as exc:
+        raise HarnessError(
+            f"execution-tree ownership marker is unreadable: {staged.ownership_marker}"
+        ) from exc
+    if recorded_marker != canonical_marker or canonical_marker.is_symlink():
+        raise HarnessError(
+            f"execution-tree ownership marker is outside the owned shard: "
+            f"{staged.ownership_marker}"
+        )
+
+    expected_marker = _marker_document(
+        run_id=staged.run_id,
+        shard_index=staged.shard_index,
+        source_manifest_digest=staged.source_manifest.digest,
+        plan_digest=staged.plan_digest,
+    )
+    if _read_marker(staged) != expected_marker:
+        raise HarnessError(
+            f"execution-tree ownership marker does not match shard {staged.shard_index}"
+        )
+    if not child_liveness_proven:
+        raise HarnessError(
+            f"shard {staged.shard_index} death is not proved; retaining {tree_root}"
+        )
+
+    state_path = tree_root / ".mutation-harness/state.json"
+    if state_path.exists():
+        if state_path.is_symlink():
+            raise HarnessError(f"shard state is a symlink: {state_path}")
+        try:
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise HarnessError(f"shard state is unreadable: {state_path}") from exc
+        if not isinstance(state, dict):
+            raise HarnessError(f"shard state is not a JSON object: {state_path}")
+        if state.get("applied") is not None:
+            raise HarnessError(
+                f"shard {staged.shard_index} has an applied mutation; retaining {tree_root}"
+            )
+
+    observed = build_source_manifest(tree_root)
+    if observed != staged.source_manifest:
+        raise HarnessError(
+            f"shard {staged.shard_index} source is not restored: expected "
+            f"{staged.source_manifest.digest}, observed {observed.digest}"
+        )
+    verify_source_manifest(staged.source_root, staged.source_manifest)
+    _git(
+        staged.source_root,
+        "worktree",
+        "remove",
+        "--force",
+        str(tree_root),
+    )

--- a/scripts/mutation_harness_execution_tree.py
+++ b/scripts/mutation_harness_execution_tree.py
@@ -665,8 +665,31 @@ def _materialize_workspace_inputs(
         destination = destination_root / relative
         if not source.exists() and not source.is_symlink():
             raise HarnessError(f"workspace input does not exist: {relative}")
-        _copy_workspace_path(source, destination)
-        _assert_independent_copy(source, destination)
+        try:
+            resolved_source = source.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise HarnessError(
+                f"workspace input cannot be resolved: {relative}"
+            ) from exc
+        try:
+            resolved_source.relative_to(source_root.resolve(strict=True))
+        except ValueError:
+            raise HarnessError(
+                f"workspace input resolves outside repository: {relative}"
+            ) from None
+        directory_root = (
+            resolved_source if resolved_source.is_dir() else resolved_source.parent
+        )
+        _copy_workspace_path(
+            source,
+            destination,
+            directory_root=directory_root,
+        )
+        _assert_independent_copy(
+            source,
+            destination,
+            directory_root=directory_root,
+        )
         if destination.is_dir() and (destination / "pyvenv.cfg").is_file():
             relocate_python_environment(
                 source_root=source_root,
@@ -700,46 +723,98 @@ def _validated_workspace_input(source_root: Path, raw: str) -> str:
     return relative
 
 
-def _copy_workspace_path(source: Path, destination: Path) -> None:
+def _workspace_source_target(
+    source: Path, *, directory_root: Path
+) -> tuple[Path, os.stat_result]:
+    """Resolve one source path and contain directory links to the input root."""
+
     metadata = source.lstat()
     if stat.S_ISLNK(metadata.st_mode):
-        resolved = source.resolve(strict=True)
-        resolved_mode = resolved.stat().st_mode
-        if stat.S_ISREG(resolved_mode):
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(resolved, destination, follow_symlinks=True)
-            return
-        if stat.S_ISDIR(resolved_mode):
-            _copy_workspace_path(resolved, destination)
-            return
-        if not resolved.is_file():
+        try:
+            resolved = source.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
             raise HarnessError(
-                f"workspace input link must resolve to a regular file or directory: {source}"
-            )
-    if stat.S_ISREG(metadata.st_mode):
+                f"workspace input link cannot be resolved: {source}"
+            ) from exc
+        resolved_metadata = resolved.stat()
+        if stat.S_ISDIR(resolved_metadata.st_mode):
+            try:
+                resolved.relative_to(directory_root)
+            except ValueError:
+                raise HarnessError(
+                    f"workspace input directory link escapes workspace input: {source}"
+                ) from None
+        return resolved, resolved_metadata
+    return source, metadata
+
+
+def _enter_workspace_directory(
+    source: Path,
+    metadata: os.stat_result,
+    active_directories: frozenset[tuple[int, int]],
+) -> frozenset[tuple[int, int]]:
+    identity = (metadata.st_dev, metadata.st_ino)
+    if identity in active_directories:
+        raise HarnessError(f"workspace input directory link cycle: {source}")
+    return active_directories | {identity}
+
+
+def _copy_workspace_path(
+    source: Path,
+    destination: Path,
+    *,
+    directory_root: Path,
+    active_directories: frozenset[tuple[int, int]] = frozenset(),
+) -> None:
+    source_target, target_metadata = _workspace_source_target(
+        source,
+        directory_root=directory_root,
+    )
+    if stat.S_ISREG(target_metadata.st_mode):
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, destination, follow_symlinks=True)
+        if source_target == source:
+            shutil.copy2(source, destination, follow_symlinks=True)
+        else:
+            shutil.copy2(source_target, destination, follow_symlinks=True)
         return
-    if not stat.S_ISDIR(metadata.st_mode):
+    if not stat.S_ISDIR(target_metadata.st_mode):
         raise HarnessError(f"workspace input has unsupported type: {source}")
 
+    active = _enter_workspace_directory(
+        source_target,
+        target_metadata,
+        active_directories,
+    )
     destination.mkdir(parents=True)
-    shutil.copystat(source, destination, follow_symlinks=True)
-    for child in sorted(source.iterdir(), key=lambda path: path.name):
-        _copy_workspace_path(child, destination / child.name)
+    shutil.copystat(source_target, destination, follow_symlinks=True)
+    for child in sorted(source_target.iterdir(), key=lambda path: path.name):
+        _copy_workspace_path(
+            child,
+            destination / child.name,
+            directory_root=directory_root,
+            active_directories=active,
+        )
 
 
-def _assert_independent_copy(source: Path, destination: Path) -> None:
-    source_metadata = source.lstat()
+def _assert_independent_copy(
+    source: Path,
+    destination: Path,
+    *,
+    directory_root: Path,
+    active_directories: frozenset[tuple[int, int]] = frozenset(),
+) -> None:
+    source_target, source_target_metadata = _workspace_source_target(
+        source,
+        directory_root=directory_root,
+    )
     destination_metadata = destination.lstat()
     if stat.S_ISLNK(destination_metadata.st_mode):
         raise HarnessError(f"workspace input copy contains a symlink: {destination}")
-    source_target = (
-        source.resolve(strict=True) if stat.S_ISLNK(source_metadata.st_mode) else source
-    )
-    source_target_metadata = source_target.stat()
     if stat.S_ISREG(destination_metadata.st_mode):
-        source_identity = (source_target.stat().st_dev, source_target.stat().st_ino)
+        source_identity = (
+            source_target_metadata.st_dev,
+            source_target_metadata.st_ino,
+        )
         destination_identity = (
             destination_metadata.st_dev,
             destination_metadata.st_ino,
@@ -753,12 +828,22 @@ def _assert_independent_copy(source: Path, destination: Path) -> None:
         raise HarnessError(
             f"workspace input copy changed filesystem type: {destination}"
         )
+    active = _enter_workspace_directory(
+        source_target,
+        source_target_metadata,
+        active_directories,
+    )
     source_children = {child.name: child for child in source_target.iterdir()}
     destination_children = {child.name: child for child in destination.iterdir()}
     if source_children.keys() != destination_children.keys():
         raise HarnessError(f"workspace input copy is incomplete: {destination}")
     for name, source_child in source_children.items():
-        _assert_independent_copy(source_child, destination_children[name])
+        _assert_independent_copy(
+            source_child,
+            destination_children[name],
+            directory_root=directory_root,
+            active_directories=active,
+        )
 
 
 def _replace_invoking_root(path: Path, invoking: bytes, shard: bytes) -> None:

--- a/scripts/mutation_harness_execution_tree.py
+++ b/scripts/mutation_harness_execution_tree.py
@@ -25,6 +25,13 @@ from scripts.mutation_harness import HarnessError
 
 OWNERSHIP_MARKER = ".mutation-harness/execution-tree-owner.json"
 OWNERSHIP_SCHEMA_VERSION = 1
+HARNESS_IGNORE_PROBES = (
+    ".mutation-harness/state.json",
+    ".mutation-harness/snapshots/execution-tree-probe",
+    ".mutation-harness/lock/pid",
+    ".mutation-harness/runs/execution-tree-probe/manifest.json",
+    OWNERSHIP_MARKER,
+)
 
 
 @dataclass(frozen=True)
@@ -106,22 +113,30 @@ def _assert_repository_root(root: Path) -> Path:
 
 
 def _assert_harness_state_is_ignored(root: Path) -> None:
-    check = _git(
-        root,
-        "check-ignore",
-        "--no-index",
-        "--quiet",
-        ".mutation-harness",
-        check=False,
-    )
-    if check.returncode == 1:
+    missing_probes: list[str] = []
+    for probe in HARNESS_IGNORE_PROBES:
+        check = _git(
+            root,
+            "check-ignore",
+            "--no-index",
+            "--quiet",
+            probe,
+            check=False,
+        )
+        if check.returncode == 1:
+            missing_probes.append(probe)
+            continue
+        if check.returncode != 0:
+            detail = check.stderr.decode(errors="replace").strip()
+            raise HarnessError(
+                f"could not verify .mutation-harness exclusion for {probe}: {detail}"
+            )
+    if missing_probes:
         raise HarnessError(
             ".mutation-harness is not excluded by gitignore; staging could copy "
-            "live mutation state into a shard"
+            "live mutation state into a shard. Unignored probes: "
+            + ", ".join(missing_probes)
         )
-    if check.returncode != 0:
-        detail = check.stderr.decode(errors="replace").strip()
-        raise HarnessError(f"could not verify .mutation-harness exclusion: {detail}")
 
 
 def _is_harness_state_path(relative: str) -> bool:

--- a/scripts/mutation_harness_optin.py
+++ b/scripts/mutation_harness_optin.py
@@ -1,0 +1,407 @@
+"""Fail-closed plan validation for mutation-harness sharding.
+
+The serial harness accepts version-1 plans. Parallel execution adds a reviewed
+resource and toolchain contract, so it validates the complete plan vocabulary
+before any execution tree is staged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "name",
+        "build",
+        "mutations",
+        "sharding",
+        "$build_note",
+        "$comment",
+        "$determination",
+        "$limitation",
+        "$where_mutations_die",
+    }
+)
+MUTATION_KEYS = frozenset(
+    {
+        "id",
+        "file",
+        "find",
+        "replace",
+        "proof",
+        "rationale",
+        "build",
+        "expect_occurrences",
+        "allow_comment_anchor",
+        "expected_survivor_reason",
+        "$note",
+        "observed_kill",
+    }
+)
+SHARDING_KEYS = frozenset(
+    {
+        "max_shards",
+        "workspace_inputs",
+        "external_resources",
+        "shared_mutable_resource_exclusions",
+    }
+)
+EXTERNAL_RESOURCE_POLICIES = frozenset({"none", "isolated", "shared-readonly"})
+GO_CACHE_EXCLUSIONS = ("go-build-cache", "go-module-cache")
+
+_BARE_PYTHON_RE = re.compile(
+    r"(?:^|[;&|()\s])(?:python(?:3(?:\.\d+)*)?|pytest|uv)(?=\s|$)"
+)
+_PWD_PYTHON_RE = re.compile(r"\$PWD/[^\s'\"]*/bin/python(?:3(?:\.\d+)*)?")
+_PWD_CONSOLE_SCRIPT_RE = re.compile(r"\$PWD/[^\s'\"]*/bin/(?:pytest|uv)(?=\s|$)")
+_SHARD_IMPORT_RE = re.compile(
+    r"(?:^|\s)PYTHONPATH\s*=\s*(?:['\"])?\$PWD(?:/[^\s'\"]*)?"
+)
+_SHELL_GO_TEST_RE = re.compile(r"(?:^|[;&|()\s])go\s+test(?:\s|$)")
+_SHELL_COUNT_ONE_RE = re.compile(r"(?:^|\s)-count(?:=|\s+)1(?:\s|$)")
+_SHELL_RUN_RE = re.compile(
+    r"(?:^|\s)-run(?:=|\s+)(?P<pattern>'[^']*'|\"[^\"]*\"|[^\s;&|]+)"
+)
+_SAFE_ENV_COMPONENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+
+
+class PlanContractError(RuntimeError):
+    """A plan cannot safely opt in to sharded execution."""
+
+
+@dataclass(frozen=True)
+class ShardingPlan:
+    """The reviewed, additive sharding contract for a version-1 plan."""
+
+    max_shards: int
+    workspace_inputs: tuple[str, ...]
+    external_resources: str
+    shared_mutable_resource_exclusions: tuple[str, ...]
+
+
+def _refuse_unknown_keys(
+    path: Path, raw: dict[str, Any], allowed: frozenset[str], context: str
+) -> None:
+    unknown = sorted(set(raw).difference(allowed))
+    if unknown:
+        rendered = ", ".join(repr(key) for key in unknown)
+        raise PlanContractError(f"{path}: unknown {context} key(s): {rendered}")
+
+
+def _safe_workspace_input(value: object) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise PlanContractError(
+            "sharding.workspace_inputs entries must be non-empty repo-relative "
+            "POSIX paths"
+        )
+    if os.path.isabs(value):
+        raise PlanContractError(
+            f"sharding.workspace_inputs must be repo-relative, got {value!r}"
+        )
+    candidate = PurePosixPath(value)
+    if candidate in {
+        PurePosixPath("."),
+        PurePosixPath(".git"),
+        PurePosixPath(".mutation-harness"),
+    }:
+        raise PlanContractError(
+            f"sharding.workspace_inputs may not name {candidate.as_posix()!r}"
+        )
+    if ".." in candidate.parts or candidate.parts[0] in {".git", ".mutation-harness"}:
+        raise PlanContractError(f"sharding.workspace_inputs path is unsafe: {value!r}")
+    return candidate.as_posix()
+
+
+def _validated_argv(value: object, context: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise PlanContractError(f"{context} must be a non-empty argv array")
+    if not all(isinstance(word, str) and word for word in value):
+        raise PlanContractError(f"{context} argv entries must be non-empty strings")
+    return tuple(value)
+
+
+def _command_text(argv: tuple[str, ...]) -> str:
+    if len(argv) >= 3 and argv[0] in {"bash", "sh"} and argv[1] in {"-c", "-lc"}:
+        return argv[2]
+    return " ".join(argv)
+
+
+def _entry_point(argv: tuple[str, ...]) -> str:
+    if argv[0] != "env":
+        return argv[0]
+    for word in argv[1:]:
+        if word.startswith("-") or "=" in word:
+            continue
+        return word
+    return ""
+
+
+def _validate_python_resolution(identifier: str, argv: tuple[str, ...]) -> None:
+    text = _command_text(argv)
+    direct = _entry_point(argv)
+    is_shell_wrapper = (
+        len(argv) >= 3
+        and direct in {"bash", "sh"}
+        and argv[1]
+        in {
+            "-c",
+            "-lc",
+        }
+    )
+    path_resolved = bool(re.fullmatch(r"python(?:3(?:\.\d+)*)?|pytest|uv", direct))
+    path_resolved = path_resolved or (
+        is_shell_wrapper and bool(_BARE_PYTHON_RE.search(text))
+    )
+    if path_resolved:
+        raise PlanContractError(
+            f"{identifier}: sharding refuses a PATH-resolved Python entry point; "
+            "use a $PWD-anchored interpreter"
+        )
+
+    if (
+        _PWD_CONSOLE_SCRIPT_RE.search(text)
+        or direct.startswith("$PWD/")
+        and direct.endswith(("/pytest", "/uv"))
+    ):
+        raise PlanContractError(
+            f"{identifier}: a $PWD-anchored Python console script retains an "
+            "absolute shebang; use $PWD/.venv/bin/python -m <tool>"
+        )
+
+    reaches_python = bool(_PWD_PYTHON_RE.search(text)) or (
+        direct.startswith("$PWD/") and "/bin/python" in direct
+    )
+    has_shard_import = bool(_SHARD_IMPORT_RE.search(text)) or any(
+        word.startswith("PYTHONPATH=$PWD/") for word in argv
+    )
+    if reaches_python and not has_shard_import:
+        raise PlanContractError(
+            f"{identifier}: Python proof lacks a shard-rooted import path such "
+            'as PYTHONPATH="$PWD/src"'
+        )
+
+
+def _direct_flag(argv: tuple[str, ...], name: str) -> str | None:
+    for index, word in enumerate(argv):
+        prefix = f"{name}="
+        if word.startswith(prefix):
+            return word[len(prefix) :]
+        if word == name and index + 1 < len(argv):
+            return argv[index + 1]
+    return None
+
+
+def _validate_go_test_freshness(identifier: str, argv: tuple[str, ...]) -> bool:
+    """Validate a named ``go test`` proof and report whether it uses Go."""
+
+    if len(argv) >= 2 and argv[0] == "go" and argv[1] == "test":
+        pattern = _direct_flag(argv, "-run")
+        if pattern is None or pattern == "^$":
+            return True
+        if _direct_flag(argv, "-count") != "1":
+            raise PlanContractError(
+                f"{identifier}: named go test proof {pattern!r} must declare -count=1"
+            )
+        return True
+
+    text = _command_text(argv)
+    if not _SHELL_GO_TEST_RE.search(text):
+        return False
+    run_match = _SHELL_RUN_RE.search(text)
+    if run_match is None:
+        return True
+    pattern = run_match.group("pattern").strip("'\"")
+    if pattern != "^$" and not _SHELL_COUNT_ONE_RE.search(text):
+        raise PlanContractError(
+            f"{identifier}: named go test proof {pattern!r} must declare -count=1"
+        )
+    return True
+
+
+def _validate_mutation_commands(raw: dict[str, Any]) -> bool:
+    entries = raw.get("mutations")
+    if not isinstance(entries, list) or not entries:
+        raise PlanContractError("plan must declare a non-empty mutations array")
+    uses_go = False
+    plan_build = raw.get("build")
+    if plan_build is not None:
+        argv = _validated_argv(plan_build, "plan.build")
+        _validate_python_resolution("plan.build", argv)
+        uses_go = (len(argv) >= 2 and argv[0] == "go" and argv[1] == "test") or bool(
+            _SHELL_GO_TEST_RE.search(_command_text(argv))
+        )
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise PlanContractError(f"mutation {index} must be an object")
+        identifier = str(entry.get("id") or f"mutation {index}")
+        proof = entry.get("proof")
+        if not isinstance(proof, list) or not proof:
+            raise PlanContractError(f"{identifier}: proof must be a non-empty array")
+        mutation_build = entry.get("build")
+        if mutation_build is not None:
+            build_argv = _validated_argv(mutation_build, f"{identifier}.build")
+            _validate_python_resolution(f"{identifier}.build", build_argv)
+            uses_go = (
+                uses_go
+                or (
+                    len(build_argv) >= 2
+                    and build_argv[0] == "go"
+                    and build_argv[1] == "test"
+                )
+                or bool(_SHELL_GO_TEST_RE.search(_command_text(build_argv)))
+            )
+        for proof_index, value in enumerate(proof):
+            argv = _validated_argv(value, f"{identifier}.proof[{proof_index}]")
+            _validate_python_resolution(identifier, argv)
+            uses_go = _validate_go_test_freshness(identifier, argv) or uses_go
+    return uses_go
+
+
+def _load_sharding_plan(
+    path: Path, raw: dict[str, Any], *, uses_go: bool
+) -> ShardingPlan | None:
+    value = raw.get("sharding")
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise PlanContractError(f"{path}: sharding must be an object")
+    _refuse_unknown_keys(path, value, SHARDING_KEYS, "sharding")
+
+    max_shards = value.get("max_shards")
+    if (
+        not isinstance(max_shards, int)
+        or isinstance(max_shards, bool)
+        or max_shards < 1
+    ):
+        raise PlanContractError("sharding.max_shards must be an integer at least 1")
+
+    workspace_raw = value.get("workspace_inputs", [])
+    if not isinstance(workspace_raw, list):
+        raise PlanContractError("sharding.workspace_inputs must be an array")
+    workspace_inputs = tuple(_safe_workspace_input(item) for item in workspace_raw)
+    if len(workspace_inputs) != len(set(workspace_inputs)):
+        raise PlanContractError("sharding.workspace_inputs contains a duplicate path")
+
+    external_resources = value.get("external_resources")
+    if external_resources not in EXTERNAL_RESOURCE_POLICIES:
+        allowed = "|".join(sorted(EXTERNAL_RESOURCE_POLICIES))
+        raise PlanContractError(
+            f"sharding.external_resources must be exactly one of {allowed}"
+        )
+
+    exclusions_raw = value.get("shared_mutable_resource_exclusions", [])
+    if not isinstance(exclusions_raw, list) or not all(
+        isinstance(item, str) and item for item in exclusions_raw
+    ):
+        raise PlanContractError(
+            "sharding.shared_mutable_resource_exclusions must be an array of names"
+        )
+    exclusions = tuple(exclusions_raw)
+    unknown_exclusions = sorted(set(exclusions).difference(GO_CACHE_EXCLUSIONS))
+    if unknown_exclusions:
+        raise PlanContractError(
+            "unknown shared mutable resource exclusion(s): "
+            + ", ".join(unknown_exclusions)
+        )
+    if len(exclusions) != len(set(exclusions)):
+        raise PlanContractError("shared mutable resource exclusions contain duplicates")
+    if (
+        uses_go
+        and external_resources == "none"
+        and set(exclusions) != set(GO_CACHE_EXCLUSIONS)
+    ):
+        raise PlanContractError(
+            "Go plans declaring external_resources 'none' must explicitly name "
+            "the go-build-cache and go-module-cache exclusions"
+        )
+
+    return ShardingPlan(
+        max_shards=max_shards,
+        workspace_inputs=workspace_inputs,
+        external_resources=external_resources,
+        shared_mutable_resource_exclusions=exclusions,
+    )
+
+
+def load_plan_contract(path: Path) -> tuple[dict[str, Any], ShardingPlan | None]:
+    """Load the closed version-1 plan vocabulary and optional shard opt-in."""
+
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PlanContractError(f"could not read plan {path}: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise PlanContractError(f"{path} must be a JSON object")
+    _refuse_unknown_keys(path, loaded, TOP_LEVEL_KEYS, "top-level")
+    if loaded.get("schema_version") != SCHEMA_VERSION:
+        raise PlanContractError(
+            f"{path}: schema_version must be {SCHEMA_VERSION}, got "
+            f"{loaded.get('schema_version')!r}"
+        )
+    entries = loaded.get("mutations")
+    if not isinstance(entries, list) or not entries:
+        raise PlanContractError(f"{path}: mutations must be a non-empty array")
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise PlanContractError(f"{path}: mutation {index} must be an object")
+        _refuse_unknown_keys(path, entry, MUTATION_KEYS, f"mutation {index}")
+
+    # Toolchain gates apply only to an actual opt-in. Existing serial plans stay
+    # compatible, but cannot be made parallel by adding only max_shards.
+    if "sharding" not in loaded:
+        return loaded, None
+    uses_go = _validate_mutation_commands(loaded)
+    return loaded, _load_sharding_plan(path, loaded, uses_go=uses_go)
+
+
+def validate_requested_shards(
+    contract: ShardingPlan | None, requested_shards: int
+) -> None:
+    """Refuse invalid, non-opted, or over-limit parallel requests."""
+
+    if (
+        not isinstance(requested_shards, int)
+        or isinstance(requested_shards, bool)
+        or requested_shards < 1
+    ):
+        raise PlanContractError("requested shards must be an integer at least 1")
+    if requested_shards == 1:
+        return
+    if contract is None:
+        raise PlanContractError(
+            "the plan does not opt in to sharding; add a reviewed sharding object"
+        )
+    if requested_shards > contract.max_shards:
+        raise PlanContractError(
+            f"requested {requested_shards} shards exceeds declared max_shards "
+            f"{contract.max_shards}"
+        )
+
+
+def external_resource_environment(
+    contract: ShardingPlan, run_id: str, shard_index: int
+) -> dict[str, str]:
+    """Return the required namespace for an isolated external-resource plan."""
+
+    if contract.external_resources != "isolated":
+        return {}
+    if not _SAFE_ENV_COMPONENT.fullmatch(run_id):
+        raise PlanContractError(f"run id {run_id!r} is not safe for an environment")
+    if (
+        not isinstance(shard_index, int)
+        or isinstance(shard_index, bool)
+        or shard_index < 0
+    ):
+        raise PlanContractError("shard index must be a non-negative integer")
+    return {
+        "MUTATION_HARNESS_RUN_ID": run_id,
+        "MUTATION_HARNESS_SHARD_INDEX": str(shard_index),
+    }

--- a/scripts/mutation_harness_optin.py
+++ b/scripts/mutation_harness_optin.py
@@ -66,7 +66,9 @@ _SHARD_IMPORT_RE = re.compile(
     r"(?:^|\s)PYTHONPATH\s*=\s*(?:['\"])?\$PWD(?:/[^\s'\"]*)?"
 )
 _SHELL_GO_TEST_RE = re.compile(r"(?:^|[;&|()\s])go\s+test(?:\s|$)")
-_SHELL_COUNT_ONE_RE = re.compile(r"(?:^|\s)-count(?:=|\s+)1(?:\s|$)")
+_SHELL_COUNT_RE = re.compile(
+    r"(?:^|\s)-count(?:=(?P<equals>[^\s;&|]+)|\s+(?P<spaced>[^\s;&|]+))"
+)
 _SHELL_RUN_RE = re.compile(
     r"(?:^|\s)-run(?:=|\s+)(?P<pattern>'[^']*'|\"[^\"]*\"|[^\s;&|]+)"
 )
@@ -199,6 +201,35 @@ def _direct_flag(argv: tuple[str, ...], name: str) -> str | None:
     return None
 
 
+def _direct_flag_values(argv: tuple[str, ...], name: str) -> list[str]:
+    values: list[str] = []
+    for index, word in enumerate(argv):
+        prefix = f"{name}="
+        if word.startswith(prefix):
+            values.append(word[len(prefix) :])
+        elif word == name:
+            values.append(argv[index + 1] if index + 1 < len(argv) else "")
+    return values
+
+
+def _shell_count_values(text: str) -> list[str]:
+    values: list[str] = []
+    for match in _SHELL_COUNT_RE.finditer(text):
+        value = match.group("equals") or match.group("spaced") or ""
+        values.append(value.strip("'\""))
+    return values
+
+
+def _require_single_count_one(
+    identifier: str, pattern: str, count_values: list[str]
+) -> None:
+    if count_values != ["1"]:
+        raise PlanContractError(
+            f"{identifier}: named go test proof {pattern!r} must declare exactly "
+            "one unambiguous -count=1"
+        )
+
+
 def _validate_go_test_freshness(identifier: str, argv: tuple[str, ...]) -> bool:
     """Validate a named ``go test`` proof and report whether it uses Go."""
 
@@ -206,10 +237,9 @@ def _validate_go_test_freshness(identifier: str, argv: tuple[str, ...]) -> bool:
         pattern = _direct_flag(argv, "-run")
         if pattern is None or pattern == "^$":
             return True
-        if _direct_flag(argv, "-count") != "1":
-            raise PlanContractError(
-                f"{identifier}: named go test proof {pattern!r} must declare -count=1"
-            )
+        _require_single_count_one(
+            identifier, pattern, _direct_flag_values(argv, "-count")
+        )
         return True
 
     text = _command_text(argv)
@@ -219,10 +249,8 @@ def _validate_go_test_freshness(identifier: str, argv: tuple[str, ...]) -> bool:
     if run_match is None:
         return True
     pattern = run_match.group("pattern").strip("'\"")
-    if pattern != "^$" and not _SHELL_COUNT_ONE_RE.search(text):
-        raise PlanContractError(
-            f"{identifier}: named go test proof {pattern!r} must declare -count=1"
-        )
+    if pattern != "^$":
+        _require_single_count_one(identifier, pattern, _shell_count_values(text))
     return True
 
 

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -52,6 +52,61 @@ def _trusted_root_state_directory(root: Path) -> Path:
     return directory
 
 
+def _trusted_authority_directory(path: Path, label: str) -> None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError as exc:
+        raise RecoveryError(f"{label} {path} does not exist") from exc
+    except OSError as exc:
+        raise RecoveryError(f"{label} {path} could not be inspected: {exc}") from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise RecoveryError(f"{label} {path} is a symlink; refusing recovery")
+    if not stat.S_ISDIR(info.st_mode):
+        raise RecoveryError(f"{label} {path} is not a directory; refusing recovery")
+
+
+def _trusted_authority_file(path: Path, label: str) -> None:
+    try:
+        info = path.lstat()
+    except FileNotFoundError as exc:
+        raise RecoveryError(f"{label} {path} does not exist") from exc
+    except OSError as exc:
+        raise RecoveryError(f"{label} {path} could not be inspected: {exc}") from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise RecoveryError(f"{label} {path} is a symlink; refusing recovery")
+    if not stat.S_ISREG(info.st_mode):
+        raise RecoveryError(f"{label} {path} is not a regular file; refusing recovery")
+
+
+def _trusted_recovery_authority_file(root: Path, path: Path) -> None:
+    """Validate every lexical authority component without resolving links."""
+
+    state_directory = _trusted_root_state_directory(root)
+    if not path.is_absolute() or ".." in path.parts:
+        raise RecoveryError(f"recovery authority path is not lexical-safe: {path}")
+    try:
+        relative = path.relative_to(state_directory)
+    except ValueError as exc:
+        raise RecoveryError(
+            f"recovery authority path {path} escapes {state_directory}"
+        ) from exc
+    if relative.parts == (STATE_FILENAME,):
+        _trusted_authority_file(path, "root state file")
+        return
+    if (
+        len(relative.parts) == 3
+        and relative.parts[0] == RUNS_DIRNAME
+        and relative.parts[2] == MANIFEST_FILENAME
+    ):
+        runs_directory = state_directory / RUNS_DIRNAME
+        run_directory = runs_directory / relative.parts[1]
+        _trusted_authority_directory(runs_directory, "runs directory")
+        _trusted_authority_directory(run_directory, "run directory")
+        _trusted_authority_file(path, "run manifest")
+        return
+    raise RecoveryError(f"unrecognized recovery authority path: {path}")
+
+
 @dataclass(frozen=True)
 class ShardRecord:
     """One shard path and its recovery evidence from the run manifest."""
@@ -164,7 +219,7 @@ def _read_json(path: Path, label: str) -> dict[str, Any]:
 def _read_root_recovery_json(root: Path, path: Path, label: str) -> dict[str, Any]:
     """Recheck the root state parent immediately before each recovery read."""
 
-    _trusted_root_state_directory(root)
+    _trusted_recovery_authority_file(root, path)
     return _read_json(path, label)
 
 
@@ -202,7 +257,7 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
 def _write_root_recovery_json(root: Path, path: Path, payload: dict[str, Any]) -> None:
     """Recheck the root state parent immediately before each recovery write."""
 
-    _trusted_root_state_directory(root)
+    _trusted_recovery_authority_file(root, path)
     _atomic_write_json(path, payload)
 
 
@@ -230,13 +285,15 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
             f"root state records run_id {recorded_run_id!r}, not {run_id!r}"
         )
 
-    expected_manifest = (
-        state_directory / RUNS_DIRNAME / run_id / MANIFEST_FILENAME
-    ).resolve()
+    expected_manifest = state_directory / RUNS_DIRNAME / run_id / MANIFEST_FILENAME
     manifest_value = coordinator.get("manifest_path")
     if not isinstance(manifest_value, str) or not manifest_value:
         raise RecoveryError("coordinator run has no manifest path")
-    manifest_path = Path(manifest_value).resolve()
+    manifest_path = Path(manifest_value)
+    if not manifest_path.is_absolute() or ".." in manifest_path.parts:
+        raise RecoveryError(
+            f"manifest path {manifest_path} is not an absolute lexical path"
+        )
     if manifest_path != expected_manifest:
         raise RecoveryError(
             f"manifest path {manifest_path} is outside the recorded run boundary "

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -1,0 +1,561 @@
+"""Bounded recovery for interrupted mutation-harness coordinator runs."""
+
+from __future__ import annotations
+
+import fcntl
+import importlib
+import json
+import os
+import re
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+STATE_DIRNAME = ".mutation-harness"
+STATE_FILENAME = "state.json"
+RUNS_DIRNAME = "runs"
+MANIFEST_FILENAME = "manifest.json"
+SCHEMA_VERSION = 1
+_SAFE_RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+
+RestoreMutation = Callable[[Path], str]
+CleanupOwnedTree = Callable[[Path, Path, int], None]
+
+
+class RecoveryError(RuntimeError):
+    """Recovery could not prove that an intended action was safe."""
+
+
+@dataclass(frozen=True)
+class ShardRecord:
+    """One shard path and its recovery evidence from the run manifest."""
+
+    shard_index: int
+    root: Path
+    temporary_root: Path
+    ownership_marker: Path
+    liveness_lock: Path
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    """Validated coordinator and manifest state for one interrupted run."""
+
+    run_id: str
+    manifest_path: Path
+    source_root: Path
+    source_manifest: dict[str, Any]
+    source_manifest_digest: str
+    plan_digest: str
+    diagnostic_pid: int | None
+    shards: tuple[ShardRecord, ...]
+
+
+@dataclass(frozen=True)
+class RecoveryPreflight:
+    """The exact manifest-bounded actions and unknown evidence."""
+
+    remove: tuple[Path, ...]
+    leave: tuple[Path, ...]
+    unknown: tuple[str, ...]
+
+    def render(self, run_id: str) -> str:
+        lines = [f"FORCE RECOVERY PREFLIGHT {run_id}", "REMOVE:"]
+        lines.extend(f"  {path}" for path in self.remove)
+        lines.append("LEAVE:")
+        lines.extend(f"  {path}" for path in self.leave)
+        lines.append("UNKNOWN:")
+        lines.extend(f"  {item}" for item in self.unknown)
+        return "\n".join(lines) + "\n"
+
+
+@contextmanager
+def hold_liveness_lock(path: Path) -> Iterator[None]:
+    """Hold a process-lifetime advisory lock for one shard child."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _acquire_liveness_lease(path: Path) -> int | None:
+    """Hold the shard lock through cleanup, or return None for a live child."""
+
+    if path.is_symlink():
+        raise RecoveryError(f"liveness lock {path} is a symlink")
+    try:
+        descriptor = os.open(path, os.O_RDWR | os.O_CLOEXEC)
+    except OSError as exc:
+        raise RecoveryError(f"liveness lock {path} could not be opened: {exc}") from exc
+    try:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            os.close(descriptor)
+            return None
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _diagnostic_pid_exists(pid: int | None) -> bool:
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _recovery_blocked(*, liveness_lock_held: bool, diagnostic_pid_exists: bool) -> bool:
+    """Decide liveness from the advisory lock; PID status is diagnostic only."""
+
+    _ = diagnostic_pid_exists
+    return liveness_lock_held
+
+
+def _read_json(path: Path, label: str) -> dict[str, Any]:
+    if path.is_symlink():
+        raise RecoveryError(f"{label} {path} is a symlink")
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RecoveryError(f"{label} {path} could not be read: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise RecoveryError(f"{label} {path} must be a JSON object")
+    return loaded
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise RecoveryError(f"state path {path} is a symlink")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+    descriptor = -1
+    temporary: Path | None = None
+    for attempt in range(128):
+        candidate = path.with_name(f".{path.name}.recovery-{os.getpid()}-{attempt}")
+        try:
+            descriptor = os.open(candidate, flags, 0o600)
+        except FileExistsError:
+            continue
+        temporary = candidate
+        break
+    if temporary is None:
+        raise RecoveryError(f"could not allocate an atomic state file beside {path}")
+    try:
+        data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            descriptor = -1
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.replace(path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def _contained_path(path: Path, root: Path, label: str) -> Path:
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    if resolved == root_resolved or not resolved.is_relative_to(root_resolved):
+        raise RecoveryError(f"{label} {path} escapes shard root {root}")
+    return resolved
+
+
+def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord]:
+    if not _SAFE_RUN_ID.fullmatch(run_id):
+        raise RecoveryError(f"run id {run_id!r} is not a plain name")
+    root = root.resolve()
+    state_path = root / STATE_DIRNAME / STATE_FILENAME
+    state = _read_json(state_path, "root state")
+    coordinator = state.get("coordinator_run")
+    if not isinstance(coordinator, dict):
+        raise RecoveryError(f"root state does not record coordinator run {run_id}")
+    recorded_run_id = coordinator.get("run_id")
+    if recorded_run_id != run_id:
+        raise RecoveryError(
+            f"root state records run_id {recorded_run_id!r}, not {run_id!r}"
+        )
+
+    expected_manifest = (
+        root / STATE_DIRNAME / RUNS_DIRNAME / run_id / MANIFEST_FILENAME
+    ).resolve()
+    manifest_value = coordinator.get("manifest_path")
+    if not isinstance(manifest_value, str) or not manifest_value:
+        raise RecoveryError("coordinator run has no manifest path")
+    manifest_path = Path(manifest_value).resolve()
+    if manifest_path != expected_manifest:
+        raise RecoveryError(
+            f"manifest path {manifest_path} is outside the recorded run boundary "
+            f"{expected_manifest}"
+        )
+    manifest = _read_json(manifest_path, "run manifest")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise RecoveryError(
+            f"run manifest schema_version must be {SCHEMA_VERSION}, got "
+            f"{manifest.get('schema_version')!r}"
+        )
+    if manifest.get("run_id") != run_id:
+        raise RecoveryError(
+            f"run manifest records run_id {manifest.get('run_id')!r}, not {run_id!r}"
+        )
+
+    source_digest = manifest.get("source_manifest_digest")
+    plan_digest = manifest.get("plan_digest")
+    if not isinstance(source_digest, str) or not source_digest:
+        raise RecoveryError("run manifest has no source_manifest_digest")
+    if not isinstance(plan_digest, str) or not plan_digest:
+        raise RecoveryError("run manifest has no plan_digest")
+    if coordinator.get("source_manifest_digest") != source_digest:
+        raise RecoveryError("coordinator and manifest source digests differ")
+    if coordinator.get("plan_digest") != plan_digest:
+        raise RecoveryError("coordinator and manifest plan digests differ")
+    source_root_value = manifest.get("source_root")
+    source_manifest = manifest.get("source_manifest")
+    if not isinstance(source_root_value, str) or not source_root_value:
+        raise RecoveryError("run manifest has no source_root")
+    source_root = Path(source_root_value).resolve()
+    if source_root != root:
+        raise RecoveryError(
+            f"run manifest source_root {source_root} does not match recovery root {root}"
+        )
+    if not isinstance(source_manifest, dict):
+        raise RecoveryError("run manifest has no recovery-loadable source_manifest")
+    if source_manifest.get("digest") != source_digest:
+        raise RecoveryError(
+            "serialized source manifest digest does not match run metadata"
+        )
+
+    raw_shards = manifest.get("shards")
+    if not isinstance(raw_shards, list) or not raw_shards:
+        raise RecoveryError("run manifest must record at least one shard")
+    shards: list[ShardRecord] = []
+    seen_indexes: set[int] = set()
+    seen_roots: set[Path] = set()
+    for position, raw in enumerate(raw_shards):
+        if not isinstance(raw, dict):
+            raise RecoveryError(f"run manifest shard {position} must be an object")
+        index = raw.get("shard_index")
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+            raise RecoveryError(
+                f"run manifest shard {position} has invalid shard_index"
+            )
+        if index in seen_indexes:
+            raise RecoveryError(f"run manifest repeats shard_index {index}")
+        seen_indexes.add(index)
+        root_value = raw.get("root")
+        shard_source_root_value = raw.get("source_root")
+        temporary_root_value = raw.get("temporary_root")
+        marker_value = raw.get("ownership_marker")
+        lock_value = raw.get("liveness_lock")
+        if not isinstance(root_value, str) or not root_value:
+            raise RecoveryError(f"run manifest shard {index} has incomplete paths")
+        if not isinstance(shard_source_root_value, str) or not shard_source_root_value:
+            raise RecoveryError(f"run manifest shard {index} has incomplete paths")
+        if Path(shard_source_root_value).resolve() != source_root:
+            raise RecoveryError(
+                f"run manifest shard {index} source_root differs from the run root"
+            )
+        if not isinstance(temporary_root_value, str) or not temporary_root_value:
+            raise RecoveryError(f"run manifest shard {index} has incomplete paths")
+        if not isinstance(marker_value, str) or not marker_value:
+            raise RecoveryError(f"run manifest shard {index} has incomplete paths")
+        if not isinstance(lock_value, str) or not lock_value:
+            raise RecoveryError(f"run manifest shard {index} has incomplete paths")
+        shard_root = Path(root_value).resolve()
+        temporary_root = Path(temporary_root_value).resolve()
+        if temporary_root in {
+            Path("/").resolve(),
+            root,
+            (root / STATE_DIRNAME).resolve(),
+        }:
+            raise RecoveryError(
+                f"run manifest shard {index} names unsafe temporary_root "
+                f"{temporary_root}"
+            )
+        if shard_root in {Path("/").resolve(), root, (root / STATE_DIRNAME).resolve()}:
+            raise RecoveryError(
+                f"run manifest shard {index} names unsafe root {shard_root}"
+            )
+        if shard_root in seen_roots:
+            raise RecoveryError(f"run manifest repeats shard root {shard_root}")
+        if shard_root == temporary_root or not shard_root.is_relative_to(
+            temporary_root
+        ):
+            raise RecoveryError(
+                f"run manifest shard {index} root {shard_root} escapes temporary_root "
+                f"{temporary_root}"
+            )
+        seen_roots.add(shard_root)
+        marker = _contained_path(Path(marker_value), shard_root, "ownership marker")
+        lock = _contained_path(Path(lock_value), shard_root, "liveness lock")
+        shards.append(
+            ShardRecord(
+                shard_index=index,
+                root=shard_root,
+                temporary_root=temporary_root,
+                ownership_marker=marker,
+                liveness_lock=lock,
+            )
+        )
+    return state, RunRecord(
+        run_id=run_id,
+        manifest_path=manifest_path,
+        source_root=source_root,
+        source_manifest=source_manifest,
+        source_manifest_digest=source_digest,
+        plan_digest=plan_digest,
+        diagnostic_pid=(
+            coordinator.get("pid") if isinstance(coordinator.get("pid"), int) else None
+        ),
+        shards=tuple(shards),
+    )
+
+
+def _marker_error(record: RunRecord, shard: ShardRecord) -> str | None:
+    try:
+        marker = _read_json(shard.ownership_marker, "ownership marker")
+    except RecoveryError as exc:
+        return str(exc)
+    expected: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": record.run_id,
+        "shard_index": shard.shard_index,
+        "source_manifest_digest": record.source_manifest_digest,
+        "plan_digest": record.plan_digest,
+    }
+    for key, value in expected.items():
+        if marker.get(key) != value:
+            return (
+                f"{shard.ownership_marker}: ownership marker {key} is "
+                f"{marker.get(key)!r}, expected {value!r}"
+            )
+    return None
+
+
+def _build_preflight(record: RunRecord) -> tuple[RecoveryPreflight, tuple[int, ...]]:
+    remove: list[Path] = []
+    leave: list[Path] = []
+    unknown: list[str] = []
+    leases: list[int] = []
+    for shard in record.shards:
+        marker_error = _marker_error(record, shard)
+        if marker_error is not None:
+            leave.append(shard.root)
+            unknown.append(marker_error)
+            continue
+        try:
+            lease = _acquire_liveness_lease(shard.liveness_lock)
+        except RecoveryError as exc:
+            leave.append(shard.root)
+            unknown.append(str(exc))
+            continue
+        if _recovery_blocked(
+            liveness_lock_held=lease is None,
+            diagnostic_pid_exists=_diagnostic_pid_exists(record.diagnostic_pid),
+        ):
+            leave.append(shard.root)
+            unknown.append(f"{shard.liveness_lock}: liveness lock is held")
+            continue
+        if lease is None:
+            raise RecoveryError("liveness decision and acquired lease disagree")
+        leases.append(lease)
+        remove.append(shard.root)
+    return (
+        RecoveryPreflight(
+            remove=tuple(remove), leave=tuple(leave), unknown=tuple(unknown)
+        ),
+        tuple(leases),
+    )
+
+
+def _shard_has_applied_state(root: Path) -> bool:
+    state_path = root / STATE_DIRNAME / STATE_FILENAME
+    if state_path.is_symlink():
+        raise RecoveryError(f"shard state {state_path} is a symlink")
+    try:
+        state = _read_json(state_path, "shard state")
+    except RecoveryError as exc:
+        if not state_path.exists():
+            return False
+        raise exc
+    applied = state.get("applied")
+    if applied is None:
+        return False
+    if not isinstance(applied, dict):
+        raise RecoveryError(f"shard state {state_path} has an invalid applied record")
+    return True
+
+
+def _default_restore(root: Path) -> str:
+    from scripts.mutation_harness import restore
+
+    return restore(root)
+
+
+def _default_cleanup_for(record: RunRecord) -> CleanupOwnedTree:
+    try:
+        module = importlib.import_module("scripts.mutation_harness_execution_tree")
+    except ImportError as exc:
+        raise RecoveryError(
+            "execution-tree cleanup backend is unavailable; retain the owned shard"
+        ) from exc
+    cleanup = getattr(module, "cleanup_execution_tree", None)
+    manifest_from_dict = getattr(module, "source_manifest_from_dict", None)
+    staged_type = getattr(module, "StagedExecutionTree", None)
+    if not callable(cleanup) or not callable(manifest_from_dict) or staged_type is None:
+        raise RecoveryError(
+            "execution-tree cleanup backend has no recovery-safe cleanup entry point"
+        )
+
+    try:
+        source_manifest = manifest_from_dict(record.source_manifest)
+    except Exception as exc:
+        raise RecoveryError(f"serialized source manifest is invalid: {exc}") from exc
+
+    def cleanup_one(root: Path, marker: Path, shard_index: int) -> None:
+        staged = staged_type(
+            root=root,
+            ownership_marker=marker,
+            shard_index=shard_index,
+            run_id=record.run_id,
+            source_root=record.source_root,
+            source_manifest=source_manifest,
+            plan_digest=record.plan_digest,
+        )
+        cleanup(
+            staged,
+            temporary_root=next(
+                shard.temporary_root
+                for shard in record.shards
+                if shard.root == root and shard.shard_index == shard_index
+            ),
+            child_liveness_proven=True,
+        )
+
+    return cleanup_one
+
+
+def _recover_one(
+    shard: ShardRecord,
+    *,
+    restore_mutation: RestoreMutation,
+    cleanup_owned_tree: CleanupOwnedTree,
+) -> None:
+    if _shard_has_applied_state(shard.root):
+        try:
+            restore_mutation(shard.root)
+        except Exception as exc:
+            raise RecoveryError(
+                f"{shard.root}: applied mutation restore failed: {exc}"
+            ) from exc
+        if _shard_has_applied_state(shard.root):
+            raise RecoveryError(
+                f"{shard.root}: restore returned but applied state remains"
+            )
+    try:
+        cleanup_owned_tree(shard.root, shard.ownership_marker, shard.shard_index)
+    except Exception as exc:
+        raise RecoveryError(f"{shard.root}: verified cleanup failed: {exc}") from exc
+    if shard.root.exists():
+        raise RecoveryError(
+            f"{shard.root}: cleanup returned but the owned shard still exists"
+        )
+
+
+def recover_run(
+    root: Path,
+    run_id: str,
+    *,
+    force: bool = False,
+    restore_mutation: RestoreMutation | None = None,
+    cleanup_owned_tree: CleanupOwnedTree | None = None,
+    output: TextIO | None = None,
+) -> str:
+    """Recover only manifest-owned shards, then clear root state last.
+
+    Recorded PID and process start time are diagnostics. They never decide
+    liveness. A held advisory shard lock is the sole live-child refusal.
+    """
+
+    import sys
+
+    root = root.resolve()
+    state_path = root / STATE_DIRNAME / STATE_FILENAME
+    state, record = _load_run_record(root, run_id)
+    preflight, liveness_leases = _build_preflight(record)
+    try:
+        if force:
+            stream = output or sys.stdout
+            stream.write(preflight.render(run_id))
+            stream.flush()
+        elif preflight.unknown:
+            raise RecoveryError(preflight.unknown[0])
+
+        coordinator = state["coordinator_run"]
+        if not isinstance(coordinator, dict):
+            raise RecoveryError("coordinator state changed during recovery")
+        coordinator["lifecycle"] = "recovering"
+        _atomic_write_json(state_path, state)
+
+        restore_callback = restore_mutation or _default_restore
+        cleanup_callback = cleanup_owned_tree or _default_cleanup_for(record)
+        removable = set(preflight.remove)
+        failures: list[str] = []
+        removed = 0
+        for shard in record.shards:
+            if shard.root not in removable:
+                continue
+            try:
+                _recover_one(
+                    shard,
+                    restore_mutation=restore_callback,
+                    cleanup_owned_tree=cleanup_callback,
+                )
+            except RecoveryError as exc:
+                failures.append(str(exc))
+                if not force:
+                    break
+            else:
+                removed += 1
+
+        retained = len(record.shards) - removed
+        if retained or failures or preflight.unknown:
+            coordinator["lifecycle"] = "recovering"
+            coordinator["recovery_unknown"] = [*preflight.unknown, *failures]
+            _atomic_write_json(state_path, state)
+            detail = failures[0] if failures else preflight.unknown[0]
+            raise RecoveryError(
+                f"recovery retained {retained} shard(s); root state remains: {detail}"
+            )
+
+        # The durable run record is updated before the root gate is cleared. The
+        # coordinator state remains present during every restore and cleanup call.
+        manifest = _read_json(record.manifest_path, "run manifest")
+        manifest["lifecycle"] = "aborted"
+        _atomic_write_json(record.manifest_path, manifest)
+        coordinator["lifecycle"] = "aborted"
+        _atomic_write_json(state_path, state)
+
+        # Clear the root coordinator record last. Preserve unrelated root state.
+        state.pop("coordinator_run", None)
+        _atomic_write_json(state_path, state)
+        return f"recovered run {run_id} as aborted; removed {removed} owned shard(s)"
+    finally:
+        for descriptor in liveness_leases:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -1457,6 +1457,11 @@ def _recover_partial_staging(
     import sys
 
     partials = _partial_staging_shards(record)
+    if partials and cleanup_owned_tree is None:
+        raise RecoveryError(
+            "default recovery refuses an existing staged Git tree; "
+            "private tree and root state remain"
+        )
     temporary_root = record.staging_temporary_root
     if temporary_root is None:
         raise RecoveryError("partial recovery has no temporary_root")
@@ -1479,11 +1484,6 @@ def _recover_partial_staging(
     _write_root_recovery_json(root, state_path, state)
 
     cleanup_callback = cleanup_owned_tree
-    if partials and cleanup_callback is None:
-        raise RecoveryError(
-            "default recovery refuses an existing staged Git tree; "
-            "private tree and root state remain"
-        )
     failures: list[str] = []
     removed = 0
     for partial in partials:

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -347,7 +347,7 @@ def _private_temporary_root(value: object, source_root: Path) -> Path:
 
 
 def _private_temporary_root_path(value: object, source_root: Path) -> Path:
-    """Validate an existing or absent private-root path without following it."""
+    """Validate the lexical private-root authority before resolving descendants."""
 
     if not isinstance(value, str) or not value:
         raise RecoveryError("run manifest has no durable temporary_root authority")
@@ -364,13 +364,34 @@ def _private_temporary_root_path(value: object, source_root: Path) -> Path:
         raise RecoveryError(
             f"temporary_root {path} is outside the private run boundary"
         )
-    if path.is_relative_to(source_root) or source_root.is_relative_to(path):
-        raise RecoveryError(f"temporary_root {path} overlaps source_root {source_root}")
-
     current = temporary_base
     for component in path.relative_to(temporary_base).parts[:-1]:
         current /= component
         _trusted_authority_directory(current, "temporary-root parent")
+
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        if path.is_relative_to(source_root) or source_root.is_relative_to(path):
+            raise RecoveryError(
+                f"temporary_root {path} overlaps source_root {source_root}"
+            )
+        return path
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {path} could not be inspected: {exc}"
+        ) from exc
+    if not stat.S_ISDIR(info.st_mode):
+        kind = "a symlink" if stat.S_ISLNK(info.st_mode) else "not a directory"
+        raise RecoveryError(f"temporary_root {path} is {kind}; refusing recovery")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {path} could not be resolved: {exc}"
+        ) from exc
+    if resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved):
+        raise RecoveryError(f"temporary_root {path} overlaps source_root {source_root}")
     return path
 
 
@@ -387,6 +408,16 @@ def _missing_private_temporary_root(value: object, source_root: Path) -> Path | 
             f"temporary_root {path} could not be inspected: {exc}"
         ) from exc
     return None
+
+
+def _require_existing_private_temporary_root(record: RunRecord) -> None:
+    """Recheck the root authority before using preflight paths for cleanup."""
+
+    value = str(record.temporary_root) if record.temporary_root is not None else None
+    if _missing_private_temporary_root(value, record.source_root) is not None:
+        raise RecoveryError(
+            f"temporary_root {value} disappeared during recovery; root state remains"
+        )
 
 
 def _shard_authority(raw_shards: object, label: str) -> list[dict[str, object]]:
@@ -481,9 +512,9 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
     manifest_temporary_root = manifest.get("temporary_root")
     if coordinator.get("temporary_root") != manifest_temporary_root:
         raise RecoveryError("coordinator and manifest temporary_root values differ")
-    temporary_root: Path | None = None
+    recorded_temporary_root: Path | None = None
     if raw_shards:
-        temporary_root = _private_temporary_root_path(
+        recorded_temporary_root = _private_temporary_root_path(
             manifest_temporary_root, source_root
         )
     staging_temporary_root: Path | None = None
@@ -553,15 +584,15 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         if not isinstance(lock_value, str) or not lock_value:
             raise RecoveryError(f"run manifest shard {index} has incomplete paths")
         shard_root = Path(root_value).resolve()
-        temporary_root = Path(temporary_root_value).resolve()
-        if temporary_root in {
+        resolved_temporary_root = Path(temporary_root_value).resolve()
+        if resolved_temporary_root in {
             Path("/").resolve(),
             root,
             (root / STATE_DIRNAME).resolve(),
         }:
             raise RecoveryError(
                 f"run manifest shard {index} names unsafe temporary_root "
-                f"{temporary_root}"
+                f"{resolved_temporary_root}"
             )
         if shard_root in {Path("/").resolve(), root, (root / STATE_DIRNAME).resolve()}:
             raise RecoveryError(
@@ -569,12 +600,12 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
             )
         if shard_root in seen_roots:
             raise RecoveryError(f"run manifest repeats shard root {shard_root}")
-        if shard_root == temporary_root or not shard_root.is_relative_to(
-            temporary_root
+        if shard_root == resolved_temporary_root or not shard_root.is_relative_to(
+            resolved_temporary_root
         ):
             raise RecoveryError(
                 f"run manifest shard {index} root {shard_root} escapes temporary_root "
-                f"{temporary_root}"
+                f"{resolved_temporary_root}"
             )
         seen_roots.add(shard_root)
         marker = _contained_path(Path(marker_value), shard_root, "ownership marker")
@@ -583,7 +614,7 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
             ShardRecord(
                 shard_index=index,
                 root=shard_root,
-                temporary_root=temporary_root,
+                temporary_root=resolved_temporary_root,
                 ownership_marker=marker,
                 liveness_lock=lock,
             )
@@ -599,7 +630,7 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         diagnostic_pid=(
             coordinator.get("pid") if isinstance(coordinator.get("pid"), int) else None
         ),
-        temporary_root=temporary_root,
+        temporary_root=recorded_temporary_root,
         staging_temporary_root=staging_temporary_root,
         staging_shard_limit=staging_shard_limit,
         shards=tuple(shards),
@@ -1050,6 +1081,7 @@ def recover_run(
         )
     preflight, liveness_leases = _build_preflight(record)
     try:
+        _require_existing_private_temporary_root(record)
         if force:
             stream = output or sys.stdout
             stream.write(preflight.render(run_id))
@@ -1063,6 +1095,7 @@ def recover_run(
         coordinator["lifecycle"] = "recovering"
         _write_root_recovery_json(root, state_path, state)
 
+        _require_existing_private_temporary_root(record)
         restore_callback = restore_mutation or _default_restore
         cleanup_callback = cleanup_owned_tree or _default_cleanup_for(record)
         removable = set(preflight.remove)
@@ -1072,6 +1105,7 @@ def recover_run(
             if shard.root not in removable:
                 continue
             try:
+                _require_existing_private_temporary_root(record)
                 _recover_one(
                     shard,
                     restore_mutation=restore_callback,

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -304,10 +304,12 @@ def _private_temporary_root(value: object, source_root: Path) -> Path:
         raise RecoveryError(
             f"temporary_root {path} is not canonical or contains a symlink"
         )
+    if resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved):
+        raise RecoveryError(f"temporary_root {path} overlaps source_root {source_root}")
     if (
         resolved == temporary_base
         or not resolved.is_relative_to(temporary_base)
-        or resolved in {Path("/").resolve(), source_root, source_root / STATE_DIRNAME}
+        or resolved in {Path("/").resolve(), source_root / STATE_DIRNAME}
     ):
         raise RecoveryError(
             f"temporary_root {path} is outside the private run boundary"

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import stat
+import tempfile
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -20,6 +21,8 @@ RUNS_DIRNAME = "runs"
 MANIFEST_FILENAME = "manifest.json"
 SCHEMA_VERSION = 1
 _SAFE_RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+_PARTIAL_SHARD_NAME = re.compile(r"shard-(0|[1-9][0-9]*)")
+_EXECUTION_TREE_MARKER = Path(STATE_DIRNAME) / "execution-tree-owner.json"
 
 RestoreMutation = Callable[[Path], str]
 CleanupOwnedTree = Callable[[Path, Path, int], None]
@@ -129,7 +132,18 @@ class RunRecord:
     source_manifest_digest: str
     plan_digest: str
     diagnostic_pid: int | None
+    staging_temporary_root: Path | None
+    staging_shard_limit: int | None
     shards: tuple[ShardRecord, ...]
+
+
+@dataclass(frozen=True)
+class PartialShardRecord:
+    """One fully validated pre-child staging tree."""
+
+    shard_index: int
+    root: Path
+    ownership_marker: Path
 
 
 @dataclass(frozen=True)
@@ -269,6 +283,54 @@ def _contained_path(path: Path, root: Path, label: str) -> Path:
     return resolved
 
 
+def _private_temporary_root(value: object, source_root: Path) -> Path:
+    """Validate a canonical private directory below the operating-system temp root."""
+
+    if not isinstance(value, str) or not value:
+        raise RecoveryError(
+            "zero-shard run manifest has no durable temporary_root authority"
+        )
+    path = Path(value)
+    if not path.is_absolute() or ".." in path.parts:
+        raise RecoveryError(f"temporary_root {path} is not an absolute lexical path")
+    try:
+        temporary_base = Path(tempfile.gettempdir()).resolve(strict=True)
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {path} could not be resolved: {exc}"
+        ) from exc
+    if resolved != path:
+        raise RecoveryError(
+            f"temporary_root {path} is not canonical or contains a symlink"
+        )
+    if (
+        resolved == temporary_base
+        or not resolved.is_relative_to(temporary_base)
+        or resolved in {Path("/").resolve(), source_root, source_root / STATE_DIRNAME}
+    ):
+        raise RecoveryError(
+            f"temporary_root {path} is outside the private run boundary"
+        )
+
+    relative = resolved.relative_to(temporary_base)
+    current = temporary_base
+    for component in relative.parts:
+        current /= component
+        _trusted_authority_directory(current, "temporary-root component")
+    try:
+        mode = stat.S_IMODE(resolved.lstat().st_mode)
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {path} could not be inspected: {exc}"
+        ) from exc
+    if mode != 0o700:
+        raise RecoveryError(
+            f"temporary_root {path} mode is {mode:#o}, expected private mode 0o700"
+        )
+    return resolved
+
+
 def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord]:
     if not _SAFE_RUN_ID.fullmatch(run_id):
         raise RecoveryError(f"run id {run_id!r} is not a plain name")
@@ -337,8 +399,42 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         )
 
     raw_shards = manifest.get("shards")
-    if not isinstance(raw_shards, list) or not raw_shards:
-        raise RecoveryError("run manifest must record at least one shard")
+    if not isinstance(raw_shards, list):
+        raise RecoveryError("run manifest shards must be a list")
+    staging_temporary_root: Path | None = None
+    staging_shard_limit: int | None = None
+    if not raw_shards:
+        if coordinator.get("lifecycle") != "aborted":
+            raise RecoveryError(
+                "zero-shard recovery requires an aborted coordinator lifecycle"
+            )
+        if coordinator.get("shards") != []:
+            raise RecoveryError(
+                "zero-shard manifest differs from the coordinator shard record"
+            )
+        requested_shards = manifest.get("requested_shards")
+        effective_shards = manifest.get("effective_shards")
+        if (
+            not isinstance(requested_shards, int)
+            or isinstance(requested_shards, bool)
+            or requested_shards < 1
+            or not isinstance(effective_shards, int)
+            or isinstance(effective_shards, bool)
+            or effective_shards < 1
+            or effective_shards > requested_shards
+        ):
+            raise RecoveryError(
+                "zero-shard run manifest has invalid requested/effective shard bounds"
+            )
+        manifest_temporary_root = manifest.get("temporary_root")
+        if coordinator.get("temporary_root") != manifest_temporary_root:
+            raise RecoveryError(
+                "zero-shard coordinator and manifest temporary_root values differ"
+            )
+        staging_temporary_root = _private_temporary_root(
+            manifest_temporary_root, source_root
+        )
+        staging_shard_limit = effective_shards
     shards: list[ShardRecord] = []
     seen_indexes: set[int] = set()
     seen_roots: set[Path] = set()
@@ -418,6 +514,8 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         diagnostic_pid=(
             coordinator.get("pid") if isinstance(coordinator.get("pid"), int) else None
         ),
+        staging_temporary_root=staging_temporary_root,
+        staging_shard_limit=staging_shard_limit,
         shards=tuple(shards),
     )
 
@@ -441,6 +539,94 @@ def _marker_error(record: RunRecord, shard: ShardRecord) -> str | None:
                 f"{marker.get(key)!r}, expected {value!r}"
             )
     return None
+
+
+def _partial_staging_shards(record: RunRecord) -> tuple[PartialShardRecord, ...]:
+    """Validate every entry before authorizing any pre-child staging cleanup."""
+
+    temporary_root = record.staging_temporary_root
+    shard_limit = record.staging_shard_limit
+    if temporary_root is None or shard_limit is None:
+        raise RecoveryError("zero-shard recovery has no private staging authority")
+    _private_temporary_root(str(temporary_root), record.source_root)
+    try:
+        entries = sorted(temporary_root.iterdir(), key=lambda path: path.name)
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {temporary_root} could not be enumerated: {exc}"
+        ) from exc
+
+    partials: list[PartialShardRecord] = []
+    expected_marker_keys = {
+        "schema_version",
+        "run_id",
+        "shard_index",
+        "source_manifest_digest",
+        "plan_digest",
+    }
+    for entry in entries:
+        match = _PARTIAL_SHARD_NAME.fullmatch(entry.name)
+        if match is None:
+            raise RecoveryError(f"unexpected private-root entry {entry}")
+        shard_index = int(match.group(1))
+        if shard_index >= shard_limit:
+            raise RecoveryError(
+                f"partial shard {entry} exceeds effective shard bound {shard_limit}"
+            )
+        try:
+            info = entry.lstat()
+        except OSError as exc:
+            raise RecoveryError(
+                f"partial shard {entry} could not be inspected: {exc}"
+            ) from exc
+        if stat.S_ISLNK(info.st_mode):
+            raise RecoveryError(f"partial shard {entry} is a symlink")
+        if not stat.S_ISDIR(info.st_mode):
+            raise RecoveryError(f"partial shard {entry} is not a directory")
+        if entry.resolve(strict=True) != entry:
+            raise RecoveryError(f"partial shard {entry} is not canonical")
+
+        state_directory = entry / STATE_DIRNAME
+        _trusted_authority_directory(state_directory, "partial shard state directory")
+        marker_path = entry / _EXECUTION_TREE_MARKER
+        _trusted_authority_file(marker_path, "ownership marker")
+        try:
+            state_entries = {path.name for path in state_directory.iterdir()}
+        except OSError as exc:
+            raise RecoveryError(
+                f"partial shard state directory {state_directory} could not be read: {exc}"
+            ) from exc
+        if state_entries != {marker_path.name}:
+            raise RecoveryError(
+                f"partial shard {entry} has child liveness or unexpected state evidence"
+            )
+
+        marker = _read_json(marker_path, "ownership marker")
+        if set(marker) != expected_marker_keys:
+            raise RecoveryError(
+                f"{marker_path}: ownership marker does not have the exact field set"
+            )
+        expected: dict[str, object] = {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": record.run_id,
+            "shard_index": shard_index,
+            "source_manifest_digest": record.source_manifest_digest,
+            "plan_digest": record.plan_digest,
+        }
+        for key, value in expected.items():
+            if marker.get(key) != value:
+                raise RecoveryError(
+                    f"{marker_path}: ownership marker {key} is "
+                    f"{marker.get(key)!r}, expected {value!r}"
+                )
+        partials.append(
+            PartialShardRecord(
+                shard_index=shard_index,
+                root=entry,
+                ownership_marker=marker_path,
+            )
+        )
+    return tuple(partials)
 
 
 def _build_preflight(record: RunRecord) -> tuple[RecoveryPreflight, tuple[int, ...]]:
@@ -511,11 +697,20 @@ def _default_cleanup_for(record: RunRecord) -> CleanupOwnedTree:
             "execution-tree cleanup backend is unavailable; retain the owned shard"
         ) from exc
     cleanup = getattr(module, "cleanup_execution_tree", None)
+    cleanup_partial = getattr(module, "cleanup_partial_execution_tree", None)
     manifest_from_dict = getattr(module, "source_manifest_from_dict", None)
     staged_type = getattr(module, "StagedExecutionTree", None)
-    if not callable(cleanup) or not callable(manifest_from_dict) or staged_type is None:
+    if not callable(manifest_from_dict):
         raise RecoveryError(
             "execution-tree cleanup backend has no recovery-safe cleanup entry point"
+        )
+    if record.shards and (not callable(cleanup) or staged_type is None):
+        raise RecoveryError(
+            "execution-tree cleanup backend has no completed-shard cleanup entry point"
+        )
+    if not record.shards and not callable(cleanup_partial):
+        raise RecoveryError(
+            "execution-tree cleanup backend has no partial-staging cleanup entry point"
         )
 
     try:
@@ -524,6 +719,26 @@ def _default_cleanup_for(record: RunRecord) -> CleanupOwnedTree:
         raise RecoveryError(f"serialized source manifest is invalid: {exc}") from exc
 
     def cleanup_one(root: Path, marker: Path, shard_index: int) -> None:
+        if not record.shards:
+            temporary_root = record.staging_temporary_root
+            if temporary_root is None:
+                raise RecoveryError("partial cleanup has no temporary_root")
+            if marker != root / _EXECUTION_TREE_MARKER:
+                raise RecoveryError("partial cleanup marker path changed")
+            assert callable(cleanup_partial)
+            cleanup_partial(
+                record.source_root,
+                root,
+                temporary_root=temporary_root,
+                run_id=record.run_id,
+                shard_index=shard_index,
+                source_manifest=source_manifest,
+                plan_digest=record.plan_digest,
+                child_liveness_proven=True,
+            )
+            return
+        assert staged_type is not None
+        assert callable(cleanup)
         staged = staged_type(
             root=root,
             ownership_marker=marker,
@@ -573,6 +788,94 @@ def _recover_one(
         )
 
 
+def _recover_partial_staging(
+    root: Path,
+    state_path: Path,
+    state: dict[str, Any],
+    record: RunRecord,
+    *,
+    force: bool,
+    cleanup_owned_tree: CleanupOwnedTree | None,
+    output: TextIO | None,
+) -> str:
+    """Recover staging that aborted after ownership marking but before children."""
+
+    import sys
+
+    partials = _partial_staging_shards(record)
+    temporary_root = record.staging_temporary_root
+    if temporary_root is None:
+        raise RecoveryError("partial recovery has no temporary_root")
+    preflight = RecoveryPreflight(
+        remove=tuple([*(partial.root for partial in partials), temporary_root]),
+        leave=(),
+        unknown=(),
+    )
+    if force:
+        stream = output or sys.stdout
+        stream.write(preflight.render(record.run_id))
+        stream.flush()
+
+    coordinator = state.get("coordinator_run")
+    if not isinstance(coordinator, dict):
+        raise RecoveryError("coordinator state changed during recovery")
+    coordinator["lifecycle"] = "recovering"
+    _write_root_recovery_json(root, state_path, state)
+
+    cleanup_callback = cleanup_owned_tree
+    if partials and cleanup_callback is None:
+        cleanup_callback = _default_cleanup_for(record)
+    failures: list[str] = []
+    removed = 0
+    for partial in partials:
+        try:
+            if cleanup_callback is None:
+                raise RecoveryError("partial cleanup callback is unavailable")
+            cleanup_callback(
+                partial.root,
+                partial.ownership_marker,
+                partial.shard_index,
+            )
+            if partial.root.exists():
+                raise RecoveryError(
+                    f"{partial.root}: cleanup returned but the partial shard still exists"
+                )
+        except Exception as exc:
+            failures.append(f"{partial.root}: verified partial cleanup failed: {exc}")
+            if not force:
+                break
+        else:
+            removed += 1
+
+    if not failures:
+        try:
+            _private_temporary_root(str(temporary_root), record.source_root)
+            temporary_root.rmdir()
+        except (OSError, RecoveryError) as exc:
+            failures.append(f"{temporary_root}: private-root cleanup failed: {exc}")
+
+    if failures:
+        coordinator["lifecycle"] = "recovering"
+        coordinator["recovery_unknown"] = failures
+        _write_root_recovery_json(root, state_path, state)
+        raise RecoveryError(
+            f"recovery retained pre-child staging; root state remains: {failures[0]}"
+        )
+
+    manifest = _read_root_recovery_json(root, record.manifest_path, "run manifest")
+    manifest["lifecycle"] = "aborted"
+    _write_root_recovery_json(root, record.manifest_path, manifest)
+    coordinator["lifecycle"] = "aborted"
+    _write_root_recovery_json(root, state_path, state)
+
+    state.pop("coordinator_run", None)
+    _write_root_recovery_json(root, state_path, state)
+    return (
+        f"recovered run {record.run_id} as aborted; removed {removed} "
+        "owned staging shard(s)"
+    )
+
+
 def recover_run(
     root: Path,
     run_id: str,
@@ -593,6 +896,16 @@ def recover_run(
     root = root.resolve()
     state_path = root / STATE_DIRNAME / STATE_FILENAME
     state, record = _load_run_record(root, run_id)
+    if not record.shards:
+        return _recover_partial_staging(
+            root,
+            state_path,
+            state,
+            record,
+            force=force,
+            cleanup_owned_tree=cleanup_owned_tree,
+            output=output,
+        )
     preflight, liveness_leases = _build_preflight(record)
     try:
         if force:

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import fcntl
-import importlib
 import json
 import os
 import re
@@ -13,7 +12,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any, TextIO, cast
 
 STATE_DIRNAME = ".mutation-harness"
 STATE_FILENAME = "state.json"
@@ -36,11 +35,14 @@ _SHARD_AUTHORITY_KEYS = (
 )
 
 RestoreMutation = Callable[[Path], str]
-CleanupOwnedTree = Callable[[Path, Path, int], None]
 
 
 class RecoveryError(RuntimeError):
     """Recovery could not prove that an intended action was safe."""
+
+
+class RecoveryAuthorityChanged(RecoveryError):
+    """A destructive target no longer has its preflight filesystem identity."""
 
 
 def _trusted_root_state_directory(root: Path) -> Path:
@@ -189,6 +191,58 @@ class ShardCleanupAuthority:
 
 
 @dataclass(frozen=True)
+class OpenFilesystemCapability:
+    """One open object; ``path`` is diagnostic and must never authorize I/O."""
+
+    path: Path
+    descriptor: int
+    device: int
+    inode: int
+    file_type: int
+
+    def require_unchanged(self) -> None:
+        """Verify this open descriptor without reopening a mutable path."""
+
+        try:
+            actual = os.fstat(self.descriptor)
+        except OSError as exc:
+            raise RecoveryAuthorityChanged(
+                f"{self.path} capability could not be inspected: {exc}"
+            ) from exc
+        if (
+            actual.st_dev,
+            actual.st_ino,
+            stat.S_IFMT(actual.st_mode),
+        ) != (self.device, self.inode, self.file_type):
+            raise RecoveryAuthorityChanged(
+                f"{self.path} capability identity changed during cleanup"
+            )
+
+
+@dataclass(frozen=True)
+class QuarantinedShard:
+    """Open capabilities for one atomically isolated cleanup target."""
+
+    shard_index: int
+    quarantine: OpenFilesystemCapability
+    shard: OpenFilesystemCapability
+    ownership_marker: OpenFilesystemCapability
+    liveness_lock: OpenFilesystemCapability
+
+    def require_unchanged(self) -> None:
+        """Recheck every capability without resolving a mutable path."""
+
+        self.quarantine.require_unchanged()
+        self.shard.require_unchanged()
+        self.ownership_marker.require_unchanged()
+        self.liveness_lock.require_unchanged()
+
+
+CleanupOwnedTree = Callable[[QuarantinedShard], None]
+PartialCleanupOwnedTree = Callable[[Path, Path, int], None]
+
+
+@dataclass(frozen=True)
 class RecoveryPreflight:
     """The exact manifest-bounded actions and unknown evidence."""
 
@@ -296,7 +350,7 @@ def _read_root_recovery_json(root: Path, path: Path, label: str) -> dict[str, An
     return _read_json(path, label)
 
 
-def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.is_symlink():
         raise RecoveryError(f"state path {path} is a symlink")
@@ -314,7 +368,6 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     if temporary is None:
         raise RecoveryError(f"could not allocate an atomic state file beside {path}")
     try:
-        data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
         with os.fdopen(descriptor, "wb", closefd=True) as stream:
             descriptor = -1
             stream.write(data)
@@ -327,11 +380,33 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
         temporary.unlink(missing_ok=True)
 
 
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    _atomic_write_bytes(path, data)
+
+
 def _write_root_recovery_json(root: Path, path: Path, payload: dict[str, Any]) -> None:
     """Recheck the root state parent immediately before each recovery write."""
 
     _trusted_recovery_authority_file(root, path)
     _atomic_write_json(path, payload)
+
+
+def _read_root_recovery_bytes(root: Path, path: Path) -> bytes:
+    """Read exact root-state bytes after validating the recovery authority."""
+
+    _trusted_recovery_authority_file(root, path)
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise RecoveryError(f"root state {path} could not be read: {exc}") from exc
+
+
+def _write_root_recovery_bytes(root: Path, path: Path, payload: bytes) -> None:
+    """Restore exact root-state bytes after validating the recovery authority."""
+
+    _trusted_recovery_authority_file(root, path)
+    _atomic_write_bytes(path, payload)
 
 
 def _contained_path(path: Path, root: Path, label: str) -> Path:
@@ -507,9 +582,12 @@ def _require_existing_private_temporary_root(
 ) -> None:
     """Require the exact directory identity authorized by preflight."""
 
-    actual = _capture_private_temporary_root_identity(record)
+    try:
+        actual = _capture_private_temporary_root_identity(record)
+    except RecoveryError as exc:
+        raise RecoveryAuthorityChanged(str(exc)) from exc
     if actual != expected:
-        raise RecoveryError(
+        raise RecoveryAuthorityChanged(
             f"temporary_root {record.temporary_root} identity changed after preflight; "
             "root state remains"
         )
@@ -826,7 +904,12 @@ def _require_shard_cleanup_authority(
 ) -> None:
     """Require the exact shard, marker, and lock identities bound by preflight."""
 
-    actual = _capture_shard_cleanup_authority(record, shard, temporary_root_identity)
+    try:
+        actual = _capture_shard_cleanup_authority(
+            record, shard, temporary_root_identity
+        )
+    except RecoveryError as exc:
+        raise RecoveryAuthorityChanged(str(exc)) from exc
     if actual != expected:
         if actual.root_identity != expected.root_identity:
             label = f"shard root {shard.root}"
@@ -834,7 +917,7 @@ def _require_shard_cleanup_authority(
             label = f"ownership marker {shard.ownership_marker}"
         else:
             label = f"liveness lock {shard.liveness_lock}"
-        raise RecoveryError(f"{label} identity changed after preflight")
+        raise RecoveryAuthorityChanged(f"{label} identity changed after preflight")
 
 
 def _require_preflight_shard_authorities(
@@ -1040,82 +1123,273 @@ def _shard_has_applied_state(root: Path) -> bool:
     return True
 
 
+def _open_capability(
+    descriptor: int,
+    *,
+    path: Path,
+    expected_device: int,
+    expected_inode: int,
+    expected_file_type: int,
+    label: str,
+) -> OpenFilesystemCapability:
+    """Bind an already-open descriptor to an expected filesystem identity."""
+
+    try:
+        actual = os.fstat(descriptor)
+    except OSError as exc:
+        raise RecoveryAuthorityChanged(
+            f"{label} capability could not be inspected: {exc}"
+        ) from exc
+    if (
+        actual.st_dev,
+        actual.st_ino,
+        stat.S_IFMT(actual.st_mode),
+    ) != (expected_device, expected_inode, expected_file_type):
+        raise RecoveryAuthorityChanged(f"{label} identity changed during quarantine")
+    return OpenFilesystemCapability(
+        path=path,
+        descriptor=descriptor,
+        device=expected_device,
+        inode=expected_inode,
+        file_type=expected_file_type,
+    )
+
+
+def _open_relative_no_follow(
+    root_descriptor: int,
+    relative: Path,
+    *,
+    label: str,
+    expect_directory: bool,
+) -> int:
+    """Open a descendant through directory descriptors without following links."""
+
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        raise RecoveryAuthorityChanged(f"{label} relative path is unsafe: {relative}")
+    directory_flags = (
+        os.O_RDONLY
+        | os.O_CLOEXEC
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    current = os.dup(root_descriptor)
+    try:
+        for component in relative.parts[:-1]:
+            next_descriptor = os.open(
+                component,
+                directory_flags,
+                dir_fd=current,
+            )
+            os.close(current)
+            current = next_descriptor
+        final_flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
+        if expect_directory:
+            final_flags |= getattr(os, "O_DIRECTORY", 0)
+        return os.open(relative.parts[-1], final_flags, dir_fd=current)
+    except OSError as exc:
+        raise RecoveryAuthorityChanged(
+            f"{label} could not be opened through its bound shard: {exc}"
+        ) from exc
+    finally:
+        os.close(current)
+
+
+def _verified_quarantine_cleanup(
+    record: RunRecord,
+    shard: ShardRecord,
+    temporary_root_identity: TemporaryRootIdentity,
+    shard_authority: ShardCleanupAuthority,
+    liveness_lease: int,
+    cleanup_owned_tree: CleanupOwnedTree,
+) -> None:
+    """Give a trusted injected callback only stable, open capabilities."""
+
+    _require_shard_cleanup_authority(
+        record, shard, temporary_root_identity, shard_authority
+    )
+    temporary_root = record.temporary_root
+    if temporary_root is None:
+        raise RecoveryError("shard cleanup has no recorded temporary_root")
+    quarantine_name = (
+        f".mutation-harness-recovery-{record.run_id}-shard-"
+        f"{shard.shard_index}-{shard_authority.root_identity.inode}"
+    )
+    quarantine_root = temporary_root / quarantine_name
+    directory_flags = (
+        os.O_RDONLY
+        | os.O_CLOEXEC
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    temporary_descriptor = -1
+    quarantine_descriptor = -1
+    shard_descriptor = -1
+    marker_descriptor = -1
+    moved_lock_descriptor = -1
+    quarantine_created = False
+    renamed = False
+    try:
+        temporary_descriptor = os.open(temporary_root, directory_flags)
+        opened_root = os.fstat(temporary_descriptor)
+        if not stat.S_ISDIR(opened_root.st_mode) or (
+            opened_root.st_dev,
+            opened_root.st_ino,
+        ) != (temporary_root_identity.device, temporary_root_identity.inode):
+            raise RecoveryAuthorityChanged(
+                f"temporary_root {temporary_root} identity changed at cleanup boundary"
+            )
+        try:
+            os.stat(
+                quarantine_name,
+                dir_fd=temporary_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise RecoveryError(
+                f"cleanup quarantine {quarantine_root} could not be inspected: {exc}"
+            ) from exc
+        else:
+            raise RecoveryError(f"cleanup quarantine {quarantine_root} already exists")
+        os.mkdir(quarantine_name, mode=0o700, dir_fd=temporary_descriptor)
+        quarantine_created = True
+        created_quarantine = os.stat(
+            quarantine_name,
+            dir_fd=temporary_descriptor,
+            follow_symlinks=False,
+        )
+        quarantine_descriptor = os.open(
+            quarantine_name,
+            directory_flags,
+            dir_fd=temporary_descriptor,
+        )
+        quarantine_capability = _open_capability(
+            quarantine_descriptor,
+            path=quarantine_root,
+            expected_device=created_quarantine.st_dev,
+            expected_inode=created_quarantine.st_ino,
+            expected_file_type=stat.S_IFDIR,
+            label=f"cleanup quarantine {quarantine_root}",
+        )
+        _require_shard_cleanup_authority(
+            record, shard, temporary_root_identity, shard_authority
+        )
+        os.rename(
+            shard.root.name,
+            shard.root.name,
+            src_dir_fd=temporary_descriptor,
+            dst_dir_fd=quarantine_descriptor,
+        )
+        renamed = True
+
+        quarantined_root = quarantine_root / shard.root.name
+        marker_relative = shard.ownership_marker.relative_to(shard.root)
+        lock_relative = shard.liveness_lock.relative_to(shard.root)
+        quarantined_marker = quarantined_root / marker_relative
+        quarantined_lock = quarantined_root / lock_relative
+        shard_descriptor = _open_relative_no_follow(
+            quarantine_descriptor,
+            Path(shard.root.name),
+            label=f"shard root {shard.root}",
+            expect_directory=True,
+        )
+        shard_capability = _open_capability(
+            shard_descriptor,
+            path=quarantined_root,
+            expected_device=shard_authority.root_identity.device,
+            expected_inode=shard_authority.root_identity.inode,
+            expected_file_type=stat.S_IFDIR,
+            label=f"shard root {shard.root}",
+        )
+        marker_descriptor = _open_relative_no_follow(
+            shard_descriptor,
+            marker_relative,
+            label=f"ownership marker {shard.ownership_marker}",
+            expect_directory=False,
+        )
+        marker_capability = _open_capability(
+            marker_descriptor,
+            path=quarantined_marker,
+            expected_device=shard_authority.ownership_marker_identity.device,
+            expected_inode=shard_authority.ownership_marker_identity.inode,
+            expected_file_type=stat.S_IFREG,
+            label=f"ownership marker {shard.ownership_marker}",
+        )
+        moved_lock_descriptor = _open_relative_no_follow(
+            shard_descriptor,
+            lock_relative,
+            label=f"liveness lock {shard.liveness_lock}",
+            expect_directory=False,
+        )
+        moved_lock_capability = _open_capability(
+            moved_lock_descriptor,
+            path=quarantined_lock,
+            expected_device=shard_authority.liveness_lock_identity.device,
+            expected_inode=shard_authority.liveness_lock_identity.inode,
+            expected_file_type=stat.S_IFREG,
+            label=f"liveness lock {shard.liveness_lock}",
+        )
+        lease_capability = _open_capability(
+            liveness_lease,
+            path=quarantined_lock,
+            expected_device=shard_authority.liveness_lock_identity.device,
+            expected_inode=shard_authority.liveness_lock_identity.inode,
+            expected_file_type=stat.S_IFREG,
+            label=f"leased liveness lock {shard.liveness_lock}",
+        )
+        moved_lock_capability.require_unchanged()
+        capability = QuarantinedShard(
+            shard_index=shard.shard_index,
+            quarantine=quarantine_capability,
+            shard=shard_capability,
+            ownership_marker=marker_capability,
+            liveness_lock=lease_capability,
+        )
+        capability.require_unchanged()
+        cleanup_owned_tree(capability)
+        capability.require_unchanged()
+        try:
+            os.stat(
+                shard.root.name,
+                dir_fd=quarantine_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise RecoveryError(
+                f"{quarantined_root}: cleanup result could not be inspected: {exc}"
+            ) from exc
+        else:
+            raise RecoveryError(
+                f"{quarantined_root}: cleanup returned but the quarantined shard "
+                "still exists"
+            )
+        os.rmdir(quarantine_name, dir_fd=temporary_descriptor)
+        quarantine_created = False
+    finally:
+        if quarantine_created and not renamed and temporary_descriptor >= 0:
+            try:
+                os.rmdir(quarantine_name, dir_fd=temporary_descriptor)
+            except OSError:
+                pass
+        if moved_lock_descriptor >= 0:
+            os.close(moved_lock_descriptor)
+        if marker_descriptor >= 0:
+            os.close(marker_descriptor)
+        if shard_descriptor >= 0:
+            os.close(shard_descriptor)
+        if quarantine_descriptor >= 0:
+            os.close(quarantine_descriptor)
+        if temporary_descriptor >= 0:
+            os.close(temporary_descriptor)
+
+
 def _default_restore(root: Path) -> str:
     from scripts.mutation_harness import restore
 
     return restore(root)
-
-
-def _default_cleanup_for(record: RunRecord) -> CleanupOwnedTree:
-    try:
-        module = importlib.import_module("scripts.mutation_harness_execution_tree")
-    except ImportError as exc:
-        raise RecoveryError(
-            "execution-tree cleanup backend is unavailable; retain the owned shard"
-        ) from exc
-    cleanup = getattr(module, "cleanup_execution_tree", None)
-    cleanup_partial = getattr(module, "cleanup_partial_execution_tree", None)
-    manifest_from_dict = getattr(module, "source_manifest_from_dict", None)
-    staged_type = getattr(module, "StagedExecutionTree", None)
-    if not callable(manifest_from_dict):
-        raise RecoveryError(
-            "execution-tree cleanup backend has no recovery-safe cleanup entry point"
-        )
-    if record.shards and (not callable(cleanup) or staged_type is None):
-        raise RecoveryError(
-            "execution-tree cleanup backend has no completed-shard cleanup entry point"
-        )
-    if not record.shards and not callable(cleanup_partial):
-        raise RecoveryError(
-            "execution-tree cleanup backend has no partial-staging cleanup entry point"
-        )
-
-    try:
-        source_manifest = manifest_from_dict(record.source_manifest)
-    except Exception as exc:
-        raise RecoveryError(f"serialized source manifest is invalid: {exc}") from exc
-
-    def cleanup_one(root: Path, marker: Path, shard_index: int) -> None:
-        if not record.shards:
-            temporary_root = record.staging_temporary_root
-            if temporary_root is None:
-                raise RecoveryError("partial cleanup has no temporary_root")
-            if marker != root / _EXECUTION_TREE_MARKER:
-                raise RecoveryError("partial cleanup marker path changed")
-            assert callable(cleanup_partial)
-            cleanup_partial(
-                record.source_root,
-                root,
-                temporary_root=temporary_root,
-                run_id=record.run_id,
-                shard_index=shard_index,
-                source_manifest=source_manifest,
-                plan_digest=record.plan_digest,
-                child_liveness_proven=True,
-            )
-            return
-        assert staged_type is not None
-        assert callable(cleanup)
-        staged = staged_type(
-            root=root,
-            ownership_marker=marker,
-            shard_index=shard_index,
-            run_id=record.run_id,
-            source_root=record.source_root,
-            source_manifest=source_manifest,
-            plan_digest=record.plan_digest,
-        )
-        cleanup(
-            staged,
-            temporary_root=next(
-                shard.temporary_root
-                for shard in record.shards
-                if shard.root == root and shard.shard_index == shard_index
-            ),
-            child_liveness_proven=True,
-        )
-
-    return cleanup_one
 
 
 def _recover_one(
@@ -1124,6 +1398,7 @@ def _recover_one(
     *,
     temporary_root_identity: TemporaryRootIdentity,
     shard_authority: ShardCleanupAuthority,
+    liveness_lease: int,
     restore_mutation: RestoreMutation,
     cleanup_owned_tree: CleanupOwnedTree,
 ) -> None:
@@ -1147,8 +1422,18 @@ def _recover_one(
     _require_shard_cleanup_authority(
         record, shard, temporary_root_identity, shard_authority
     )
+
     try:
-        cleanup_owned_tree(shard.root, shard.ownership_marker, shard.shard_index)
+        _verified_quarantine_cleanup(
+            record,
+            shard,
+            temporary_root_identity,
+            shard_authority,
+            liveness_lease,
+            cleanup_owned_tree,
+        )
+    except RecoveryAuthorityChanged:
+        raise
     except Exception as exc:
         raise RecoveryError(f"{shard.root}: verified cleanup failed: {exc}") from exc
     if shard.root.exists():
@@ -1164,7 +1449,7 @@ def _recover_partial_staging(
     record: RunRecord,
     *,
     force: bool,
-    cleanup_owned_tree: CleanupOwnedTree | None,
+    cleanup_owned_tree: PartialCleanupOwnedTree | None,
     output: TextIO | None,
 ) -> str:
     """Recover staging that aborted after ownership marking but before children."""
@@ -1195,7 +1480,10 @@ def _recover_partial_staging(
 
     cleanup_callback = cleanup_owned_tree
     if partials and cleanup_callback is None:
-        cleanup_callback = _default_cleanup_for(record)
+        raise RecoveryError(
+            "default recovery refuses an existing staged Git tree; "
+            "private tree and root state remain"
+        )
     failures: list[str] = []
     removed = 0
     for partial in partials:
@@ -1298,7 +1586,7 @@ def recover_run(
     *,
     force: bool = False,
     restore_mutation: RestoreMutation | None = None,
-    cleanup_owned_tree: CleanupOwnedTree | None = None,
+    cleanup_owned_tree: CleanupOwnedTree | PartialCleanupOwnedTree | None = None,
     output: TextIO | None = None,
 ) -> str:
     """Recover only manifest-owned shards, then clear root state last.
@@ -1312,6 +1600,7 @@ def recover_run(
     root = root.resolve()
     state_path = root / STATE_DIRNAME / STATE_FILENAME
     state, record = _load_run_record(root, run_id)
+    state_bytes_before = _read_root_recovery_bytes(root, state_path)
     if not record.shards:
         return _recover_partial_staging(
             root,
@@ -1319,7 +1608,7 @@ def recover_run(
             state,
             record,
             force=force,
-            cleanup_owned_tree=cleanup_owned_tree,
+            cleanup_owned_tree=cast(PartialCleanupOwnedTree | None, cleanup_owned_tree),
             output=output,
         )
     missing_temporary_root = _missing_private_temporary_root(
@@ -1333,6 +1622,12 @@ def recover_run(
             state,
             record,
         )
+    if cleanup_owned_tree is None:
+        raise RecoveryError(
+            "default recovery refuses existing recorded Git shard trees; "
+            "private tree, root state, and run manifest remain"
+        )
+    cleanup_callback = cast(CleanupOwnedTree, cleanup_owned_tree)
     preflight, liveness_leases = _build_preflight(record)
     try:
         temporary_root_identity = preflight.temporary_root_identity
@@ -1356,11 +1651,16 @@ def recover_run(
         _require_existing_private_temporary_root(record, temporary_root_identity)
         _require_preflight_shard_authorities(record, preflight, temporary_root_identity)
         restore_callback = restore_mutation or _default_restore
-        cleanup_callback = cleanup_owned_tree or _default_cleanup_for(record)
         removable = set(preflight.remove)
         shard_authorities = {
             (authority.shard_index, authority.root): authority
             for authority in preflight.shard_authorities
+        }
+        shard_leases = {
+            (authority.shard_index, authority.root): lease
+            for authority, lease in zip(
+                preflight.shard_authorities, liveness_leases, strict=True
+            )
         }
         failures: list[str] = []
         removed = 0
@@ -1373,6 +1673,11 @@ def recover_run(
                     raise RecoveryError(
                         f"shard {shard.shard_index} has no preflight cleanup authority"
                     )
+                liveness_lease = shard_leases.get((shard.shard_index, shard.root))
+                if liveness_lease is None:
+                    raise RecoveryError(
+                        f"shard {shard.shard_index} has no held liveness lease"
+                    )
                 _require_shard_cleanup_authority(
                     record, shard, temporary_root_identity, shard_authority
                 )
@@ -1381,9 +1686,14 @@ def recover_run(
                     shard,
                     temporary_root_identity=temporary_root_identity,
                     shard_authority=shard_authority,
+                    liveness_lease=liveness_lease,
                     restore_mutation=restore_callback,
                     cleanup_owned_tree=cleanup_callback,
                 )
+            except RecoveryAuthorityChanged:
+                if removed == 0:
+                    _write_root_recovery_bytes(root, state_path, state_bytes_before)
+                raise
             except RecoveryError as exc:
                 failures.append(str(exc))
                 if not force:

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import os
 import re
+import stat
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -26,6 +27,29 @@ CleanupOwnedTree = Callable[[Path, Path, int], None]
 
 class RecoveryError(RuntimeError):
     """Recovery could not prove that an intended action was safe."""
+
+
+def _trusted_root_state_directory(root: Path) -> Path:
+    """Return the lexical root state directory without following a link."""
+
+    directory = root / STATE_DIRNAME
+    try:
+        info = directory.lstat()
+    except FileNotFoundError as exc:
+        raise RecoveryError(f"root state directory {directory} does not exist") from exc
+    except OSError as exc:
+        raise RecoveryError(
+            f"root state directory {directory} could not be inspected: {exc}"
+        ) from exc
+    if stat.S_ISLNK(info.st_mode):
+        raise RecoveryError(
+            f"root state directory {directory} is a symlink; refusing recovery"
+        )
+    if not stat.S_ISDIR(info.st_mode):
+        raise RecoveryError(
+            f"root state directory {directory} is not a directory; refusing recovery"
+        )
+    return directory
 
 
 @dataclass(frozen=True)
@@ -137,6 +161,13 @@ def _read_json(path: Path, label: str) -> dict[str, Any]:
     return loaded
 
 
+def _read_root_recovery_json(root: Path, path: Path, label: str) -> dict[str, Any]:
+    """Recheck the root state parent immediately before each recovery read."""
+
+    _trusted_root_state_directory(root)
+    return _read_json(path, label)
+
+
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.is_symlink():
@@ -168,6 +199,13 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
         temporary.unlink(missing_ok=True)
 
 
+def _write_root_recovery_json(root: Path, path: Path, payload: dict[str, Any]) -> None:
+    """Recheck the root state parent immediately before each recovery write."""
+
+    _trusted_root_state_directory(root)
+    _atomic_write_json(path, payload)
+
+
 def _contained_path(path: Path, root: Path, label: str) -> Path:
     resolved = path.resolve()
     root_resolved = root.resolve()
@@ -180,8 +218,9 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
     if not _SAFE_RUN_ID.fullmatch(run_id):
         raise RecoveryError(f"run id {run_id!r} is not a plain name")
     root = root.resolve()
-    state_path = root / STATE_DIRNAME / STATE_FILENAME
-    state = _read_json(state_path, "root state")
+    state_directory = _trusted_root_state_directory(root)
+    state_path = state_directory / STATE_FILENAME
+    state = _read_root_recovery_json(root, state_path, "root state")
     coordinator = state.get("coordinator_run")
     if not isinstance(coordinator, dict):
         raise RecoveryError(f"root state does not record coordinator run {run_id}")
@@ -192,7 +231,7 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         )
 
     expected_manifest = (
-        root / STATE_DIRNAME / RUNS_DIRNAME / run_id / MANIFEST_FILENAME
+        state_directory / RUNS_DIRNAME / run_id / MANIFEST_FILENAME
     ).resolve()
     manifest_value = coordinator.get("manifest_path")
     if not isinstance(manifest_value, str) or not manifest_value:
@@ -203,7 +242,7 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
             f"manifest path {manifest_path} is outside the recorded run boundary "
             f"{expected_manifest}"
         )
-    manifest = _read_json(manifest_path, "run manifest")
+    manifest = _read_root_recovery_json(root, manifest_path, "run manifest")
     if manifest.get("schema_version") != SCHEMA_VERSION:
         raise RecoveryError(
             f"run manifest schema_version must be {SCHEMA_VERSION}, got "
@@ -510,7 +549,7 @@ def recover_run(
         if not isinstance(coordinator, dict):
             raise RecoveryError("coordinator state changed during recovery")
         coordinator["lifecycle"] = "recovering"
-        _atomic_write_json(state_path, state)
+        _write_root_recovery_json(root, state_path, state)
 
         restore_callback = restore_mutation or _default_restore
         cleanup_callback = cleanup_owned_tree or _default_cleanup_for(record)
@@ -537,7 +576,7 @@ def recover_run(
         if retained or failures or preflight.unknown:
             coordinator["lifecycle"] = "recovering"
             coordinator["recovery_unknown"] = [*preflight.unknown, *failures]
-            _atomic_write_json(state_path, state)
+            _write_root_recovery_json(root, state_path, state)
             detail = failures[0] if failures else preflight.unknown[0]
             raise RecoveryError(
                 f"recovery retained {retained} shard(s); root state remains: {detail}"
@@ -545,15 +584,15 @@ def recover_run(
 
         # The durable run record is updated before the root gate is cleared. The
         # coordinator state remains present during every restore and cleanup call.
-        manifest = _read_json(record.manifest_path, "run manifest")
+        manifest = _read_root_recovery_json(root, record.manifest_path, "run manifest")
         manifest["lifecycle"] = "aborted"
-        _atomic_write_json(record.manifest_path, manifest)
+        _write_root_recovery_json(root, record.manifest_path, manifest)
         coordinator["lifecycle"] = "aborted"
-        _atomic_write_json(state_path, state)
+        _write_root_recovery_json(root, state_path, state)
 
         # Clear the root coordinator record last. Preserve unrelated root state.
         state.pop("coordinator_run", None)
-        _atomic_write_json(state_path, state)
+        _write_root_recovery_json(root, state_path, state)
         return f"recovered run {run_id} as aborted; removed {removed} owned shard(s)"
     finally:
         for descriptor in liveness_leases:

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -23,6 +23,17 @@ SCHEMA_VERSION = 1
 _SAFE_RUN_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
 _PARTIAL_SHARD_NAME = re.compile(r"shard-(0|[1-9][0-9]*)")
 _EXECUTION_TREE_MARKER = Path(STATE_DIRNAME) / "execution-tree-owner.json"
+_INCOMPLETE_COORDINATOR_LIFECYCLES = frozenset(
+    {"staging", "running", "stopping", "aborted", "recovering"}
+)
+_SHARD_AUTHORITY_KEYS = (
+    "shard_index",
+    "root",
+    "source_root",
+    "temporary_root",
+    "ownership_marker",
+    "liveness_lock",
+)
 
 RestoreMutation = Callable[[Path], str]
 CleanupOwnedTree = Callable[[Path, Path, int], None]
@@ -127,11 +138,13 @@ class RunRecord:
 
     run_id: str
     manifest_path: Path
+    manifest: dict[str, Any]
     source_root: Path
     source_manifest: dict[str, Any]
     source_manifest_digest: str
     plan_digest: str
     diagnostic_pid: int | None
+    temporary_root: Path | None
     staging_temporary_root: Path | None
     staging_shard_limit: int | None
     shards: tuple[ShardRecord, ...]
@@ -333,6 +346,60 @@ def _private_temporary_root(value: object, source_root: Path) -> Path:
     return resolved
 
 
+def _private_temporary_root_path(value: object, source_root: Path) -> Path:
+    """Validate an existing or absent private-root path without following it."""
+
+    if not isinstance(value, str) or not value:
+        raise RecoveryError("run manifest has no durable temporary_root authority")
+    path = Path(value)
+    if not path.is_absolute() or ".." in path.parts:
+        raise RecoveryError(f"temporary_root {path} is not an absolute lexical path")
+    try:
+        temporary_base = Path(tempfile.gettempdir()).resolve(strict=True)
+    except OSError as exc:
+        raise RecoveryError(
+            f"system temporary root could not be resolved: {exc}"
+        ) from exc
+    if path == temporary_base or not path.is_relative_to(temporary_base):
+        raise RecoveryError(
+            f"temporary_root {path} is outside the private run boundary"
+        )
+    if path.is_relative_to(source_root) or source_root.is_relative_to(path):
+        raise RecoveryError(f"temporary_root {path} overlaps source_root {source_root}")
+
+    current = temporary_base
+    for component in path.relative_to(temporary_base).parts[:-1]:
+        current /= component
+        _trusted_authority_directory(current, "temporary-root parent")
+    return path
+
+
+def _missing_private_temporary_root(value: object, source_root: Path) -> Path | None:
+    """Return the safe recorded root only when its own lstat reports ENOENT."""
+
+    path = _private_temporary_root_path(value, source_root)
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return path
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {path} could not be inspected: {exc}"
+        ) from exc
+    return None
+
+
+def _shard_authority(raw_shards: object, label: str) -> list[dict[str, object]]:
+    if not isinstance(raw_shards, list):
+        raise RecoveryError(f"{label} shards must be a list")
+    projected: list[dict[str, object]] = []
+    for position, raw in enumerate(raw_shards):
+        if not isinstance(raw, dict):
+            raise RecoveryError(f"{label} shard {position} must be an object")
+        projected.append({key: raw.get(key) for key in _SHARD_AUTHORITY_KEYS})
+    return projected
+
+
 def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord]:
     if not _SAFE_RUN_ID.fullmatch(run_id):
         raise RecoveryError(f"run id {run_id!r} is not a plain name")
@@ -389,6 +456,8 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
     if not isinstance(source_root_value, str) or not source_root_value:
         raise RecoveryError("run manifest has no source_root")
     source_root = Path(source_root_value).resolve()
+    if coordinator.get("source_root") != source_root_value:
+        raise RecoveryError("coordinator and manifest source roots differ")
     if source_root != root:
         raise RecoveryError(
             f"run manifest source_root {source_root} does not match recovery root {root}"
@@ -399,10 +468,24 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         raise RecoveryError(
             "serialized source manifest digest does not match run metadata"
         )
+    if coordinator.get("source_manifest") != source_manifest:
+        raise RecoveryError("coordinator and manifest source manifests differ")
 
     raw_shards = manifest.get("shards")
     if not isinstance(raw_shards, list):
         raise RecoveryError("run manifest shards must be a list")
+    if _shard_authority(coordinator.get("shards"), "coordinator") != _shard_authority(
+        raw_shards, "run manifest"
+    ):
+        raise RecoveryError("coordinator and manifest shard authorities differ")
+    manifest_temporary_root = manifest.get("temporary_root")
+    if coordinator.get("temporary_root") != manifest_temporary_root:
+        raise RecoveryError("coordinator and manifest temporary_root values differ")
+    temporary_root: Path | None = None
+    if raw_shards:
+        temporary_root = _private_temporary_root_path(
+            manifest_temporary_root, source_root
+        )
     staging_temporary_root: Path | None = None
     staging_shard_limit: int | None = None
     if not raw_shards:
@@ -427,11 +510,6 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         ):
             raise RecoveryError(
                 "zero-shard run manifest has invalid requested/effective shard bounds"
-            )
-        manifest_temporary_root = manifest.get("temporary_root")
-        if coordinator.get("temporary_root") != manifest_temporary_root:
-            raise RecoveryError(
-                "zero-shard coordinator and manifest temporary_root values differ"
             )
         staging_temporary_root = _private_temporary_root(
             manifest_temporary_root, source_root
@@ -466,6 +544,10 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
             )
         if not isinstance(temporary_root_value, str) or not temporary_root_value:
             raise RecoveryError(f"run manifest shard {index} has incomplete paths")
+        if temporary_root_value != manifest_temporary_root:
+            raise RecoveryError(
+                f"run manifest shard {index} temporary_root differs from the run root"
+            )
         if not isinstance(marker_value, str) or not marker_value:
             raise RecoveryError(f"run manifest shard {index} has incomplete paths")
         if not isinstance(lock_value, str) or not lock_value:
@@ -509,6 +591,7 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
     return state, RunRecord(
         run_id=run_id,
         manifest_path=manifest_path,
+        manifest=manifest,
         source_root=source_root,
         source_manifest=source_manifest,
         source_manifest_digest=source_digest,
@@ -516,6 +599,7 @@ def _load_run_record(root: Path, run_id: str) -> tuple[dict[str, Any], RunRecord
         diagnostic_pid=(
             coordinator.get("pid") if isinstance(coordinator.get("pid"), int) else None
         ),
+        temporary_root=temporary_root,
         staging_temporary_root=staging_temporary_root,
         staging_shard_limit=staging_shard_limit,
         shards=tuple(shards),
@@ -878,6 +962,51 @@ def _recover_partial_staging(
     )
 
 
+def _recover_absent_temporary_root(
+    root: Path,
+    state_path: Path,
+    state: dict[str, Any],
+    record: RunRecord,
+) -> str:
+    """Clear an incomplete run after the whole recorded private root vanished."""
+
+    coordinator = state.get("coordinator_run")
+    if not isinstance(coordinator, dict):
+        raise RecoveryError("coordinator state changed during recovery")
+    lifecycle = coordinator.get("lifecycle")
+    if lifecycle not in _INCOMPLETE_COORDINATOR_LIFECYCLES:
+        raise RecoveryError(
+            f"coordinator lifecycle {lifecycle!r} is not an incomplete lifecycle"
+        )
+
+    manifest = _read_root_recovery_json(root, record.manifest_path, "run manifest")
+    if manifest != record.manifest:
+        raise RecoveryError("run manifest changed during recovery")
+    manifest["lifecycle"] = "aborted"
+    _write_root_recovery_json(root, record.manifest_path, manifest)
+    coordinator["lifecycle"] = "aborted"
+    _write_root_recovery_json(root, state_path, state)
+
+    # This is deliberately the final observation before clear-state-last. A path
+    # that appeared after the first ENOENT is new, unauthorised filesystem state.
+    if (
+        _missing_private_temporary_root(
+            coordinator.get("temporary_root"), record.source_root
+        )
+        is None
+    ):
+        raise RecoveryError(
+            f"temporary_root {coordinator.get('temporary_root')} exists or was "
+            "replaced during recovery; root state remains"
+        )
+    state.pop("coordinator_run", None)
+    _write_root_recovery_json(root, state_path, state)
+    return (
+        f"recovered run {record.run_id} as aborted; recorded temporary root was "
+        "absent; removed 0 owned shard(s)"
+    )
+
+
 def recover_run(
     root: Path,
     run_id: str,
@@ -907,6 +1036,17 @@ def recover_run(
             force=force,
             cleanup_owned_tree=cleanup_owned_tree,
             output=output,
+        )
+    missing_temporary_root = _missing_private_temporary_root(
+        str(record.temporary_root) if record.temporary_root is not None else None,
+        record.source_root,
+    )
+    if missing_temporary_root is not None:
+        return _recover_absent_temporary_root(
+            root,
+            state_path,
+            state,
+            record,
         )
     preflight, liveness_leases = _build_preflight(record)
     try:

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -169,6 +169,26 @@ class TemporaryRootIdentity:
 
 
 @dataclass(frozen=True)
+class FilesystemIdentity:
+    """Stable identity for one preflight-authorized filesystem object."""
+
+    device: int
+    inode: int
+    canonical_path: Path
+
+
+@dataclass(frozen=True)
+class ShardCleanupAuthority:
+    """Every filesystem identity that authorizes one shard cleanup."""
+
+    shard_index: int
+    root: Path
+    root_identity: FilesystemIdentity
+    ownership_marker_identity: FilesystemIdentity
+    liveness_lock_identity: FilesystemIdentity
+
+
+@dataclass(frozen=True)
 class RecoveryPreflight:
     """The exact manifest-bounded actions and unknown evidence."""
 
@@ -176,6 +196,7 @@ class RecoveryPreflight:
     leave: tuple[Path, ...]
     unknown: tuple[str, ...]
     temporary_root_identity: TemporaryRootIdentity | None
+    shard_authorities: tuple[ShardCleanupAuthority, ...]
 
     def render(self, run_id: str) -> str:
         lines = [f"FORCE RECOVERY PREFLIGHT {run_id}", "REMOVE:"]
@@ -201,21 +222,36 @@ def hold_liveness_lock(path: Path) -> Iterator[None]:
         os.close(descriptor)
 
 
-def _acquire_liveness_lease(path: Path) -> int | None:
+def _acquire_liveness_lease(
+    path: Path, expected_identity: FilesystemIdentity
+) -> int | None:
     """Hold the shard lock through cleanup, or return None for a live child."""
 
-    if path.is_symlink():
-        raise RecoveryError(f"liveness lock {path} is a symlink")
+    flags = os.O_RDWR | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0)
     try:
-        descriptor = os.open(path, os.O_RDWR | os.O_CLOEXEC)
+        descriptor = os.open(path, flags)
     except OSError as exc:
         raise RecoveryError(f"liveness lock {path} could not be opened: {exc}") from exc
     try:
+        opened = os.fstat(descriptor)
+        opened_identity = (opened.st_dev, opened.st_ino)
+        expected = (expected_identity.device, expected_identity.inode)
+        if not stat.S_ISREG(opened.st_mode) or opened_identity != expected:
+            raise RecoveryError(
+                f"liveness lock {path} identity changed while it was opened"
+            )
         try:
             fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError:
             os.close(descriptor)
             return None
+        if (
+            _capture_filesystem_identity(path, "liveness lock", expect_directory=False)
+            != expected_identity
+        ):
+            raise RecoveryError(
+                f"liveness lock {path} identity changed while acquiring its lease"
+            )
         return descriptor
     except Exception:
         os.close(descriptor)
@@ -479,6 +515,36 @@ def _require_existing_private_temporary_root(
         )
 
 
+def _capture_filesystem_identity(
+    path: Path, label: str, *, expect_directory: bool
+) -> FilesystemIdentity:
+    """Capture one canonical non-symlink object with a stable lstat identity."""
+
+    try:
+        before = path.lstat()
+    except OSError as exc:
+        raise RecoveryError(f"{label} {path} could not be inspected: {exc}") from exc
+    expected_type = stat.S_ISDIR if expect_directory else stat.S_ISREG
+    expected_name = "directory" if expect_directory else "regular file"
+    if not expected_type(before.st_mode):
+        kind = "symlink" if stat.S_ISLNK(before.st_mode) else "wrong type"
+        raise RecoveryError(f"{label} {path} is a {kind}, expected {expected_name}")
+    try:
+        canonical_path = path.resolve(strict=True)
+        after = path.lstat()
+    except OSError as exc:
+        raise RecoveryError(f"{label} {path} could not be resolved: {exc}") from exc
+    before_identity = (before.st_dev, before.st_ino)
+    after_identity = (after.st_dev, after.st_ino)
+    if not expected_type(after.st_mode) or after_identity != before_identity:
+        raise RecoveryError(f"{label} {path} identity changed during inspection")
+    return FilesystemIdentity(
+        device=before.st_dev,
+        inode=before.st_ino,
+        canonical_path=canonical_path,
+    )
+
+
 def _shard_authority(raw_shards: object, label: str) -> list[dict[str, object]]:
     if not isinstance(raw_shards, list):
         raise RecoveryError(f"{label} shards must be a list")
@@ -717,6 +783,77 @@ def _marker_error(record: RunRecord, shard: ShardRecord) -> str | None:
     return None
 
 
+def _capture_shard_cleanup_authority(
+    record: RunRecord,
+    shard: ShardRecord,
+    temporary_root_identity: TemporaryRootIdentity,
+) -> ShardCleanupAuthority:
+    """Capture every path identity used to authorize one shard cleanup."""
+
+    _require_existing_private_temporary_root(record, temporary_root_identity)
+    root_identity = _capture_filesystem_identity(
+        shard.root, "shard root", expect_directory=True
+    )
+    marker_identity = _capture_filesystem_identity(
+        shard.ownership_marker, "ownership marker", expect_directory=False
+    )
+    lock_identity = _capture_filesystem_identity(
+        shard.liveness_lock, "liveness lock", expect_directory=False
+    )
+    if root_identity.canonical_path != shard.root:
+        raise RecoveryError(f"shard root {shard.root} is not canonical")
+    if marker_identity.canonical_path != shard.ownership_marker:
+        raise RecoveryError(
+            f"ownership marker {shard.ownership_marker} is not canonical"
+        )
+    if lock_identity.canonical_path != shard.liveness_lock:
+        raise RecoveryError(f"liveness lock {shard.liveness_lock} is not canonical")
+    _require_existing_private_temporary_root(record, temporary_root_identity)
+    return ShardCleanupAuthority(
+        shard_index=shard.shard_index,
+        root=shard.root,
+        root_identity=root_identity,
+        ownership_marker_identity=marker_identity,
+        liveness_lock_identity=lock_identity,
+    )
+
+
+def _require_shard_cleanup_authority(
+    record: RunRecord,
+    shard: ShardRecord,
+    temporary_root_identity: TemporaryRootIdentity,
+    expected: ShardCleanupAuthority,
+) -> None:
+    """Require the exact shard, marker, and lock identities bound by preflight."""
+
+    actual = _capture_shard_cleanup_authority(record, shard, temporary_root_identity)
+    if actual != expected:
+        if actual.root_identity != expected.root_identity:
+            label = f"shard root {shard.root}"
+        elif actual.ownership_marker_identity != expected.ownership_marker_identity:
+            label = f"ownership marker {shard.ownership_marker}"
+        else:
+            label = f"liveness lock {shard.liveness_lock}"
+        raise RecoveryError(f"{label} identity changed after preflight")
+
+
+def _require_preflight_shard_authorities(
+    record: RunRecord,
+    preflight: RecoveryPreflight,
+    temporary_root_identity: TemporaryRootIdentity,
+) -> None:
+    """Recheck all destructive targets before recovery changes durable state."""
+
+    shards = {(shard.shard_index, shard.root): shard for shard in record.shards}
+    for authority in preflight.shard_authorities:
+        shard = shards.get((authority.shard_index, authority.root))
+        if shard is None:
+            raise RecoveryError("recovery preflight names an unknown shard authority")
+        _require_shard_cleanup_authority(
+            record, shard, temporary_root_identity, authority
+        )
+
+
 def _partial_staging_shards(record: RunRecord) -> tuple[PartialShardRecord, ...]:
     """Validate every entry before authorizing any pre-child staging cleanup."""
 
@@ -811,14 +948,42 @@ def _build_preflight(record: RunRecord) -> tuple[RecoveryPreflight, tuple[int, .
     leave: list[Path] = []
     unknown: list[str] = []
     leases: list[int] = []
+    authorities: list[ShardCleanupAuthority] = []
     for shard in record.shards:
+        try:
+            marker_identity = _capture_filesystem_identity(
+                shard.ownership_marker,
+                "ownership marker",
+                expect_directory=False,
+            )
+            root_identity = _capture_filesystem_identity(
+                shard.root, "shard root", expect_directory=True
+            )
+        except RecoveryError as exc:
+            leave.append(shard.root)
+            unknown.append(str(exc))
+            continue
         marker_error = _marker_error(record, shard)
         if marker_error is not None:
             leave.append(shard.root)
             unknown.append(marker_error)
             continue
         try:
-            lease = _acquire_liveness_lease(shard.liveness_lock)
+            authority = _capture_shard_cleanup_authority(
+                record, shard, temporary_root_identity
+            )
+            if authority.ownership_marker_identity != marker_identity:
+                raise RecoveryError(
+                    f"ownership marker {shard.ownership_marker} identity changed "
+                    "during preflight"
+                )
+            if authority.root_identity != root_identity:
+                raise RecoveryError(
+                    f"shard root {shard.root} identity changed during preflight"
+                )
+            lease = _acquire_liveness_lease(
+                shard.liveness_lock, authority.liveness_lock_identity
+            )
         except RecoveryError as exc:
             leave.append(shard.root)
             unknown.append(str(exc))
@@ -832,7 +997,18 @@ def _build_preflight(record: RunRecord) -> tuple[RecoveryPreflight, tuple[int, .
             continue
         if lease is None:
             raise RecoveryError("liveness decision and acquired lease disagree")
+        try:
+            _require_shard_cleanup_authority(
+                record, shard, temporary_root_identity, authority
+            )
+        except RecoveryError as exc:
+            fcntl.flock(lease, fcntl.LOCK_UN)
+            os.close(lease)
+            leave.append(shard.root)
+            unknown.append(str(exc))
+            continue
         leases.append(lease)
+        authorities.append(authority)
         remove.append(shard.root)
     return (
         RecoveryPreflight(
@@ -840,6 +1016,7 @@ def _build_preflight(record: RunRecord) -> tuple[RecoveryPreflight, tuple[int, .
             leave=tuple(leave),
             unknown=tuple(unknown),
             temporary_root_identity=temporary_root_identity,
+            shard_authorities=tuple(authorities),
         ),
         tuple(leases),
     )
@@ -946,10 +1123,13 @@ def _recover_one(
     shard: ShardRecord,
     *,
     temporary_root_identity: TemporaryRootIdentity,
+    shard_authority: ShardCleanupAuthority,
     restore_mutation: RestoreMutation,
     cleanup_owned_tree: CleanupOwnedTree,
 ) -> None:
-    _require_existing_private_temporary_root(record, temporary_root_identity)
+    _require_shard_cleanup_authority(
+        record, shard, temporary_root_identity, shard_authority
+    )
     if _shard_has_applied_state(shard.root):
         try:
             restore_mutation(shard.root)
@@ -957,12 +1137,16 @@ def _recover_one(
             raise RecoveryError(
                 f"{shard.root}: applied mutation restore failed: {exc}"
             ) from exc
-        _require_existing_private_temporary_root(record, temporary_root_identity)
+        _require_shard_cleanup_authority(
+            record, shard, temporary_root_identity, shard_authority
+        )
         if _shard_has_applied_state(shard.root):
             raise RecoveryError(
                 f"{shard.root}: restore returned but applied state remains"
             )
-    _require_existing_private_temporary_root(record, temporary_root_identity)
+    _require_shard_cleanup_authority(
+        record, shard, temporary_root_identity, shard_authority
+    )
     try:
         cleanup_owned_tree(shard.root, shard.ownership_marker, shard.shard_index)
     except Exception as exc:
@@ -996,6 +1180,7 @@ def _recover_partial_staging(
         leave=(),
         unknown=(),
         temporary_root_identity=None,
+        shard_authorities=(),
     )
     if force:
         stream = output or sys.stdout
@@ -1154,6 +1339,7 @@ def recover_run(
         if temporary_root_identity is None:
             raise RecoveryError("recovery preflight has no temporary-root identity")
         _require_existing_private_temporary_root(record, temporary_root_identity)
+        _require_preflight_shard_authorities(record, preflight, temporary_root_identity)
         if force:
             stream = output or sys.stdout
             stream.write(preflight.render(run_id))
@@ -1168,22 +1354,33 @@ def recover_run(
         _write_root_recovery_json(root, state_path, state)
 
         _require_existing_private_temporary_root(record, temporary_root_identity)
+        _require_preflight_shard_authorities(record, preflight, temporary_root_identity)
         restore_callback = restore_mutation or _default_restore
         cleanup_callback = cleanup_owned_tree or _default_cleanup_for(record)
         removable = set(preflight.remove)
+        shard_authorities = {
+            (authority.shard_index, authority.root): authority
+            for authority in preflight.shard_authorities
+        }
         failures: list[str] = []
         removed = 0
         for shard in record.shards:
             if shard.root not in removable:
                 continue
             try:
-                _require_existing_private_temporary_root(
-                    record, temporary_root_identity
+                shard_authority = shard_authorities.get((shard.shard_index, shard.root))
+                if shard_authority is None:
+                    raise RecoveryError(
+                        f"shard {shard.shard_index} has no preflight cleanup authority"
+                    )
+                _require_shard_cleanup_authority(
+                    record, shard, temporary_root_identity, shard_authority
                 )
                 _recover_one(
                     record,
                     shard,
                     temporary_root_identity=temporary_root_identity,
+                    shard_authority=shard_authority,
                     restore_mutation=restore_callback,
                     cleanup_owned_tree=cleanup_callback,
                 )

--- a/scripts/mutation_harness_recovery.py
+++ b/scripts/mutation_harness_recovery.py
@@ -160,12 +160,22 @@ class PartialShardRecord:
 
 
 @dataclass(frozen=True)
+class TemporaryRootIdentity:
+    """Filesystem identity bound when shard recovery preflight starts."""
+
+    device: int
+    inode: int
+    canonical_path: Path
+
+
+@dataclass(frozen=True)
 class RecoveryPreflight:
     """The exact manifest-bounded actions and unknown evidence."""
 
     remove: tuple[Path, ...]
     leave: tuple[Path, ...]
     unknown: tuple[str, ...]
+    temporary_root_identity: TemporaryRootIdentity | None
 
     def render(self, run_id: str) -> str:
         lines = [f"FORCE RECOVERY PREFLIGHT {run_id}", "REMOVE:"]
@@ -346,6 +356,14 @@ def _private_temporary_root(value: object, source_root: Path) -> Path:
     return resolved
 
 
+def _require_temporary_root_directory(info: os.stat_result, path: Path) -> None:
+    """Refuse a final temporary-root component that is not a directory."""
+
+    if not stat.S_ISDIR(info.st_mode):
+        kind = "a symlink" if stat.S_ISLNK(info.st_mode) else "not a directory"
+        raise RecoveryError(f"temporary_root {path} is {kind}; refusing recovery")
+
+
 def _private_temporary_root_path(value: object, source_root: Path) -> Path:
     """Validate the lexical private-root authority before resolving descendants."""
 
@@ -381,9 +399,7 @@ def _private_temporary_root_path(value: object, source_root: Path) -> Path:
         raise RecoveryError(
             f"temporary_root {path} could not be inspected: {exc}"
         ) from exc
-    if not stat.S_ISDIR(info.st_mode):
-        kind = "a symlink" if stat.S_ISLNK(info.st_mode) else "not a directory"
-        raise RecoveryError(f"temporary_root {path} is {kind}; refusing recovery")
+    _require_temporary_root_directory(info, path)
     try:
         resolved = path.resolve(strict=True)
     except OSError as exc:
@@ -410,13 +426,56 @@ def _missing_private_temporary_root(value: object, source_root: Path) -> Path | 
     return None
 
 
-def _require_existing_private_temporary_root(record: RunRecord) -> None:
-    """Recheck the root authority before using preflight paths for cleanup."""
+def _capture_private_temporary_root_identity(
+    record: RunRecord,
+) -> TemporaryRootIdentity:
+    """Bind one existing directory identity without authorizing descendants."""
 
     value = str(record.temporary_root) if record.temporary_root is not None else None
-    if _missing_private_temporary_root(value, record.source_root) is not None:
+    path = _private_temporary_root_path(value, record.source_root)
+    try:
+        before = path.lstat()
+    except FileNotFoundError as exc:
         raise RecoveryError(
             f"temporary_root {value} disappeared during recovery; root state remains"
+        ) from exc
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {path} could not be inspected: {exc}"
+        ) from exc
+    _require_temporary_root_directory(before, path)
+    try:
+        canonical_path = path.resolve(strict=True)
+        after = path.lstat()
+    except OSError as exc:
+        raise RecoveryError(
+            f"temporary_root {path} could not be identity-checked: {exc}"
+        ) from exc
+    before_identity = (before.st_dev, before.st_ino)
+    after_identity = (after.st_dev, after.st_ino)
+    _require_temporary_root_directory(after, path)
+    if after_identity != before_identity:
+        raise RecoveryError(
+            f"temporary_root {path} identity changed during inspection; "
+            "root state remains"
+        )
+    return TemporaryRootIdentity(
+        device=before.st_dev,
+        inode=before.st_ino,
+        canonical_path=canonical_path,
+    )
+
+
+def _require_existing_private_temporary_root(
+    record: RunRecord, expected: TemporaryRootIdentity
+) -> None:
+    """Require the exact directory identity authorized by preflight."""
+
+    actual = _capture_private_temporary_root_identity(record)
+    if actual != expected:
+        raise RecoveryError(
+            f"temporary_root {record.temporary_root} identity changed after preflight; "
+            "root state remains"
         )
 
 
@@ -747,6 +806,7 @@ def _partial_staging_shards(record: RunRecord) -> tuple[PartialShardRecord, ...]
 
 
 def _build_preflight(record: RunRecord) -> tuple[RecoveryPreflight, tuple[int, ...]]:
+    temporary_root_identity = _capture_private_temporary_root_identity(record)
     remove: list[Path] = []
     leave: list[Path] = []
     unknown: list[str] = []
@@ -776,7 +836,10 @@ def _build_preflight(record: RunRecord) -> tuple[RecoveryPreflight, tuple[int, .
         remove.append(shard.root)
     return (
         RecoveryPreflight(
-            remove=tuple(remove), leave=tuple(leave), unknown=tuple(unknown)
+            remove=tuple(remove),
+            leave=tuple(leave),
+            unknown=tuple(unknown),
+            temporary_root_identity=temporary_root_identity,
         ),
         tuple(leases),
     )
@@ -879,11 +942,14 @@ def _default_cleanup_for(record: RunRecord) -> CleanupOwnedTree:
 
 
 def _recover_one(
+    record: RunRecord,
     shard: ShardRecord,
     *,
+    temporary_root_identity: TemporaryRootIdentity,
     restore_mutation: RestoreMutation,
     cleanup_owned_tree: CleanupOwnedTree,
 ) -> None:
+    _require_existing_private_temporary_root(record, temporary_root_identity)
     if _shard_has_applied_state(shard.root):
         try:
             restore_mutation(shard.root)
@@ -891,10 +957,12 @@ def _recover_one(
             raise RecoveryError(
                 f"{shard.root}: applied mutation restore failed: {exc}"
             ) from exc
+        _require_existing_private_temporary_root(record, temporary_root_identity)
         if _shard_has_applied_state(shard.root):
             raise RecoveryError(
                 f"{shard.root}: restore returned but applied state remains"
             )
+    _require_existing_private_temporary_root(record, temporary_root_identity)
     try:
         cleanup_owned_tree(shard.root, shard.ownership_marker, shard.shard_index)
     except Exception as exc:
@@ -927,6 +995,7 @@ def _recover_partial_staging(
         remove=tuple([*(partial.root for partial in partials), temporary_root]),
         leave=(),
         unknown=(),
+        temporary_root_identity=None,
     )
     if force:
         stream = output or sys.stdout
@@ -1081,7 +1150,10 @@ def recover_run(
         )
     preflight, liveness_leases = _build_preflight(record)
     try:
-        _require_existing_private_temporary_root(record)
+        temporary_root_identity = preflight.temporary_root_identity
+        if temporary_root_identity is None:
+            raise RecoveryError("recovery preflight has no temporary-root identity")
+        _require_existing_private_temporary_root(record, temporary_root_identity)
         if force:
             stream = output or sys.stdout
             stream.write(preflight.render(run_id))
@@ -1095,7 +1167,7 @@ def recover_run(
         coordinator["lifecycle"] = "recovering"
         _write_root_recovery_json(root, state_path, state)
 
-        _require_existing_private_temporary_root(record)
+        _require_existing_private_temporary_root(record, temporary_root_identity)
         restore_callback = restore_mutation or _default_restore
         cleanup_callback = cleanup_owned_tree or _default_cleanup_for(record)
         removable = set(preflight.remove)
@@ -1105,9 +1177,13 @@ def recover_run(
             if shard.root not in removable:
                 continue
             try:
-                _require_existing_private_temporary_root(record)
+                _require_existing_private_temporary_root(
+                    record, temporary_root_identity
+                )
                 _recover_one(
+                    record,
                     shard,
+                    temporary_root_identity=temporary_root_identity,
                     restore_mutation=restore_callback,
                     cleanup_owned_tree=cleanup_callback,
                 )

--- a/tests/tooling/mutation-plans/chaos-3807-lane-a.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-a.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3807 Lane A serial progress and result durability",
+  "$comment": "Lane A owns only serial progress and durable per-mutation results. These mutations disable the two new load-bearing writes and use the shared harness to prove the focused contract tests go green to red to green.",
+  "$limitation": "This plan does not claim sharded isolation, coordinator aggregation, recovery, plan opt-in, or liveness coverage. Those are owned by later CHAOS-3807 lanes. Event vocabulary, proof-output exclusion, stdout compatibility, and additive report fields are pinned by contract tests because they are data-shape and compatibility contracts rather than independent boolean guards.",
+  "build": [
+    ".venv/bin/python",
+    "-c",
+    "import sys; sys.dont_write_bytecode=True; import importlib.util as u; s=u.spec_from_file_location(\"mh_lane_a_build_check\",\"scripts/mutation_harness.py\"); m=u.module_from_spec(s); sys.modules[\"mh_lane_a_build_check\"]=m; s.loader.exec_module(m)"
+  ],
+  "mutations": [
+    {
+      "id": "A1_PROGRESS_FLUSH",
+      "file": "scripts/mutation_harness.py",
+      "find": "        self._stream.flush()",
+      "replace": "        if False:\n            self._stream.flush()",
+      "expect_occurrences": 1,
+      "rationale": "A progress write is not observable progress until the selected stderr stream is flushed. Buffered output delivered only when the harness exits recreates the silent-run defect.",
+      "proof": [
+        [
+          ".venv/bin/python",
+          "-m",
+          "pytest",
+          "-q",
+          "--confcutdir=tests/tooling",
+          "tests/tooling/test_mutation_harness.py::test_progress_flushes_the_selected_stderr_stream"
+        ]
+      ]
+    },
+    {
+      "id": "A2_RESULT_BEFORE_NEXT",
+      "file": "scripts/mutation_harness.py",
+      "find": "                _write_result_record(result_stream, selected_run_id, ordinal, result)",
+      "replace": "                if False:\n                    _write_result_record(result_stream, selected_run_id, ordinal, result)",
+      "expect_occurrences": 1,
+      "rationale": "Each completed measurement must reach the durable result stream before the next mutation begins, so an abort loses remaining work but never erases results already measured.",
+      "proof": [
+        [
+          ".venv/bin/python",
+          "-m",
+          "pytest",
+          "-q",
+          "--confcutdir=tests/tooling",
+          "tests/tooling/test_mutation_harness.py::test_result_stream_survives_an_abort_before_the_next_mutation"
+        ]
+      ]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/chaos-3807-lane-a.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-a.json
@@ -30,8 +30,8 @@
     {
       "id": "A2_RESULT_BEFORE_NEXT",
       "file": "scripts/mutation_harness.py",
-      "find": "                    _write_result_record(result_stream, selected_run_id, ordinal, result)",
-      "replace": "                    if False:\n                        _write_result_record(result_stream, selected_run_id, ordinal, result)",
+      "find": "                    _write_result_record(\n                        result_stream, selected_run_id, ordinal, result\n                    )",
+      "replace": "                    if False:\n                        _write_result_record(\n                            result_stream, selected_run_id, ordinal, result\n                        )",
       "expect_occurrences": 1,
       "rationale": "Each completed measurement must reach the durable result stream before the next mutation begins, so an abort loses remaining work but never erases results already measured.",
       "proof": [

--- a/tests/tooling/mutation-plans/chaos-3807-lane-a.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-a.json
@@ -30,8 +30,8 @@
     {
       "id": "A2_RESULT_BEFORE_NEXT",
       "file": "scripts/mutation_harness.py",
-      "find": "                _write_result_record(result_stream, selected_run_id, ordinal, result)",
-      "replace": "                if False:\n                    _write_result_record(result_stream, selected_run_id, ordinal, result)",
+      "find": "                    _write_result_record(result_stream, selected_run_id, ordinal, result)",
+      "replace": "                    if False:\n                        _write_result_record(result_stream, selected_run_id, ordinal, result)",
       "expect_occurrences": 1,
       "rationale": "Each completed measurement must reach the durable result stream before the next mutation begins, so an abort loses remaining work but never erases results already measured.",
       "proof": [

--- a/tests/tooling/mutation-plans/chaos-3807-lane-b.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-b.json
@@ -188,6 +188,36 @@
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_execution_tree.py::test_manifest_refuses_unignored_harness_state_and_damaged_recovery_record"
       ]]
+    },
+    {
+      "id": "B13",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "        \".mutation-harness\",\n        check=False,\n",
+      "replace": "        \".mutation-harness/execution-tree-probe\",\n        check=False,\n",
+      "rationale": "the ignore assertion must check the state directory as a whole rather than one selectively ignored child",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_manifest_refuses_selective_harness_child_ignore"
+      ]]
+    },
+    {
+      "id": "B14",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "        state_metadata = state_path.lstat()\n",
+      "replace": "        state_metadata = state_path.stat()\n",
+      "rationale": "cleanup must inspect the lexical state path so a dangling symlink cannot look absent",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_cleanup_refuses_a_dangling_shard_state_symlink"
+      ]]
     }
   ]
 }

--- a/tests/tooling/mutation-plans/chaos-3807-lane-b.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-b.json
@@ -1,0 +1,193 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3807 Lane B execution-tree guards",
+  "$limitation": "These mutations cover the Lane B execution-tree guards. Coordinator assignment, aggregation, root state, progress, plan opt-in, and recovery liveness-lock semantics belong to their owning lanes.",
+  "build": [
+    ".venv/bin/python",
+    "-m",
+    "py_compile",
+    "scripts/mutation_harness_execution_tree.py"
+  ],
+  "mutations": [
+    {
+      "id": "B1",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if workspace_inputs:\n        _materialize_workspace_inputs(source, destination, workspace_inputs)\n    verify_source_manifest(source, source_manifest)\n    return StagedExecutionTree(\n",
+      "replace": "    if workspace_inputs:\n        _materialize_workspace_inputs(source, destination, workspace_inputs)\n    if source_manifest.digest == \"disabled-final-recheck\":\n        verify_source_manifest(source, source_manifest)\n    return StagedExecutionTree(\n",
+      "rationale": "staging must recheck the invoking manifest after the last overlay byte is copied",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_stage_rechecks_invoking_manifest_after_the_overlay"
+      ]]
+    },
+    {
+      "id": "B2",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "            relocate_python_environment(\n                source_root=source_root,\n                shard_root=destination_root,\n                environment=destination,\n            )\n",
+      "replace": "            if False:\n                relocate_python_environment(\n                    source_root=source_root,\n                    shard_root=destination_root,\n                    environment=destination,\n                )\n",
+      "rationale": "a copied Python environment must be relocated before it can execute a shard proof",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_python_workspace_is_relocated_and_probe_reads_shard_bytes"
+      ]]
+    },
+    {
+      "id": "B3",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "            probe_python_toolchain_independence(\n                shard_root=destination_root,\n                environment=destination,\n            )\n",
+      "replace": "            if False:\n                probe_python_toolchain_independence(\n                    shard_root=destination_root,\n                    environment=destination,\n                )\n",
+      "rationale": "the pre-mutation probe must observe shard-only source bytes independently of relocation",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_stage_probe_is_independent_from_the_relocation_pass"
+      ]]
+    },
+    {
+      "id": "B4",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "        shutil.copy2(source, destination, follow_symlinks=True)\n",
+      "replace": "        os.link(source, destination)\n",
+      "rationale": "regular workspace-input files must have independent inodes rather than hard links",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_workspace_input_copy_has_no_links_and_is_byte_independent"
+      ]]
+    },
+    {
+      "id": "B5",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "        shutil.copy2(resolved, destination, follow_symlinks=True)\n",
+      "replace": "        os.symlink(os.readlink(source), destination)\n",
+      "rationale": "workspace-input symlinks must be materialized as independent regular files",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_workspace_input_copy_has_no_links_and_is_byte_independent"
+      ]]
+    },
+    {
+      "id": "B6",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if residue:\n        joined = \"\\n\".join(residue[:20])\n",
+      "replace": "    if False and residue:\n        joined = \"\\n\".join(residue[:20])\n",
+      "rationale": "an unknown absolute binding to the invoking root must fail relocation",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_relocation_refuses_unknown_invoking_root_residue"
+      ]]
+    },
+    {
+      "id": "B7",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if _read_marker(staged) != expected_marker:\n",
+      "replace": "    if False and _read_marker(staged) != expected_marker:\n",
+      "rationale": "cleanup must not delete a path whose ownership marker does not match the recorded shard",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_cleanup_refuses_escape_wrong_marker_live_holder_applied_and_dirty_source"
+      ]]
+    },
+    {
+      "id": "B8",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if not child_liveness_proven:\n",
+      "replace": "    if False and not child_liveness_proven:\n",
+      "rationale": "cleanup requires positive evidence that the shard child is dead",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_cleanup_refuses_escape_wrong_marker_live_holder_applied_and_dirty_source"
+      ]]
+    },
+    {
+      "id": "B9",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "        if state.get(\"applied\") is not None:\n",
+      "replace": "        if state.get(\"applied\") is None:\n",
+      "rationale": "cleanup must retain a shard while its applied-mutation record exists",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_cleanup_refuses_escape_wrong_marker_live_holder_applied_and_dirty_source"
+      ]]
+    },
+    {
+      "id": "B10",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if observed != staged.source_manifest:\n",
+      "replace": "    if False and observed != staged.source_manifest:\n",
+      "rationale": "cleanup must prove the shard source manifest is restored before removal",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_cleanup_refuses_escape_wrong_marker_live_holder_applied_and_dirty_source"
+      ]]
+    },
+    {
+      "id": "B11",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if mode != 0o700:\n",
+      "replace": "    if False and mode != 0o700:\n",
+      "rationale": "execution-tree temporary roots must remain owner-only",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_private_temp_root_is_mode_0700_and_staging_rejects_wider_mode"
+      ]]
+    },
+    {
+      "id": "B12",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if check.returncode == 1:\n",
+      "replace": "    if False and check.returncode == 1:\n",
+      "rationale": "source manifests must fail if live mutation-harness state is not ignored",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_manifest_refuses_unignored_harness_state_and_damaged_recovery_record"
+      ]]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/chaos-3807-lane-b.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-b.json
@@ -177,8 +177,8 @@
     {
       "id": "B12",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "    if check.returncode == 1:\n",
-      "replace": "    if False and check.returncode == 1:\n",
+      "find": "    if missing_probes:\n",
+      "replace": "    if False and missing_probes:\n",
       "rationale": "source manifests must fail if live mutation-harness state is not ignored",
       "proof": [[
         ".venv/bin/python",
@@ -192,8 +192,8 @@
     {
       "id": "B13",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "        \".mutation-harness\",\n        check=False,\n",
-      "replace": "        \".mutation-harness/execution-tree-probe\",\n        check=False,\n",
+      "find": "HARNESS_IGNORE_PROBES = (\n    \".mutation-harness/state.json\",\n    \".mutation-harness/snapshots/execution-tree-probe\",\n    \".mutation-harness/lock/pid\",\n    \".mutation-harness/runs/execution-tree-probe/manifest.json\",\n    OWNERSHIP_MARKER,\n)\n",
+      "replace": "HARNESS_IGNORE_PROBES = (\".mutation-harness/execution-tree-probe\",)\n",
       "rationale": "the ignore assertion must check the state directory as a whole rather than one selectively ignored child",
       "proof": [[
         ".venv/bin/python",

--- a/tests/tooling/mutation-plans/chaos-3807-lane-b.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-b.json
@@ -293,6 +293,21 @@
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_execution_tree.py::test_workspace_input_refuses_a_directory_symlink_cycle"
       ]]
+    },
+    {
+      "id": "B20",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    environment_variables[\"PYTHONDONTWRITEBYTECODE\"] = \"1\"\n",
+      "replace": "    environment_variables.pop(\"PYTHONDONTWRITEBYTECODE\", None)\n",
+      "rationale": "A failed independence probe must not write Python bytecode into the invoking source tree and then mask the real relocation refusal as source drift.",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_stage_probe_is_independent_from_the_relocation_pass"
+      ]]
     }
   ]
 }

--- a/tests/tooling/mutation-plans/chaos-3807-lane-b.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-b.json
@@ -12,8 +12,8 @@
     {
       "id": "B1",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "    if workspace_inputs:\n        _materialize_workspace_inputs(source, destination, workspace_inputs)\n    verify_source_manifest(source, source_manifest)\n    return StagedExecutionTree(\n",
-      "replace": "    if workspace_inputs:\n        _materialize_workspace_inputs(source, destination, workspace_inputs)\n    if source_manifest.digest == \"disabled-final-recheck\":\n        verify_source_manifest(source, source_manifest)\n    return StagedExecutionTree(\n",
+      "find": "        if workspace_inputs:\n            _materialize_workspace_inputs(source, destination, workspace_inputs)\n        verify_source_manifest(source, source_manifest)\n        return StagedExecutionTree(\n",
+      "replace": "        if workspace_inputs:\n            _materialize_workspace_inputs(source, destination, workspace_inputs)\n        if source_manifest.digest == \"disabled-final-recheck\":\n            verify_source_manifest(source, source_manifest)\n        return StagedExecutionTree(\n",
       "rationale": "staging must recheck the invoking manifest after the last overlay byte is copied",
       "proof": [[
         ".venv/bin/python",
@@ -117,8 +117,8 @@
     {
       "id": "B8",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "    if not child_liveness_proven:\n",
-      "replace": "    if False and not child_liveness_proven:\n",
+      "find": "    if _read_marker(staged) != expected_marker:\n        raise HarnessError(\n            f\"execution-tree ownership marker does not match shard {staged.shard_index}\"\n        )\n    if not child_liveness_proven:\n",
+      "replace": "    if _read_marker(staged) != expected_marker:\n        raise HarnessError(\n            f\"execution-tree ownership marker does not match shard {staged.shard_index}\"\n        )\n    if False and not child_liveness_proven:\n",
       "rationale": "cleanup requires positive evidence that the shard child is dead",
       "proof": [[
         ".venv/bin/python",
@@ -132,8 +132,8 @@
     {
       "id": "B9",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "        if state.get(\"applied\") is not None:\n",
-      "replace": "        if state.get(\"applied\") is None:\n",
+      "find": "        if not isinstance(state, dict):\n            raise HarnessError(f\"shard state is not a JSON object: {state_path}\")\n        if state.get(\"applied\") is not None:\n",
+      "replace": "        if not isinstance(state, dict):\n            raise HarnessError(f\"shard state is not a JSON object: {state_path}\")\n        if state.get(\"applied\") is None:\n",
       "rationale": "cleanup must retain a shard while its applied-mutation record exists",
       "proof": [[
         ".venv/bin/python",
@@ -207,8 +207,8 @@
     {
       "id": "B14",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "        state_metadata = state_path.lstat()\n",
-      "replace": "        state_metadata = state_path.stat()\n",
+      "find": "    state_path = state_directory / \"state.json\"\n    try:\n        state_metadata = state_path.lstat()\n    except FileNotFoundError:\n        state_metadata = None\n    except OSError as exc:\n        raise HarnessError(f\"shard state is unreadable: {state_path}\") from exc\n",
+      "replace": "    state_path = state_directory / \"state.json\"\n    try:\n        state_metadata = state_path.stat()\n    except FileNotFoundError:\n        state_metadata = None\n    except OSError as exc:\n        raise HarnessError(f\"shard state is unreadable: {state_path}\") from exc\n",
       "rationale": "cleanup must inspect the lexical state path so a dangling symlink cannot look absent",
       "proof": [[
         ".venv/bin/python",
@@ -217,6 +217,36 @@
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_execution_tree.py::test_cleanup_refuses_a_dangling_shard_state_symlink"
+      ]]
+    },
+    {
+      "id": "B15",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "            _relocate_direct_url_metadata(\n                direct_url,\n                source_root=source_root,\n                shard_root=shard_root,\n            )\n",
+      "replace": "            if False:\n                _relocate_direct_url_metadata(\n                    direct_url,\n                    source_root=source_root,\n                    shard_root=shard_root,\n                )\n",
+      "rationale": "recognized editable direct_url.json file URIs must be relocated before the unknown-residue gate",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_editable_direct_url_metadata_is_relocated_to_the_shard"
+      ]]
+    },
+    {
+      "id": "B16",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "        if created_by_call:\n",
+      "replace": "        if False and created_by_call:\n",
+      "rationale": "a post-marker staging failure must roll back the newly owned partial worktree",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_staging_failure_after_marker_rolls_back_only_the_owned_partial_tree"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-b.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-b.json
@@ -57,8 +57,8 @@
     {
       "id": "B4",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "        shutil.copy2(source, destination, follow_symlinks=True)\n",
-      "replace": "        os.link(source, destination)\n",
+      "find": "            shutil.copy2(source, destination, follow_symlinks=True)\n",
+      "replace": "            os.link(source, destination)\n",
       "rationale": "regular workspace-input files must have independent inodes rather than hard links",
       "proof": [[
         ".venv/bin/python",
@@ -72,8 +72,8 @@
     {
       "id": "B5",
       "file": "scripts/mutation_harness_execution_tree.py",
-      "find": "        shutil.copy2(resolved, destination, follow_symlinks=True)\n",
-      "replace": "        os.symlink(os.readlink(source), destination)\n",
+      "find": "            shutil.copy2(source_target, destination, follow_symlinks=True)\n",
+      "replace": "            os.symlink(os.readlink(source), destination)\n",
       "rationale": "workspace-input symlinks must be materialized as independent regular files",
       "proof": [[
         ".venv/bin/python",
@@ -247,6 +247,51 @@
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_execution_tree.py::test_staging_failure_after_marker_rolls_back_only_the_owned_partial_tree"
+      ]]
+    },
+    {
+      "id": "B17",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "        try:\n            resolved_source.relative_to(source_root.resolve(strict=True))\n        except ValueError:\n            raise HarnessError(\n                f\"workspace input resolves outside repository: {relative}\"\n            ) from None\n",
+      "replace": "        _ = source_root\n",
+      "rationale": "a declared top-level workspace input must not resolve outside the invoking repository",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_workspace_input_refuses_a_top_level_link_outside_the_repository"
+      ]]
+    },
+    {
+      "id": "B18",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "            try:\n                resolved.relative_to(directory_root)\n            except ValueError:\n                raise HarnessError(\n                    f\"workspace input directory link escapes workspace input: {source}\"\n                ) from None\n",
+      "replace": "            _ = directory_root\n",
+      "rationale": "a nested directory link must remain inside its declared workspace-input tree",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_workspace_input_refuses_an_external_directory_symlink"
+      ]]
+    },
+    {
+      "id": "B19",
+      "file": "scripts/mutation_harness_execution_tree.py",
+      "find": "    if identity in active_directories:\n        raise HarnessError(f\"workspace input directory link cycle: {source}\")\n",
+      "replace": "    if False and identity in active_directories:\n        raise HarnessError(f\"workspace input directory link cycle: {source}\")\n",
+      "rationale": "directory aliases must not recursively revisit an active source inode",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_execution_tree.py::test_workspace_input_refuses_a_directory_symlink_cycle"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-c.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "CHAOS-3807 Lane C coordinator guards",
-  "$limitation": "Pins coordinator-only assignment, aggregation, source recheck, completion barrier, crash classification, root locking, event sequencing, and fail-closed normalization. Execution-tree ownership cleanup and recovery liveness decisions belong to Lanes B and D.",
+  "$limitation": "Pins coordinator-only assignment, aggregation, source recheck, completion barrier, crash classification, root locking, durable run-root authority, event sequencing, and fail-closed normalization. Execution-tree ownership cleanup and recovery liveness decisions belong to Lanes B and D.",
   "build": [
     ".venv/bin/python",
     "-m",
@@ -153,11 +153,21 @@
     {
       "id": "C15-source-and-temporary-roots-disjoint",
       "file": "scripts/mutation_harness_coordinator.py",
-      "find": "    if _paths_overlap(resolved_source, resolved_temporary):",
-      "replace": "    if False and _paths_overlap(resolved_source, resolved_temporary):",
+      "find": "    if _paths_overlap(resolved_source, resolved_temporary):\n        raise HarnessError(\n            f\"child temporary_root {resolved_temporary} overlaps the invoking \"",
+      "replace": "    if False and _paths_overlap(resolved_source, resolved_temporary):\n        raise HarnessError(\n            f\"child temporary_root {resolved_temporary} overlaps the invoking \"",
       "rationale": "The private temporary root must be disjoint from the invoking source root in both ancestry directions, so no shard can stage or mutate under the source tree.",
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "child_paths_must_not_overlap"]
+      ]
+    },
+    {
+      "id": "C16-durable-run-temporary-root",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        \"temporary_root\": recorded_temporary,",
+      "replace": "        \"temporary_root\": state[\"source_root\"],",
+      "rationale": "Recovery must receive the canonical run-level private root from durable manifest authority even when staging fails before the first shard is recorded.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "manifest_records_run_temporary_root"]
       ]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-c.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-c.json
@@ -123,8 +123,8 @@
     {
       "id": "C12-normalizer-unrecognised-path-refusal",
       "file": "scripts/mutation_harness_coordinator.py",
-      "find": "    absolute = _POSIX_ABSOLUTE_PATH_RE.search(normalized)",
-      "replace": "    absolute = None",
+      "find": "            for match in _POSIX_ABSOLUTE_PATH_RE.finditer(normalized)",
+      "replace": "            for match in ()",
       "rationale": "The canonical detail normalizer must expose an unknown absolute path as a comparison gap instead of erasing or accepting it.",
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "normalizer_refuses"]
@@ -198,6 +198,66 @@
       "rationale": "Rollback may unlink only the exact regular manifest inode with the exact bytes written by this startup attempt.",
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "manifest_cleanup_refuses_identity_or_content_tampering"]
+      ]
+    },
+    {
+      "id": "C20-contextual-origin-form-request-target",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    request_target_spans = _contextual_request_target_spans(normalized)",
+      "replace": "    request_target_spans: tuple[tuple[int, int], ...] = ()",
+      "rationale": "Canonical comparison must preserve a syntactically valid origin-form request target only when an explicit immediate request, URL, or HTTP-method context identifies it as non-filesystem text.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "serial_and_sharded_projection_match_with_origin_form_request_target"]
+      ]
+    },
+    {
+      "id": "C21-explicit-go-toolchain-root",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        replacements.append((str(resolved_go_root), \"<GOROOT>\"))",
+      "replace": "        pass",
+      "rationale": "Only an explicitly caller-bound canonical Go toolchain root may normalize platform-specific Go stack-frame prefixes; suffix lookalikes remain unknown absolute paths.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "projection_normalizes_only_the_explicit_go_toolchain_root"]
+      ]
+    },
+    {
+      "id": "C22-indexed-request-assertion-targets",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    spans.extend(_indexed_request_assertion_spans(detail))",
+      "replace": "    spans.extend(())",
+      "rationale": "Both quoted origin-form values in a bounded request[index]=actual want=expected assertion are request targets, not filesystem paths.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "normalizer_preserves_indexed_request_assertion_targets"]
+      ]
+    },
+    {
+      "id": "C23-structured-request-field-target",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    spans.extend(_structured_request_field_spans(detail))",
+      "replace": "    spans.extend(())",
+      "rationale": "A syntactically valid origin-form value under the bounded generic-oracle requests field remains comparable even when the diagnostic tail truncates its closing quote.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "normalizer_preserves_structured_request_field_target"]
+      ]
+    },
+    {
+      "id": "C24-shell-temporary-template",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    allowed_absolute_spans = request_target_spans + _shell_temp_template_spans(\n        normalized\n    )",
+      "replace": "    allowed_absolute_spans = request_target_spans",
+      "rationale": "The literal mktemp -d ${TMPDIR:-/tmp}/name.XXXXXX command template is deterministic shell syntax, not an unclassified runtime absolute path.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "normalizer_preserves_only_explicit_shell_temp_templates"]
+      ]
+    },
+    {
+      "id": "C25-go-test-package-summary-duration",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    normalized = _GO_TEST_PACKAGE_DURATION_RE.sub(r\"\\g<prefix><DURATION>\", normalized)",
+      "replace": "    normalized = normalized",
+      "rationale": "The Go test package summary duration is run-varying test time and must normalize only on an exact ok-or-FAIL tabular summary line.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "projection_normalizes_go_test_package_summary_duration"]
       ]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-c.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "CHAOS-3807 Lane C coordinator guards",
-  "$limitation": "Pins coordinator-only assignment, aggregation, source recheck, completion barrier, crash classification, root locking, durable run-root authority, event sequencing, and fail-closed normalization. Execution-tree ownership cleanup and recovery liveness decisions belong to Lanes B and D.",
+  "$limitation": "Pins coordinator-only assignment, aggregation, source recheck, completion barrier, crash classification, root locking, transactional startup, durable run-root authority, event sequencing, and fail-closed normalization. Execution-tree ownership cleanup and recovery liveness decisions belong to Lanes B and D.",
   "build": [
     ".venv/bin/python",
     "-m",
@@ -168,6 +168,16 @@
       "rationale": "Recovery must receive the canonical run-level private root from durable manifest authority even when staging fails before the first shard is recorded.",
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "manifest_records_run_temporary_root"]
+      ]
+    },
+    {
+      "id": "C17-pre-authority-private-root-cleanup",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "            temporary_root.rmdir()",
+      "replace": "            pass",
+      "rationale": "A startup failure before durable root-state authority must not orphan the empty private run root created by this coordinator call.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "state_initialization_failure"]
       ]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-c.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-c.json
@@ -213,8 +213,8 @@
     {
       "id": "C21-explicit-go-toolchain-root",
       "file": "scripts/mutation_harness_coordinator.py",
-      "find": "        replacements.append((str(resolved_go_root), \"<GOROOT>\"))",
-      "replace": "        pass",
+      "find": "        normalized = _replace_bound_absolute_root(\n            normalized, resolved_go_root, \"<GOROOT>\"\n        )",
+      "replace": "        normalized = normalized",
       "rationale": "Only an explicitly caller-bound canonical Go toolchain root may normalize platform-specific Go stack-frame prefixes; suffix lookalikes remain unknown absolute paths.",
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "projection_normalizes_only_the_explicit_go_toolchain_root"]
@@ -258,6 +258,16 @@
       "rationale": "The Go test package summary duration is run-varying test time and must normalize only on an exact ok-or-FAIL tabular summary line.",
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "projection_normalizes_go_test_package_summary_duration"]
+      ]
+    },
+    {
+      "id": "C26-go-toolchain-root-token-boundary",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        + _absolute_root_right_boundary()",
+      "replace": "        + r\"(?=$|.)\"",
+      "rationale": "An explicit GOROOT may normalize only as a complete absolute-path token or before the platform path separator, never as the prefix of a sibling, suffix, or embedded token.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "projection_normalizes_only_the_explicit_go_toolchain_root"]
       ]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-c.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-c.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3807 Lane C coordinator guards",
+  "$limitation": "Pins coordinator-only assignment, aggregation, source recheck, completion barrier, crash classification, root locking, event sequencing, and fail-closed normalization. Execution-tree ownership cleanup and recovery liveness decisions belong to Lanes B and D.",
+  "build": [
+    ".venv/bin/python",
+    "-m",
+    "py_compile",
+    "scripts/mutation_harness_coordinator.py"
+  ],
+  "mutations": [
+    {
+      "id": "C01-root-lock-before-staging",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    lock = acquire_lock(root)",
+      "replace": "    lock = _state_dir(root) / \"lock\"",
+      "rationale": "The coordinator must atomically own the root lock before it writes staging state or calls a staging factory.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "root_lock"]
+      ]
+    },
+    {
+      "id": "C02-source-manifest-rechecks",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        if source_manifest_reader() != source_manifest_digest:",
+      "replace": "        if False and source_manifest_reader() != source_manifest_digest:",
+      "expect_occurrences": 3,
+      "rationale": "The source manifest must be checked before staging, after staging, and again before an aggregate can be authoritative.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "source_manifest_drift"]
+      ]
+    },
+    {
+      "id": "C03-missing-result-refusal",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    if missing:",
+      "replace": "    if False and missing:",
+      "rationale": "An absent selected mutation result is unmeasured and must invalidate the aggregate.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "malformed_child_results"]
+      ]
+    },
+    {
+      "id": "C04-duplicate-result-refusal",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    if duplicates:",
+      "replace": "    if False and duplicates:",
+      "rationale": "Two results for one selected mutation are ambiguous and must invalidate the aggregate.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "malformed_child_results"]
+      ]
+    },
+    {
+      "id": "C05-unknown-result-refusal",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        if binding is None:\n            unknown.add(record.mutation_id)\n            continue",
+      "replace": "        if binding is None:\n            continue",
+      "rationale": "A child cannot add a result for a mutation outside the coordinator's selected plan.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "malformed_child_results"]
+      ]
+    },
+    {
+      "id": "C06-plan-digest-binding",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        if record.plan_digest != plan_digest:",
+      "replace": "        if False and record.plan_digest != plan_digest:",
+      "rationale": "A durable child result is authoritative only for the exact selected plan digest.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "malformed_child_results"]
+      ]
+    },
+    {
+      "id": "C07-selected-plan-result-order",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    ordered_ids.sort(key=lambda identifier: expected[identifier][1])",
+      "replace": "    ordered_ids.reverse()",
+      "rationale": "Final results must follow selected plan ordinal and never shard completion or stream order.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "aggregate_reorders"]
+      ]
+    },
+    {
+      "id": "C08-all-children-before-report",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    if not all_children_complete:",
+      "replace": "    if False and not all_children_complete:",
+      "rationale": "A final aggregate cannot be written while any launched child can still produce events or results.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "final_report_refuses"]
+      ]
+    },
+    {
+      "id": "C09-child-crash-is-not-survivor",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        if any(code != 0 for code in exits.values()):",
+      "replace": "        if False and any(code != 0 for code in exits.values()):",
+      "rationale": "A crashed child makes the run terminally failed; its remaining assignments are unmeasured, never survivors.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "child_crash_before_measurement"]
+      ]
+    },
+    {
+      "id": "C10-streamed-result-drop-classification",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        measured_lost = tuple(sorted(set(unmeasured) & finished_ids))",
+      "replace": "        measured_lost = tuple(sorted(set(unmeasured) & set()))",
+      "rationale": "A terminal mutation event without its durable result is measured-and-lost, distinct from work never measured.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "result_drop_after_finished"]
+      ]
+    },
+    {
+      "id": "C11-event-monotonic-sequence",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        self.sequence += 1",
+      "replace": "        self.sequence += 0",
+      "rationale": "Only the coordinator assigns the root event log's strictly monotonic sequence.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "resequences_events"]
+      ]
+    },
+    {
+      "id": "C12-normalizer-unrecognised-path-refusal",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    absolute = _POSIX_ABSOLUTE_PATH_RE.search(normalized)",
+      "replace": "    absolute = None",
+      "rationale": "The canonical detail normalizer must expose an unknown absolute path as a comparison gap instead of erasing or accepting it.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "normalizer_refuses"]
+      ]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/chaos-3807-lane-c.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-c.json
@@ -129,6 +129,36 @@
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "normalizer_refuses"]
       ]
+    },
+    {
+      "id": "C13-complete-lifecycle-events-required",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        _append_missing_lifecycle_errors(runtime, errors)",
+      "replace": "        if False: _append_missing_lifecycle_errors(runtime, errors)",
+      "rationale": "A durable result without exactly one mutation_started and mutation_finished pair is not a complete measurement and cannot yield an accepted aggregate.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "complete_results_without_mutation_lifecycle"]
+      ]
+    },
+    {
+      "id": "C14-partial-result-stream-still-reports",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        if not line.endswith(b\"\\n\"):\n            errors.append(f\"child result stream {path} ends with a partial JSON line\")\n            continue",
+      "replace": "        if not line.endswith(b\"\\n\"):\n            raise HarnessError(f\"child result stream {path} ends with a partial JSON line\")",
+      "rationale": "A malformed result tail is aggregate evidence, not permission to abort before the coordinator writes a non-authoritative report containing every earlier durable result.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "partial_child_result_stream"]
+      ]
+    },
+    {
+      "id": "C15-source-and-temporary-roots-disjoint",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "    if _paths_overlap(resolved_source, resolved_temporary):",
+      "replace": "    if False and _paths_overlap(resolved_source, resolved_temporary):",
+      "rationale": "The private temporary root must be disjoint from the invoking source root in both ancestry directions, so no shard can stage or mutate under the source tree.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "child_paths_must_not_overlap"]
+      ]
     }
   ]
 }

--- a/tests/tooling/mutation-plans/chaos-3807-lane-c.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-c.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "CHAOS-3807 Lane C coordinator guards",
-  "$limitation": "Pins coordinator-only assignment, aggregation, source recheck, completion barrier, crash classification, root locking, transactional startup, durable run-root authority, event sequencing, and fail-closed normalization. Execution-tree ownership cleanup and recovery liveness decisions belong to Lanes B and D.",
+  "$limitation": "Pins coordinator-only assignment, aggregation, source recheck, completion barrier, crash classification, root locking, identity-bound transactional startup, durable run-root authority, event sequencing, and fail-closed normalization. Execution-tree ownership cleanup and recovery liveness decisions belong to Lanes B and D.",
   "build": [
     ".venv/bin/python",
     "-m",
@@ -173,11 +173,31 @@
     {
       "id": "C17-pre-authority-private-root-cleanup",
       "file": "scripts/mutation_harness_coordinator.py",
-      "find": "            temporary_root.rmdir()",
-      "replace": "            pass",
+      "find": "        claim.path.rmdir()",
+      "replace": "        pass",
       "rationale": "A startup failure before durable root-state authority must not orphan the empty private run root created by this coordinator call.",
       "proof": [
         [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "state_initialization_failure"]
+      ]
+    },
+    {
+      "id": "C18-factory-validation-ownership",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        temporary_root_claim = temporary_root_factory(run_id)",
+      "replace": "        temporary_root_claim = TemporaryRootClaim.borrowed(temporary_root_factory(run_id).path)",
+      "rationale": "A newly created private root must retain its captured cleanup authority before overlap validation can fail.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "owned_private_root_is_removed_when_overlap_validation_fails"]
+      ]
+    },
+    {
+      "id": "C19-manifest-identity-and-content-cleanup",
+      "file": "scripts/mutation_harness_coordinator.py",
+      "find": "        _remove_claimed_regular_file(manifest_claim)",
+      "replace": "        manifest_claim.path.unlink() if manifest_claim is not None else None",
+      "rationale": "Rollback may unlink only the exact regular manifest inode with the exact bytes written by this startup attempt.",
+      "proof": [
+        [".venv/bin/python", "-m", "pytest", "-q", "--confcutdir=tests/tooling", "tests/tooling/test_mutation_harness_coordinator.py", "-k", "manifest_cleanup_refuses_identity_or_content_tampering"]
       ]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, and recovery of manifest-authorized pre-child staging with source/temporary-root disjointness. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, and the bounded whole-recorded-root ENOENT reboot path with a final absence recheck. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -166,6 +166,32 @@
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_zero_shard_recovery_rejects_private_root_below_source",
         "tests/tooling/test_mutation_harness_lane_d.py::test_zero_shard_recovery_rejects_private_root_above_source"
+      ]]
+    },
+    {
+      "id": "D13-whole-temporary-root-absent-recovery",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "if missing_temporary_root is not None:\n        return _recover_absent_temporary_root(",
+      "replace": "if False and missing_temporary_root is not None:\n        return _recover_absent_temporary_root(",
+      "rationale": "a reboot that removes the entire recorded private temporary root must take the bounded ENOENT recovery path instead of treating every missing descendant marker as independent UNKNOWN state",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_missing_recorded_temporary_root_recovers_without_fabricating_results"
+      ]]
+    },
+    {
+      "id": "D14-whole-temporary-root-absence-recheck",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "if (\n        _missing_private_temporary_root(\n            coordinator.get(\"temporary_root\"), record.source_root\n        )\n        is None\n    ):",
+      "replace": "if False and (\n        _missing_private_temporary_root(\n            coordinator.get(\"temporary_root\"), record.source_root\n        )\n        is None\n    ):",
+      "rationale": "the recorded private root must still be absent immediately before clear-state-last so a path that appears or is replaced during recovery is retained as unauthorised state",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_missing_temporary_root_rechecks_absence_immediately_before_state_clear"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, the recorded temporary-root final-component lexical type guard, preflight-to-cleanup temporary-root identity binding, and per-shard root, owner-marker, and leased-lock identity binding. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, the recorded temporary-root final-component lexical type guard, preflight-to-cleanup temporary-root identity binding, per-shard root, owner-marker, and leased-lock identity binding, fail-closed default refusal of any still-existing recorded Git shard, and the trusted-test-only fd capability boundary with an exit identity recheck. Default recovery never invokes Git porcelain or moves an existing shard. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -208,23 +208,23 @@
       ]]
     },
     {
-      "id": "D16-temporary-root-preflight-identity",
+      "id": "D16-temporary-root-cleanup-descriptor-identity",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "actual = _capture_private_temporary_root_identity(record)\n    if actual != expected:\n        raise RecoveryError(\n            f\"temporary_root {record.temporary_root} identity changed after preflight; \"\n            \"root state remains\"\n        )",
-      "replace": "actual = _capture_private_temporary_root_identity(record)\n    if False and actual != expected:\n        raise RecoveryError(\n            f\"temporary_root {record.temporary_root} identity changed after preflight; \"\n            \"root state remains\"\n        )",
-      "rationale": "cleanup must retain a matching-marker directory that replaced the device and inode authorized by preflight at the same lexical temporary-root path",
+      "find": "        _require_shard_cleanup_authority(\n            record, shard, temporary_root_identity, shard_authority\n        )\n        os.rename(",
+      "replace": "        if False:\n            _require_shard_cleanup_authority(\n                record, shard, temporary_root_identity, shard_authority\n            )\n        os.rename(",
+      "rationale": "cleanup must recheck the recorded temporary-root identity after opening its bound descriptor and before the fd-relative quarantine rename",
       "proof": [[
         ".venv/bin/pytest",
         "-q",
         "--confcutdir=tests/tooling",
-        "tests/tooling/test_mutation_harness_lane_d.py::test_temporary_root_identity_change_with_original_shard_is_retained"
+        "tests/tooling/test_mutation_harness_lane_d.py::test_cleanup_boundary_rechecks_root_after_opening_its_descriptor"
       ]]
     },
     {
       "id": "D17-shard-cleanup-authority-identity",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "actual = _capture_shard_cleanup_authority(record, shard, temporary_root_identity)\n    if actual != expected:",
-      "replace": "actual = _capture_shard_cleanup_authority(record, shard, temporary_root_identity)\n    if False and actual != expected:",
+      "find": "    try:\n        actual = _capture_shard_cleanup_authority(\n            record, shard, temporary_root_identity\n        )\n    except RecoveryError as exc:\n        raise RecoveryAuthorityChanged(str(exc)) from exc\n    if actual != expected:",
+      "replace": "    try:\n        actual = _capture_shard_cleanup_authority(\n            record, shard, temporary_root_identity\n        )\n    except RecoveryError as exc:\n        raise RecoveryAuthorityChanged(str(exc)) from exc\n    if False and actual != expected:",
       "rationale": "cleanup must retain a shard when its root, ownership marker, or leased liveness lock no longer has the device and inode authorized by preflight",
       "proof": [[
         ".venv/bin/pytest",
@@ -232,6 +232,32 @@
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_shard_same_path_directory_replacement_is_retained",
         "tests/tooling/test_mutation_harness_lane_d.py::test_shard_authority_file_replacement_after_preflight_is_retained"
+      ]]
+    },
+    {
+      "id": "D18-default-existing-git-shard-refusal",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "    if cleanup_owned_tree is None:\n        raise RecoveryError(\n            \"default recovery refuses existing recorded Git shard trees; \"",
+      "replace": "    if False and cleanup_owned_tree is None:\n        raise RecoveryError(\n            \"default recovery refuses existing recorded Git shard trees; \"",
+      "rationale": "default public recovery must refuse every still-existing recorded Git shard before preflight, quarantine, restore, repair, cleanup, or durable-state mutation",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_default_recovery_refuses_a_real_registered_git_shard_without_mutation"
+      ]]
+    },
+    {
+      "id": "D19-cleanup-capability-exit-identity",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "        cleanup_owned_tree(capability)\n        capability.require_unchanged()\n        try:",
+      "replace": "        cleanup_owned_tree(capability)\n        _ = capability\n        try:",
+      "rationale": "a trusted injected cleanup callback must not be able to replace any open quarantine, shard, marker, or leased-lock descriptor without an exit identity refusal",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_cleanup_callback_rechecks_every_open_capability_at_exit"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, and clear-state-last behavior. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, and independent root and descendant authority-directory symlink refusals. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -112,6 +112,19 @@
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_recovery_refuses_symlinked_root_state_directory"
+      ]]
+    },
+    {
+      "id": "D9-descendant-authority-directory-symlink",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "if stat.S_ISLNK(info.st_mode):\n        raise RecoveryError(f\"{label} {path} is a symlink; refusing recovery\")\n    if not stat.S_ISDIR(info.st_mode):",
+      "replace": "if stat.S_ISLNK(info.st_mode):\n        return\n    if not stat.S_ISDIR(info.st_mode):",
+      "rationale": "recovery must lstat and reject symlinks in descendant authority directories before following them outside the root state tree",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_recovery_refuses_symlinked_runs_authority_directory"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, and the bounded whole-recorded-root ENOENT reboot path with a final absence recheck. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, and the recorded temporary-root final-component lexical type guard. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -91,8 +91,8 @@
     {
       "id": "D7-clear-root-state-last",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _write_root_recovery_json(root, state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
-      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _write_root_recovery_json(root, state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
+      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record)\n        restore_callback = restore_mutation or _default_restore",
+      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record)\n        restore_callback = restore_mutation or _default_restore",
       "rationale": "the root coordinator record must remain present until every owned shard restore and cleanup is verified",
       "proof": [[
         ".venv/bin/pytest",
@@ -157,8 +157,8 @@
     {
       "id": "D12-source-temporary-root-disjointness",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "if resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved):\n        raise RecoveryError(f\"temporary_root {path} overlaps source_root {source_root}\")",
-      "replace": "if False and (resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved)):\n        raise RecoveryError(f\"temporary_root {path} overlaps source_root {source_root}\")",
+      "find": "if resolved != path:\n        raise RecoveryError(\n            f\"temporary_root {path} is not canonical or contains a symlink\"\n        )\n    if resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved):\n        raise RecoveryError(f\"temporary_root {path} overlaps source_root {source_root}\")",
+      "replace": "if resolved != path:\n        raise RecoveryError(\n            f\"temporary_root {path} is not canonical or contains a symlink\"\n        )\n    if False and (resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved)):\n        raise RecoveryError(f\"temporary_root {path} overlaps source_root {source_root}\")",
       "rationale": "recovery must independently enforce source and temporary-root disjointness before a source descendant or ancestor can enter any cleanup preflight",
       "proof": [[
         ".venv/bin/pytest",
@@ -192,6 +192,19 @@
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_missing_temporary_root_rechecks_absence_immediately_before_state_clear"
+      ]]
+    },
+    {
+      "id": "D15-temporary-root-final-component-type",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "if not stat.S_ISDIR(info.st_mode):\n        kind = \"a symlink\" if stat.S_ISLNK(info.st_mode) else \"not a directory\"\n        raise RecoveryError(f\"temporary_root {path} is {kind}; refusing recovery\")",
+      "replace": "if False and not stat.S_ISDIR(info.st_mode):\n        kind = \"a symlink\" if stat.S_ISLNK(info.st_mode) else \"not a directory\"\n        raise RecoveryError(f\"temporary_root {path} is {kind}; refusing recovery\")",
+      "rationale": "the recorded temporary-root final component must be lstat-verified as a directory before recovery can resolve any shard or follow a replacement symlink",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_existing_symlinked_temporary_root_never_authorizes_replacement_cleanup"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, and independent root and descendant authority-directory symlink refusals. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, and recovery of manifest-authorized pre-child staging. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -139,6 +139,19 @@
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_direct_named_go_test_rejects_duplicate_conflicting_count",
         "tests/tooling/test_mutation_harness_lane_d.py::test_shell_named_go_test_rejects_duplicate_conflicting_count"
+      ]]
+    },
+    {
+      "id": "D11-zero-shard-staging-recovery",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "if not raw_shards:\n        if coordinator.get(\"lifecycle\") != \"aborted\":",
+      "replace": "if False and not raw_shards:\n        if coordinator.get(\"lifecycle\") != \"aborted\":",
+      "rationale": "an aborted run with zero recorded children must enter the separately authorized partial-staging recovery path instead of remaining permanently wedged",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_zero_recorded_shards_recovers_owned_partial_staging_tree"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, and recovery of manifest-authorized pre-child staging. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, and recovery of manifest-authorized pre-child staging with source/temporary-root disjointness. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -152,6 +152,20 @@
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_zero_recorded_shards_recovers_owned_partial_staging_tree"
+      ]]
+    },
+    {
+      "id": "D12-source-temporary-root-disjointness",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "if resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved):\n        raise RecoveryError(f\"temporary_root {path} overlaps source_root {source_root}\")",
+      "replace": "if False and (resolved.is_relative_to(source_root) or source_root.is_relative_to(resolved)):\n        raise RecoveryError(f\"temporary_root {path} overlaps source_root {source_root}\")",
+      "rationale": "recovery must independently enforce source and temporary-root disjointness before a source descendant or ancestor can enter any cleanup preflight",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_zero_shard_recovery_rejects_private_root_below_source",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_zero_shard_recovery_rejects_private_root_above_source"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, and the recorded temporary-root final-component lexical type guard. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, the recorded temporary-root final-component lexical type guard, and preflight-to-cleanup temporary-root device/inode identity binding. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -91,8 +91,8 @@
     {
       "id": "D7-clear-root-state-last",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record)\n        restore_callback = restore_mutation or _default_restore",
-      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record)\n        restore_callback = restore_mutation or _default_restore",
+      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record, temporary_root_identity)\n        restore_callback = restore_mutation or _default_restore",
+      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record, temporary_root_identity)\n        restore_callback = restore_mutation or _default_restore",
       "rationale": "the root coordinator record must remain present until every owned shard restore and cleanup is verified",
       "proof": [[
         ".venv/bin/pytest",
@@ -197,14 +197,27 @@
     {
       "id": "D15-temporary-root-final-component-type",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "if not stat.S_ISDIR(info.st_mode):\n        kind = \"a symlink\" if stat.S_ISLNK(info.st_mode) else \"not a directory\"\n        raise RecoveryError(f\"temporary_root {path} is {kind}; refusing recovery\")",
-      "replace": "if False and not stat.S_ISDIR(info.st_mode):\n        kind = \"a symlink\" if stat.S_ISLNK(info.st_mode) else \"not a directory\"\n        raise RecoveryError(f\"temporary_root {path} is {kind}; refusing recovery\")",
+      "find": "def _require_temporary_root_directory(info: os.stat_result, path: Path) -> None:\n    \"\"\"Refuse a final temporary-root component that is not a directory.\"\"\"\n\n    if not stat.S_ISDIR(info.st_mode):",
+      "replace": "def _require_temporary_root_directory(info: os.stat_result, path: Path) -> None:\n    \"\"\"Refuse a final temporary-root component that is not a directory.\"\"\"\n\n    if False and not stat.S_ISDIR(info.st_mode):",
       "rationale": "the recorded temporary-root final component must be lstat-verified as a directory before recovery can resolve any shard or follow a replacement symlink",
       "proof": [[
         ".venv/bin/pytest",
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_existing_symlinked_temporary_root_never_authorizes_replacement_cleanup"
+      ]]
+    },
+    {
+      "id": "D16-temporary-root-preflight-identity",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "actual = _capture_private_temporary_root_identity(record)\n    if actual != expected:\n        raise RecoveryError(\n            f\"temporary_root {record.temporary_root} identity changed after preflight; \"\n            \"root state remains\"\n        )",
+      "replace": "actual = _capture_private_temporary_root_identity(record)\n    if False and actual != expected:\n        raise RecoveryError(\n            f\"temporary_root {record.temporary_root} identity changed after preflight; \"\n            \"root state remains\"\n        )",
+      "rationale": "cleanup must retain a matching-marker directory that replaced the device and inode authorized by preflight at the same lexical temporary-root path",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_temporary_root_same_path_directory_replacement_is_retained"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, the recorded temporary-root final-component lexical type guard, and preflight-to-cleanup temporary-root device/inode identity binding. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, the recorded temporary-root final-component lexical type guard, preflight-to-cleanup temporary-root identity binding, and per-shard root, owner-marker, and leased-lock identity binding. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -91,8 +91,8 @@
     {
       "id": "D7-clear-root-state-last",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record, temporary_root_identity)\n        restore_callback = restore_mutation or _default_restore",
-      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record, temporary_root_identity)\n        restore_callback = restore_mutation or _default_restore",
+      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record, temporary_root_identity)\n        _require_preflight_shard_authorities(record, preflight, temporary_root_identity)\n        restore_callback = restore_mutation or _default_restore",
+      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _write_root_recovery_json(root, state_path, state)\n\n        _require_existing_private_temporary_root(record, temporary_root_identity)\n        _require_preflight_shard_authorities(record, preflight, temporary_root_identity)\n        restore_callback = restore_mutation or _default_restore",
       "rationale": "the root coordinator record must remain present until every owned shard restore and cleanup is verified",
       "proof": [[
         ".venv/bin/pytest",
@@ -217,7 +217,21 @@
         ".venv/bin/pytest",
         "-q",
         "--confcutdir=tests/tooling",
-        "tests/tooling/test_mutation_harness_lane_d.py::test_temporary_root_same_path_directory_replacement_is_retained"
+        "tests/tooling/test_mutation_harness_lane_d.py::test_temporary_root_identity_change_with_original_shard_is_retained"
+      ]]
+    },
+    {
+      "id": "D17-shard-cleanup-authority-identity",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "actual = _capture_shard_cleanup_authority(record, shard, temporary_root_identity)\n    if actual != expected:",
+      "replace": "actual = _capture_shard_cleanup_authority(record, shard, temporary_root_identity)\n    if False and actual != expected:",
+      "rationale": "cleanup must retain a shard when its root, ownership marker, or leased liveness lock no longer has the device and inode authorized by preflight",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_shard_same_path_directory_replacement_is_retained",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_shard_authority_file_replacement_after_preflight_is_retained"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -91,14 +91,27 @@
     {
       "id": "D7-clear-root-state-last",
       "file": "scripts/mutation_harness_recovery.py",
-      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _atomic_write_json(state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
-      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _atomic_write_json(state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
+      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _write_root_recovery_json(root, state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
+      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _write_root_recovery_json(root, state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
       "rationale": "the root coordinator record must remain present until every owned shard restore and cleanup is verified",
       "proof": [[
         ".venv/bin/pytest",
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_root_state_is_cleared_only_after_verified_cleanup"
+      ]]
+    },
+    {
+      "id": "D8-root-state-parent-symlink",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "if stat.S_ISLNK(info.st_mode):\n        raise RecoveryError(\n            f\"root state directory {directory} is a symlink; refusing recovery\"\n        )",
+      "replace": "if stat.S_ISLNK(info.st_mode):\n        return directory",
+      "rationale": "recovery must reject a symlinked root state parent before any read or write can escape the repository",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_recovery_refuses_symlinked_root_state_directory"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -8,7 +8,7 @@
     "scripts/mutation_harness_optin.py",
     "scripts/mutation_harness_recovery.py"
   ],
-  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, the recorded temporary-root final-component lexical type guard, preflight-to-cleanup temporary-root identity binding, per-shard root, owner-marker, and leased-lock identity binding, fail-closed default refusal of any still-existing recorded Git shard, and the trusted-test-only fd capability boundary with an exit identity recheck. Default recovery never invokes Git porcelain or moves an existing shard. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, clear-state-last behavior, independent root and descendant authority-directory symlink refusals, recovery of manifest-authorized pre-child staging with source/temporary-root disjointness, the bounded whole-recorded-root ENOENT reboot path with a final absence recheck, the recorded temporary-root final-component lexical type guard, preflight-to-cleanup temporary-root identity binding, per-shard root, owner-marker, and leased-lock identity binding, fail-closed default refusal of any still-existing recorded or partially staged Git shard before output or durable-state mutation, and the trusted-test-only fd capability boundary with an exit identity recheck. Default recovery never invokes Git porcelain or moves an existing shard. Authority-file symlinks are redundantly rejected by the lexical component validator and JSON reader and are covered by direct regressions rather than a compound mutation. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
   "mutations": [
     {
       "id": "D1-closed-plan-keys",
@@ -258,6 +258,19 @@
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_cleanup_callback_rechecks_every_open_capability_at_exit"
+      ]]
+    },
+    {
+      "id": "D20-default-partial-git-refusal-before-state-change",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "    if partials and cleanup_owned_tree is None:\n        raise RecoveryError(\n            \"default recovery refuses an existing staged Git tree; \"",
+      "replace": "    if False and partials and cleanup_owned_tree is None:\n        raise RecoveryError(\n            \"default recovery refuses an existing staged Git tree; \"",
+      "rationale": "default public recovery must refuse a still-existing partial Git shard before force preflight output, lifecycle mutation, durable-state writes, cleanup, or loss of retry semantics",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_default_partial_recovery_refuses_before_output_or_state_change"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -65,8 +65,8 @@
     {
       "id": "D5-fresh-named-go-proof",
       "file": "scripts/mutation_harness_optin.py",
-      "find": "if _direct_flag(argv, \"-count\") != \"1\":",
-      "replace": "if False and _direct_flag(argv, \"-count\") != \"1\":",
+      "find": "_require_single_count_one(\n            identifier, pattern, _direct_flag_values(argv, \"-count\")\n        )",
+      "replace": "count_values = _direct_flag_values(argv, \"-count\")\n        if count_values:\n            _require_single_count_one(identifier, pattern, count_values)",
       "rationale": "a named Go proof must declare -count=1 before a plan can opt in to parallel measurement",
       "proof": [[
         ".venv/bin/pytest",
@@ -125,6 +125,20 @@
         "-q",
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_lane_d.py::test_recovery_refuses_symlinked_runs_authority_directory"
+      ]]
+    },
+    {
+      "id": "D10-unambiguous-go-count",
+      "file": "scripts/mutation_harness_optin.py",
+      "find": "if count_values != [\"1\"]:\n        raise PlanContractError(",
+      "replace": "if not count_values:\n        raise PlanContractError(",
+      "rationale": "a fresh named Go proof must contain exactly one effective -count declaration and it must be 1; later duplicate flags must not override the reviewed freshness gate",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_direct_named_go_test_rejects_duplicate_conflicting_count",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_shell_named_go_test_rejects_duplicate_conflicting_count"
       ]]
     }
   ]

--- a/tests/tooling/mutation-plans/chaos-3807-lane-d.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-d.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3807 Lane D recovery and sharding opt-in guards",
+  "build": [
+    ".venv/bin/python",
+    "-m",
+    "py_compile",
+    "scripts/mutation_harness_optin.py",
+    "scripts/mutation_harness_recovery.py"
+  ],
+  "$limitation": "Pins Lane D closed schema, opt-in limits, Python resolution, fresh named Go proofs, advisory-lock liveness, and clear-state-last behavior. Execution-tree ownership and coordinator aggregation guards belong to their owning lane plans.",
+  "mutations": [
+    {
+      "id": "D1-closed-plan-keys",
+      "file": "scripts/mutation_harness_optin.py",
+      "find": "if unknown:\n        rendered = \", \".join(repr(key) for key in unknown)",
+      "replace": "if False and unknown:\n        rendered = \", \".join(repr(key) for key in unknown)",
+      "rationale": "an unknown plan key must fail closed instead of silently degrading a mistyped opt-in",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_closed_top_level_vocabulary_names_unknown_key"
+      ]]
+    },
+    {
+      "id": "D2-max-shards-bound",
+      "file": "scripts/mutation_harness_optin.py",
+      "find": "if requested_shards > contract.max_shards:",
+      "replace": "if False and requested_shards > contract.max_shards:",
+      "rationale": "a plan must refuse a request above its reviewed maximum instead of silently widening resource fan-out",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_request_above_declared_max_is_refused"
+      ]]
+    },
+    {
+      "id": "D3-external-resource-vocabulary",
+      "file": "scripts/mutation_harness_optin.py",
+      "find": "if external_resources not in EXTERNAL_RESOURCE_POLICIES:",
+      "replace": "if False and external_resources not in EXTERNAL_RESOURCE_POLICIES:",
+      "rationale": "external resources must use the closed none, isolated, or shared-readonly contract",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_external_resources_use_the_closed_policy_set"
+      ]]
+    },
+    {
+      "id": "D4-path-python-refusal",
+      "file": "scripts/mutation_harness_optin.py",
+      "find": "if path_resolved:\n        raise PlanContractError(",
+      "replace": "if False and path_resolved:\n        raise PlanContractError(",
+      "rationale": "parallel plans must not resolve a Python entry point through PATH back to an invoking-tree installation",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_path_resolved_python_entry_points_are_refused"
+      ]]
+    },
+    {
+      "id": "D5-fresh-named-go-proof",
+      "file": "scripts/mutation_harness_optin.py",
+      "find": "if _direct_flag(argv, \"-count\") != \"1\":",
+      "replace": "if False and _direct_flag(argv, \"-count\") != \"1\":",
+      "rationale": "a named Go proof must declare -count=1 before a plan can opt in to parallel measurement",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_named_go_test_without_count_one_is_refused"
+      ]]
+    },
+    {
+      "id": "D6-advisory-lock-liveness",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "return liveness_lock_held",
+      "replace": "return diagnostic_pid_exists",
+      "rationale": "recovery liveness must follow the advisory shard lock, never a stale or reused diagnostic PID",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_reused_live_unrelated_pid_does_not_block_without_held_lock"
+      ]]
+    },
+    {
+      "id": "D7-clear-root-state-last",
+      "file": "scripts/mutation_harness_recovery.py",
+      "find": "coordinator[\"lifecycle\"] = \"recovering\"\n        _atomic_write_json(state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
+      "replace": "coordinator[\"lifecycle\"] = \"recovering\"\n        state.pop(\"coordinator_run\", None)\n        _atomic_write_json(state_path, state)\n\n        restore_callback = restore_mutation or _default_restore",
+      "rationale": "the root coordinator record must remain present until every owned shard restore and cleanup is verified",
+      "proof": [[
+        ".venv/bin/pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_lane_d.py::test_root_state_is_cleared_only_after_verified_cleanup"
+      ]]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/chaos-3807-lane-e.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-e.json
@@ -51,7 +51,7 @@
         "pytest",
         "-q",
         "--confcutdir=tests/tooling",
-        "tests/tooling/test_mutation_harness_integration.py::test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify"
+        "tests/tooling/test_mutation_harness_integration.py::test_public_recovery_clears_an_incomplete_run_when_recorded_temporary_root_is_absent"
       ]]
     },
     {

--- a/tests/tooling/mutation-plans/chaos-3807-lane-e.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-e.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3807 Lane E public sharding integration guards",
+  "$limitation": "Pins only the shared-harness dispatch, coordinator-child durable result bridge, and public recovery bridge. Execution-tree, coordinator aggregation, and recovery authority guards remain covered by the Lane B, C, and D plans.",
+  "build": [
+    ".venv/bin/python",
+    "-m",
+    "py_compile",
+    "scripts/mutation_harness.py"
+  ],
+  "mutations": [
+    {
+      "id": "E1-public-sharded-dispatch",
+      "file": "scripts/mutation_harness.py",
+      "find": "        if int(args.shards) == 1:\n",
+      "replace": "        if True:\n",
+      "rationale": "A reviewed request above one shard must enter the coordinator path instead of silently executing the serial path.",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_integration.py::test_public_cli_runs_two_isolated_shards_and_restores_source"
+      ]]
+    },
+    {
+      "id": "E2-child-result-before-terminal-event",
+      "file": "scripts/mutation_harness.py",
+      "find": "                    _write_child_result_record(child_protocol, mutation, result)\n",
+      "replace": "                    if False:\n                        _write_child_result_record(child_protocol, mutation, result)\n",
+      "rationale": "A child measurement must be durable before its terminal event so the coordinator never accepts an event-only result that was lost on abort.",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_integration.py::test_public_cli_runs_two_isolated_shards_and_restores_source"
+      ]]
+    },
+    {
+      "id": "E3-public-recovery-delegation",
+      "file": "scripts/mutation_harness.py",
+      "find": "        return recover_backend(root, run_id, force=force)\n",
+      "replace": "        return f\"recovered run {run_id} as aborted; removed 0 owned shard(s)\"\n",
+      "rationale": "The public recovery command must invoke the authority-checked recovery backend; reporting success without cleanup would leave coordinator state and owned trees behind.",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_integration.py::test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify"
+      ]]
+    },
+    {
+      "id": "E4-private-run-root-cleanup",
+      "file": "scripts/mutation_harness.py",
+      "find": "            if not owned_roots:\n                temporary_root.rmdir()\n",
+      "replace": "            if False and not owned_roots:\n                temporary_root.rmdir()\n",
+      "rationale": "After every owned execution tree is removed, the coordinator must also remove its now-empty private run root instead of leaking a durable temporary directory.",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_integration.py::test_public_cli_runs_two_isolated_shards_and_restores_source"
+      ]]
+    }
+  ]
+}

--- a/tests/tooling/mutation-plans/chaos-3807-lane-e.json
+++ b/tests/tooling/mutation-plans/chaos-3807-lane-e.json
@@ -68,6 +68,21 @@
         "--confcutdir=tests/tooling",
         "tests/tooling/test_mutation_harness_integration.py::test_public_cli_runs_two_isolated_shards_and_restores_source"
       ]]
+    },
+    {
+      "id": "E5-child-python-bytecode-suppression",
+      "file": "scripts/mutation_harness.py",
+      "find": "        environment[\"PYTHONDONTWRITEBYTECODE\"] = \"1\"\n",
+      "replace": "        environment.pop(\"PYTHONDONTWRITEBYTECODE\", None)\n",
+      "rationale": "Harness-owned Python children must not create untracked bytecode that turns a restored shard into a cleanup failure on hosts without global Python ignore rules.",
+      "proof": [[
+        ".venv/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "--confcutdir=tests/tooling",
+        "tests/tooling/test_mutation_harness_integration.py::test_public_sharded_children_suppress_python_bytecode"
+      ]]
     }
   ]
 }

--- a/tests/tooling/test_mutation_harness.py
+++ b/tests/tooling/test_mutation_harness.py
@@ -14,10 +14,14 @@ run in milliseconds.
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import os
 import shlex
+import signal
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -30,7 +34,9 @@ from scripts.mutation_harness import (
     VERDICT_SURVIVED,
     VERDICT_SURVIVED_DECLARED,
     HarnessError,
+    Result,
     _load_sharding_plan,
+    _ProgressEmitter,
     accept_manual_repair,
     acquire_lock,
     coordinator_run,
@@ -143,6 +149,364 @@ def test_sharding_interfaces_are_explicit_unimplemented_seams(tree: Path) -> Non
         )
     with pytest.raises(NotImplementedError):
         recover_run(tree, "run-3807")
+
+
+def test_progress_flushes_the_selected_stderr_stream(tree: Path) -> None:
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="utf-8", line_buffering=False)
+    try:
+        emitter = _ProgressEmitter(tree, "flush-test", "human", stream=stream)
+        emitter.emit("run_started", completed=0, active=0, total=1, phase="running")
+
+        assert raw.getvalue() == (
+            b"mutation harness: run_started (0/1 complete, 0 active)\n"
+        )
+    finally:
+        stream.detach()
+
+
+def test_progress_modes_keep_events_off_stdout(
+    tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    plan = _plan(tree, [_mutation()])
+
+    run_plan(tree, plan, None, assert_all_killed=False, progress="human")
+    human = capsys.readouterr()
+    assert human.out == ""
+    assert "mutation harness: mutation_started M1" in human.err
+
+    run_plan(tree, plan, None, assert_all_killed=False, progress="jsonl")
+    jsonl = capsys.readouterr()
+    assert jsonl.out == ""
+    stderr_events = [json.loads(line) for line in jsonl.err.splitlines()]
+    assert [event["sequence"] for event in stderr_events] == list(
+        range(1, len(stderr_events) + 1)
+    )
+    assert [event["event"] for event in stderr_events] == [
+        "run_started",
+        "mutation_started",
+        "mutation_finished",
+        "run_finished",
+    ]
+
+    run_plan(tree, plan, None, assert_all_killed=False, progress="none")
+    silent = capsys.readouterr()
+    assert silent.out == ""
+    assert silent.err == ""
+
+
+def test_events_exclude_captured_proof_output(tree: Path) -> None:
+    proof_secret = "proof-output-must-not-enter-events"
+    noisy_proof = [
+        sys.executable,
+        "-c",
+        (
+            "import pathlib,sys;"
+            f"print({proof_secret!r});"
+            f"text=pathlib.Path({SOURCE_NAME!r}).read_text();"
+            f"sys.exit(0 if {GUARD!r} in text else 1)"
+        ),
+    ]
+    plan = _plan(tree, [_mutation(proof=[noisy_proof])])
+
+    results, _ = run_plan(tree, plan, None, assert_all_killed=False)
+
+    assert proof_secret in results[0].detail
+    run_directory = next((tree / ".mutation-harness" / "runs").iterdir())
+    event_text = (run_directory / "events.jsonl").read_text(encoding="utf-8")
+    assert proof_secret not in event_text
+    events = [json.loads(line) for line in event_text.splitlines()]
+    assert [event["event"] for event in events] == [
+        "run_started",
+        "mutation_started",
+        "mutation_finished",
+        "run_finished",
+    ]
+    assert events[0] | {"elapsed_ms": 0} == {
+        "schema_version": 1,
+        "sequence": 1,
+        "run_id": events[0]["run_id"],
+        "event": "run_started",
+        "phase": "running",
+        "completed": 0,
+        "active": 0,
+        "total": 1,
+        "elapsed_ms": 0,
+    }
+    assert events[1]["plan_ordinal"] == 0
+    assert events[1]["mutation_id"] == "M1"
+    assert (events[1]["completed"], events[1]["active"], events[1]["total"]) == (
+        0,
+        1,
+        1,
+    )
+    assert events[2]["verdict"] == "KILLED"
+    assert (events[2]["completed"], events[2]["active"], events[2]["total"]) == (
+        1,
+        0,
+        1,
+    )
+    assert all("shard_index" not in event for event in events)
+    assert all(
+        set(event)
+        <= {
+            "schema_version",
+            "sequence",
+            "run_id",
+            "event",
+            "shard_index",
+            "plan_ordinal",
+            "mutation_id",
+            "phase",
+            "verdict",
+            "completed",
+            "active",
+            "total",
+            "elapsed_ms",
+        }
+        for event in events
+    )
+
+
+def test_result_stream_survives_an_abort_before_the_next_mutation(
+    tree: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import scripts.mutation_harness as harness
+
+    plan = _plan(tree, [_mutation(id="M1"), _mutation(id="M2")])
+    calls = 0
+
+    def controlled_run(
+        _root: Path, mutation: object, _snapshot_directory: Path
+    ) -> Result:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return Result("M1", VERDICT_KILLED, detail="measured before abort")
+        run_directory = next((tree / ".mutation-harness" / "runs").iterdir())
+        records = [
+            json.loads(line)
+            for line in (run_directory / "results.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        assert [record["id"] for record in records] == ["M1"]
+        raise HarnessError("controlled abort before M2 completes")
+
+    monkeypatch.setattr(harness, "_run_one", controlled_run)
+
+    with pytest.raises(HarnessError, match="controlled abort"):
+        run_plan(tree, plan, None, assert_all_killed=False)
+
+    run_directory = next((tree / ".mutation-harness" / "runs").iterdir())
+    result_lines = (
+        (run_directory / "results.jsonl").read_text(encoding="utf-8").splitlines()
+    )
+    assert len(result_lines) == 1
+    assert json.loads(result_lines[0]) == {
+        "schema_version": 1,
+        "run_id": run_directory.name,
+        "plan_ordinal": 0,
+        "id": "M1",
+        "verdict": "KILLED",
+        "detail": "measured before abort",
+        "failing_proof": None,
+        "warnings": [],
+    }
+    assert not (tree / ".mutation-harness" / "report.json").exists()
+
+
+def test_serial_report_preserves_result_fields_and_adds_stream_paths(
+    tree: Path,
+) -> None:
+    plan = _plan(
+        tree,
+        [
+            _mutation(
+                proof=[ALWAYS_PASSES_PROOF],
+                build=ALWAYS_PASSES_PROOF,
+            )
+        ],
+    )
+
+    run_plan(tree, plan, None, assert_all_killed=False)
+
+    report = json.loads(
+        (tree / ".mutation-harness" / "report.json").read_text(encoding="utf-8")
+    )
+    assert report["schema_version"] == 1
+    assert report["plan"] == "synthetic"
+    assert report["plan_path"] == str(plan)
+    assert report["results"] == [
+        {
+            "id": "M1",
+            "verdict": "SURVIVED",
+            "detail": (
+                "every proof command still passed with the mutation applied. Either "
+                "a test is missing, or this mutation is invalid (no-op, wrong target, "
+                "or asserted against the constant it mutates). Classify it by "
+                "declaring expected_survivor_reason, or add the missing test."
+            ),
+            "failing_proof": None,
+            "warnings": [],
+        }
+    ]
+    assert report["mode"] == "serial"
+    assert report["event_log"] == (
+        f".mutation-harness/runs/{report['run_id']}/events.jsonl"
+    )
+    assert report["result_stream"] == (
+        f".mutation-harness/runs/{report['run_id']}/results.jsonl"
+    )
+
+
+def test_serial_cli_stdout_is_byte_compatible_golden(
+    tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    plan = _plan(
+        tree,
+        [
+            _mutation(
+                proof=[ALWAYS_PASSES_PROOF],
+                build=ALWAYS_PASSES_PROOF,
+            )
+        ],
+    )
+
+    assert (
+        main(
+            [
+                "--root",
+                str(tree),
+                "run",
+                "--plan",
+                str(plan),
+                "--progress",
+                "none",
+            ]
+        )
+        == 0
+    )
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == (
+        "\n"
+        "| mutation | verdict | detail |\n"
+        "| --- | --- | --- |\n"
+        "| M1 | SURVIVED | every proof command still passed with the mutation "
+        "applied. Either a test is missing, or this mutation is inva |\n"
+        "\n"
+        "\n"
+        "M1 SURVIVED:\n"
+        "every proof command still passed with the mutation applied. Either a "
+        "test is missing, or this mutation is invalid (no-op, wrong target, or "
+        "asserted against the constant it mutates). Classify it by declaring "
+        "expected_survivor_reason, or add the missing test.\n"
+    )
+
+
+def test_cli_progress_defaults_to_human(
+    tree: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    plan = _plan(tree, [_mutation()])
+
+    assert main(["--root", str(tree), "run", "--plan", str(plan)]) == 0
+
+    captured = capsys.readouterr()
+    assert "| M1 | KILLED |" in captured.out
+    assert "mutation harness: run_started" in captured.err
+    assert "mutation harness: mutation_finished M1" in captured.err
+
+
+def test_durable_event_is_readable_while_the_proof_child_is_alive(
+    tree: Path,
+) -> None:
+    release = tree / "release-proof"
+    proof_pid = tree / "proof.pid"
+    blocking_proof = [
+        sys.executable,
+        "-c",
+        (
+            "import os\n"
+            "import pathlib\n"
+            "import time\n"
+            f"pathlib.Path({proof_pid.name!r}).write_text(str(os.getpid()))\n"
+            f"release = pathlib.Path({release.name!r})\n"
+            "while not release.exists():\n"
+            "    time.sleep(0.01)\n"
+            f"text = pathlib.Path({SOURCE_NAME!r}).read_text()\n"
+            f"raise SystemExit(0 if {GUARD!r} in text else 1)\n"
+        ),
+    ]
+    plan = _plan(tree, [_mutation(proof=[blocking_proof])])
+    script = Path(__file__).parents[2] / "scripts" / "mutation_harness.py"
+    stdout_path = tree / "harness.stdout"
+    stderr_path = tree / "harness.stderr"
+    with stdout_path.open("wb") as stdout_file, stderr_path.open("wb") as stderr_file:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(script),
+                "--root",
+                str(tree),
+                "run",
+                "--plan",
+                str(plan),
+                "--assert-all-killed",
+                "--progress",
+                "none",
+            ],
+            cwd=script.parents[1],
+            stdout=stdout_file,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
+    assert process.stdout is None
+    assert process.stderr is None
+
+    try:
+        deadline = time.monotonic() + 10
+        live_event: dict[str, object] | None = None
+        while time.monotonic() < deadline:
+            event_logs = list(
+                (tree / ".mutation-harness" / "runs").glob("*/events.jsonl")
+            )
+            if proof_pid.exists() and event_logs:
+                child_pid = int(proof_pid.read_text(encoding="utf-8"))
+                try:
+                    os.kill(child_pid, 0)
+                except ProcessLookupError:
+                    pass
+                else:
+                    raw_lines = event_logs[0].read_text(encoding="utf-8").splitlines()
+                    parsed = [json.loads(line) for line in raw_lines]
+                    live_event = next(
+                        (
+                            event
+                            for event in parsed
+                            if event["event"] == "mutation_started"
+                        ),
+                        None,
+                    )
+                    if live_event is not None and process.poll() is None:
+                        break
+            time.sleep(0.01)
+
+        assert live_event is not None
+        assert live_event["mutation_id"] == "M1"
+        assert process.poll() is None
+        release.write_text("continue\n", encoding="utf-8")
+        assert process.wait(timeout=10) == 0
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=10)
+
+    event_log = next((tree / ".mutation-harness" / "runs").glob("*/events.jsonl"))
+    event_lines = event_log.read_text(encoding="utf-8").splitlines()
+    assert event_lines
+    assert all(isinstance(json.loads(line), dict) for line in event_lines)
 
 
 def test_a_mutation_the_proof_notices_is_killed(tree: Path) -> None:

--- a/tests/tooling/test_mutation_harness.py
+++ b/tests/tooling/test_mutation_harness.py
@@ -125,10 +125,11 @@ def test_coordinator_state_blocks_verify_until_recovery(tree: Path) -> None:
     ]
 
 
-def test_sharding_interfaces_are_explicit_unimplemented_seams(tree: Path) -> None:
-    with pytest.raises(NotImplementedError):
-        _load_sharding_plan(tree / "plan.json", {})
-    with pytest.raises(NotImplementedError):
+def test_sharding_interfaces_are_wired_fail_closed_seams(tree: Path) -> None:
+    plan = _plan(tree, [_mutation()])
+
+    assert _load_sharding_plan(plan, {}) is None
+    with pytest.raises(HarnessError, match="git rev-parse"):
         stage_execution_tree(
             tree,
             tree / "shard",
@@ -138,16 +139,16 @@ def test_sharding_interfaces_are_explicit_unimplemented_seams(tree: Path) -> Non
             plan_digest="plan-digest",
             workspace_inputs=(),
         )
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(HarnessError, match="does not opt in to sharding"):
         coordinator_run(
             tree,
-            tree / "plan.json",
+            plan,
             None,
             False,
             requested_shards=2,
             progress="human",
         )
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(HarnessError, match="state"):
         recover_run(tree, "run-3807")
 
 
@@ -360,8 +361,11 @@ def test_serial_report_preserves_result_fields_and_adds_stream_paths(
     )
 
 
+@pytest.mark.parametrize("shard_arguments", [[], ["--shards", "1"]])
 def test_serial_cli_stdout_is_byte_compatible_golden(
-    tree: Path, capsys: pytest.CaptureFixture[str]
+    tree: Path,
+    capsys: pytest.CaptureFixture[str],
+    shard_arguments: list[str],
 ) -> None:
     plan = _plan(
         tree,
@@ -383,6 +387,7 @@ def test_serial_cli_stdout_is_byte_compatible_golden(
                 str(plan),
                 "--progress",
                 "none",
+                *shard_arguments,
             ]
         )
         == 0

--- a/tests/tooling/test_mutation_harness.py
+++ b/tests/tooling/test_mutation_harness.py
@@ -30,11 +30,15 @@ from scripts.mutation_harness import (
     VERDICT_SURVIVED,
     VERDICT_SURVIVED_DECLARED,
     HarnessError,
+    _load_sharding_plan,
     accept_manual_repair,
     acquire_lock,
+    coordinator_run,
     main,
+    recover_run,
     restore,
     run_plan,
+    stage_execution_tree,
     verify,
 )
 
@@ -90,6 +94,55 @@ def _mutation(**overrides: object) -> dict[str, object]:
 
 def test_verify_passes_on_a_clean_tree(tree: Path) -> None:
     assert verify(tree) == []
+
+
+def test_coordinator_state_blocks_verify_until_recovery(tree: Path) -> None:
+    state = tree / ".mutation-harness"
+    state.mkdir()
+    (state / "state.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "coordinator_run": {
+                    "run_id": "run-3807",
+                    "lifecycle": "staging",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert verify(tree) == [
+        "coordinator run run-3807 remains in lifecycle staging. No result from "
+        "this tree is trustworthy until it is recovered. Recover it with: "
+        "python3 scripts/mutation_harness.py recover-run --run-id run-3807"
+    ]
+
+
+def test_sharding_interfaces_are_explicit_unimplemented_seams(tree: Path) -> None:
+    with pytest.raises(NotImplementedError):
+        _load_sharding_plan(tree / "plan.json", {})
+    with pytest.raises(NotImplementedError):
+        stage_execution_tree(
+            tree,
+            tree / "shard",
+            run_id="run-3807",
+            shard_index=0,
+            source_manifest_digest="source-digest",
+            plan_digest="plan-digest",
+            workspace_inputs=(),
+        )
+    with pytest.raises(NotImplementedError):
+        coordinator_run(
+            tree,
+            tree / "plan.json",
+            None,
+            False,
+            requested_shards=2,
+            progress="human",
+        )
+    with pytest.raises(NotImplementedError):
+        recover_run(tree, "run-3807")
 
 
 def test_a_mutation_the_proof_notices_is_killed(tree: Path) -> None:

--- a/tests/tooling/test_mutation_harness_coordinator.py
+++ b/tests/tooling/test_mutation_harness_coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import replace
@@ -29,6 +30,7 @@ from scripts.mutation_harness_coordinator import (  # noqa: E402
     ChildSpec,
     DetailNormalizationError,
     ShardAssignment,
+    TemporaryRootClaim,
     _validate_child_spec,
     _write_manifest,
     aggregate_child_results,
@@ -226,6 +228,7 @@ def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
     plan = tmp_path / "plan.json"
     plan.write_text("{}", encoding="utf-8")
     temporary_root = (tmp_path.parent / f"{tmp_path.name}-private").resolve()
+    temporary_root.mkdir()
     first = begin_coordinator_run(
         tmp_path,
         run_id="first",
@@ -236,7 +239,9 @@ def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
         plan_digest=PLAN_DIGEST,
         requested_shards=2,
         effective_shards=2,
-        temporary_root_factory=lambda _run_id: temporary_root,
+        temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+            temporary_root
+        ),
     )
     try:
         state = _read_state(tmp_path)
@@ -254,7 +259,9 @@ def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
                 plan_digest=PLAN_DIGEST,
                 requested_shards=2,
                 effective_shards=2,
-                temporary_root_factory=lambda _run_id: temporary_root,
+                temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+                    temporary_root
+                ),
             )
     finally:
         first.clear_and_release()
@@ -396,7 +403,7 @@ def _coordinate(
     mutation_ids: Sequence[str] = ("M1", "M2", "M3"),
     source_reader: Callable[[], str] | None = None,
     factory: Callable[[ShardAssignment, str], ChildSpec] | None = None,
-    temporary_root_factory: Callable[[str], Path] | None = None,
+    temporary_root_factory: Callable[[str], TemporaryRootClaim] | None = None,
     before_report: Callable[[], None] | None = None,
 ):
     source = tmp_path / "source"
@@ -420,7 +427,7 @@ def _coordinate(
         plan_digest=PLAN_DIGEST,
         source_manifest_reader=source_reader or (lambda: SOURCE_DIGEST),
         temporary_root_factory=temporary_root_factory
-        or (lambda _run_id: shards.resolve()),
+        or (lambda _run_id: TemporaryRootClaim.borrowed(shards.resolve())),
         child_factory=factory or _factory(shards, assert_root_locked=source),
         run_id=RUN_ID,
         before_report=before_report,
@@ -465,7 +472,9 @@ def test_manifest_records_run_temporary_root_before_first_shard_staging_failure(
         _coordinate(
             tmp_path,
             factory=staging_failure,
-            temporary_root_factory=lambda _run_id: temporary_root,
+            temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+                temporary_root
+            ),
         )
 
     state = _read_state(source)
@@ -487,6 +496,7 @@ def test_run_temporary_root_must_not_overlap_source_before_manifest_write(
     plan = source / "plan.json"
     plan.write_text("{}", encoding="utf-8")
     temporary_root = (tmp_path / relative).resolve()
+    temporary_root.mkdir(exist_ok=True)
 
     with pytest.raises(HarnessError, match="overlaps the invoking source root"):
         begin_coordinator_run(
@@ -499,7 +509,9 @@ def test_run_temporary_root_must_not_overlap_source_before_manifest_write(
             plan_digest=PLAN_DIGEST,
             requested_shards=2,
             effective_shards=2,
-            temporary_root_factory=lambda _run_id: temporary_root,
+            temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+                temporary_root
+            ),
         )
 
     assert _read_state(source) is None
@@ -514,6 +526,7 @@ def test_manifest_serialization_rechecks_digests_and_run_root_binding(
     plan = source / "plan.json"
     plan.write_text("{}", encoding="utf-8")
     temporary_root = (tmp_path / "private-run").resolve()
+    temporary_root.mkdir()
     lease = begin_coordinator_run(
         source,
         run_id=RUN_ID,
@@ -524,7 +537,9 @@ def test_manifest_serialization_rechecks_digests_and_run_root_binding(
         plan_digest=PLAN_DIGEST,
         requested_shards=2,
         effective_shards=2,
-        temporary_root_factory=lambda _run_id: temporary_root,
+        temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+            temporary_root
+        ),
     )
     try:
         lease.state["source_manifest"]["digest"] = "tampered"
@@ -555,11 +570,11 @@ def test_startup_collision_precedes_private_root_creation_and_preserves_run_dir(
     temporary_root = tmp_path / "private-run"
     factory_called = False
 
-    def create_temporary_root(_run_id: str) -> Path:
+    def create_temporary_root(_run_id: str) -> TemporaryRootClaim:
         nonlocal factory_called
         factory_called = True
         temporary_root.mkdir()
-        return temporary_root
+        return TemporaryRootClaim.created(temporary_root)
 
     with pytest.raises(FileExistsError):
         begin_coordinator_run(
@@ -592,9 +607,9 @@ def test_manifest_initialization_failure_removes_only_call_owned_empty_artifacts
     plan.write_text("{}", encoding="utf-8")
     temporary_root = tmp_path / "private-run"
 
-    def create_temporary_root(_run_id: str) -> Path:
+    def create_temporary_root(_run_id: str) -> TemporaryRootClaim:
         temporary_root.mkdir()
-        return temporary_root
+        return TemporaryRootClaim.created(temporary_root)
 
     def fail_manifest(_lease: object) -> None:
         raise OSError("injected manifest write failure")
@@ -630,9 +645,9 @@ def test_state_initialization_failure_removes_manifest_and_call_owned_roots(
     plan.write_text("{}", encoding="utf-8")
     temporary_root = tmp_path / "private-run"
 
-    def create_temporary_root(_run_id: str) -> Path:
+    def create_temporary_root(_run_id: str) -> TemporaryRootClaim:
         temporary_root.mkdir()
-        return temporary_root
+        return TemporaryRootClaim.created(temporary_root)
 
     def fail_state(_root: Path, _state: object) -> None:
         raise OSError("injected state write failure")
@@ -655,6 +670,191 @@ def test_state_initialization_failure_removes_manifest_and_call_owned_roots(
 
     assert not temporary_root.exists()
     assert not (source / ".mutation-harness" / "runs" / RUN_ID).exists()
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
+
+
+def test_owned_private_root_is_removed_when_overlap_validation_fails(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = source / "private-run"
+
+    def create_overlapping_temporary_root(_run_id: str) -> TemporaryRootClaim:
+        temporary_root.mkdir()
+        return TemporaryRootClaim.created(temporary_root)
+
+    with pytest.raises(HarnessError, match="overlaps the invoking source root"):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=create_overlapping_temporary_root,
+        )
+
+    assert not temporary_root.exists()
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
+
+
+def test_preexisting_empty_private_root_never_gains_cleanup_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = tmp_path / "preexisting-private-run"
+    temporary_root.mkdir()
+    original_identity = temporary_root.stat().st_dev, temporary_root.stat().st_ino
+
+    def fail_state(_root: Path, _state: object) -> None:
+        raise OSError("injected state write failure")
+
+    monkeypatch.setattr(coordinator_module, "_write_state", fail_state)
+
+    with pytest.raises(OSError, match="injected state write failure"):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+                temporary_root
+            ),
+        )
+
+    assert temporary_root.is_dir()
+    assert (temporary_root.stat().st_dev, temporary_root.stat().st_ino) == (
+        original_identity
+    )
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
+
+
+def test_replaced_private_root_is_not_removed_by_stale_creation_claim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = tmp_path / "private-run"
+    foreign_root = tmp_path / "foreign-empty-root"
+    foreign_root.mkdir()
+    foreign_identity = foreign_root.stat().st_dev, foreign_root.stat().st_ino
+
+    def create_temporary_root(_run_id: str) -> TemporaryRootClaim:
+        temporary_root.mkdir()
+        return TemporaryRootClaim.created(temporary_root)
+
+    def fail_state(_root: Path, _state: object) -> None:
+        temporary_root.rmdir()
+        os.replace(foreign_root, temporary_root)
+        raise OSError("injected state write failure after root replacement")
+
+    monkeypatch.setattr(coordinator_module, "_write_state", fail_state)
+
+    with pytest.raises(OSError, match="after root replacement"):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=create_temporary_root,
+        )
+
+    assert temporary_root.is_dir()
+    assert (
+        temporary_root.stat().st_dev,
+        temporary_root.stat().st_ino,
+    ) == foreign_identity
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
+
+
+@pytest.mark.parametrize(
+    "tamper_kind", ["same_inode", "regular_replacement", "hardlink", "symlink"]
+)
+def test_manifest_cleanup_refuses_identity_or_content_tampering(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tamper_kind: str
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = tmp_path / "private-run"
+    manifest_path = source / ".mutation-harness" / "runs" / RUN_ID / "manifest.json"
+    run_sentinel = manifest_path.parent / "sentinel"
+    foreign = tmp_path / f"foreign-{tamper_kind}"
+    expected_bytes = f"foreign {tamper_kind}\n".encode()
+
+    def create_temporary_root(_run_id: str) -> TemporaryRootClaim:
+        temporary_root.mkdir()
+        return TemporaryRootClaim.created(temporary_root)
+
+    def fail_state(_root: Path, _state: object) -> None:
+        run_sentinel.write_bytes(b"preserve run evidence\n")
+        if tamper_kind == "same_inode":
+            manifest_path.write_bytes(expected_bytes)
+        elif tamper_kind == "regular_replacement":
+            foreign.write_bytes(expected_bytes)
+            os.replace(foreign, manifest_path)
+        elif tamper_kind == "hardlink":
+            foreign.write_bytes(expected_bytes)
+            manifest_path.unlink()
+            os.link(foreign, manifest_path)
+        else:
+            foreign.write_bytes(expected_bytes)
+            manifest_path.unlink()
+            manifest_path.symlink_to(foreign)
+        raise OSError("injected state write failure after manifest tamper")
+
+    monkeypatch.setattr(coordinator_module, "_write_state", fail_state)
+
+    with pytest.raises(OSError, match="after manifest tamper"):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=create_temporary_root,
+        )
+
+    assert manifest_path.read_bytes() == expected_bytes
+    if tamper_kind == "symlink":
+        assert manifest_path.is_symlink()
+        assert manifest_path.readlink() == foreign
+    elif tamper_kind == "hardlink":
+        assert manifest_path.stat().st_ino == foreign.stat().st_ino
+    else:
+        assert not manifest_path.is_symlink()
+    assert run_sentinel.read_bytes() == b"preserve run evidence\n"
+    assert not temporary_root.exists()
     assert _read_state(source) is None
     assert not (source / ".mutation-harness" / "lock").exists()
 

--- a/tests/tooling/test_mutation_harness_coordinator.py
+++ b/tests/tooling/test_mutation_harness_coordinator.py
@@ -1,0 +1,498 @@
+"""Independent contracts for the CHAOS-3807 mutation-shard coordinator."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import replace
+from importlib.util import cache_from_source
+from pathlib import Path
+
+import pytest
+
+# The shared harness restores bytes without restoring mtimes. A same-size
+# mutation can otherwise leave a timestamp-valid pyc and make POST-RESTORE run
+# mutated bytecode after the production source is clean.
+Path(cache_from_source("scripts/mutation_harness_coordinator.py")).unlink(
+    missing_ok=True
+)
+
+from scripts.mutation_harness import HarnessError, Result, _read_state  # noqa: E402
+from scripts.mutation_harness_coordinator import (  # noqa: E402
+    AGGREGATE_CHILD_FAILED,
+    AGGREGATE_COMPLETE,
+    AGGREGATE_SOURCE_DRIFTED,
+    AggregateRefusal,
+    ChildSpec,
+    DetailNormalizationError,
+    ShardAssignment,
+    aggregate_child_results,
+    append_durable_jsonl,
+    begin_coordinator_run,
+    canonical_result_projection,
+    coordinator_run,
+    normalize_detail,
+    select_and_assign,
+    write_aggregate_report,
+)
+
+PLAN_DIGEST = "a" * 64
+SOURCE_DIGEST = "b" * 64
+RUN_ID = "run-lane-c"
+
+
+def _source_manifest() -> dict[str, object]:
+    return {"head": "head", "entries": [], "digest": SOURCE_DIGEST}
+
+
+def _raw_result(
+    mutation_id: str,
+    ordinal: int,
+    shard_index: int,
+    *,
+    run_id: str = RUN_ID,
+    plan_digest: str = PLAN_DIGEST,
+    verdict: str = "KILLED",
+) -> dict[str, object]:
+    """Build the child wire object without using coordinator serializers."""
+
+    return {
+        "schema_version": 1,
+        "run_id": run_id,
+        "shard_index": shard_index,
+        "plan_digest": plan_digest,
+        "plan_ordinal": ordinal,
+        "mutation_id": mutation_id,
+        "result": {
+            "id": mutation_id,
+            "verdict": verdict,
+            "detail": f"observed {mutation_id}",
+            "failing_proof": "proof command",
+            "warnings": [],
+        },
+    }
+
+
+def _assignments(ids: Sequence[str], shards: int = 2) -> tuple[ShardAssignment, ...]:
+    return select_and_assign(ids, None, shards)
+
+
+def test_only_selection_is_assigned_by_selected_ordinal_not_original_ordinal() -> None:
+    identifiers = ["M0", "M1", "M2", "M3", "M4", "M5"]
+
+    assignments = select_and_assign(identifiers, {"M1", "M4", "M5"}, 2)
+
+    # Independent oracle: filter in plan order, enumerate that selected list,
+    # then apply selected ordinal modulo the effective shard count.
+    selected = [(1, "M1"), (4, "M4"), (5, "M5")]
+    expected = {
+        0: [("M1", 1, 0), ("M5", 5, 2)],
+        1: [("M4", 4, 1)],
+    }
+    assert {
+        assignment.shard_index: [
+            (item.identifier, item.plan_ordinal, item.selected_ordinal)
+            for item in assignment.mutations
+        ]
+        for assignment in assignments
+    } == expected
+    assert [item for _ordinal, item in selected] == ["M1", "M4", "M5"]
+
+
+@pytest.mark.parametrize(
+    ("records", "message"),
+    [
+        ([_raw_result("M1", 0, 0)], "missing mutation results: ['M2']"),
+        (
+            [
+                _raw_result("M1", 0, 0),
+                _raw_result("M1", 0, 0),
+                _raw_result("M2", 1, 1),
+            ],
+            "duplicate mutation results: ['M1']",
+        ),
+        (
+            [
+                _raw_result("M1", 0, 0),
+                _raw_result("M2", 1, 1),
+                _raw_result("FOREIGN", 2, 0),
+            ],
+            "unknown mutation results: ['FOREIGN']",
+        ),
+        (
+            [
+                _raw_result("M1", 0, 0, plan_digest="c" * 64),
+                _raw_result("M2", 1, 1),
+            ],
+            "plan digest mismatch",
+        ),
+    ],
+)
+def test_malformed_child_results_are_refused(
+    records: Sequence[Mapping[str, object]], message: str
+) -> None:
+    with pytest.raises(
+        AggregateRefusal, match=message.replace("[", r"\[").replace("]", r"\]")
+    ):
+        aggregate_child_results(
+            records,
+            _assignments(["M1", "M2"]),
+            run_id=RUN_ID,
+            plan_digest=PLAN_DIGEST,
+        )
+
+
+def test_aggregate_reorders_shard_streams_by_selected_plan_ordinal() -> None:
+    assignments = _assignments(["M1", "M2", "M3"], shards=2)
+    shard_order = [
+        _raw_result("M1", 0, 0),
+        _raw_result("M3", 2, 0),
+        _raw_result("M2", 1, 1),
+    ]
+
+    aggregate = aggregate_child_results(
+        shard_order,
+        assignments,
+        run_id=RUN_ID,
+        plan_digest=PLAN_DIGEST,
+    )
+
+    assert [result.identifier for result in aggregate.results] == ["M1", "M2", "M3"]
+
+
+def test_durable_result_append_is_visible_before_a_later_result(tmp_path: Path) -> None:
+    stream = tmp_path / "shard" / "results.jsonl"
+
+    append_durable_jsonl(stream, _raw_result("M1", 0, 0))
+
+    assert json.loads(stream.read_text(encoding="utf-8"))["mutation_id"] == "M1"
+    append_durable_jsonl(stream, _raw_result("M2", 1, 0))
+    assert [
+        json.loads(line)["mutation_id"]
+        for line in stream.read_text(encoding="utf-8").splitlines()
+    ] == ["M1", "M2"]
+
+
+def test_normalizer_changes_only_named_runtime_bytes_and_preserves_real_difference(
+    tmp_path: Path,
+) -> None:
+    shard = tmp_path / "shard-0"
+    temp = tmp_path / "pytest-temp"
+    left = Result(
+        "M1",
+        "KILLED",
+        f"{shard}/pkg/check_test.go:8 --- FAIL: TestGuard (0.31s) "
+        f"tmp={temp}/x url=https://example.test/a expected=1",
+        failing_proof="go test",
+    )
+    right = Result(
+        "M1",
+        "KILLED",
+        f"{shard}/pkg/check_test.go:8 --- FAIL: TestGuard (1.22s) "
+        f"tmp={temp}/y url=https://example.test/a expected=2",
+        failing_proof="go test",
+    )
+
+    left_projection = canonical_result_projection(
+        [left], shard_roots=[shard], temporary_roots=[temp]
+    )
+    right_projection = canonical_result_projection(
+        [right], shard_roots=[shard], temporary_roots=[temp]
+    )
+
+    assert "<SHARD_ROOT>" in left_projection[0]["detail"]
+    assert "<TMP>" in left_projection[0]["detail"]
+    assert "<DURATION>" in left_projection[0]["detail"]
+    assert left_projection != right_projection
+
+
+def test_normalizer_refuses_an_unrecognised_absolute_path(tmp_path: Path) -> None:
+    with pytest.raises(DetailNormalizationError, match="unrecognised absolute path"):
+        normalize_detail(
+            "failure read /opt/foreign/state.txt",
+            shard_roots=[tmp_path / "shard"],
+            temporary_roots=[tmp_path / "temp"],
+        )
+
+
+def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
+    tmp_path: Path,
+) -> None:
+    plan = tmp_path / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    first = begin_coordinator_run(
+        tmp_path,
+        run_id="first",
+        source_head="head",
+        source_manifest=_source_manifest(),
+        source_manifest_digest=SOURCE_DIGEST,
+        plan_path=plan,
+        plan_digest=PLAN_DIGEST,
+        requested_shards=2,
+        effective_shards=2,
+    )
+    try:
+        state = _read_state(tmp_path)
+        assert state is not None
+        assert state["coordinator_run"]["lifecycle"] == "staging"
+        assert (tmp_path / ".mutation-harness" / "lock").is_dir()
+        with pytest.raises(HarnessError, match="another mutation run holds"):
+            begin_coordinator_run(
+                tmp_path,
+                run_id="second",
+                source_head="head",
+                source_manifest=_source_manifest(),
+                source_manifest_digest=SOURCE_DIGEST,
+                plan_path=plan,
+                plan_digest=PLAN_DIGEST,
+                requested_shards=2,
+                effective_shards=2,
+            )
+    finally:
+        first.clear_and_release()
+
+
+def test_final_report_refuses_incomplete_children(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+
+    with pytest.raises(HarnessError, match="before all children complete"):
+        write_aggregate_report(
+            report,
+            {"schema_version": 1, "results": []},
+            all_children_complete=False,
+        )
+
+    assert not report.exists()
+
+
+def test_child_protocol_refuses_a_result_stream_in_the_source_root(
+    tmp_path: Path,
+) -> None:
+    children = tmp_path / "children"
+    children.mkdir()
+    foreign_result = tmp_path / "child-result.jsonl"
+
+    def bad_factory(assignment: ShardAssignment, run_id: str) -> ChildSpec:
+        spec = _factory(children)(assignment, run_id)
+        return replace(spec, result_stream=foreign_result)
+
+    with pytest.raises(HarnessError, match="result_stream escapes shard root"):
+        _coordinate(tmp_path, mutation_ids=("M1",), factory=bad_factory)
+
+    assert not foreign_result.exists()
+
+
+def _child_code(
+    assignment: ShardAssignment,
+    *,
+    write_results: bool = True,
+    exit_code: int = 0,
+) -> str:
+    selected = [
+        (item.identifier, item.selected_ordinal) for item in assignment.mutations
+    ]
+    return "\n".join(
+        [
+            "import json, os, pathlib, sys",
+            f"selected = {selected!r}",
+            "result_path = pathlib.Path(os.environ['MUTATION_HARNESS_RESULT_STREAM'])",
+            "result_path.parent.mkdir(parents=True, exist_ok=True)",
+            "for mutation_id, ordinal in selected:",
+            "    common = {'schema_version': 1, 'run_id': os.environ['MUTATION_HARNESS_RUN_ID'], 'shard_index': int(os.environ['MUTATION_HARNESS_SHARD_INDEX']), 'plan_ordinal': ordinal, 'mutation_id': mutation_id}",
+            "    print(json.dumps({**common, 'event': 'mutation_started', 'phase': 'baseline'}), flush=True)",
+            "    print(json.dumps({**common, 'event': 'mutation_finished', 'verdict': 'KILLED'}), flush=True)",
+            *(
+                [
+                    "    record = {**common, 'plan_digest': os.environ['MUTATION_HARNESS_PLAN_DIGEST'], 'result': {'id': mutation_id, 'verdict': 'KILLED', 'detail': 'observed ' + mutation_id, 'failing_proof': 'proof', 'warnings': []}}",
+                    "    with result_path.open('a', encoding='utf-8') as handle:",
+                    "        handle.write(json.dumps(record) + '\\n')",
+                    "        handle.flush()",
+                    "        os.fsync(handle.fileno())",
+                ]
+                if write_results
+                else []
+            ),
+            f"sys.exit({exit_code})",
+        ]
+    )
+
+
+def _factory(
+    tmp_path: Path,
+    *,
+    write_results: bool = True,
+    exit_code: int = 0,
+    assert_root_locked: Path | None = None,
+) -> Callable[[ShardAssignment, str], ChildSpec]:
+    def build(assignment: ShardAssignment, run_id: str) -> ChildSpec:
+        if assert_root_locked is not None:
+            state = _read_state(assert_root_locked)
+            assert state is not None
+            assert state["coordinator_run"]["run_id"] == run_id
+            assert state["coordinator_run"]["lifecycle"] == "staging"
+            assert (assert_root_locked / ".mutation-harness" / "lock").is_dir()
+        shard = tmp_path / f"shard-{assignment.shard_index}"
+        shard.mkdir()
+        marker = shard / ".mutation-owner.json"
+        marker.write_text(run_id, encoding="utf-8")
+        return ChildSpec(
+            assignment=assignment,
+            root=shard,
+            source_root=assert_root_locked or tmp_path.parent,
+            temporary_root=tmp_path,
+            argv=(
+                sys.executable,
+                "-c",
+                _child_code(
+                    assignment,
+                    write_results=write_results,
+                    exit_code=exit_code,
+                ),
+            ),
+            result_stream=shard / ".mutation-harness" / "results.jsonl",
+            ownership_marker=marker,
+            liveness_lock=shard / ".mutation-harness" / "child.liveness",
+        )
+
+    return build
+
+
+def _coordinate(
+    tmp_path: Path,
+    *,
+    mutation_ids: Sequence[str] = ("M1", "M2", "M3"),
+    source_reader: Callable[[], str] | None = None,
+    factory: Callable[[ShardAssignment, str], ChildSpec] | None = None,
+    before_report: Callable[[], None] | None = None,
+):
+    plan = tmp_path / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    shards = tmp_path / "children"
+    shards.mkdir(exist_ok=True)
+    return coordinator_run(
+        tmp_path,
+        plan,
+        "lane-c-plan",
+        mutation_ids,
+        None,
+        True,
+        requested_shards=2,
+        progress="none",
+        source_head="head",
+        source_manifest=_source_manifest(),
+        source_manifest_digest=SOURCE_DIGEST,
+        plan_digest=PLAN_DIGEST,
+        source_manifest_reader=source_reader or (lambda: SOURCE_DIGEST),
+        child_factory=factory or _factory(shards, assert_root_locked=tmp_path),
+        run_id=RUN_ID,
+        before_report=before_report,
+    )
+
+
+def test_coordinator_resequences_events_orders_results_and_reports_after_children(
+    tmp_path: Path,
+) -> None:
+    completed_marker = tmp_path / "checked-before-report"
+
+    def before_report() -> None:
+        # Every child wrote its durable terminal result before this hook.
+        streams = list(
+            (tmp_path / "children").glob("*/.mutation-harness/results.jsonl")
+        )
+        assert len(streams) == 2
+        assert all(
+            stream.read_text(encoding="utf-8").endswith("\n") for stream in streams
+        )
+        completed_marker.write_text("complete", encoding="utf-8")
+
+    outcome = _coordinate(tmp_path, before_report=before_report)
+
+    assert outcome.aggregate_status == AGGREGATE_COMPLETE
+    assert outcome.exit_code == 0
+    assert [result.identifier for result in outcome.results] == ["M1", "M2", "M3"]
+    events = [
+        json.loads(line)
+        for line in outcome.event_log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [event["sequence"] for event in events] == list(range(1, len(events) + 1))
+    assert events[-1]["event"] == "run_finished"
+    assert all("proof" not in event for event in events)
+    report = json.loads(outcome.report_path.read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (outcome.event_log_path.parent / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert completed_marker.read_text(encoding="utf-8") == "complete"
+    assert report["aggregate_status"] == AGGREGATE_COMPLETE
+    assert [result["id"] for result in report["results"]] == ["M1", "M2", "M3"]
+    assert report["canonical_projection"]["normalized"] == ["detail"]
+    assert manifest["source_manifest"] == _source_manifest()
+    assert manifest["source_root"] == str(tmp_path)
+    assert all(shard["temporary_root"] for shard in manifest["shards"])
+    assert all(shard["liveness_lock"] for shard in manifest["shards"])
+    assert _read_state(tmp_path) is None
+
+
+def test_result_drop_after_finished_event_is_measured_lost_not_survivor(
+    tmp_path: Path,
+) -> None:
+    children = tmp_path / "children"
+    children.mkdir()
+    outcome = _coordinate(
+        tmp_path,
+        mutation_ids=("M1",),
+        factory=_factory(children, write_results=False, exit_code=7),
+    )
+
+    assert outcome.aggregate_status == AGGREGATE_CHILD_FAILED
+    assert outcome.exit_code == 1
+    assert outcome.results == ()
+    assert outcome.measured_lost_ids == ("M1",)
+    assert outcome.unmeasured_ids == ()
+    report = json.loads(outcome.report_path.read_text(encoding="utf-8"))
+    assert report["measured_lost_mutation_ids"] == ["M1"]
+    assert "SURVIVED" not in outcome.report_path.read_text(encoding="utf-8")
+
+
+def test_child_crash_before_measurement_is_unmeasured_not_survivor(
+    tmp_path: Path,
+) -> None:
+    children = tmp_path / "children"
+    children.mkdir()
+
+    def crash_factory(assignment: ShardAssignment, run_id: str) -> ChildSpec:
+        spec = _factory(children)(assignment, run_id)
+        return ChildSpec(
+            assignment=spec.assignment,
+            root=spec.root,
+            source_root=spec.source_root,
+            temporary_root=spec.temporary_root,
+            argv=(sys.executable, "-c", "raise SystemExit(9)"),
+            result_stream=spec.result_stream,
+            ownership_marker=spec.ownership_marker,
+            liveness_lock=spec.liveness_lock,
+        )
+
+    outcome = _coordinate(
+        tmp_path,
+        mutation_ids=("M1", "M2"),
+        factory=crash_factory,
+    )
+
+    assert outcome.aggregate_status == AGGREGATE_CHILD_FAILED
+    assert outcome.exit_code == 1
+    assert outcome.results == ()
+    assert outcome.unmeasured_ids == ("M1", "M2")
+    assert outcome.measured_lost_ids == ()
+
+
+def test_source_manifest_drift_before_aggregate_is_non_authoritative(
+    tmp_path: Path,
+) -> None:
+    readings = iter((SOURCE_DIGEST, SOURCE_DIGEST, "drifted"))
+    outcome = _coordinate(tmp_path, source_reader=lambda: next(readings))
+
+    assert outcome.aggregate_status == AGGREGATE_SOURCE_DRIFTED
+    assert outcome.exit_code == 1
+    report = json.loads(outcome.report_path.read_text(encoding="utf-8"))
+    assert "source manifest changed before aggregation" in report["aggregate_errors"]

--- a/tests/tooling/test_mutation_harness_coordinator.py
+++ b/tests/tooling/test_mutation_harness_coordinator.py
@@ -360,6 +360,52 @@ def test_projection_normalizes_only_the_explicit_go_toolchain_root(
 
     assert serial_projection == sharded_projection
     assert "<GOROOT>/src/testing/testing.go" in serial_projection[0]["detail"]
+    assert (
+        normalize_detail(
+            f"toolchain={serial_go_root}",
+            shard_roots=[],
+            temporary_roots=[],
+            go_root=serial_go_root,
+        )
+        == "toolchain=<GOROOT>"
+    )
+    assert (
+        normalize_detail(
+            f"frame=({serial_go_root}):1974",
+            shard_roots=[],
+            temporary_roots=[],
+            go_root=serial_go_root,
+        )
+        == "frame=(<GOROOT>):1974"
+    )
+    descendant = f"{serial_go_root}{os.sep}src{os.sep}runtime{os.sep}panic.go"
+    assert (
+        normalize_detail(
+            descendant,
+            shard_roots=[],
+            temporary_roots=[],
+            go_root=serial_go_root,
+        )
+        == f"<GOROOT>{os.sep}src{os.sep}runtime{os.sep}panic.go"
+    )
+    alternate_separator = "\\" if os.sep == "/" else "/"
+    unknown_paths = [
+        f"{serial_go_root}.suffix/src/testing/testing.go",
+        f"{serial_go_root}-sibling/src/testing/testing.go",
+        str(serial_go_root.parent / f"prefix-{serial_go_root.name}" / "src"),
+        str(serial_go_root.parent / f"embedded-{serial_go_root.name}-token" / "src"),
+        f"{serial_go_root}{alternate_separator}src{alternate_separator}testing.go",
+    ]
+    for unknown in unknown_paths:
+        with pytest.raises(
+            DetailNormalizationError, match="unrecognised absolute path"
+        ):
+            normalize_detail(
+                unknown,
+                shard_roots=[],
+                temporary_roots=[],
+                go_root=serial_go_root,
+            )
     with pytest.raises(DetailNormalizationError, match="unrecognised absolute path"):
         normalize_detail(
             "/tmp/lookalike/src/testing/testing.go:1974 +0x1a0",

--- a/tests/tooling/test_mutation_harness_coordinator.py
+++ b/tests/tooling/test_mutation_harness_coordinator.py
@@ -18,6 +18,7 @@ Path(cache_from_source("scripts/mutation_harness_coordinator.py")).unlink(
     missing_ok=True
 )
 
+import scripts.mutation_harness_coordinator as coordinator_module  # noqa: E402
 from scripts.mutation_harness import HarnessError, Result, _read_state  # noqa: E402
 from scripts.mutation_harness_coordinator import (  # noqa: E402
     AGGREGATE_CHILD_FAILED,
@@ -538,6 +539,124 @@ def test_manifest_serialization_rechecks_digests_and_run_root_binding(
             _write_manifest(lease)
     finally:
         lease.clear_and_release()
+
+
+def test_startup_collision_precedes_private_root_creation_and_preserves_run_dir(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    run_dir = source / ".mutation-harness" / "runs" / RUN_ID
+    run_dir.mkdir(parents=True)
+    sentinel = run_dir / "sentinel"
+    sentinel.write_bytes(b"pre-existing run evidence\n")
+    temporary_root = tmp_path / "private-run"
+    factory_called = False
+
+    def create_temporary_root(_run_id: str) -> Path:
+        nonlocal factory_called
+        factory_called = True
+        temporary_root.mkdir()
+        return temporary_root
+
+    with pytest.raises(FileExistsError):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=create_temporary_root,
+        )
+
+    assert not factory_called
+    assert not temporary_root.exists()
+    assert sentinel.read_bytes() == b"pre-existing run evidence\n"
+    assert sorted(path.name for path in run_dir.iterdir()) == ["sentinel"]
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
+
+
+def test_manifest_initialization_failure_removes_only_call_owned_empty_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = tmp_path / "private-run"
+
+    def create_temporary_root(_run_id: str) -> Path:
+        temporary_root.mkdir()
+        return temporary_root
+
+    def fail_manifest(_lease: object) -> None:
+        raise OSError("injected manifest write failure")
+
+    monkeypatch.setattr(coordinator_module, "_write_manifest", fail_manifest)
+
+    with pytest.raises(OSError, match="injected manifest write failure"):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=create_temporary_root,
+        )
+
+    assert not temporary_root.exists()
+    assert not (source / ".mutation-harness" / "runs" / RUN_ID).exists()
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
+
+
+def test_state_initialization_failure_removes_manifest_and_call_owned_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = tmp_path / "private-run"
+
+    def create_temporary_root(_run_id: str) -> Path:
+        temporary_root.mkdir()
+        return temporary_root
+
+    def fail_state(_root: Path, _state: object) -> None:
+        raise OSError("injected state write failure")
+
+    monkeypatch.setattr(coordinator_module, "_write_state", fail_state)
+
+    with pytest.raises(OSError, match="injected state write failure"):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=create_temporary_root,
+        )
+
+    assert not temporary_root.exists()
+    assert not (source / ".mutation-harness" / "runs" / RUN_ID).exists()
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
 
 
 def test_coordinator_resequences_events_orders_results_and_reports_after_children(

--- a/tests/tooling/test_mutation_harness_coordinator.py
+++ b/tests/tooling/test_mutation_harness_coordinator.py
@@ -222,6 +222,208 @@ def test_normalizer_refuses_an_unrecognised_absolute_path(tmp_path: Path) -> Non
         )
 
 
+@pytest.mark.parametrize(
+    "detail",
+    [
+        (
+            "gitlab_feature_flags_route.go:42: unexpected request "
+            "/api/v4/projects/123/feature_flags?page=1&per_page=100"
+        ),
+        'failed URL="/api/v4/projects/a%20b/feature_flags?name=%2Fready",',
+        "request-target: '/api/v4/projects/123/feature_flags?enabled=true'.",
+        "GET `/api/v4/projects/123/feature_flags?page=1` HTTP/1.1",
+    ],
+)
+def test_normalizer_preserves_contextual_origin_form_request_targets(
+    tmp_path: Path,
+    detail: str,
+) -> None:
+    assert (
+        normalize_detail(
+            detail,
+            shard_roots=[tmp_path / "shard"],
+            temporary_roots=[tmp_path / "temp"],
+        )
+        == detail
+    )
+
+
+def test_normalizer_preserves_indexed_request_assertion_targets() -> None:
+    detail = (
+        'request[0]="/api/v4/projects/group%2Fproject/feature-flags?page=1" '
+        'want="/api/v4/projects/group%2Fproject/feature_flags?page=1"'
+    )
+
+    assert normalize_detail(detail, shard_roots=[], temporary_roots=[]) == detail
+
+
+def test_normalizer_preserves_structured_request_field_target() -> None:
+    detail = (
+        'field "requests": python=[]interface {}{map[string]interface {}'
+        '{"t":"str", "v":"/api/v4/pro'
+    )
+
+    assert normalize_detail(detail, shard_roots=[], temporary_roots=[]) == detail
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "failure /api/v4/projects/123/feature_flags?page=1",
+        "prerequest /api/v4/projects/123/feature_flags?page=1",
+        "requesting /api/v4/projects/123/feature_flags?page=1",
+        "request failed at /api/v4/projects/123/feature_flags?page=1",
+        "unexpected request /api/v4/projects/../secrets?page=1",
+        "unexpected request /api/v4/projects/%2e%2e/secrets?page=1",
+        "unexpected request /api/v4/projects/%252e%252e/secrets?page=1",
+        "unexpected request //server/share?page=1",
+        "unexpected request /api/v4/projects/%ZZ?page=1",
+        "unexpected request /api/v4/projects/123#fragment",
+        'request[0]="/api/v4/projects/123" got="/api/v4/projects/123"',
+        'field "request_count": value={"v":"/api/v4/projects/123"}',
+    ],
+)
+def test_normalizer_refuses_non_contextual_or_traversal_lookalikes(
+    tmp_path: Path,
+    detail: str,
+) -> None:
+    with pytest.raises(DetailNormalizationError, match="unrecognised absolute path"):
+        normalize_detail(
+            detail,
+            shard_roots=[tmp_path / "shard"],
+            temporary_roots=[tmp_path / "temp"],
+        )
+
+
+def test_serial_and_sharded_projection_match_with_origin_form_request_target(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "source"
+    shard_root = tmp_path / "private" / "shard-0"
+    serial = Result(
+        "R2-claim-validate-guard",
+        "KILLED",
+        f"{source_root}/gitlab_feature_flags_route.go:42: unexpected request "
+        "/api/v4/projects/123/feature_flags?page=1&per_page=100 (0.31s)",
+        failing_proof="go test",
+    )
+    sharded = Result(
+        "R2-claim-validate-guard",
+        "KILLED",
+        f"{shard_root}/gitlab_feature_flags_route.go:42: unexpected request "
+        "/api/v4/projects/123/feature_flags?page=1&per_page=100 (1.22s)",
+        failing_proof="go test",
+    )
+
+    serial_projection = canonical_result_projection(
+        [serial], shard_roots=[source_root], temporary_roots=[]
+    )
+    sharded_projection = canonical_result_projection(
+        [sharded], shard_roots=[shard_root], temporary_roots=[]
+    )
+
+    assert serial_projection == sharded_projection
+
+
+def test_projection_normalizes_only_the_explicit_go_toolchain_root(
+    tmp_path: Path,
+) -> None:
+    serial_go_root = tmp_path / "serial-toolchain" / "go"
+    sharded_go_root = tmp_path / "sharded-toolchain" / "go"
+    serial_go_root.mkdir(parents=True)
+    sharded_go_root.mkdir(parents=True)
+    serial = Result(
+        "M1",
+        "KILLED",
+        f"{serial_go_root}/src/testing/testing.go:1974 +0x1a0",
+        failing_proof="go test",
+    )
+    sharded = Result(
+        "M1",
+        "KILLED",
+        f"{sharded_go_root}/src/testing/testing.go:1974 +0x1a0",
+        failing_proof="go test",
+    )
+
+    serial_projection = canonical_result_projection(
+        [serial],
+        shard_roots=[],
+        temporary_roots=[],
+        go_root=serial_go_root,
+    )
+    sharded_projection = canonical_result_projection(
+        [sharded],
+        shard_roots=[],
+        temporary_roots=[],
+        go_root=sharded_go_root,
+    )
+
+    assert serial_projection == sharded_projection
+    assert "<GOROOT>/src/testing/testing.go" in serial_projection[0]["detail"]
+    with pytest.raises(DetailNormalizationError, match="unrecognised absolute path"):
+        normalize_detail(
+            "/tmp/lookalike/src/testing/testing.go:1974 +0x1a0",
+            shard_roots=[],
+            temporary_roots=[],
+            go_root=serial_go_root,
+        )
+    with pytest.raises(DetailNormalizationError, match="existing toolchain directory"):
+        normalize_detail(
+            "failure /opt/foreign/state.txt",
+            shard_roots=[],
+            temporary_roots=[],
+            go_root=Path("/"),
+        )
+
+
+def test_projection_normalizes_go_test_package_summary_duration() -> None:
+    serial = Result(
+        "M1",
+        "KILLED",
+        "    FAIL\tgithub.com/full-chaos/dev-health-ops/internal/providersync\t0.363s\nFAIL",
+        failing_proof="go test",
+    )
+    sharded = Result(
+        "M1",
+        "KILLED",
+        "    FAIL\tgithub.com/full-chaos/dev-health-ops/internal/providersync\t0.362s\nFAIL",
+        failing_proof="go test",
+    )
+
+    serial_projection = canonical_result_projection(
+        [serial], shard_roots=[], temporary_roots=[]
+    )
+    sharded_projection = canonical_result_projection(
+        [sharded], shard_roots=[], temporary_roots=[]
+    )
+
+    assert serial_projection == sharded_projection
+    assert "\t<DURATION>\n" in serial_projection[0]["detail"]
+    assert (
+        normalize_detail(
+            "latency\t0.363s",
+            shard_roots=[],
+            temporary_roots=[],
+        )
+        == "latency\t0.363s"
+    )
+
+
+def test_normalizer_preserves_only_explicit_shell_temp_templates() -> None:
+    detail = (
+        'proof_dir=$(mktemp -d "${TMPDIR:-/tmp}/chaos3702-proof.XXXXXX") '
+        'cache_dir=$(mktemp -d "${TMPDIR:-/tmp}/chaos3702-cache.XXXXXX")'
+    )
+
+    assert normalize_detail(detail, shard_roots=[], temporary_roots=[]) == detail
+    with pytest.raises(DetailNormalizationError, match="unrecognised absolute path"):
+        normalize_detail(
+            "proof_dir=/chaos3702-proof.XXXXXX",
+            shard_roots=[],
+            temporary_roots=[],
+        )
+
+
 def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
     tmp_path: Path,
 ) -> None:

--- a/tests/tooling/test_mutation_harness_coordinator.py
+++ b/tests/tooling/test_mutation_harness_coordinator.py
@@ -22,11 +22,13 @@ from scripts.mutation_harness import HarnessError, Result, _read_state  # noqa: 
 from scripts.mutation_harness_coordinator import (  # noqa: E402
     AGGREGATE_CHILD_FAILED,
     AGGREGATE_COMPLETE,
+    AGGREGATE_INVALID,
     AGGREGATE_SOURCE_DRIFTED,
     AggregateRefusal,
     ChildSpec,
     DetailNormalizationError,
     ShardAssignment,
+    _validate_child_spec,
     aggregate_child_results,
     append_durable_jsonl,
     begin_coordinator_run,
@@ -271,10 +273,11 @@ def test_child_protocol_refuses_a_result_stream_in_the_source_root(
 ) -> None:
     children = tmp_path / "children"
     children.mkdir()
-    foreign_result = tmp_path / "child-result.jsonl"
+    source = tmp_path / "source"
+    foreign_result = source / "child-result.jsonl"
 
     def bad_factory(assignment: ShardAssignment, run_id: str) -> ChildSpec:
-        spec = _factory(children)(assignment, run_id)
+        spec = _factory(children, source_root=source)(assignment, run_id)
         return replace(spec, result_stream=foreign_result)
 
     with pytest.raises(HarnessError, match="result_stream escapes shard root"):
@@ -287,10 +290,30 @@ def _child_code(
     assignment: ShardAssignment,
     *,
     write_results: bool = True,
+    emit_events: bool = True,
+    event_sequence: Sequence[str] | None = None,
     exit_code: int = 0,
 ) -> str:
     selected = [
         (item.identifier, item.selected_ordinal) for item in assignment.mutations
+    ]
+    events = (
+        tuple(event_sequence)
+        if event_sequence is not None
+        else (("mutation_started", "mutation_finished") if emit_events else ())
+    )
+    event_lines = [
+        (
+            "    print(json.dumps({**common, 'event': "
+            f"{event!r}, "
+            + (
+                "'phase': 'baseline'"
+                if event == "mutation_started"
+                else "'verdict': 'KILLED'"
+            )
+            + "}), flush=True)"
+        )
+        for event in events
     ]
     return "\n".join(
         [
@@ -300,8 +323,7 @@ def _child_code(
             "result_path.parent.mkdir(parents=True, exist_ok=True)",
             "for mutation_id, ordinal in selected:",
             "    common = {'schema_version': 1, 'run_id': os.environ['MUTATION_HARNESS_RUN_ID'], 'shard_index': int(os.environ['MUTATION_HARNESS_SHARD_INDEX']), 'plan_ordinal': ordinal, 'mutation_id': mutation_id}",
-            "    print(json.dumps({**common, 'event': 'mutation_started', 'phase': 'baseline'}), flush=True)",
-            "    print(json.dumps({**common, 'event': 'mutation_finished', 'verdict': 'KILLED'}), flush=True)",
+            *event_lines,
             *(
                 [
                     "    record = {**common, 'plan_digest': os.environ['MUTATION_HARNESS_PLAN_DIGEST'], 'result': {'id': mutation_id, 'verdict': 'KILLED', 'detail': 'observed ' + mutation_id, 'failing_proof': 'proof', 'warnings': []}}",
@@ -322,7 +344,10 @@ def _factory(
     tmp_path: Path,
     *,
     write_results: bool = True,
+    emit_events: bool = True,
+    event_sequence: Sequence[str] | None = None,
     exit_code: int = 0,
+    source_root: Path | None = None,
     assert_root_locked: Path | None = None,
 ) -> Callable[[ShardAssignment, str], ChildSpec]:
     def build(assignment: ShardAssignment, run_id: str) -> ChildSpec:
@@ -339,7 +364,7 @@ def _factory(
         return ChildSpec(
             assignment=assignment,
             root=shard,
-            source_root=assert_root_locked or tmp_path.parent,
+            source_root=source_root or assert_root_locked or tmp_path.parent,
             temporary_root=tmp_path,
             argv=(
                 sys.executable,
@@ -347,6 +372,8 @@ def _factory(
                 _child_code(
                     assignment,
                     write_results=write_results,
+                    emit_events=emit_events,
+                    event_sequence=event_sequence,
                     exit_code=exit_code,
                 ),
             ),
@@ -366,12 +393,14 @@ def _coordinate(
     factory: Callable[[ShardAssignment, str], ChildSpec] | None = None,
     before_report: Callable[[], None] | None = None,
 ):
-    plan = tmp_path / "plan.json"
+    source = tmp_path / "source"
+    source.mkdir(exist_ok=True)
+    plan = source / "plan.json"
     plan.write_text("{}", encoding="utf-8")
     shards = tmp_path / "children"
     shards.mkdir(exist_ok=True)
     return coordinator_run(
-        tmp_path,
+        source,
         plan,
         "lane-c-plan",
         mutation_ids,
@@ -384,7 +413,7 @@ def _coordinate(
         source_manifest_digest=SOURCE_DIGEST,
         plan_digest=PLAN_DIGEST,
         source_manifest_reader=source_reader or (lambda: SOURCE_DIGEST),
-        child_factory=factory or _factory(shards, assert_root_locked=tmp_path),
+        child_factory=factory or _factory(shards, assert_root_locked=source),
         run_id=RUN_ID,
         before_report=before_report,
     )
@@ -427,10 +456,153 @@ def test_coordinator_resequences_events_orders_results_and_reports_after_childre
     assert [result["id"] for result in report["results"]] == ["M1", "M2", "M3"]
     assert report["canonical_projection"]["normalized"] == ["detail"]
     assert manifest["source_manifest"] == _source_manifest()
-    assert manifest["source_root"] == str(tmp_path)
+    assert manifest["source_root"] == str(tmp_path / "source")
     assert all(shard["temporary_root"] for shard in manifest["shards"])
     assert all(shard["liveness_lock"] for shard in manifest["shards"])
-    assert _read_state(tmp_path) is None
+    assert _read_state(tmp_path / "source") is None
+
+
+def test_complete_results_without_mutation_lifecycle_events_invalidate_aggregate(
+    tmp_path: Path,
+) -> None:
+    children = tmp_path / "children"
+    children.mkdir()
+
+    outcome = _coordinate(
+        tmp_path,
+        mutation_ids=("M1",),
+        factory=_factory(
+            children,
+            source_root=tmp_path / "source",
+            emit_events=False,
+        ),
+    )
+
+    assert outcome.aggregate_status == AGGREGATE_INVALID
+    assert outcome.exit_code == 1
+    report = json.loads(outcome.report_path.read_text(encoding="utf-8"))
+    assert report["aggregate_errors"] == [
+        "shard 0 missing mutation_started event for M1",
+        "shard 0 missing mutation_finished event for M1",
+    ]
+    events = [
+        json.loads(line)
+        for line in outcome.event_log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert events[-1]["completed"] == 0
+
+
+@pytest.mark.parametrize(
+    ("event_sequence", "error"),
+    [
+        (
+            ("mutation_started", "mutation_started", "mutation_finished"),
+            "duplicate or late mutation_started",
+        ),
+        (("mutation_finished",), "mutation_finished event without one prior"),
+    ],
+)
+def test_duplicate_or_invalid_mutation_lifecycle_events_invalidate_aggregate(
+    tmp_path: Path, event_sequence: tuple[str, ...], error: str
+) -> None:
+    children = tmp_path / "children"
+    children.mkdir()
+
+    outcome = _coordinate(
+        tmp_path,
+        mutation_ids=("M1",),
+        factory=_factory(
+            children,
+            source_root=tmp_path / "source",
+            event_sequence=event_sequence,
+        ),
+    )
+
+    assert outcome.aggregate_status == AGGREGATE_INVALID
+    assert outcome.exit_code == 1
+    report = json.loads(outcome.report_path.read_text(encoding="utf-8"))
+    assert any(error in item for item in report["aggregate_errors"])
+
+
+def test_partial_child_result_stream_still_writes_non_authoritative_report(
+    tmp_path: Path,
+) -> None:
+    children = tmp_path / "children"
+    children.mkdir()
+
+    def partial_factory(assignment: ShardAssignment, run_id: str) -> ChildSpec:
+        spec = _factory(children, source_root=tmp_path / "source")(assignment, run_id)
+        if assignment.shard_index == 1:
+            return spec
+        measured, partial = assignment.mutations
+        child = "\n".join(
+            [
+                "import json, os, pathlib, sys",
+                f"measured_id, measured_ordinal = {(measured.identifier, measured.selected_ordinal)!r}",
+                f"partial_id, partial_ordinal = {(partial.identifier, partial.selected_ordinal)!r}",
+                "path = pathlib.Path(os.environ['MUTATION_HARNESS_RESULT_STREAM'])",
+                "path.parent.mkdir(parents=True, exist_ok=True)",
+                "common = {'schema_version': 1, 'run_id': os.environ['MUTATION_HARNESS_RUN_ID'], 'shard_index': int(os.environ['MUTATION_HARNESS_SHARD_INDEX']), 'plan_ordinal': measured_ordinal, 'mutation_id': measured_id}",
+                "print(json.dumps({**common, 'event': 'mutation_started', 'phase': 'baseline'}), flush=True)",
+                "print(json.dumps({**common, 'event': 'mutation_finished', 'verdict': 'KILLED'}), flush=True)",
+                "record = {**common, 'plan_digest': os.environ['MUTATION_HARNESS_PLAN_DIGEST'], 'result': {'id': measured_id, 'verdict': 'KILLED', 'detail': 'observed ' + measured_id, 'failing_proof': 'proof', 'warnings': []}}",
+                "path.write_text(json.dumps(record) + '\\n', encoding='utf-8')",
+                "common = {'schema_version': 1, 'run_id': os.environ['MUTATION_HARNESS_RUN_ID'], 'shard_index': int(os.environ['MUTATION_HARNESS_SHARD_INDEX']), 'plan_ordinal': partial_ordinal, 'mutation_id': partial_id}",
+                "print(json.dumps({**common, 'event': 'mutation_started', 'phase': 'baseline'}), flush=True)",
+                "with path.open('a', encoding='utf-8') as handle: handle.write('{\"schema_version\":1')",
+                "sys.exit(9)",
+            ]
+        )
+        return replace(spec, argv=(sys.executable, "-c", child))
+
+    outcome = _coordinate(
+        tmp_path,
+        mutation_ids=("M1", "M2", "M3"),
+        factory=partial_factory,
+    )
+
+    assert outcome.aggregate_status == AGGREGATE_CHILD_FAILED
+    assert outcome.exit_code == 1
+    assert [result.identifier for result in outcome.results] == ["M1", "M2"]
+    assert outcome.unmeasured_ids == ("M3",)
+    assert outcome.measured_lost_ids == ()
+    report = json.loads(outcome.report_path.read_text(encoding="utf-8"))
+    assert report["unmeasured_mutation_ids"] == ["M3"]
+    assert any("partial JSON line" in error for error in report["aggregate_errors"])
+    assert any(
+        "missing mutation_finished" in error for error in report["aggregate_errors"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("temporary", "shard"),
+    [
+        ("source", "source/shard"),
+        ("source/temp", "source/temp/shard"),
+        (".", "execution"),
+        (".", "."),
+    ],
+)
+def test_child_paths_must_not_overlap_source_root(
+    tmp_path: Path, temporary: str, shard: str
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    temporary_root = (tmp_path / temporary).resolve()
+    shard_root = (tmp_path / shard).resolve()
+    spec = ChildSpec(
+        assignment=_assignments(["M1"], shards=1)[0],
+        root=shard_root,
+        source_root=source,
+        temporary_root=temporary_root,
+        argv=(sys.executable, "-c", "pass"),
+        result_stream=shard_root / "results.jsonl",
+        ownership_marker=shard_root / "owner.json",
+        liveness_lock=shard_root / "live.lock",
+    )
+
+    with pytest.raises(HarnessError, match="overlaps the invoking source root"):
+        _validate_child_spec(source, spec, set())
 
 
 def test_result_drop_after_finished_event_is_measured_lost_not_survivor(
@@ -441,7 +613,12 @@ def test_result_drop_after_finished_event_is_measured_lost_not_survivor(
     outcome = _coordinate(
         tmp_path,
         mutation_ids=("M1",),
-        factory=_factory(children, write_results=False, exit_code=7),
+        factory=_factory(
+            children,
+            source_root=tmp_path / "source",
+            write_results=False,
+            exit_code=7,
+        ),
     )
 
     assert outcome.aggregate_status == AGGREGATE_CHILD_FAILED
@@ -461,7 +638,7 @@ def test_child_crash_before_measurement_is_unmeasured_not_survivor(
     children.mkdir()
 
     def crash_factory(assignment: ShardAssignment, run_id: str) -> ChildSpec:
-        spec = _factory(children)(assignment, run_id)
+        spec = _factory(children, source_root=tmp_path / "source")(assignment, run_id)
         return ChildSpec(
             assignment=spec.assignment,
             root=spec.root,

--- a/tests/tooling/test_mutation_harness_coordinator.py
+++ b/tests/tooling/test_mutation_harness_coordinator.py
@@ -29,6 +29,7 @@ from scripts.mutation_harness_coordinator import (  # noqa: E402
     DetailNormalizationError,
     ShardAssignment,
     _validate_child_spec,
+    _write_manifest,
     aggregate_child_results,
     append_durable_jsonl,
     begin_coordinator_run,
@@ -223,6 +224,7 @@ def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
 ) -> None:
     plan = tmp_path / "plan.json"
     plan.write_text("{}", encoding="utf-8")
+    temporary_root = (tmp_path.parent / f"{tmp_path.name}-private").resolve()
     first = begin_coordinator_run(
         tmp_path,
         run_id="first",
@@ -233,6 +235,7 @@ def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
         plan_digest=PLAN_DIGEST,
         requested_shards=2,
         effective_shards=2,
+        temporary_root_factory=lambda _run_id: temporary_root,
     )
     try:
         state = _read_state(tmp_path)
@@ -250,6 +253,7 @@ def test_root_lock_is_owned_before_staging_and_is_mutually_exclusive(
                 plan_digest=PLAN_DIGEST,
                 requested_shards=2,
                 effective_shards=2,
+                temporary_root_factory=lambda _run_id: temporary_root,
             )
     finally:
         first.clear_and_release()
@@ -391,6 +395,7 @@ def _coordinate(
     mutation_ids: Sequence[str] = ("M1", "M2", "M3"),
     source_reader: Callable[[], str] | None = None,
     factory: Callable[[ShardAssignment, str], ChildSpec] | None = None,
+    temporary_root_factory: Callable[[str], Path] | None = None,
     before_report: Callable[[], None] | None = None,
 ):
     source = tmp_path / "source"
@@ -413,10 +418,126 @@ def _coordinate(
         source_manifest_digest=SOURCE_DIGEST,
         plan_digest=PLAN_DIGEST,
         source_manifest_reader=source_reader or (lambda: SOURCE_DIGEST),
+        temporary_root_factory=temporary_root_factory
+        or (lambda _run_id: shards.resolve()),
         child_factory=factory or _factory(shards, assert_root_locked=source),
         run_id=RUN_ID,
         before_report=before_report,
     )
+
+
+def test_manifest_records_run_temporary_root_before_first_shard_staging_failure(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    temporary_root = (tmp_path / "private-run").resolve()
+    temporary_root.mkdir()
+
+    def staging_failure(_assignment: ShardAssignment, _run_id: str) -> ChildSpec:
+        state = _read_state(source)
+        assert state is not None
+        run_state = state["coordinator_run"]
+        assert run_state["lifecycle"] == "staging"
+        assert run_state["temporary_root"] == str(temporary_root)
+        manifest = json.loads(
+            Path(run_state["manifest_path"]).read_text(encoding="utf-8")
+        )
+        assert set(manifest) == {
+            "effective_shards",
+            "plan_digest",
+            "plan_path",
+            "requested_shards",
+            "run_id",
+            "schema_version",
+            "shards",
+            "source_head",
+            "source_manifest",
+            "source_manifest_digest",
+            "source_root",
+            "temporary_root",
+        }
+        assert manifest["temporary_root"] == str(temporary_root)
+        assert manifest["shards"] == []
+        raise HarnessError("staging failed before the first shard")
+
+    with pytest.raises(HarnessError, match="staging failed before the first shard"):
+        _coordinate(
+            tmp_path,
+            factory=staging_failure,
+            temporary_root_factory=lambda _run_id: temporary_root,
+        )
+
+    state = _read_state(source)
+    assert state is not None
+    run_state = state["coordinator_run"]
+    assert run_state["lifecycle"] == "aborted"
+    assert run_state["temporary_root"] == str(temporary_root)
+    manifest = json.loads(Path(run_state["manifest_path"]).read_text(encoding="utf-8"))
+    assert manifest["temporary_root"] == str(temporary_root)
+    assert manifest["shards"] == []
+
+
+@pytest.mark.parametrize("relative", ["source/private-run", "."])
+def test_run_temporary_root_must_not_overlap_source_before_manifest_write(
+    tmp_path: Path, relative: str
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = (tmp_path / relative).resolve()
+
+    with pytest.raises(HarnessError, match="overlaps the invoking source root"):
+        begin_coordinator_run(
+            source,
+            run_id=RUN_ID,
+            source_head="head",
+            source_manifest=_source_manifest(),
+            source_manifest_digest=SOURCE_DIGEST,
+            plan_path=plan,
+            plan_digest=PLAN_DIGEST,
+            requested_shards=2,
+            effective_shards=2,
+            temporary_root_factory=lambda _run_id: temporary_root,
+        )
+
+    assert _read_state(source) is None
+    assert not (source / ".mutation-harness" / "lock").exists()
+
+
+def test_manifest_serialization_rechecks_digests_and_run_root_binding(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    plan = source / "plan.json"
+    plan.write_text("{}", encoding="utf-8")
+    temporary_root = (tmp_path / "private-run").resolve()
+    lease = begin_coordinator_run(
+        source,
+        run_id=RUN_ID,
+        source_head="head",
+        source_manifest=_source_manifest(),
+        source_manifest_digest=SOURCE_DIGEST,
+        plan_path=plan,
+        plan_digest=PLAN_DIGEST,
+        requested_shards=2,
+        effective_shards=2,
+        temporary_root_factory=lambda _run_id: temporary_root,
+    )
+    try:
+        lease.state["source_manifest"]["digest"] = "tampered"
+        with pytest.raises(HarnessError, match="mapping digest does not match"):
+            _write_manifest(lease)
+
+        lease.state["source_manifest"]["digest"] = SOURCE_DIGEST
+        lease.state["shards"].append(
+            {"temporary_root": str((tmp_path / "foreign-run").resolve())}
+        )
+        with pytest.raises(HarnessError, match="does not match the coordinator run"):
+            _write_manifest(lease)
+    finally:
+        lease.clear_and_release()
 
 
 def test_coordinator_resequences_events_orders_results_and_reports_after_children(
@@ -602,7 +723,7 @@ def test_child_paths_must_not_overlap_source_root(
     )
 
     with pytest.raises(HarnessError, match="overlaps the invoking source root"):
-        _validate_child_spec(source, spec, set())
+        _validate_child_spec(source, temporary_root, spec, set())
 
 
 def test_result_drop_after_finished_event_is_measured_lost_not_survivor(

--- a/tests/tooling/test_mutation_harness_execution_tree.py
+++ b/tests/tooling/test_mutation_harness_execution_tree.py
@@ -1,0 +1,458 @@
+"""Independent contract tests for mutation-harness execution trees."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import scripts.mutation_harness_execution_tree as execution_tree
+from scripts.mutation_harness import HarnessError
+from scripts.mutation_harness_execution_tree import (
+    OWNERSHIP_MARKER,
+    StagedExecutionTree,
+    build_source_manifest,
+    cleanup_execution_tree,
+    create_private_temp_root,
+    probe_python_toolchain_independence,
+    source_manifest_from_dict,
+    source_manifest_to_dict,
+    stage_execution_tree,
+)
+
+
+def _git(
+    root: Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "commit.gpgSign=false",
+            *args,
+        ],
+        cwd=root,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def source_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "source"
+    root.mkdir()
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "tests@example.invalid")
+    _git(root, "config", "user.name", "Execution Tree Tests")
+    (root / ".gitignore").write_text(".mutation-harness/\nignored-input/\n")
+    (root / "tracked.txt").write_bytes(b"committed\n")
+    executable = root / "run.sh"
+    executable.write_bytes(b"#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+    (root / "deleted.txt").write_bytes(b"delete me\n")
+    os.symlink("tracked.txt", root / "tracked-link")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "fixture")
+
+    (root / "tracked.txt").write_bytes(b"dirty tracked bytes\n")
+    (root / "deleted.txt").unlink()
+    executable.chmod(0o744)
+    (root / "untracked.txt").write_bytes(b"untracked overlay\n")
+    (root / ".mutation-harness").mkdir()
+    (root / ".mutation-harness" / "state.json").write_text("must be excluded")
+    return root
+
+
+def test_source_manifest_captures_workspace_without_touching_index(
+    source_repo: Path,
+) -> None:
+    index = source_repo / ".git" / "index"
+    index_before = index.read_bytes()
+
+    manifest = build_source_manifest(source_repo)
+    entries = {entry.path: entry for entry in manifest.entries}
+
+    assert entries["tracked.txt"].digest == _sha256(b"dirty tracked bytes\n")
+    assert entries["deleted.txt"].kind == "deleted"
+    assert entries["run.sh"].mode & stat.S_IXUSR
+    assert entries["tracked-link"].kind == "symlink"
+    assert entries["tracked-link"].link_target == "tracked.txt"
+    assert entries["untracked.txt"].tracked is False
+    assert ".mutation-harness/state.json" not in entries
+    assert index.read_bytes() == index_before
+    assert source_manifest_from_dict(source_manifest_to_dict(manifest)) == manifest
+
+
+def test_manifest_refuses_unignored_harness_state_and_damaged_recovery_record(
+    source_repo: Path,
+) -> None:
+    manifest = build_source_manifest(source_repo)
+    damaged = source_manifest_to_dict(manifest)
+    damaged["head"] = "different-head"
+    with pytest.raises(HarnessError, match="digest mismatch"):
+        source_manifest_from_dict(damaged)
+
+    (source_repo / ".gitignore").write_text("ignored-input/\n", encoding="utf-8")
+    with pytest.raises(HarnessError, match="not excluded by gitignore"):
+        build_source_manifest(source_repo)
+
+
+def _sha256(data: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def test_stage_creates_independent_same_path_overlays(source_repo: Path) -> None:
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "private"
+    temporary_root.mkdir(mode=0o700)
+
+    first = stage_execution_tree(
+        source_repo,
+        temporary_root / "shard-0",
+        run_id="run-3807",
+        shard_index=0,
+        source_manifest=manifest,
+        plan_digest="plan-digest",
+        workspace_inputs=(),
+    )
+    second = stage_execution_tree(
+        source_repo,
+        temporary_root / "shard-1",
+        run_id="run-3807",
+        shard_index=1,
+        source_manifest=manifest,
+        plan_digest="plan-digest",
+        workspace_inputs=(),
+    )
+
+    assert (first.root / "tracked.txt").read_bytes() == b"dirty tracked bytes\n"
+    assert not (first.root / "deleted.txt").exists()
+    assert stat.S_IMODE((first.root / "run.sh").stat().st_mode) == 0o744
+    assert os.readlink(first.root / "tracked-link") == "tracked.txt"
+    assert (first.root / "untracked.txt").read_bytes() == b"untracked overlay\n"
+    assert not (first.root / ".mutation-harness" / "state.json").exists()
+    assert build_source_manifest(first.root) == manifest
+    assert _git(first.root, "symbolic-ref", "-q", "HEAD", check=False).returncode != 0
+
+    (first.root / "tracked.txt").write_bytes(b"mutated shard zero\n")
+    assert (second.root / "tracked.txt").read_bytes() == b"dirty tracked bytes\n"
+    assert (source_repo / "tracked.txt").read_bytes() == b"dirty tracked bytes\n"
+    assert build_source_manifest(source_repo) == manifest
+
+
+def test_private_temp_root_is_mode_0700_and_staging_rejects_wider_mode(
+    source_repo: Path,
+) -> None:
+    private = create_private_temp_root(prefix="chaos-3807-test-")
+    try:
+        assert stat.S_IMODE(private.stat().st_mode) == 0o700
+    finally:
+        shutil.rmtree(private)
+
+    wider = source_repo.parent / "wider-root"
+    wider.mkdir(mode=0o755)
+    wider.chmod(0o755)
+    with pytest.raises(HarnessError, match="must have mode 0700"):
+        stage_execution_tree(
+            source_repo,
+            wider / "shard",
+            run_id="run-wide",
+            shard_index=0,
+            source_manifest=build_source_manifest(source_repo),
+            plan_digest="plan-digest",
+            workspace_inputs=(),
+        )
+
+
+def test_stage_rechecks_invoking_manifest_after_the_overlay(
+    source_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "drift-private"
+    temporary_root.mkdir(mode=0o700)
+    original_copy = execution_tree._copy_manifest_entry
+
+    def copy_then_drift(
+        source: Path,
+        destination: Path,
+        entry: execution_tree.SourceManifestEntry,
+    ) -> None:
+        original_copy(source, destination, entry)
+        if entry == manifest.entries[-1]:
+            (source / "tracked.txt").write_bytes(b"drifted during staging\n")
+
+    monkeypatch.setattr(execution_tree, "_copy_manifest_entry", copy_then_drift)
+    with pytest.raises(HarnessError, match="workspace changed"):
+        stage_execution_tree(
+            source_repo,
+            temporary_root / "shard",
+            run_id="run-drift",
+            shard_index=0,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=(),
+        )
+
+
+def test_workspace_input_copy_has_no_links_and_is_byte_independent(
+    source_repo: Path,
+) -> None:
+    workspace = source_repo / "ignored-input"
+    workspace.mkdir()
+    original = workspace / "payload.bin"
+    original.write_bytes(b"workspace input\n")
+    os.link(original, workspace / "source-hardlink.bin")
+    os.symlink("payload.bin", workspace / "source-symlink.bin")
+    source_digest = _sha256(original.read_bytes())
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "workspace-private"
+    temporary_root.mkdir(mode=0o700)
+
+    staged = stage_execution_tree(
+        source_repo,
+        temporary_root / "shard",
+        run_id="run-workspace",
+        shard_index=0,
+        source_manifest=manifest,
+        plan_digest="plan-digest",
+        workspace_inputs=("ignored-input",),
+    )
+    copied = staged.root / "ignored-input"
+
+    copied_files = sorted(path for path in copied.rglob("*") if path.is_file())
+    assert copied_files
+    assert all(not path.is_symlink() for path in copied.rglob("*"))
+    assert len({(path.stat().st_dev, path.stat().st_ino) for path in copied_files}) == 3
+    assert all(
+        (path.stat().st_dev, path.stat().st_ino)
+        != (original.stat().st_dev, original.stat().st_ino)
+        for path in copied_files
+    )
+
+    (copied / "payload.bin").write_bytes(b"shard-only change\n")
+    assert _sha256(original.read_bytes()) == source_digest
+    assert build_source_manifest(source_repo) == manifest
+
+
+def _python_workspace(source_repo: Path) -> Path:
+    with (source_repo / ".gitignore").open("a", encoding="utf-8") as handle:
+        handle.write(".venv-probe/\n")
+    package = source_repo / "src/probe_pkg"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("SOURCE = 'fixture'\n", encoding="utf-8")
+    environment = source_repo / ".venv-probe"
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(environment)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    site_packages = next(environment.glob("lib/python*/site-packages"))
+    source_path = str((source_repo / "src").resolve())
+    (site_packages / "__editable__.probe.pth").write_text(
+        source_path + "\n", encoding="utf-8"
+    )
+    (site_packages / "__editable___probe_finder.py").write_text(
+        f"MAPPING = {{'probe_pkg': {source_path!r}}}\n", encoding="utf-8"
+    )
+    (environment / "bin/probe-tool").write_text(
+        f"#!{environment / 'bin/python'}\nprint('probe')\n",
+        encoding="utf-8",
+    )
+    with (environment / "pyvenv.cfg").open("a", encoding="utf-8") as handle:
+        handle.write(f"invoking-root = {source_repo}\n")
+    return environment
+
+
+def test_python_workspace_is_relocated_and_probe_reads_shard_bytes(
+    source_repo: Path,
+) -> None:
+    environment = _python_workspace(source_repo)
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "python-private"
+    temporary_root.mkdir(mode=0o700)
+
+    staged = stage_execution_tree(
+        source_repo,
+        temporary_root / "shard",
+        run_id="run-python",
+        shard_index=0,
+        source_manifest=manifest,
+        plan_digest="plan-digest",
+        workspace_inputs=(environment.name,),
+    )
+    copied_environment = staged.root / environment.name
+    invoking_bytes = os.fsencode(str(source_repo.resolve()))
+    shard_bytes = os.fsencode(str(staged.root.resolve()))
+
+    assert all(not path.is_symlink() for path in copied_environment.rglob("*"))
+    assert not any(
+        invoking_bytes in path.read_bytes()
+        for path in copied_environment.rglob("*")
+        if path.is_file()
+    )
+    relocated = [
+        copied_environment / "bin/probe-tool",
+        copied_environment / "pyvenv.cfg",
+        *copied_environment.rglob("__editable__*.pth"),
+        *copied_environment.rglob("__editable__*_finder.py"),
+    ]
+    assert all(shard_bytes in path.read_bytes() for path in relocated)
+    assert build_source_manifest(source_repo) == manifest
+
+
+def test_toolchain_probe_rejects_a_deliberately_unrelocated_copy(
+    source_repo: Path,
+) -> None:
+    environment = _python_workspace(source_repo)
+    bad_shard = source_repo.parent / "bad-shard"
+    shutil.copytree(source_repo / "src", bad_shard / "src")
+    shutil.copytree(environment, bad_shard / environment.name, symlinks=False)
+
+    with pytest.raises(HarnessError, match="did not read shard-only bytes"):
+        probe_python_toolchain_independence(
+            shard_root=bad_shard,
+            environment=bad_shard / environment.name,
+        )
+
+
+def test_relocation_refuses_unknown_invoking_root_residue(source_repo: Path) -> None:
+    environment = _python_workspace(source_repo)
+    (environment / "opaque-binding.bin").write_bytes(
+        b"binding=" + os.fsencode(str(source_repo.resolve()))
+    )
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "residue-private"
+    temporary_root.mkdir(mode=0o700)
+
+    with pytest.raises(HarnessError, match="still resolves to the invoking root"):
+        stage_execution_tree(
+            source_repo,
+            temporary_root / "shard",
+            run_id="run-residue",
+            shard_index=0,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=(environment.name,),
+        )
+
+
+def test_stage_probe_is_independent_from_the_relocation_pass(
+    source_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    environment = _python_workspace(source_repo)
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "probe-private"
+    temporary_root.mkdir(mode=0o700)
+    monkeypatch.setattr(
+        execution_tree, "relocate_python_environment", lambda **_kwargs: None
+    )
+
+    with pytest.raises(HarnessError, match="did not read shard-only bytes"):
+        stage_execution_tree(
+            source_repo,
+            temporary_root / "shard",
+            run_id="run-independent-probe",
+            shard_index=0,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=(environment.name,),
+        )
+
+
+def _stage_for_cleanup(source_repo: Path, temporary_root: Path) -> StagedExecutionTree:
+    manifest = build_source_manifest(source_repo)
+    return stage_execution_tree(
+        source_repo,
+        temporary_root / "cleanup-shard",
+        run_id="run-cleanup",
+        shard_index=3,
+        source_manifest=manifest,
+        plan_digest="cleanup-plan",
+        workspace_inputs=(),
+    )
+
+
+def test_cleanup_refuses_escape_wrong_marker_live_holder_applied_and_dirty_source(
+    source_repo: Path,
+) -> None:
+    temporary_root = source_repo.parent / "cleanup-private"
+    temporary_root.mkdir(mode=0o700)
+    staged = _stage_for_cleanup(source_repo, temporary_root)
+
+    with pytest.raises(HarnessError, match="death is not proved"):
+        cleanup_execution_tree(
+            staged, temporary_root=temporary_root, child_liveness_proven=False
+        )
+    assert staged.root.exists()
+
+    original_marker = staged.ownership_marker.read_bytes()
+    staged.ownership_marker.write_text(json.dumps({"run_id": "foreign"}))
+    with pytest.raises(HarnessError, match="ownership marker does not match"):
+        cleanup_execution_tree(
+            staged, temporary_root=temporary_root, child_liveness_proven=True
+        )
+    staged.ownership_marker.write_bytes(original_marker)
+
+    foreign_marker = source_repo.parent / "foreign-owner.json"
+    foreign_marker.write_bytes(original_marker)
+    redirected_marker = replace(staged, ownership_marker=foreign_marker)
+    with pytest.raises(HarnessError, match="outside the owned shard"):
+        cleanup_execution_tree(
+            redirected_marker,
+            temporary_root=temporary_root,
+            child_liveness_proven=True,
+        )
+    assert staged.root.exists()
+
+    state = staged.root / ".mutation-harness/state.json"
+    state.write_text("[]", encoding="utf-8")
+    with pytest.raises(HarnessError, match="state is not a JSON object"):
+        cleanup_execution_tree(
+            staged, temporary_root=temporary_root, child_liveness_proven=True
+        )
+    state.write_text(json.dumps({"applied": {"id": "M1"}}), encoding="utf-8")
+    with pytest.raises(HarnessError, match="has an applied mutation"):
+        cleanup_execution_tree(
+            staged, temporary_root=temporary_root, child_liveness_proven=True
+        )
+    state.unlink()
+
+    target = staged.root / "tracked.txt"
+    restored_bytes = target.read_bytes()
+    target.write_bytes(b"still mutated\n")
+    with pytest.raises(HarnessError, match="source is not restored"):
+        cleanup_execution_tree(
+            staged, temporary_root=temporary_root, child_liveness_proven=True
+        )
+    target.write_bytes(restored_bytes)
+
+    outside = source_repo.parent / "outside-sentinel"
+    outside.mkdir()
+    outside_marker = outside / OWNERSHIP_MARKER
+    outside_marker.parent.mkdir(parents=True)
+    outside_marker.write_bytes(original_marker)
+    escaped = replace(staged, root=outside, ownership_marker=outside_marker)
+    with pytest.raises(HarnessError, match="escapes the run root"):
+        cleanup_execution_tree(
+            escaped, temporary_root=temporary_root, child_liveness_proven=True
+        )
+    assert outside.exists()
+
+    cleanup_execution_tree(
+        staged, temporary_root=temporary_root, child_liveness_proven=True
+    )
+    assert not staged.root.exists()
+    assert build_source_manifest(source_repo) == staged.source_manifest

--- a/tests/tooling/test_mutation_harness_execution_tree.py
+++ b/tests/tooling/test_mutation_harness_execution_tree.py
@@ -107,6 +107,16 @@ def test_manifest_refuses_unignored_harness_state_and_damaged_recovery_record(
         build_source_manifest(source_repo)
 
 
+def test_manifest_refuses_selective_harness_child_ignore(source_repo: Path) -> None:
+    (source_repo / ".gitignore").write_text(
+        ".mutation-harness/execution-tree-probe\nignored-input/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(HarnessError, match="not excluded by gitignore"):
+        build_source_manifest(source_repo)
+
+
 def _sha256(data: bytes) -> str:
     import hashlib
 
@@ -383,6 +393,20 @@ def _stage_for_cleanup(source_repo: Path, temporary_root: Path) -> StagedExecuti
         plan_digest="cleanup-plan",
         workspace_inputs=(),
     )
+
+
+def test_cleanup_refuses_a_dangling_shard_state_symlink(source_repo: Path) -> None:
+    temporary_root = source_repo.parent / "dangling-state-private"
+    temporary_root.mkdir(mode=0o700)
+    staged = _stage_for_cleanup(source_repo, temporary_root)
+    state = staged.root / ".mutation-harness/state.json"
+    os.symlink("missing-state-target.json", state)
+
+    with pytest.raises(HarnessError, match="state is a symlink"):
+        cleanup_execution_tree(
+            staged, temporary_root=temporary_root, child_liveness_proven=True
+        )
+    assert staged.root.exists()
 
 
 def test_cleanup_refuses_escape_wrong_marker_live_holder_applied_and_dirty_source(

--- a/tests/tooling/test_mutation_harness_execution_tree.py
+++ b/tests/tooling/test_mutation_harness_execution_tree.py
@@ -268,6 +268,105 @@ def test_workspace_input_copy_has_no_links_and_is_byte_independent(
     assert build_source_manifest(source_repo) == manifest
 
 
+def test_workspace_input_materializes_an_internal_directory_symlink(
+    source_repo: Path,
+) -> None:
+    workspace = source_repo / "ignored-input"
+    library = workspace / "lib"
+    library.mkdir(parents=True)
+    (library / "payload.bin").write_bytes(b"internal directory target\n")
+    os.symlink("lib", workspace / "lib64")
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "directory-link-private"
+    temporary_root.mkdir(mode=0o700)
+
+    staged = stage_execution_tree(
+        source_repo,
+        temporary_root / "shard",
+        run_id="run-directory-link",
+        shard_index=0,
+        source_manifest=manifest,
+        plan_digest="plan-digest",
+        workspace_inputs=("ignored-input",),
+    )
+
+    copied_alias = staged.root / "ignored-input/lib64"
+    assert copied_alias.is_dir()
+    assert not copied_alias.is_symlink()
+    assert (copied_alias / "payload.bin").read_bytes() == b"internal directory target\n"
+
+
+def test_workspace_input_refuses_an_external_directory_symlink(
+    source_repo: Path,
+) -> None:
+    workspace = source_repo / "ignored-input"
+    workspace.mkdir()
+    outside = source_repo.parent / "outside-workspace-input"
+    outside.mkdir()
+    (outside / "secret.bin").write_bytes(b"must not be copied\n")
+    os.symlink(outside, workspace / "external")
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "external-link-private"
+    temporary_root.mkdir(mode=0o700)
+
+    with pytest.raises(HarnessError, match="directory link escapes workspace input"):
+        stage_execution_tree(
+            source_repo,
+            temporary_root / "shard",
+            run_id="run-external-directory-link",
+            shard_index=0,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=("ignored-input",),
+        )
+
+
+def test_workspace_input_refuses_a_top_level_link_outside_the_repository(
+    source_repo: Path,
+) -> None:
+    with (source_repo / ".gitignore").open("a", encoding="utf-8") as handle:
+        handle.write("ignored-input\n")
+    outside = source_repo.parent / "outside-workspace-input"
+    outside.mkdir()
+    (outside / "secret.bin").write_bytes(b"must not be copied\n")
+    os.symlink(outside, source_repo / "ignored-input")
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "top-level-link-private"
+    temporary_root.mkdir(mode=0o700)
+
+    with pytest.raises(HarnessError, match="resolves outside repository"):
+        stage_execution_tree(
+            source_repo,
+            temporary_root / "shard",
+            run_id="run-top-level-directory-link",
+            shard_index=0,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=("ignored-input",),
+        )
+
+
+def test_workspace_input_refuses_a_directory_symlink_cycle(source_repo: Path) -> None:
+    workspace = source_repo / "ignored-input"
+    nested = workspace / "nested"
+    nested.mkdir(parents=True)
+    os.symlink("..", nested / "cycle")
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "cycle-link-private"
+    temporary_root.mkdir(mode=0o700)
+
+    with pytest.raises(HarnessError, match="directory link cycle"):
+        stage_execution_tree(
+            source_repo,
+            temporary_root / "shard",
+            run_id="run-directory-link-cycle",
+            shard_index=0,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=("ignored-input",),
+        )
+
+
 def _python_workspace(source_repo: Path) -> Path:
     with (source_repo / ".gitignore").open("a", encoding="utf-8") as handle:
         handle.write(".venv-probe/\n")

--- a/tests/tooling/test_mutation_harness_execution_tree.py
+++ b/tests/tooling/test_mutation_harness_execution_tree.py
@@ -335,6 +335,49 @@ def test_python_workspace_is_relocated_and_probe_reads_shard_bytes(
     assert build_source_manifest(source_repo) == manifest
 
 
+def test_editable_direct_url_metadata_is_relocated_to_the_shard(
+    source_repo: Path,
+) -> None:
+    environment = _python_workspace(source_repo)
+    site_packages = next(environment.glob("lib/python*/site-packages"))
+    distribution = site_packages / "dev_health_ops-1.1.0.post572.dist-info"
+    distribution.mkdir()
+    direct_url = distribution / "direct_url.json"
+    direct_url.write_text(
+        json.dumps(
+            {
+                "dir_info": {"editable": True},
+                "url": source_repo.resolve().as_uri(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest = build_source_manifest(source_repo)
+    temporary_root = source_repo.parent / "direct-url-private"
+    temporary_root.mkdir(mode=0o700)
+
+    staged = stage_execution_tree(
+        source_repo,
+        temporary_root / "shard",
+        run_id="run-direct-url",
+        shard_index=0,
+        source_manifest=manifest,
+        plan_digest="plan-digest",
+        workspace_inputs=(environment.name,),
+    )
+
+    relocated = json.loads(
+        (
+            staged.root / environment.name / direct_url.relative_to(environment)
+        ).read_text(encoding="utf-8")
+    )
+    assert relocated == {
+        "dir_info": {"editable": True},
+        "url": staged.root.resolve().as_uri(),
+    }
+    assert build_source_manifest(source_repo) == manifest
+
+
 def test_toolchain_probe_rejects_a_deliberately_unrelocated_copy(
     source_repo: Path,
 ) -> None:
@@ -392,6 +435,67 @@ def test_stage_probe_is_independent_from_the_relocation_pass(
             plan_digest="plan-digest",
             workspace_inputs=(environment.name,),
         )
+
+
+def test_staging_failure_after_marker_rolls_back_only_the_owned_partial_tree(
+    source_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = source_repo / "ignored-input"
+    workspace.mkdir()
+    (workspace / "payload.txt").write_text("workspace\n", encoding="utf-8")
+    manifest = build_source_manifest(source_repo)
+    index = source_repo / ".git/index"
+    index_before = index.read_bytes()
+    temporary_root = source_repo.parent / "rollback-private"
+    temporary_root.mkdir(mode=0o700)
+    destination = temporary_root / "shard-0"
+    outside_sentinel = temporary_root / "outside-sentinel.txt"
+    outside_sentinel.write_text("must survive\n", encoding="utf-8")
+
+    def fail_after_marker(
+        _source: Path, staged_root: Path, _workspace_inputs: tuple[str, ...]
+    ) -> None:
+        assert (staged_root / OWNERSHIP_MARKER).is_file()
+        raise HarnessError("deliberate post-marker staging failure")
+
+    monkeypatch.setattr(
+        execution_tree, "_materialize_workspace_inputs", fail_after_marker
+    )
+    with pytest.raises(HarnessError, match="deliberate post-marker staging failure"):
+        stage_execution_tree(
+            source_repo,
+            destination,
+            run_id="run-rollback",
+            shard_index=0,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=("ignored-input",),
+        )
+
+    assert not destination.exists()
+    assert outside_sentinel.read_text(encoding="utf-8") == "must survive\n"
+    assert index.read_bytes() == index_before
+    assert build_source_manifest(source_repo) == manifest
+    assert (
+        str(destination)
+        not in _git(source_repo, "worktree", "list", "--porcelain").stdout
+    )
+
+    preexisting = temporary_root / "preexisting-shard"
+    preexisting.mkdir()
+    preexisting_sentinel = preexisting / "sentinel.txt"
+    preexisting_sentinel.write_text("preexisting\n", encoding="utf-8")
+    with pytest.raises(HarnessError, match="destination already exists"):
+        stage_execution_tree(
+            source_repo,
+            preexisting,
+            run_id="run-preexisting",
+            shard_index=1,
+            source_manifest=manifest,
+            plan_digest="plan-digest",
+            workspace_inputs=("ignored-input",),
+        )
+    assert preexisting_sentinel.read_text(encoding="utf-8") == "preexisting\n"
 
 
 def _stage_for_cleanup(source_repo: Path, temporary_root: Path) -> StagedExecutionTree:

--- a/tests/tooling/test_mutation_harness_execution_tree.py
+++ b/tests/tooling/test_mutation_harness_execution_tree.py
@@ -117,6 +117,18 @@ def test_manifest_refuses_selective_harness_child_ignore(source_repo: Path) -> N
         build_source_manifest(source_repo)
 
 
+def test_manifest_accepts_directory_ignore_when_state_directory_is_absent(
+    source_repo: Path,
+) -> None:
+    state_directory = source_repo / ".mutation-harness"
+    shutil.rmtree(state_directory)
+
+    manifest = build_source_manifest(source_repo)
+
+    assert manifest.entries
+    assert not state_directory.exists()
+
+
 def _sha256(data: bytes) -> str:
     import hashlib
 

--- a/tests/tooling/test_mutation_harness_execution_tree.py
+++ b/tests/tooling/test_mutation_harness_execution_tree.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -520,9 +521,19 @@ def test_stage_probe_is_independent_from_the_relocation_pass(
     manifest = build_source_manifest(source_repo)
     temporary_root = source_repo.parent / "probe-private"
     temporary_root.mkdir(mode=0o700)
+    observed_environment: dict[str, str] = {}
+    real_run = execution_tree.subprocess.run
+
+    def observe_probe(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        environment_variables = kwargs.get("env")
+        if isinstance(environment_variables, dict):
+            observed_environment.update(environment_variables)
+        return real_run(*args, **kwargs)
+
     monkeypatch.setattr(
         execution_tree, "relocate_python_environment", lambda **_kwargs: None
     )
+    monkeypatch.setattr(execution_tree.subprocess, "run", observe_probe)
 
     with pytest.raises(HarnessError, match="did not read shard-only bytes"):
         stage_execution_tree(
@@ -534,6 +545,9 @@ def test_stage_probe_is_independent_from_the_relocation_pass(
             plan_digest="plan-digest",
             workspace_inputs=(environment.name,),
         )
+
+    assert observed_environment["PYTHONDONTWRITEBYTECODE"] == "1"
+    assert not (source_repo / "src/probe_pkg/__pycache__").exists()
 
 
 def test_staging_failure_after_marker_rolls_back_only_the_owned_partial_tree(

--- a/tests/tooling/test_mutation_harness_integration.py
+++ b/tests/tooling/test_mutation_harness_integration.py
@@ -1,0 +1,270 @@
+"""Public integration contracts for CHAOS-3807 sharded mutation runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.mutation_harness import main, verify
+from scripts.mutation_harness_coordinator import (
+    ChildSpec,
+    _record_child,
+    _write_manifest,
+    begin_coordinator_run,
+    select_and_assign,
+)
+from scripts.mutation_harness_execution_tree import (
+    build_source_manifest,
+    create_private_temp_root,
+    source_manifest_to_dict,
+    stage_execution_tree,
+)
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+INTEGRATED_SCRIPTS = (
+    "mutation_harness.py",
+    "mutation_harness_coordinator.py",
+    "mutation_harness_execution_tree.py",
+    "mutation_harness_optin.py",
+    "mutation_harness_recovery.py",
+)
+
+
+def _git(root: Path, *arguments: str) -> None:
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def _integration_repository(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "repository"
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    for name in INTEGRATED_SCRIPTS:
+        shutil.copy2(REPOSITORY_ROOT / "scripts" / name, scripts / name)
+    (root / ".gitignore").write_text(".mutation-harness/\n", encoding="utf-8")
+    (root / "widget.txt").write_text(
+        "guard-one=enabled\nguard-two=enabled\n", encoding="utf-8"
+    )
+    plan = root / "plan.json"
+    plan.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "name": "lane-e-integration",
+                "sharding": {
+                    "max_shards": 2,
+                    "workspace_inputs": [],
+                    "external_resources": "none",
+                    "shared_mutable_resource_exclusions": [],
+                },
+                "mutations": [
+                    {
+                        "id": "M1",
+                        "file": "widget.txt",
+                        "find": "guard-one=enabled",
+                        "replace": "guard-one=disabled",
+                        "proof": [
+                            ["bash", "-c", "grep -q guard-one=enabled widget.txt"]
+                        ],
+                        "rationale": "the first guard must remain observable",
+                    },
+                    {
+                        "id": "M2",
+                        "file": "widget.txt",
+                        "find": "guard-two=enabled",
+                        "replace": "guard-two=disabled",
+                        "proof": [
+                            ["bash", "-c", "grep -q guard-two=enabled widget.txt"]
+                        ],
+                        "rationale": "the second guard must remain observable",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "mutation@example.invalid")
+    _git(root, "config", "user.name", "Mutation Test")
+    _git(root, "config", "commit.gpgsign", "false")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "fixture")
+    return root, plan
+
+
+def test_public_cli_runs_two_isolated_shards_and_restores_source(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+    original = (root / "widget.txt").read_bytes()
+
+    exit_code = main(
+        [
+            "--root",
+            str(root),
+            "run",
+            "--plan",
+            str(plan),
+            "--shards",
+            "2",
+            "--assert-all-killed",
+            "--progress",
+            "none",
+        ]
+    )
+
+    assert exit_code == 0
+    assert (root / "widget.txt").read_bytes() == original
+    report = json.loads(
+        (root / ".mutation-harness" / "report.json").read_text(encoding="utf-8")
+    )
+    assert report["mode"] == "sharded"
+    assert report["aggregate_status"] == "COMPLETE"
+    assert [(item["id"], item["verdict"]) for item in report["results"]] == [
+        ("M1", "KILLED"),
+        ("M2", "KILLED"),
+    ]
+    assert all(
+        set(item) == {"id", "verdict", "detail", "failing_proof", "warnings"}
+        for item in report["results"]
+    )
+    assert not Path(report["shards"][0]["temporary_root"]).exists()
+    events = [
+        json.loads(line)
+        for line in Path(report["event_log_path"])
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events[-1]["event"] == "run_finished"
+    assert all("proof" not in event for event in events)
+    assert verify(root) == []
+    assert "mutation harness:" not in capsys.readouterr().err
+
+
+def test_public_cli_refuses_shards_without_closed_plan_opt_in(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+    raw = json.loads(plan.read_text(encoding="utf-8"))
+    raw.pop("sharding")
+    plan.write_text(json.dumps(raw), encoding="utf-8")
+
+    exit_code = main(["--root", str(root), "run", "--plan", str(plan), "--shards", "2"])
+
+    assert exit_code == 2
+    assert "does not opt in to sharding" in capsys.readouterr().err
+    assert not (root / ".mutation-harness" / "state.json").exists()
+
+
+def test_public_cli_enforces_max_shards_before_staging(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+
+    exit_code = main(["--root", str(root), "run", "--plan", str(plan), "--shards", "3"])
+
+    assert exit_code == 2
+    assert "exceeds declared max_shards 2" in capsys.readouterr().err
+    assert not (root / ".mutation-harness" / "state.json").exists()
+
+
+def test_public_cli_applies_only_before_effective_shard_assignment(
+    tmp_path: Path,
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+
+    exit_code = main(
+        [
+            "--root",
+            str(root),
+            "run",
+            "--plan",
+            str(plan),
+            "--only",
+            "M2",
+            "--shards",
+            "2",
+            "--assert-all-killed",
+            "--progress",
+            "none",
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(
+        (root / ".mutation-harness" / "report.json").read_text(encoding="utf-8")
+    )
+    assert report["requested_shards"] == 2
+    assert report["effective_shards"] == 1
+    assert [item["id"] for item in report["results"]] == ["M2"]
+
+
+def test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+    source_manifest = build_source_manifest(root)
+    plan_digest = hashlib.sha256(plan.read_bytes()).hexdigest()
+    run_id = "run-lane-e-recovery"
+    assignment = select_and_assign(["M1"], None, 1)[0]
+    lease = begin_coordinator_run(
+        root,
+        run_id=run_id,
+        source_head=source_manifest.head,
+        source_manifest=source_manifest_to_dict(source_manifest),
+        source_manifest_digest=source_manifest.digest,
+        plan_path=plan,
+        plan_digest=plan_digest,
+        requested_shards=1,
+        effective_shards=1,
+    )
+    _write_manifest(lease)
+    temporary_root = create_private_temp_root(prefix="mutation-harness-recovery-")
+    staged = stage_execution_tree(
+        root,
+        temporary_root / "shard-0",
+        run_id=run_id,
+        shard_index=0,
+        source_manifest=source_manifest,
+        plan_digest=plan_digest,
+        workspace_inputs=(),
+    )
+    liveness_lock = staged.root / ".mutation-harness" / "child.liveness"
+    liveness_lock.touch()
+    _record_child(
+        lease,
+        ChildSpec(
+            assignment=assignment,
+            root=staged.root,
+            source_root=root,
+            temporary_root=temporary_root,
+            argv=("unused",),
+            result_stream=staged.root / ".mutation-harness" / "results.jsonl",
+            ownership_marker=staged.ownership_marker,
+            liveness_lock=liveness_lock,
+        ),
+    )
+    lease.transition("running")
+    lease.retain_and_release()
+
+    assert main(["--root", str(root), "verify"]) == 1
+    assert main(["--root", str(root), "recover-run", "--run-id", run_id]) == 0
+
+    assert not staged.root.exists()
+    assert verify(root) == []
+    captured = capsys.readouterr()
+    assert (
+        "No result from this tree is trustworthy until it is recovered" in captured.err
+    )
+    assert "recovered run run-lane-e-recovery as aborted" in captured.out

--- a/tests/tooling/test_mutation_harness_integration.py
+++ b/tests/tooling/test_mutation_harness_integration.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -103,6 +104,52 @@ def _integration_repository(tmp_path: Path) -> tuple[Path, Path]:
     return root, plan
 
 
+def _add_editable_python_workspace(root: Path, plan: Path) -> None:
+    with (root / ".gitignore").open("a", encoding="utf-8") as handle:
+        handle.write(".venv/\n")
+    package = root / "src/probe_pkg"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("SOURCE = 'fixture'\n", encoding="utf-8")
+    environment = root / ".venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(environment)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    site_packages = next(environment.glob("lib/python*/site-packages"))
+    (site_packages / "__editable__.probe.pth").write_text(
+        str((root / "src").resolve()) + "\n", encoding="utf-8"
+    )
+    distribution = site_packages / "probe-1.0.dist-info"
+    distribution.mkdir()
+    (distribution / "direct_url.json").write_text(
+        json.dumps({"dir_info": {"editable": True}, "url": root.resolve().as_uri()}),
+        encoding="utf-8",
+    )
+    (root / "proof.py").write_text(
+        "import json, pathlib, sys\n"
+        "direct_url = next(pathlib.Path('.venv').rglob('direct_url.json'))\n"
+        "assert json.loads(direct_url.read_text())['url'] == "
+        "pathlib.Path.cwd().resolve().as_uri()\n"
+        "raise SystemExit(0 if sys.argv[1] in "
+        "pathlib.Path('widget.txt').read_text() else 1)\n",
+        encoding="utf-8",
+    )
+    raw = json.loads(plan.read_text(encoding="utf-8"))
+    raw["sharding"]["workspace_inputs"] = [".venv"]
+    for mutation in raw["mutations"]:
+        guard = mutation["find"]
+        mutation["proof"] = [
+            [
+                "bash",
+                "-c",
+                f'PYTHONPATH="$PWD/src" "$PWD/.venv/bin/python" proof.py {guard}',
+            ]
+        ]
+    plan.write_text(json.dumps(raw), encoding="utf-8")
+
+
 def test_public_cli_runs_two_isolated_shards_and_restores_source(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -150,6 +197,44 @@ def test_public_cli_runs_two_isolated_shards_and_restores_source(
     assert all("proof" not in event for event in events)
     assert verify(root) == []
     assert "mutation harness:" not in capsys.readouterr().err
+
+
+def test_public_two_shard_run_relocates_editable_direct_url_metadata(
+    tmp_path: Path,
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+    _add_editable_python_workspace(root, plan)
+
+    exit_code = main(
+        [
+            "--root",
+            str(root),
+            "run",
+            "--plan",
+            str(plan),
+            "--shards",
+            "2",
+            "--assert-all-killed",
+            "--progress",
+            "none",
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(
+        (root / ".mutation-harness" / "report.json").read_text(encoding="utf-8")
+    )
+    assert report["aggregate_status"] == "COMPLETE"
+    assert [result["verdict"] for result in report["results"]] == [
+        "KILLED",
+        "KILLED",
+    ]
+    source_direct_url = next((root / ".venv").rglob("direct_url.json"))
+    assert json.loads(source_direct_url.read_text(encoding="utf-8"))["url"] == (
+        root.resolve().as_uri()
+    )
+    assert not Path(report["shards"][0]["temporary_root"]).exists()
+    assert verify(root) == []
 
 
 def test_public_cli_refuses_shards_without_closed_plan_opt_in(
@@ -218,6 +303,7 @@ def test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify(
     plan_digest = hashlib.sha256(plan.read_bytes()).hexdigest()
     run_id = "run-lane-e-recovery"
     assignment = select_and_assign(["M1"], None, 1)[0]
+    temporary_root = create_private_temp_root(prefix="mutation-harness-recovery-")
     lease = begin_coordinator_run(
         root,
         run_id=run_id,
@@ -228,9 +314,9 @@ def test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify(
         plan_digest=plan_digest,
         requested_shards=1,
         effective_shards=1,
+        temporary_root_factory=lambda _run_id: temporary_root,
     )
     _write_manifest(lease)
-    temporary_root = create_private_temp_root(prefix="mutation-harness-recovery-")
     staged = stage_execution_tree(
         root,
         temporary_root / "shard-0",
@@ -268,3 +354,64 @@ def test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify(
         "No result from this tree is trustworthy until it is recovered" in captured.err
     )
     assert "recovered run run-lane-e-recovery as aborted" in captured.out
+
+
+def test_public_force_recovery_cleans_zero_recorded_staging_shards(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+    source_manifest = build_source_manifest(root)
+    plan_digest = hashlib.sha256(plan.read_bytes()).hexdigest()
+    run_id = "run-lane-e-zero-shard"
+    temporary_root = create_private_temp_root(prefix="mutation-harness-zero-shard-")
+    lease = begin_coordinator_run(
+        root,
+        run_id=run_id,
+        source_head=source_manifest.head,
+        source_manifest=source_manifest_to_dict(source_manifest),
+        source_manifest_digest=source_manifest.digest,
+        plan_path=plan,
+        plan_digest=plan_digest,
+        requested_shards=2,
+        effective_shards=2,
+        temporary_root_factory=lambda _run_id: temporary_root,
+    )
+    _write_manifest(lease)
+    staged = stage_execution_tree(
+        root,
+        temporary_root / "shard-0",
+        run_id=run_id,
+        shard_index=0,
+        source_manifest=source_manifest,
+        plan_digest=plan_digest,
+        workspace_inputs=(),
+    )
+    lease.transition("aborted")
+    lease.retain_and_release()
+
+    assert (
+        json.loads(
+            (root / ".mutation-harness" / "state.json").read_text(encoding="utf-8")
+        )["coordinator_run"]["shards"]
+        == []
+    )
+    assert (
+        main(
+            [
+                "--root",
+                str(root),
+                "recover-run",
+                "--run-id",
+                run_id,
+                "--force",
+            ]
+        )
+        == 0
+    )
+
+    assert not staged.root.exists()
+    assert not temporary_root.exists()
+    assert verify(root) == []
+    captured = capsys.readouterr()
+    assert "FORCE RECOVERY PREFLIGHT run-lane-e-zero-shard" in captured.out
+    assert "removed 1 owned staging shard(s)" in captured.out

--- a/tests/tooling/test_mutation_harness_integration.py
+++ b/tests/tooling/test_mutation_harness_integration.py
@@ -14,6 +14,7 @@ import pytest
 from scripts.mutation_harness import main, verify
 from scripts.mutation_harness_coordinator import (
     ChildSpec,
+    TemporaryRootClaim,
     _record_child,
     _write_manifest,
     begin_coordinator_run,
@@ -314,7 +315,9 @@ def test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify(
         plan_digest=plan_digest,
         requested_shards=1,
         effective_shards=1,
-        temporary_root_factory=lambda _run_id: temporary_root,
+        temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+            temporary_root
+        ),
     )
     _write_manifest(lease)
     staged = stage_execution_tree(
@@ -374,7 +377,9 @@ def test_public_force_recovery_cleans_zero_recorded_staging_shards(
         plan_digest=plan_digest,
         requested_shards=2,
         effective_shards=2,
-        temporary_root_factory=lambda _run_id: temporary_root,
+        temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+            temporary_root
+        ),
     )
     _write_manifest(lease)
     staged = stage_execution_tree(

--- a/tests/tooling/test_mutation_harness_integration.py
+++ b/tests/tooling/test_mutation_harness_integration.py
@@ -22,6 +22,7 @@ from scripts.mutation_harness_coordinator import (
 )
 from scripts.mutation_harness_execution_tree import (
     build_source_manifest,
+    cleanup_execution_tree,
     create_private_temp_root,
     source_manifest_to_dict,
     stage_execution_tree,
@@ -37,7 +38,7 @@ INTEGRATED_SCRIPTS = (
 )
 
 
-def _git(root: Path, *arguments: str) -> None:
+def _git(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
     completed = subprocess.run(
         ["git", *arguments],
         cwd=root,
@@ -46,6 +47,15 @@ def _git(root: Path, *arguments: str) -> None:
         text=True,
     )
     assert completed.returncode == 0, completed.stderr
+    return completed
+
+
+def _tree_file_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and not path.is_symlink()
+    }
 
 
 def _integration_repository(tmp_path: Path) -> tuple[Path, Path]:
@@ -296,8 +306,9 @@ def test_public_cli_applies_only_before_effective_shard_assignment(
     assert [item["id"] for item in report["results"]] == ["M2"]
 
 
-def test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize("force", [False, True])
+def test_public_recovery_clears_an_incomplete_run_when_recorded_temporary_root_is_absent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], force: bool
 ) -> None:
     root, plan = _integration_repository(tmp_path)
     source_manifest = build_source_manifest(root)
@@ -347,20 +358,176 @@ def test_public_recovery_cleans_an_owned_incomplete_run_and_unblocks_verify(
     lease.transition("running")
     lease.retain_and_release()
 
-    assert main(["--root", str(root), "verify"]) == 1
-    assert main(["--root", str(root), "recover-run", "--run-id", run_id]) == 0
-
-    assert not staged.root.exists()
-    assert verify(root) == []
-    captured = capsys.readouterr()
-    assert (
-        "No result from this tree is trustworthy until it is recovered" in captured.err
+    state_path = root / ".mutation-harness" / "state.json"
+    manifest_path = Path(
+        json.loads(state_path.read_text(encoding="utf-8"))["coordinator_run"][
+            "manifest_path"
+        ]
     )
-    assert "recovered run run-lane-e-recovery as aborted" in captured.out
+    cleanup_execution_tree(
+        staged,
+        temporary_root=temporary_root,
+        child_liveness_proven=True,
+    )
+    temporary_root.rmdir()
+    assert not temporary_root.exists()
+
+    assert main(["--root", str(root), "verify"]) == 1
+    verify_failure = capsys.readouterr()
+    assert verify_failure.out == ""
+    assert "No result from this tree is trustworthy until it is recovered" in (
+        verify_failure.err
+    )
+
+    recover_arguments = ["--root", str(root), "recover-run", "--run-id", run_id]
+    if force:
+        recover_arguments.append("--force")
+    assert main(recover_arguments) == 0
+
+    recovered = capsys.readouterr()
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {"schema_version": 1}
+    recovered_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert recovered_manifest["lifecycle"] == "aborted"
+    assert "results" not in recovered_manifest
+    assert not (root / ".mutation-harness" / "report.json").exists()
+    assert main(["--root", str(root), "verify"]) == 0
+    verify_success = capsys.readouterr()
+    assert verify_success.err == ""
+    assert (
+        verify_success.out == "mutation harness: tree is clean, no mutation applied\n"
+    )
+    assert recovered.err == ""
+    assert recovered.out == (
+        "recovered run run-lane-e-recovery as aborted; recorded temporary root "
+        "was absent; removed 0 owned shard(s)\n"
+    )
 
 
-def test_public_force_recovery_cleans_zero_recorded_staging_shards(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@pytest.mark.parametrize("force", [False, True])
+def test_public_recovery_refuses_a_surviving_recorded_git_tree_before_changes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], force: bool
+) -> None:
+    root, plan = _integration_repository(tmp_path)
+    source_manifest = build_source_manifest(root)
+    plan_digest = hashlib.sha256(plan.read_bytes()).hexdigest()
+    run_id = "run-lane-e-recorded-refusal"
+    assignment = select_and_assign(["M1"], None, 1)[0]
+    temporary_root = create_private_temp_root(prefix="mutation-harness-refusal-")
+    lease = begin_coordinator_run(
+        root,
+        run_id=run_id,
+        source_head=source_manifest.head,
+        source_manifest=source_manifest_to_dict(source_manifest),
+        source_manifest_digest=source_manifest.digest,
+        plan_path=plan,
+        plan_digest=plan_digest,
+        requested_shards=1,
+        effective_shards=1,
+        temporary_root_factory=lambda _run_id: TemporaryRootClaim.borrowed(
+            temporary_root
+        ),
+    )
+    _write_manifest(lease)
+    staged = stage_execution_tree(
+        root,
+        temporary_root / "shard-0",
+        run_id=run_id,
+        shard_index=0,
+        source_manifest=source_manifest,
+        plan_digest=plan_digest,
+        workspace_inputs=(),
+    )
+    liveness_lock = staged.root / ".mutation-harness" / "child.liveness"
+    liveness_lock.touch()
+    _record_child(
+        lease,
+        ChildSpec(
+            assignment=assignment,
+            root=staged.root,
+            source_root=root,
+            temporary_root=temporary_root,
+            argv=("unused",),
+            result_stream=staged.root / ".mutation-harness" / "results.jsonl",
+            ownership_marker=staged.ownership_marker,
+            liveness_lock=liveness_lock,
+        ),
+    )
+    lease.transition("running")
+    lease.retain_and_release()
+
+    state_path = root / ".mutation-harness" / "state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+    tree_before = _tree_file_bytes(staged.root)
+    tree_identity_before = (staged.root.stat().st_dev, staged.root.stat().st_ino)
+    temporary_root_identity_before = (
+        temporary_root.stat().st_dev,
+        temporary_root.stat().st_ino,
+    )
+    source_status_before = _git(
+        root, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    ).stdout
+    registration_before = _git(root, "worktree", "list", "--porcelain").stdout
+
+    try:
+        recover_arguments = [
+            "--root",
+            str(root),
+            "recover-run",
+            "--run-id",
+            run_id,
+        ]
+        if force:
+            recover_arguments.append("--force")
+        assert main(recover_arguments) == 2
+
+        refusal = capsys.readouterr()
+        assert refusal.out == ""
+        assert refusal.err == (
+            "mutation harness: default recovery refuses existing recorded Git shard "
+            "trees; private tree, root state, and run manifest remain\n"
+        )
+        assert state_path.read_bytes() == state_before
+        assert manifest_path.read_bytes() == manifest_before
+        assert _tree_file_bytes(staged.root) == tree_before
+        assert (staged.root.stat().st_dev, staged.root.stat().st_ino) == (
+            tree_identity_before
+        )
+        assert (temporary_root.stat().st_dev, temporary_root.stat().st_ino) == (
+            temporary_root_identity_before
+        )
+        assert (
+            _git(
+                root,
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=all",
+            ).stdout
+            == source_status_before
+        )
+        assert _git(root, "worktree", "list", "--porcelain").stdout == (
+            registration_before
+        )
+        assert main(["--root", str(root), "verify"]) == 1
+        blocked = capsys.readouterr()
+        assert blocked.out == ""
+        assert "No result from this tree is trustworthy until it is recovered" in (
+            blocked.err
+        )
+    finally:
+        cleanup_execution_tree(
+            staged,
+            temporary_root=temporary_root,
+            child_liveness_proven=True,
+        )
+        temporary_root.rmdir()
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_public_recovery_refuses_a_surviving_zero_recorded_partial_git_tree_before_changes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], force: bool
 ) -> None:
     root, plan = _integration_repository(tmp_path)
     source_manifest = build_source_manifest(root)
@@ -394,29 +561,72 @@ def test_public_force_recovery_cleans_zero_recorded_staging_shards(
     lease.transition("aborted")
     lease.retain_and_release()
 
-    assert (
-        json.loads(
-            (root / ".mutation-harness" / "state.json").read_text(encoding="utf-8")
-        )["coordinator_run"]["shards"]
-        == []
+    state_path = root / ".mutation-harness" / "state.json"
+    state_before = state_path.read_bytes()
+    assert json.loads(state_before)["coordinator_run"]["shards"] == []
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+    tree_before = _tree_file_bytes(staged.root)
+    tree_identity_before = (staged.root.stat().st_dev, staged.root.stat().st_ino)
+    temporary_root_identity_before = (
+        temporary_root.stat().st_dev,
+        temporary_root.stat().st_ino,
     )
-    assert (
-        main(
-            [
-                "--root",
-                str(root),
-                "recover-run",
-                "--run-id",
-                run_id,
-                "--force",
-            ]
-        )
-        == 0
-    )
+    source_status_before = _git(
+        root, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    ).stdout
+    registration_before = _git(root, "worktree", "list", "--porcelain").stdout
 
-    assert not staged.root.exists()
-    assert not temporary_root.exists()
-    assert verify(root) == []
-    captured = capsys.readouterr()
-    assert "FORCE RECOVERY PREFLIGHT run-lane-e-zero-shard" in captured.out
-    assert "removed 1 owned staging shard(s)" in captured.out
+    try:
+        recover_arguments = [
+            "--root",
+            str(root),
+            "recover-run",
+            "--run-id",
+            run_id,
+        ]
+        if force:
+            recover_arguments.append("--force")
+        assert main(recover_arguments) == 2
+
+        refusal = capsys.readouterr()
+        assert refusal.out == ""
+        assert refusal.err == (
+            "mutation harness: default recovery refuses an existing staged Git tree; "
+            "private tree and root state remain\n"
+        )
+        assert state_path.read_bytes() == state_before
+        assert manifest_path.read_bytes() == manifest_before
+        assert _tree_file_bytes(staged.root) == tree_before
+        assert (staged.root.stat().st_dev, staged.root.stat().st_ino) == (
+            tree_identity_before
+        )
+        assert (temporary_root.stat().st_dev, temporary_root.stat().st_ino) == (
+            temporary_root_identity_before
+        )
+        assert (
+            _git(
+                root,
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=all",
+            ).stdout
+            == source_status_before
+        )
+        assert _git(root, "worktree", "list", "--porcelain").stdout == (
+            registration_before
+        )
+        assert main(["--root", str(root), "verify"]) == 1
+        blocked = capsys.readouterr()
+        assert blocked.out == ""
+        assert "No result from this tree is trustworthy until it is recovered" in (
+            blocked.err
+        )
+    finally:
+        cleanup_execution_tree(
+            staged,
+            temporary_root=temporary_root,
+            child_liveness_proven=True,
+        )
+        temporary_root.rmdir()

--- a/tests/tooling/test_mutation_harness_integration.py
+++ b/tests/tooling/test_mutation_harness_integration.py
@@ -306,6 +306,40 @@ def test_public_cli_applies_only_before_effective_shard_assignment(
     assert [item["id"] for item in report["results"]] == ["M2"]
 
 
+def test_public_sharded_children_suppress_python_bytecode(tmp_path: Path) -> None:
+    root, plan = _integration_repository(tmp_path)
+    raw = json.loads(plan.read_text(encoding="utf-8"))
+    raw["mutations"][0]["proof"] = [
+        [
+            "bash",
+            "-c",
+            'test "$PYTHONDONTWRITEBYTECODE" = 1 && '
+            "grep -q guard-one=enabled widget.txt",
+        ]
+    ]
+    plan.write_text(json.dumps(raw), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--root",
+            str(root),
+            "run",
+            "--plan",
+            str(plan),
+            "--only",
+            "M1",
+            "--shards",
+            "2",
+            "--assert-all-killed",
+            "--progress",
+            "none",
+        ]
+    )
+
+    assert exit_code == 0
+    assert verify(root) == []
+
+
 @pytest.mark.parametrize("force", [False, True])
 def test_public_recovery_clears_an_incomplete_run_when_recorded_temporary_root_is_absent(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], force: bool

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -421,6 +421,175 @@ def _recovery_fixture(
     return root, shard, ownership_marker, liveness_lock
 
 
+def _rewrite_recorded_temporary_root(root: Path, replacement: Path) -> None:
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    for run_record in (state["coordinator_run"], manifest):
+        original = Path(run_record["temporary_root"])
+        run_record["temporary_root"] = str(replacement)
+        for shard_record in run_record["shards"]:
+            for field in ("root", "ownership_marker", "liveness_lock"):
+                relative = Path(shard_record[field]).relative_to(original)
+                shard_record[field] = str(replacement / relative)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def _swap_temporary_root_for_symlink(temporary_root: Path, replacement: Path) -> None:
+    temporary_root.rename(replacement)
+    temporary_root.symlink_to(replacement, target_is_directory=True)
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_existing_symlinked_temporary_root_never_authorizes_replacement_cleanup(
+    tmp_path: Path, force: bool
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    replacement = tmp_path / "replacement-private-run"
+    _swap_temporary_root_for_symlink(temporary_root, replacement)
+    sentinel = replacement / "shard-0/sentinel.txt"
+    sentinel.write_text("do not remove", encoding="utf-8")
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="temporary_root.*symlink"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "do not remove"
+    assert temporary_root.is_symlink()
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_existing_non_directory_temporary_root_is_refused_before_shard_resolution(
+    tmp_path: Path, force: bool
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    replacement = tmp_path / "replacement-private-run"
+    temporary_root.rename(replacement)
+    sentinel = replacement / "shard-0/sentinel.txt"
+    sentinel.write_text("do not remove", encoding="utf-8")
+    temporary_root.write_text("not a directory", encoding="utf-8")
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="temporary_root.*not a directory"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "do not remove"
+    assert temporary_root.read_text(encoding="utf-8") == "not a directory"
+    assert state_path.read_bytes() == state_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_temporary_root_parent_symlink_is_refused_before_shard_resolution(
+    tmp_path: Path, force: bool
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    real_parent = tmp_path / "real-parent"
+    real_parent.mkdir()
+    moved_root = real_parent / temporary_root.name
+    temporary_root.rename(moved_root)
+    linked_parent = tmp_path / "linked-parent"
+    linked_parent.symlink_to(real_parent, target_is_directory=True)
+    recorded_root = linked_parent / temporary_root.name
+    _rewrite_recorded_temporary_root(root, recorded_root)
+    sentinel = moved_root / "shard-0/sentinel.txt"
+    sentinel.write_text("do not remove", encoding="utf-8")
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="temporary-root parent.*symlink"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "do not remove"
+    assert state_path.read_bytes() == state_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_existing_temporary_root_uses_canonical_source_overlap_check(
+    tmp_path: Path, force: bool
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    nested_root = root / "nested-private-run"
+    temporary_root.rename(nested_root)
+    _rewrite_recorded_temporary_root(root, nested_root)
+    sentinel = nested_root / "shard-0/sentinel.txt"
+    sentinel.write_text("do not remove", encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="overlaps source_root"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "do not remove"
+    assert "coordinator_run" in json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_temporary_root_swapped_to_symlink_after_preflight_is_retained(
+    tmp_path: Path, force: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    replacement = tmp_path / "replacement-after-preflight"
+    sentinel = shard / "sentinel.txt"
+    sentinel.write_text("do not remove", encoding="utf-8")
+    original = recovery_backend._build_preflight
+
+    def swap_after_preflight(
+        record: recovery_backend.RunRecord,
+    ) -> tuple[recovery_backend.RecoveryPreflight, tuple[int, ...]]:
+        preflight = original(record)
+        _swap_temporary_root_for_symlink(temporary_root, replacement)
+        return preflight
+
+    monkeypatch.setattr(recovery_backend, "_build_preflight", swap_after_preflight)
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="temporary_root.*symlink"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    moved_sentinel = replacement / "shard-0/sentinel.txt"
+    assert moved_sentinel.read_text(encoding="utf-8") == "do not remove"
+    assert state_path.read_bytes() == state_before
+
+
 @pytest.mark.parametrize("force", [False, True])
 @pytest.mark.parametrize("lifecycle", ["running", "recovering"])
 def test_missing_recorded_temporary_root_recovers_without_fabricating_results(

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -442,6 +442,27 @@ def _swap_temporary_root_for_symlink(temporary_root: Path, replacement: Path) ->
     temporary_root.symlink_to(replacement, target_is_directory=True)
 
 
+def _swap_temporary_root_for_matching_directory(
+    temporary_root: Path, moved_original: Path
+) -> tuple[Path, Path]:
+    original_marker = (
+        temporary_root / "shard-0/.mutation-harness-owner.json"
+    ).read_bytes()
+    temporary_root.rename(moved_original)
+    replacement_shard = temporary_root / "shard-0"
+    temporary_root.mkdir(mode=0o700)
+    replacement_shard.mkdir(mode=0o700)
+    (replacement_shard / ".mutation-harness-owner.json").write_bytes(original_marker)
+    (replacement_shard / ".mutation-harness-liveness.lock").write_text(
+        "", encoding="utf-8"
+    )
+    replacement_sentinel = replacement_shard / "replacement-sentinel.txt"
+    replacement_sentinel.write_text("do not remove replacement", encoding="utf-8")
+    moved_sentinel = moved_original / "shard-0/original-sentinel.txt"
+    moved_sentinel.write_text("do not remove original", encoding="utf-8")
+    return replacement_sentinel, moved_sentinel
+
+
 @pytest.mark.parametrize("force", [False, True])
 def test_existing_symlinked_temporary_root_never_authorizes_replacement_cleanup(
     tmp_path: Path, force: bool
@@ -588,6 +609,52 @@ def test_temporary_root_swapped_to_symlink_after_preflight_is_retained(
     moved_sentinel = replacement / "shard-0/sentinel.txt"
     assert moved_sentinel.read_text(encoding="utf-8") == "do not remove"
     assert state_path.read_bytes() == state_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_temporary_root_same_path_directory_replacement_is_retained(
+    tmp_path: Path, force: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    moved_original = tmp_path / "moved-original-private-run"
+    original = recovery_backend._build_preflight
+    replacement_sentinel: Path | None = None
+    moved_sentinel: Path | None = None
+
+    def swap_after_preflight(
+        record: recovery_backend.RunRecord,
+    ) -> tuple[recovery_backend.RecoveryPreflight, tuple[int, ...]]:
+        nonlocal replacement_sentinel, moved_sentinel
+        preflight = original(record)
+        replacement_sentinel, moved_sentinel = (
+            _swap_temporary_root_for_matching_directory(temporary_root, moved_original)
+        )
+        return preflight
+
+    monkeypatch.setattr(recovery_backend, "_build_preflight", swap_after_preflight)
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="temporary_root.*identity changed"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert replacement_sentinel is not None
+    assert replacement_sentinel.read_text(encoding="utf-8") == (
+        "do not remove replacement"
+    )
+    assert temporary_root.stat().st_mode & 0o777 == 0o700
+    assert moved_sentinel is not None
+    assert moved_sentinel.read_text(encoding="utf-8") == "do not remove original"
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
 
 
 @pytest.mark.parametrize("force", [False, True])

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -689,7 +689,7 @@ def test_zero_shard_recovery_rejects_source_as_private_root(
     state_path.write_text(json.dumps(state), encoding="utf-8")
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    with pytest.raises(RecoveryError, match="outside the private run boundary"):
+    with pytest.raises(RecoveryError, match="overlaps source_root"):
         recover_run(
             root,
             "run-3807",
@@ -698,6 +698,83 @@ def test_zero_shard_recovery_rejects_source_as_private_root(
         )
 
     assert temporary_root.exists()
+    assert shard.exists()
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_zero_shard_recovery_rejects_private_root_below_source(
+    tmp_path: Path, force: bool
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    nested = root / "nested"
+    nested.mkdir(mode=0o700)
+    nested_shard = nested / "shard-0"
+    shard.rename(nested_shard)
+    temporary_root.rmdir()
+    sentinel = nested_shard / "sentinel.txt"
+    sentinel.write_bytes(b"do not remove")
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    state["coordinator_run"]["temporary_root"] = str(nested.resolve())
+    manifest["temporary_root"] = str(nested.resolve())
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    cleanup_calls: list[Path] = []
+
+    def cleanup(partial: Path, marker: Path, shard_index: int) -> None:
+        del marker, shard_index
+        cleanup_calls.append(partial)
+
+    with pytest.raises(RecoveryError, match="overlaps source_root"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=cleanup,
+        )
+
+    assert cleanup_calls == []
+    assert sentinel.read_bytes() == b"do not remove"
+    assert nested_shard.exists()
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_zero_shard_recovery_rejects_private_root_above_source(
+    tmp_path: Path, force: bool
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    sentinel = shard / "sentinel.txt"
+    sentinel.write_bytes(b"do not remove")
+    temporary_root.chmod(0o700)
+    tmp_path.chmod(0o700)
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    state["coordinator_run"]["temporary_root"] = str(tmp_path.resolve())
+    manifest["temporary_root"] = str(tmp_path.resolve())
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    cleanup_calls: list[Path] = []
+
+    def cleanup(partial: Path, marker: Path, shard_index: int) -> None:
+        del marker, shard_index
+        cleanup_calls.append(partial)
+
+    with pytest.raises(RecoveryError, match="overlaps source_root"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=cleanup,
+        )
+
+    assert cleanup_calls == []
+    assert sentinel.read_bytes() == b"do not remove"
     assert shard.exists()
 
 

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -238,8 +238,78 @@ def test_named_go_test_without_count_one_is_refused(tmp_path: Path) -> None:
         )
 
 
+def test_direct_named_go_test_rejects_duplicate_conflicting_count(
+    tmp_path: Path,
+) -> None:
+    proof = [
+        [
+            "go",
+            "test",
+            "-count=1",
+            "-count=0",
+            "-run",
+            "^TestNamed$",
+            "./...",
+        ]
+    ]
+    with pytest.raises(PlanContractError, match="exactly one.*-count=1"):
+        load_plan_contract(
+            _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+        )
+
+
+def test_shell_named_go_test_rejects_duplicate_conflicting_count(
+    tmp_path: Path,
+) -> None:
+    proof = [
+        [
+            "bash",
+            "-c",
+            "go test -count=1 -count 0 -run '^TestNamed$' ./...",
+        ]
+    ]
+    with pytest.raises(PlanContractError, match="exactly one.*-count=1"):
+        load_plan_contract(
+            _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+        )
+
+
+@pytest.mark.parametrize(
+    "proof",
+    [
+        [["go", "test", "-count", "1", "-count", "0", "-run", "^TestNamed$"]],
+        [["go", "test", "-count=1", "-count", "1", "-run", "^TestNamed$"]],
+        [["bash", "-c", "go test -count 1 -count=0 -run '^TestNamed$'"]],
+        [["bash", "-c", "go test -count=1 -count=1 -run '^TestNamed$'"]],
+    ],
+)
+def test_named_go_test_rejects_all_duplicate_count_forms(
+    tmp_path: Path, proof: list[list[str]]
+) -> None:
+    with pytest.raises(PlanContractError, match="exactly one.*-count=1"):
+        load_plan_contract(
+            _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+        )
+
+
 def test_named_go_test_with_count_one_is_accepted(tmp_path: Path) -> None:
     proof = [["go", "test", "-count=1", "-run", "^TestGuard$", "./..."]]
+    _, contract = load_plan_contract(
+        _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+    )
+    assert contract is not None
+
+
+@pytest.mark.parametrize(
+    "proof",
+    [
+        [["go", "test", "-count", "1", "-run", "^TestGuard$", "./..."]],
+        [["bash", "-c", "go test -count 1 -run '^TestGuard$' ./..."]],
+    ],
+)
+def test_named_go_test_accepts_one_spaced_count_one(
+    tmp_path: Path, proof: list[list[str]]
+) -> None:
     _, contract = load_plan_contract(
         _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
     )

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import scripts.mutation_harness_recovery as recovery_backend
 from scripts.mutation_harness_optin import (
     PlanContractError,
     ShardingPlan,
@@ -380,6 +381,7 @@ def _recovery_fixture(
         "source_manifest": {"head": "head", "entries": [], "digest": "source-digest"},
         "source_manifest_digest": "source-digest",
         "plan_digest": "plan-digest",
+        "temporary_root": str((tmp_path / "private-run").resolve()),
         "shards": [
             {
                 "shard_index": 0,
@@ -400,8 +402,11 @@ def _recovery_fixture(
         "pid": os.getpid(),
         "process_start_time": "unrelated-live-process",
         "lifecycle": "running",
+        "source_root": str(root.resolve()),
+        "source_manifest": manifest["source_manifest"],
         "source_manifest_digest": "source-digest",
         "plan_digest": "plan-digest",
+        "temporary_root": manifest["temporary_root"],
         "manifest_path": str(manifest_path.resolve()),
         "shards": manifest["shards"],
     }
@@ -414,6 +419,154 @@ def _recovery_fixture(
         encoding="utf-8",
     )
     return root, shard, ownership_marker, liveness_lock
+
+
+@pytest.mark.parametrize("force", [False, True])
+@pytest.mark.parametrize("lifecycle", ["running", "recovering"])
+def test_missing_recorded_temporary_root_recovers_without_fabricating_results(
+    tmp_path: Path,
+    force: bool,
+    lifecycle: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root, shard, _, _ = _recovery_fixture(
+        tmp_path, state_overrides={"lifecycle": lifecycle}
+    )
+    temporary_root = shard.parent
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["unrelated"] = {"keep": True}
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    source_manifest_before = json.loads(manifest_path.read_text(encoding="utf-8"))[
+        "source_manifest"
+    ]
+    lock_directory = root / ".mutation-harness/lock"
+    lock_directory.mkdir()
+    lock_pid = lock_directory / "pid"
+    lock_pid.write_text("2147483646\n", encoding="utf-8")
+    shutil.rmtree(temporary_root)
+
+    message = recover_run(root, "run-3807", force=force)
+
+    assert message == (
+        "recovered run run-3807 as aborted; recorded temporary root was absent; "
+        "removed 0 owned shard(s)"
+    )
+    assert capsys.readouterr().out == ""
+    recovered_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert recovered_state == {"schema_version": 1, "unrelated": {"keep": True}}
+    recovered_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert recovered_manifest["source_manifest"] == source_manifest_before
+    assert "results" not in recovered_manifest
+    assert lock_pid.read_text(encoding="utf-8") == "2147483646\n"
+
+
+@pytest.mark.parametrize("force", [False, True])
+@pytest.mark.parametrize("missing", ["marker", "shard"])
+def test_existing_temporary_root_with_missing_shard_or_marker_remains_blocked(
+    tmp_path: Path, force: bool, missing: str
+) -> None:
+    root, shard, marker, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    if missing == "marker":
+        marker.unlink()
+    else:
+        shutil.rmtree(shard)
+        (temporary_root / "keep.txt").write_text("keep", encoding="utf-8")
+    state_path = root / ".mutation-harness/state.json"
+
+    with pytest.raises(RecoveryError, match="ownership marker"):
+        recover_run(
+            root, "run-3807", force=force, cleanup_owned_tree=_remove_owned_tree
+        )
+
+    assert temporary_root.exists()
+    if missing == "marker":
+        assert shard.exists()
+    else:
+        assert (temporary_root / "keep.txt").read_text(encoding="utf-8") == "keep"
+    assert "coordinator_run" in json.loads(state_path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "message"),
+    [
+        ("run_id", "other-run", "root state records run_id"),
+        ("source_root", "/other/source", "source roots differ"),
+        ("source_manifest_digest", "other-source", "source digests differ"),
+        ("plan_digest", "other-plan", "plan digests differ"),
+        ("temporary_root", "/tmp/other-private-root", "temporary_root values differ"),
+    ],
+)
+def test_missing_temporary_root_requires_matching_state_and_manifest_authority(
+    tmp_path: Path, field: str, replacement: str, message: str
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["coordinator_run"][field] = replacement
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    shutil.rmtree(shard.parent)
+
+    with pytest.raises(RecoveryError, match=message):
+        recover_run(root, "run-3807")
+
+    assert "coordinator_run" in json.loads(state_path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("lifecycle", ["complete", "completed", "unknown"])
+def test_missing_temporary_root_refuses_non_incomplete_lifecycle(
+    tmp_path: Path, lifecycle: str
+) -> None:
+    root, shard, _, _ = _recovery_fixture(
+        tmp_path, state_overrides={"lifecycle": lifecycle}
+    )
+    shutil.rmtree(shard.parent)
+
+    with pytest.raises(RecoveryError, match="not an incomplete lifecycle"):
+        recover_run(root, "run-3807")
+
+    assert "coordinator_run" in json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+
+
+def test_missing_temporary_root_rechecks_absence_immediately_before_state_clear(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    shutil.rmtree(temporary_root)
+    checks = 0
+    original = recovery_backend._missing_private_temporary_root
+
+    def replace_before_second_check(value: object, source_root: Path) -> Path | None:
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            temporary_root.mkdir(mode=0o700)
+            (temporary_root / "replacement.txt").write_text(
+                "do not remove", encoding="utf-8"
+            )
+        return original(value, source_root)
+
+    monkeypatch.setattr(
+        recovery_backend,
+        "_missing_private_temporary_root",
+        replace_before_second_check,
+    )
+
+    with pytest.raises(RecoveryError, match="exists or was replaced"):
+        recover_run(root, "run-3807")
+
+    assert checks == 2
+    assert (temporary_root / "replacement.txt").read_text(encoding="utf-8") == (
+        "do not remove"
+    )
+    assert "coordinator_run" in json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
 
 
 def _remove_owned_tree(root: Path, marker: Path, shard_index: int) -> None:
@@ -999,6 +1152,10 @@ def test_manifest_owned_path_cannot_escape_its_shard(tmp_path: Path) -> None:
     manifest_path = Path(state["coordinator_run"]["manifest_path"])
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["shards"][0]["ownership_marker"] = str(sentinel.resolve())
+    state["coordinator_run"]["shards"][0]["ownership_marker"] = str(sentinel.resolve())
+    (root / ".mutation-harness/state.json").write_text(
+        json.dumps(state), encoding="utf-8"
+    )
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     with pytest.raises(RecoveryError, match="escapes shard root"):
@@ -1042,17 +1199,18 @@ def test_force_preflight_is_exact_and_never_removes_unlisted_path(
     )
     foreign_lock = foreign / ".mutation-harness-liveness.lock"
     foreign_lock.write_text("", encoding="utf-8")
-    manifest["shards"].append(
-        {
-            "shard_index": 1,
-            "root": str(foreign.resolve()),
-            "source_root": str(root.resolve()),
-            "temporary_root": str((tmp_path / "private-run").resolve()),
-            "ownership_marker": str(foreign_marker.resolve()),
-            "liveness_lock": str(foreign_lock.resolve()),
-            "assigned_ordinals": [1],
-        }
-    )
+    foreign_record = {
+        "shard_index": 1,
+        "root": str(foreign.resolve()),
+        "source_root": str(root.resolve()),
+        "temporary_root": str((tmp_path / "private-run").resolve()),
+        "ownership_marker": str(foreign_marker.resolve()),
+        "liveness_lock": str(foreign_lock.resolve()),
+        "assigned_ordinals": [1],
+    }
+    manifest["shards"].append(foreign_record)
+    state["coordinator_run"]["shards"].append(foreign_record)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     with pytest.raises(RecoveryError, match="retained 1 shard"):

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -1009,7 +1009,7 @@ def test_cleanup_boundary_rechecks_root_after_opening_its_descriptor(
     def open_with_root_replacement(
         path: str | bytes | Path,
         flags: int,
-        mode: int = 0o777,
+        mode: int = 0o600,
         *,
         dir_fd: int | None = None,
     ) -> int:

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -1,0 +1,539 @@
+"""Lane D contracts for mutation-plan opt-in and recovery."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scripts.mutation_harness_optin import (
+    PlanContractError,
+    ShardingPlan,
+    external_resource_environment,
+    load_plan_contract,
+    validate_requested_shards,
+)
+from scripts.mutation_harness_recovery import (
+    RecoveryError,
+    hold_liveness_lock,
+    recover_run,
+)
+
+
+def _mutation(proof: list[list[str]] | None = None) -> dict[str, object]:
+    return {
+        "id": "M1",
+        "file": "widget.go",
+        "find": "if guarded {",
+        "replace": "if false {",
+        "proof": proof or [["go", "test", "-count=1", "-run", "^TestGuard$", "./..."]],
+        "rationale": "the guard must remain observable",
+    }
+
+
+def _plan(
+    tmp_path: Path,
+    *,
+    mutation: dict[str, object] | None = None,
+    sharding: dict[str, object] | None = None,
+    **extra: object,
+) -> Path:
+    raw: dict[str, object] = {
+        "schema_version": 1,
+        "name": "lane-d-synthetic",
+        "$limitation": "synthetic scope only",
+        "mutations": [mutation or _mutation()],
+        **extra,
+    }
+    if sharding is not None:
+        raw["sharding"] = sharding
+    path = tmp_path / "plan.json"
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    return path
+
+
+def _opt_in(**overrides: object) -> dict[str, object]:
+    contract: dict[str, object] = {
+        "max_shards": 2,
+        "workspace_inputs": [".venv"],
+        "external_resources": "none",
+        "shared_mutable_resource_exclusions": [
+            "go-build-cache",
+            "go-module-cache",
+        ],
+    }
+    contract.update(overrides)
+    return contract
+
+
+@pytest.mark.parametrize("unknown", ["sharidng", "unknown_metadata"])
+def test_closed_top_level_vocabulary_names_unknown_key(
+    tmp_path: Path, unknown: str
+) -> None:
+    plan = _plan(tmp_path)
+    raw = json.loads(plan.read_text(encoding="utf-8"))
+    raw[unknown] = True
+    plan.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(PlanContractError, match=unknown):
+        load_plan_contract(plan)
+
+
+def test_closed_mutation_vocabulary_names_unknown_key(tmp_path: Path) -> None:
+    mutation = _mutation()
+    mutation["proofs"] = mutation.pop("proof")
+    with pytest.raises(PlanContractError, match="proofs"):
+        load_plan_contract(_plan(tmp_path, mutation=mutation))
+
+
+@pytest.mark.parametrize("max_shards", [0, -1, True, 1.5, "2"])
+def test_max_shards_must_be_an_integer_at_least_one(
+    tmp_path: Path, max_shards: object
+) -> None:
+    with pytest.raises(PlanContractError, match="max_shards"):
+        load_plan_contract(_plan(tmp_path, sharding=_opt_in(max_shards=max_shards)))
+
+
+@pytest.mark.parametrize(
+    "workspace_input",
+    [
+        "../outside",
+        "/absolute",
+        ".git",
+        ".git/hooks",
+        ".mutation-harness",
+        ".mutation-harness/runs",
+    ],
+)
+def test_workspace_inputs_are_safe_repo_relative_paths(
+    tmp_path: Path, workspace_input: str
+) -> None:
+    with pytest.raises(PlanContractError, match="workspace_inputs"):
+        load_plan_contract(
+            _plan(
+                tmp_path,
+                sharding=_opt_in(workspace_inputs=[workspace_input]),
+            )
+        )
+
+
+@pytest.mark.parametrize("policy", ["", "readwrite", "NONE", 1, None])
+def test_external_resources_use_the_closed_policy_set(
+    tmp_path: Path, policy: object
+) -> None:
+    with pytest.raises(PlanContractError, match="external_resources"):
+        load_plan_contract(_plan(tmp_path, sharding=_opt_in(external_resources=policy)))
+
+
+@pytest.mark.parametrize("policy", ["none", "isolated", "shared-readonly"])
+def test_each_external_resource_policy_is_accepted(tmp_path: Path, policy: str) -> None:
+    _, contract = load_plan_contract(
+        _plan(tmp_path, sharding=_opt_in(external_resources=policy))
+    )
+    assert contract is not None
+    assert contract.external_resources == policy
+
+
+def test_isolated_resources_receive_distinct_shard_namespaces(tmp_path: Path) -> None:
+    _, contract = load_plan_contract(
+        _plan(tmp_path, sharding=_opt_in(external_resources="isolated"))
+    )
+    assert contract is not None
+    assert external_resource_environment(contract, "run-3807", 1) == {
+        "MUTATION_HARNESS_RUN_ID": "run-3807",
+        "MUTATION_HARNESS_SHARD_INDEX": "1",
+    }
+
+
+def test_go_cache_exclusions_must_be_explicitly_named(tmp_path: Path) -> None:
+    with pytest.raises(PlanContractError, match="go-build-cache.*go-module-cache"):
+        load_plan_contract(
+            _plan(
+                tmp_path,
+                sharding=_opt_in(shared_mutable_resource_exclusions=[]),
+            )
+        )
+
+
+def test_request_above_declared_max_is_refused(tmp_path: Path) -> None:
+    _, contract = load_plan_contract(_plan(tmp_path, sharding=_opt_in()))
+    assert contract is not None
+    with pytest.raises(PlanContractError, match="requested 3.*max_shards 2"):
+        validate_requested_shards(contract, 3)
+
+
+def test_parallel_request_without_opt_in_is_refused() -> None:
+    with pytest.raises(PlanContractError, match="does not opt in"):
+        validate_requested_shards(None, 2)
+
+
+@pytest.mark.parametrize(
+    "proof",
+    [
+        [["python3", "-m", "pytest", "tests/tooling"]],
+        [["pytest", "tests/tooling"]],
+        [["uv", "run", "pytest", "tests/tooling"]],
+        [["env", "PYTHONPATH=$PWD/src", "python3", "-m", "pytest"]],
+        [["bash", "-c", "python -m pytest tests/tooling"]],
+    ],
+)
+def test_path_resolved_python_entry_points_are_refused(
+    tmp_path: Path, proof: list[list[str]]
+) -> None:
+    with pytest.raises(PlanContractError, match="PATH-resolved Python"):
+        load_plan_contract(
+            _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+        )
+
+
+def test_python_without_shard_rooted_imports_is_refused(tmp_path: Path) -> None:
+    proof = [["$PWD/.venv/bin/python", "-m", "pytest", "tests/tooling"]]
+    with pytest.raises(PlanContractError, match="shard-rooted import"):
+        load_plan_contract(
+            _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+        )
+
+
+def test_unsafe_pwd_anchored_console_script_is_refused(tmp_path: Path) -> None:
+    proof = [["$PWD/.venv/bin/pytest", "tests/tooling"]]
+    with pytest.raises(PlanContractError, match="console script"):
+        load_plan_contract(
+            _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+        )
+
+
+def test_bash_wrapper_with_pwd_interpreter_and_import_path_is_accepted(
+    tmp_path: Path,
+) -> None:
+    proof = [
+        [
+            "bash",
+            "-c",
+            'PYTHONPATH="$PWD/src" PYTHON="$PWD/.venv/bin/python" go test '
+            "-count=1 -run '^TestGuard$' ./...",
+        ]
+    ]
+    _, contract = load_plan_contract(
+        _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+    )
+    assert contract == ShardingPlan(
+        max_shards=2,
+        workspace_inputs=(".venv",),
+        external_resources="none",
+        shared_mutable_resource_exclusions=(
+            "go-build-cache",
+            "go-module-cache",
+        ),
+    )
+
+
+def test_named_go_test_without_count_one_is_refused(tmp_path: Path) -> None:
+    proof = [["go", "test", "-run", "^TestGuard$", "./..."]]
+    with pytest.raises(PlanContractError, match="-count=1"):
+        load_plan_contract(
+            _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+        )
+
+
+def test_named_go_test_with_count_one_is_accepted(tmp_path: Path) -> None:
+    proof = [["go", "test", "-count=1", "-run", "^TestGuard$", "./..."]]
+    _, contract = load_plan_contract(
+        _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+    )
+    assert contract is not None
+
+
+def test_build_only_go_test_is_exempt_from_count_one(tmp_path: Path) -> None:
+    proof = [["go", "test", "-run", "^$", "./..."]]
+    _, contract = load_plan_contract(
+        _plan(tmp_path, mutation=_mutation(proof), sharding=_opt_in())
+    )
+    assert contract is not None
+
+
+def test_representative_gitlab_plan_is_accepted() -> None:
+    root = Path(__file__).resolve().parents[2]
+    plan = (
+        root
+        / "internal/providersync/testdata/mutation-plans/gitlab_feature_flags_route.json"
+    )
+    _, contract = load_plan_contract(plan)
+    assert contract is not None
+    validate_requested_shards(contract, 2)
+
+
+def test_named_python_plan_is_refused_when_artificially_opted_in(
+    tmp_path: Path,
+) -> None:
+    root = Path(__file__).resolve().parents[2]
+    source = root / "tests/tooling/mutation-plans/scheduled-reports.json"
+    raw = json.loads(source.read_text(encoding="utf-8"))
+    raw["sharding"] = _opt_in()
+    plan = tmp_path / source.name
+    plan.write_text(json.dumps(raw), encoding="utf-8")
+    with pytest.raises(PlanContractError, match="PATH-resolved Python"):
+        load_plan_contract(plan)
+
+
+def _recovery_fixture(
+    tmp_path: Path,
+    *,
+    run_id: str = "run-3807",
+    marker: object | None = None,
+    state_overrides: dict[str, object] | None = None,
+) -> tuple[Path, Path, Path, Path]:
+    root = tmp_path / "repo"
+    run_dir = root / ".mutation-harness" / "runs" / run_id
+    shard = tmp_path / "private-run" / "shard-0"
+    shard.mkdir(parents=True)
+    ownership_marker = shard / ".mutation-harness-owner.json"
+    marker_payload = marker
+    if marker_payload is None:
+        marker_payload = {
+            "schema_version": 1,
+            "run_id": run_id,
+            "shard_index": 0,
+            "source_manifest_digest": "source-digest",
+            "plan_digest": "plan-digest",
+        }
+    ownership_marker.write_text(json.dumps(marker_payload), encoding="utf-8")
+    liveness_lock = shard / ".mutation-harness-liveness.lock"
+    liveness_lock.write_text("", encoding="utf-8")
+
+    manifest = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "source_root": str(root.resolve()),
+        "source_manifest": {"head": "head", "entries": [], "digest": "source-digest"},
+        "source_manifest_digest": "source-digest",
+        "plan_digest": "plan-digest",
+        "shards": [
+            {
+                "shard_index": 0,
+                "root": str(shard.resolve()),
+                "source_root": str(root.resolve()),
+                "temporary_root": str((tmp_path / "private-run").resolve()),
+                "ownership_marker": str(ownership_marker.resolve()),
+                "liveness_lock": str(liveness_lock.resolve()),
+                "assigned_ordinals": [0],
+            }
+        ],
+    }
+    run_dir.mkdir(parents=True)
+    manifest_path = run_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    coordinator: dict[str, object] = {
+        "run_id": run_id,
+        "pid": os.getpid(),
+        "process_start_time": "unrelated-live-process",
+        "lifecycle": "running",
+        "source_manifest_digest": "source-digest",
+        "plan_digest": "plan-digest",
+        "manifest_path": str(manifest_path.resolve()),
+        "shards": manifest["shards"],
+    }
+    if state_overrides:
+        coordinator.update(state_overrides)
+    state_path = root / ".mutation-harness" / "state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"schema_version": 1, "coordinator_run": coordinator}),
+        encoding="utf-8",
+    )
+    return root, shard, ownership_marker, liveness_lock
+
+
+def _remove_owned_tree(root: Path, marker: Path, shard_index: int) -> None:
+    assert marker.is_relative_to(root)
+    assert shard_index == 0
+    shutil.rmtree(root)
+
+
+def test_reused_live_unrelated_pid_does_not_block_without_held_lock(
+    tmp_path: Path,
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    message = recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+    assert message == "recovered run run-3807 as aborted; removed 1 owned shard(s)"
+    assert not shard.exists()
+    state = json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+    assert "coordinator_run" not in state
+
+
+def test_held_liveness_lock_refuses_recovery(tmp_path: Path) -> None:
+    root, shard, _, liveness_lock = _recovery_fixture(tmp_path)
+    with hold_liveness_lock(liveness_lock):
+        with pytest.raises(RecoveryError, match="liveness lock is held"):
+            recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+    assert shard.exists()
+    assert "coordinator_run" in json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+
+
+def test_manifest_path_escape_is_refused(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    escaped = tmp_path / "outside-manifest.json"
+    escaped.write_text("{}", encoding="utf-8")
+    state["coordinator_run"]["manifest_path"] = str(escaped)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    with pytest.raises(RecoveryError, match="manifest path"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+    assert shard.exists()
+
+
+def test_manifest_owned_path_cannot_escape_its_shard(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    sentinel = tmp_path / "outside-owner.json"
+    sentinel.write_text("keep", encoding="utf-8")
+    state = json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["shards"][0]["ownership_marker"] = str(sentinel.resolve())
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="escapes shard root"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+    assert shard.exists()
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+
+
+@pytest.mark.parametrize("unreadable", [False, True])
+def test_wrong_or_unreadable_ownership_marker_is_retained(
+    tmp_path: Path, unreadable: bool
+) -> None:
+    root, shard, marker, _ = _recovery_fixture(
+        tmp_path,
+        marker={"schema_version": 1, "run_id": "foreign", "shard_index": 0},
+    )
+    if unreadable:
+        marker.unlink()
+        marker.mkdir()
+    with pytest.raises(RecoveryError, match="ownership marker"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+    assert shard.exists()
+
+
+def test_force_preflight_is_exact_and_never_removes_unlisted_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    sentinel = tmp_path / "outside-sentinel"
+    sentinel.write_text("keep", encoding="utf-8")
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    foreign = tmp_path / "private-run" / "shard-foreign"
+    foreign.mkdir()
+    foreign_marker = foreign / ".mutation-harness-owner.json"
+    foreign_marker.write_text(
+        json.dumps({"schema_version": 1, "run_id": "foreign", "shard_index": 1}),
+        encoding="utf-8",
+    )
+    foreign_lock = foreign / ".mutation-harness-liveness.lock"
+    foreign_lock.write_text("", encoding="utf-8")
+    manifest["shards"].append(
+        {
+            "shard_index": 1,
+            "root": str(foreign.resolve()),
+            "source_root": str(root.resolve()),
+            "temporary_root": str((tmp_path / "private-run").resolve()),
+            "ownership_marker": str(foreign_marker.resolve()),
+            "liveness_lock": str(foreign_lock.resolve()),
+            "assigned_ordinals": [1],
+        }
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="retained 1 shard"):
+        recover_run(
+            root,
+            "run-3807",
+            force=True,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+    output = capsys.readouterr().out
+    assert output == (
+        "FORCE RECOVERY PREFLIGHT run-3807\n"
+        "REMOVE:\n"
+        f"  {shard.resolve()}\n"
+        "LEAVE:\n"
+        f"  {foreign.resolve()}\n"
+        "UNKNOWN:\n"
+        f"  {foreign_marker.resolve()}: ownership marker run_id is 'foreign', "
+        "expected 'run-3807'\n"
+    )
+    assert not shard.exists()
+    assert foreign.exists()
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+    assert "coordinator_run" in json.loads(state_path.read_text(encoding="utf-8"))
+
+
+def test_root_state_is_cleared_only_after_verified_cleanup(tmp_path: Path) -> None:
+    root, _, _, _ = _recovery_fixture(tmp_path)
+    state_path = root / ".mutation-harness/state.json"
+
+    def cleanup(shard: Path, marker: Path, shard_index: int) -> None:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        assert state["coordinator_run"]["lifecycle"] == "recovering"
+        _remove_owned_tree(shard, marker, shard_index)
+
+    recover_run(root, "run-3807", cleanup_owned_tree=cleanup)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert "coordinator_run" not in state
+
+
+def test_recovery_holds_the_acquired_liveness_lock_through_cleanup(
+    tmp_path: Path,
+) -> None:
+    root, _, _, liveness_lock = _recovery_fixture(tmp_path)
+
+    def cleanup(shard: Path, marker: Path, shard_index: int) -> None:
+        descriptor = os.open(liveness_lock, os.O_RDWR | os.O_CLOEXEC)
+        try:
+            with pytest.raises(BlockingIOError):
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        finally:
+            os.close(descriptor)
+        _remove_owned_tree(shard, marker, shard_index)
+
+    recover_run(root, "run-3807", cleanup_owned_tree=cleanup)
+
+
+def test_force_never_clears_unverified_applied_state(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    shard_state = shard / ".mutation-harness"
+    shard_state.mkdir()
+    (shard_state / "state.json").write_text(
+        json.dumps({"schema_version": 1, "applied": {"mutation_id": "M1"}}),
+        encoding="utf-8",
+    )
+
+    def refuse_restore(_: Path) -> str:
+        raise RuntimeError("restore mismatch")
+
+    with pytest.raises(RecoveryError, match="restore mismatch"):
+        recover_run(
+            root,
+            "run-3807",
+            force=True,
+            restore_mutation=refuse_restore,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+    assert shard.exists()
+    assert json.loads(
+        (shard / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )["applied"]
+    assert "coordinator_run" in json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -1313,6 +1313,97 @@ def _zero_shard_staging_fixture(
 
 
 @pytest.mark.parametrize("force", [False, True])
+def test_default_partial_recovery_refuses_before_output_or_state_change(
+    tmp_path: Path, force: bool
+) -> None:
+    root, temporary_root, shard, marker = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None and marker is not None
+    marker_bytes = marker.read_bytes()
+    shutil.rmtree(shard)
+    _git(root, "init", "-q")
+    source_sentinel = root / "source-sentinel.txt"
+    source_sentinel.write_text("do not change source", encoding="utf-8")
+    _git(root, "add", source_sentinel.name)
+    _git(
+        root,
+        "-c",
+        "user.name=Mutation Harness Test",
+        "-c",
+        "user.email=mutation-harness@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-qm",
+        "fixture",
+    )
+    _git(root, "worktree", "add", "-q", "--detach", str(shard), "HEAD")
+    marker.parent.mkdir()
+    marker.write_bytes(marker_bytes)
+    sentinel = shard / "real-git-partial-sentinel.txt"
+    sentinel.write_text("do not remove", encoding="utf-8")
+    temporary_root.chmod(0o700)
+
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+    tree_before = _tree_file_bytes(shard)
+    tree_identity_before = shard.stat().st_dev, shard.stat().st_ino
+    private_root_identity_before = (
+        temporary_root.stat().st_dev,
+        temporary_root.stat().st_ino,
+    )
+    source_sentinel_before = source_sentinel.read_bytes()
+    source_status_before = _git(
+        root, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    ).stdout
+    registration_before = _git(root, "worktree", "list", "--porcelain").stdout
+    output = StringIO()
+    errors: list[str] = []
+
+    for _ in range(2):
+        try:
+            recover_run(root, "run-3807", force=force, output=output)
+        except RecoveryError as exc:
+            errors.append(str(exc))
+
+    expected_error = (
+        "default recovery refuses an existing staged Git tree; "
+        "private tree and root state remain"
+    )
+    assert {
+        "errors": errors,
+        "output": output.getvalue(),
+        "state": state_path.read_bytes(),
+        "manifest": manifest_path.read_bytes(),
+        "tree": _tree_file_bytes(shard),
+        "tree_identity": (shard.stat().st_dev, shard.stat().st_ino),
+        "private_root_identity": (
+            temporary_root.stat().st_dev,
+            temporary_root.stat().st_ino,
+        ),
+        "private_root_mode": stat.S_IMODE(temporary_root.stat().st_mode),
+        "source_sentinel": source_sentinel.read_bytes(),
+        "source_status": _git(
+            root, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+        ).stdout,
+        "registration": _git(root, "worktree", "list", "--porcelain").stdout,
+    } == {
+        "errors": [expected_error, expected_error],
+        "output": "",
+        "state": state_before,
+        "manifest": manifest_before,
+        "tree": tree_before,
+        "tree_identity": tree_identity_before,
+        "private_root_identity": private_root_identity_before,
+        "private_root_mode": 0o700,
+        "source_sentinel": source_sentinel_before,
+        "source_status": source_status_before,
+        "registration": registration_before,
+    }
+
+
+@pytest.mark.parametrize("force", [False, True])
 def test_zero_recorded_shards_recovers_owned_partial_staging_tree(
     tmp_path: Path, force: bool, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -6,6 +6,9 @@ import fcntl
 import json
 import os
 import shutil
+import stat
+import subprocess
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -421,6 +424,25 @@ def _recovery_fixture(
     return root, shard, ownership_marker, liveness_lock
 
 
+def _git(root: Path, *arguments: str) -> subprocess.CompletedProcess[bytes]:
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    return completed
+
+
+def _tree_file_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and not path.is_symlink()
+    }
+
+
 def _rewrite_recorded_temporary_root(root: Path, replacement: Path) -> None:
     state_path = root / ".mutation-harness/state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))
@@ -830,6 +852,260 @@ def test_shard_authority_file_replacement_after_preflight_is_retained(
 
 
 @pytest.mark.parametrize("force", [False, True])
+def test_default_recovery_refuses_a_real_registered_git_shard_without_mutation(
+    tmp_path: Path, force: bool
+) -> None:
+    root, shard, marker, liveness = _recovery_fixture(tmp_path)
+    marker_bytes = marker.read_bytes()
+    liveness_bytes = liveness.read_bytes()
+    shutil.rmtree(shard)
+    _git(root, "init", "-q")
+    source_sentinel = root / "source-sentinel.txt"
+    source_sentinel.write_text("do not change source", encoding="utf-8")
+    _git(root, "add", source_sentinel.name)
+    _git(
+        root,
+        "-c",
+        "user.name=Mutation Harness Test",
+        "-c",
+        "user.email=mutation-harness@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "-qm",
+        "fixture",
+    )
+    _git(root, "worktree", "add", "-q", "--detach", str(shard), "HEAD")
+    marker.write_bytes(marker_bytes)
+    liveness.write_bytes(liveness_bytes)
+    sentinel = shard / "real-git-shard-sentinel.txt"
+    sentinel.write_text("do not remove", encoding="utf-8")
+    shard.parent.chmod(0o700)
+
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+    tree_before = _tree_file_bytes(shard)
+    tree_identity_before = shard.stat().st_dev, shard.stat().st_ino
+    private_root_identity_before = (
+        shard.parent.stat().st_dev,
+        shard.parent.stat().st_ino,
+    )
+    source_sentinel_before = source_sentinel.read_bytes()
+    source_status_before = _git(
+        root, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    ).stdout
+    registration_before = _git(root, "worktree", "list", "--porcelain").stdout
+    output = StringIO()
+
+    with pytest.raises(
+        RecoveryError, match="default recovery refuses existing recorded Git shard"
+    ):
+        recover_run(root, "run-3807", force=force, output=output)
+
+    assert output.getvalue() == ""
+    assert sentinel.read_text(encoding="utf-8") == "do not remove"
+    assert _tree_file_bytes(shard) == tree_before
+    assert (shard.stat().st_dev, shard.stat().st_ino) == tree_identity_before
+    assert (shard.parent.stat().st_dev, shard.parent.stat().st_ino) == (
+        private_root_identity_before
+    )
+    assert stat.S_IMODE(shard.parent.stat().st_mode) == 0o700
+    assert source_sentinel.read_bytes() == source_sentinel_before
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+    assert (
+        _git(root, "status", "--porcelain=v1", "-z", "--untracked-files=all").stdout
+        == source_status_before
+    )
+    assert _git(root, "worktree", "list", "--porcelain").stdout == (registration_before)
+
+
+@pytest.mark.parametrize(
+    "capability_name",
+    [
+        "quarantine",
+        "shard",
+        "ownership_marker",
+        "liveness_lock",
+    ],
+)
+@pytest.mark.parametrize("force", [False, True])
+def test_cleanup_callback_rechecks_every_open_capability_at_exit(
+    tmp_path: Path,
+    force: bool,
+    capability_name: str,
+) -> None:
+    root, _, _, _ = _recovery_fixture(tmp_path)
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+    original_sentinel: Path | None = None
+    replacement = tmp_path / f"replacement-{capability_name}"
+
+    def cleanup_at_boundary(
+        capability: recovery_backend.QuarantinedShard,
+    ) -> None:
+        nonlocal original_sentinel
+        selected = getattr(capability, capability_name)
+        original_sentinel = capability.shard.path / "original-sentinel.txt"
+        original_sentinel.write_text("do not remove original", encoding="utf-8")
+        if selected.file_type == stat.S_IFDIR:
+            replacement.mkdir(mode=0o700)
+            replacement_descriptor = os.open(
+                replacement,
+                os.O_RDONLY
+                | os.O_CLOEXEC
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
+        else:
+            replacement.write_text("do not remove replacement", encoding="utf-8")
+            replacement_descriptor = os.open(
+                replacement,
+                os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+            )
+        try:
+            os.dup2(replacement_descriptor, selected.descriptor)
+        finally:
+            os.close(replacement_descriptor)
+
+    with pytest.raises(RecoveryError, match="capability identity changed"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=cleanup_at_boundary,
+        )
+
+    assert original_sentinel is not None
+    assert original_sentinel.read_text(encoding="utf-8") == "do not remove original"
+    assert replacement.exists()
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_cleanup_boundary_rechecks_root_after_opening_its_descriptor(
+    tmp_path: Path, force: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    moved_original = tmp_path / "descriptor-race-original-root"
+    quarantine_name = (
+        f".mutation-harness-recovery-run-3807-shard-0-{shard.stat().st_ino}"
+    )
+    replacement_sentinel = temporary_root / "replacement-root-sentinel.txt"
+    original_sentinel = moved_original / "original-root-sentinel.txt"
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+    real_open = os.open
+    swapped = False
+
+    def open_with_root_replacement(
+        path: str | bytes | Path,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal swapped
+        if os.fsdecode(path) == quarantine_name and dir_fd is not None and not swapped:
+            swapped = True
+            _replace_temporary_root_around_original_shard(
+                temporary_root, moved_original
+            )
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(recovery_backend.os, "open", open_with_root_replacement)
+
+    with pytest.raises(RecoveryError, match="temporary_root.*identity changed"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert replacement_sentinel.read_text(encoding="utf-8") == (
+        "do not remove replacement root"
+    )
+    assert (
+        original_sentinel.read_text(encoding="utf-8") == "do not remove original root"
+    )
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_quarantine_rename_refuses_a_replaced_shard_without_deleting_it(
+    tmp_path: Path, force: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, shard, marker, liveness = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    moved_original = tmp_path / "rename-race-original-shard"
+    original_inode = shard.stat().st_ino
+    quarantine_root = temporary_root / (
+        f".mutation-harness-recovery-run-3807-shard-0-{original_inode}"
+    )
+    replacement_sentinel = quarantine_root / "shard-0/replacement-sentinel.txt"
+    original_sentinel = moved_original / "original-sentinel.txt"
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+    real_rename = os.rename
+    swapped = False
+
+    def rename_with_replacement(
+        source: str | bytes,
+        destination: str | bytes,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        nonlocal swapped
+        if src_dir_fd is not None and dst_dir_fd is not None and not swapped:
+            swapped = True
+            real_rename(shard, moved_original)
+            shard.mkdir(mode=0o700)
+            real_rename(moved_original / marker.name, marker)
+            real_rename(moved_original / liveness.name, liveness)
+            (shard / replacement_sentinel.name).write_text(
+                "do not remove replacement", encoding="utf-8"
+            )
+            original_sentinel.write_text("do not remove original", encoding="utf-8")
+        real_rename(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    monkeypatch.setattr(recovery_backend.os, "rename", rename_with_replacement)
+
+    with pytest.raises(RecoveryError, match="shard root.*during quarantine"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert temporary_root.is_dir()
+    assert replacement_sentinel.read_text(encoding="utf-8") == (
+        "do not remove replacement"
+    )
+    assert original_sentinel.read_text(encoding="utf-8") == "do not remove original"
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize("force", [False, True])
 @pytest.mark.parametrize("lifecycle", ["running", "recovering"])
 def test_missing_recorded_temporary_root_recovers_without_fabricating_results(
     tmp_path: Path,
@@ -977,7 +1253,13 @@ def test_missing_temporary_root_rechecks_absence_immediately_before_state_clear(
     )
 
 
-def _remove_owned_tree(root: Path, marker: Path, shard_index: int) -> None:
+def _remove_owned_tree(capability: recovery_backend.QuarantinedShard) -> None:
+    assert capability.shard_index == 0
+    capability.require_unchanged()
+    shutil.rmtree(capability.shard.path)
+
+
+def _remove_partial_tree(root: Path, marker: Path, shard_index: int) -> None:
     assert marker.is_relative_to(root)
     assert shard_index == 0
     shutil.rmtree(root)
@@ -1041,7 +1323,7 @@ def test_zero_recorded_shards_recovers_owned_partial_staging_tree(
         root,
         "run-3807",
         force=force,
-        cleanup_owned_tree=_remove_owned_tree,
+        cleanup_owned_tree=_remove_partial_tree,
     )
 
     assert message == (
@@ -1071,7 +1353,7 @@ def test_zero_recorded_shards_recovers_empty_private_root(tmp_path: Path) -> Non
     root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path, empty=True)
     assert shard is None
 
-    message = recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+    message = recover_run(root, "run-3807", cleanup_owned_tree=_remove_partial_tree)
 
     assert message == (
         "recovered run run-3807 as aborted; removed 0 owned staging shard(s)"
@@ -1285,7 +1567,11 @@ def test_zero_shard_recovery_rejects_private_root_below_source(
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     cleanup_calls: list[Path] = []
 
-    def cleanup(partial: Path, marker: Path, shard_index: int) -> None:
+    def cleanup(
+        partial: Path,
+        marker: Path,
+        shard_index: int,
+    ) -> None:
         del marker, shard_index
         cleanup_calls.append(partial)
 
@@ -1322,7 +1608,11 @@ def test_zero_shard_recovery_rejects_private_root_above_source(
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     cleanup_calls: list[Path] = []
 
-    def cleanup(partial: Path, marker: Path, shard_index: int) -> None:
+    def cleanup(
+        partial: Path,
+        marker: Path,
+        shard_index: int,
+    ) -> None:
         del marker, shard_index
         cleanup_calls.append(partial)
 
@@ -1393,7 +1683,11 @@ def test_zero_shard_root_state_is_cleared_after_partial_cleanup(
     state_path = root / ".mutation-harness/state.json"
     observed_lifecycle: list[str] = []
 
-    def cleanup(partial: Path, marker: Path, shard_index: int) -> None:
+    def cleanup(
+        partial: Path,
+        marker: Path,
+        shard_index: int,
+    ) -> None:
         assert marker.is_relative_to(partial)
         assert shard_index == 0
         state = json.loads(state_path.read_text(encoding="utf-8"))
@@ -1649,10 +1943,12 @@ def test_root_state_is_cleared_only_after_verified_cleanup(tmp_path: Path) -> No
     root, _, _, _ = _recovery_fixture(tmp_path)
     state_path = root / ".mutation-harness/state.json"
 
-    def cleanup(shard: Path, marker: Path, shard_index: int) -> None:
+    def cleanup(
+        capability: recovery_backend.QuarantinedShard,
+    ) -> None:
         state = json.loads(state_path.read_text(encoding="utf-8"))
         assert state["coordinator_run"]["lifecycle"] == "recovering"
-        _remove_owned_tree(shard, marker, shard_index)
+        _remove_owned_tree(capability)
 
     recover_run(root, "run-3807", cleanup_owned_tree=cleanup)
     state = json.loads(state_path.read_text(encoding="utf-8"))
@@ -1664,14 +1960,17 @@ def test_recovery_holds_the_acquired_liveness_lock_through_cleanup(
 ) -> None:
     root, _, _, liveness_lock = _recovery_fixture(tmp_path)
 
-    def cleanup(shard: Path, marker: Path, shard_index: int) -> None:
-        descriptor = os.open(liveness_lock, os.O_RDWR | os.O_CLOEXEC)
+    def cleanup(
+        capability: recovery_backend.QuarantinedShard,
+    ) -> None:
+        assert capability.liveness_lock.path.name == liveness_lock.name
+        descriptor = os.open(capability.liveness_lock.path, os.O_RDWR | os.O_CLOEXEC)
         try:
             with pytest.raises(BlockingIOError):
                 fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
         finally:
             os.close(descriptor)
-        _remove_owned_tree(shard, marker, shard_index)
+        _remove_owned_tree(capability)
 
     recover_run(root, "run-3807", cleanup_owned_tree=cleanup)
 

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -422,6 +422,353 @@ def _remove_owned_tree(root: Path, marker: Path, shard_index: int) -> None:
     shutil.rmtree(root)
 
 
+def _zero_shard_staging_fixture(
+    tmp_path: Path, *, empty: bool = False
+) -> tuple[Path, Path, Path | None, Path | None]:
+    root, shard, old_marker, old_liveness = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    temporary_root.chmod(0o700)
+    old_marker.unlink()
+    old_liveness.unlink()
+    marker: Path | None = None
+    if empty:
+        shard.rmdir()
+        shard_path: Path | None = None
+    else:
+        state_directory = shard / ".mutation-harness"
+        state_directory.mkdir()
+        marker = state_directory / "execution-tree-owner.json"
+        marker.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "run_id": "run-3807",
+                    "shard_index": 0,
+                    "source_manifest_digest": "source-digest",
+                    "plan_digest": "plan-digest",
+                }
+            ),
+            encoding="utf-8",
+        )
+        shard_path = shard
+
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    coordinator = state["coordinator_run"]
+    coordinator["lifecycle"] = "aborted"
+    coordinator["temporary_root"] = str(temporary_root)
+    coordinator["shards"] = []
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path = Path(coordinator["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["temporary_root"] = str(temporary_root)
+    manifest["requested_shards"] = 2
+    manifest["effective_shards"] = 2
+    manifest["shards"] = []
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return root, temporary_root, shard_path, marker
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_zero_recorded_shards_recovers_owned_partial_staging_tree(
+    tmp_path: Path, force: bool, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+
+    message = recover_run(
+        root,
+        "run-3807",
+        force=force,
+        cleanup_owned_tree=_remove_owned_tree,
+    )
+
+    assert message == (
+        "recovered run run-3807 as aborted; removed 1 owned staging shard(s)"
+    )
+    output = capsys.readouterr().out
+    if force:
+        assert output == (
+            "FORCE RECOVERY PREFLIGHT run-3807\n"
+            "REMOVE:\n"
+            f"  {shard}\n"
+            f"  {temporary_root}\n"
+            "LEAVE:\n"
+            "UNKNOWN:\n"
+        )
+    else:
+        assert output == ""
+    assert not shard.exists()
+    assert not temporary_root.exists()
+    state = json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+    assert "coordinator_run" not in state
+
+
+def test_zero_recorded_shards_recovers_empty_private_root(tmp_path: Path) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path, empty=True)
+    assert shard is None
+
+    message = recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert message == (
+        "recovered run run-3807 as aborted; removed 0 owned staging shard(s)"
+    )
+    assert not temporary_root.exists()
+    state = json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+    assert "coordinator_run" not in state
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_zero_shard_recovery_rejects_unowned_partial_even_with_force(
+    tmp_path: Path, force: bool
+) -> None:
+    root, temporary_root, shard, marker = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None and marker is not None
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["run_id"] = "foreign"
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="ownership marker run_id"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert shard.exists()
+    assert temporary_root.exists()
+    assert "coordinator_run" in json.loads(
+        (root / ".mutation-harness/state.json").read_text(encoding="utf-8")
+    )
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_zero_shard_recovery_rejects_symlinked_partial_tree(
+    tmp_path: Path, force: bool
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path, empty=True)
+    assert shard is None
+    outside = tmp_path / "outside-partial"
+    outside.mkdir()
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("do not change", encoding="utf-8")
+    (temporary_root / "shard-0").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RecoveryError, match="partial shard.*symlink"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "do not change"
+    assert temporary_root.exists()
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_zero_shard_recovery_rejects_extra_private_root_entry(
+    tmp_path: Path, force: bool
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    extra = temporary_root / "unexpected.txt"
+    extra.write_text("do not remove", encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="unexpected private-root entry"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert extra.read_text(encoding="utf-8") == "do not remove"
+    assert shard.exists()
+
+
+def test_zero_shard_recovery_rejects_symlinked_ownership_marker(
+    tmp_path: Path,
+) -> None:
+    root, temporary_root, shard, marker = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None and marker is not None
+    payload = marker.read_bytes()
+    outside_marker = tmp_path / "outside-owner.json"
+    outside_marker.write_bytes(payload)
+    marker.unlink()
+    marker.symlink_to(outside_marker)
+
+    with pytest.raises(RecoveryError, match="ownership marker.*symlink"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert outside_marker.read_bytes() == payload
+    assert shard.exists()
+    assert temporary_root.exists()
+
+
+def test_zero_shard_recovery_requires_durable_private_root_authority(
+    tmp_path: Path,
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    state["coordinator_run"].pop("temporary_root")
+    manifest.pop("temporary_root")
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="no durable temporary_root authority"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert temporary_root.exists()
+    assert shard.exists()
+
+
+def test_zero_shard_recovery_requires_matching_private_root_authority(
+    tmp_path: Path,
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["coordinator_run"]["temporary_root"] = str(tmp_path / "other-private")
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="temporary_root values differ"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert temporary_root.exists()
+    assert shard.exists()
+
+
+def test_zero_shard_recovery_rejects_symlinked_private_root(tmp_path: Path) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    outside = tmp_path / "outside-private"
+    outside.mkdir(mode=0o700)
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("do not change", encoding="utf-8")
+    linked = tmp_path / "linked-private"
+    linked.symlink_to(outside, target_is_directory=True)
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    state["coordinator_run"]["temporary_root"] = str(linked)
+    manifest["temporary_root"] = str(linked)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="contains a symlink"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert sentinel.read_text(encoding="utf-8") == "do not change"
+    assert temporary_root.exists()
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_zero_shard_recovery_rejects_source_as_private_root(
+    tmp_path: Path, force: bool
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    state_path = root / ".mutation-harness/state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    manifest_path = Path(state["coordinator_run"]["manifest_path"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    state["coordinator_run"]["temporary_root"] = str(root.resolve())
+    manifest["temporary_root"] = str(root.resolve())
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="outside the private run boundary"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert temporary_root.exists()
+    assert shard.exists()
+
+
+def test_zero_shard_recovery_rejects_child_liveness_evidence(tmp_path: Path) -> None:
+    root, temporary_root, shard, marker = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None and marker is not None
+    liveness = marker.parent / "liveness.lock"
+    liveness.write_text("", encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="child liveness or unexpected state"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert liveness.exists()
+    assert shard.exists()
+    assert temporary_root.exists()
+
+
+def test_zero_shard_recovery_rejects_marker_with_extra_field(tmp_path: Path) -> None:
+    root, temporary_root, shard, marker = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None and marker is not None
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["unexpected"] = True
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="exact field set"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert shard.exists()
+    assert temporary_root.exists()
+
+
+def test_zero_shard_recovery_rejects_partial_above_effective_bound(
+    tmp_path: Path,
+) -> None:
+    root, temporary_root, shard, marker = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None and marker is not None
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["shard_index"] = 2
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+    escaped_bound = temporary_root / "shard-2"
+    shard.rename(escaped_bound)
+
+    with pytest.raises(RecoveryError, match="exceeds effective shard bound"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert escaped_bound.exists()
+    assert temporary_root.exists()
+
+
+def test_zero_shard_root_state_is_cleared_after_partial_cleanup(
+    tmp_path: Path,
+) -> None:
+    root, temporary_root, shard, _ = _zero_shard_staging_fixture(tmp_path)
+    assert shard is not None
+    state_path = root / ".mutation-harness/state.json"
+    observed_lifecycle: list[str] = []
+
+    def cleanup(partial: Path, marker: Path, shard_index: int) -> None:
+        assert marker.is_relative_to(partial)
+        assert shard_index == 0
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        observed_lifecycle.append(state["coordinator_run"]["lifecycle"])
+        shutil.rmtree(partial)
+
+    recover_run(root, "run-3807", cleanup_owned_tree=cleanup)
+
+    assert observed_lifecycle == ["recovering"]
+    assert not temporary_root.exists()
+    assert "coordinator_run" not in json.loads(state_path.read_text(encoding="utf-8"))
+
+
 def test_reused_live_unrelated_pid_does_not_block_without_held_lock(
     tmp_path: Path,
 ) -> None:

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -389,6 +389,38 @@ def test_manifest_path_escape_is_refused(tmp_path: Path) -> None:
     assert shard.exists()
 
 
+def test_recovery_refuses_symlinked_root_state_directory(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    state_directory = root / ".mutation-harness"
+    outside = tmp_path / "outside-state"
+    state_directory.rename(outside)
+    state_directory.symlink_to(outside, target_is_directory=True)
+    sentinel = outside / "sentinel.txt"
+    sentinel.write_text("do not change", encoding="utf-8")
+    state_path = outside / "state.json"
+    state_before = state_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="root state directory.*symlink"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert state_path.read_bytes() == state_before
+    assert sentinel.read_text(encoding="utf-8") == "do not change"
+    assert shard.exists()
+
+
+def test_recovery_refuses_non_directory_root_state_parent(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    state_parent = root / ".mutation-harness"
+    state_parent.write_text("not a directory", encoding="utf-8")
+    before = state_parent.read_bytes()
+
+    with pytest.raises(RecoveryError, match="root state directory.*not a directory"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert state_parent.read_bytes() == before
+
+
 def test_manifest_owned_path_cannot_escape_its_shard(tmp_path: Path) -> None:
     root, shard, _, _ = _recovery_fixture(tmp_path)
     sentinel = tmp_path / "outside-owner.json"

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -421,6 +421,80 @@ def test_recovery_refuses_non_directory_root_state_parent(tmp_path: Path) -> Non
     assert state_parent.read_bytes() == before
 
 
+def test_recovery_refuses_symlinked_runs_authority_directory(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    runs = root / ".mutation-harness/runs"
+    outside_runs = tmp_path / "outside-runs"
+    runs.rename(outside_runs)
+    runs.symlink_to(outside_runs, target_is_directory=True)
+    sentinel = outside_runs / "sentinel.txt"
+    sentinel.write_text("do not change", encoding="utf-8")
+    manifest = outside_runs / "run-3807/manifest.json"
+    manifest_before = manifest.read_bytes()
+
+    with pytest.raises(RecoveryError, match="runs directory.*symlink"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert manifest.read_bytes() == manifest_before
+    assert sentinel.read_text(encoding="utf-8") == "do not change"
+    assert shard.exists()
+
+
+def test_recovery_refuses_symlinked_run_id_authority_directory(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    run_directory = root / ".mutation-harness/runs/run-3807"
+    outside_run = tmp_path / "outside-run-id"
+    run_directory.rename(outside_run)
+    run_directory.symlink_to(outside_run, target_is_directory=True)
+    sentinel = outside_run / "sentinel.txt"
+    sentinel.write_text("do not change", encoding="utf-8")
+    manifest = outside_run / "manifest.json"
+    manifest_before = manifest.read_bytes()
+
+    with pytest.raises(RecoveryError, match="run directory.*symlink"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert manifest.read_bytes() == manifest_before
+    assert sentinel.read_text(encoding="utf-8") == "do not change"
+    assert shard.exists()
+
+
+def test_recovery_refuses_symlinked_manifest_authority_file(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    manifest = root / ".mutation-harness/runs/run-3807/manifest.json"
+    outside_manifest = tmp_path / "outside-manifest.json"
+    manifest.rename(outside_manifest)
+    manifest.symlink_to(outside_manifest)
+    manifest_before = outside_manifest.read_bytes()
+    sentinel = tmp_path / "outside-manifest-sentinel.txt"
+    sentinel.write_text("do not change", encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="run manifest.*symlink"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert outside_manifest.read_bytes() == manifest_before
+    assert sentinel.read_text(encoding="utf-8") == "do not change"
+    assert shard.exists()
+
+
+def test_recovery_refuses_symlinked_root_state_file(tmp_path: Path) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    state = root / ".mutation-harness/state.json"
+    outside_state = tmp_path / "outside-state.json"
+    state.rename(outside_state)
+    state.symlink_to(outside_state)
+    state_before = outside_state.read_bytes()
+    sentinel = tmp_path / "outside-state-sentinel.txt"
+    sentinel.write_text("do not change", encoding="utf-8")
+
+    with pytest.raises(RecoveryError, match="root state file.*symlink"):
+        recover_run(root, "run-3807", cleanup_owned_tree=_remove_owned_tree)
+
+    assert outside_state.read_bytes() == state_before
+    assert sentinel.read_text(encoding="utf-8") == "do not change"
+    assert shard.exists()
+
+
 def test_manifest_owned_path_cannot_escape_its_shard(tmp_path: Path) -> None:
     root, shard, _, _ = _recovery_fixture(tmp_path)
     sentinel = tmp_path / "outside-owner.json"

--- a/tests/tooling/test_mutation_harness_lane_d.py
+++ b/tests/tooling/test_mutation_harness_lane_d.py
@@ -463,6 +463,34 @@ def _swap_temporary_root_for_matching_directory(
     return replacement_sentinel, moved_sentinel
 
 
+def _swap_shard_for_matching_directory(
+    shard: Path, moved_original: Path
+) -> tuple[Path, Path]:
+    original_marker = (shard / ".mutation-harness-owner.json").read_bytes()
+    shard.rename(moved_original)
+    shard.mkdir(mode=0o700)
+    (shard / ".mutation-harness-owner.json").write_bytes(original_marker)
+    (shard / ".mutation-harness-liveness.lock").write_text("", encoding="utf-8")
+    replacement_sentinel = shard / "replacement-sentinel.txt"
+    replacement_sentinel.write_text("do not remove replacement", encoding="utf-8")
+    moved_sentinel = moved_original / "original-sentinel.txt"
+    moved_sentinel.write_text("do not remove original", encoding="utf-8")
+    return replacement_sentinel, moved_sentinel
+
+
+def _replace_temporary_root_around_original_shard(
+    temporary_root: Path, moved_original: Path
+) -> tuple[Path, Path]:
+    temporary_root.rename(moved_original)
+    moved_sentinel = moved_original / "original-root-sentinel.txt"
+    moved_sentinel.write_text("do not remove original root", encoding="utf-8")
+    temporary_root.mkdir(mode=0o700)
+    (moved_original / "shard-0").rename(temporary_root / "shard-0")
+    replacement_sentinel = temporary_root / "replacement-root-sentinel.txt"
+    replacement_sentinel.write_text("do not remove replacement root", encoding="utf-8")
+    return replacement_sentinel, moved_sentinel
+
+
 @pytest.mark.parametrize("force", [False, True])
 def test_existing_symlinked_temporary_root_never_authorizes_replacement_cleanup(
     tmp_path: Path, force: bool
@@ -653,6 +681,150 @@ def test_temporary_root_same_path_directory_replacement_is_retained(
     assert temporary_root.stat().st_mode & 0o777 == 0o700
     assert moved_sentinel is not None
     assert moved_sentinel.read_text(encoding="utf-8") == "do not remove original"
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_temporary_root_identity_change_with_original_shard_is_retained(
+    tmp_path: Path, force: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    temporary_root = shard.parent
+    moved_original = tmp_path / "moved-original-root-only"
+    original = recovery_backend._build_preflight
+    replacement_sentinel: Path | None = None
+    moved_sentinel: Path | None = None
+
+    def swap_after_preflight(
+        record: recovery_backend.RunRecord,
+    ) -> tuple[recovery_backend.RecoveryPreflight, tuple[int, ...]]:
+        nonlocal replacement_sentinel, moved_sentinel
+        preflight = original(record)
+        replacement_sentinel, moved_sentinel = (
+            _replace_temporary_root_around_original_shard(
+                temporary_root, moved_original
+            )
+        )
+        return preflight
+
+    monkeypatch.setattr(recovery_backend, "_build_preflight", swap_after_preflight)
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="temporary_root.*identity changed"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert replacement_sentinel is not None
+    assert replacement_sentinel.read_text(encoding="utf-8") == (
+        "do not remove replacement root"
+    )
+    assert moved_sentinel is not None
+    assert moved_sentinel.read_text(encoding="utf-8") == "do not remove original root"
+    assert (temporary_root / "shard-0").is_dir()
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_shard_same_path_directory_replacement_is_retained(
+    tmp_path: Path, force: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    moved_original = tmp_path / "moved-original-shard-0"
+    original = recovery_backend._build_preflight
+    replacement_sentinel: Path | None = None
+    moved_sentinel: Path | None = None
+
+    def swap_after_preflight(
+        record: recovery_backend.RunRecord,
+    ) -> tuple[recovery_backend.RecoveryPreflight, tuple[int, ...]]:
+        nonlocal replacement_sentinel, moved_sentinel
+        preflight = original(record)
+        replacement_sentinel, moved_sentinel = _swap_shard_for_matching_directory(
+            shard, moved_original
+        )
+        return preflight
+
+    monkeypatch.setattr(recovery_backend, "_build_preflight", swap_after_preflight)
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match="shard root.*identity changed"):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert replacement_sentinel is not None
+    assert replacement_sentinel.read_text(encoding="utf-8") == (
+        "do not remove replacement"
+    )
+    assert moved_sentinel is not None
+    assert moved_sentinel.read_text(encoding="utf-8") == "do not remove original"
+    assert state_path.read_bytes() == state_before
+    assert manifest_path.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize(
+    ("authority_name", "expected_error"),
+    [
+        (".mutation-harness-owner.json", "ownership marker.*identity changed"),
+        (".mutation-harness-liveness.lock", "liveness lock.*identity changed"),
+    ],
+)
+@pytest.mark.parametrize("force", [False, True])
+def test_shard_authority_file_replacement_after_preflight_is_retained(
+    tmp_path: Path,
+    force: bool,
+    authority_name: str,
+    expected_error: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, shard, _, _ = _recovery_fixture(tmp_path)
+    authority = shard / authority_name
+    moved_authority = tmp_path / f"moved-original-{authority_name}"
+    original = recovery_backend._build_preflight
+
+    def swap_after_preflight(
+        record: recovery_backend.RunRecord,
+    ) -> tuple[recovery_backend.RecoveryPreflight, tuple[int, ...]]:
+        preflight = original(record)
+        content = authority.read_bytes()
+        authority.rename(moved_authority)
+        authority.write_bytes(content)
+        return preflight
+
+    monkeypatch.setattr(recovery_backend, "_build_preflight", swap_after_preflight)
+    sentinel = shard / "replacement-authority-sentinel.txt"
+    sentinel.write_text("do not remove shard", encoding="utf-8")
+    state_path = root / ".mutation-harness/state.json"
+    state_before = state_path.read_bytes()
+    manifest_path = Path(json.loads(state_before)["coordinator_run"]["manifest_path"])
+    manifest_before = manifest_path.read_bytes()
+
+    with pytest.raises(RecoveryError, match=expected_error):
+        recover_run(
+            root,
+            "run-3807",
+            force=force,
+            cleanup_owned_tree=_remove_owned_tree,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "do not remove shard"
+    assert moved_authority.exists()
+    assert authority.exists()
     assert state_path.read_bytes() == state_before
     assert manifest_path.read_bytes() == manifest_before
 


### PR DESCRIPTION
## Summary

- Add durable, flushed serial mutation progress and result streams while preserving serial CLI defaults.
- Add opt-in sharding through one native coordinator. Each shard runs in a separate disposable Git worktree with an exact invoking-workspace overlay.
- Add ordered aggregation, canonical serial versus sharded comparison, bounded crash recovery, and fail-closed cleanup authority.
- Support Linux virtual-environment directory aliases such as lib64 to lib while rejecting external directory targets, top-level repository escapes, and directory cycles.

## Verification

- Rebased head: 9109809b24691e4a890439ac3498ce1d836b6e6e.
- Mutation-harness tests: 314 passed.
- Mutation plans A-E: 71 of 71 KILLED, with no INVALID or SURVIVED results.
- Full local gate: PASSED, all 9 declared stages executed.
- Full unit suite: 13,386 passed, 639 skipped, 1 expected xfail.
- Ruff and mypy passed; mypy checked 2,411 source files in the full gate.
- ClickHouse scratch provisioning, all 86 migrations, and the live ArgMax proof passed.
- Audited 62-mutation acceptance: serial and two-shard runs each produced 62 of 62 KILLED results; their canonical projections were exactly equal with SHA-256 9fa50a8b12eea629c6694a0e23b2cdef489749151290cfc6a88d6b8b7c749f81.
- Public reboot recovery recovers an incomplete run only when its recorded temporary root is absent. Surviving Git worktrees fail closed without changing tree or recovery state.

SCREENSHOT-WAIVER: backend and tooling only; no rendered UI changes.