### PR TITLE
Fix the pre-existing CI failures on feat/go-worker-runtime-migration

### DIFF
--- a/cmd/dev-health-scheduler/dependencies.go
+++ b/cmd/dev-health-scheduler/dependencies.go
@@ -8,6 +8,7 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
 	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
+	"github.com/full-chaos/dev-health-ops/internal/processreadiness"
 	schedulersync "github.com/full-chaos/dev-health-ops/internal/scheduler/sync"
 	"github.com/full-chaos/dev-health-ops/internal/storage/postgres"
 	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
@@ -307,7 +308,33 @@ func buildSchedulerLoopWithSources(
 		return nil, errSchedulerActivationUnavailable
 	}
 	database, err := sources.openDatabase(ctx, cfg)
+	if err != nil && postgres.ConfigurationRejected(err) {
+		// A DECLARED configuration rejection -- most commonly no DSN supplied
+		// at all -- keeps the process live and unready, exactly as the worker
+		// does, so an operator scrapes named readiness failures instead of
+		// reading a crash loop (CHAOS-3873). The scheduler previously treated
+		// every open failure as fatal, so an unconfigured scheduler container
+		// exited before it could publish its operator port at all.
+		//
+		// The same five names the goOwnsMarkers gate closes are closed here,
+		// so the externally visible readiness surface does not change shape
+		// depending on WHY the loop is not running.
+		if registerErr := processreadiness.RegisterUnavailable(
+			registry,
+			"domain_postgres",
+			"queue_postgres",
+			"coordinator_postgres",
+			"river_schema",
+			"scheduler_loop",
+		); registerErr != nil {
+			return nil, registerErr
+		}
+		return nil, errSchedulerDatabaseUnconfigured
+	}
 	if err != nil || database == nil {
+		// Operational failure -- unreachable host, refused credentials, an
+		// unparseable DSN. Crash-loop rather than idle as an alive-but-unready
+		// zombie.
 		return nil, errSchedulerActivationUnavailable
 	}
 	closeOnError := true

--- a/cmd/dev-health-scheduler/main.go
+++ b/cmd/dev-health-scheduler/main.go
@@ -48,6 +48,14 @@ var schedulerOwnership = schedulersync.TransferScheduleMarkerOwnershipToGo()
 
 var errSchedulerActivationUnavailable = errors.New("scheduler activation is unavailable")
 
+// errSchedulerDatabaseUnconfigured marks the one non-fatal outcome of building
+// the loop: the database contract was DECLARED-rejected (typically no DSN), so
+// buildSchedulerLoopWithSources has already closed the readiness names and the
+// process must stay live and unready rather than exit. It is a distinct
+// sentinel rather than a (nil, nil) return so that a loop factory returning nil
+// by mistake still fails loudly.
+var errSchedulerDatabaseUnconfigured = errors.New("scheduler database is not configured")
+
 // schedulerActivation is a source-reviewed, package-private composition seam.
 // It deliberately cannot be influenced by process environment or deployment
 // profile. The production loop factory is reached only through the checked-in
@@ -130,6 +138,11 @@ func configureSchedulerDependenciesWithSources(
 		return nil, errSchedulerActivationUnavailable
 	}
 	loop, err := sources.buildLoop(ctx, cfg, registry)
+	if errors.Is(err, errSchedulerDatabaseUnconfigured) {
+		// Live, unready, no components: the readiness names are already
+		// registered unavailable by the loop factory.
+		return nil, nil
+	}
 	if err != nil || loop == nil {
 		return nil, errSchedulerActivationUnavailable
 	}

--- a/cmd/dev-health-scheduler/main_test.go
+++ b/cmd/dev-health-scheduler/main_test.go
@@ -36,10 +36,64 @@ func TestSchedulerSpecRejectsAnActivatedRuntimeWithoutDatabaseConfiguration(t *t
 		t.Fatal("scheduler dependency configuration is not wired")
 	}
 
+	// Failing closed means LIVE AND UNREADY, not exiting. This previously
+	// asserted errSchedulerActivationUnavailable, which is what made an
+	// unconfigured scheduler container exit before it could publish its
+	// operator port -- ci/check_go_containers.sh's smoke contract requires the
+	// process to stay up, serve /healthz 200 and /readyz 503, and name the
+	// checks that failed. An absent DSN is a DECLARED configuration rejection
+	// (postgres.ConfigurationRejected), so it is reported through readiness an
+	// operator can scrape rather than a crash loop that names nothing.
 	registry := health.NewRegistry(100 * time.Millisecond)
 	components, err := configureSchedulerDependencies(context.Background(), config.Config{}, registry)
