### PR TITLE
Lane B: per-queue saturation is per-process, not fleet-wide

### DIFF
--- a/alerts/rules.yml
+++ b/alerts/rules.yml
@@ -153,9 +153,15 @@ groups:
             The oldest available job for queue {{ $labels.queue }} is
             {{ $value | humanizeDuration }} old.
 
+      # worker_execution_saturation_ratio is PER PROCESS: each replica reports
+      # its own running count over its own MaxWorkers. Averaging across
+      # replicas is therefore what yields the queue's fleet utilization, and it
+      # matches the AverageValue target the HPAs in deploy/kubernetes use.
+      # `max by (queue)` would fire whenever any single replica filled up, even
+      # with idle capacity elsewhere in the group (CHAOS-3867).
       - alert: GoWorkerExecutionSaturated
         expr: |
-          max by (queue) (worker_execution_saturation_ratio) > 0.9
+          avg by (queue) (worker_execution_saturation_ratio) > 0.9
         for: 10m
         labels:
           severity: warning
@@ -164,7 +170,7 @@ groups:
           summary: "Go worker queue {{ $labels.queue }} is saturated"
           description: |
             Active work has consumed more than 90% of the declared concurrency
-            budget for queue {{ $labels.queue }}.
+            budget for queue {{ $labels.queue }}, averaged across its replicas.
 
       - alert: GoWorkerAttemptFailureRateHigh
         expr: |

--- a/cmd/dev-health-worker/queue_health.go
+++ b/cmd/dev-health-worker/queue_health.go
@@ -156,6 +156,12 @@ func (monitor *queueHealthMonitor) report(
 	// worker's capacity was already committed. It is the earliest signal that a
 	// queue is about to build a backlog, so it is reported independently of
 	// depth.
+	//
+	// This is a PER-PROCESS ratio -- this client's running jobs over its own
+	// MaxWorkers -- so the log line means "this replica is nearly full", which
+	// is the actionable statement a single process can make. Fleet utilization
+	// is the average across replicas, which is what the GoWorkerExecutionSaturated
+	// alert and the HPA targets compute (CHAOS-3867).
 	for _, capacity := range snapshot.QueueCapacities {
 		if capacity.Saturation <= queueSaturationWarnRatio {
 			continue

--- a/internal/jobruntime/observer.go
+++ b/internal/jobruntime/observer.go
@@ -28,7 +28,7 @@ type JobLabels struct {
 // row's ScheduledAt, since that is the only place the adapter observes both
 // the job's availability time and its execution start. Deployment sampling
 // sets worker_execution_saturation_ratio{queue} directly from configured
-// worker capacity and active executions.
+// worker capacity and active executions, both scoped to this process.
 //
 // Pool adapters use worker_database_pool_saturation_ratio{pool} and
 // worker_database_pool_acquire_seconds{pool,result}; pool is bounded to

--- a/internal/jobruntime/telemetry.go
+++ b/internal/jobruntime/telemetry.go
@@ -724,7 +724,7 @@ func (collector *MetricsCollector) writeJobs(output *strings.Builder) {
 		writeIntSample(output, "worker_jobs_running", jobMetricLabels(labels), collector.jobsRunning[labels])
 	}
 
-	writeMetadata(output, "worker_execution_saturation_ratio", "Fraction of configured worker execution capacity currently in use.", "gauge")
+	writeMetadata(output, "worker_execution_saturation_ratio", "Fraction of THIS process's configured worker execution capacity currently in use. Per-process, not fleet-wide: average across replicas for fleet utilization.", "gauge")
 	for _, labels := range queues {
 		writeFloatSample(output, "worker_execution_saturation_ratio", queueMetricLabels(labels), collector.executionSaturation[labels])
 	}

--- a/internal/storage/river/telemetry.go
+++ b/internal/storage/river/telemetry.go
@@ -70,7 +70,11 @@ type QueueAgeTelemetry struct {
 	OldestAvailableAge time.Duration
 }
 
-// QueueCapacityTelemetry reports one queue's live running count and capacity.
+// QueueCapacityTelemetry reports one queue's live running count and capacity,
+// both scoped to THIS process. Running counts only jobs this client claimed and
+// Capacity is this client's MaxWorkers for the queue, so Saturation is a
+// per-process ratio. Averaging it across replicas gives fleet utilization;
+// summing Running across replicas gives the fleet's in-flight count.
 type QueueCapacityTelemetry struct {
 	Queue      string
 	Capacity   int64
@@ -464,12 +468,22 @@ local_running AS (
         AND river_job.attempted_by[array_upper(river_job.attempted_by, 1)] = $7::text
 ),
 queue_running AS (
+    -- Scoped to THIS client, like local_running above. The capacity this count
+    -- is divided by is QueueCapacityTelemetry.Capacity, which is this
+    -- process's MaxWorkers, so a fleet-wide numerator made every replica
+    -- report saturation of roughly N at N replicas -- clamped to 1.0, so the
+    -- signal an operator would use to decide scale-out was pegged at 100%
+    -- exactly under scale-out (CHAOS-3867). Per-process is also what the
+    -- sibling LocalRunning/ExecutionSaturation metrics already report, and it
+    -- aggregates correctly: averaging the ratio across replicas gives fleet
+    -- utilization without depending on presence-table freshness.
     SELECT
         river_job.queue,
         count(*)::bigint AS running
     FROM {{river_job}} AS river_job
     WHERE river_job.queue = ANY($3::text[])
         AND river_job.state = 'running'
+        AND river_job.attempted_by[array_upper(river_job.attempted_by, 1)] = $7::text
     GROUP BY river_job.queue
 ),
 unsupported_available AS (

--- a/internal/storage/river/telemetry_integration_test.go
+++ b/internal/storage/river/telemetry_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestQueueTelemetrySamplerReadsPinnedRiverSchemaWithoutClaimingJobs(t *testing.T) {
@@ -138,5 +139,106 @@ func TestQueueTelemetrySamplerReadsPinnedRiverSchemaWithoutClaimingJobs(t *testi
 	}
 	if err := sampler.CheckAvailableContractVersions(ctx); !errors.Is(err, riverstore.ErrUnsupportedAvailableContractVersion) {
 		t.Fatalf("unknown kind readiness error = %v", err)
+	}
+}
+
+// TestQueueSaturationIsPerProcessAcrossReplicas is CHAOS-3867 evidence.
+//
+// The per-queue running count was fleet-wide while the capacity it is divided
+// by is this process's MaxWorkers, so every replica of an N-replica group
+// reported saturation of roughly N -- clamped to 1.0. The signal an operator
+// uses to decide scale-out was therefore pegged at 100% exactly under
+// scale-out, and the queue_saturation warning (threshold 0.9) fired
+// permanently at N >= 2.
+func TestQueueSaturationIsPerProcessAcrossReplicas(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeInstance(t, instance)
+
+	adminPool := openPool(t, ctx, instance.URI)
+	defer adminPool.Close()
+	createRuntimeRoles(t, ctx, adminPool)
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, adminPool, riverstore.MigrationOptions{
+		Schema: "river", DomainRole: domainRole, QueueRole: queueRole,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	queuePool := openPool(t, ctx, roleURI(t, instance.URI, queueRole, queuePassword, "worker_test"))
+	defer queuePool.Close()
+	samplerFor := func(clientID string) *riverstore.QueueTelemetrySampler {
+		t.Helper()
+		sampler, err := riverstore.NewQueueTelemetrySampler(queuePool, riverstore.QueueTelemetryConfig{
+			Schema:   "river",
+			ClientID: clientID,
+			Queues:   []riverstore.QueueTelemetryQueue{{Name: "retention", MaxWorkers: 2}},
+			Jobs: []riverstore.QueueTelemetryJob{
+				{Queue: "retention", Kind: "system.retention_cleanup", SupportedVersions: []int{1}},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sampler
+	}
+	saturationFor := func(sampler *riverstore.QueueTelemetrySampler) (float64, int64) {
+		t.Helper()
+		snapshot, err := sampler.Snapshot(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, capacity := range snapshot.QueueCapacities {
+			if capacity.Queue == "retention" {
+				return capacity.Saturation, capacity.Running
+			}
+		}
+		t.Fatal("retention queue missing from snapshot")
+		return 0, 0
+	}
+
+	first, second := samplerFor("replica-1"), samplerFor("replica-2")
+
+	// An idle two-replica group must not trip the 0.9 queue_saturation warning.
+	for name, sampler := range map[string]*riverstore.QueueTelemetrySampler{
+		"replica-1": first, "replica-2": second,
+	} {
+		if saturation, running := saturationFor(sampler); saturation != 0 || running != 0 {
+			t.Fatalf("idle %s reported saturation=%v running=%d, want 0/0", name, saturation, running)
+		}
+	}
+
+	// Each replica claims one of its two slots: 2 of 4 fleet slots busy, so
+	// true utilization is 50%. Fleet-wide counting reported 2/2 = 1.0 on BOTH.
+	insertRunningRetentionJob(t, ctx, adminPool, "replica-1")
+	insertRunningRetentionJob(t, ctx, adminPool, "replica-2")
+
+	for name, sampler := range map[string]*riverstore.QueueTelemetrySampler{
+		"replica-1": first, "replica-2": second,
+	} {
+		saturation, running := saturationFor(sampler)
+		if running != 1 {
+			t.Fatalf("%s counted %d running jobs, want only its own 1", name, running)
+		}
+		if saturation != 0.5 {
+			t.Fatalf("%s reported saturation=%v at 50%% true utilization, want 0.5", name, saturation)
+		}
+	}
+}
+
+func insertRunningRetentionJob(t *testing.T, ctx context.Context, pool *pgxpool.Pool, clientID string) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO river.river_job
+			(state, max_attempts, args, kind, queue, scheduled_at, attempted_by)
+		VALUES ('running', 3, '{"contract_version":1}'::jsonb, 'system.retention_cleanup',
+			'retention', now(), $1)`,
+		[]string{clientID},
+	); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/tests/workers/test_go_worker_alerts.py
+++ b/tests/workers/test_go_worker_alerts.py
@@ -44,8 +44,12 @@ def test_go_worker_alerts_use_runtime_metric_dimensions() -> None:
         "max by (queue) (worker_job_oldest_age_seconds)"
         in alerts["GoWorkerOldestAvailableJobHigh"]
     )
+    # worker_execution_saturation_ratio is per process, so the fleet's
+    # utilization is the AVERAGE across replicas -- the same aggregation the
+    # Kubernetes HPAs target. `max` would fire whenever one replica filled up
+    # while the group still had idle capacity (CHAOS-3867).
     assert (
-        "max by (queue) (worker_execution_saturation_ratio)"
+        "avg by (queue) (worker_execution_saturation_ratio)"
         in alerts["GoWorkerExecutionSaturated"]
     )
     assert (


### PR DESCRIPTION
## Summary

- **What changed:** CHAOS-3867. The `queue_running` CTE counted `state='running'` for **every** client, but the capacity it is divided by is `QueueCapacityTelemetry.Capacity` — this process's `MaxWorkers`. Every replica of an N-replica group therefore reported saturation of roughly N, clamped to 1.0.
- **Why:** the signal an operator uses to decide scale-out was pegged at 100% **exactly under scale-out**, and the `queue_saturation` warning fired permanently at N ≥ 2.

The running count is now scoped to this client, matching the `local_running` CTE directly above it and the `LocalRunning`/`ExecutionSaturation` scalars, which were already client-scoped.

**Semantics chosen: per-process.** The issue offered either scoping the numerator or dividing by fleet capacity. Per-process needs no dependency on presence-table freshness, matches the sibling metrics, and aggregates cleanly — averaging the ratio across replicas gives fleet utilization. It is now stated in the metric help text, the `QueueCapacityTelemetry` doc comment, the `Observer` contract, and the `queue_saturation` log site.

**Alert aligned to match:** `GoWorkerExecutionSaturated` moves from `max by (queue)` to `avg by (queue)`, which is the queue's fleet utilization and the same aggregation the Kubernetes HPAs already target with `AverageValue: 800m`. `max` would fire whenever a single replica filled up while the group still had idle capacity.

### Worth a reviewer's attention

**The pre-existing integration test in this package was already failing at head.** `TestQueueTelemetrySamplerReadsPinnedRiverSchemaWithoutClaimingJobs` inserts three running `retention` jobs — two owned by `client-ops`, one by `other-client` — and asserts `Running == 2`, i.e. the client-scoped count. With the fleet-wide CTE it got 3:

```
$ git stash && go test -tags=integration -run TestQueueTelemetrySamplerReadsPinnedRiverSchema... ./internal/storage/river/
--- FAIL: TestQueueTelemetrySamplerReadsPinnedRiverSchemaWithoutClaimingJobs (2.77s)
    telemetry_integration_test.go:113: live queue capacities = map[heartbeat:{heartbeat 2 1 0.5} retention:{retention 2 3 1}]
FAIL
```

So the correct behaviour was already written down and the test had been red — undetected because `go.yml`'s `push`/`pull_request` triggers are commented out, so neither the Go gate nor the Docker-backed integration job runs on PRs. This is the second concrete breakage that disabled CI has hidden (the first was the dead multi-replica gate in #1774). Worth deciding on separately.

## Checklist

- [x] I added/updated tests, or provided required governance evidence below.
- [x] I ran relevant local validation (minimum: `./ci/run_tests.sh unit` for `src/` changes).
- [x] I documented risk and rollback considerations.
- [x] I called out breaking changes, migrations, or config impacts (or wrote `none`).

## Test Evidence

TEST-EVIDENCE:

**New acceptance test — two replicas at 50% true utilization report 0.5, not 1.0:**

```
$ GOWORK=off go test -tags=integration -count=1 -run TestQueueSaturationIsPerProcessAcrossReplicas ./internal/storage/river/
--- PASS: TestQueueSaturationIsPerProcessAcrossReplicas (2.84s)
ok  	github.com/full-chaos/dev-health-ops/internal/storage/river	2.854s
```

It covers both acceptance criteria: an idle two-replica group reports `0` (well under the 0.9 threshold), and with each replica holding one of its two slots — 2 of 4 fleet slots busy — each reports `0.5`. Reverting the CTE fails it:

```
--- FAIL: TestQueueSaturationIsPerProcessAcrossReplicas (2.93s)
    telemetry_integration_test.go:225: replica-1 counted 2 running jobs, want only its own 1
```

**Whole package, integration tag (including the previously-red test):**

```
$ GOWORK=off go test -tags=integration -count=1 ./internal/storage/river/
ok  	github.com/full-chaos/dev-health-ops/internal/storage/river	9.987s
```

**Go tree + alert contract:**

```
$ go test ./...                                              # no failures
$ .venv/bin/python -m pytest tests/workers/test_go_worker_alerts.py -q
5 passed
```

**`ci/local_validate.sh` (SKIP_CLICKHOUSE=1 — no ClickHouse container in this environment):**

```
✔  mutation harness: no mutation applied
✔  lint: ruff format --check
✔  lint: ruff check
✔  typecheck: mypy
✗  unit suite (FULL, not subset)      9 failed, 13366 passed, 653 skipped
```

All 9 failures are **pre-existing and unrelated** — the same set verified against base in #1774 (`test_helm_migration_hook.py` ×4, `test_worker_metrics_process.py` ×2, `test_worker_workgraph.py`, `test_governance_workflow.py`, `test_helm_api_probes.py`). None touch files in this diff.

## Risk Notes

RISK-NOTES:

- **Blast radius:** one observability metric and one alert expression. No execution path, routing, migration, or replica default changes; the sampler still only reads, never claims.
- **Behavioural changes a reviewer should weigh:**
  - `worker_execution_saturation_ratio{queue}` will **drop** for any group already running more than one replica — from a pegged 1.0 to the true per-process value. That is the fix, but dashboards or saved queries reading it as fleet-wide will now read low by a factor of N unless they average.
  - `GoWorkerExecutionSaturated` changes aggregation, so it becomes both quieter (no longer permanently firing at N ≥ 2) and slightly less sensitive (one hot replica in a group with spare capacity no longer alerts). If you'd rather keep a per-replica hot-spot alert, that wants a second rule with `max`; I did not add one because the issue asked for one semantics, aligned.
  - HPA behaviour is unchanged in intent and now correct in practice: `AverageValue: 800m` was already averaging across pods, it was just averaging a broken input.
- **Migrations:** none.
- **Rollback:** revert the branch. The two commits are independently revertable; the second is comment-only.
- **Monitoring after merge:** expect `worker_execution_saturation_ratio` to fall and `GoWorkerExecutionSaturated` to stop firing on multi-replica groups. If it stays quiet through a genuine backlog, the threshold — not the aggregation — is the thing to revisit.

## Optional Context

- Linked issues: [CHAOS-3867](https://linear.app/fullchaos/issue/CHAOS-3867)
- SCREENSHOT-WAIVER: backend/observability-only change; no user-facing surface.
- Additional notes: container-backed validation ran with a locally-started Docker daemon and a `mirror.gcr.io` registry mirror, because this environment's egress policy blocks Docker Hub's blob CDN. Images were pulled by the exact pinned digests already in the repo; no repository file was changed for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgFRWxVJLUMooPAELwBPXu)_