### PR TITLE
Lane E: cutover-day runbook and claimed-state reconciliation

### DIFF
--- a/cmd/dev-health-scheduler/fixed.go
+++ b/cmd/dev-health-scheduler/fixed.go
@@ -132,12 +132,12 @@ var errFixedScheduleUnbuilt = errors.New("declared fixed schedule has no built p
 // maps onto the schedule table with matching cadence, timezone and catch-up
 // policy, an ownership property, and never constructs a producer at all.
 //
-// This is currently SUBSUMED by the goOwnsMarkers gate: the process already
-// registers unavailable in main.go because checkedInSchedulerActivation
-// .goOwnsMarkers is false, so on today's tree this check never decides anything.
-// It is deliberately not dead code. It becomes load-bearing at the exact moment
-// someone flips that flag, which is the moment a paper-owned schedule must stop
-// the process rather than quietly never run.
+// This check is LOAD-BEARING on today's tree. It was previously subsumed by the
+// goOwnsMarkers gate -- the process registered unavailable in main.go because
+// checkedInSchedulerActivation.goOwnsMarkers was false, so the check never
+// decided anything -- but main.go now sets that flag TRUE. The moment it was
+// flipped is exactly the moment a paper-owned schedule must stop the process
+// rather than quietly never run, which is what this check does.
 func refuseUnbuiltFixedSchedules(
 	producers *schedulerfixed.ProducerSet,
 	schedules []schedulerfixed.Schedule,

--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -398,7 +398,7 @@
       "compatibility_dependency": "The checked-in `dispatch_sync_run` route is River; this Celery task remains only as the declared rollback_route=celery compatibility target.",
       "deletion_evidence_requirement": "Delete this Python task after the Celery rollback route is retired and the native Go dispatch coordinator has completed the required rollback and soak evidence.",
       "acceptance_test_id": "tests/test_sync_units.py",
-      "notes": "transport-routes.json kind dispatch_sync_run, route=river, rollback_route=celery; native Go coordinator is the active path"
+      "notes": "transport-routes.json kind dispatch_sync_run, route=river, rollback_route=celery; the deployed sync_dispatch_transport_routes row is still transport='celery' (seeded by 0049, and no migration flips it), so the native Go coordinator is the CHECKED-IN route, not the running one, until an operator applies it with `dev-health-workerctl routes apply`"
     },
     {
       "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1184",
@@ -446,7 +446,7 @@
       "compatibility_dependency": "The checked-in `finalize_sync_run` route is River; this Celery task remains only as the declared rollback_route=celery compatibility target.",
       "deletion_evidence_requirement": "Delete this Python task after the Celery rollback route is retired and the native Go finalizer has completed the required rollback and soak evidence.",
       "acceptance_test_id": "tests/test_sync_units.py",
-      "notes": "transport-routes.json kind finalize_sync_run, route=river, rollback_route=celery; native Go coordinator is the active path"
+      "notes": "transport-routes.json kind finalize_sync_run, route=river, rollback_route=celery; the deployed sync_dispatch_transport_routes row is still transport='celery' (seeded by 0049, and no migration flips it), so the native Go coordinator is the CHECKED-IN route, not the running one, until an operator applies it with `dev-health-workerctl routes apply`"
     },
     {
       "id": "celery_task:src/dev_health_ops/workers/sync_reconciler.py:78",
@@ -1094,7 +1094,7 @@
       "compatibility_dependency": "The checked-in `reference_discovery` route is River; this Celery task remains only as the declared rollback_route=celery compatibility target.",
       "deletion_evidence_requirement": "Delete this Python task after the Celery rollback route is retired and native Go reference discovery has completed the required rollback and soak evidence.",
       "acceptance_test_id": "tests/test_sync_units.py",
-      "notes": "transport-routes.json kind reference_discovery, route=river, rollback_route=celery; native Go coordinator is the active path"
+      "notes": "transport-routes.json kind reference_discovery, route=river, rollback_route=celery; the deployed sync_dispatch_transport_routes row is still transport='celery' (seeded by 0049, and no migration flips it), so the native Go coordinator is the CHECKED-IN route, not the running one, until an operator applies it with `dev-health-workerctl routes apply`"
     },
     {
       "id": "beat_entry:src/dev_health_ops/workers/config.py:143",

--- a/deploy/go-workers/CUTOVER-RUNBOOK.md
+++ b/deploy/go-workers/CUTOVER-RUNBOOK.md
@@ -1,0 +1,224 @@
+# Celery-to-River cutover day
+
+One document, start to finish, for the operator running the cutover. It exists
+because the procedure was previously spread across four sources that each held
+one part of it: the coexistence runbook in [`README.md`](./README.md), migration
+`0066`'s docstring, the route mechanics in `docs/reference/cli/index.md`, and
+`docs/operate/run/workers-and-jobs.md`. Those remain the reference material;
+this is the order of operations.
+
+**What this document covers:** moving the 23 checked-in worker job kinds from
+Celery to River, verifying them, and rolling back.
+
+**What it deliberately does not cover:**
+
+- **Provider sync routes.** Every `WORKER_*_ENABLED` switch stays off. All 59
+  provider/dataset pairs in `contracts/provider-matrix/v1/matrix.json` are
+  `route_ready`, but enabling them is a separate, per-route decision with its
+  own parity evidence. Cutover day does not flip one.
+- **`sync.provider_unit`.** Migration `0066` deliberately leaves it on the
+  `river_canary` route seeded by `0061`. Promoting it is its own reviewed
+  change.
+- **The four sync-dispatch kinds** (`dispatch_sync_run`, `finalize_sync_run`,
+  `post_sync`, `reference_discovery`). Those live in
+  `sync_dispatch_transport_routes`, which `0049` seeds `transport='celery'` and
+  which no migration flips. They move only through
+  `dev-health-workerctl routes apply`, separately from this procedure.
+- **The scheduler.** Beat ownership is not transferred here.
+
+---
+
+## Preconditions
+
+Do not start until every one of these is true. Each is a stop, not a warning.
+
+1. **The coexistence canary has been run and held.** Follow
+   [`README.md` § CHAOS-3052 deployment runbook](./README.md) to completion.
+   Cutover day begins from a topology that has already been green.
+2. **Every Go group that owns a retargeted queue is scaled up and ready.**
+   This is the ordering requirement in `0066`'s own docstring: a kind routed to
+   River stages envelopes in `worker_job_outbox` for the reconciler to insert.
+   With no consumer for the owning queue, work accumulates unexecuted and
+   nothing fails loudly.
+
+   ```bash
+   dev-health-workerctl workers queues status
+   ```
+
+   Confirm for each group: `queues`, `desired_replicas`, non-zero expiring
+   `live_replicas`, `drain_state` clear, and connection-budget headroom.
+3. **The reconciler is running and ready.** It is what relays outbox rows into
+   River. A cutover with workers but no reconciler stages work nowhere.
+4. **The application schema is current, with `0066` still pending.**
+
+   ```bash
+   python -m dev_health_ops.cli migrate postgres upgrade
+   python -m dev_health_ops.cli migrate postgres status --check
+   ```
+
+   Without the opt-in below, this advances the `application_schema` branch and
+   leaves the sibling `0066` River activation pending. **Never run
+   `alembic upgrade head`** — the graph intentionally has multiple heads, and a
+   direct run against a database with no Go workers would silently stop
+   background processing for every retargeted kind.
+5. **Baseline metrics captured**, so post-cutover numbers mean something:
+   `worker_jobs_available`, `worker_job_oldest_age_seconds`,
+   `worker_execution_saturation_ratio`, `worker_database_pool_saturation_ratio`.
+6. **A rollback decision-maker is on the call** and the decision points below
+   have been read in advance, not during an incident.
+
+---
+
+## Phase 1 — Drain Celery
+
+`0066` cannot see a Celery message already in the broker. Draining is what
+makes the cutover a handoff rather than an overlap.
+
+Order matters:
+
+1. **Stop Celery producers first** — the API and anything that enqueues.
+   Draining consumers while producers keep enqueuing does not converge.
+2. **Let the Celery consumers finish in-flight work.** Watch queue depth to
+   zero. Do not kill workers mid-task; a partially-completed task is exactly
+   the state neither runtime can reason about.
+3. **Stop the Celery consumers and Beat.**
+4. **Confirm the broker is empty** for every queue owning a retargeted kind.
+
+> Do **not** use `workers queues drain` for this. That command pauses named
+> queues for a whole Go group — it is for Go-side rollouts, not for Celery
+> shutdown.
+
+---
+
+## Phase 2 — Run the cutover migration
+
+The authorization is a one-shot, scoped to this run. There is **no** separate
+interactive confirmation once it is present: with the variable set, any
+migration run that reaches `0066` applies it.
+
+```bash
+# 1. SET — scoped to this command, not exported to a shell you keep using.
+DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER=1 \
+  python -m dev_health_ops.cli migrate postgres upgrade
+
+# 2. VERIFY — the river_cutover branch head is now applied.
+python -m dev_health_ops.cli migrate postgres status --check
+```
+
+Without the variable, `0066` raises rather than applying — that refusal is the
+guard working, not a failure to diagnose.
+
+**3. UNSET.** Remove the authorization from the environment, the deployment
+manifest, the CI job, and any shell still open. Leaving it set turns every
+future migration run into an unattended cutover. If your `migrate` service
+mounts a live checkout of this repository, this is not hypothetical — see
+[`README.md` § Live landmine](./README.md) and CHAOS-3143.
+
+Confirm the variable is gone before continuing:
+
+```bash
+env | grep DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER   # must print nothing
+```
+
+---
+
+## Phase 3 — Per-kind verification
+
+`0066` retargets 23 kinds. After it commits, `job-routes apply` is a verifying
+no-op for every one of them, which makes it a safe read-back:
+
+```bash
+for kind in \
+  investment.chunk investment.dispatch investment.finalize investment.materialize \
+  metrics.daily_dispatch metrics.daily_finalize metrics.daily_partition \
+  metrics.remaining.capacity metrics.remaining.complexity metrics.remaining.dora \
+  metrics.remaining.extra_metrics metrics.remaining.membership_backfill \
+  metrics.remaining.recommendations metrics.remaining.release_impact \
+  metrics.remaining.team_metrics \
+  operational.billing_notification operational.webhook_delivery \
+  report.execute_on_demand report.execute_scheduled \
+  sync.team_autoimport system.heartbeat system.retention_cleanup workgraph.build
+do
+  dev-health-workerctl job-routes status "$kind"
+done
+```
+
+The authoritative list is `_KINDS` in
+`src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py`;
+if it has changed, that file wins over the copy above.
+
+For each kind confirm: `transport=river`, not paused, and the generation
+incremented. Then confirm work is actually moving, not merely routed:
+
+- `worker_job_outbox` is draining, not growing.
+- `worker_jobs_available` falls and `worker_job_oldest_age_seconds` does not
+  climb monotonically.
+- Each retargeted queue shows `active_jobs` and completed work in
+  `workers queues status`.
+
+A kind routed to River with a growing outbox and no active jobs means the
+consumer for its queue is missing — that is the failure mode Phase 1's
+precondition 2 exists to prevent, and it is a rollback trigger.
+
+---
+
+## Rollback
+
+### Decision points
+
+Roll back if any of these hold after the cutover:
+
+- A retargeted kind shows a growing `worker_job_outbox` with no corresponding
+  River execution.
+- `worker_job_oldest_age_seconds` climbs past its alert threshold for a queue
+  and does not recover.
+- A Go group cannot hold readiness, or a group's replicas crash-loop.
+- Any retargeted kind produces terminal failures at a rate the pre-cutover
+  baseline did not show.
+
+### Per-kind rollback — the audited path, and the default
+
+Prefer this. It proves quiescence per kind: `jobroute.Controller.Rollback`
+refuses to move a route while `worker_job_outbox` holds pending or claimed rows
+for the kind, or `worker_job_runs` shows it running. That refusal is the
+protection against two runtimes owning the same work.
+
+```bash
+dev-health-workerctl job-routes rollback \
+  --reason cutover_rollback \
+  --correlation-id <change-id> \
+  <kind>
+```
+
+If it refuses, the kind is still executing. Let it finish; do not force it.
+
+### Wholesale downgrade — stop Go first
+
+`0066`'s `downgrade()` is plain SQL and **does not prove quiescence**. Running
+it while Go workers are live can leave two runtimes owning the same kind.
+
+Order is not optional:
+
+1. **Stop the Go workers and the reconciler.** All of them, for every
+   retargeted queue.
+2. Confirm no `worker_job_runs` rows are running and no `worker_job_outbox`
+   rows are pending or claimed.
+3. Only then run the downgrade of the `river_cutover` branch.
+4. Restart the Celery consumers, Beat, and the producers.
+
+The inverse of Phase 1: Go stops before routes move back, exactly as Celery
+stopped before routes moved forward.
+
+---
+
+## After cutover
+
+- Keep the Celery worker, Beat, and Valkey DB 0 definitions in place. The
+  Go-only overlays (`compose.go-workers-only.yml`, `go-workers-only.yaml`,
+  `values-go-workers-only.yaml`) scale them to zero rather than deleting them,
+  and Go-only remains a release gate, not a switch — see
+  [`README.md` § Go-only is a release gate](./README.md).
+- `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER` stays unset.
+- For failures after this point, use
+  `docs/operate/runbooks/worker-or-queue-failure.md`, which carries the
+  post-cutover rollback scenario.

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -1,5 +1,12 @@
 # Go worker deployment
 
+> **Running the cutover?** Use
+> [`CUTOVER-RUNBOOK.md`](./CUTOVER-RUNBOOK.md). It is the single end-to-end
+> procedure for cutover day: preconditions, Celery drain order, the `0066`
+> authorization (set, run, verify, **unset**), per-kind verification, and
+> rollback. This file remains the deployment and coexistence reference it
+> depends on.
+
 `deployment.json` is the deployment manifest shared by the job contract,
 connection-budget checks, and stack renderers. Its River entries are deployment
 groups. They select registered queues; they are not application worker types
@@ -540,152 +547,13 @@ container's actual environment (`docker inspect --format
 '{{range .Config.Env}}{{println .}}{{end}}'`), not by reading the compose
 file.
 
-## CHAOS-3142 end-to-end proof: final report
+## CHAOS-3142 end-to-end proof
 
-This is the durable record of what CHAOS-3142 actually proved, against both
-a real shared local stack and an isolated throwaway one, and exactly where
-it stopped. Written here rather than in a session-scoped note because this
-is the artifact that outlives the session.
+The durable record of what CHAOS-3142 proved — against a real shared local
+stack and an isolated throwaway one — and exactly where the chain stopped, has
+moved to
+[`chaos-3142-local-bringup-report.md`](./chaos-3142-local-bringup-report.md).
+It is a verification record rather than a procedure, and it was crowding the
+operational content in this file.
 
-### Proven, against a real shared local stack
-
-- Coordinator-role provisioning on a pre-existing, pre-CHAOS-3033-split
-  Postgres cluster: `go-river-provision` created the `devhealth_coordinator`
-  login where none existed before.
-- The exact grant/readiness asymmetry this document names above, hit for
-  real: `coordinatorPosture()` requires `fixed_schedule_occurrences`
-  (`0065_add_fixed_schedule_occurrences.py`), which didn't exist on this
-  database (`alembic_version` was `0064`, two migrations behind head); the
-  `to_regclass`-guarded grant was silently skipped;
-  `coordinator_postgres` readiness failed with no stated reason until a
-  **targeted** `alembic upgrade 0065` (never `head` — see above) created the
-  table and a re-run of `go-worker-migrate` picked up the previously-skipped
-  grant.
-- `go-reconciler` reaching `/readyz` → `{"status":"ok"}` with `RestartCount
-  0` against the real stack, and staying that way — `CheckCoordinatorAuthorization`
-  re-queries live on every poll, so no restart was needed once the grant
-  landed.
-- Non-zero, real metric series from the real reconciler:
-  `worker_outbox_reconciler_up 1`, `sync_dispatch_observer_up 1`, and their
-  paired `..._last_success_age_seconds` gauges reporting sub-second real
-  values — the "present but zero" failure mode this document elsewhere
-  warns against did not occur here.
-
-### Proven, against an isolated throwaway project
-
-Using a separate compose project (`-p <name>`, its own network/volumes,
-never the shared stack), with a hand-seeded additive
-`Integration`/`IntegrationSource`/`IntegrationDataset`/`SyncRun`/
-`SyncRunUnit`/`SyncRunReferenceDiscovery`/`integration_credentials` row set
-for a synthetic org (github/repo-metadata), and the durable route
-(`worker_job_routes.transport`) and Python producer switch
-(`WORKER_GITHUB_REPO_METADATA_ENABLED`) both flipped ONLY inside that
-isolated project — never on shared infrastructure:
-
-- Producer gate (`dispatch_sync_run`) → `worker_job_outbox` row
-  (`status=delivered`) → reconciler relay → River job → Go handler pickup
-  and execution, all confirmed end to end.
-- The Go handler reached a real `github.com` HTTP round-trip (a fake PAT, so
-  a `retryable`, not `permanent`, failure — real network I/O happened, this
-  wasn't a local rejection) and `worker_budget_wait_seconds{provider="github",
-  cost_class="light"}` carried `count=6`, `sum=0.000241334` — a real,
-  non-zero series, not the present-and-zero shape this document elsewhere
-  calls out as the actual failure mode to guard against.
-
-### Not proven
-
-A ClickHouse `repos` row, on either stack. `worker_sync_lease_expired_total`
-also never carried a non-zero series in any run: this is expected and
-**not a regression signal** — that metric only increments on a claim that
-itself recovered an *expired* lease
-(`providerunit.Handler.observeLeaseRecovery` checks `claim.Recovered`, a
-no-op for an ordinary first-attempt claim), and nothing in this proof
-deliberately expired and re-claimed a lease.
-
-**Correction (this section originally overstated the credential blocker —
-see below):** the isolated project's synthetic org needed a fake PAT
-because its Postgres volume was fresh and empty; that limitation does not
-carry over to a stack with real data, and an earlier version of this report
-wrongly transplanted it onto the real shared stack without checking. On the
-real stack the blocker is routing, not credentials — see the next section.
-
-### Not attempted against the real shared stack, and why
-
-**Blocked on a deliberate routing decision, not on credential
-availability.** A working, decryptable, correctly-shaped github credential
-already exists on the real shared stack — this was checked directly rather
-than assumed:
-
-- `integrations`: 16 rows with `provider='github'`, 7 with a `credential_id`
-  set.
-- `integration_credentials` for `provider='github'`: 3 active rows, all
-  `last_test_success = true`, most recently tested 2026-07-05.
-- All three decrypt successfully today, using the app's own `decrypt_value`
-  with the **current** `SETTINGS_ENCRYPTION_KEY` (run inside the
-  `dev-health-api-1` container) — which also confirms that key is the one
-  they were encrypted with. Two decrypt to a JSON object with keys
-  `app_id`, `base_url`, `installation_id`, `org`, `private_key`, `token` —
-  a real `token`, in the JSON-object shape `complete_route.go` requires,
-  not a bare string (see "Provider credentials" below). The third is
-  app-only: `app_id`, `installation_id`, `private_key`.
-
-So credential availability and shape are not what stands between this stack
-and a real ClickHouse `repos` row. What does, and was deliberately not
-touched, is the two-key routing interlock, both halves of which were
-considered and explicitly left alone:
-
-1. **They are not independent, and the order matters.** Flipping the
-   durable route (`worker_job_routes.transport` for `sync.provider_unit`,
-   currently `celery`, would need `river_canary`) alone, with the Python
-   producer switch (`WORKER_GITHUB_REPO_METADATA_ENABLED`) still off, is not
-   a smaller, safer version of flipping both — it actively raises.
-   `dispatch_sync_run` (`src/dev_health_ops/workers/sync_units.py`) consults
-   `ProviderUnitRouteSwitches.is_route_ready(provider, dataset)` (matrix-only,
-   unconditional) BEFORE consulting the switch. If the matrix says a pair is
-   route-ready and the durable route already points at River, but the
-   switch is off, that combination is treated as an explicit ownership
-   fault — `dispatch_sync_run` raises
-   `WorkerJobRouteError("sync provider canary capability is unavailable")`
-   rather than degrading to Celery, by design ("never a reason to silently
-   fall back to legacy Celery dispatch for a pair the matrix says is done").
-   So the durable-route flip cannot be evaluated, or left in place, on its
-   own — getting past it requires the Python switch too, immediately, for
-   every org.
-2. **The Python switch requires a live container recreate, not a
-   reversible row.** Neither route switch is wired into `api`/`worker`/
-   `beat`/`worker-heavy`/`worker-ingest` in the repo-root `compose.yml` at
-   all (confirmed: `docker inspect` on the running containers, and a grep of
-   the compose file, both show zero occurrences outside the `go-worker`
-   service block). Setting it means recreating `dev-health-worker-1` — the
-   real Celery worker actively processing real organizations' real sync
-   traffic — with new environment. That is a materially different, and
-   materially bigger, ask than one reversible `UPDATE` on a single
-   `worker_job_routes` row, and it was not authorized. The user re-decided
-   with the corrected facts above (credentials exist; the blocker is purely
-   the routing interlock) and still chose to stop here — this is a
-   deliberate scope decision, not a missing capability.
-
-### Reachability: what completing the chain would actually take
-
-With both interlock halves flipped, the chain **can** complete to a real
-ClickHouse `repos` row using one of the three existing credentials above —
-no GitHub PAT needs to be obtained or seeded. Whoever picks this up needs
-only:
-
-1. `UPDATE worker_job_routes SET transport='river_canary', generation=generation+1, updated_at=now() WHERE job_kind='sync.provider_unit'` — matches the already-checked-in policy in `contracts/jobs/v1/migration-state.json` (`"route": "river_canary"`, from CHAOS-3123), not a new state.
-2. `WORKER_GITHUB_REPO_METADATA_ENABLED=true` on `dev-health-worker-1` (and anywhere else `dispatch_sync_run` runs), which requires recreating that container with the new environment — wire the variable into the repo-root `compose.yml`'s Python service blocks first, the same way it's already wired for `go-worker`.
-3. `go-worker` running and ready (see the crash-loop section above for what that needs).
-
-Revert both (1) and (2) back to `celery`/`false` afterward — this is a
-canary capability being exercised on demand, not a standing cutover.
-
-### Credential shape, restated for this report
-
-See "Provider credentials the Go executor can decrypt" above for the full
-detail. The two gotchas worth restating here because they are exactly what
-blocked the isolated-project proof until found: the decrypted plaintext
-must be a JSON object (`{"token": "..."}`), not a bare token string; and the
-claim query resolves `credential_id` via `COALESCE(sync_runs.credential_id,
-integrations.credential_id)`, so a credential row that exists but isn't
-linked from `integrations.credential_id` is invisible to a claim even
-though direct `(org_id, provider)` lookup would find it.
+For cutover day, see [`CUTOVER-RUNBOOK.md`](./CUTOVER-RUNBOOK.md).

--- a/deploy/go-workers/chaos-3142-local-bringup-report.md
+++ b/deploy/go-workers/chaos-3142-local-bringup-report.md
@@ -1,0 +1,155 @@
+# CHAOS-3142 end-to-end proof: final report
+
+Moved out of [`README.md`](./README.md), which is the operational runbook. This
+is an incident/verification record: what a specific investigation proved, what
+it did not, and why. It is kept for provenance, not as a procedure to follow.
+For the cutover procedure see [`CUTOVER-RUNBOOK.md`](./CUTOVER-RUNBOOK.md); for
+deployment and coexistence see [`README.md`](./README.md).
+
+This is the durable record of what CHAOS-3142 actually proved, against both
+a real shared local stack and an isolated throwaway one, and exactly where
+it stopped. Written here rather than in a session-scoped note because this
+is the artifact that outlives the session.
+
+### Proven, against a real shared local stack
+
+- Coordinator-role provisioning on a pre-existing, pre-CHAOS-3033-split
+  Postgres cluster: `go-river-provision` created the `devhealth_coordinator`
+  login where none existed before.
+- The exact grant/readiness asymmetry this document names above, hit for
+  real: `coordinatorPosture()` requires `fixed_schedule_occurrences`
+  (`0065_add_fixed_schedule_occurrences.py`), which didn't exist on this
+  database (`alembic_version` was `0064`, two migrations behind head); the
+  `to_regclass`-guarded grant was silently skipped;
+  `coordinator_postgres` readiness failed with no stated reason until a
+  **targeted** `alembic upgrade 0065` (never `head` — see above) created the
+  table and a re-run of `go-worker-migrate` picked up the previously-skipped
+  grant.
+- `go-reconciler` reaching `/readyz` → `{"status":"ok"}` with `RestartCount
+  0` against the real stack, and staying that way — `CheckCoordinatorAuthorization`
+  re-queries live on every poll, so no restart was needed once the grant
+  landed.
+- Non-zero, real metric series from the real reconciler:
+  `worker_outbox_reconciler_up 1`, `sync_dispatch_observer_up 1`, and their
+  paired `..._last_success_age_seconds` gauges reporting sub-second real
+  values — the "present but zero" failure mode this document elsewhere
+  warns against did not occur here.
+
+### Proven, against an isolated throwaway project
+
+Using a separate compose project (`-p <name>`, its own network/volumes,
+never the shared stack), with a hand-seeded additive
+`Integration`/`IntegrationSource`/`IntegrationDataset`/`SyncRun`/
+`SyncRunUnit`/`SyncRunReferenceDiscovery`/`integration_credentials` row set
+for a synthetic org (github/repo-metadata), and the durable route
+(`worker_job_routes.transport`) and Python producer switch
+(`WORKER_GITHUB_REPO_METADATA_ENABLED`) both flipped ONLY inside that
+isolated project — never on shared infrastructure:
+
+- Producer gate (`dispatch_sync_run`) → `worker_job_outbox` row
+  (`status=delivered`) → reconciler relay → River job → Go handler pickup
+  and execution, all confirmed end to end.
+- The Go handler reached a real `github.com` HTTP round-trip (a fake PAT, so
+  a `retryable`, not `permanent`, failure — real network I/O happened, this
+  wasn't a local rejection) and `worker_budget_wait_seconds{provider="github",
+  cost_class="light"}` carried `count=6`, `sum=0.000241334` — a real,
+  non-zero series, not the present-and-zero shape this document elsewhere
+  calls out as the actual failure mode to guard against.
+
+### Not proven
+
+A ClickHouse `repos` row, on either stack. `worker_sync_lease_expired_total`
+also never carried a non-zero series in any run: this is expected and
+**not a regression signal** — that metric only increments on a claim that
+itself recovered an *expired* lease
+(`providerunit.Handler.observeLeaseRecovery` checks `claim.Recovered`, a
+no-op for an ordinary first-attempt claim), and nothing in this proof
+deliberately expired and re-claimed a lease.
+
+**Correction (this section originally overstated the credential blocker —
+see below):** the isolated project's synthetic org needed a fake PAT
+because its Postgres volume was fresh and empty; that limitation does not
+carry over to a stack with real data, and an earlier version of this report
+wrongly transplanted it onto the real shared stack without checking. On the
+real stack the blocker is routing, not credentials — see the next section.
+
+### Not attempted against the real shared stack, and why
+
+**Blocked on a deliberate routing decision, not on credential
+availability.** A working, decryptable, correctly-shaped github credential
+already exists on the real shared stack — this was checked directly rather
+than assumed:
+
+- `integrations`: 16 rows with `provider='github'`, 7 with a `credential_id`
+  set.
+- `integration_credentials` for `provider='github'`: 3 active rows, all
+  `last_test_success = true`, most recently tested 2026-07-05.
+- All three decrypt successfully today, using the app's own `decrypt_value`
+  with the **current** `SETTINGS_ENCRYPTION_KEY` (run inside the
+  `dev-health-api-1` container) — which also confirms that key is the one
+  they were encrypted with. Two decrypt to a JSON object with keys
+  `app_id`, `base_url`, `installation_id`, `org`, `private_key`, `token` —
+  a real `token`, in the JSON-object shape `complete_route.go` requires,
+  not a bare string (see "Provider credentials" below). The third is
+  app-only: `app_id`, `installation_id`, `private_key`.
+
+So credential availability and shape are not what stands between this stack
+and a real ClickHouse `repos` row. What does, and was deliberately not
+touched, is the two-key routing interlock, both halves of which were
+considered and explicitly left alone:
+
+1. **They are not independent, and the order matters.** Flipping the
+   durable route (`worker_job_routes.transport` for `sync.provider_unit`,
+   currently `celery`, would need `river_canary`) alone, with the Python
+   producer switch (`WORKER_GITHUB_REPO_METADATA_ENABLED`) still off, is not
+   a smaller, safer version of flipping both — it actively raises.
+   `dispatch_sync_run` (`src/dev_health_ops/workers/sync_units.py`) consults
+   `ProviderUnitRouteSwitches.is_route_ready(provider, dataset)` (matrix-only,
+   unconditional) BEFORE consulting the switch. If the matrix says a pair is
+   route-ready and the durable route already points at River, but the
+   switch is off, that combination is treated as an explicit ownership
+   fault — `dispatch_sync_run` raises
+   `WorkerJobRouteError("sync provider canary capability is unavailable")`
+   rather than degrading to Celery, by design ("never a reason to silently
+   fall back to legacy Celery dispatch for a pair the matrix says is done").
+   So the durable-route flip cannot be evaluated, or left in place, on its
+   own — getting past it requires the Python switch too, immediately, for
+   every org.
+2. **The Python switch requires a live container recreate, not a
+   reversible row.** Neither route switch is wired into `api`/`worker`/
+   `beat`/`worker-heavy`/`worker-ingest` in the repo-root `compose.yml` at
+   all (confirmed: `docker inspect` on the running containers, and a grep of
+   the compose file, both show zero occurrences outside the `go-worker`
+   service block). Setting it means recreating `dev-health-worker-1` — the
+   real Celery worker actively processing real organizations' real sync
+   traffic — with new environment. That is a materially different, and
+   materially bigger, ask than one reversible `UPDATE` on a single
+   `worker_job_routes` row, and it was not authorized. The user re-decided
+   with the corrected facts above (credentials exist; the blocker is purely
+   the routing interlock) and still chose to stop here — this is a
+   deliberate scope decision, not a missing capability.
+
+### Reachability: what completing the chain would actually take
+
+With both interlock halves flipped, the chain **can** complete to a real
+ClickHouse `repos` row using one of the three existing credentials above —
+no GitHub PAT needs to be obtained or seeded. Whoever picks this up needs
+only:
+
+1. `UPDATE worker_job_routes SET transport='river_canary', generation=generation+1, updated_at=now() WHERE job_kind='sync.provider_unit'` — matches the already-checked-in policy in `contracts/jobs/v1/migration-state.json` (`"route": "river_canary"`, from CHAOS-3123), not a new state.
+2. `WORKER_GITHUB_REPO_METADATA_ENABLED=true` on `dev-health-worker-1` (and anywhere else `dispatch_sync_run` runs), which requires recreating that container with the new environment — wire the variable into the repo-root `compose.yml`'s Python service blocks first, the same way it's already wired for `go-worker`.
+3. `go-worker` running and ready (see the crash-loop section above for what that needs).
+
+Revert both (1) and (2) back to `celery`/`false` afterward — this is a
+canary capability being exercised on demand, not a standing cutover.
+
+### Credential shape, restated for this report
+
+See "Provider credentials the Go executor can decrypt" above for the full
+detail. The two gotchas worth restating here because they are exactly what
+blocked the isolated-project proof until found: the decrypted plaintext
+must be a JSON object (`{"token": "..."}`), not a bare token string; and the
+claim query resolves `credential_id` via `COALESCE(sync_runs.credential_id,
+integrations.credential_id)`, so a credential row that exists but isn't
+linked from `integrations.credential_id` is invisible to a claim even
+though direct `(org_id, provider)` lookup would find it.

--- a/docs/operate/runbooks/worker-or-queue-failure.md
+++ b/docs/operate/runbooks/worker-or-queue-failure.md
@@ -5,6 +5,7 @@ content_type: runbook
 owner: platform-operations
 source_of_truth:
   - docs/operate/run/workers-and-jobs.md
+  - deploy/go-workers/CUTOVER-RUNBOOK.md
   - docs/operate/configure/databases-and-storage.md
   - current worker health, queue, outbox, operator, and route contracts
 applicability: current
@@ -72,6 +73,18 @@ For readiness failure, distinguish:
 - dependency sampling failure.
 
 Long-running Go processes must not receive `MIGRATION_DATABASE_URI`. Correct schema through the one-shot migration process, then restart the affected process and verify readiness.
+
+## Post-cutover rollback
+
+Applies once migration `0066` has moved the checked-in worker job kinds to River. The full forward procedure, including its preconditions and per-kind verification, is `deploy/go-workers/CUTOVER-RUNBOOK.md`.
+
+Roll back when a retargeted kind shows a growing worker outbox with no corresponding River execution, when oldest-available job age climbs past its threshold for a queue and does not recover, when a Go group cannot hold readiness, or when a retargeted kind fails terminally at a rate the pre-cutover baseline did not show.
+
+Prefer per-kind rollback. It is audited and it proves quiescence: the route controller refuses to move a kind while its outbox holds pending or claimed rows, or while a run for it is still executing. A refusal means the kind is still working — let it finish rather than forcing it.
+
+Wholesale downgrade of the cutover migration is plain SQL and proves nothing about quiescence. Stop the Go workers and the reconciler for every retargeted queue first, confirm no run is executing and no outbox row is pending or claimed, and only then downgrade and restart the Celery consumers, Beat, and producers. Stopping Go before routes move back is the inverse of draining Celery before they moved forward, and it is what keeps two runtimes from owning the same kind.
+
+Confirm `DEV_HEALTH_ALLOW_CELERY_RIVER_CUTOVER` is unset afterwards. Left set, any later migration run re-applies the cutover unattended.
 
 ## Outbox and reconciler recovery
 

--- a/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
+++ b/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
@@ -8,8 +8,11 @@ to ``go_default`` in the same release, which makes ``river`` the checked-in rout
 and leaves ``celery`` as the declared rollback route.
 
 ``sync.provider_unit`` is the exception and stays on its canary route.  See
-``_PROMOTABLE_TRANSPORTS`` below for why: its Go route surface covers one of the
-59 provider/dataset pairs, so promoting it would stop the other 58 from syncing.
+``_PROMOTABLE_TRANSPORTS`` below for why.  The canary route lets
+``ProviderUnitRouteSwitches`` confine River to the pairs whose per-route
+``WORKER_*_ENABLED`` switch is on, while every other pair still dispatches
+through Celery; promoting the kind to plain ``river`` would route all 59 pairs
+at once, regardless of those switches.
 
 Why the route rows are seeded here rather than promoted one at a time with
 ``dev-health-workerctl job-routes apply``:
@@ -65,15 +68,17 @@ _CUTOVER_OPT_IN_VALUE: Final = "1"
 # sync.provider_unit is deliberately NOT migrated here and keeps the
 # river_canary row that 0061 seeded.
 #
-# Its Go route surface covers exactly one provider/dataset pair --
-# launchdarkly/feature-flags is the only entry in
-# contracts/provider-matrix/v1/matrix.json with route_ready true, against 58
-# that are not (github 17, gitlab 19, jira 6, linear 5, pagerduty 11). The
-# canary route exists so ProviderUnitRouteSwitches can confine River to that
-# one ready pair while every other pair still dispatches through Celery.
+# When this migration was written, launchdarkly/feature-flags was the only
+# entry in contracts/provider-matrix/v1/matrix.json with route_ready true. That
+# is no longer the case -- all 59 pairs are now route_ready -- but the reason
+# this kind stays on canary is unchanged: route readiness is not the same as
+# being enabled. The canary route is what lets ProviderUnitRouteSwitches
+# confine River to the pairs whose per-route WORKER_*_ENABLED switch is on,
+# every one of which still defaults off.
 #
-# Promoting this kind to plain river would route all 59 pairs at a handler that
-# serves one, so the 58 unserved pairs would fail closed and stop syncing.
+# Promoting this kind to plain river would route all 59 pairs to the Go handler
+# in one step, bypassing those switches and the per-route parity evidence they
+# gate. That is a separate reviewed decision, not part of a wholesale cutover.
 # Leaving it at river_canary is not an oversight or a deferral of cleanup: it is
 # the only state in which this kind currently works.
 #


### PR DESCRIPTION
## Summary

- **What changed:** CHAOS-3874. A single cutover-day runbook, plus three corrections where documentation claimed something the code contradicts.
- **Why:** the procedure was spread across four sources an operator had to synthesize *under time pressure*, and `worker-or-queue-failure.md` had no post-cutover rollback at all.

**`deploy/go-workers/CUTOVER-RUNBOOK.md`** is now the order of operations: preconditions → Celery drain order → the `0066` authorization (set, run, verify, **unset**) → per-kind verification → rollback. The four previous sources stay as the reference material it cites.

It's equally explicit about what cutover day **does not** do — no `WORKER_*_ENABLED` switch is flipped, `sync.provider_unit` stays on its canary route, the four sync-dispatch kinds move only through `routes apply`, and Beat ownership does not transfer. Those omissions are the ones most likely to be assumed.

### Placement decision

It lives in `deploy/go-workers/`, not `docs/`. Adding a page under `docs/` requires a row in the **frozen IA** (`docs-data/ia`, 211 nodes) that `scripts/validate_docs_v2_publication.py` enforces — a governance change to the customer site for what is an internal cutover procedure. The issue offered both locations; this keeps the governed site untouched.

For the same reason, the new section in `worker-or-queue-failure.md` references the runbook **by path rather than by link**: the validator resolves local links against `docs_dir`, so a link escaping `docs/` is reported as broken.

### Three truthfulness fixes

| Claim | Reality |
|---|---|
| `transitional-inventory.json`: "native Go coordinator is the active path" (×3 rows) | `sync_dispatch_transport_routes` is seeded `transport='celery'` by `0049`, and `0049` is the **only** migration that touches the table. River is the *checked-in* route, not the running one. |
| `fixed.go`: the paper-owned-schedule check "is currently SUBSUMED… `goOwnsMarkers` is false" | `main.go:75` sets it **true**. The check is load-bearing — the comment told a reader the exact opposite. |
| `0066` docstring: launchdarkly/feature-flags is "the only entry… with `route_ready` true, against 58 that are not" | **All 59** pairs are now `route_ready`. Why `sync.provider_unit` stays on canary is unchanged, but the reason is readiness *vs. being enabled*, not readiness alone. |

The third wasn't in the issue — I found it while writing the runbook and verifying the claim before repeating it. No behaviour changed in any of the three; comments and metadata only.

## Checklist

- [x] I added/updated tests, or provided required governance evidence below.
- [x] I ran relevant local validation (minimum: `./ci/run_tests.sh unit` for `src/` changes).
- [x] I documented risk and rollback considerations.
- [x] I called out breaking changes, migrations, or config impacts (or wrote `none`).

## Test Evidence

TEST-EVIDENCE:

**The docs gate — the constraint this lane had to satisfy:**

```
$ .venv/bin/python scripts/validate_docs_v2_publication.py
Validated 184 canonical pages, 135 redirects, and 211 frozen IA nodes.
```

Unchanged from baseline (184/135/211), which is the point: the governed site gains no page and loses none.

**Transitional inventory contract:**

```
$ .venv/bin/python ci/check_transitional_inventory.py
OK: transitional workload inventory contract is consistent with discovery.
```

**Targeted suites and Go:**

```
$ .venv/bin/python -m pytest tests/ -k "inventory or transitional or docs or migration_0066 or river_cutover" -q
259 passed, 33 skipped

$ go build ./... && go test ./cmd/dev-health-scheduler/
ok  	github.com/full-chaos/dev-health-ops/cmd/dev-health-scheduler
```

**`ci/local_validate.sh` (SKIP_CLICKHOUSE=1 — no ClickHouse container in this environment):**

```
✔  mutation harness: no mutation applied
✔  lint: ruff format --check
✔  lint: ruff check
✔  typecheck: mypy
✗  unit suite (FULL, not subset)      8 failed, 13364 passed, 653 skipped
```

All 8 are **pre-existing and unrelated** — the same set verified against base in #1774. Five are the Helm-rendering tests that fail here only because helm cannot be installed in this environment; they pass in CI (#1777 went green with them).

**Every factual claim in the runbook was verified against source before being written**, not paraphrased from the issue:

| Claim | Verified against |
|---|---|
| 23 kinds retargeted, `sync.provider_unit` excepted | `_KINDS` in `0066` (counted), `_PROMOTABLE_TRANSPORTS` |
| Go consumers must run *before* `0066` commits; Celery drained *before* it runs | `0066` docstring, "Ordering requirement" |
| `job-routes apply` is a verifying no-op afterwards | `0066` docstring; `ApplyCheckedIn` early-return |
| `downgrade()` does not prove quiescence | `0066` `downgrade()` docstring |
| Per-kind rollback refuses while outbox/runs are live | same |
| Exact operator command surface and required flags | `dispatchJobRoutes` / `dispatchRoutes` in `cmd/dev-health-workerctl/main.go` |
| Sync-dispatch routes seeded `celery`, never flipped | `0049`; grepped all migrations for the table |
| All 59 pairs `route_ready` | `contracts/provider-matrix/v1/matrix.json` (counted) |
| Never `alembic upgrade head`; multiple heads intentional | `README.md` multi-head guidance |

## Risk Notes

RISK-NOTES:

- **Blast radius:** documentation, one JSON metadata field, and two code comments. No executable behaviour changes — `go build` and the scheduler tests confirm the comment edit is inert, and the inventory change is a `notes` string.
- **The runbook is untested in the sense that matters.** It has never been executed against a real cutover, because the cutover has not happened. Its commands and orderings are verified against source (table above), but "the steps are individually correct" is not the same as "the sequence works end to end." Treat the first real run as a rehearsal with the rollback path staffed.
- **`deployment_state` is unchanged**, no migration is applied, and no switch is flipped. The runbook describes the cutover; it does not perform it.
- **Deliberately left in place:** the local bring-up guidance in `README.md` (ClickHouse native port, session DSNs, `SETTINGS_ENCRYPTION_KEY` delivery, readiness diagnosis). The issue called for the incident narrative to move out, and the 150-line end-to-end *proof report* did — to `chaos-3142-local-bringup-report.md`. The bring-up sections are operator instruction rather than narrative, and several are load-bearing (the ClickHouse port section is the documented basis for Lane D's fix in #1777). Removing them would have cost more than the tidiness gained. Flag it if you want them moved too.
- **Rollback:** revert the branch. The single commit is self-contained; the moved report is a pure file move plus a pointer.

## Optional Context

- Linked issues: [CHAOS-3874](https://linear.app/fullchaos/issue/CHAOS-3874)
- SCREENSHOT-WAIVER: documentation and metadata only; no rendered UI surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgFRWxVJLUMooPAELwBPXu)_