### PR TITLE
Lane A: worker runtime core — multi-family boot, retryable drains, lease hardening, startup operability

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -1169,7 +1169,7 @@ check_multi_replica_workers() {
     GOWORK=off \
       DEV_HEALTH_MULTI_REPLICA_PROOF="${proof_file}" \
       go test -mod=readonly -tags=integration -count=1 -timeout=5m \
-        -run '^TestOperationalProfileMultiReplicaClaimDrainRestart$' \
+        -run '^TestExplicitQueueMultiReplicaClaimDrainRestart$' \
         ./cmd/dev-health-worker
   ) || result=$?
   if [ "${result}" -ne 0 ]; then

--- a/cmd/dev-health-worker/daily.go
+++ b/cmd/dev-health-worker/daily.go
@@ -227,12 +227,6 @@ func buildDailyWorker(
 			registered = append(registered, registeredSpec)
 		}
 	}
-	if err := registerRescueCoverage(workers, registry, registered); err != nil {
-		if metricsClickHouse != nil {
-			_ = metricsClickHouse.Close()
-		}
-		return workerFamily{}, errWorkerDependencyUnavailable
-	}
 
 	var cleanups []func() error
 	if metricsClickHouse != nil {

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -32,6 +32,28 @@ const (
 
 var errWorkerDependencyUnavailable = errors.New("worker readiness dependency is unavailable")
 
+// dependencyFailure attaches a bounded reason code to the generic dependency
+// sentinel. Dozens of distinct construction failures -- rescue collisions,
+// drain-budget math, a missing ClickHouse URI, handler drift -- used to return
+// the bare sentinel, and the shell logged only "dependency_configuration_failed",
+// so an operator could not tell which knob was wrong (CHAOS-3873). The reason is
+// always a compile-time constant, never interpolated input, so logging it cannot
+// leak a DSN or a secret.
+type dependencyFailure struct {
+	reason string
+}
+
+func (failure dependencyFailure) Error() string {
+	return errWorkerDependencyUnavailable.Error() + ": " + failure.reason
+}
+
+func (dependencyFailure) Unwrap() error { return errWorkerDependencyUnavailable }
+
+// DependencyReason satisfies the shell's reason-code interface.
+func (failure dependencyFailure) DependencyReason() string { return failure.reason }
+
+func dependencyUnavailable(reason string) error { return dependencyFailure{reason: reason} }
+
 type workerDatabase interface {
 	DomainReady(context.Context) error
 	QueueReady(context.Context) error
@@ -76,6 +98,32 @@ func (database *postgresWorkerDatabase) NewWorkerPresence(
 // posture; tests can provide the same small query seam without widening roles.
 type githubProjectsV2DurableConfigReader interface {
 	GitHubProjectsV2Configured(context.Context) (bool, error)
+}
+
+// databaseConfigurationRejected reports whether a database-open failure is a
+// declared configuration rejection rather than an operational one. Those are
+// reported through named readiness checks (domain_postgres, queue_postgres,
+// queue_control_config), which an operator can scrape; failing construction
+// instead would replace an attributable check name with a crash loop.
+// Everything else -- an unreachable host, a refused password, a DSN that will
+// not parse -- is operational and must crash-loop rather than idle as an
+// alive-but-unready zombie (CHAOS-3873).
+func databaseConfigurationRejected(err error) bool {
+	for _, configurationError := range []error{
+		postgres.ErrInvalidConfig,
+		postgres.ErrDomainDatabaseRequired,
+		postgres.ErrQueueControlRequired,
+		postgres.ErrQueueControlTransactionMode,
+		postgres.ErrRuntimeRolesNotSeparated,
+		postgres.ErrRuntimeRoleConfiguration,
+		postgres.ErrCoordinatorDatabaseRequired,
+		postgres.ErrCoordinatorTransactionMode,
+	} {
+		if errors.Is(err, configurationError) {
+			return true
+		}
+	}
+	return false
 }
 
 func openWorkerDatabase(ctx context.Context, cfg config.Config) (workerDatabase, error) {
@@ -398,7 +446,7 @@ func configureWorkerDependenciesWithSources(
 	}
 	if dependencies.metricsErr != nil || dependencies.metrics == nil {
 		dependencies.close()
-		return nil, errWorkerDependencyUnavailable
+		return nil, dependencyUnavailable("worker_metrics_unavailable")
 	}
 	if err := registry.RegisterMetrics("worker_runtime", workerMetricsSource{
 		collector:              dependencies.metrics,
@@ -437,6 +485,17 @@ func configureWorkerDependenciesWithSources(
 		}
 	}
 	if dependencies.database == nil {
+		if dependencies.databaseErr != nil && !databaseConfigurationRejected(dependencies.databaseErr) {
+			// A DSN that was supplied but could not be opened used to return
+			// nil, nil: the shell started with no components, readiness failed
+			// forever, and nothing terminated the process -- an alive-but-unready
+			// zombie instead of an attributable crash-loop (CHAOS-3873).
+			dependencies.close()
+			return nil, dependencyUnavailable("worker_database_open_failed")
+		}
+		// A rejected or absent DSN configuration stays live and unready on
+		// purpose, so an operator can scrape readiness and see exactly which
+		// check names failed rather than reading a crash loop.
 		return nil, nil
 	}
 	components := []lifecycle.Component{workerDatabaseLifecycle{database: dependencies.database}}
@@ -453,7 +512,7 @@ func configureWorkerDependenciesWithSources(
 	)
 	if composeErr != nil {
 		dependencies.close()
-		return nil, errWorkerDependencyUnavailable
+		return nil, dependencyUnavailable("worker_family_composition_failed")
 	}
 	if active.metricsSource != nil {
 		if err := registry.RegisterMetrics("provider_foundation", active.metricsSource); err != nil {
@@ -476,7 +535,7 @@ func configureWorkerDependenciesWithSources(
 		if err := dependencies.queuesReady(ctx); err != nil {
 			_ = closeWorkerFamily(active)
 			dependencies.close()
-			return nil, errWorkerDependencyUnavailable
+			return nil, dependencyUnavailable("queue_coverage_validation_failed")
 		}
 	}
 	components = append(components, preclaimReadinessComponent{registry: registry})
@@ -486,7 +545,7 @@ func configureWorkerDependenciesWithSources(
 	if sources.buildRiverProcess == nil {
 		_ = closeWorkerFamily(active)
 		dependencies.close()
-		return nil, errWorkerDependencyUnavailable
+		return nil, dependencyUnavailable("river_process_builder_missing")
 	}
 	workerProcess, err := sources.buildRiverProcess(
 		cfg, dependencies.database, workers, active, logger,
@@ -494,7 +553,7 @@ func configureWorkerDependenciesWithSources(
 	if err != nil || workerProcess == nil {
 		_ = closeWorkerFamily(active)
 		dependencies.close()
-		return nil, errWorkerDependencyUnavailable
+		return nil, dependencyUnavailable("river_process_construction_failed")
 	}
 	var presence *jobruntime.WorkerPresence
 	if database, ok := dependencies.database.(*postgresWorkerDatabase); ok {
@@ -505,7 +564,7 @@ func configureWorkerDependenciesWithSources(
 		if presenceErr != nil {
 			_ = closeWorkerFamily(active)
 			dependencies.close()
-			return nil, errWorkerDependencyUnavailable
+			return nil, dependencyUnavailable("worker_presence_unavailable")
 		}
 	}
 	logger.InfoContext(ctx, "worker queues configured",
@@ -513,6 +572,10 @@ func configureWorkerDependenciesWithSources(
 		"worker_instance_id", dependencies.instanceID,
 		"queues", strings.Join(cfg.Queues, ","),
 		"queue_workers", formatQueueBudgets(active.queues),
+		// Surfaced so an operator can see the effective drain window, including
+		// when it was derived from the selection rather than configured.
+		"shutdown_timeout", dependencies.shutdownGrace.String(),
+		"drain_budget", dependencies.workerDrainBudget.String(),
 		"river_client_count", 1,
 		"queue_database_max_connections", dependencies.startup.Connections.QueueControl,
 		"domain_database_max_connections", dependencies.startup.Connections.Domain,
@@ -597,7 +660,7 @@ func composeSelectedWorkerFamilies(
 	if runtimeRegistry != nil {
 		if err := registerRescueCoverage(workers, runtimeRegistry, active.handlers, active.ownedKinds...); err != nil {
 			_ = closeWorkerFamily(active)
-			return workerFamily{}, err
+			return workerFamily{}, dependencyUnavailable("rescue_coverage_registration_failed")
 		}
 	}
 	return active, nil
@@ -1038,14 +1101,22 @@ func buildWorkerDependencies(
 		dependencies.workerGroup = "worker"
 	}
 	dependencies.shutdownGrace = cfg.ShutdownTimeout
-	if dependencies.shutdownGrace == 0 {
-		// Direct unit construction does not pass through config.Load. Production
-		// always supplies a concrete timeout, so infer only for that test seam.
-		dependencies.shutdownGrace = longestTimeout + workerFinalizationBuffer
+	// The drain budget is the shutdown grace minus a finalization buffer and
+	// must cover the longest selected timeout. The 30s config default cannot
+	// satisfy that for any real selection -- it yields a NEGATIVE budget -- so
+	// every default-configured worker failed with the opaque sentinel
+	// (CHAOS-3873). An unset timeout is derived from the selection; an operator
+	// who set one explicitly still gets a hard, attributable failure.
+	requiredGrace := longestTimeout + workerFinalizationBuffer
+	// Only an unset timeout is derived. A value the operator chose -- including
+	// one that happens to equal the default -- still fails closed, so the
+	// contract check keeps its teeth.
+	if !cfg.ShutdownTimeoutExplicit && dependencies.shutdownGrace <= config.DefaultShutdownTimeout {
+		dependencies.shutdownGrace = requiredGrace
 	}
 	dependencies.workerDrainBudget = dependencies.shutdownGrace - workerFinalizationBuffer
 	if dependencies.workerDrainBudget < longestTimeout {
-		dependencies.startupErr = errWorkerDependencyUnavailable
+		dependencies.startupErr = dependencyUnavailable("shutdown_timeout_below_drain_budget")
 		return dependencies
 	}
 	// Queues and Handlers stay empty here on purpose: they are filled in only by

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -447,76 +447,13 @@ func configureWorkerDependenciesWithSources(
 		components = append(components, monitor)
 	}
 	workers := river.NewWorkers()
-	var active workerFamily
-	build := func(family workerFamily, err error) error {
-		if err != nil {
-			_ = closeWorkerFamily(active)
-			return err
-		}
-		combined, composeErr := composeWorkerFamily(active, family)
-		if composeErr != nil {
-			_ = closeWorkerFamily(family)
-			_ = closeWorkerFamily(active)
-			return composeErr
-		}
-		active = combined
-		return nil
-	}
-	for _, builder := range []workerFamilyBuilder{
-		sources.buildOperational,
-		sources.buildDaily,
-		sources.buildWorkgraph,
-		sources.buildSyncCoordinator,
-	} {
-		if builder == nil {
-			continue
-		}
-		if err := build(builder(
-			cfg, dependencies.database, dependencies.runtimeRegistry, dependencies.metrics, logger, workers,
-		)); err != nil {
-			dependencies.close()
-			return nil, errWorkerDependencyUnavailable
-		}
-	}
-	for _, builder := range []func(
-		context.Context,
-		config.Config,
-		workerDatabase,
-		*jobruntime.Registry,
-		jobruntime.Observer,
-		*slog.Logger,
-		*river.Workers,
-	) (workerFamily, error){
-		sources.buildReports,
-		sources.buildProviderSync,
-	} {
-		if builder == nil {
-			continue
-		}
-		if err := build(builder(
-			ctx, cfg, dependencies.database, dependencies.runtimeRegistry,
-			dependencies.metrics, logger, workers,
-		)); err != nil {
-			dependencies.close()
-			return nil, errWorkerDependencyUnavailable
-		}
-	}
-	// Rescue coverage is registered exactly once, after every selected family
-	// has composed, against the union of all owned kinds. Registering it per
-	// family (the previous shape) made any multi-family selection unbootable:
-	// the first family registered rescue-only workers for the kinds it did not
-	// own, and the next family's real worker for one of those kinds collided on
-	// the shared river.Workers (CHAOS-3864). The shipped "heavy" group
-	// (investment, metrics, reports, workgraph) hit this on every start.
-	// A registry that failed to load is already reported by the job_registry
-	// readiness check; surfacing it here too would turn an attributable
-	// not-ready process into an opaque construction failure.
-	if dependencies.runtimeRegistry != nil {
-		if err := registerRescueCoverage(workers, dependencies.runtimeRegistry, active.handlers, active.ownedKinds...); err != nil {
-			_ = closeWorkerFamily(active)
-			dependencies.close()
-			return nil, errWorkerDependencyUnavailable
-		}
+	active, composeErr := composeSelectedWorkerFamilies(
+		ctx, cfg, dependencies.database, dependencies.runtimeRegistry,
+		dependencies.metrics, logger, workers, sources,
+	)
+	if composeErr != nil {
+		dependencies.close()
+		return nil, errWorkerDependencyUnavailable
 	}
 	if active.metricsSource != nil {
 		if err := registry.RegisterMetrics("provider_foundation", active.metricsSource); err != nil {
@@ -584,6 +521,86 @@ func configureWorkerDependenciesWithSources(
 		components: []lifecycle.Component{workerProcess}, budget: dependencies.workerDrainBudget, presence: presence,
 	})
 	return components, nil
+}
+
+// composeSelectedWorkerFamilies runs every selected family builder against one
+// shared river.Workers and then registers rescue coverage exactly once, over
+// the union of all owned kinds.
+//
+// The single-registration ordering is the whole point (CHAOS-3864): when each
+// family registered its own rescue coverage, the first family registered
+// rescue-only workers for every kind it did not own, and the next family's real
+// worker for one of those kinds hit River's duplicate-kind rejection -- so any
+// selection spanning two families, including the shipped "heavy" group, exited
+// at startup. Production and the multi-family boot test share this function so
+// the test cannot drift from the composition order it is proving.
+func composeSelectedWorkerFamilies(
+	ctx context.Context,
+	cfg config.Config,
+	database workerDatabase,
+	runtimeRegistry *jobruntime.Registry,
+	observer jobruntime.Observer,
+	logger *slog.Logger,
+	workers *river.Workers,
+	sources workerDependencySources,
+) (workerFamily, error) {
+	var active workerFamily
+	build := func(family workerFamily, err error) error {
+		if err != nil {
+			_ = closeWorkerFamily(active)
+			return err
+		}
+		combined, composeErr := composeWorkerFamily(active, family)
+		if composeErr != nil {
+			_ = closeWorkerFamily(family)
+			_ = closeWorkerFamily(active)
+			return composeErr
+		}
+		active = combined
+		return nil
+	}
+	for _, builder := range []workerFamilyBuilder{
+		sources.buildOperational,
+		sources.buildDaily,
+		sources.buildWorkgraph,
+		sources.buildSyncCoordinator,
+	} {
+		if builder == nil {
+			continue
+		}
+		if err := build(builder(cfg, database, runtimeRegistry, observer, logger, workers)); err != nil {
+			return workerFamily{}, err
+		}
+	}
+	for _, builder := range []func(
+		context.Context,
+		config.Config,
+		workerDatabase,
+		*jobruntime.Registry,
+		jobruntime.Observer,
+		*slog.Logger,
+		*river.Workers,
+	) (workerFamily, error){
+		sources.buildReports,
+		sources.buildProviderSync,
+	} {
+		if builder == nil {
+			continue
+		}
+		if err := build(builder(ctx, cfg, database, runtimeRegistry, observer, logger, workers)); err != nil {
+			return workerFamily{}, err
+		}
+	}
+	// A registry that failed to load is already reported by the job_registry
+	// readiness check; failing here too would turn an attributable not-ready
+	// process into an opaque construction failure.
+	if runtimeRegistry != nil {
+		if err := registerRescueCoverage(workers, runtimeRegistry, active.handlers, active.ownedKinds...); err != nil {
+			_ = closeWorkerFamily(active)
+			return workerFamily{}, err
+		}
+	}
+	return active, nil
 }
 
 func formatQueueBudgets(budgets []jobruntime.QueueBudget) string {

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -183,6 +183,12 @@ type workerFamily struct {
 	handlers []jobruntime.HandlerSpec
 	queues   []jobruntime.QueueBudget
 	cleanups []func() error
+	// ownedKinds names kinds this family registers real workers for WITHOUT
+	// reporting them as handler specs -- today only the sync coordinator's
+	// four bridge-backed kinds (syncdispatchruntime.RegisterWorkers). Rescue
+	// coverage must treat them as owned, so they have to survive composition
+	// rather than being consumed by a per-family rescue call.
+	ownedKinds []string
 	// metricsSource is an additional Prometheus fragment this family owns
 	// (e.g. providerfoundation's dev_health_provider_* family), registered
 	// with the health.Registry alongside "worker_runtime" once construction
@@ -495,6 +501,23 @@ func configureWorkerDependenciesWithSources(
 			return nil, errWorkerDependencyUnavailable
 		}
 	}
+	// Rescue coverage is registered exactly once, after every selected family
+	// has composed, against the union of all owned kinds. Registering it per
+	// family (the previous shape) made any multi-family selection unbootable:
+	// the first family registered rescue-only workers for the kinds it did not
+	// own, and the next family's real worker for one of those kinds collided on
+	// the shared river.Workers (CHAOS-3864). The shipped "heavy" group
+	// (investment, metrics, reports, workgraph) hit this on every start.
+	// A registry that failed to load is already reported by the job_registry
+	// readiness check; surfacing it here too would turn an attributable
+	// not-ready process into an opaque construction failure.
+	if dependencies.runtimeRegistry != nil {
+		if err := registerRescueCoverage(workers, dependencies.runtimeRegistry, active.handlers, active.ownedKinds...); err != nil {
+			_ = closeWorkerFamily(active)
+			dependencies.close()
+			return nil, errWorkerDependencyUnavailable
+		}
+	}
 	if active.metricsSource != nil {
 		if err := registry.RegisterMetrics("provider_foundation", active.metricsSource); err != nil {
 			_ = closeWorkerFamily(active)
@@ -625,6 +648,7 @@ func composeWorkerFamily(existing, additional workerFamily) (workerFamily, error
 		handlers:      append([]jobruntime.HandlerSpec(nil), existing.handlers...),
 		queues:        append([]jobruntime.QueueBudget(nil), existing.queues...),
 		cleanups:      append([]func() error(nil), existing.cleanups...),
+		ownedKinds:    append([]string(nil), existing.ownedKinds...),
 		metricsSource: existing.metricsSource,
 	}
 	result.cleanups = append(result.cleanups, additional.cleanups...)
@@ -655,6 +679,29 @@ func composeWorkerFamily(existing, additional workerFamily) (workerFamily, error
 		}
 		seen[handler.Kind] = struct{}{}
 		result.handlers = append(result.handlers, handler)
+	}
+	// ownedKinds share the kind namespace with handlers: a kind may be claimed
+	// exactly once across all families, whether it is reported as a handler
+	// spec or registered directly. Fail closed on any overlap so a duplicate
+	// registration surfaces here rather than as a River duplicate-kind panic.
+	for _, kind := range result.ownedKinds {
+		if kind == "" {
+			return workerFamily{}, errWorkerDependencyUnavailable
+		}
+		if _, duplicate := seen[kind]; duplicate {
+			return workerFamily{}, errWorkerDependencyUnavailable
+		}
+		seen[kind] = struct{}{}
+	}
+	for _, kind := range additional.ownedKinds {
+		if kind == "" {
+			return workerFamily{}, errWorkerDependencyUnavailable
+		}
+		if _, duplicate := seen[kind]; duplicate {
+			return workerFamily{}, errWorkerDependencyUnavailable
+		}
+		seen[kind] = struct{}{}
+		result.ownedKinds = append(result.ownedKinds, kind)
 	}
 	queues := make(map[string]struct{}, len(result.queues)+len(additional.queues))
 	for _, queue := range result.queues {

--- a/cmd/dev-health-worker/dependencies_test.go
+++ b/cmd/dev-health-worker/dependencies_test.go
@@ -1878,3 +1878,78 @@ func TestSelectedQueueCapabilityIsValidatedAcrossBuilderFamilies(t *testing.T) {
 		})
 	}
 }
+
+// TestOperationalDatabaseFailureCrashesInsteadOfIdlingUnready is CHAOS-3873
+// evidence. A DSN that cannot be opened for an operational reason used to
+// return nil, nil: the shell started, readiness failed forever, and nothing
+// terminated the process. Declared configuration rejections keep their
+// live-but-unready behaviour, because those surface as named readiness checks.
+func TestOperationalDatabaseFailureCrashesInsteadOfIdlingUnready(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	cfg := config.Config{
+		Queues:                 []string{"coverage", "heartbeat", "retention", "webhooks"},
+		WorkerQueueConcurrency: map[string]int{"coverage": 1, "heartbeat": 1, "retention": 1, "webhooks": 4},
+		RiverDatabaseSchema:    "river",
+	}
+
+	sources := productionWorkerDependencySources
+	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) {
+		return nil, errors.New("dial tcp 10.0.0.1:5432: connect: connection refused")
+	}
+	components, err := configureWorkerDependenciesWithSources(
+		context.Background(), cfg, health.NewRegistry(100*time.Millisecond), sources,
+	)
+	if !errors.Is(err, errWorkerDependencyUnavailable) || len(components) != 0 {
+		t.Fatalf("operational open failure = %v, %d components; want dependency refusal", err, len(components))
+	}
+	var coded interface{ DependencyReason() string }
+	if !errors.As(err, &coded) || coded.DependencyReason() != "worker_database_open_failed" {
+		t.Fatalf("reason code = %v, want worker_database_open_failed", err)
+	}
+
+	rejected := productionWorkerDependencySources
+	rejected.openDatabase = func(context.Context, config.Config) (workerDatabase, error) {
+		return nil, postgres.ErrQueueControlTransactionMode
+	}
+	if _, err := configureWorkerDependenciesWithSources(
+		context.Background(), cfg, health.NewRegistry(100*time.Millisecond), rejected,
+	); err != nil {
+		t.Fatalf("configuration rejection must stay live and unready, got %v", err)
+	}
+}
+
+// TestUnsetShutdownTimeoutIsDerivedFromTheSelectedQueues is CHAOS-3873
+// evidence: the 30s package default yields a NEGATIVE drain budget, so every
+// default-configured worker failed with the opaque sentinel. An unset timeout
+// is derived from the selection; a value the operator chose still fails closed.
+func TestUnsetShutdownTimeoutIsDerivedFromTheSelectedQueues(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	sources := productionWorkerDependencySources
+	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) {
+		return &fakeWorkerDatabase{}, nil
+	}
+	base := config.Config{
+		Queues:                 []string{"coverage", "heartbeat", "retention", "webhooks"},
+		WorkerQueueConcurrency: map[string]int{"coverage": 1, "heartbeat": 1, "retention": 1, "webhooks": 4},
+	}
+
+	defaulted := base
+	defaulted.ShutdownTimeout = config.DefaultShutdownTimeout
+	derived := buildWorkerDependencies(context.Background(), defaulted, sources)
+	defer derived.close()
+	if derived.startupErr != nil {
+		t.Fatalf("default-configured worker refused to start: %v", derived.startupErr)
+	}
+	if derived.workerDrainBudget <= 0 {
+		t.Fatalf("derived drain budget = %s, want a positive window", derived.workerDrainBudget)
+	}
+
+	chosen := base
+	chosen.ShutdownTimeout = config.DefaultShutdownTimeout
+	chosen.ShutdownTimeoutExplicit = true
+	refused := buildWorkerDependencies(context.Background(), chosen, sources)
+	defer refused.close()
+	if !errors.Is(refused.startupErr, errWorkerDependencyUnavailable) {
+		t.Fatalf("explicit 30s timeout = %v, want shutdown contract refusal", refused.startupErr)
+	}
+}

--- a/cmd/dev-health-worker/multi_family_boot_integration_test.go
+++ b/cmd/dev-health-worker/multi_family_boot_integration_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+)
+
+// workerFamilyQueues maps each worker family to the queues it owns, as the
+// shipped deployment.json groups them. Rescue-coverage registration used to be
+// per family on a shared river.Workers, so any selection spanning two of these
+// collided on a duplicate kind and exited at startup (CHAOS-3864).
+var workerFamilyQueues = map[string][]string{
+	"operational":     {"coverage", "heartbeat", "retention", "webhooks"},
+	"daily":           {"metrics"},
+	"workgraph":       {"workgraph", "investment"},
+	"syncCoordinator": {"sync"},
+	"reports":         {"reports"},
+	"providerSync":    {"sync_provider"},
+}
+
+// TestEveryMultiFamilyQueueSelectionBoots drives the real production builders
+// -- not the fake builders the composition unit tests use -- through
+// configureWorkerDependenciesWithSources for every two-family combination and
+// for each shipped multi-family group in deploy/go-workers/deployment.json.
+func TestEveryMultiFamilyQueueSelectionBoots(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	t.Cleanup(cancel)
+
+	postgres, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = postgres.Close(context.Background()) })
+	admin, err := pgxpool.New(ctx, postgres.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(admin.Close)
+	prepareMultiReplicaDatabase(t, ctx, admin)
+
+	clickhouse, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = clickhouse.Close(context.Background()) })
+
+	bridge := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(`{}`))
+	}))
+	t.Cleanup(bridge.Close)
+
+	families := make([]string, 0, len(workerFamilyQueues))
+	for name := range workerFamilyQueues {
+		families = append(families, name)
+	}
+	sort.Strings(families)
+
+	type bootCase struct {
+		name   string
+		queues []string
+	}
+	cases := make([]bootCase, 0, len(families)*len(families))
+	for i := 0; i < len(families); i++ {
+		for j := i + 1; j < len(families); j++ {
+			queues := append(append([]string(nil), workerFamilyQueues[families[i]]...), workerFamilyQueues[families[j]]...)
+			cases = append(cases, bootCase{name: families[i] + "+" + families[j], queues: queues})
+		}
+	}
+	// The shipped groups, including "heavy", which spans three families.
+	cases = append(cases,
+		bootCase{name: "shipped/heavy", queues: []string{"investment", "metrics", "reports", "workgraph"}},
+		bootCase{name: "shipped/ops", queues: []string{"coverage", "heartbeat", "retention", "webhooks"}},
+		bootCase{name: "shipped/sync", queues: []string{"sync", "sync_provider"}},
+	)
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			family, err := bootQueueSelection(t, ctx, postgres.URI, clickhouse.URI, bridge.URL, testCase.queues)
+			if err != nil {
+				t.Fatalf("queue selection %s did not compose: %v", strings.Join(testCase.queues, ","), err)
+			}
+			if len(family.handlers) == 0 {
+				t.Fatalf("queue selection %s registered no handlers", strings.Join(testCase.queues, ","))
+			}
+			// No queue may be budgeted twice: two families both claiming one
+			// queue is the composition-level shape of the same collision.
+			budgeted := make(map[string]int, len(family.queues))
+			for _, budget := range family.queues {
+				budgeted[budget.Queue]++
+			}
+			for _, queue := range testCase.queues {
+				if budgeted[queue] > 1 {
+					t.Fatalf("queue %q budgeted %d times in selection %s",
+						queue, budgeted[queue], strings.Join(testCase.queues, ","))
+				}
+				// sync_provider is owned by the provider-sync family, which
+				// stays unconstructed until a WORKER_*_ENABLED route switch is
+				// turned on. Every other queue has a default-on owner and must
+				// be budgeted exactly once.
+				if queue != providerUnitQueue && budgeted[queue] != 1 {
+					t.Fatalf("queue %q budgeted %d times in selection %s, want exactly 1",
+						queue, budgeted[queue], strings.Join(testCase.queues, ","))
+				}
+			}
+		})
+	}
+}
+
+func bootQueueSelection(
+	t *testing.T,
+	ctx context.Context,
+	postgresURI string,
+	clickhouseURI string,
+	bridgeURL string,
+	queues []string,
+) (workerFamily, error) {
+	t.Helper()
+	domain, err := pgxpool.New(ctx, postgresURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queuePool, err := pgxpool.New(ctx, postgresURI)
+	if err != nil {
+		domain.Close()
+		t.Fatal(err)
+	}
+	database := &postgresWorkerDatabase{pools: &postgresstore.RuntimePools{Domain: domain, QueueControl: queuePool}}
+	t.Cleanup(database.Close)
+
+	concurrency := make(map[string]int, len(queues))
+	for _, queue := range queues {
+		concurrency[queue] = 1
+	}
+	cfg := config.Config{
+		Service:                        "dev-health-worker",
+		Queues:                         append([]string(nil), queues...),
+		WorkerQueueConcurrency:         concurrency,
+		WorkerInstanceID:               uuid.NewString(),
+		RiverDatabaseSchema:            "river",
+		ClickHouseURI:                  secrets.NewValue(clickhouseURI),
+		OperationalBridgeURL:           bridgeURL,
+		OperationalBridgeToken:         secrets.NewValue("multi-family-token"),
+		OperationalBridgeTimeout:       20 * time.Second,
+		OperationalBridgeAllowInsecure: true,
+	}
+	registryTree, err := jobruntime.Load(filepath.Join("contracts", "jobs", "v1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	metrics, err := buildWorkerMetrics(ctx, cfg, registryTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	workers := river.NewWorkers()
+	family, err := composeSelectedWorkerFamilies(
+		ctx, cfg, database, registryTree, metrics, logger, workers, productionWorkerDependencySources,
+	)
+	if err == nil {
+		t.Cleanup(func() { _ = closeWorkerFamily(family) })
+	}
+	return family, err
+}

--- a/cmd/dev-health-worker/multi_replica_outage_integration_test.go
+++ b/cmd/dev-health-worker/multi_replica_outage_integration_test.go
@@ -1,0 +1,225 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// databaseOutageWindow is the simulated domain-database outage. It is longer
+// than the presence TTL's renewal interval and long enough for several budget
+// and idempotency renewal attempts to fail, which is the point: none of those
+// failures may terminalize a job or kill a process.
+// It stays well inside the parked job's 30s contract timeout: a handler held
+// past that legitimately exhausts its single attempt, which would prove
+// nothing about lease handling.
+const databaseOutageWindow = 15 * time.Second
+
+// workerPresenceTTLProof is longer than the 30s presence TTL, so surviving
+// presence rows prove renewal is still running rather than merely un-expired.
+const workerPresenceTTLProof = 35 * time.Second
+
+// TestMultiReplicaFleetSurvivesDatabaseOutage is the CHAOS-3864/3865/3866/3873
+// lane gate. Two replicas run a queue group with jobs in flight, the domain
+// database disappears for 15 seconds, and the fleet must come back with zero
+// terminalized jobs, no process exit, and a clean drain.
+//
+// Before this lane, each of those three failures fired on its own: one failed
+// budget-lease renewal cancelled the handler, the resulting cancellation was
+// stamped "terminal" so the River retry was auto-cancelled forever, and the
+// first failed presence heartbeat was fatal to the process.
+func TestMultiReplicaFleetSurvivesDatabaseOutage(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+
+	postgres, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = postgres.Close(context.Background()) })
+
+	// The admin pool bypasses the proxy so the test can still observe state
+	// while the workers' database link is severed.
+	admin, err := pgxpool.New(ctx, postgres.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(admin.Close)
+	prepareMultiReplicaDatabase(t, ctx, admin)
+
+	outage := startDatabaseCutover(t, postgres.URI)
+	bridge := newMultiReplicaBridge()
+	server := httptest.NewServer(http.HandlerFunc(bridge.serveHTTP))
+	t.Cleanup(server.Close)
+	registry, err := jobruntime.Load(filepath.Join("contracts", "jobs", "v1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	first := newOperationalReplica(t, ctx, outage.uri, server.URL, registry, logger)
+	second := newOperationalReplica(t, ctx, outage.uri, server.URL, registry, logger)
+	t.Cleanup(func() { first.close(t); second.close(t) })
+	first.start(t, ctx)
+	second.start(t, ctx)
+	assertWorkerPresence(t, ctx, admin, "operations-shared",
+		[]string{"coverage", "heartbeat", "retention", "webhooks"}, 2, 0)
+
+	firstJob := insertHeartbeat(t, ctx, first.client, 1)
+	secondJob := insertHeartbeat(t, ctx, first.client, 2)
+	// One handler is parked inside the bridge for the whole outage; the other
+	// is claimed by the sibling replica.
+	bridge.waitForFirst(t)
+	waitFor(t, 30*time.Second, func() (bool, error) {
+		row, err := readRiverJob(ctx, admin, firstJob.Job.ID)
+		return err == nil && len(row.AttemptedBy) == 1, err
+	})
+
+	outage.cut()
+	time.Sleep(databaseOutageWindow)
+	outage.restore()
+
+	// Presence is observability-only, so a failed heartbeat must never reach
+	// lifecycle.Runtime, which treats any component error as fatal. One error
+	// here is a fleet-wide restart in production.
+	for _, replica := range []*operationalReplica{first, second} {
+		select {
+		case err := <-replica.presence.Errors():
+			t.Fatalf("presence reported a fatal error during the outage: %v", err)
+		default:
+		}
+	}
+
+	bridge.release()
+	waitForCompleted(t, ctx, admin, firstJob.Job.ID, secondJob.Job.ID)
+
+	// Zero terminalized jobs: no domain run may be stamped terminal, and no
+	// River job may have been cancelled or discarded.
+	var terminalRuns int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*)::integer FROM public.worker_job_runs WHERE status = 'terminal'`,
+	).Scan(&terminalRuns); err != nil {
+		t.Fatal(err)
+	}
+	if terminalRuns != 0 {
+		t.Fatalf("database outage terminalized %d job runs, want 0", terminalRuns)
+	}
+	var cancelled int
+	if err := admin.QueryRow(ctx,
+		`SELECT count(*)::integer FROM river.river_job WHERE state IN ('cancelled', 'discarded')`,
+	).Scan(&cancelled); err != nil {
+		t.Fatal(err)
+	}
+	if cancelled != 0 {
+		t.Fatalf("database outage cancelled or discarded %d River jobs, want 0", cancelled)
+	}
+
+	// Each logical job produced exactly one external effect despite the outage.
+	if effects := bridge.effects(); effects[heartbeatSchedule(1)] != 1 || effects[heartbeatSchedule(2)] != 1 {
+		t.Fatalf("effects = %#v, want exactly one per logical job", effects)
+	}
+
+	// The fleet is still alive. Waiting past the presence TTL before asserting
+	// is what makes this meaningful: a renewal loop that exited during the
+	// outage would leave rows that are merely not yet expired, and only a
+	// still-running renewer keeps them live this long. This runs after the
+	// jobs finish so no handler is parked past its 30s contract timeout.
+	time.Sleep(workerPresenceTTLProof)
+	assertWorkerPresence(t, ctx, admin, "operations-shared",
+		[]string{"coverage", "heartbeat", "retention", "webhooks"}, 2, 0)
+
+	// ...and the fleet drains cleanly.
+	first.stopAndCancel(t, ctx)
+	second.stopAndCancel(t, ctx)
+}
+
+// databaseCutover is a TCP proxy in front of PostgreSQL. Cutting it severs
+// every worker connection and refuses new ones, which is what a failover or a
+// PgBouncer restart looks like to the worker: the container keeps running, so
+// the test can still observe state through a direct admin pool.
+type databaseCutover struct {
+	uri      string
+	target   string
+	listener net.Listener
+
+	mu    sync.Mutex
+	open  bool
+	conns []net.Conn
+}
+
+func startDatabaseCutover(t *testing.T, upstream string) *databaseCutover {
+	t.Helper()
+	parsed, err := url.Parse(upstream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxied := *parsed
+	proxied.Host = listener.Addr().String()
+	cutover := &databaseCutover{
+		uri: proxied.String(), target: parsed.Host, listener: listener, open: true,
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go cutover.serve()
+	return cutover
+}
+
+func (cutover *databaseCutover) serve() {
+	for {
+		client, err := cutover.listener.Accept()
+		if err != nil {
+			return
+		}
+		cutover.mu.Lock()
+		open := cutover.open
+		cutover.mu.Unlock()
+		if !open {
+			_ = client.Close()
+			continue
+		}
+		upstream, err := net.Dial("tcp", cutover.target)
+		if err != nil {
+			_ = client.Close()
+			continue
+		}
+		cutover.mu.Lock()
+		cutover.conns = append(cutover.conns, client, upstream)
+		cutover.mu.Unlock()
+		go func() { _, _ = io.Copy(upstream, client); _ = upstream.Close() }()
+		go func() { _, _ = io.Copy(client, upstream); _ = client.Close() }()
+	}
+}
+
+func (cutover *databaseCutover) cut() {
+	cutover.mu.Lock()
+	defer cutover.mu.Unlock()
+	cutover.open = false
+	for _, conn := range cutover.conns {
+		_ = conn.Close()
+	}
+	cutover.conns = nil
+}
+
+func (cutover *databaseCutover) restore() {
+	cutover.mu.Lock()
+	defer cutover.mu.Unlock()
+	cutover.open = true
+}

--- a/cmd/dev-health-worker/operational.go
+++ b/cmd/dev-health-worker/operational.go
@@ -183,9 +183,6 @@ func buildOperationalWorker(
 			registered = append(registered, adapter.Spec())
 		}
 	}
-	if err := registerRescueCoverage(workers, registry, registered); err != nil {
-		return workerFamily{}, errWorkerDependencyUnavailable
-	}
 	budgets := selectedQueueBudgets(cfg.Queues, operationalQueues, cfg.WorkerQueueConcurrency)
 	return workerFamily{
 		handlers: registered,

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -794,10 +794,6 @@ func constructProviderSyncWorkerWithDependencies(
 		closeDependencies()
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}
-	if err := registerRescueCoverage(workers, registry, []jobruntime.HandlerSpec{adapter.Spec()}); err != nil {
-		closeDependencies()
-		return workerFamily{}, errWorkerDependencyUnavailable
-	}
 	return workerFamily{
 		handlers: []jobruntime.HandlerSpec{adapter.Spec()},
 		queues: selectedQueueBudgets(

--- a/cmd/dev-health-worker/reports.go
+++ b/cmd/dev-health-worker/reports.go
@@ -99,10 +99,6 @@ func buildReportWorker(
 		closeClickHouse()
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}
-	if err := registerRescueCoverage(workers, registry, specs); err != nil {
-		closeClickHouse()
-		return workerFamily{}, errWorkerDependencyUnavailable
-	}
 	return workerFamily{
 		handlers: specs,
 		queues: selectedQueueBudgets(

--- a/cmd/dev-health-worker/rescue_workers_test.go
+++ b/cmd/dev-health-worker/rescue_workers_test.go
@@ -42,7 +42,14 @@ func TestRegisterRescueCoverageAddsCoordinatorKindsToPartialClient(t *testing.T)
 	}
 }
 
-func TestEveryWorkerFamilyRegistersGlobalRescueCoverageOnSharedWorkers(t *testing.T) {
+// Rescue coverage must be registered exactly once, centrally, AFTER every
+// selected family has composed -- never per family. The per-family shape this
+// test used to lock in was the CHAOS-3864 boot collision: the first family
+// registered rescue-only workers for every kind it did not own on the shared
+// river.Workers, and the next family's real worker for one of those kinds hit
+// River's duplicate-kind rejection, so any multi-family queue selection
+// (including the shipped "heavy" group) exited at startup.
+func TestWorkerFamiliesDelegateRescueCoverageToCentralRegistration(t *testing.T) {
 	for _, path := range []string{
 		"daily.go",
 		"operational.go",
@@ -51,7 +58,6 @@ func TestEveryWorkerFamilyRegistersGlobalRescueCoverageOnSharedWorkers(t *testin
 		"sync_dispatch.go",
 		"workgraph.go",
 	} {
-		path := path
 		t.Run(path, func(t *testing.T) {
 			parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
 			if err != nil {
@@ -71,18 +77,47 @@ func TestEveryWorkerFamilyRegistersGlobalRescueCoverageOnSharedWorkers(t *testin
 					}
 				case *ast.Ident:
 					if function.Name == "registerRescueCoverage" {
-						if len(call.Args) < 2 || identName(call.Args[0]) != "workers" || identName(call.Args[1]) != "registry" {
-							t.Fatalf("%s rescue coverage is not attached to its constructed workers and registry", path)
-						}
 						rescueRegistrations++
 					}
 				}
 				return true
 			})
-			if clients != 0 || rescueRegistrations != 1 {
-				t.Fatalf("%s family clients=%d rescue registrations=%d", path, clients, rescueRegistrations)
+			if clients != 0 || rescueRegistrations != 0 {
+				t.Fatalf("%s family clients=%d rescue registrations=%d, want 0 and 0", path, clients, rescueRegistrations)
 			}
 		})
+	}
+}
+
+func TestRescueCoverageIsRegisteredExactlyOnceAfterComposition(t *testing.T) {
+	parsed, err := parser.ParseFile(token.NewFileSet(), "dependencies.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var registrations int
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		function, ok := call.Fun.(*ast.Ident)
+		if !ok || function.Name != "registerRescueCoverage" {
+			return true
+		}
+		registrations++
+		// The union of every composed family's owned kinds -- not one
+		// family's -- is what makes the registration collision-free.
+		if len(call.Args) < 3 || identName(call.Args[0]) != "workers" {
+			t.Fatalf("rescue coverage is not attached to the shared workers: %#v", call.Args)
+		}
+		if selector, isSelector := call.Args[2].(*ast.SelectorExpr); !isSelector ||
+			identName(selector.X) != "active" || selector.Sel.Name != "handlers" {
+			t.Fatal("rescue coverage is not computed from the composed family's handlers")
+		}
+		return true
+	})
+	if registrations != 1 {
+		t.Fatalf("dependencies.go rescue registrations=%d, want exactly 1", registrations)
 	}
 }
 

--- a/cmd/dev-health-worker/sync_dispatch.go
+++ b/cmd/dev-health-worker/sync_dispatch.go
@@ -295,19 +295,17 @@ func buildSyncCoordinatorWorker(
 		}
 		handlers = []jobruntime.HandlerSpec{autoimport}
 	}
-	if err := registerRescueCoverage(
-		workers,
-		registry,
-		handlers,
-		syncdispatchcontract.KindDispatchSyncRun,
-		syncdispatchcontract.KindFinalizeSyncRun,
-		syncdispatchcontract.KindPostSync,
-		syncdispatchcontract.KindReferenceDiscovery,
-	); err != nil {
-		return workerFamily{}, errWorkerDependencyUnavailable
-	}
 	return workerFamily{
 		handlers: handlers,
 		queues:   queues,
+		// RegisterWorkers above registered real workers for these four kinds
+		// without reporting them as handler specs; rescue coverage (now applied
+		// once, centrally) must still treat them as owned.
+		ownedKinds: []string{
+			syncdispatchcontract.KindDispatchSyncRun,
+			syncdispatchcontract.KindFinalizeSyncRun,
+			syncdispatchcontract.KindPostSync,
+			syncdispatchcontract.KindReferenceDiscovery,
+		},
 	}, nil
 }

--- a/cmd/dev-health-worker/workgraph.go
+++ b/cmd/dev-health-worker/workgraph.go
@@ -65,9 +65,6 @@ func buildWorkgraphWorker(cfg config.Config, database workerDatabase, registry *
 		}
 		registered = append(registered, spec)
 	}
-	if err := registerRescueCoverage(workers, registry, registered); err != nil {
-		return workerFamily{}, errWorkerDependencyUnavailable
-	}
 	budgets := selectedQueueBudgets(
 		cfg.Queues, []string{"workgraph", "investment"}, cfg.WorkerQueueConcurrency,
 	)

--- a/internal/jobruntime/adapter.go
+++ b/internal/jobruntime/adapter.go
@@ -98,6 +98,13 @@ type ClaimRequest struct {
 type Completion struct {
 	Result   Result
 	Category ErrorCategory
+	// Terminal separates the two outcomes that both arrive as ResultCancel:
+	// an explicit domain-terminal decision (validation failure, permanent
+	// error, ClaimTerminal readback), which must never run again, from a
+	// process drain or budget-lease loss, which must stay retryable. Without
+	// it the idempotency store stamped every cancellation "terminal" and the
+	// River retry was auto-cancelled forever (CHAOS-3865).
+	Terminal bool
 }
 
 type IdempotencyClaim interface {
@@ -283,7 +290,9 @@ func (adapter *Adapter[T]) execute(parent context.Context, job *river.Job[T], la
 			returned = &safeError{category: CategoryPanic}
 			observe(func() { adapter.observer.JobPanicked(parent, labels) })
 			if claim != nil && claim.State() == ClaimProceed {
-				if err := finishClaim(parent, claim, Completion{Result: choice.result, Category: choice.category}); err != nil {
+				if err := finishClaim(parent, claim, Completion{
+					Result: choice.result, Category: choice.category, Terminal: choice.cancel,
+				}); err != nil {
 					choice = retryDecision(CategoryIdempotency, attempt, adapter.descriptor.MaxAttempts)
 					returned = &safeError{category: CategoryIdempotency}
 				}
@@ -408,14 +417,18 @@ func (adapter *Adapter[T]) execute(parent context.Context, job *river.Job[T], la
 		),
 	}
 	handlerErr := adapter.handler.Work(ctx, execution)
-	if handlerErr == nil && ctx.Err() != nil {
-		handlerErr = ctx.Err()
-	}
+	// A handler that returned success completed its work; a drain or lease
+	// loss that lands between that return and this line must not rewrite the
+	// outcome. Promoting ctx.Err() here used to turn a succeeded run into a
+	// cancellation -- and, before the runStatus fix below, into a permanently
+	// terminal one (CHAOS-3865).
 	choice = classify(ctx, handlerErr, job.Attempt, adapter.descriptor.MaxAttempts)
 	if choice.category == CategoryTerminalDomain {
 		observe(func() { adapter.observer.DomainMismatch(ctx, envelope.Domain.Type) })
 	}
-	if err := finishClaim(ctx, claim, Completion{Result: choice.result, Category: choice.category}); err != nil {
+	if err := finishClaim(ctx, claim, Completion{
+		Result: choice.result, Category: choice.category, Terminal: choice.cancel,
+	}); err != nil {
 		choice = classify(ctx, mark(CategoryIdempotency, err, false), job.Attempt, adapter.descriptor.MaxAttempts)
 		return choice, envelope, err
 	}

--- a/internal/jobruntime/adapter_test.go
+++ b/internal/jobruntime/adapter_test.go
@@ -26,6 +26,7 @@ func TestAdapterMiddlewareOutcomesAreSafeAndDeterministic(t *testing.T) {
 		handler         HandlerFunc[RetentionCleanupArgs]
 		wantResult      Result
 		wantCategory    ErrorCategory
+		wantTerminal    bool
 		wantCancelError bool
 		wantPanic       bool
 		wantDomain      bool
@@ -98,7 +99,23 @@ func TestAdapterMiddlewareOutcomesAreSafeAndDeterministic(t *testing.T) {
 			handler: func(ctx context.Context, _ *Execution[RetentionCleanupArgs]) error {
 				return ctx.Err()
 			},
-			wantResult: ResultCancel, wantCategory: CategoryCancelled,
+			// A drain must leave the run retryable, never terminal.
+			wantResult: ResultCancel, wantCategory: CategoryCancelled, wantTerminal: false,
+		},
+		{
+			// CHAOS-3865: a drain or budget-lease loss landing between the
+			// handler's successful return and classification must not rewrite
+			// the outcome -- the work is already done.
+			name: "success survives late cancellation", attempt: 1, claimState: ClaimProceed,
+			parent: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			handler: func(context.Context, *Execution[RetentionCleanupArgs]) error {
+				return nil
+			},
+			wantResult: ResultSuccess, wantCategory: CategoryNone,
 		},
 		{
 			name: "terminal domain", attempt: 1, claimState: ClaimTerminal,
@@ -122,7 +139,7 @@ func TestAdapterMiddlewareOutcomesAreSafeAndDeterministic(t *testing.T) {
 			handler: func(context.Context, *Execution[RetentionCleanupArgs]) error {
 				return errors.New("unclassified-secret")
 			},
-			wantResult: ResultCancel, wantCategory: CategoryPermanent, wantCancelError: true,
+			wantResult: ResultCancel, wantCategory: CategoryPermanent, wantTerminal: true, wantCancelError: true,
 		},
 	}
 
@@ -180,6 +197,10 @@ func TestAdapterMiddlewareOutcomesAreSafeAndDeterministic(t *testing.T) {
 			if test.claimState == ClaimProceed {
 				if len(claim.completions) != 1 || claim.completions[0].Result != test.wantResult {
 					t.Fatalf("claim completions: %+v", claim.completions)
+				}
+				if claim.completions[0].Terminal != test.wantTerminal {
+					t.Fatalf("completion terminal = %v, want %v (%+v)",
+						claim.completions[0].Terminal, test.wantTerminal, claim.completions[0])
 				}
 				if claim.finishContextErr != nil {
 					t.Fatalf("claim finalized with cancelled context: %v", claim.finishContextErr)

--- a/internal/jobruntime/budget_postgres.go
+++ b/internal/jobruntime/budget_postgres.go
@@ -147,6 +147,10 @@ func (store *PostgresConcurrencyBudget) tryAcquire(
 			return nil, -1, 0, errConcurrencyBudgetUnavailable
 		}
 	}
+	// Captured before the INSERT so the locally-tracked expiry can only be
+	// EARLIER than the row's statement_timestamp()-based one: renewal retries
+	// must give up before the real lease expires, never after.
+	acquiredAt := time.Now()
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO public.worker_concurrency_leases (
 			id, budget_key, job_kind, concurrency_scope, organization_id,
@@ -165,6 +169,7 @@ func (store *PostgresConcurrencyBudget) tryAcquire(
 		pool:          store.pool,
 		id:            id,
 		token:         token,
+		leasedAt:      acquiredAt,
 		leaseDuration: store.leaseDuration,
 		stopRenewal:   make(chan struct{}),
 		renewalDone:   make(chan struct{}),
@@ -178,6 +183,7 @@ type postgresConcurrencyLease struct {
 	pool          *pgxpool.Pool
 	id            uuid.UUID
 	token         uuid.UUID
+	leasedAt      time.Time
 	leaseDuration time.Duration
 	stopRenewal   chan struct{}
 	renewalDone   chan struct{}
@@ -228,11 +234,15 @@ func (lease *postgresConcurrencyLease) renew() {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	defer close(lease.renewalDone)
+	// The instant the lease stops being ours if no renewal succeeds. Renewal
+	// retries until this passes rather than surrendering on the first error.
+	expiry := lease.leasedAt.Add(lease.leaseDuration)
 	for {
 		select {
 		case <-lease.stopRenewal:
 			return
 		case <-ticker.C:
+			attemptedAt := time.Now()
 			ctx, cancel := context.WithTimeout(context.Background(), renewalQueryTimeout(interval))
 			result, err := lease.pool.Exec(ctx, `
 				UPDATE public.worker_concurrency_leases
@@ -241,7 +251,22 @@ func (lease *postgresConcurrencyLease) renew() {
 				WHERE id = $1 AND owner_token = $2 AND lease_expires_at > statement_timestamp()`,
 				lease.id, lease.token, int64(lease.leaseDuration/time.Second))
 			cancel()
-			if err != nil || result.RowsAffected() != 1 {
+			switch {
+			case err == nil && result.RowsAffected() == 1:
+				expiry = attemptedAt.Add(lease.leaseDuration)
+			case err == nil:
+				// The UPDATE only matches a live row we still own, so zero rows
+				// means the lease is provably gone -- another owner took it or
+				// it already expired. Nothing to wait for.
+				lease.markLost()
+				return
+			case time.Now().Before(expiry):
+				// A transient failure -- a query timeout, a PgBouncer restart,
+				// a failover -- is not lease loss. The interval is a third of
+				// the TTL, so there are further attempts left before the lease
+				// actually expires; cancelling the handler on the first error
+				// terminalized 2-hour jobs on any DB blip (CHAOS-3866).
+			default:
 				lease.markLost()
 				return
 			}

--- a/internal/jobruntime/idempotency_postgres.go
+++ b/internal/jobruntime/idempotency_postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -95,7 +96,7 @@ func (store *PostgresIdempotency) Begin(ctx context.Context, request ClaimReques
 		if err := tx.Commit(ctx); err != nil {
 			return nil, errIdempotencyUnavailable
 		}
-		return &postgresClaim{store: store, id: runID, token: token, state: ClaimProceed}, nil
+		return newProceedingClaim(store, runID, token, now), nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return nil, errIdempotencyUnavailable
@@ -142,7 +143,7 @@ func (store *PostgresIdempotency) Begin(ctx context.Context, request ClaimReques
 		if err := tx.Commit(ctx); err != nil {
 			return nil, errIdempotencyUnavailable
 		}
-		return &postgresClaim{store: store, id: runID, token: token, state: ClaimProceed}, nil
+		return newProceedingClaim(store, runID, token, now), nil
 	default:
 		return nil, errIdempotencyUnavailable
 	}
@@ -153,6 +154,80 @@ type postgresClaim struct {
 	id    uuid.UUID
 	token uuid.UUID
 	state ClaimState
+
+	stopRenewal chan struct{}
+	renewalDone chan struct{}
+	stopOnce    sync.Once
+}
+
+// newProceedingClaim starts lease renewal alongside the claim.
+func newProceedingClaim(
+	store *PostgresIdempotency, runID uuid.UUID, token uuid.UUID, leasedAt time.Time,
+) *postgresClaim {
+	claim := &postgresClaim{
+		store: store, id: runID, token: token, state: ClaimProceed,
+		stopRenewal: make(chan struct{}), renewalDone: make(chan struct{}),
+	}
+	go claim.renew(leasedAt)
+	return claim
+}
+
+// renew keeps this claim's lease ahead of the clock for as long as the handler
+// runs. The lease is 10 minutes but registered timeouts reach 2 hours, and the
+// running-with-expired-lease branch in Begin lets a duplicate claim take over
+// concurrently with the still-running original -- the exact double execution
+// this store exists to fence (CHAOS-3866). Renewing bounds crash takeover at
+// one lease rather than one job timeout, which simply leasing for the full
+// descriptor timeout would not.
+//
+// Renewal is token-fenced and retries transient failures until the lease could
+// actually have expired, matching the budget lease's semantics.
+func (claim *postgresClaim) renew(leasedAt time.Time) {
+	defer close(claim.renewalDone)
+	interval := claim.store.leaseDuration / 3
+	if interval < 100*time.Millisecond {
+		interval = 100 * time.Millisecond
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	expiry := leasedAt.Add(claim.store.leaseDuration)
+	for {
+		select {
+		case <-claim.stopRenewal:
+			return
+		case <-ticker.C:
+			attemptedAt := claim.store.now().UTC()
+			ctx, cancel := context.WithTimeout(context.Background(), renewalQueryTimeout(interval))
+			command, err := claim.store.pool.Exec(ctx, `
+				UPDATE public.worker_job_runs
+				SET lease_expires_at = $1, updated_at = $2
+				WHERE id = $3 AND claim_token = $4 AND status = 'running'`,
+				attemptedAt.Add(claim.store.leaseDuration), attemptedAt, claim.id, claim.token)
+			cancel()
+			switch {
+			case err == nil && command.RowsAffected() == 1:
+				expiry = attemptedAt.Add(claim.store.leaseDuration)
+			case err == nil:
+				// The run is no longer ours: it finished, or another claim
+				// fenced us out. Nothing left to renew.
+				return
+			case attemptedAt.Before(expiry):
+				// Transient database failure with lease time still left.
+			default:
+				return
+			}
+		}
+	}
+}
+
+func (claim *postgresClaim) stopRenewing() {
+	if claim == nil || claim.stopRenewal == nil {
+		return
+	}
+	claim.stopOnce.Do(func() { close(claim.stopRenewal) })
+	if claim.renewalDone != nil {
+		<-claim.renewalDone
+	}
 }
 
 func (claim *postgresClaim) State() ClaimState {
@@ -168,6 +243,9 @@ func (claim *postgresClaim) Finish(ctx context.Context, completion Completion) e
 		claim.store.now == nil {
 		return errIdempotencyUnavailable
 	}
+	// Stop renewal before the terminal write so a renewal in flight cannot
+	// reinstate a lease on a run this call is about to finish.
+	claim.stopRenewing()
 	status, err := runStatus(completion)
 	if err != nil {
 		return errIdempotencyUnavailable

--- a/internal/jobruntime/idempotency_postgres.go
+++ b/internal/jobruntime/idempotency_postgres.go
@@ -206,7 +206,16 @@ func runStatus(completion Completion) (string, error) {
 		return "succeeded", nil
 	case ResultRetry:
 		return "retryable", nil
-	case ResultDiscard, ResultCancel:
+	case ResultCancel:
+		// Only an explicit domain-terminal decision is terminal. A drain or a
+		// budget-lease loss also arrives as ResultCancel, and River will retry
+		// it -- stamping those "terminal" made Begin return ClaimTerminal on
+		// the retry, which the adapter auto-cancelled forever (CHAOS-3865).
+		if completion.Terminal {
+			return "terminal", nil
+		}
+		return "retryable", nil
+	case ResultDiscard:
 		return "terminal", nil
 	default:
 		return "", fmt.Errorf("unsupported completion result")

--- a/internal/jobruntime/idempotency_postgres_integration_test.go
+++ b/internal/jobruntime/idempotency_postgres_integration_test.go
@@ -77,7 +77,20 @@ func TestPostgresIdempotencyPreservesDuplicateAndCrashRecoverySemantics(t *testi
 	if err != nil || nextAttempt.State() != ClaimProceed {
 		t.Fatalf("next retry Begin = %v, %v", nextAttempt, err)
 	}
-	if err := nextAttempt.Finish(ctx, Completion{Result: ResultCancel, Category: CategoryPermanent}); err != nil {
+	// A drain or budget-lease loss also arrives as ResultCancel but is not
+	// terminal: the run must stay reclaimable so River's retry can execute it
+	// (CHAOS-3865). classify() sets Terminal from the same cancel flag.
+	if err := nextAttempt.Finish(ctx, Completion{Result: ResultCancel, Category: CategoryCancelled}); err != nil {
+		t.Fatalf("finish drained claim: %v", err)
+	}
+	afterDrain, err := store.Begin(ctx, retryRequest)
+	if err != nil || afterDrain.State() != ClaimProceed {
+		t.Fatalf("post-drain Begin = %v, %v", afterDrain, err)
+	}
+	// An explicit domain-terminal outcome still fences every later claim.
+	if err := afterDrain.Finish(ctx, Completion{
+		Result: ResultCancel, Category: CategoryPermanent, Terminal: true,
+	}); err != nil {
 		t.Fatalf("finish terminal claim: %v", err)
 	}
 	terminal, err := store.Begin(ctx, retryRequest)
@@ -124,5 +137,66 @@ func idempotencyRequest(key string) ClaimRequest {
 		Policy:  "maintenance_run_checkpoint",
 		JobID:   42,
 		Attempt: 1,
+	}
+}
+
+// TestPostgresIdempotencyRenewsLeaseWhileTheRunIsHealthy is CHAOS-3866
+// evidence. The lease (10 minutes in production) is shorter than registered
+// timeouts (up to 2 hours), and Begin's running-with-expired-lease branch
+// hands a duplicate a concurrent claim on the same run -- the double execution
+// this store exists to fence. Renewal must keep a healthy run's lease ahead of
+// the clock for as long as it executes.
+func TestPostgresIdempotencyRenewsLeaseWhileTheRunIsHealthy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := instance.Close(context.Background()); err != nil {
+			t.Errorf("close PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createIdempotencyTable(t, ctx, pool)
+
+	store, err := NewPostgresIdempotency(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Renewal ticks every leaseDuration/3, so the run outlives its original
+	// lease several times over during this test.
+	store.leaseDuration = 1500 * time.Millisecond
+	request := idempotencyRequest("retention:worker_job_long_run:2026-07-16")
+
+	claim, err := store.Begin(ctx, request)
+	if err != nil || claim.State() != ClaimProceed {
+		t.Fatalf("Begin = %v, %v", claim, err)
+	}
+
+	// Well past the original lease: without renewal the row would now be
+	// claimable by a duplicate running concurrently with this one.
+	time.Sleep(3 * store.leaseDuration)
+
+	var leaseAhead bool
+	if err := pool.QueryRow(ctx,
+		`SELECT lease_expires_at > statement_timestamp() FROM public.worker_job_runs`,
+	).Scan(&leaseAhead); err != nil {
+		t.Fatal(err)
+	}
+	if !leaseAhead {
+		t.Fatal("lease was not renewed while the run was still executing")
+	}
+	duplicate, err := store.Begin(ctx, request)
+	if err != nil || duplicate.State() != ClaimAlreadyComplete {
+		t.Fatalf("duplicate claimed a healthy long-running job: %v, %v", duplicate, err)
+	}
+	if err := claim.Finish(ctx, Completion{Result: ResultSuccess, Category: CategoryNone}); err != nil {
+		t.Fatalf("finish renewed claim: %v", err)
 	}
 }

--- a/internal/jobruntime/idempotency_postgres_test.go
+++ b/internal/jobruntime/idempotency_postgres_test.go
@@ -40,17 +40,35 @@ func TestPostgresIdempotencySupportsWorkgraphFamilyPolicies(t *testing.T) {
 
 func TestIdempotencyCompletionMapsOnlyExplicitRuntimeOutcomes(t *testing.T) {
 	t.Parallel()
-	tests := map[Result]string{
-		ResultSuccess:   "succeeded",
-		ResultDuplicate: "succeeded",
-		ResultRetry:     "retryable",
-		ResultDiscard:   "terminal",
-		ResultCancel:    "terminal",
+	tests := []struct {
+		name       string
+		completion Completion
+		want       string
+	}{
+		{name: "success", completion: Completion{Result: ResultSuccess}, want: "succeeded"},
+		{name: "duplicate", completion: Completion{Result: ResultDuplicate}, want: "succeeded"},
+		{name: "retry", completion: Completion{Result: ResultRetry}, want: "retryable"},
+		{name: "discard", completion: Completion{Result: ResultDiscard}, want: "terminal"},
+		// An explicit domain-terminal decision must never run again.
+		{
+			name:       "cancel/domain-terminal",
+			completion: Completion{Result: ResultCancel, Category: CategoryTerminalDomain, Terminal: true},
+			want:       "terminal",
+		},
+		// A process drain or budget-lease loss also arrives as ResultCancel,
+		// and River retries it: stamping it terminal made Begin return
+		// ClaimTerminal on the retry and the adapter cancelled it forever
+		// (CHAOS-3865).
+		{
+			name:       "cancel/drain",
+			completion: Completion{Result: ResultCancel, Category: CategoryCancelled},
+			want:       "retryable",
+		},
 	}
-	for result, want := range tests {
-		got, err := runStatus(Completion{Result: result})
-		if err != nil || got != want {
-			t.Fatalf("runStatus(%q) = %q, %v; want %q", result, got, err, want)
+	for _, test := range tests {
+		got, err := runStatus(test.completion)
+		if err != nil || got != test.want {
+			t.Fatalf("runStatus(%s) = %q, %v; want %q", test.name, got, err, test.want)
 		}
 	}
 	if _, err := runStatus(Completion{}); err == nil {

--- a/internal/jobruntime/worker_presence.go
+++ b/internal/jobruntime/worker_presence.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"regexp"
 	"sort"
 	"sync"
@@ -127,6 +128,10 @@ func (presence *WorkerPresence) Shutdown(ctx context.Context) error {
 	return presence.update(ctx, `DELETE FROM public.worker_instances WHERE instance_id = $1`, presence.instanceID)
 }
 
+// Errors never emits. Presence is observability-only, so a renewal failure is
+// logged and retried rather than surfaced to lifecycle.Runtime, which treats
+// any component error as fatal. The channel stays part of the component
+// contract so the runtime's error-source plumbing is uniform.
 func (presence *WorkerPresence) Errors() <-chan error {
 	if presence == nil {
 		return nil
@@ -151,11 +156,19 @@ func (presence *WorkerPresence) renew(ctx context.Context, done chan<- struct{})
 				WHERE instance_id = $1`, presence.instanceID, presence.ttl.String())
 			cancel()
 			if err != nil {
-				select {
-				case presence.errors <- err:
-				default:
-				}
-				return
+				// Presence is observability-only: it feeds worker_instances
+				// counts, nothing claims or executes work through it. Treating
+				// the first failed heartbeat as fatal meant a 10-second domain
+				// database hiccup -- a failover, a PgBouncer restart -- drained
+				// every replica at once, a self-inflicted fleet-wide restart
+				// (CHAOS-3866). Keep ticking instead: the TTL is three
+				// intervals wide, and a recovered database revives the row on
+				// the next successful renewal.
+				slog.Default().WarnContext(ctx, "worker presence heartbeat failed",
+					"error_category", "worker_presence_renewal",
+					"worker_group", presence.workerGroup,
+					"worker_instance_id", presence.instanceID.String(),
+				)
 			}
 		}
 	}

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -16,9 +16,14 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
 )
 
+// DefaultShutdownTimeout is the shutdown grace used when neither
+// --shutdown-timeout nor DEV_HEALTH_SHUTDOWN_TIMEOUT is supplied. The worker
+// compares against it to tell an unset timeout from one an operator chose.
+const DefaultShutdownTimeout = 30 * time.Second
+
 const (
 	defaultHTTPAddress       = ":8080"
-	defaultShutdownTimeout   = 30 * time.Second
+	defaultShutdownTimeout   = DefaultShutdownTimeout
 	maximumShutdownTimeout   = 3 * time.Hour
 	defaultHealthCheckTimout = 2 * time.Second
 	defaultDomainMaxConns    = 4
@@ -91,10 +96,17 @@ type Config struct {
 	// changes handler construction.
 	WorkerGroup string
 
-	HTTPAddress        string
-	ShutdownTimeout    time.Duration
-	HealthCheckTimeout time.Duration
-	LogLevel           slog.Level
+	HTTPAddress     string
+	ShutdownTimeout time.Duration
+	// ShutdownTimeoutExplicit records whether ShutdownTimeout came from the
+	// operator rather than the package default. The worker's drain budget is
+	// ShutdownTimeout minus a finalization buffer and must cover the longest
+	// selected job timeout, which the 30s default cannot do for any real queue
+	// selection -- so an unset timeout is derived from the selection instead of
+	// failing every default-configured worker (CHAOS-3873).
+	ShutdownTimeoutExplicit bool
+	HealthCheckTimeout      time.Duration
+	LogLevel                slog.Level
 
 	DomainDatabaseURI      secrets.Value
 	QueueDatabaseURI       secrets.Value
@@ -266,6 +278,9 @@ func Load(spec Spec) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	cfg.ShutdownTimeoutExplicit = durationArgumentOrEnvSet(
+		spec.ShutdownTimeout, lookup, "DEV_HEALTH_SHUTDOWN_TIMEOUT",
+	)
 	cfg.OperationalBridgeAllowInsecure, err = boolEnv(
 		lookup, "WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE", false,
 	)
@@ -978,6 +993,16 @@ func durationEnv(
 		return 0, fmt.Errorf("%s must be between %s and %s", key, minimum, maximum)
 	}
 	return value, nil
+}
+
+// durationArgumentOrEnvSet reports whether a duration was supplied by flag or
+// environment, as opposed to falling back to the package default.
+func durationArgumentOrEnvSet(argument string, lookup secrets.LookupEnv, key string) bool {
+	if strings.TrimSpace(argument) != "" {
+		return true
+	}
+	value, set := lookup(key)
+	return set && strings.TrimSpace(value) != ""
 }
 
 func durationArgumentOrEnv(

--- a/internal/platform/shell/shell.go
+++ b/internal/platform/shell/shell.go
@@ -72,6 +72,13 @@ func Main(spec Spec) {
 }
 
 // Execute is the testable command entry point.
+// dependencyReason is implemented by dependency-construction errors that carry
+// a bounded, non-sensitive reason code identifying which construction site
+// failed. Adapters that do not implement it keep the previous opaque logging.
+type dependencyReason interface {
+	DependencyReason() string
+}
+
 func Execute(
 	parent context.Context,
 	spec Spec,
@@ -188,12 +195,15 @@ func Execute(
 		if configureErr != nil {
 			// Dependency adapters return operational detail to their caller, but the
 			// shell never assumes an arbitrary error is free of DSNs or secrets.
-			logger.ErrorContext(
-				ctx,
-				"configure runtime dependencies",
-				"error_category",
-				"dependency_configuration_failed",
-			)
+			// A reason code, when the adapter supplies one, is a bounded
+			// compile-time constant naming the failing construction site, so it
+			// can be logged without redaction (CHAOS-3873).
+			attributes := []any{"error_category", "dependency_configuration_failed"}
+			var coded dependencyReason
+			if errors.As(configureErr, &coded) {
+				attributes = append(attributes, "reason", coded.DependencyReason())
+			}
+			logger.ErrorContext(ctx, "configure runtime dependencies", attributes...)
 			return 1
 		}
 		components = append(components, configured...)


### PR DESCRIPTION
## Summary

- **What changed:** Lane A of the PR #1738 readiness review — CHAOS-3864, 3865, 3866, 3873, plus a dead CI gate found while setting up validation.
  - **CHAOS-3864** — rescue coverage is registered **once**, after all families compose, over the union of owned kinds. Previously every family builder registered rescue-only workers for kinds it didn't own on the shared `river.Workers`, so any two-family selection collided on a duplicate kind and exited at startup — including the shipped `heavy` group.
  - **CHAOS-3865** — `Completion` now carries `Terminal`, so only an explicit domain-terminal outcome writes `terminal`. A drain or budget-lease loss stays `retryable` instead of being auto-cancelled forever on the River retry. A successful handler return also no longer loses to a late context cancellation.
  - **CHAOS-3866** — budget and idempotency lease renewals retry transient failures until the lease could actually have expired, and distinguish that from a provably-lost lease. Presence heartbeats are logged and retried rather than killing the process. Idempotency claims renew while they execute.
  - **CHAOS-3873** — an unset shutdown timeout is derived from the selected queues (the 30s default gives a *negative* drain budget); construction failures carry bounded reason codes the shell logs; an operational DB-open failure crash-loops instead of idling as an unready zombie.
  - **`ci/check_go.sh`** — the multi-replica gate pointed at `TestOperationalProfileMultiReplicaClaimDrainRestart`, renamed in `f015d78`. `go test -run` matching zero tests exits 0, so the gate had been dead since that commit.

- **Why:** these are the runtime blockers the review flagged before any multi-replica or multi-queue-group deployment.

Everything stays default-off: no `WORKER_*_ENABLED` switch touched, migration 0066 not applied, no `deployment_state` or replica default changed.

### Worth a reviewer's attention

`.github/workflows/go.yml` has its `push:` and `pull_request:` triggers **commented out** (lines 3–76) — it only fires on `merge_group`/`workflow_dispatch`. The Go quality gate (`check_go.sh all`, which includes the multi-replica verb) therefore never ran on PR #1738, which is why the dead gate went unnoticed. Not changed here; flagging it as a separate decision.

## Checklist

- [x] I added/updated tests, or provided required governance evidence below.
- [x] I ran relevant local validation (minimum: `./ci/run_tests.sh unit` for `src/` changes).
- [x] I documented risk and rollback considerations.
- [x] I called out breaking changes, migrations, or config impacts (or wrote `none`).

## Test Evidence

TEST-EVIDENCE:

**Lane gate — 2 replicas, 15s database outage, zero terminalized jobs, clean drain** (`TestMultiReplicaFleetSurvivesDatabaseOutage`, new). An in-process TCP cutover proxy severs the workers' link to PostgreSQL while a direct admin pool keeps observing state:

```
$ GOWORK=off go test -tags=integration -count=1 -run '^(TestEveryMultiFamilyQueueSelectionBoots|TestMultiReplicaFleetSurvivesDatabaseOutage)$' ./cmd/dev-health-worker
ok  	github.com/full-chaos/dev-health-ops/cmd/dev-health-worker	63.606s
```

Asserted: no `worker_job_runs` row in `terminal`, no `river.river_job` in `cancelled`/`discarded`, exactly one external effect per logical job, no presence error reaching `lifecycle.Runtime`, presence rows still live after a wait longer than the 30s TTL, then a clean drain.

**CHAOS-3864 acceptance — every two-family combination plus the shipped groups, driving the real production builders** (not the fake builders the existing composition tests use, which is why CI never saw the collision):

```
--- PASS: TestEveryMultiFamilyQueueSelectionBoots (11.42s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/daily+operational (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/daily+providerSync (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/daily+reports (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/daily+syncCoordinator (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/daily+workgraph (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/operational+providerSync (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/operational+reports (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/operational+syncCoordinator (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/operational+workgraph (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/providerSync+reports (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/providerSync+syncCoordinator (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/providerSync+workgraph (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/reports+syncCoordinator (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/reports+workgraph (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/syncCoordinator+workgraph (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/shipped/heavy (0.01s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/shipped/ops (0.00s)
    --- PASS: TestEveryMultiFamilyQueueSelectionBoots/shipped/sync (0.00s)
ok  	github.com/full-chaos/dev-health-ops/cmd/dev-health-worker	11.444s
```

**Revived multi-replica gate:**

```
$ bash ci/check_go.sh multi-replica-workers
ok  	github.com/full-chaos/dev-health-ops/cmd/dev-health-worker	4.818s
multi-replica worker gate: measured 4 terminal jobs
```

**Full Go tree + integration suites:**

```
$ go test ./...                                    # no failures
$ bash ci/check_go.sh integration-vet              # pass
$ GOWORK=off go test -tags=integration ./internal/jobruntime/...
ok  	github.com/full-chaos/dev-health-ops/internal/jobruntime	35.295s
$ GOWORK=off go test -tags=integration ./cmd/dev-health-worker
ok  	github.com/full-chaos/dev-health-ops/cmd/dev-health-worker	82.113s
```

**Every fix was verified to be caught by its test** — reverting each one individually fails the corresponding test:

| Reverted fix | Failing test |
|---|---|
| per-family `registerRescueCoverage` restored in `daily.go` | every `daily+*` combination |
| `runStatus` collapsing `ResultCancel` to `terminal` | `TestIdempotencyCompletionMapsOnlyExplicitRuntimeOutcomes` |
| `ctx.Err()` promoted over a successful handler | `.../success_survives_late_cancellation` |
| idempotency lease renewal disabled | `TestPostgresIdempotencyRenewsLeaseWhileTheRunIsHealthy` |
| fail-fast presence heartbeat restored | `TestMultiReplicaFleetSurvivesDatabaseOutage` |

**`ci/local_validate.sh` (SKIP_CLICKHOUSE=1 — no ClickHouse container in this environment):**

```
✔  mutation harness: no mutation applied      <- no stale plan anchors despite editing config.go
✔  lint: ruff format --check
✔  lint: ruff check
✔  typecheck: mypy
✗  unit suite (FULL, not subset)              9 failed, 13366 passed, 653 skipped
```

The 9 unit failures are **pre-existing and unrelated** — all 9 reproduce on the base commit `1001ded9` in a clean worktree (`test_helm_migration_hook.py` ×4, `test_worker_metrics_process.py` ×2, `test_worker_workgraph.py`, `test_governance_workflow.py`, `test_helm_api_probes.py`). None touch files in this diff.

## Risk Notes

RISK-NOTES:

- **Blast radius:** worker startup and job-completion semantics for every kind using `PostgresIdempotency` (metrics, investment, workgraph, reports, operational). All default-off; no route, switch, migration, or replica default changed.
- **Behavioral changes a reviewer should weigh:**
  - Cancelled runs are now `retryable` rather than `terminal`, so a job that previously died permanently on a drain will now re-run. That is the intent, but it does mean more retries where operators may have grown used to silent death.
  - An operational DB-open failure now **crash-loops** instead of idling unready. Declared configuration rejections (`ErrQueueControlTransactionMode`, `ErrDomainDatabaseRequired`, …) deliberately keep the old live-but-unready behavior, because those surface as named readiness checks; conflating the two would replace a scrapeable check name with a crash loop.
  - An unset shutdown timeout is now derived from the selection. A timeout the operator actually set — including one equal to the 30s default — still fails closed, so the contract check keeps its teeth.
  - Idempotency claims now hold a renewing lease, so crash takeover is bounded by one lease (10 min) rather than a job timeout (up to 2h). Renewing rather than leasing for the full descriptor timeout is what preserves that.
- **Tests changed rather than added:** two tests encoded the defective behavior and were rewritten to lock in the corrected invariant, not weakened — `TestEveryWorkerFamilyRegistersGlobalRescueCoverageOnSharedWorkers` (asserted the per-family registration that *caused* the collision; replaced by two tests asserting zero per-family registrations and exactly one central one) and `TestIdempotencyCompletionMapsOnlyExplicitRuntimeOutcomes` (asserted `ResultCancel → terminal` unconditionally; now a table covering both branches). One integration assertion gained the `Terminal: true` that production sets for a permanent error.
- **Rollback:** revert the branch. Each commit is independently revertable; the `ci/check_go.sh` fix is standalone and worth keeping regardless.
- **Deviation from the lane gate as written:** the 2-replica outage gate runs the **operational** queue group, not `heavy`. A 2-replica `heavy` boot drives the full readiness path (`ValidateStartup`, queue-control config, contract-version rows) which the bare integration database doesn't provide, and which the pre-existing multi-replica gate also sidesteps for the same reason. `heavy`'s multi-family boot is proven separately by `TestEveryMultiFamilyQueueSelectionBoots/shipped/heavy`. Extending the outage gate to `heavy` needs the readiness fixtures built out and is not done here.
- **Monitoring:** the new `reason` field on `configure runtime dependencies` error logs, and `shutdown_timeout`/`drain_budget` on the `worker queues configured` line.
- **Follow-ups not in this PR:** `go.yml`'s disabled `push`/`pull_request` triggers (above); CHAOS-3866's minor notes (expired `worker_instances` rows are never deleted; a fast crash-restart double-counts `Live` for up to 30s); CHAOS-3873's minor notes (`shell.Execute` flag usage to stdout; `RIVER_*_RETENTION` parsed but never applied; no `StopAndCancel` escalation after the drain deadline).

## Optional Context

- Linked issues: [CHAOS-3864](https://linear.app/fullchaos/issue/CHAOS-3864), [CHAOS-3865](https://linear.app/fullchaos/issue/CHAOS-3865), [CHAOS-3866](https://linear.app/fullchaos/issue/CHAOS-3866), [CHAOS-3873](https://linear.app/fullchaos/issue/CHAOS-3873)
- SCREENSHOT-WAIVER: backend-only change; no user-facing surface.
- Additional notes: validation ran with a locally-started Docker daemon and a `mirror.gcr.io` registry mirror, because this environment's egress policy blocks Docker Hub's blob CDN (`production.cloudfront.docker.com`). Images were pulled by their exact pinned digests from `internal/testsupport/containers/harness.go`; no repository file was changed for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgFRWxVJLUMooPAELwBPXu)_