### PR TITLE
Lane C: provider sync parity — rate-limit deferral, Jira timestamps, PagerDuty watermark, terminal categories

### DIFF
--- a/internal/jobruntime/errors.go
+++ b/internal/jobruntime/errors.go
@@ -24,6 +24,7 @@ const (
 	CategoryTerminalDomain ErrorCategory = "terminal_domain"
 	CategoryTenant         ErrorCategory = "tenant_scope"
 	CategoryBudget         ErrorCategory = "budget"
+	CategoryRateLimited    ErrorCategory = "rate_limit"
 	CategoryIdempotency    ErrorCategory = "idempotency"
 )
 
@@ -69,6 +70,19 @@ func BudgetContention(err error, delay time.Duration) error {
 		delay = time.Second
 	}
 	return &markedError{category: CategoryBudget, cause: nonNilError(err), snooze: delay}
+}
+
+// RateLimited marks provider-signalled rate limiting. Like BudgetContention it
+// snoozes rather than failing, because a 429 is the provider scheduling us, not
+// the job going wrong: burning one of the unit's bounded attempts on a 30-60
+// minute GitHub reset window exhausted all of them in minutes and terminalized
+// the unit (CHAOS-3868). It carries its own category so rate-limited work is
+// distinguishable from shared-bucket contention in metrics and logs.
+func RateLimited(err error, delay time.Duration) error {
+	if delay <= 0 {
+		delay = time.Second
+	}
+	return &markedError{category: CategoryRateLimited, cause: nonNilError(err), snooze: delay}
 }
 
 // SnoozeDelay exposes the typed decision to domain handlers and tests without

--- a/internal/jobruntime/telemetry.go
+++ b/internal/jobruntime/telemetry.go
@@ -1016,7 +1016,7 @@ func validErrorCategory(category ErrorCategory) bool {
 	switch category {
 	case CategoryNone, CategoryValidation, CategoryPanic, CategoryTimeout, CategoryCancelled,
 		CategoryRetryable, CategoryPermanent, CategoryTerminalDomain, CategoryTenant,
-		CategoryBudget, CategoryIdempotency:
+		CategoryBudget, CategoryRateLimited, CategoryIdempotency:
 		return true
 	default:
 		return false

--- a/internal/jobs/providerunit/deterministic_terminal_category_test.go
+++ b/internal/jobs/providerunit/deterministic_terminal_category_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
 	"github.com/full-chaos/dev-health-ops/internal/providersync"
 )
 
@@ -39,6 +40,27 @@ func TestDeterministicTerminalCategoryContract(t *testing.T) {
 			name:     "effect recovery ambiguous",
 			err:      providersync.ErrEffectRecoveryAmbiguous,
 			category: EffectRecoveryAmbiguousCategory,
+		},
+		{
+			// Deterministic given the provider's current state: a repo with
+			// more in-window rows than the cap refuses identically on every
+			// attempt, so retrying only re-fetched up to 100 list pages and
+			// 10k detail GETs five times over (CHAOS-3871).
+			name:     "pagination cap refusal",
+			err:      providersync.ErrPaginationCapExceeded,
+			category: PaginationIncompleteCategory,
+		},
+		{
+			// Already non-retryable at the HTTP layer; the unit handler was
+			// still spending four more executions against a dead credential.
+			name:     "authentication",
+			err:      &providerfoundation.ProviderError{Class: providerfoundation.ErrorAuthentication, StatusCode: 401},
+			category: AuthCategory,
+		},
+		{
+			name:     "not found",
+			err:      &providerfoundation.ProviderError{Class: providerfoundation.ErrorNotFound, StatusCode: 404},
+			category: NotFoundCategory,
 		},
 	}
 	for _, testCase := range deterministic {
@@ -86,6 +108,11 @@ func TestDeterministicTerminalCategoryContract(t *testing.T) {
 		errors.New("connection reset by peer"),
 		providersync.ErrInvalidConfiguration,
 		fmt.Errorf("wrapped: %w", errors.New("timeout")),
+		// A rate limit is deferred by its own branch upstream of this mapper
+		// and must never be terminalized here, and a transient provider fault
+		// still deserves its bounded retries.
+		&providerfoundation.ProviderError{Class: providerfoundation.ErrorRateLimited, StatusCode: 429},
+		&providerfoundation.ProviderError{Class: providerfoundation.ErrorTransient, StatusCode: 503},
 	} {
 		if category, ok := deterministicTerminalCategory(err); ok {
 			t.Errorf("deterministicTerminalCategory(%v) = (%q, true), want retryable",

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -74,9 +74,47 @@ const ProviderDatasetUnavailableCategory = "provider_dataset_unavailable"
 // destinations this lane adds. That is intended -- the error means the same
 // thing wherever it comes from -- but it does change the recorded category and
 // the retry count for existing adapters that previously exhausted instead.
+// Categories matching Python's vocabulary in
+// src/dev_health_ops/workers/sync_units.py (_PROVIDER_ERROR_PATTERNS and
+// _classify_error), so a unit that fails for the same reason in either runtime
+// reports the same category.
+const (
+	// AuthCategory covers 401 and non-rate-limit 403.
+	AuthCategory = "auth"
+	// NotFoundCategory covers 404.
+	NotFoundCategory = "not_found"
+	// PaginationIncompleteCategory covers a fail-closed pagination or row-cap
+	// refusal -- Python's PaginationException category.
+	PaginationIncompleteCategory = "pagination_incomplete"
+)
+
 func deterministicTerminalCategory(err error) (string, bool) {
 	if errors.Is(err, providersync.ErrProviderDatasetUnavailable) {
 		return ProviderDatasetUnavailableCategory, true
+	}
+	// A fail-closed pagination or row-cap refusal is deterministic given the
+	// provider's current state: a repo with more in-window rows than the cap
+	// returns the same refusal on every attempt. Retrying it re-fetched up to
+	// 100 list pages and 10k detail GETs on each of 5 attempts, then again on
+	// every scheduled tick, and finally reported the generic exhaustion
+	// category. The refusal itself is correct; the repetition is not
+	// (CHAOS-3871).
+	if errors.Is(err, providersync.ErrPaginationCapExceeded) {
+		return PaginationIncompleteCategory, true
+	}
+	// Authentication and not-found are already non-retryable at the HTTP layer
+	// (providerfoundation.ProviderError.Retryable), so the unit handler was
+	// spending four more full executions against a dead credential or a
+	// deleted repository before collapsing the precise cause into
+	// provider_unit_exhausted. Python fails these once, with the category.
+	var providerErr *providerfoundation.ProviderError
+	if errors.As(err, &providerErr) {
+		switch providerErr.Class {
+		case providerfoundation.ErrorAuthentication:
+			return AuthCategory, true
+		case providerfoundation.ErrorNotFound:
+			return NotFoundCategory, true
+		}
 	}
 	if errors.Is(err, providersync.ErrRepositoryIdentityAmbiguous) {
 		return RepositoryIdentityCategory, true

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -138,6 +138,20 @@ type UnitRepository interface {
 	) error
 }
 
+// RateLimitCategory is the terminal category for a unit whose rate-limit
+// deferral episode is spent. Python fails with a rate-limit category rather
+// than a generic exhaustion, so an operator can tell "the provider kept
+// throttling us for two hours" from "this unit is broken".
+const RateLimitCategory = "rate_limit"
+
+// RateLimitDeferralRepository is optional so existing repository test doubles
+// and older rolling binaries stay source-compatible, exactly like
+// ChunkContinuationRepository. Production's PostgresRepository implements it.
+type RateLimitDeferralRepository interface {
+	RateLimitEpisode(context.Context, providersync.Claim) (providersync.RateLimitEpisode, error)
+	DeferForRateLimit(context.Context, providersync.Claim, time.Time, time.Time) error
+}
+
 // ChunkContinuationRepository is optional so legacy repository test doubles
 // and older rolling binaries remain source-compatible. Production's
 // PostgresRepository implements it for the opt-in chunk route.
@@ -431,6 +445,42 @@ func (handler *Handler) Work(
 		handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "continued", err)
 		return jobruntime.RetryableAfter(err, delay)
 	}
+	// A provider rate limit is the provider scheduling us, not the unit
+	// failing. Python defers it up to 10 times over 2 hours without consuming
+	// the failure budget; Go had no branch at all, so a 429 burned one of five
+	// attempts on a 5s-5m backoff and a 30-60 minute reset window terminalized
+	// the unit in two or three minutes (CHAOS-3868).
+	if retryAfter, rateLimited := providerRateLimitDelay(err); rateLimited {
+		if deferrer, supported := handler.Repository.(RateLimitDeferralRepository); supported {
+			episode, episodeErr := deferrer.RateLimitEpisode(context.WithoutCancel(ctx), session.Claim)
+			if episodeErr != nil {
+				return jobruntime.Retryable(episodeErr)
+			}
+			plan, granted := planRateLimitDeferral(retryAfter, episode, session.Claim.ID, completedAt)
+			if granted {
+				if deferErr := deferrer.DeferForRateLimit(
+					context.WithoutCancel(ctx), session.Claim, plan.notBefore, completedAt,
+				); deferErr != nil {
+					return jobruntime.Retryable(deferErr)
+				}
+				handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultRetrying)
+				handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "rate_limited", err)
+				return jobruntime.RateLimited(err, plan.countdown)
+			}
+			// The episode's count or wall-clock budget is spent. Fail with the
+			// rate-limit category rather than letting it fall through to the
+			// generic provider_unit_exhausted, which buries the real cause.
+			if failErr := handler.Repository.Fail(
+				context.WithoutCancel(ctx), session.Claim, RateLimitCategory,
+				startedAt, completedAt,
+			); failErr != nil {
+				return jobruntime.Retryable(failErr)
+			}
+			handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultFailed)
+			handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "failed", err)
+			return jobruntime.Permanent(err)
+		}
+	}
 	// A healthy shared request bucket can be full when sibling provider units
 	// overlap. That is scheduling contention, not an execution failure. Persist
 	// the domain deferral before returning River's attempt-neutral snooze so a
@@ -488,6 +538,17 @@ func (handler *Handler) Work(
 	handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultRetrying)
 	handler.logLifecycle(ctx, execution, session.Claim, "sync_provider_unit_finished", "retrying", err)
 	return jobruntime.Retryable(err)
+}
+
+// providerRateLimitDelay reports whether the failure is a provider rate limit
+// and, if so, the delay the provider asked for (already resolved from
+// Retry-After or the reset headers by providerfoundation).
+func providerRateLimitDelay(err error) (time.Duration, bool) {
+	var providerErr *providerfoundation.ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != providerfoundation.ErrorRateLimited {
+		return 0, false
+	}
+	return providerErr.RetryAfter, true
 }
 
 func providerBudgetContentionDelay(unitID string) time.Duration {

--- a/internal/jobs/providerunit/providerunit_test.go
+++ b/internal/jobs/providerunit/providerunit_test.go
@@ -731,6 +731,8 @@ type memoryUnitRepository struct {
 	releaseErr          error
 	releaseCalls        int
 	contentionDeferrals int
+	rateLimitDeferrals  int
+	rateLimitFirstSeen  *time.Time
 	availableAt         time.Time
 }
 
@@ -839,6 +841,38 @@ func (repository *memoryUnitRepository) DeferForBudgetContention(
 		return providersync.ErrLeaseLost
 	}
 	repository.contentionDeferrals++
+	repository.availableAt = availableAt
+	repository.status = "dispatching"
+	return nil
+}
+
+func (repository *memoryUnitRepository) RateLimitEpisode(
+	_ context.Context,
+	_ providersync.Claim,
+) (providersync.RateLimitEpisode, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	return providersync.RateLimitEpisode{
+		Deferrals: repository.rateLimitDeferrals, FirstSeenAt: repository.rateLimitFirstSeen,
+	}, nil
+}
+
+func (repository *memoryUnitRepository) DeferForRateLimit(
+	_ context.Context,
+	claim providersync.Claim,
+	availableAt time.Time,
+	now time.Time,
+) error {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	if repository.status != "running" || repository.lastClaim.Owner != claim.Owner {
+		return providersync.ErrLeaseLost
+	}
+	repository.rateLimitDeferrals++
+	if repository.rateLimitFirstSeen == nil {
+		stamped := now
+		repository.rateLimitFirstSeen = &stamped
+	}
 	repository.availableAt = availableAt
 	repository.status = "dispatching"
 	return nil

--- a/internal/jobs/providerunit/rate_limit_defer.go
+++ b/internal/jobs/providerunit/rate_limit_defer.go
@@ -1,0 +1,85 @@
+package providerunit
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providersync"
+)
+
+// Rate-limit deferral policy, ported from
+// src/dev_health_ops/workers/rate_limit_defer.py. A provider 429 is deferred
+// work, not a task failure: Python re-enqueues the unit as RETRYING without
+// consuming the genuine-failure retry budget, bounded by a count budget and a
+// wall-clock budget so a permanently rate-limited provider still eventually
+// surfaces as a real failure.
+//
+// Go had no rate-limit branch at all: a 429 burned one of max_attempts: 5 on a
+// 5s-5m backoff, so a 30-60 minute GitHub reset window exhausted every attempt
+// in two or three minutes and terminalized the unit (CHAOS-3868).
+const (
+	rateLimitMaxDeferrals = 10
+	rateLimitMaxTotalWait = 2 * time.Hour
+	// A single countdown chunk. Longer provider windows are chunked: the
+	// absolute not-before fence is carried on the row, so the unit re-defers
+	// without calling the provider again until the window elapses.
+	rateLimitMaxCountdown = 600 * time.Second
+	// Used when the provider signalled a rate limit without a usable delay.
+	rateLimitDefaultDelay = 60 * time.Second
+	// Additive jitter de-correlates many orgs waking against one provider at
+	// the same instant. Derived from the unit ID rather than a random source so
+	// a retry of the same unit is reproducible, matching how
+	// providerBudgetContentionDelay jitters.
+	rateLimitMaxJitter = 5 * time.Second
+)
+
+// rateLimitDeferral is one planned deferral step.
+type rateLimitDeferral struct {
+	// countdown is the attempt-neutral River snooze for this step.
+	countdown time.Duration
+	// notBefore is the absolute fence persisted on the unit, so a process
+	// restart resumes the same window instead of calling the provider early.
+	notBefore time.Time
+}
+
+// planRateLimitDeferral returns the next deferral, or ok=false when the
+// episode's count or wall-clock budget is spent and the caller must fall
+// through to terminal failure handling.
+func planRateLimitDeferral(
+	retryAfter time.Duration,
+	episode providersync.RateLimitEpisode,
+	unitID string,
+	now time.Time,
+) (rateLimitDeferral, bool) {
+	firstSeen := now
+	if episode.FirstSeenAt != nil && !episode.FirstSeenAt.IsZero() {
+		firstSeen = *episode.FirstSeenAt
+	}
+	elapsed := now.Sub(firstSeen)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	if episode.Deferrals >= rateLimitMaxDeferrals || elapsed >= rateLimitMaxTotalWait {
+		return rateLimitDeferral{}, false
+	}
+	delay := retryAfter
+	if delay <= 0 {
+		delay = rateLimitDefaultDelay
+	}
+	// Never schedule a wait that runs past the wall-clock deadline.
+	if remaining := rateLimitMaxTotalWait - elapsed; delay > remaining {
+		delay = remaining
+	}
+	countdown := delay
+	if countdown > rateLimitMaxCountdown {
+		countdown = rateLimitMaxCountdown
+	}
+	countdown += rateLimitJitter(unitID)
+	return rateLimitDeferral{countdown: countdown, notBefore: now.Add(delay)}, true
+}
+
+func rateLimitJitter(unitID string) time.Duration {
+	digest := sha256.Sum256([]byte("rate-limit:" + unitID))
+	return time.Duration(binary.BigEndian.Uint64(digest[:8])%uint64(rateLimitMaxJitter/time.Millisecond)) * time.Millisecond
+}

--- a/internal/jobs/providerunit/rate_limit_defer_test.go
+++ b/internal/jobs/providerunit/rate_limit_defer_test.go
@@ -1,0 +1,191 @@
+package providerunit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	"github.com/full-chaos/dev-health-ops/internal/providersync"
+)
+
+func rateLimitError(retryAfter time.Duration) error {
+	return &providerfoundation.ProviderError{
+		Class: providerfoundation.ErrorRateLimited, StatusCode: 429, RetryAfter: retryAfter,
+	}
+}
+
+// TestProviderRateLimitDefersWithoutConsumingTheAttempt is CHAOS-3868's first
+// acceptance case. Go had no rate-limit branch: a 429 fell through to
+// ReleaseForRetry and burned one of five attempts on a 5s-5m backoff, so a
+// 30-60 minute GitHub reset window exhausted every attempt in two or three
+// minutes and terminalized the unit as provider_unit_exhausted.
+func TestProviderRateLimitDefersWithoutConsumingTheAttempt(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	unit := providerUnit()
+	repository := newMemoryUnitRepository(unit)
+	handler := &Handler{
+		Repository:    repository,
+		Switches:      providersync.CompleteRouteSwitches{LaunchDarklyFeatureFlags: true},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: func(*providersync.LeaseSession) (providersync.CompleteRouteExecutor, error) {
+			return providersync.CompleteRouteExecutor{}, rateLimitError(2 * time.Minute)
+		},
+	}
+	execution := providerExecution(unit, now, 5)
+	execution.Definition.MaxAttempts = 5
+
+	err := handler.Work(context.Background(), execution)
+	delay, snoozed := jobruntime.SnoozeDelay(err)
+	if !snoozed {
+		t.Fatalf("Work() = %v; want an attempt-neutral snooze", err)
+	}
+	if delay < 2*time.Minute || delay > 2*time.Minute+rateLimitMaxJitter {
+		t.Fatalf("snooze=%s, want the provider's 2m window plus jitter", delay)
+	}
+	if repository.status != "dispatching" || repository.failures != 0 {
+		t.Fatalf("status=%q failures=%d; a rate limit must defer, not fail",
+			repository.status, repository.failures)
+	}
+	if repository.releaseCalls != 0 {
+		t.Fatalf("rate limit consumed %d ordinary retry releases", repository.releaseCalls)
+	}
+	if repository.rateLimitDeferrals != 1 {
+		t.Fatalf("rate_limit_deferrals=%d, want 1", repository.rateLimitDeferrals)
+	}
+	if !repository.availableAt.Equal(now.Add(2 * time.Minute)) {
+		t.Fatalf("not-before fence=%v, want %v", repository.availableAt, now.Add(2*time.Minute))
+	}
+}
+
+// A provider that signals a rate limit without any usable delay still gets
+// Python's 60s default rather than the generic transient backoff.
+func TestProviderRateLimitWithoutDelayUsesTheDefaultCountdown(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	unit := providerUnit()
+	repository := newMemoryUnitRepository(unit)
+	handler := &Handler{
+		Repository:    repository,
+		Switches:      providersync.CompleteRouteSwitches{LaunchDarklyFeatureFlags: true},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return now },
+		BuildExecutor: func(*providersync.LeaseSession) (providersync.CompleteRouteExecutor, error) {
+			return providersync.CompleteRouteExecutor{}, rateLimitError(0)
+		},
+	}
+	execution := providerExecution(unit, now, 5)
+	execution.Definition.MaxAttempts = 5
+
+	delay, snoozed := jobruntime.SnoozeDelay(handler.Work(context.Background(), execution))
+	if !snoozed || delay < rateLimitDefaultDelay || delay > rateLimitDefaultDelay+rateLimitMaxJitter {
+		t.Fatalf("snooze=%s snoozed=%v, want ~%s", delay, snoozed, rateLimitDefaultDelay)
+	}
+}
+
+// TestProviderRateLimitBudgetExhaustionFailsWithTheRateLimitCategory is
+// CHAOS-3868's third acceptance case: a permanently throttled provider must
+// still become a real failure, and must say WHY rather than collapsing into
+// the generic provider_unit_exhausted.
+func TestProviderRateLimitBudgetExhaustionFailsWithTheRateLimitCategory(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name    string
+		episode providersync.RateLimitEpisode
+	}{
+		{
+			name:    "count budget spent",
+			episode: providersync.RateLimitEpisode{Deferrals: rateLimitMaxDeferrals},
+		},
+		{
+			name: "wall clock budget spent",
+			episode: providersync.RateLimitEpisode{
+				Deferrals: 2, FirstSeenAt: timePointer(now.Add(-rateLimitMaxTotalWait - time.Minute)),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			unit := providerUnit()
+			repository := newMemoryUnitRepository(unit)
+			repository.rateLimitDeferrals = test.episode.Deferrals
+			repository.rateLimitFirstSeen = test.episode.FirstSeenAt
+			handler := &Handler{
+				Repository:    repository,
+				Switches:      providersync.CompleteRouteSwitches{LaunchDarklyFeatureFlags: true},
+				LeaseDuration: time.Minute,
+				Heartbeat:     10 * time.Second,
+				Now:           func() time.Time { return now },
+				BuildExecutor: func(*providersync.LeaseSession) (providersync.CompleteRouteExecutor, error) {
+					return providersync.CompleteRouteExecutor{}, rateLimitError(time.Minute)
+				},
+			}
+			execution := providerExecution(unit, now, 1)
+			execution.Definition.MaxAttempts = 5
+
+			err := handler.Work(context.Background(), execution)
+			if _, snoozed := jobruntime.SnoozeDelay(err); snoozed {
+				t.Fatalf("Work() = %v; a spent episode must not defer again", err)
+			}
+			if repository.status != "failed" || repository.failures != 1 {
+				t.Fatalf("status=%q failures=%d, want a single terminal failure",
+					repository.status, repository.failures)
+			}
+			if repository.lastFailCategory != RateLimitCategory {
+				t.Fatalf("category=%q, want %q", repository.lastFailCategory, RateLimitCategory)
+			}
+		})
+	}
+}
+
+func TestPlanRateLimitDeferralMirrorsThePythonPolicy(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+
+	// A window longer than one countdown chunk is chunked, but the absolute
+	// not-before fence still covers the whole window so the unit re-defers
+	// without calling the provider again.
+	plan, ok := planRateLimitDeferral(45*time.Minute, providersync.RateLimitEpisode{}, "unit-1", now)
+	if !ok {
+		t.Fatal("a fresh episode refused to defer")
+	}
+	if plan.countdown < rateLimitMaxCountdown || plan.countdown > rateLimitMaxCountdown+rateLimitMaxJitter {
+		t.Fatalf("countdown=%s, want it chunked to ~%s", plan.countdown, rateLimitMaxCountdown)
+	}
+	if !plan.notBefore.Equal(now.Add(45 * time.Minute)) {
+		t.Fatalf("not-before=%s, want the full provider window", plan.notBefore)
+	}
+
+	// A deferral must never be scheduled past the wall-clock deadline.
+	started := now.Add(-rateLimitMaxTotalWait + 10*time.Minute)
+	plan, ok = planRateLimitDeferral(
+		time.Hour, providersync.RateLimitEpisode{Deferrals: 3, FirstSeenAt: &started}, "unit-1", now,
+	)
+	if !ok {
+		t.Fatal("an episode with budget left refused to defer")
+	}
+	if !plan.notBefore.Equal(now.Add(10 * time.Minute)) {
+		t.Fatalf("not-before=%s, want it clamped to the remaining budget", plan.notBefore)
+	}
+
+	// Both budgets terminate the episode.
+	if _, ok := planRateLimitDeferral(
+		time.Minute, providersync.RateLimitEpisode{Deferrals: rateLimitMaxDeferrals}, "unit-1", now,
+	); ok {
+		t.Fatal("count budget was not enforced")
+	}
+	spent := now.Add(-rateLimitMaxTotalWait)
+	if _, ok := planRateLimitDeferral(
+		time.Minute, providersync.RateLimitEpisode{Deferrals: 1, FirstSeenAt: &spent}, "unit-1", now,
+	); ok {
+		t.Fatal("wall-clock budget was not enforced")
+	}
+}
+
+func timePointer(at time.Time) *time.Time { return &at }

--- a/internal/providerfoundation/http.go
+++ b/internal/providerfoundation/http.go
@@ -158,7 +158,7 @@ func (c *HTTPClient) Do(ctx context.Context, method, path string, body io.Reader
 			if attempt == c.Retry.MaxAttempts {
 				return nil, last
 			}
-			if err := c.wait(ctx, c.retryDelay(attempt, 0)); err != nil {
+			if err := c.wait(ctx, c.retryDelay(attempt, 0, ErrorTransient)); err != nil {
 				return nil, err
 			}
 			continue
@@ -170,9 +170,20 @@ func (c *HTTPClient) Do(ctx context.Context, method, path string, body io.Reader
 		}
 		message, _ := io.ReadAll(io.LimitReader(response.Body, maxProviderErrorBody))
 		classification = ClassifyHTTPWithMessage(c.Provider, response.StatusCode, response.Header, string(message))
-		retryDelay := c.retryDelay(attempt, classification.RetryAfter)
+		retryDelay := c.retryDelay(attempt, classification.RetryAfter, classification.Class)
 		if classification.Class == ErrorRateLimited && c.Gate != nil {
-			if err := c.Gate.Penalize(ctx, retryDelay); err != nil {
+			// The gate is shared cross-runtime (Celery workers read the same
+			// key) and accepts up to 300s, so arm it with the provider's own
+			// delay rather than this client's truncated retry wait --
+			// under-penalizing it sent Celery back at the provider early too.
+			penalty := classification.RetryAfter
+			if penalty <= 0 {
+				penalty = retryDelay
+			}
+			if penalty > RateLimitMaxHonoredDelay {
+				penalty = RateLimitMaxHonoredDelay
+			}
+			if err := c.Gate.Penalize(ctx, penalty); err != nil {
 				_ = response.Body.Close()
 				return nil, err
 			}
@@ -271,10 +282,18 @@ func (c *HTTPClient) DoUnauthenticated(
 	return response, nil
 }
 
-func (c *HTTPClient) retryDelay(attempt int, retryAfter time.Duration) time.Duration {
+func (c *HTTPClient) retryDelay(attempt int, retryAfter time.Duration, class ErrorClass) time.Duration {
 	if retryAfter > 0 {
-		if retryAfter > c.Retry.MaxWait {
-			return c.Retry.MaxWait
+		// A rate limit is the provider telling us exactly how long to wait.
+		// Truncating that to the generic 30s MaxWait and retrying anyway is
+		// what escalates a primary limit into a secondary one, so honour it up
+		// to Python's 300s ceiling. Every other class keeps MaxWait.
+		honored := c.Retry.MaxWait
+		if class == ErrorRateLimited && RateLimitMaxHonoredDelay > honored {
+			honored = RateLimitMaxHonoredDelay
+		}
+		if retryAfter > honored {
+			return honored
 		}
 		return retryAfter
 	}
@@ -348,10 +367,14 @@ func ClassifyHTTP(provider string, status int, headers http.Header) *ProviderErr
 }
 
 func ClassifyHTTPWithMessage(provider string, status int, headers http.Header, message string) *ProviderError {
-	retryAfter := ParseRetryAfter(headerValue(headers, "retry-after"), time.Now())
+	now := time.Now()
+	retryAfter := ParseRetryAfter(headerValue(headers, "retry-after"), now)
 	message = strings.ToLower(message)
 	if isRateLimitedForbidden(provider, status, headers, message) {
-		return &ProviderError{Class: ErrorRateLimited, StatusCode: status, RetryAfter: retryAfter}
+		return &ProviderError{
+			Class: ErrorRateLimited, StatusCode: status,
+			RetryAfter: rateLimitRetryAfter(headers, retryAfter, now),
+		}
 	}
 	switch status {
 	case 0:
@@ -363,7 +386,10 @@ func ClassifyHTTPWithMessage(provider string, status int, headers http.Header, m
 	case http.StatusConflict:
 		return &ProviderError{Class: ErrorConflict, StatusCode: status}
 	case http.StatusTooManyRequests:
-		return &ProviderError{Class: ErrorRateLimited, StatusCode: status, RetryAfter: retryAfter}
+		return &ProviderError{
+			Class: ErrorRateLimited, StatusCode: status,
+			RetryAfter: rateLimitRetryAfter(headers, retryAfter, now),
+		}
 	}
 	if status >= 500 && status <= 599 {
 		return &ProviderError{Class: ErrorTransient, StatusCode: status, RetryAfter: retryAfter}
@@ -406,6 +432,47 @@ func hasHeader(headers http.Header, wanted string) bool {
 		}
 	}
 	return false
+}
+
+// RateLimitMaxHonoredDelay bounds how long a provider-supplied rate-limit
+// delay may park a request or the shared cooldown gate. It matches Python's
+// RateLimitConfig.max_backoff_seconds (300s, connectors/utils/rate_limit_queue.py).
+//
+// The generic RetryPolicy.MaxWait (30s by default) stays the cap for ordinary
+// transient errors: clamping a rate limit to it meant Go kept re-hitting a
+// provider inside its own stated window, which is exactly what escalates
+// GitHub from a primary to a secondary limit (CHAOS-3868).
+const RateLimitMaxHonoredDelay = 300 * time.Second
+
+// ParseRateLimitReset derives a delay from an absolute epoch-seconds reset
+// header. GitHub primary limits usually carry only x-ratelimit-reset and no
+// Retry-After; GitLab uses RateLimit-Reset. Python resolves both
+// (providers/github/ratelimit.py github_retry_after_seconds); Go previously
+// looked at retry-after alone and fell back to a generic backoff.
+func ParseRateLimitReset(raw string, now time.Time) time.Duration {
+	seconds, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil {
+		return 0
+	}
+	delay := time.Duration((seconds - float64(now.UnixNano())/float64(time.Second)) * float64(time.Second))
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+// rateLimitRetryAfter prefers an explicit Retry-After and falls back to the
+// provider's reset header, mirroring Python's resolution order.
+func rateLimitRetryAfter(headers http.Header, retryAfter time.Duration, now time.Time) time.Duration {
+	if retryAfter > 0 {
+		return retryAfter
+	}
+	for _, header := range []string{"x-ratelimit-reset", "ratelimit-reset"} {
+		if delay := ParseRateLimitReset(headerValue(headers, header), now); delay > 0 {
+			return delay
+		}
+	}
+	return retryAfter
 }
 
 func ParseRetryAfter(raw string, now time.Time) time.Duration {

--- a/internal/providerfoundation/http_rate_limit_test.go
+++ b/internal/providerfoundation/http_rate_limit_test.go
@@ -1,0 +1,137 @@
+package providerfoundation
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestClassifyDerivesRateLimitDelayFromResetHeaders is CHAOS-3868 evidence.
+// GitHub primary limits usually carry only x-ratelimit-reset and no
+// Retry-After, and GitLab uses RateLimit-Reset; Go read retry-after alone and
+// fell back to a generic 5s-5m backoff, so it re-hit the provider well inside
+// its own stated window -- which is what escalates a primary limit into a
+// secondary one.
+func TestClassifyDerivesRateLimitDelayFromResetHeaders(t *testing.T) {
+	t.Parallel()
+	reset := time.Now().Add(20 * time.Minute)
+	tests := []struct {
+		name     string
+		provider string
+		status   int
+		headers  http.Header
+	}{
+		{
+			name: "github primary limit", provider: "github", status: http.StatusForbidden,
+			headers: http.Header{
+				"X-Ratelimit-Remaining": {"0"},
+				"X-Ratelimit-Reset":     {epochSeconds(reset)},
+			},
+		},
+		{
+			name: "gitlab 429 reset", provider: "gitlab", status: http.StatusTooManyRequests,
+			headers: http.Header{"Ratelimit-Reset": {epochSeconds(reset)}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			classification := ClassifyHTTP(test.provider, test.status, test.headers)
+			if classification == nil || classification.Class != ErrorRateLimited {
+				t.Fatalf("classification=%+v, want rate limited", classification)
+			}
+			// Allow a second of slack for the clock read inside the classifier.
+			if classification.RetryAfter < 19*time.Minute || classification.RetryAfter > 20*time.Minute+time.Second {
+				t.Fatalf("RetryAfter=%s, want ~20m derived from the reset header", classification.RetryAfter)
+			}
+		})
+	}
+}
+
+// An explicit Retry-After still wins over the reset header, matching Python's
+// resolution order.
+func TestClassifyPrefersRetryAfterOverResetHeader(t *testing.T) {
+	t.Parallel()
+	classification := ClassifyHTTP("github", http.StatusTooManyRequests, http.Header{
+		"Retry-After":       {"120"},
+		"X-Ratelimit-Reset": {epochSeconds(time.Now().Add(time.Hour))},
+	})
+	if classification == nil || classification.RetryAfter != 2*time.Minute {
+		t.Fatalf("classification=%+v, want the explicit 120s Retry-After", classification)
+	}
+}
+
+// A reset header rides along on responses that are not rate limits at all, so
+// it must not become a retry delay for them.
+func TestClassifyIgnoresResetHeaderOnNonRateLimitedResponses(t *testing.T) {
+	t.Parallel()
+	classification := ClassifyHTTP("github", http.StatusInternalServerError, http.Header{
+		"X-Ratelimit-Reset": {epochSeconds(time.Now().Add(time.Hour))},
+	})
+	if classification == nil || classification.Class != ErrorTransient {
+		t.Fatalf("classification=%+v, want transient", classification)
+	}
+	if classification.RetryAfter != 0 {
+		t.Fatalf("RetryAfter=%s, want 0 for a non-rate-limited response", classification.RetryAfter)
+	}
+}
+
+type recordingGate struct {
+	penalties []time.Duration
+}
+
+func (gate *recordingGate) Wait(context.Context) (time.Duration, error) { return 0, nil }
+
+func (gate *recordingGate) Penalize(_ context.Context, delay time.Duration) error {
+	gate.penalties = append(gate.penalties, delay)
+	return nil
+}
+
+// TestRateLimitPenalizesSharedGateWithUntruncatedDelay is CHAOS-3868 evidence.
+// The Valkey gate is shared cross-runtime -- Celery workers read the same key
+// -- and accepts up to 300s, but it was armed with this client's already
+// truncated retry wait, so it under-penalized the Celery workers too.
+func TestRateLimitPenalizesSharedGateWithUntruncatedDelay(t *testing.T) {
+	t.Parallel()
+	policy := RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: 25 * time.Millisecond}
+	client := newTestHTTPClient(t, HTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		return testHTTPResponse(request, http.StatusTooManyRequests, http.Header{
+			"Retry-After": {"240"},
+		}, `{"message":"rate limit"}`), nil
+	}), policy)
+	gate := &recordingGate{}
+	client.Gate = gate
+
+	if _, err := client.Do(context.Background(), http.MethodGet, "/items", nil); err == nil {
+		t.Fatal("rate-limited response did not surface an error")
+	}
+	if len(gate.penalties) != 1 || gate.penalties[0] != 4*time.Minute {
+		t.Fatalf("gate penalties=%v, want one 4m penalty, not the %s retry wait", gate.penalties, policy.MaxWait)
+	}
+}
+
+// A provider delay beyond the honoured ceiling is capped rather than parking
+// the shared gate unbounded, exactly as Python clamps it.
+func TestRateLimitGatePenaltyIsCappedAtTheHonouredCeiling(t *testing.T) {
+	t.Parallel()
+	policy := RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: 25 * time.Millisecond}
+	client := newTestHTTPClient(t, HTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		return testHTTPResponse(request, http.StatusTooManyRequests, http.Header{
+			"Retry-After": {"3600"},
+		}, `{"message":"rate limit"}`), nil
+	}), policy)
+	gate := &recordingGate{}
+	client.Gate = gate
+
+	if _, err := client.Do(context.Background(), http.MethodGet, "/items", nil); err == nil {
+		t.Fatal("rate-limited response did not surface an error")
+	}
+	if len(gate.penalties) != 1 || gate.penalties[0] != RateLimitMaxHonoredDelay {
+		t.Fatalf("gate penalties=%v, want one %s penalty", gate.penalties, RateLimitMaxHonoredDelay)
+	}
+}
+
+func epochSeconds(at time.Time) string {
+	return strconv.FormatInt(at.Unix(), 10)
+}

--- a/internal/providerfoundation/http_regression_test.go
+++ b/internal/providerfoundation/http_regression_test.go
@@ -51,8 +51,15 @@ func TestHTTPClientClampsIntegerAndDateRetryAfter(t *testing.T) {
 			if parsed <= policy.MaxWait {
 				t.Fatalf("fixture did not exceed max wait: %s", parsed)
 			}
-			if got := client.retryDelay(1, parsed); got != policy.MaxWait {
+			// Generic transient errors keep the policy's own ceiling.
+			if got := client.retryDelay(1, parsed, ErrorTransient); got != policy.MaxWait {
 				t.Fatalf("retry delay=%s, want %s", got, policy.MaxWait)
+			}
+			// A rate limit is the provider stating its own window, so it is
+			// honoured up to Python's 300s ceiling instead of being truncated
+			// to MaxWait and retried inside the window (CHAOS-3868).
+			if got := client.retryDelay(1, parsed, ErrorRateLimited); got != RateLimitMaxHonoredDelay {
+				t.Fatalf("rate-limit delay=%s, want %s", got, RateLimitMaxHonoredDelay)
 			}
 		})
 	}
@@ -77,7 +84,7 @@ func TestHTTPClientRetryJitterStaysWithinBounds(t *testing.T) {
 				t.Fatal("unexpected request")
 				return nil, nil
 			}), test.policy)
-			if got := client.retryDelay(test.attempt, 0); got < test.minimum || got > test.maximum {
+			if got := client.retryDelay(test.attempt, 0, ErrorTransient); got < test.minimum || got > test.maximum {
 				t.Fatalf("retry delay=%s, want [%s,%s]", got, test.minimum, test.maximum)
 			}
 		})
@@ -96,7 +103,7 @@ func TestHTTPClientRetryJitterFallsBackWhenEntropyFails(t *testing.T) {
 	}), policy)
 	client.entropy = failingEntropyReader{}
 
-	if got := client.retryDelay(1, 0); got != policy.InitialWait {
+	if got := client.retryDelay(1, 0, ErrorTransient); got != policy.InitialWait {
 		t.Fatalf("retry delay=%s, want unjittered fallback %s", got, policy.InitialWait)
 	}
 	response, err := client.Do(context.Background(), http.MethodGet, "/items", nil)

--- a/internal/providersync/github_tests_chunked_route.go
+++ b/internal/providersync/github_tests_chunked_route.go
@@ -391,7 +391,7 @@ func (handler GitHubTestsRouteHandler) CollectChunks(
 						}
 						rows, parseErr := parseGitHubTestsArtifact(archive, repoID, pipeline.RunID, claim.OrgID, pipeline.StartedAtPtr(), pipeline.FinishedAt, normalizedAt)
 						if parseErr != nil {
-							return fmt.Errorf("%w: reports skipped=%d: %v", ErrGitHubTestsIncomplete, rows.Skipped, parseErr)
+							return fmt.Errorf("%w: artifact parse failed: %v", ErrGitHubTestsIncomplete, parseErr)
 						}
 						reportIncomplete, optional := rows.optionalIncomplete()
 						if !optional {

--- a/internal/providersync/github_tests_route.go
+++ b/internal/providersync/github_tests_route.go
@@ -308,7 +308,7 @@ func (handler GitHubTestsRouteHandler) Collect(
 			}
 			rows, parseErr := parseGitHubTestsArtifact(archive, repoID, pipeline.RunID, claim.OrgID, pipeline.StartedAtPtr(), pipeline.FinishedAt, normalizedAt)
 			if parseErr != nil {
-				return CompleteRouteBatch{}, fmt.Errorf("%w: reports skipped=%d: %v", ErrGitHubTestsIncomplete, rows.Skipped, parseErr)
+				return CompleteRouteBatch{}, fmt.Errorf("%w: artifact parse failed: %v", ErrGitHubTestsIncomplete, parseErr)
 			}
 			reportIncomplete, optional := rows.optionalIncomplete()
 			if !optional {

--- a/internal/providersync/jira_incidents_generic_oracle_test.go
+++ b/internal/providersync/jira_incidents_generic_oracle_test.go
@@ -41,6 +41,28 @@ func oracleJiraIncidentCases() []oracleCase {
 				"priority": map[string]any{"name": "Highest"},
 			}},
 		}},
+		// CHAOS-3869: the shapes Jira Cloud REST actually returns -- a numeric
+		// "+0000" offset with millisecond precision, which strict RFC3339
+		// parsing rejected. Every other case here is Z-suffixed, which is why
+		// the oracle could not catch it either.
+		{ID: "jira_cloud_numeric_offset", Input: map[string]any{
+			"cloud_id": "cloud-123", "base_url": "https://acme.atlassian.net",
+			"raw_issue": map[string]any{"id": "10003", "key": "JSM-7", "fields": map[string]any{
+				"summary": "Checkout latency", "created": "2026-07-22T10:00:00.000+0000",
+				"updated": "2026-07-22T10:05:00.000+0000", "resolutiondate": "2026-07-22T10:30:00.000+0000",
+				"status":   map[string]any{"name": "Done", "statusCategory": map[string]any{"key": "done"}},
+				"priority": map[string]any{"name": "High"},
+			}},
+		}},
+		{ID: "jira_cloud_non_utc_offset", Input: map[string]any{
+			"cloud_id": "cloud-123", "base_url": "https://acme.atlassian.net",
+			"raw_issue": map[string]any{"id": "10004", "key": "JSM-8", "fields": map[string]any{
+				"summary": "Region failover", "created": "2026-07-22T12:00:00.000+0200",
+				"updated": "2026-07-22T12:05:00.000+0200", "resolutiondate": nil,
+				"status":   map[string]any{"name": "Investigating", "statusCategory": map[string]any{"key": "indeterminate"}},
+				"priority": nil,
+			}},
+		}},
 		{ID: "resolved_without_priority", Input: map[string]any{
 			"cloud_id": "CLOUD-XYZ", "base_url": "https://team.atlassian.net/",
 			"raw_issue": map[string]any{"id": "10002", "key": "OPS-9", "fields": map[string]any{

--- a/internal/providersync/jira_incidents_route.go
+++ b/internal/providersync/jira_incidents_route.go
@@ -478,11 +478,18 @@ func normalizeJiraIncident(
 }
 
 func parseJiraIncidentTime(raw string) (time.Time, error) {
-	parsed, err := time.Parse(time.RFC3339Nano, raw)
-	if err != nil {
-		return time.Time{}, providerfoundation.ErrNormalizationInvalid
+	// Shares normalizeJiraOffset with the work-items path: Jira Cloud returns
+	// "+0000" offsets that strict RFC3339 parsing rejects, which failed every
+	// real incidents unit with ErrNormalizationInvalid -- a category that is
+	// not deterministically terminal, so it burned all 5 attempts and
+	// terminalized the whole dataset (CHAOS-3869).
+	normalized := normalizeJiraOffset(strings.TrimSpace(raw))
+	for _, layout := range jiraTimestampLayouts {
+		if parsed, err := time.Parse(layout, normalized); err == nil {
+			return parsed.UTC().Truncate(time.Microsecond), nil
+		}
 	}
-	return parsed.UTC().Truncate(time.Microsecond), nil
+	return time.Time{}, providerfoundation.ErrNormalizationInvalid
 }
 
 type jiraOperationalField struct {

--- a/internal/providersync/jira_incidents_route_test.go
+++ b/internal/providersync/jira_incidents_route_test.go
@@ -54,7 +54,7 @@ func (doer *jiraIncidentDoer) Do(request *http.Request) (*http.Response, error) 
 		if !strings.Contains(payload["jql"].(string), `project in (JSM)`) {
 			doer.t.Fatalf("JQL=%q", payload["jql"])
 		}
-		body = `{"issues":[{"id":"10001","key":"JSM-1","fields":{"summary":"API down","created":"2026-07-22T10:00:00Z","updated":"2026-07-22T10:05:00Z","resolutiondate":null,"status":{"name":"Investigating","statusCategory":{"key":"indeterminate"}},"priority":{"name":"Highest"}}},{"id":"10002","key":"JSM-2","fields":{"summary":"Ordinary request","created":"2026-07-22T11:00:00Z","updated":"2026-07-22T11:05:00Z","resolutiondate":null,"status":{"name":"Open","statusCategory":{"key":"new"}},"priority":null}}],"isLast":true}`
+		body = `{"issues":[{"id":"10001","key":"JSM-1","fields":{"summary":"API down","created":"2026-07-22T10:00:00.000+0000","updated":"2026-07-22T10:05:00.000+0000","resolutiondate":null,"status":{"name":"Investigating","statusCategory":{"key":"indeterminate"}},"priority":{"name":"Highest"}}},{"id":"10002","key":"JSM-2","fields":{"summary":"Ordinary request","created":"2026-07-22T11:00:00.000+0000","updated":"2026-07-22T11:05:00.000+0000","resolutiondate":null,"status":{"name":"Open","statusCategory":{"key":"new"}},"priority":null}}],"isLast":true}`
 	case "https://api.atlassian.com/jsm/incidents/cloudId/cloud-123/v1/incident/10001":
 		body = `{}`
 	case "https://api.atlassian.com/jsm/incidents/cloudId/cloud-123/v1/incident/10002":
@@ -280,5 +280,41 @@ func TestJiraIncidentsRouteRechecksRevokedEntitlementAtClickHouseWrite(t *testin
 	}).WriteEffect(context.Background(), claim, batch.Effects[0])
 	if !errors.Is(err, ErrJiraIncidentEntitlementDisabled) || checks != 2 || writer.prepared != 0 {
 		t.Fatalf("write checks=%d prepared=%d err=%v", checks, writer.prepared, err)
+	}
+}
+
+// TestParseJiraIncidentTimeAcceptsRealJiraCloudShapes is CHAOS-3869 evidence.
+// Jira Cloud REST returns created/updated/resolutiondate as
+// "2026-07-22T10:00:00.000+0000" -- a numeric offset with no colon, which
+// time.Parse(time.RFC3339Nano, ...) rejects. Strict parsing here failed every
+// real incidents unit with ErrNormalizationInvalid, a category that is not
+// deterministically terminal, so it burned all 5 attempts and terminalized the
+// dataset. Route fixtures were Z-suffixed, so CI could not catch it.
+func TestParseJiraIncidentTimeAcceptsRealJiraCloudShapes(t *testing.T) {
+	t.Parallel()
+	want := time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)
+	for _, raw := range []string{
+		"2026-07-22T10:00:00.000+0000",
+		"2026-07-22T10:00:00+0000",
+		"2026-07-22T10:00:00.000Z",
+		"2026-07-22T10:00:00Z",
+		"2026-07-22T10:00:00.000+00:00",
+		" 2026-07-22T10:00:00.000+0000 ",
+	} {
+		parsed, err := parseJiraIncidentTime(raw)
+		if err != nil {
+			t.Fatalf("parseJiraIncidentTime(%q) = %v", raw, err)
+		}
+		if !parsed.Equal(want) {
+			t.Fatalf("parseJiraIncidentTime(%q) = %s, want %s", raw, parsed, want)
+		}
+	}
+	// A non-zero offset must still be honoured, not silently treated as UTC.
+	offset, err := parseJiraIncidentTime("2026-07-22T12:00:00.000+0200")
+	if err != nil || !offset.Equal(want) {
+		t.Fatalf("parseJiraIncidentTime(+0200) = %s, %v; want %s", offset, err, want)
+	}
+	if _, err := parseJiraIncidentTime("not-a-timestamp"); err == nil {
+		t.Fatal("malformed timestamp was accepted")
 	}
 }

--- a/internal/providersync/jira_work_items_rows.go
+++ b/internal/providersync/jira_work_items_rows.go
@@ -649,19 +649,35 @@ func jiraTime(value any) *time.Time {
 			return &parsed
 		}
 	}
-	if strings.HasSuffix(raw, "Z") {
-		raw = strings.TrimSuffix(raw, "Z") + "+00:00"
-	}
-	if len(raw) >= 5 && (raw[len(raw)-5] == '+' || raw[len(raw)-5] == '-') && raw[len(raw)-3] != ':' {
-		raw = raw[:len(raw)-2] + ":" + raw[len(raw)-2:]
-	}
-	for _, layout := range []string{time.RFC3339Nano, "2006-01-02T15:04:05.000-07:00"} {
+	raw = normalizeJiraOffset(raw)
+	for _, layout := range jiraTimestampLayouts {
 		if parsed, err := time.Parse(layout, raw); err == nil {
 			parsed = parsed.UTC()
 			return &parsed
 		}
 	}
 	return nil
+}
+
+// jiraTimestampLayouts are the shapes Jira REST returns for datetime fields.
+var jiraTimestampLayouts = []string{time.RFC3339Nano, "2006-01-02T15:04:05.000-07:00"}
+
+// normalizeJiraOffset rewrites Jira Cloud's numeric offset into the colon form
+// RFC3339 requires: the API returns "2026-07-22T10:00:00.000+0000", which
+// time.Parse(time.RFC3339Nano, ...) rejects outright. A "Z" suffix becomes an
+// explicit zero offset so one layout set covers every shape.
+//
+// This lived only on the work-items path; the incidents route parsed strict
+// RFC3339 and so rejected every real Jira Cloud incident (CHAOS-3869). Route
+// fixtures were Z-suffixed, which is why CI could not catch it.
+func normalizeJiraOffset(raw string) string {
+	if strings.HasSuffix(raw, "Z") {
+		raw = strings.TrimSuffix(raw, "Z") + "+00:00"
+	}
+	if len(raw) >= 5 && (raw[len(raw)-5] == '+' || raw[len(raw)-5] == '-') && raw[len(raw)-3] != ':' {
+		raw = raw[:len(raw)-2] + ":" + raw[len(raw)-2:]
+	}
+	return raw
 }
 
 func jiraFloat(value any) *float64 {

--- a/internal/providersync/pagerduty_incidents_route.go
+++ b/internal/providersync/pagerduty_incidents_route.go
@@ -523,6 +523,21 @@ func (handler PagerDutyIncidentFamilyRouteHandler) collectPagerDutyIncidents(
 		rows = append(rows, row)
 		watermark = pagerDutyMaxTime(watermark, createdAt)
 	}
+	// An empty window is a complete answer, not a missing one: a quiet
+	// PagerDuty account (the common case) has no incidents to derive a
+	// watermark from, and leaving it nil meant Complete skipped the watermark
+	// write entirely. The incremental window [W, now] then grew without bound,
+	// every run re-listed the whole span, and watermark-lag monitoring fired
+	// forever. Python's shared worker falls back to the window end for exactly
+	// this reason (sync_units.py, run_sync_unit).
+	//
+	// Guarded on CapReached: a capped page collection did NOT see the whole
+	// window, so advancing past it would skip incidents the unit never read.
+	// That fail-closed refusal is the behaviour Go deliberately added over
+	// Python and it is preserved here (CHAOS-3870).
+	if watermark == nil && !parents.CapReached {
+		watermark = claim.BeforeAt
+	}
 	effect, err := effectBatchFromValues("operational_incidents", EffectReadbackRequired, rows)
 	if err != nil {
 		return CompleteRouteBatch{}, err

--- a/internal/providersync/pagerduty_incidents_route_test.go
+++ b/internal/providersync/pagerduty_incidents_route_test.go
@@ -254,3 +254,54 @@ func mustPagerDutyAlertRow(t *testing.T, raw []byte) pagerDutyAlertRow {
 	}
 	return row
 }
+
+// TestPagerDutyIncidentsRouteAdvancesWatermarkOnAnEmptyWindow is CHAOS-3870
+// evidence. A quiet PagerDuty account -- no incidents in the window, the
+// common case -- produced no watermark, so Complete skipped the watermark
+// write entirely: the incremental window [W, now] grew without bound, every
+// run re-listed the whole span, and watermark-lag monitoring fired forever.
+// Python's shared worker falls back to the window end for exactly this case.
+func TestPagerDutyIncidentsRouteAdvancesWatermarkOnAnEmptyWindow(t *testing.T) {
+	t.Parallel()
+	doer := &pagerDutyIncidentFamilyDoer{t: t, responses: []pagerDutyIncidentFamilyResponse{{
+		body: `{"incidents":[],"more":false}`,
+	}}}
+	client := pagerDutyIncidentFamilyTestClient(t, doer)
+	claim := nativeTestClaim("pagerduty", "incidents")
+	credential := providerfoundation.Credential{Provider: "pagerduty", Config: map[string]string{"subdomain": "acme"}}
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).Collect(
+		context.Background(), claim, credential, client,
+		time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Watermark == nil {
+		t.Fatal("empty window left the watermark unset, so it can never advance")
+	}
+	if !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark = %s, want window end %s", batch.Watermark, claim.BeforeAt)
+	}
+	if batch.Evidence.Records != 0 {
+		t.Fatalf("empty window reported %d records", batch.Evidence.Records)
+	}
+}
+
+// A window the route could not read in full must NOT advance: the fail-closed
+// refusal Go added over Python (which silently truncated and advanced anyway)
+// is preserved.
+func TestPagerDutyIncidentsRouteWithholdsWatermarkWhenTheWindowWasCapped(t *testing.T) {
+	t.Parallel()
+	batch, err := (PagerDutyIncidentFamilyRouteHandler{}).collectPagerDutyIncidents(
+		nativeTestClaim("pagerduty", "incidents"), "acme",
+		time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC),
+		pagerDutyIncidentPageCollection{Items: nil, Pages: 1, CapReached: true},
+		1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Watermark != nil {
+		t.Fatalf("capped window advanced the watermark to %s", batch.Watermark)
+	}
+}

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -270,6 +270,66 @@ func (repository *PostgresRepository) ReleaseForRetry(
 // It is intentionally separate from the Python planner's intrinsic
 // budget_deferred episode: a sibling holding a short-lived HTTP slot says
 // nothing about whether this unit can fit the configured sync budget.
+// RateLimitEpisode is the persisted rate-limit deferral bookkeeping for one
+// unit. Python carries the equivalent state in task kwargs
+// (rate_limit_deferrals / rate_limit_first_seen_at); Go keeps it on the row so
+// a process restart resumes the same episode rather than starting a fresh
+// 2-hour budget.
+type RateLimitEpisode struct {
+	Deferrals   int
+	FirstSeenAt *time.Time
+}
+
+// RateLimitEpisode reads the current deferral counters for a leased unit.
+func (repository *PostgresRepository) RateLimitEpisode(
+	ctx context.Context,
+	claim Claim,
+) (RateLimitEpisode, error) {
+	if repository == nil || repository.Pool == nil || ctx == nil || claim.Validate() != nil {
+		return RateLimitEpisode{}, ErrInvalidConfiguration
+	}
+	var episode RateLimitEpisode
+	if err := repository.Pool.QueryRow(ctx, `
+		SELECT COALESCE(rate_limit_deferrals, 0), rate_limit_first_seen_at
+		FROM public.sync_run_units
+		WHERE id = $1::uuid`, claim.ID,
+	).Scan(&episode.Deferrals, &episode.FirstSeenAt); err != nil {
+		return RateLimitEpisode{}, ErrInvalidConfiguration
+	}
+	return episode, nil
+}
+
+// DeferForRateLimit keeps a rate-limited unit claimable without consuming its
+// bounded failure budget, mirroring Python's treatment of a 429 as deferred
+// work rather than a failure. The attempt decrement matches
+// DeferForBudgetContention: River's snooze is already attempt-neutral, and the
+// authoritative sync-unit attempt must stay neutral with it.
+func (repository *PostgresRepository) DeferForRateLimit(
+	ctx context.Context,
+	claim Claim,
+	availableAt time.Time,
+	now time.Time,
+) error {
+	if repository == nil || repository.Pool == nil || ctx == nil ||
+		claim.Validate() != nil || now.IsZero() || !availableAt.After(now) ||
+		availableAt.Sub(now) > rateLimitMaxTotalWait {
+		return ErrInvalidConfiguration
+	}
+	command, err := repository.Pool.Exec(
+		ctx, deferForRateLimitSQL,
+		claim.ID, claim.Owner, now.UTC(), availableAt.UTC(),
+	)
+	if err != nil || command.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	return nil
+}
+
+// rateLimitMaxTotalWait bounds a single deferral's not-before fence. It equals
+// the episode wall-clock budget in internal/jobs/providerunit, which is the
+// longest a deferral could legitimately be scheduled for.
+const rateLimitMaxTotalWait = 2 * time.Hour
+
 func (repository *PostgresRepository) DeferForBudgetContention(
 	ctx context.Context,
 	claim Claim,
@@ -649,6 +709,34 @@ SET status = 'dispatching',
     updated_at = $3
 FROM contention
 WHERE unit.id = contention.id
+  AND unit.status = 'running'
+  AND unit.lease_owner = $2
+  AND unit.lease_expires_at IS NOT NULL
+  AND unit.lease_expires_at > $3`
+
+const deferForRateLimitSQL = `
+UPDATE public.sync_run_units AS unit
+SET status = 'dispatching',
+    attempts = GREATEST(unit.attempts - 1, 0),
+    available_at = $4,
+    error = 'provider_rate_limited',
+    rate_limit_deferrals = COALESCE(unit.rate_limit_deferrals, 0) + 1,
+    rate_limit_first_seen_at = COALESCE(unit.rate_limit_first_seen_at, $3),
+    result = (
+      COALESCE(unit.result::jsonb, jsonb_build_object()) ||
+      jsonb_build_object(
+        'error_category', 'provider_rate_limited',
+        'not_before', to_jsonb($4::timestamptz),
+        'rate_limit_deferrals', COALESCE(unit.rate_limit_deferrals, 0) + 1
+      )
+    ),
+    first_blocked_at = COALESCE(unit.first_blocked_at, $3),
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    last_heartbeat_at = $3,
+    last_retry_reason = 'provider_rate_limited',
+    updated_at = $3
+WHERE unit.id = $1::uuid
   AND unit.status = 'running'
   AND unit.lease_owner = $2
   AND unit.lease_expires_at IS NOT NULL

--- a/internal/providersync/testdata/mutation-plans/provider_budget_contention_deferral.json
+++ b/internal/providersync/testdata/mutation-plans/provider_budget_contention_deferral.json
@@ -129,8 +129,8 @@
     {
       "id": "M6-contention-charged-to-intrinsic-counter",
       "file": "internal/providersync/repository_postgres.go",
-      "find": "    first_blocked_at = COALESCE(unit.first_blocked_at, $3),\n",
-      "replace": "    budget_deferrals = unit.budget_deferrals + 1,\n    first_blocked_at = COALESCE(unit.first_blocked_at, $3),\n",
+      "find": "'provider_budget_contention_deferrals', contention.next_deferrals\n      )\n    ),\n    first_blocked_at = COALESCE(unit.first_blocked_at, $3),\n",
+      "replace": "'provider_budget_contention_deferrals', contention.next_deferrals\n      )\n    ),\n    budget_deferrals = unit.budget_deferrals + 1,\n    first_blocked_at = COALESCE(unit.first_blocked_at, $3),\n",
       "expect_occurrences": 1,
       "rationale": "Short-lived HTTP slot contention must not advance the Python planner's intrinsic budget episode.",
       "proof": [

--- a/tests/tooling/test_go_integration_sharding.py
+++ b/tests/tooling/test_go_integration_sharding.py
@@ -243,7 +243,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
 
     expected_provider_tests = _providersync_top_level_tests()
     expected_integration_tests = _providersync_integration_tagged_tests()
-    assert len(expected_provider_tests) == 919
+    assert len(expected_provider_tests) == 922
     assert len(expected_integration_tests) == 107
     assert expected_integration_tests < expected_provider_tests
 
@@ -260,7 +260,7 @@ def test_shard_plan_is_exhaustive_nonempty_and_machine_readable(
     provider_flattened = [
         test_name for tests in provider_assignments.values() for test_name in tests
     ]
-    assert len(provider_flattened) == len(set(provider_flattened)) == 919
+    assert len(provider_flattened) == len(set(provider_flattened)) == 922
     assert set(provider_flattened) == expected_provider_tests
     assert {
         name
@@ -321,7 +321,7 @@ def test_each_shard_dry_run_executes_only_its_manifest_assignment() -> None:
         )
 
     expected_tests = _providersync_top_level_tests()
-    assert len(selected_tests) == len(set(selected_tests)) == 919
+    assert len(selected_tests) == len(set(selected_tests)) == 922
     assert set(selected_tests) == expected_tests
 
 


### PR DESCRIPTION
## Summary

- **What changed:** Lane C of the PR #1738 readiness review — the four provider-parity regressions that gate enabling any provider route on real traffic.
  - **CHAOS-3868** — rate limits are now deferred, not failed. Two commits: the header/classification half (reset headers, 300s honoured ceiling, un-truncated shared-gate penalty) and the unit-level deferral loop (attempt-neutral snooze, 10-deferral/2h episode budget, `rate_limit_deferrals` bookkeeping, `rate_limit` terminal category).
  - **CHAOS-3869** — `parseJiraIncidentTime` accepted strict RFC3339 only, so every real Jira Cloud incident (`+0000` offsets) failed as `ErrNormalizationInvalid` and terminalized the whole dataset. Now shares `normalizeJiraOffset` with the work-items path.
  - **CHAOS-3870** — PagerDuty's parent incidents watermark never advanced on an empty window, so a quiet account re-listed an ever-growing span forever. Now falls back to the window end, guarded on `CapReached`.
  - **CHAOS-3871** — `auth` / `not_found` / `pagination_incomplete` terminalize on first occurrence with Python's category vocabulary instead of burning five attempts and collapsing into `provider_unit_exhausted`.

- **Why:** all four are behavioural regressions against the running Celery workers. Heavy orgs — the ones that actually hit rate limits — would have gone from "slow" to "terminally failed".

Everything stays default-off: no `WORKER_*_ENABLED` switch touched, no migration applied, no `deployment_state` or replica default changed.

### Two findings that differ from the issues as written

**The three Semgrep threads on CHAOS-3871 are not nil dereferences.** `parseGitHubTestsArtifact` returns `githubTestsReportRows` **by value** and `CollectGitLabPageParamPages` returns `PageCollection` **by value**, so all three flagged expressions read a zero value, never a nil pointer. Two are nonetheless a genuine diagnostics defect and are fixed: both GitHub tests routes interpolated `rows.Skipped` into the artifact-parse error, and that value is structurally always `0` on that path (the parse failed before populating anything), so the message told an operator "skipped=0" regardless of reality. The third (`gitlab_blame_route.go:340`) is correct as written — every error path returns a zero `PageCollection`, so `0` pages is the true count. I'd rather leave it correct than churn it to close a thread.

**CHAOS-3870's fix deliberately does *not* go in the shared completion path**, despite the issue suggesting it might belong there. The 59-route sweep (below) shows a nil watermark is an established *withholding* signal in five routes — they return nil **with** their effects when an optional surface failed — so a blanket `nil -> window_end` fallback in `Complete` would advance watermarks past data that was never persisted. That would regress one of the review's own "confirmed improvements over Python".

## Checklist

- [x] I added/updated tests, or provided required governance evidence below.
- [x] I ran relevant local validation (minimum: `./ci/run_tests.sh unit` for `src/` changes).
- [x] I documented risk and rollback considerations.
- [x] I called out breaking changes, migrations, or config impacts (or wrote `none`).

## Test Evidence

TEST-EVIDENCE:

**CHAOS-3870 — the 59-route empty-window sweep.** All 30 watermark-construction sites across the route tree, classified by how each derives its watermark:

| How the watermark is built | Sites | Advances on an empty window? |
|---|---|---|
| `claim.BeforeAt` assigned directly — github commits, commit-stats, deployments (×2), files, blame, security, prs; gitlab commits, commit-stats, deployments, feature-flags, prs, security; launchdarkly | 15 | Yes |
| `&claim.BeforeAt.UTC()` — gitlab/incidents, jira/incidents, linear/work-items | 3 | Yes |
| Inherits its base batch — github/pr-reviews (from github/prs) | 1 | Yes |
| `claim.BeforeAt` gated on `len(incomplete) == 0` — github/work-items, jira/atlassian, jira/work-items, gitlab/blame, gitlab/files | 5 | Yes — withholds only on partial failure. Correct as-is, and the reason the fix is not shared. |
| Mirrors its derived batch under an equality assertion — gitlab/work-items | 1 | Yes |
| Explicit `nil` — github/repository, gitlab/repository | 2 | N/A — snapshot datasets, no time window |
| **Derived from row timestamps** — pagerduty incidents parent, pagerduty enrichment | 2 | **Parent: NO → this bug, fixed here.** Enrichment: clamps to the earliest undrained incident on purpose; parity-safe, unchanged. |

PagerDuty's parent dataset was the only route that could fail to advance on a window it had fully read.

**Go gates:**

```
$ go test ./...                       # no failures
$ go vet ./...                        # clean
$ bash ci/check_go.sh fast            # fmt, vet, test, build, contract, integration-vet,
                                      # shard plans, multi-replica gate all pass
```

**Every fix verified to be caught by its test** — reverting each one individually fails the corresponding test:

| Reverted fix | Failing test |
|---|---|
| strict RFC3339 in `parseJiraIncidentTime` | `TestParseJiraIncidentTimeAcceptsRealJiraCloudShapes` + 2 incidents route tests |
| rate-limit branch in `Handler.Work` | all 3 `TestProviderRateLimit*` tests |
| `x-ratelimit-reset` fallback / 300s ceiling / gate penalty | 5 new `providerfoundation` tests |

**`ci/local_validate.sh` (SKIP_CLICKHOUSE=1 — no ClickHouse container in this environment):**

```
✔  mutation harness: no mutation applied
✔  lint: ruff format --check
✔  lint: ruff check
✔  typecheck: mypy
✗  unit suite (FULL, not subset)      8 failed, 13364 passed, 653 skipped
```

All 8 failures are **pre-existing and unrelated** — every one reproduces on base `1001ded9` in a clean worktree (`test_helm_migration_hook.py` ×4, `test_worker_metrics_process.py` ×2, `test_governance_workflow.py`, `test_helm_api_probes.py`). None touch files in this diff.

**Live-Python oracles: no new divergence.** The oracle suite cannot execute in this environment — `jira/incidents/row` and 123 others fail inside Python itself (`OperationalOrderingEncodingError: UTC datetime with fold=0 required`), on the base commit too, under both the local interpreter and CI's pinned 3.13.14. To prove this lane introduces no divergence I collected the failing-test set on both sides:

```
$ diff base_failures.txt lane_c_failures.txt && echo IDENTICAL
IDENTICAL: no new oracle failures introduced      # 124 tests, byte-identical sets
```

The two new `+0000` oracle cases added to `jira_incidents_generic_oracle_test.go` are therefore **added but not executed here**; CI must confirm them.

## Risk Notes

RISK-NOTES:

- **Blast radius:** provider sync unit execution and HTTP retry behaviour for all 59 route pairs. All routes remain default-off, so nothing changes in production until a `WORKER_*_ENABLED` switch is turned on.
- **Behavioural changes a reviewer should weigh:**
  - A rate-limited unit now stays claimable for up to 2 hours instead of failing in ~2 minutes. That is the intent, but it does mean a throttled provider holds unit slots much longer; the 10-deferral/2h budget is what bounds it.
  - `auth` / `not_found` / `pagination_incomplete` now fail on the **first** attempt. A fault that was genuinely transient but surfaced as a 401 (e.g. a token mid-rotation) will no longer be retried by the unit. This matches Python's `max_retries=0` for these, and the HTTP layer already treated them as non-retryable.
  - The shared Valkey gate is now armed with a larger penalty (up to 300s vs ≤30s). This intentionally slows the **Celery** workers too, since they read the same key — that under-penalization was itself part of the finding.
  - `CategoryRateLimited` is a new runtime error category; anything enumerating categories needs it (`validErrorCategory` updated).
- **Migrations:** none. `rate_limit_deferrals` / `rate_limit_first_seen_at` already exist on `sync_run_units` — Go only ever cleared them and now writes them.
- **Maintenance updates carried in this branch:** the `provider_budget_contention_deferral` mutation plan's M6 anchor (the plain `first_blocked_at` line now also appears in the new `deferForRateLimitSQL`, and a drifted anchor measures nothing while still being listed as coverage), and the pinned providersync top-level test count in the sharding manifest test (919 → 922).
- **Rollback:** revert the branch. The five commits are independently revertable; CHAOS-3868 is split into a header half and a deferral half so either can be reverted alone.
- **Not done in this lane:** CHAOS-3869's secondary JQL check. Python interpolates `window_start.isoformat()` (`+00:00`) and Go uses `RFC3339Nano` (`Z`); both are ISO-8601 and Jira's enhanced JQL endpoint accepts them, but I could not verify against a live Jira, and Python's form is the production-proven one. I left Go's query format alone rather than change a production query on an unverified hunch — flagged on the issue.
- **Monitoring:** `rate_limit_deferrals` on `sync_run_units` now increments, restoring the CHAOS-2760/3412 budget-guard observability; `last_retry_reason = 'provider_rate_limited'`; the `rate_limit` failure category.

## Optional Context

- Linked issues: [CHAOS-3868](https://linear.app/fullchaos/issue/CHAOS-3868), [CHAOS-3869](https://linear.app/fullchaos/issue/CHAOS-3869), [CHAOS-3870](https://linear.app/fullchaos/issue/CHAOS-3870), [CHAOS-3871](https://linear.app/fullchaos/issue/CHAOS-3871)
- SCREENSHOT-WAIVER: backend-only change; no user-facing surface.
- Additional notes: as with Lane A (#1774), container-backed validation ran with a locally-started Docker daemon and a `mirror.gcr.io` registry mirror, because this environment's egress policy blocks Docker Hub's blob CDN. Images were pulled by the exact pinned digests already in the repo; no repository file was changed for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgFRWxVJLUMooPAELwBPXu)_