### PR TITLE
feat(worker): configure runtime topology with CLI flags

### DIFF
--- a/cmd/dev-health-worker/main_test.go
+++ b/cmd/dev-health-worker/main_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"maps"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
@@ -64,18 +66,18 @@ func TestWorkerCommandUsesExplicitQueuesInsteadOfProfiles(t *testing.T) {
 	}
 }
 
-func TestWorkerCommandPassesCanonicalQueuesToDependencyConstruction(t *testing.T) {
+func TestWorkerCommandPassesProcessArgumentsToDependencyConstruction(t *testing.T) {
 	t.Parallel()
 
 	spec := workerSpec
-	var received []string
+	var received config.Config
 	spec.ConfigureDependenciesWithLogger = func(
 		_ context.Context,
 		cfg config.Config,
 		_ *health.Registry,
 		_ *slog.Logger,
 	) ([]lifecycle.Component, error) {
-		received = append([]string(nil), cfg.Queues...)
+		received = cfg
 		return nil, errors.New("stop after observing queue selection")
 	}
 
@@ -83,20 +85,32 @@ func TestWorkerCommandPassesCanonicalQueuesToDependencyConstruction(t *testing.T
 	code := shell.Execute(
 		context.Background(),
 		spec,
-		[]string{"--queues", "webhooks,heartbeat", "--queues", "retention"},
-		func(key string) (string, bool) {
-			if key == "DEV_HEALTH_QUEUE_CONCURRENCY" {
-				return "heartbeat=1,retention=2,webhooks=4", true
-			}
-			return "", false
+		[]string{
+			"--queues", "webhooks,heartbeat",
+			"--queues", "retention",
+			"--queue-concurrency", "heartbeat=1,retention=2",
+			"--queue-concurrency", "webhooks=4",
+			"--worker-group", "api-workers",
+			"--shutdown-timeout", "17m",
 		},
+		func(string) (string, bool) { return "", false },
 		shell.IO{Stdout: &stdout, Stderr: &stderr},
 	)
 	if code != 1 {
 		t.Fatalf("exit code = %d, want dependency failure; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 	want := []string{"heartbeat", "retention", "webhooks"}
-	if !slices.Equal(received, want) {
-		t.Fatalf("dependency queues = %v, want %v", received, want)
+	if !slices.Equal(received.Queues, want) {
+		t.Fatalf("dependency queues = %v, want %v", received.Queues, want)
+	}
+	wantConcurrency := map[string]int{"heartbeat": 1, "retention": 2, "webhooks": 4}
+	if !maps.Equal(received.WorkerQueueConcurrency, wantConcurrency) {
+		t.Fatalf("queue concurrency = %v, want %v", received.WorkerQueueConcurrency, wantConcurrency)
+	}
+	if received.WorkerGroup != "api-workers" {
+		t.Fatalf("worker group = %q, want api-workers", received.WorkerGroup)
+	}
+	if received.ShutdownTimeout != 17*time.Minute {
+		t.Fatalf("shutdown timeout = %s, want 17m", received.ShutdownTimeout)
 	}
 }

--- a/deploy/docker-compose/compose.go-workers.yml
+++ b/deploy/docker-compose/compose.go-workers.yml
@@ -9,7 +9,6 @@
 # containers alone does not transfer a queue or scheduler ownership.
 x-go-worker-env-base: &go-worker-env-base
   DEV_HEALTH_HTTP_ADDR: ":8080"
-  DEV_HEALTH_SHUTDOWN_TIMEOUT: 7260s
   POSTGRES_URI: ${POSTGRES_URI:?transaction-pooler domain PostgreSQL URI is required}
   WORKER_DATABASE_URI: ${WORKER_DATABASE_URI:?session-pooler queue-control PostgreSQL URI is required}
   CLICKHOUSE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:8123/${CLICKHOUSE_DB:-default}
@@ -146,11 +145,13 @@ services:
     user: "65532:65532"
     security_opt: [no-new-privileges:true]
     tmpfs: [/tmp]
+    command:
+      - --queues=investment,metrics,reports,workgraph
+      - --queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1
+      - --worker-group=heavy
+      - --shutdown-timeout=7260s
     environment: &go-worker-env
       <<: *go-worker-env-base
-      DEV_HEALTH_QUEUES: investment,metrics,reports,workgraph
-      DEV_HEALTH_QUEUE_CONCURRENCY: investment=1,metrics=2,reports=2,workgraph=1
-      DEV_HEALTH_WORKER_GROUP: heavy
     networks: [dev-health]
     stop_grace_period: 7260s
     depends_on:
@@ -166,12 +167,13 @@ services:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: ops
+    command:
+      - --queues=coverage,heartbeat,retention,webhooks
+      - --queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4
+      - --worker-group=ops
+      - --shutdown-timeout=960s
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_QUEUES: coverage,heartbeat,retention,webhooks
-      DEV_HEALTH_QUEUE_CONCURRENCY: coverage=1,heartbeat=1,retention=1,webhooks=4
-      DEV_HEALTH_WORKER_GROUP: ops
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 960s
     stop_grace_period: 960s
 
   # This worker group selects both registered sync queues. Its queue set is a
@@ -180,12 +182,13 @@ services:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: sync
+    command:
+      - --queues=sync,sync_provider
+      - --queue-concurrency=sync=4,sync_provider=2
+      - --worker-group=sync
+      - --shutdown-timeout=960s
     environment:
       <<: *go-worker-env-base
-      DEV_HEALTH_QUEUES: sync,sync_provider
-      DEV_HEALTH_QUEUE_CONCURRENCY: sync=4,sync_provider=2
-      DEV_HEALTH_WORKER_GROUP: sync
-      DEV_HEALTH_SHUTDOWN_TIMEOUT: 960s
     stop_grace_period: 960s
 
   go-reconciler:
@@ -193,6 +196,7 @@ services:
     image: ${DEV_HEALTH_GO_RECONCILER_IMAGE:-ghcr.io/full-chaos/dev-health-go-reconciler:latest}
     labels:
       dev-health.io/worker-group: reconciler
+    command: []
     environment:
       <<: *go-worker-env-base
       DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
@@ -204,6 +208,7 @@ services:
     image: ${DEV_HEALTH_GO_SCHEDULER_IMAGE:-ghcr.io/full-chaos/dev-health-go-scheduler:latest}
     labels:
       dev-health.io/worker-group: scheduler
+    command: []
     environment:
       <<: *go-worker-env-base
       DEV_HEALTH_SHUTDOWN_TIMEOUT: 60s
@@ -215,6 +220,7 @@ services:
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-external
+    command: []
     environment:
       <<: *go-worker-env-base
       DEV_HEALTH_PROFILE: external
@@ -226,6 +232,7 @@ services:
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-ingest
+    command: []
     environment:
       <<: *go-worker-env-base
       DEV_HEALTH_PROFILE: ingest
@@ -239,6 +246,7 @@ services:
     image: ${DEV_HEALTH_GO_STREAM_RUNNER_IMAGE:-ghcr.io/full-chaos/dev-health-go-stream-runner:latest}
     labels:
       dev-health.io/worker-group: stream-pagerduty
+    command: []
     environment:
       <<: *go-worker-env-base
       DEV_HEALTH_PROFILE: pagerduty

--- a/deploy/docker-swarm/stack.go-workers.yml
+++ b/deploy/docker-swarm/stack.go-workers.yml
@@ -50,19 +50,19 @@ services:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: heavy
-    environment: {<<: *go-worker-env-base, DEV_HEALTH_QUEUES: "investment,metrics,reports,workgraph", DEV_HEALTH_QUEUE_CONCURRENCY: "investment=1,metrics=2,reports=2,workgraph=1", DEV_HEALTH_WORKER_GROUP: heavy, DEV_HEALTH_SHUTDOWN_TIMEOUT: 7260s}
+    command: ["--queues=investment,metrics,reports,workgraph", "--queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1", "--worker-group=heavy", "--shutdown-timeout=7260s"]
     stop_grace_period: 7260s
   go-worker-ops:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: ops
-    environment: {<<: *go-worker-env-base, DEV_HEALTH_QUEUES: "coverage,heartbeat,retention,webhooks", DEV_HEALTH_QUEUE_CONCURRENCY: "coverage=1,heartbeat=1,retention=1,webhooks=4", DEV_HEALTH_WORKER_GROUP: ops, DEV_HEALTH_SHUTDOWN_TIMEOUT: 960s}
+    command: ["--queues=coverage,heartbeat,retention,webhooks", "--queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4", "--worker-group=ops", "--shutdown-timeout=960s"]
     stop_grace_period: 960s
   go-worker-sync-provider:
     <<: *go-worker
     labels:
       dev-health.io/worker-group: sync
-    environment: {<<: *go-worker-env-base, DEV_HEALTH_QUEUES: "sync,sync_provider", DEV_HEALTH_QUEUE_CONCURRENCY: "sync=4,sync_provider=2", DEV_HEALTH_WORKER_GROUP: sync, DEV_HEALTH_SHUTDOWN_TIMEOUT: 960s}
+    command: ["--queues=sync,sync_provider", "--queue-concurrency=sync=4,sync_provider=2", "--worker-group=sync", "--shutdown-timeout=960s"]
     stop_grace_period: 960s
   go-reconciler:
     <<: *go-worker

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -5,11 +5,12 @@ connection-budget checks, and stack renderers. Its River entries are deployment
 groups. They select registered queues; they are not application worker types
 and do not change the canonical job-kind-to-queue mapping.
 
-Each `dev-health-worker` process receives an explicit, static queue set through
-`--queues` or `DEV_HEALTH_QUEUES`. The set is normalized and checked against
-the registry before readiness. Empty, unknown, duplicate, malformed, or
-conflicting selections fail closed. Runtime queue reconfiguration is not
-supported.
+Each `dev-health-worker` process receives its explicit, static queue set,
+per-queue concurrency, group label, and shutdown budget as command arguments.
+The set is normalized and checked against the registry before readiness. Empty,
+unknown, duplicate, malformed, or conflicting selections fail closed. Runtime
+queue reconfiguration is not supported. Environment equivalents remain
+fallbacks for existing supervisors and conflict with the matching argument.
 
 The deployment owns the group name, queue concurrency, replica count, resource
 limits, autoscaling policy, and shutdown budget. A worker process constructs one
@@ -364,10 +365,11 @@ be served by the handlers it actually constructed. A deployment that selects
 both queues; a worker that selects only `sync` must not claim `sync_provider`.
 The same exact queue and handler checks apply to every group.
 
-Use `--queues` or `DEV_HEALTH_QUEUES` to select the queues. Do not use a named
-worker preset or rely on a service name to select them. The process reports
-the canonical queue set, per-queue concurrency, worker identity, one River
-client, and effective database limits in its startup and readiness evidence.
+Use `--queues`, `--queue-concurrency`, `--worker-group`, and
+`--shutdown-timeout` to declare the process topology. Do not use a named worker
+preset or rely on a service name to select queues. The process reports the
+canonical queue set, per-queue concurrency, worker identity, one River client,
+and effective database limits in its startup and readiness evidence.
 
 The `sync.team_autoimport` handler still needs
 `WORKER_OPERATIONAL_BRIDGE_URL` and `WORKER_OPERATIONAL_BRIDGE_TOKEN` when the

--- a/deploy/go-workers/compose-go-workers.yml
+++ b/deploy/go-workers/compose-go-workers.yml
@@ -225,10 +225,12 @@ services:
       # secret_env, so it is required, not optional.
       - path: ./ops/.env
         required: false
+    command:
+      - --queues=sync,sync_provider
+      - --queue-concurrency=sync=4,sync_provider=2
+      - --worker-group=sync
+      - --shutdown-timeout=960s
     environment:
-      DEV_HEALTH_QUEUES: sync,sync_provider
-      DEV_HEALTH_QUEUE_CONCURRENCY: sync=4,sync_provider=2
-      DEV_HEALTH_WORKER_GROUP: sync
       POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-devhealth}
       PGBOUNCER_TRANSACTION_MODE: "true"
       WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@pgbouncer-river-queue:6433/${POSTGRES_DB:-devhealth}

--- a/deploy/helm/dev-health/templates/go-workers.yaml
+++ b/deploy/helm/dev-health/templates/go-workers.yaml
@@ -40,25 +40,25 @@ spec:
         - name: {{ $group.name }}
           image: {{ $group.image }}
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          {{- if $group.queues }}
+          {{- $parts := list }}
+          {{- range $queue := $group.queues }}
+          {{- $parts = append $parts (printf "%s=%v" $queue (index $group.queueConcurrency $queue)) }}
+          {{- end }}
+          args:
+            - {{ printf "--queues=%s" (join "," $group.queues) | quote }}
+            - {{ printf "--queue-concurrency=%s" (join "," $parts) | quote }}
+            - {{ printf "--worker-group=%s" $group.name | quote }}
+            - {{ printf "--shutdown-timeout=%ds" (int $group.terminationGracePeriodSeconds) | quote }}
+          {{- end }}
           env:
-            {{- with $group.queues }}
-            - {name: DEV_HEALTH_QUEUES, value: {{ join "," . | quote }}}
-            {{- end }}
-            {{- if $group.queueConcurrency }}
-            {{- $parts := list }}
-            {{- range $queue := $group.queues }}
-            {{- $parts = append $parts (printf "%s=%v" $queue (index $group.queueConcurrency $queue)) }}
-            {{- end }}
-            - {name: DEV_HEALTH_QUEUE_CONCURRENCY, value: {{ join "," $parts | quote }}}
-            {{- end }}
-            {{- if $group.queues }}
-            - {name: DEV_HEALTH_WORKER_GROUP, value: {{ $group.name | quote }}}
-            {{- end }}
             {{- if $group.runtimeProfile }}
             - {name: DEV_HEALTH_PROFILE, value: {{ $group.runtimeProfile | quote }}}
             {{- end }}
             - {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}
+            {{- if not $group.queues }}
             - {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: {{ printf "%ds" (int $group.terminationGracePeriodSeconds) | quote }}}
+            {{- end }}
             {{- if $.Values.goWorkers.pgbouncer.enabled }}
             # Every Go worker group uses the bounded domain transaction pool plus
             # the River queue session pool. Only coordinator binaries receive

--- a/deploy/kubernetes/go-workers.yaml
+++ b/deploy/kubernetes/go-workers.yaml
@@ -33,7 +33,8 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/full-chaos/dev-health-go-worker:latest
-          env: [{name: DEV_HEALTH_QUEUES, value: "investment,metrics,reports,workgraph"}, {name: DEV_HEALTH_QUEUE_CONCURRENCY, value: "investment=1,metrics=2,reports=2,workgraph=1"}, {name: DEV_HEALTH_WORKER_GROUP, value: heavy}, {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 7260s}]
+          args: ["--queues=investment,metrics,reports,workgraph", "--queue-concurrency=investment=1,metrics=2,reports=2,workgraph=1", "--worker-group=heavy", "--shutdown-timeout=7260s"]
+          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -59,7 +60,8 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/full-chaos/dev-health-go-worker:latest
-          env: [{name: DEV_HEALTH_QUEUES, value: "coverage,heartbeat,retention,webhooks"}, {name: DEV_HEALTH_QUEUE_CONCURRENCY, value: "coverage=1,heartbeat=1,retention=1,webhooks=4"}, {name: DEV_HEALTH_WORKER_GROUP, value: ops}, {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 960s}]
+          args: ["--queues=coverage,heartbeat,retention,webhooks", "--queue-concurrency=coverage=1,heartbeat=1,retention=1,webhooks=4", "--worker-group=ops", "--shutdown-timeout=960s"]
+          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
@@ -85,7 +87,8 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/full-chaos/dev-health-go-worker:latest
-          env: [{name: DEV_HEALTH_QUEUES, value: "sync,sync_provider"}, {name: DEV_HEALTH_QUEUE_CONCURRENCY, value: "sync=4,sync_provider=2"}, {name: DEV_HEALTH_WORKER_GROUP, value: sync}, {name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}, {name: DEV_HEALTH_SHUTDOWN_TIMEOUT, value: 960s}]
+          args: ["--queues=sync,sync_provider", "--queue-concurrency=sync=4,sync_provider=2", "--worker-group=sync", "--shutdown-timeout=960s"]
+          env: [{name: DEV_HEALTH_HTTP_ADDR, value: ":8080"}]
           envFrom: [{configMapRef: {name: dev-health-config}}, {secretRef: {name: dev-health-secrets}}]
           ports: [{name: metrics, containerPort: 8080}]
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}

--- a/docs/operate/run/workers-and-jobs.md
+++ b/docs/operate/run/workers-and-jobs.md
@@ -42,19 +42,23 @@ dev-hops workers start-worker \
 ### Start a Go worker group
 
 `dev-health-worker` requires an explicit, static set of registered queues. The
-deployment may pass a comma-separated list or repeat `--queues`; the equivalent
-`DEV_HEALTH_QUEUES` value is useful in a container manifest. The process sorts
-and validates the set before readiness and constructs one River client for all
-selected queues.
+deployment passes process topology as command arguments. Queue and concurrency
+arguments may be comma-separated or repeated. The process sorts and validates
+the set before readiness and constructs one River client for all selected
+queues.
 
 ```bash
-DEV_HEALTH_QUEUES=sync,sync_provider \
-  dev-health-worker
-
 dev-health-worker \
-  --queues metrics,reports \
-  --queues webhooks
+  --queues sync,sync_provider \
+  --queue-concurrency sync=4,sync_provider=2 \
+  --worker-group sync \
+  --shutdown-timeout 960s
 ```
+
+`DEV_HEALTH_QUEUES`, `DEV_HEALTH_QUEUE_CONCURRENCY`,
+`DEV_HEALTH_WORKER_GROUP`, and `DEV_HEALTH_SHUTDOWN_TIMEOUT` remain supported as
+fallbacks for existing supervisors. Do not set a fallback together with its
+command argument; ambiguous input fails before readiness.
 
 The deployment owns the worker group name, replicas, resources, autoscaling,
 shutdown budget, and per-queue concurrency. The binary owns neither a named

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -62,13 +62,16 @@ const (
 
 // Spec describes the immutable configuration surface of one executable.
 type Spec struct {
-	Service        string
-	Profiles       []string
-	DefaultProfile string
-	Profile        string
-	RequireQueues  bool
-	Queues         []string
-	LookupEnv      secrets.LookupEnv
+	Service          string
+	Profiles         []string
+	DefaultProfile   string
+	Profile          string
+	RequireQueues    bool
+	Queues           []string
+	QueueConcurrency []string
+	WorkerGroup      string
+	ShutdownTimeout  string
+	LookupEnv        secrets.LookupEnv
 }
 
 // Config contains typed runtime settings. Sensitive values use secrets.Value,
@@ -232,8 +235,9 @@ const (
 	PagerDutyTransportRiver  = "river"
 )
 
-// Load reads and validates the process environment. CLI profile selection, if
-// supplied by Spec.Profile, takes precedence over DEV_HEALTH_PROFILE.
+// Load reads and validates explicit process arguments plus environment-backed
+// dependencies. A command argument and its environment fallback may not both
+// be set.
 func Load(spec Spec) (Config, error) {
 	lookup := spec.LookupEnv
 	if lookup == nil {
@@ -251,7 +255,8 @@ func Load(spec Spec) (Config, error) {
 	}
 
 	var err error
-	cfg.ShutdownTimeout, err = durationEnv(
+	cfg.ShutdownTimeout, err = durationArgumentOrEnv(
+		spec.ShutdownTimeout,
 		lookup,
 		"DEV_HEALTH_SHUTDOWN_TIMEOUT",
 		defaultShutdownTimeout,
@@ -975,6 +980,31 @@ func durationEnv(
 	return value, nil
 }
 
+func durationArgumentOrEnv(
+	argument string,
+	lookup secrets.LookupEnv,
+	key string,
+	fallback, minimum, maximum time.Duration,
+) (time.Duration, error) {
+	argument = strings.TrimSpace(argument)
+	environment, environmentSet := lookup(key)
+	environment = strings.TrimSpace(environment)
+	if argument != "" && environmentSet && environment != "" {
+		return 0, fmt.Errorf("--shutdown-timeout conflicts with %s", key)
+	}
+	if argument == "" {
+		return durationEnv(lookup, key, fallback, minimum, maximum)
+	}
+	value, err := time.ParseDuration(argument)
+	if err != nil {
+		return 0, errors.New("--shutdown-timeout must be a duration")
+	}
+	if value < minimum || value > maximum {
+		return 0, fmt.Errorf("--shutdown-timeout must be between %s and %s", minimum, maximum)
+	}
+	return value, nil
+}
+
 func logLevelEnv(lookup secrets.LookupEnv) (slog.Level, error) {
 	value := strings.ToLower(envOrDefault(lookup, "DEV_HEALTH_LOG_LEVEL", "info"))
 	switch value {
@@ -1056,39 +1086,60 @@ func workerQueueRuntime(spec Spec, lookup secrets.LookupEnv, queues []string) (s
 	encoded, concurrencySet := lookup("DEV_HEALTH_QUEUE_CONCURRENCY")
 	group = strings.TrimSpace(group)
 	encoded = strings.TrimSpace(encoded)
+	argumentGroup := strings.TrimSpace(spec.WorkerGroup)
+	argumentConcurrency := append([]string(nil), spec.QueueConcurrency...)
 	if !spec.RequireQueues {
-		if (groupSet && group != "") || (concurrencySet && encoded != "") {
+		if argumentGroup != "" || len(argumentConcurrency) > 0 ||
+			(groupSet && group != "") || (concurrencySet && encoded != "") {
 			return "", nil, fmt.Errorf("%s does not accept worker queue runtime settings", spec.Service)
 		}
 		return "", nil, nil
+	}
+	if argumentGroup != "" && groupSet && group != "" {
+		return "", nil, errors.New("--worker-group conflicts with DEV_HEALTH_WORKER_GROUP")
+	}
+	if len(argumentConcurrency) > 0 && concurrencySet && encoded != "" {
+		return "", nil, errors.New("--queue-concurrency conflicts with DEV_HEALTH_QUEUE_CONCURRENCY")
+	}
+	if argumentGroup != "" {
+		group = argumentGroup
+	}
+	groupSetting := "DEV_HEALTH_WORKER_GROUP"
+	if argumentGroup != "" {
+		groupSetting = "--worker-group"
 	}
 	if group == "" {
 		group = "worker"
 	}
 	if len(group) > 64 {
-		return "", nil, errors.New("DEV_HEALTH_WORKER_GROUP exceeds 64 characters")
+		return "", nil, fmt.Errorf("%s exceeds 64 characters", groupSetting)
 	}
-	if err := validateName("DEV_HEALTH_WORKER_GROUP", group); err != nil {
+	if err := validateName(groupSetting, group); err != nil {
 		return "", nil, err
 	}
-	if encoded == "" {
-		return "", nil, errors.New("DEV_HEALTH_QUEUE_CONCURRENCY is required")
+	if len(argumentConcurrency) == 0 && encoded != "" {
+		argumentConcurrency = []string{encoded}
+	}
+	if len(argumentConcurrency) == 0 {
+		return "", nil, errors.New("queue concurrency is required")
 	}
 	concurrency := make(map[string]int)
-	for _, item := range strings.Split(encoded, ",") {
-		parts := strings.Split(item, "=")
-		if len(parts) != 2 {
-			return "", nil, errors.New("DEV_HEALTH_QUEUE_CONCURRENCY must use queue=workers entries")
+	for _, raw := range argumentConcurrency {
+		for _, item := range strings.Split(raw, ",") {
+			parts := strings.Split(item, "=")
+			if len(parts) != 2 {
+				return "", nil, errors.New("queue concurrency must use queue=workers entries")
+			}
+			queue := strings.TrimSpace(parts[0])
+			workers, parseErr := strconv.Atoi(strings.TrimSpace(parts[1]))
+			if !validQueueName(queue) || parseErr != nil || workers < 1 || workers > 10_000 {
+				return "", nil, errors.New("queue concurrency has an invalid entry")
+			}
+			if _, duplicate := concurrency[queue]; duplicate {
+				return "", nil, fmt.Errorf("queue concurrency for %q is defined more than once", queue)
+			}
+			concurrency[queue] = workers
 		}
-		queue := strings.TrimSpace(parts[0])
-		workers, parseErr := strconv.Atoi(strings.TrimSpace(parts[1]))
-		if !validQueueName(queue) || parseErr != nil || workers < 1 || workers > 10_000 {
-			return "", nil, errors.New("DEV_HEALTH_QUEUE_CONCURRENCY has an invalid entry")
-		}
-		if _, duplicate := concurrency[queue]; duplicate {
-			return "", nil, fmt.Errorf("queue concurrency for %q is defined more than once", queue)
-		}
-		concurrency[queue] = workers
 	}
 	if len(concurrency) != len(queues) {
 		return "", nil, errors.New("queue concurrency must cover the selected queues exactly")

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -194,6 +194,49 @@ func TestWorkerQueueSelectionRejectsInvalidOrAmbiguousInput(t *testing.T) {
 	}
 }
 
+func TestWorkerProcessArgumentsRejectEnvironmentConflicts(t *testing.T) {
+	t.Parallel()
+
+	for name, spec := range map[string]Spec{
+		"queue concurrency": {
+			Service:          "dev-health-worker",
+			RequireQueues:    true,
+			Queues:           []string{"heartbeat"},
+			QueueConcurrency: []string{"heartbeat=1"},
+			LookupEnv: lookup(map[string]string{
+				"DEV_HEALTH_QUEUE_CONCURRENCY": "heartbeat=2",
+			}),
+		},
+		"worker group": {
+			Service:          "dev-health-worker",
+			RequireQueues:    true,
+			Queues:           []string{"heartbeat"},
+			QueueConcurrency: []string{"heartbeat=1"},
+			WorkerGroup:      "command-group",
+			LookupEnv: lookup(map[string]string{
+				"DEV_HEALTH_WORKER_GROUP": "environment-group",
+			}),
+		},
+		"shutdown timeout": {
+			Service:          "dev-health-worker",
+			RequireQueues:    true,
+			Queues:           []string{"heartbeat"},
+			QueueConcurrency: []string{"heartbeat=1"},
+			ShutdownTimeout:  "30s",
+			LookupEnv: lookup(map[string]string{
+				"DEV_HEALTH_SHUTDOWN_TIMEOUT": "60s",
+			}),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Load(spec); err == nil {
+				t.Fatal("expected command argument and environment conflict to fail")
+			}
+		})
+	}
+}
+
 func TestLoadDefaultsAndTypedOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/platform/shell/shell.go
+++ b/internal/platform/shell/shell.go
@@ -91,11 +91,20 @@ func Execute(
 	showVersion := flags.Bool("version", false, "print build metadata as JSON and exit")
 	var selectedProfile *string
 	var selectedQueues repeatedStringFlag
+	var queueConcurrency repeatedStringFlag
+	var workerGroup, shutdownTimeout string
 	if len(spec.Profiles) > 0 {
 		selectedProfile = flags.String("profile", "", "runtime profile")
 	}
 	if spec.RequireQueues {
 		flags.Var(&selectedQueues, "queues", "registered queues to consume (comma-separated or repeatable)")
+		flags.Var(
+			&queueConcurrency,
+			"queue-concurrency",
+			"queue worker budgets as queue=workers entries (comma-separated or repeatable)",
+		)
+		flags.StringVar(&workerGroup, "worker-group", "", "stable worker group label for logs and metrics")
+		flags.StringVar(&shutdownTimeout, "shutdown-timeout", "", "graceful shutdown timeout")
 	}
 	if err := flags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -129,7 +138,12 @@ func Execute(
 		Profile:        profile,
 		RequireQueues:  spec.RequireQueues,
 		Queues:         append([]string(nil), selectedQueues...),
-		LookupEnv:      lookup,
+		QueueConcurrency: append(
+			[]string(nil), queueConcurrency...,
+		),
+		WorkerGroup:     workerGroup,
+		ShutdownTimeout: shutdownTimeout,
+		LookupEnv:       lookup,
 	})
 	if err != nil {
 		fmt.Fprintf(streams.Stderr, "configuration error: %s\n", logging.RedactText(err.Error()))

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -41,6 +41,19 @@ def _container_command_string(service: dict) -> str:
     return " ".join(parts)
 
 
+def _go_worker_arguments(service: dict) -> dict[str, str]:
+    command = service.get("command") or []
+    assert isinstance(command, list), "Go worker command must use list form"
+    arguments: dict[str, str] = {}
+    for item in command:
+        name, separator, value = str(item).partition("=")
+        assert separator and name.startswith("--"), (
+            f"invalid Go worker argument: {item}"
+        )
+        arguments[name] = value
+    return arguments
+
+
 def test_compose_workers_cover_every_celery_queue() -> None:
     """CHAOS-2278: the union of -Q lists across all compose celery worker
     services must cover every queue declared in workers.config.task_queues.
@@ -277,7 +290,7 @@ def _assert_compose_beat_singleton(path: Path) -> None:
         assert replicas in (None, 1), f"{path.name}:{name} must not exceed 1 replica"
 
 
-def test_platform_go_worker_drain_contract_matches_profiles() -> None:
+def test_platform_go_worker_drain_contract_matches_groups() -> None:
     compose_path = _platform_go_compose_path()
     if compose_path is None:
         pytest.skip("platform compose checkout is unavailable")
@@ -297,7 +310,7 @@ def test_platform_go_worker_drain_contract_matches_profiles() -> None:
     for service_name, profile in service_profiles.items():
         grace = manifest[profile]["shutdown_grace_seconds"]
         service = services[service_name]
-        assert service["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"] == f"{grace}s"
+        assert _go_worker_arguments(service)["--shutdown-timeout"] == f"{grace}s"
         assert service["stop_grace_period"] == f"{grace}s"
 
 
@@ -1448,6 +1461,10 @@ def test_go_profile_overlay_worker_selects_manifest_queues_without_runtime_profi
     worker = services["go-worker"]
     environment = worker["environment"]
     assert "DEV_HEALTH_PROFILE" not in environment
+    assert "DEV_HEALTH_QUEUES" not in environment
+    assert "DEV_HEALTH_QUEUE_CONCURRENCY" not in environment
+    assert "DEV_HEALTH_WORKER_GROUP" not in environment
+    arguments = _go_worker_arguments(worker)
     sync_queues = next(
         process["queues"]
         for process in _load_yaml(_REPO_ROOT / "deploy/go-workers/deployment.json")[
@@ -1455,7 +1472,7 @@ def test_go_profile_overlay_worker_selects_manifest_queues_without_runtime_profi
         ]
         if process["name"] == "sync"
     )
-    assert environment["DEV_HEALTH_QUEUES"] == ",".join(sync_queues)
+    assert arguments["--queues"] == ",".join(sync_queues)
     sync_process = next(
         process
         for process in _load_yaml(_REPO_ROOT / "deploy/go-workers/deployment.json")[
@@ -1463,11 +1480,11 @@ def test_go_profile_overlay_worker_selects_manifest_queues_without_runtime_profi
         ]
         if process["name"] == "sync"
     )
-    assert environment["DEV_HEALTH_QUEUE_CONCURRENCY"] == ",".join(
+    assert arguments["--queue-concurrency"] == ",".join(
         f"{entry['queue']}={entry['max_workers']}"
         for entry in sync_process["queue_workers"]
     )
-    assert environment["DEV_HEALTH_WORKER_GROUP"] == "sync"
+    assert arguments["--worker-group"] == "sync"
     assert worker["profiles"] == ["go"]
 
 

--- a/tests/tooling/mutation-plans/chaos-3851-queue-selection.json
+++ b/tests/tooling/mutation-plans/chaos-3851-queue-selection.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
   "name": "CHAOS-3851 explicit queue selection",
-  "$limitation": "The plan proves required and exact queue concurrency input, propagation into the constructed startup budget, one process-level River client, independent groups with identical queue sets, worker-group label neutrality, visibility of live custom groups, and renderer emission of queue concurrency. It does not prove live multi-process claim distribution or autoscaler behavior; those require the integration and deployment environments.",
+  "$limitation": "The plan proves required and exact queue concurrency input, CLI propagation and environment conflict refusal for worker process arguments, propagation into the constructed startup budget, one process-level River client, independent groups with identical queue sets, worker-group label neutrality, visibility of live custom groups, and renderer emission of queue concurrency. It does not prove live multi-process claim distribution or autoscaler behavior; those require the integration and deployment environments.",
   "mutations": [
     {
       "id": "QS01-required-queue-concurrency",
       "file": "internal/platform/config/config.go",
-      "find": "\tif encoded == \"\" {\n\t\treturn \"\", nil, errors.New(\"DEV_HEALTH_QUEUE_CONCURRENCY is required\")\n\t}",
-      "replace": "\tif encoded == \"\" {\n\t\treturn group, map[string]int{}, nil\n\t}",
+      "find": "\tif len(argumentConcurrency) == 0 {\n\t\treturn \"\", nil, errors.New(\"queue concurrency is required\")\n\t}",
+      "replace": "\tif len(argumentConcurrency) == 0 {\n\t\treturn group, map[string]int{}, nil\n\t}",
       "expect_occurrences": 1,
       "rationale": "A River worker must fail closed when deployment does not provide per-queue concurrency; accepting an empty budget would create a queue-selected process with no reviewed capacity.",
       "build": ["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./internal/platform/config"],
@@ -76,12 +76,72 @@
     {
       "id": "QS08-renderer-emits-queue-concurrency",
       "file": "deploy/docker-compose/compose.go-workers.yml",
-      "find": "      DEV_HEALTH_QUEUE_CONCURRENCY: sync=4,sync_provider=2",
+      "find": "      - --queue-concurrency=sync=4,sync_provider=2",
       "replace": "",
       "expect_occurrences": 1,
       "rationale": "The Compose renderer must pass the deployment's queue concurrency to every Go worker; omitting it causes the process to fail closed or lose the reviewed capacity contract.",
       "build": ["python", "-m", "py_compile", "tests/workers/test_go_worker_deployment_contract.py"],
       "proof": [["pytest", "-q", "--confcutdir=tests/workers", "tests/workers/test_go_worker_deployment_contract.py", "-k", "test_river_worker_renderers_select_manifest_queues_without_profiles"]]
+    },
+    {
+      "id": "QS09-cli-queue-concurrency-propagation",
+      "file": "internal/platform/shell/shell.go",
+      "find": "\t\tQueueConcurrency: append(\n\t\t\t[]string(nil), queueConcurrency...,\n\t\t),",
+      "replace": "\t\tQueueConcurrency: nil,",
+      "expect_occurrences": 1,
+      "rationale": "The worker CLI must pass every --queue-concurrency value to typed configuration; accepting the flag while discarding it would make the visible command disagree with River capacity.",
+      "build": ["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./cmd/dev-health-worker"],
+      "proof": [["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestWorkerCommandPassesProcessArgumentsToDependencyConstruction$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "QS10-cli-worker-group-propagation",
+      "file": "internal/platform/shell/shell.go",
+      "find": "\t\tWorkerGroup:     workerGroup,",
+      "replace": "\t\tWorkerGroup:     \"\",",
+      "expect_occurrences": 1,
+      "rationale": "The worker group argument is the process observability identity; silently dropping it would collapse independently deployed groups into the default label.",
+      "build": ["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./cmd/dev-health-worker"],
+      "proof": [["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestWorkerCommandPassesProcessArgumentsToDependencyConstruction$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "QS11-cli-shutdown-timeout-propagation",
+      "file": "internal/platform/shell/shell.go",
+      "find": "\t\tShutdownTimeout: shutdownTimeout,",
+      "replace": "\t\tShutdownTimeout: \"\",",
+      "expect_occurrences": 1,
+      "rationale": "The process shutdown argument must reach lifecycle construction; dropping it would expose a reviewed drain window in the manifest while the binary uses its short default.",
+      "build": ["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./cmd/dev-health-worker"],
+      "proof": [["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestWorkerCommandPassesProcessArgumentsToDependencyConstruction$", "./cmd/dev-health-worker"]]
+    },
+    {
+      "id": "QS12-cli-concurrency-env-conflict",
+      "file": "internal/platform/config/config.go",
+      "find": "\tif len(argumentConcurrency) > 0 && concurrencySet && encoded != \"\" {",
+      "replace": "\tif false && len(argumentConcurrency) > 0 && concurrencySet && encoded != \"\" {",
+      "expect_occurrences": 1,
+      "rationale": "A command and environment value for queue concurrency are two authorities; accepting both would make the effective topology depend on undocumented precedence.",
+      "build": ["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./internal/platform/config"],
+      "proof": [["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestWorkerProcessArgumentsRejectEnvironmentConflicts$", "./internal/platform/config"]]
+    },
+    {
+      "id": "QS13-cli-group-env-conflict",
+      "file": "internal/platform/config/config.go",
+      "find": "\tif argumentGroup != \"\" && groupSet && group != \"\" {",
+      "replace": "\tif false && argumentGroup != \"\" && groupSet && group != \"\" {",
+      "expect_occurrences": 1,
+      "rationale": "A worker group command argument must not silently override an ambient group environment value because logs and fleet status would have two competing deployment identities.",
+      "build": ["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./internal/platform/config"],
+      "proof": [["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestWorkerProcessArgumentsRejectEnvironmentConflicts$", "./internal/platform/config"]]
+    },
+    {
+      "id": "QS14-cli-shutdown-env-conflict",
+      "file": "internal/platform/config/config.go",
+      "find": "\tif argument != \"\" && environmentSet && environment != \"\" {",
+      "replace": "\tif false && argument != \"\" && environmentSet && environment != \"\" {",
+      "expect_occurrences": 1,
+      "rationale": "Shutdown authority must be unambiguous; allowing both the command and environment setting makes the drain contract opaque during incident response.",
+      "build": ["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-run", "^$", "./internal/platform/config"],
+      "proof": [["env", "GOCACHE=/tmp/chaos3851-mutation-cache", "GOTOOLCHAIN=go1.25.9", "go", "test", "-count=1", "-run", "^TestWorkerProcessArgumentsRejectEnvironmentConflicts$", "./internal/platform/config"]]
     }
   ]
 }

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -101,6 +101,18 @@ def _queue_concurrency_env(process: dict) -> str:
     )
 
 
+def _process_arguments(container: dict) -> dict[str, str]:
+    raw = container.get("command") or container.get("args") or []
+    assert isinstance(raw, list), "worker process arguments must use list form"
+    arguments: dict[str, str] = {}
+    for item in raw:
+        name, separator, value = str(item).partition("=")
+        assert separator and name.startswith("--"), f"invalid process argument: {item}"
+        assert name not in arguments, f"duplicate process argument: {name}"
+        arguments[name] = value
+    return arguments
+
+
 def _load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -388,9 +400,8 @@ def test_go_deployment_surfaces_are_additive_default_off_and_group_complete() ->
             )
             == "true"
         )
-    assert (
-        compose["go-worker-sync-provider"]["environment"]["DEV_HEALTH_QUEUES"]
-        == "sync,sync_provider"
+    assert _process_arguments(compose["go-worker-sync-provider"])["--queues"] == (
+        "sync,sync_provider"
     )
 
     swarm = _load_yaml(_GO_SWARM)["services"]
@@ -473,9 +484,13 @@ def test_river_worker_renderers_select_manifest_queues_without_profiles() -> Non
             assert "DEV_HEALTH_PROFILE" not in environment, (
                 f"{renderer_name} {service_name} must select queues explicitly"
             )
-            assert _queue_env(environment["DEV_HEALTH_QUEUES"]) == expected
-            assert environment["DEV_HEALTH_QUEUE_CONCURRENCY"] == expected_concurrency
-            assert environment["DEV_HEALTH_WORKER_GROUP"] == group
+            assert "DEV_HEALTH_QUEUES" not in environment
+            assert "DEV_HEALTH_QUEUE_CONCURRENCY" not in environment
+            assert "DEV_HEALTH_WORKER_GROUP" not in environment
+            arguments = _process_arguments(services[service_name])
+            assert _queue_env(arguments["--queues"]) == expected
+            assert arguments["--queue-concurrency"] == expected_concurrency
+            assert arguments["--worker-group"] == group
 
     deployments = {
         document["metadata"]["name"]: document
@@ -492,11 +507,13 @@ def test_river_worker_renderers_select_manifest_queues_without_profiles() -> Non
             item["name"]: item.get("value") for item in container.get("env", [])
         }
         assert "DEV_HEALTH_PROFILE" not in environment
-        assert _queue_env(environment["DEV_HEALTH_QUEUES"]) == river[group]["queues"]
-        assert environment["DEV_HEALTH_QUEUE_CONCURRENCY"] == _queue_concurrency_env(
-            river[group]
-        )
-        assert environment["DEV_HEALTH_WORKER_GROUP"] == group
+        assert "DEV_HEALTH_QUEUES" not in environment
+        assert "DEV_HEALTH_QUEUE_CONCURRENCY" not in environment
+        assert "DEV_HEALTH_WORKER_GROUP" not in environment
+        arguments = _process_arguments(container)
+        assert _queue_env(arguments["--queues"]) == river[group]["queues"]
+        assert arguments["--queue-concurrency"] == _queue_concurrency_env(river[group])
+        assert arguments["--worker-group"] == group
 
     horizontal_scalers = [
         document
@@ -602,25 +619,39 @@ def test_group_replica_and_drain_contract_matches_every_renderer() -> None:
         grace = contract["shutdown_grace_seconds"]
         assert compose[service_name]["deploy"]["replicas"] == desired
         assert compose[service_name]["stop_grace_period"] == f"{grace}s"
-        assert (
-            compose[service_name]["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"]
-            == f"{grace}s"
-        )
         assert swarm[service_name]["deploy"]["replicas"] == desired
         assert swarm[service_name]["stop_grace_period"] == f"{grace}s"
-        assert (
-            swarm[service_name]["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"]
-            == f"{grace}s"
-        )
         assert kubernetes[profile]["spec"]["replicas"] == desired
         pod_spec = kubernetes[profile]["spec"]["template"]["spec"]
         assert pod_spec["terminationGracePeriodSeconds"] == grace
-        shutdown = next(
-            item
-            for item in pod_spec["containers"][0]["env"]
-            if item["name"] == "DEV_HEALTH_SHUTDOWN_TIMEOUT"
-        )
-        assert shutdown["value"] == f"{grace}s"
+        if contract["runtime"] == "river":
+            assert (
+                _process_arguments(compose[service_name])["--shutdown-timeout"]
+                == f"{grace}s"
+            )
+            assert (
+                _process_arguments(swarm[service_name])["--shutdown-timeout"]
+                == f"{grace}s"
+            )
+            assert (
+                _process_arguments(pod_spec["containers"][0])["--shutdown-timeout"]
+                == f"{grace}s"
+            )
+        else:
+            assert (
+                compose[service_name]["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"]
+                == f"{grace}s"
+            )
+            assert (
+                swarm[service_name]["environment"]["DEV_HEALTH_SHUTDOWN_TIMEOUT"]
+                == f"{grace}s"
+            )
+            shutdown = next(
+                item
+                for item in pod_spec["containers"][0]["env"]
+                if item["name"] == "DEV_HEALTH_SHUTDOWN_TIMEOUT"
+            )
+            assert shutdown["value"] == f"{grace}s"
         assert helm[profile]["replicas"] == desired
         assert helm[profile]["terminationGracePeriodSeconds"] == grace
         if contract["runtime"] == "river":
@@ -639,7 +670,7 @@ def test_group_replica_and_drain_contract_matches_every_renderer() -> None:
     helm_template = (_HELM_CHART / "templates" / "go-workers.yaml").read_text(
         encoding="utf-8"
     )
-    assert "DEV_HEALTH_SHUTDOWN_TIMEOUT" in helm_template
+    assert "--shutdown-timeout=" in helm_template
 
 
 def test_go_compose_bootstrap_is_post_alembic_fail_closed_and_route_inert() -> None:

--- a/tests/workers/test_helm_go_pgbouncer.py
+++ b/tests/workers/test_helm_go_pgbouncer.py
@@ -286,11 +286,15 @@ def test_helm_river_workers_select_manifest_queues_and_queue_metrics() -> None:
         container = deployment["spec"]["template"]["spec"]["containers"][0]
         environment = _env(container)
         assert "DEV_HEALTH_PROFILE" not in environment
-        assert environment["DEV_HEALTH_QUEUES"]["value"] == ",".join(process["queues"])
-        assert environment["DEV_HEALTH_QUEUE_CONCURRENCY"][
-            "value"
-        ] == _queue_concurrency(process)
-        assert environment["DEV_HEALTH_WORKER_GROUP"]["value"] == group
+        assert "DEV_HEALTH_QUEUES" not in environment
+        assert "DEV_HEALTH_QUEUE_CONCURRENCY" not in environment
+        assert "DEV_HEALTH_WORKER_GROUP" not in environment
+        assert container["args"] == [
+            f"--queues={','.join(process['queues'])}",
+            f"--queue-concurrency={_queue_concurrency(process)}",
+            f"--worker-group={group}",
+            f"--shutdown-timeout={process['shutdown_grace_seconds']}s",
+        ]
 
         scaler = next(
             doc


### PR DESCRIPTION
## Summary

- add CLI options for queues, per-queue concurrency, worker group, and shutdown timeout
- fail when a CLI option and its environment fallback are both set
- render worker topology as process arguments in Compose, Swarm, Kubernetes, and Helm
- clear inherited worker commands from non-worker Compose roles
- update operator documentation, deployment contract tests, and the shared mutation plan

## Validation

- bash ci/local_validate.sh: PASSED, 9/9 stages; 13,404 passed, 639 skipped, 1 xfailed
- queue-selection mutation plan: 14/14 KILLED
- focused Go tests: passed
- focused deployment tests: 88 passed, 3 Helm-only skipped because Helm is not installed
- local Compose worker image build: passed for sync, heavy, and ops images
- image CLI smoke: all three images accepted the new arguments

SCREENSHOT-WAIVER: Backend CLI and deployment configuration change; no rendered UI.