-	if !errors.Is(err, errSchedulerActivationUnavailable) || len(components) != 0 {
+	if err != nil || len(components) != 0 {
 		t.Fatalf("unconfigured activated scheduler components=%v err=%v", components, err)
+	}
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	status := registry.Readiness(context.Background())
+	if status.Ready {
+		t.Fatal("an unconfigured scheduler reported ready")
+	}
+	// Exactly the names ci/check_go_containers.sh greps for on this target,
+	// plus coordinator_postgres, so the readiness surface does not change shape
+	// depending on WHY the loop is not running.
+	for _, name := range []string{
+		"domain_postgres", "queue_postgres", "coordinator_postgres",
+		"river_schema", "scheduler_loop",
+	} {
+		if !slices.Contains(status.Failed, name) {
+			t.Fatalf("unconfigured readiness omitted %q: %#v", name, status)
+		}
+	}
+}
+
+// TestSchedulerCrashLoopsOnAnOperationalDatabaseFailure is the other half of
+// the contract the test above pins. A declared configuration rejection stays
+// live; anything operational -- an unreachable host, refused credentials, an
+// unparseable DSN -- must still terminate the process rather than idle as an
+// alive-but-unready zombie (CHAOS-3873).
+func TestSchedulerCrashLoopsOnAnOperationalDatabaseFailure(t *testing.T) {
+	registry := health.NewRegistry(100 * time.Millisecond)
+	_, err := buildSchedulerLoopWithSources(
+		context.Background(), config.Config{}, registry,
+		schedulerRuntimeSources{
+			openDatabase: func(context.Context, config.Config) (schedulerDatabase, error) {
+				return nil, errors.New("dial tcp 10.0.0.1:5432: connect: connection refused")
+			},
+			newRepository:  productionSchedulerRuntimeSources.newRepository,
+			newCoordinator: productionSchedulerRuntimeSources.newCoordinator,
+			newLoop:        productionSchedulerRuntimeSources.newLoop,
+			newFixedLoop:   productionSchedulerRuntimeSources.newFixedLoop,
+			newOccurrences: productionSchedulerRuntimeSources.newOccurrences,
+		},
+	)
+	if errors.Is(err, errSchedulerDatabaseUnconfigured) {
+		t.Fatal("an operational database failure was treated as a configuration rejection")
+	}
+	if !errors.Is(err, errSchedulerActivationUnavailable) {
+		t.Fatalf("operational failure error = %v", err)
 	}
 }
 

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -100,30 +100,11 @@ type githubProjectsV2DurableConfigReader interface {
 	GitHubProjectsV2Configured(context.Context) (bool, error)
 }
 
-// databaseConfigurationRejected reports whether a database-open failure is a
-// declared configuration rejection rather than an operational one. Those are
-// reported through named readiness checks (domain_postgres, queue_postgres,
-// queue_control_config), which an operator can scrape; failing construction
-// instead would replace an attributable check name with a crash loop.
-// Everything else -- an unreachable host, a refused password, a DSN that will
-// not parse -- is operational and must crash-loop rather than idle as an
-// alive-but-unready zombie (CHAOS-3873).
+// databaseConfigurationRejected delegates to postgres.ConfigurationRejected,
+// which owns the sentinel list it classifies. It stays as a named local so the
+// call site below still reads as a policy decision rather than a type check.
 func databaseConfigurationRejected(err error) bool {
-	for _, configurationError := range []error{
-		postgres.ErrInvalidConfig,
-		postgres.ErrDomainDatabaseRequired,
-		postgres.ErrQueueControlRequired,
-		postgres.ErrQueueControlTransactionMode,
-		postgres.ErrRuntimeRolesNotSeparated,
-		postgres.ErrRuntimeRoleConfiguration,
-		postgres.ErrCoordinatorDatabaseRequired,
-		postgres.ErrCoordinatorTransactionMode,
-	} {
-		if errors.Is(err, configurationError) {
-			return true
-		}
-	}
-	return false
+	return postgres.ConfigurationRejected(err)
 }
 
 func openWorkerDatabase(ctx context.Context, cfg config.Config) (workerDatabase, error) {

--- a/internal/storage/postgres/domain_authorization_integration_test.go
+++ b/internal/storage/postgres/domain_authorization_integration_test.go
@@ -116,6 +116,13 @@ func TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges(t *testin
 		// PostgreSQL treats FOR UPDATE/FOR SHARE as UPDATE-class, and the
 		// snapshot read-back must never be able to take a row lock.
 		"GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO " + authorizedDomainRole,
+		// Chunked provider persistence (migration 0102). domainPosture() requires
+		// the full SELECT/INSERT/UPDATE/DELETE set on both, and
+		// scripts/worker/provision_river_roles.sql now grants it. These fixtures
+		// had the CREATE TABLE but never the GRANT, so CheckDomainAuthorization
+		// failed on a posture entry no deployment satisfied either.
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.sync_run_unit_chunk_checkpoints TO " + authorizedDomainRole,
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.sync_run_unit_effect_chunks TO " + authorizedDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.dev_conversation_tombstones TO " + authorizedDomainRole,
 		"GRANT SELECT, UPDATE, DELETE ON TABLE public.dev_conversations, public.external_ingest_batches, public.provider_rate_limit_observations TO " + authorizedDomainRole,
 		"GRANT SELECT (completion_key), INSERT (completion_key) ON TABLE public.worker_job_completion_fences TO " + authorizedDomainRole,

--- a/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
+++ b/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
@@ -371,6 +371,13 @@ func startGrantHarness(t *testing.T, ctx context.Context) (*pgxpool.Pool, string
 			updated_at timestamptz NOT NULL DEFAULT now()
 		)`,
 		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY, state text NOT NULL)",
+		// Chunked provider persistence (migration 0102). These must exist BEFORE
+		// the grants run: every domain GRANT is wrapped in a to_regclass guard, so
+		// an absent table silently skips its grant while domainPosture() still
+		// requires it -- which is exactly how CheckDomainAuthorization came to
+		// fail here for every test in this file.
+		"CREATE TABLE public.sync_run_unit_chunk_checkpoints (id bigint PRIMARY KEY)",
+		"CREATE TABLE public.sync_run_unit_effect_chunks (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.sync_watermarks (id uuid PRIMARY KEY, state text NOT NULL)",
 		// Production-shaped enough for the reconciler materializer privilege proof:
 		// PostgreSQL resolves every named column and the ON CONFLICT arbiter before

--- a/internal/storage/postgres/runtime.go
+++ b/internal/storage/postgres/runtime.go
@@ -25,6 +25,43 @@ var (
 	ErrCoordinatorTransactionMode  = errors.New("transaction-mode PgBouncer cannot be used for coordinator control-plane access")
 )
 
+// ConfigurationRejected reports whether a database-open failure is a DECLARED
+// configuration rejection rather than an operational one.
+//
+// The distinction decides whether a process crash-loops or stays live and
+// unready (CHAOS-3873). A declared rejection -- a DSN that is absent, or one
+// the runtime contract refuses on sight, like queue control pointed at a
+// transaction-mode pooler -- is reported through named readiness checks an
+// operator can scrape; crashing instead would replace an attributable check
+// name with a restart loop that says nothing about which input was wrong.
+// Everything else -- an unreachable host, a refused password, a DSN that will
+// not parse -- is operational, and must crash-loop rather than idle as an
+// alive-but-unready zombie.
+//
+// This lives here, beside the sentinels it classifies, because every sentinel
+// added above has to be considered for this list. It was previously a private
+// copy of the list inside cmd/dev-health-worker, which is exactly how
+// cmd/dev-health-scheduler came to crash on an unconfigured DSN where the
+// worker stayed live: the classification existed, but only one binary could
+// reach it.
+func ConfigurationRejected(err error) bool {
+	for _, configurationError := range []error{
+		ErrInvalidConfig,
+		ErrDomainDatabaseRequired,
+		ErrQueueControlRequired,
+		ErrQueueControlTransactionMode,
+		ErrRuntimeRolesNotSeparated,
+		ErrRuntimeRoleConfiguration,
+		ErrCoordinatorDatabaseRequired,
+		ErrCoordinatorTransactionMode,
+	} {
+		if errors.Is(err, configurationError) {
+			return true
+		}
+	}
+	return false
+}
+
 // RuntimeConfig describes the PostgreSQL trust boundaries used by River
 // processes. Domain traffic may traverse transaction-mode PgBouncer. Queue
 // control must use either a bounded direct PostgreSQL endpoint or a bounded

--- a/internal/storage/postgres/runtime_authorization_integration_test.go
+++ b/internal/storage/postgres/runtime_authorization_integration_test.go
@@ -115,6 +115,10 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		// PostgreSQL treats FOR UPDATE/FOR SHARE as UPDATE-class, and the
 		// snapshot read-back must never be able to take a row lock.
 		"GRANT SELECT, INSERT, DELETE ON TABLE public.sync_run_unit_effect_snapshots TO " + runtimeAuthorizationDomainRole,
+		// Chunked provider persistence (migration 0102) -- see the matching note
+		// in domain_authorization_integration_test.go.
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.sync_run_unit_chunk_checkpoints TO " + runtimeAuthorizationDomainRole,
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.sync_run_unit_effect_chunks TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.dev_conversation_tombstones TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, UPDATE, DELETE ON TABLE public.dev_conversations, public.external_ingest_batches, public.provider_rate_limit_observations TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT (completion_key), INSERT (completion_key) ON TABLE public.worker_job_completion_fences TO " + runtimeAuthorizationDomainRole,

--- a/internal/synccoverage/intervals_test.go
+++ b/internal/synccoverage/intervals_test.go
@@ -79,13 +79,91 @@ func TestPayloadBackfillScheduleAndStatusSemantics(t *testing.T) {
 		len(workItems["gaps"].([]any)) != 1 {
 		t.Fatalf("work-items = %#v", workItems)
 	}
-	backfillWindows := payload["backfill_windows"].([]any)
-	if len(backfillWindows) != 1 {
-		t.Fatalf("backfill windows = %#v", backfillWindows)
+	// The gap is real and still counted above -- but its range starts at
+	// 12:00, and the focused-backfill selector only accepts UTC-midnight
+	// boundaries, so no window is offered for it. Python's
+	// _canonical_backfill_windows skips it for the same reason; an empty list
+	// is the server saying "not safely representable by that selector".
+	//
+	// This previously asserted a single {since: "2026-08-10", before:
+	// "2026-08-10"} window: a date-only, half-open range covering nothing,
+	// manufactured by truncating a partial day onto day boundaries. That was
+	// the defect, not the contract.
+	if backfillWindows := payload["backfill_windows"].([]any); len(backfillWindows) != 0 {
+		t.Fatalf("partial-day range must offer no backfill window, got %#v", backfillWindows)
 	}
-	window := backfillWindows[0].(map[string]any)
-	if window["since"] != "2026-08-10" || window["before"] != "2026-08-10" {
-		t.Fatalf("canonical backfill window = %#v", window)
+}
+
+func TestCanonicalBackfillWindowsAreMidnightBoundedAndScoped(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	integrationID := uuid.New()
+	first, second := uuid.New(), uuid.New()
+	payload, err := buildPayload(payloadInput{
+		Config: syncConfig{
+			ID: uuid.New(), OrgID: "org-acme", Provider: "github",
+			Active: true, IntegrationID: &integrationID,
+		},
+		Scope: effectiveScope{
+			IntegrationID: &integrationID,
+			Sources:       []source{{ID: first, Name: "acme/api"}, {ID: second, Name: "acme/web"}},
+			DatasetKeys:   []string{"commits", "prs"},
+		},
+		Backfills: []coverageInterval{
+			{
+				Since: day(now.AddDate(0, 0, -3)), Before: day(now.AddDate(0, 0, -2)),
+				SourceIDs: []string{first.String()}, DatasetKeys: []string{"prs"},
+			},
+			{
+				// Same days, different source and dataset: Python keys the scope
+				// on (since, before, source_id, dataset_key) and never merges, so
+				// this must stay its own window rather than widening the first.
+				Since: day(now.AddDate(0, 0, -3)), Before: day(now.AddDate(0, 0, -2)),
+				SourceIDs: []string{second.String()}, DatasetKeys: []string{"commits"},
+			},
+			{
+				// Partial day on the `before` end -- skipped, not truncated.
+				Since: day(now.AddDate(0, 0, -5)), Before: now.AddDate(0, 0, -4),
+				SourceIDs: []string{first.String()}, DatasetKeys: []string{"prs"},
+			},
+		},
+		ActivePairs: map[string]struct{}{}, HasSchedule: false, Now: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	windows := payload["backfill_windows"].([]any)
+	if len(windows) != 2 {
+		t.Fatalf("backfill windows = %#v", windows)
+	}
+	// Sorted by (since, before, dataset_keys, source_ids): "commits" precedes
+	// "prs" on an identical day range.
+	for index, want := range []map[string]any{
+		{
+			"since": "2026-08-09T00:00:00+00:00", "before": "2026-08-10T00:00:00+00:00",
+			"dataset_keys": "commits", "source_ids": second.String(),
+		},
+		{
+			"since": "2026-08-09T00:00:00+00:00", "before": "2026-08-10T00:00:00+00:00",
+			"dataset_keys": "prs", "source_ids": first.String(),
+		},
+	} {
+		window := windows[index].(map[string]any)
+		if window["since"] != want["since"] || window["before"] != want["before"] {
+			t.Fatalf("window %d bounds = %#v, want %v..%v", index, window, want["since"], want["before"])
+		}
+		datasets := window["dataset_keys"].([]string)
+		sources := window["source_ids"].([]string)
+		if len(datasets) != 1 || datasets[0] != want["dataset_keys"] {
+			t.Fatalf("window %d dataset_keys = %#v, want %v", index, datasets, want["dataset_keys"])
+		}
+		if len(sources) != 1 || sources[0] != want["source_ids"] {
+			t.Fatalf("window %d source_ids = %#v, want %v", index, sources, want["source_ids"])
+		}
+		if reasons := window["reasons"].([]string); len(reasons) != 1 || reasons[0] != "gap" {
+			t.Fatalf("window %d reasons = %#v", index, reasons)
+		}
 	}
 }
 

--- a/internal/synccoverage/payload.go
+++ b/internal/synccoverage/payload.go
@@ -168,7 +168,7 @@ func buildPayload(input payloadInput) (projectionPayload, error) {
 			"gap_count":              gapCount, "stale_dataset_count": staleCount, "failed_range_count": failedCount,
 		},
 		"datasets": datasetPayload, "sources": sources,
-		"backfill_windows": canonicalBackfillWindows(datasets),
+		"backfill_windows": canonicalBackfillWindows(pairs),
 	}, nil
 }
 
@@ -390,49 +390,96 @@ func notEnabledDatasets(config syncConfig, scope effectiveScope) []string {
 	return result
 }
 
-func canonicalBackfillWindows(datasets []datasetCoverage) []any {
-	type candidate struct {
-		Since, Before time.Time
-		Reasons       []string
+// canonicalBackfillWindows mirrors _canonical_backfill_windows in
+// src/dev_health_ops/api/services/sync_coverage.py, which is authoritative:
+// this payload feeds the same focused-backfill selector the Python API serves.
+//
+// Two rules carry the whole contract, and the previous implementation broke
+// both.
+//
+// First, a window is emitted ONLY when the half-open range already sits on
+// exact UTC-midnight boundaries, because that selector accepts nothing else.
+// Python skips anything else outright, so an empty list means "not safely
+// representable"; the old Go code instead COERCED a partial-day range onto day
+// boundaries (nudging a midnight `before` back a microsecond, then truncating
+// both ends), which manufactured windows for ranges the API would refuse --
+// including a degenerate since == before empty window in the oracle fixture.
+//
+// Second, the scope is (since, before, source_id, dataset_key). A backfill
+// window is only actionable against the source and dataset it came from. The
+// old code iterated datasets alone, dropped source identity entirely, and then
+// merged adjacent windows across BOTH -- so one source's gap could widen a
+// different source's window. Python does no merging at all, deliberately.
+func canonicalBackfillWindows(pairs []pairCoverage) []any {
+	type scope struct {
+		Since, Before        time.Time
+		SourceID, DatasetKey string
 	}
-	candidates := make([]candidate, 0)
-	for _, dataset := range datasets {
+	reasonsByScope := make(map[scope]map[string]struct{})
+	for _, pair := range pairs {
 		for _, group := range []struct {
 			Intervals []coverageInterval
 			Reason    string
-		}{{dataset.Gaps, "gap"}, {dataset.FailedRanges, "failed"}} {
+		}{{pair.Gaps, "gap"}, {pair.FailedRanges, "failed"}} {
 			for _, interval := range group.Intervals {
-				before := interval.Before
-				if before.Hour() == 0 && before.Minute() == 0 && before.Second() == 0 && before.Nanosecond() == 0 {
-					before = before.Add(-time.Microsecond)
+				since, before := interval.Since.UTC(), interval.Before.UTC()
+				if !isUTCMidnight(since) || !isUTCMidnight(before) {
+					continue
 				}
-				candidates = append(candidates, candidate{Since: day(interval.Since), Before: day(before), Reasons: []string{group.Reason}})
+				key := scope{
+					Since: since, Before: before,
+					SourceID: pair.SourceID, DatasetKey: pair.DatasetKey,
+				}
+				if reasonsByScope[key] == nil {
+					reasonsByScope[key] = make(map[string]struct{})
+				}
+				reasonsByScope[key][group.Reason] = struct{}{}
 			}
 		}
 	}
-	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].Since.Equal(candidates[j].Since) {
-			return candidates[i].Before.Before(candidates[j].Before)
+
+	keys := make([]scope, 0, len(reasonsByScope))
+	for key := range reasonsByScope {
+		keys = append(keys, key)
+	}
+	// Python sorts by (since, before, dataset_keys, source_ids, reasons); the
+	// first four already make the order total here, since reasons are a
+	// function of the scope.
+	sort.Slice(keys, func(i, j int) bool {
+		if !keys[i].Since.Equal(keys[j].Since) {
+			return keys[i].Since.Before(keys[j].Since)
 		}
-		return candidates[i].Since.Before(candidates[j].Since)
+		if !keys[i].Before.Equal(keys[j].Before) {
+			return keys[i].Before.Before(keys[j].Before)
+		}
+		if keys[i].DatasetKey != keys[j].DatasetKey {
+			return keys[i].DatasetKey < keys[j].DatasetKey
+		}
+		return keys[i].SourceID < keys[j].SourceID
 	})
-	merged := make([]candidate, 0)
-	for _, item := range candidates {
-		if len(merged) > 0 && !item.Since.After(merged[len(merged)-1].Before.AddDate(0, 0, 1)) {
-			last := &merged[len(merged)-1]
-			if item.Before.After(last.Before) {
-				last.Before = item.Before
-			}
-			last.Reasons = unionSorted(last.Reasons, item.Reasons)
-			continue
+
+	result := make([]any, 0, len(keys))
+	for _, key := range keys {
+		reasons := make([]string, 0, len(reasonsByScope[key]))
+		for reason := range reasonsByScope[key] {
+			reasons = append(reasons, reason)
 		}
-		merged = append(merged, item)
-	}
-	result := make([]any, 0, len(merged))
-	for _, item := range merged {
-		result = append(result, map[string]any{"since": item.Since.Format("2006-01-02"), "before": item.Before.Format("2006-01-02"), "reasons": item.Reasons})
+		sort.Strings(reasons)
+		result = append(result, map[string]any{
+			"since": isoTime(key.Since), "before": isoTime(key.Before),
+			"source_ids": []string{key.SourceID}, "dataset_keys": []string{key.DatasetKey},
+			"reasons": reasons,
+		})
 	}
 	return result
+}
+
+// isUTCMidnight reports whether value is exactly 00:00:00.000000000 UTC, the
+// only boundary the focused-backfill selector accepts.
+func isUTCMidnight(value time.Time) bool {
+	utc := value.UTC()
+	return utc.Hour() == 0 && utc.Minute() == 0 &&
+		utc.Second() == 0 && utc.Nanosecond() == 0
 }
 
 func day(value time.Time) time.Time {

--- a/scripts/worker/provision_river_roles.sql
+++ b/scripts/worker/provision_river_roles.sql
@@ -137,6 +137,30 @@ SELECT format(
        )
  WHERE to_regclass('public.sync_run_unit_effect_snapshots') IS NOT NULL
 \gexec
+-- Chunked provider persistence (migration 0102). Both tables are written and
+-- reclaimed by the domain role -- checkpoints advance per chunk, chunks are
+-- inserted, superseded, and deleted on completion -- so both need the full
+-- SELECT/INSERT/UPDATE/DELETE set domainPosture() declares.
+--
+-- This script runs BEFORE the pinned migration, so these to_regclass guards
+-- skip on a first provision and runtimeGrantStatements in
+-- internal/storage/river/migrate.go is what actually grants them once the
+-- tables exist. They are listed here for the same reason
+-- sync_run_unit_effect_snapshots is: the two lists are maintained in parallel,
+-- and a re-provision of an already-migrated database must not silently narrow
+-- the posture the migration established.
+SELECT format(
+         'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.sync_run_unit_chunk_checkpoints TO %I',
+         :'domain_role'
+       )
+ WHERE to_regclass('public.sync_run_unit_chunk_checkpoints') IS NOT NULL
+\gexec
+SELECT format(
+         'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.sync_run_unit_effect_chunks TO %I',
+         :'domain_role'
+       )
+ WHERE to_regclass('public.sync_run_unit_effect_chunks') IS NOT NULL
+\gexec
 SELECT format(
          'GRANT SELECT, INSERT, UPDATE ON TABLE public.sync_watermarks TO %I',
          :'domain_role'

--- a/src/dev_health_ops/providers/jira/jsm_models.py
+++ b/src/dev_health_ops/providers/jira/jsm_models.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 
 class JsmPayloadError(ValueError):
@@ -43,6 +43,36 @@ class JsmIncidentFields(BaseModel):
     resolution_date: datetime | None = Field(default=None, alias="resolutiondate")
     status: JsmStatus
     priority: JsmPriority | None = None
+
+    @field_validator("created", "updated", "resolution_date")
+    @classmethod
+    def _require_utc(cls, value: datetime | None) -> datetime | None:
+        """Pin every incident timestamp to UTC at the provider boundary.
+
+        Jira Cloud returns the reporter's local offset -- ``+0200`` as readily
+        as ``+0000`` -- and pydantic preserves whichever it is parsed. Two
+        things then break downstream, both silently:
+
+        * ``operational_ordering_codec.canonical_datetime`` requires a
+          zero-offset datetime and raises ``OperationalOrderingEncodingError``
+          on anything else, so a single non-UTC incident aborts the whole
+          batch's conflict-key construction.
+        * The Go incidents route already normalizes
+          (``parseJiraIncidentTime`` -> ``parsed.UTC().Truncate(microsecond)``),
+          so leaving Python on the source offset makes the two runtimes emit
+          different rows for the same payload -- exactly the divergence the
+          live-Python oracle exists to catch.
+
+        A naive value is rejected rather than assumed to be UTC, matching Go,
+        whose layouts all require an explicit offset: guessing a zone here
+        would move a timestamp by hours with no error anywhere.
+        """
+
+        if value is None:
+            return None
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("JSM incident timestamps require an explicit offset")
+        return value.astimezone(UTC)
 
 
 class JsmIncidentIssue(BaseModel):

--- a/tests/providers/jira/test_jsm_incident_normalize.py
+++ b/tests/providers/jira/test_jsm_incident_normalize.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import anyio
 import pytest
@@ -299,3 +299,67 @@ def test_normalize_rejects_malformed_issue() -> None:
 
     with pytest.raises(JsmPayloadError, match="id"):
         producer.normalize([{"key": "OPS-7", "fields": {}}])
+
+
+def test_normalize_pins_non_utc_jira_offsets_to_utc() -> None:
+    """Jira Cloud returns the reporter's local offset, not always ``+0000``.
+
+    Left on its source offset, a ``+0200`` timestamp aborts the batch:
+    ``operational_ordering_codec.canonical_datetime`` requires a zero-offset
+    datetime and raises ``OperationalOrderingEncodingError`` on anything else,
+    so one non-UTC incident takes down every conflict key in the batch. It also
+    diverged from the Go incidents route, which has always normalized
+    (``parseJiraIncidentTime`` -> ``parsed.UTC()``).
+    """
+
+    issue = _issue()
+    issue["fields"] = {
+        **issue["fields"],  # type: ignore[dict-item]
+        "created": "2026-07-20T11:00:00.000+0200",
+        "updated": "2026-07-20T12:00:00.000+0200",
+        "resolutiondate": "2026-07-20T13:00:00.000+0200",
+    }
+    producer = JsmIncidentProducer(
+        client=_Client(),
+        org_id="org-a",
+        provider_instance_id="cloud-a",
+        base_url="https://example.atlassian.net",
+        observed_at=datetime(2026, 7, 21, 0, 0, tzinfo=UTC),
+    )
+
+    batch = producer.normalize([issue])
+    incident = batch.incidents[0]
+
+    # Same instants as the +0000 fixture in _issue(), which is the point: the
+    # offset is dropped by conversion, never by truncation.
+    assert incident.source_event_at == datetime(2026, 7, 20, 9, 0, tzinfo=UTC)
+    assert incident.source_version_at == datetime(2026, 7, 20, 10, 0, tzinfo=UTC)
+    assert incident.source_version_at.utcoffset() == timedelta(0)
+    # __post_init__ builds these through canonical_datetime, which is the call
+    # that raised before the fix -- a populated conflict key is the proof the
+    # whole batch survived, not just that the field converted.
+    assert incident.source_conflict_key
+    assert incident.source_revision
+
+
+def test_normalize_rejects_a_naive_jira_timestamp() -> None:
+    """A zone-less timestamp is rejected, not assumed to be UTC.
+
+    Go's layouts all require an explicit offset, so guessing one here would
+    move an incident by hours in Python only, with no error on either side.
+    """
+
+    issue = _issue()
+    issue["fields"] = {
+        **issue["fields"],  # type: ignore[dict-item]
+        "updated": "2026-07-20T10:00:00.000",
+    }
+    producer = JsmIncidentProducer(
+        client=_Client(),
+        org_id="org-a",
+        provider_instance_id="cloud-a",
+        base_url="https://example.atlassian.net",
+    )
+
+    with pytest.raises(JsmPayloadError):
+        producer.normalize([issue])


### PR DESCRIPTION
## Summary

- **What changed:** four defects that were already on `feat/go-worker-runtime-migration` and became visible the first time `.github/workflows/go.yml` ran against a PR (on #1779). None originate in the CHAOS-386x/387x readiness lanes — the scheduler and PostgreSQL ones reproduce at **`1001ded9`**, PR #1738's own head.
- **Why:** `go.yml` was added by `d814ca0` with its `push` and `pull_request` triggers commented out, leaving `merge_group` — which only fires for the queue into `main`. A long-lived feature branch therefore had **no Go CI at any point in its life**, and these accumulated behind it.

| Fix | Kind | Reproduced at `1001ded9`? |
|---|---|---|
| `fix(scheduler)` | Real behaviour bug — crash-loops instead of reporting unready | yes |
| `fix(postgres)` | Test fixtures drifted from the declared role posture | yes |
| `fix(jira)` | Real bug — non-UTC timestamps abort whole incident batches | introduced by CHAOS-3869 |
| `fix(synccoverage)` | Real bug — backfill windows manufactured and mis-scoped | yes |

The last two are cherry-picked from #1779, where they were riding along as out-of-scope passengers on a 45k-line cleanup. They belong here. **They are still on #1779 as well** — deliberately, so that PR stays green and reviewable on its own; git reconciles the identical patches whichever merges first. Drop them from either side if you'd rather not see them twice.

Not fixed: the `river-compatibility` `session_crash_rescue_worker` failure. Reasoning at the bottom — I could not reproduce it and will not paper over it.

## The four fixes

### 1. `fix(scheduler)` — stay live and unready when the database is unconfigured

This is the one with production consequences. An unconfigured scheduler **exits at startup** instead of publishing its operator port:

```
container scheduler exited before publishing :8080; its output was:
{"level":"ERROR","msg":"configure runtime dependencies","error_category":"dependency_configuration_failed"}
```

The contract `ci/check_go_containers.sh` encodes is that a foundation binary stays live and fails *readiness* until its dependencies are configured, so an operator scrapes named checks instead of watching a restart loop. Measured side by side with no DSN set:

| binary | `/healthz` | `/readyz` | process |
|---|---|---|---|
| `dev-health-worker` | 200 | 503 | stays live ✅ |
| `dev-health-scheduler` (before) | — | — | exits ❌ |
| `dev-health-scheduler` (after) | 200 | 503 | stays live ✅ |

`dev-health-reconciler` and `dev-health-stream-runner` were checked the same way and were already correct, so this is one binary, not four.

The worker gets this right because CHAOS-3873 taught it to separate a *declared configuration rejection* from an *operational* failure. `buildSchedulerLoopWithSources` treated every `openDatabase` error as fatal, and an absent DSN is the most common declared rejection there is.

The classification list moved to `internal/storage/postgres.ConfigurationRejected`, beside the sentinels it classifies. It was a private copy inside `cmd/dev-health-worker`, and **that is exactly how the scheduler came to lack it** — the policy existed, but only one binary could reach it. Operational failures (unreachable host, refused credentials, unparseable DSN) still crash-loop.

### 2. `fix(postgres)` — the chunked-persistence tables the domain posture requires

Twelve integration tests failed with an opaque `PostgreSQL readiness check failed` across four files. `d814ca0` added `sync_run_unit_chunk_checkpoints` and `sync_run_unit_effect_chunks` to `domainPosture()` as full SELECT/INSERT/UPDATE/DELETE requirements without bringing the fixtures along:

- `domain_authorization` / `runtime_authorization` **create** both tables but never **grant** anything on them;
- `domain_grant_reconciliation` / `coordinator_statement_privileges` never create them at all — and every domain GRANT there is wrapped in a `to_regclass` guard, so an absent table silently skips its grant while the posture still requires it.

Either way `CheckRolePosture`'s single-boolean query returns false and collapses to `ErrUnavailable` by design (it must not leak catalog or driver detail), so twelve tests reported the same opaque failure with no hint that two specific tables were the cause. Diagnosed by dumping `domainPosture()` and diffing it against the grants each fixture actually issues.

**Production is not affected** — I checked before assuming. `runtimeGrantStatements` in `internal/storage/river/migrate.go` already grants both tables correctly, and that is what runs during the pinned migration. `scripts/worker/provision_river_roles.sql` gains them too, but *not* because a first provision needs it: that script runs **before** the migration, so its `to_regclass` guards skip both. It is listed there for the same reason `sync_run_unit_effect_snapshots` is — the two lists are maintained in parallel, and a re-provision of an already-migrated database must not narrow the posture the migration established.

### 3. `fix(jira)` — pin JSM incident timestamps to UTC

Jira Cloud returns the reporter's local offset, not always `+0000`. Pydantic preserved whichever it parsed, and `operational_ordering_codec.canonical_datetime` requires a zero-offset datetime — so **one `+0200` incident raised `OperationalOrderingEncodingError` and aborted conflict-key construction for the entire batch**. The Go route already normalized (`parseJiraIncidentTime` → `parsed.UTC().Truncate(microsecond)`), so the two runtimes also emitted different rows for one payload.

This came in with the CHAOS-3869 fix, which added the `jira_cloud_non_utc_offset` oracle case and fixed only the Go side. Naive timestamps are now rejected rather than assumed UTC, matching Go, whose layouts all require an explicit offset.

### 4. `fix(synccoverage)` — scope backfill windows to the source and dataset

`canonicalBackfillWindows` diverged structurally from the authoritative `_canonical_backfill_windows`; both feed the same focused-backfill selector.

- The selector only accepts UTC-midnight boundaries and Python **skips** anything else. Go **coerced** partial days onto day boundaries — nudging a midnight `before` back a microsecond, then truncating both ends — manufacturing windows the API would refuse, including a degenerate `since == before` window covering nothing.
- A window is only actionable against its own source and dataset. Go iterated datasets alone, dropped source identity, and merged adjacent windows across both, so one source's gap could widen another source's window. Python keys on `(since, before, source_id, dataset_key)` and never merges.

`TestPayloadBackfillScheduleAndStatusSemantics` asserted the degenerate window, so it encoded the defect; it now asserts the skip (with the gap still counted in `overall`), plus a new positive-path test.

## Checklist

- [x] I added/updated tests, or provided required governance evidence below.
- [x] I ran relevant local validation (minimum: `./ci/run_tests.sh unit` for `src/` changes).
- [x] I documented risk and rollback considerations.
- [x] I called out breaking changes, migrations, or config impacts (or wrote `none`).

## Test Evidence

TEST-EVIDENCE:

**`bash ci/check_go.sh fast` — green end to end, including the multi-replica gate:**

```
$ PATH="$PWD/.venv/bin:$PATH" bash ci/check_go.sh fast; echo "exit=$?"
multi-replica worker gate: measured 4 terminal jobs
exit=0
```

**The twelve PostgreSQL integration failures, before and after** (real containers, `-tags=integration -count=1`):

```
before:  --- FAIL: TestCoordinatorMaterializerCanInsertSyncDispatchOutbox
         --- FAIL: TestDomainAuthorizationAcceptsTheGrantsItIsPairedWith
         --- FAIL: TestDomainAuthorizationRejectsColumnPrivilegeGrantedToPublic
         ... 12 total, all "PostgreSQL readiness check failed"

after:   ok  github.com/full-chaos/dev-health-ops/internal/storage/postgres  91.913s
```

**Scheduler, measured against the real smoke contract** (binary run with `env -i`, no DSN):

```
healthz: 200
readyz:  503
{"failed_checks":["coordinator_postgres","domain_postgres","queue_postgres",
                  "river_schema","scheduler_loop"],"status":"not_ready"}
metrics: 200
exit code on SIGTERM: 0
```

Those are exactly the four names `ci/check_go_containers.sh` greps for on this target, plus `coordinator_postgres`, and it also asserts `/metrics` 200 and a clean exit — all four satisfied.

**Every new/changed test fails without its fix.** Verified by reverting the implementation alone and re-running:

```
scheduler   (revert dependencies.go only, keep the sentinel so it still builds)
  --- FAIL: TestSchedulerSpecRejectsAnActivatedRuntimeWithoutDatabaseConfiguration
      unconfigured activated scheduler components=[] err=scheduler activation is unavailable
  restored -> ok

jira        (revert jsm_models.py)
  FAILED test_normalize_pins_non_utc_jira_offsets_to_utc
  FAILED test_normalize_rejects_a_naive_jira_timestamp
  restored -> 11 passed
```

**Full live-Python-oracle verb**, which is where the Jira and synccoverage bugs actually surface:

```
ok  internal/providersync        102.031s
ok  internal/providerfoundation    1.568s
ok  internal/scheduler/sync        1.538s
ok  internal/jobs/metrics/daily    2.731s
ok  internal/synccoverage          1.463s
```

**Reproduction at `1001ded9`**, in a clean worktree, establishing these predate the six lane branches:

```
scheduler:  {"level":"ERROR","msg":"configure runtime dependencies", ...}   (exits)
postgres:   --- FAIL: TestDomainAuthorizationRequiresExactCanaryAndReconcilerPrivileges
                domain readiness failed: PostgreSQL readiness check failed
```

## Risk Notes

RISK-NOTES:

- **Scheduler behaviour change.** An unconfigured scheduler now stays up rather than exiting. That is the intended contract and matches the worker, but it does change what a misconfigured deployment looks like: a `Running` pod failing readiness instead of `CrashLoopBackOff`. Anything alerting on scheduler restarts as a proxy for misconfiguration should move to the readiness signal, which is strictly more informative — it names which of the five checks failed. Operational failures still crash-loop, and there is a test pinning each side so the two cannot collapse into one another.
- **`synccoverage` output shape.** `backfill_windows` now carries full RFC3339 stamps instead of date-only strings, includes `source_ids`/`dataset_keys`, and offers **fewer** windows (ones the selector would have refused are no longer suggested). Any consumer reading the old date-only form should be checked — though the Python API has always emitted the new shape, so a correct consumer already handles it.
- **`jira` stored values.** `source_version_at`/`source_event_at` shift for non-UTC-offset incidents — the same instant, expressed in UTC — and batches that previously aborted now succeed. Naive timestamps are newly rejected; Go already rejected them, so this closes a divergence rather than opening one.
- **`postgres` changes are test-only plus one parallel-list entry.** No production grant path changes: `migrate.go` already granted both tables.
- **Rollback.** `git revert` per commit; nothing is stateful and no migration, schema, or switch default changed.
- **Not fixed — `river-compatibility` `session_crash_rescue_worker`.** I ran the full harness locally twice and it **passes**, session crash-rescue included. In CI the direct (~22s) and poll-only (~19s) rescues passed and only session exceeded its `--timeout 45s`, failing at ~51s. The harness prints the worker's redacted stderr on failure and CI logged **nothing** between "sanitized diagnostic follows" and "failed" — an empty stderr plus a duration past the cap is the `--timeout` guard firing cleanly, not a panic. That is as far as one CI sample and a passing local run take me: I cannot distinguish "session mode is structurally slowest and 45s is marginal on that runner" from "a reproducible session-pooling hang". Raising the timeout would be a guess that could mask the second, so I left it. The next CI run on this branch is a free second sample; if it recurs, the per-phase timings are the thing to compare.
- **Root cause of the whole class.** `go.yml`'s `pull_request` trigger is now live (applied separately, since this session's credentials lack the `workflow` scope). That is what turns this from a one-off cleanup into something that stays fixed.

## Optional Context

- **Base branch:** `feat/go-worker-runtime-migration`, not `main`.
- **Related:** #1779 (CHAOS-3875 cleanup) — where these failures first surfaced, and where the `jira`/`synccoverage` commits also currently live.
- SCREENSHOT-WAIVER: backend-only change — process startup semantics, provider normalization, coverage payload construction, role-posture test fixtures, and provisioning SQL. No user-facing surface is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgFRWxVJLUMooPAELwBPXu)_