### PR TITLE
fix(worker): accept deployed drain windows

### DIFF
--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -18,6 +18,7 @@ import (
 const (
 	defaultHTTPAddress       = ":8080"
 	defaultShutdownTimeout   = 30 * time.Second
+	maximumShutdownTimeout   = 3 * time.Hour
 	defaultHealthCheckTimout = 2 * time.Second
 	defaultDomainMaxConns    = 4
 	defaultQueueMaxConns     = 2
@@ -243,7 +244,7 @@ func Load(spec Spec) (Config, error) {
 		"DEV_HEALTH_SHUTDOWN_TIMEOUT",
 		defaultShutdownTimeout,
 		500*time.Millisecond,
-		5*time.Minute,
+		maximumShutdownTimeout,
 	)
 	if err != nil {
 		return Config{}, err

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -130,6 +130,38 @@ func TestLoadDefaultsAndTypedOverrides(t *testing.T) {
 	}
 }
 
+func TestShutdownTimeoutSupportsDeploymentGraceWindows(t *testing.T) {
+	t.Parallel()
+
+	for name, raw := range map[string]string{
+		"sync and ops": "960s",
+		"heavy":        "7260s",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg, err := Load(workerSpec(map[string]string{
+				"DEV_HEALTH_SHUTDOWN_TIMEOUT": raw,
+			}))
+			if err != nil {
+				t.Fatalf("Load() rejected deployment shutdown timeout %s: %v", raw, err)
+			}
+			want, err := time.ParseDuration(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.ShutdownTimeout != want {
+				t.Fatalf("shutdown timeout = %s, want %s", cfg.ShutdownTimeout, want)
+			}
+		})
+	}
+
+	if _, err := Load(workerSpec(map[string]string{
+		"DEV_HEALTH_SHUTDOWN_TIMEOUT": "3h0m1s",
+	})); err == nil {
+		t.Fatal("expected shutdown timeout above the safety ceiling to fail")
+	}
+}
+
 func TestLoadSettingsEncryptionSalt(t *testing.T) {
 	t.Parallel()
 	cfg, err := Load(workerSpec(map[string]string{

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -277,6 +277,30 @@ def _assert_compose_beat_singleton(path: Path) -> None:
         assert replicas in (None, 1), f"{path.name}:{name} must not exceed 1 replica"
 
 
+def test_platform_go_worker_drain_contract_matches_profiles() -> None:
+    compose_path = _platform_go_compose_path()
+    if compose_path is None:
+        pytest.skip("platform compose checkout is unavailable")
+
+    services = _load_yaml(compose_path)["services"]
+    manifest = {
+        process["name"]: process
+        for process in _load_yaml(_REPO_ROOT / "deploy/go-workers/profiles.json")[
+            "processes"
+        ]
+    }
+    service_profiles = {
+        "go-worker": "sync",
+        "go-worker-heavy": "heavy",
+        "go-worker-ops": "ops",
+    }
+    for service_name, profile in service_profiles.items():
+        grace = manifest[profile]["shutdown_grace_seconds"]
+        service = services[service_name]
+        assert service["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"] == f"{grace}s"
+        assert service["stop_grace_period"] == f"{grace}s"
+
+
 def test_production_compose_has_one_shot_migrate_service() -> None:
     services = _load_yaml(_PROD_COMPOSE)["services"]
     migrate = services.get("migrate")

--- a/tests/tooling/mutation-plans/chaos-3850-shutdown-timeout.json
+++ b/tests/tooling/mutation-plans/chaos-3850-shutdown-timeout.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3850 Go worker shutdown timeout contract",
+  "$limitation": "The plan proves the shared parser accepts the deployed drain windows and retains its independent safety ceiling. Platform-root Compose parity is covered by a focused test because that file is outside the ops repository and mutation harness authority.",
+  "mutations": [
+    {
+      "id": "ST01-deployed-drain-window",
+      "file": "internal/platform/config/config.go",
+      "find": "\tmaximumShutdownTimeout   = 3 * time.Hour",
+      "replace": "\tmaximumShutdownTimeout   = 5 * time.Minute",
+      "expect_occurrences": 1,
+      "rationale": "The shared parser ceiling must admit the reviewed sync, ops, and heavy drain windows emitted by every deployment renderer.",
+      "build": ["env", "GOCACHE=/private/tmp/chaos3850-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./internal/platform/config"],
+      "proof": [["env", "GOCACHE=/private/tmp/chaos3850-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestShutdownTimeoutSupportsDeploymentGraceWindows$", "./internal/platform/config"]]
+    },
+    {
+      "id": "ST02-bounded-safety-ceiling",
+      "file": "internal/platform/config/config.go",
+      "find": "\tmaximumShutdownTimeout   = 3 * time.Hour",
+      "replace": "\tmaximumShutdownTimeout   = 6 * time.Hour",
+      "expect_occurrences": 1,
+      "rationale": "The deployment-compatible parser must remain bounded so an accidental multi-day shutdown deadline fails configuration instead of masking a stuck drain.",
+      "build": ["env", "GOCACHE=/private/tmp/chaos3850-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./internal/platform/config"],
+      "proof": [["env", "GOCACHE=/private/tmp/chaos3850-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestShutdownTimeoutSupportsDeploymentGraceWindows$", "./internal/platform/config"]]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- accept the deployed Go worker drain windows in DEV_HEALTH_SHUTDOWN_TIMEOUT, with a bounded three-hour ceiling
- pin the sync, ops, and heavy profile grace values through config and platform-Compose contract tests
- add shared-harness mutations for both the former five-minute cap and an unsafe ceiling expansion

Linear: https://linear.app/fullchaos/issue/CHAOS-3850/go-worker-shutdown-parser-rejects-deployed-profile-drain-windows
Stacks onto #1738.

## Validation

TEST-EVIDENCE:
- bash ci/local_validate.sh: PASS, 9/9 declared stages
- full unit suite: 13,392 passed, 639 skipped, 1 expected failure
- full Go suite: PASS
- focused Go config and worker dependency tests: PASS
- Compose contract tests: 49 passed, 3 expected standalone-checkout skips
- mutation plan: ST01/ST02 KILLED; final harness verify clean
- local ARM64 images built and all three worker profiles passed runtime dependency configuration

RISK-NOTES:
- tracked Compose, Swarm, Kubernetes, and Helm deployment defaults already matched the profile grace windows; no renderer-default change is included
- the platform-root local compose.yml is outside this repository and was updated separately for local testing
- one of two local sync replicas later showed an independent River queue-health connection timeout while its sibling and both ops/heavy replicas remained healthy; this PR does not change connection handling

SCREENSHOT-WAIVER: Backend configuration and tests only; no rendered UI.