### PR TITLE
fix(shell,lifecycle): stop discarding the cause of a fatal runtime failure

### DIFF
--- a/internal/platform/lifecycle/runtime.go
+++ b/internal/platform/lifecycle/runtime.go
@@ -106,16 +106,38 @@ func (r *Runtime) Run(ctx context.Context) error {
 	case <-ctx.Done():
 		r.logger.InfoContext(context.Background(), "shutdown requested")
 	case runErr = <-failures:
-		r.logger.ErrorContext(
-			context.Background(),
-			"runtime component failed",
-			"error_category",
-			"component_failure",
-		)
+		// The component name is a bounded, compile-time-known identifier
+		// (never operator input), and the error is attached as a raw
+		// attribute value rather than pre-stringified so the logging
+		// handler's redacting ReplaceAttr still processes it (CHAOS-3873).
+		attributes := []any{"error_category", "component_failure"}
+		var failed *componentFailure
+		if errors.As(runErr, &failed) {
+			attributes = append(attributes, "component", failed.name, "error", failed.err)
+		} else {
+			attributes = append(attributes, "error", runErr)
+		}
+		r.logger.ErrorContext(context.Background(), "runtime component failed", attributes...)
 	}
 	stopWatching()
 	return errors.Join(runErr, r.shutdown(ctx, started))
 }
+
+// componentFailure names the component whose asynchronous error triggered
+// runtime shutdown, so callers can recover a bounded, safe identifier via
+// errors.As instead of parsing it back out of formatted error text. It
+// still wraps the underlying error so errors.As/errors.Is keep working for
+// callers (e.g. a component-supplied DependencyReason) further up the chain.
+type componentFailure struct {
+	name string
+	err  error
+}
+
+func (failure *componentFailure) Error() string {
+	return fmt.Sprintf("component %s: %s", failure.name, failure.err)
+}
+
+func (failure *componentFailure) Unwrap() error { return failure.err }
 
 func watchErrors(ctx context.Context, name string, source <-chan error, failures chan<- error) {
 	select {
@@ -126,7 +148,7 @@ func watchErrors(ctx context.Context, name string, source <-chan error, failures
 			return
 		}
 		select {
-		case failures <- fmt.Errorf("component %s: %w", name, err):
+		case failures <- &componentFailure{name: name, err: err}:
 		case <-ctx.Done():
 		}
 	}

--- a/internal/platform/lifecycle/runtime_test.go
+++ b/internal/platform/lifecycle/runtime_test.go
@@ -3,12 +3,52 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+// capturingHandler records emitted slog.Record values so tests can assert on
+// structured attributes directly, without going through a text/JSON encoder.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, record.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *capturingHandler) find(message string) (slog.Record, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, record := range h.records {
+		if record.Message == message {
+			return record, true
+		}
+	}
+	return slog.Record{}, false
+}
+
+func attrMap(record slog.Record) map[string]any {
+	attrs := make(map[string]any, record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value.Any()
+		return true
+	})
+	return attrs
+}
 
 type recordingComponent struct {
 	name        string
@@ -157,6 +197,50 @@ func TestRuntimeStopsAfterAsynchronousComponentFailure(t *testing.T) {
 	}
 	if !reflect.DeepEqual(events, []string{"start:async", "stop:async"}) {
 		t.Fatalf("unexpected events: %v", events)
+	}
+}
+
+// TestRuntimeComponentFailureLogsComponentNameAndCause pins CHAOS-3906: the
+// "runtime component failed" log line must carry which component failed (a
+// bounded, safe identifier) and the underlying cause, not just a category.
+func TestRuntimeComponentFailureLogsComponentNameAndCause(t *testing.T) {
+	t.Parallel()
+
+	handler := &capturingHandler{}
+	logger := slog.New(handler)
+	failures := make(chan error, 1)
+	component := &recordingComponent{
+		name:     "async",
+		record:   func(string) {},
+		failures: failures,
+	}
+	runtime, err := New(Options{Logger: logger, ShutdownTimeout: time.Second, Components: []Component{component}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runtime.Run(context.Background()) }()
+	cause := errors.New("serve failed")
+	failures <- cause
+	if err := <-done; err == nil {
+		t.Fatal("expected asynchronous failure")
+	}
+
+	record, ok := handler.find("runtime component failed")
+	if !ok {
+		t.Fatalf("did not log a runtime component failure: %+v", handler.records)
+	}
+	attrs := attrMap(record)
+	if got := attrs["error_category"]; got != "component_failure" {
+		t.Fatalf("error_category = %v, want component_failure", got)
+	}
+	if got := attrs["component"]; got != "async" {
+		t.Fatalf("component = %v, want %q", got, "async")
+	}
+	loggedErr, ok := attrs["error"].(error)
+	if !ok || !errors.Is(loggedErr, cause) {
+		t.Fatalf("error attribute = %#v, want to wrap %v", attrs["error"], cause)
 	}
 }
 

--- a/internal/platform/shell/shell.go
+++ b/internal/platform/shell/shell.go
@@ -259,12 +259,17 @@ func Execute(
 	attrs := append(cfg.SafeAttrs(), build.Attrs()...)
 	logger.LogAttrs(ctx, slog.LevelInfo, "service starting", attrs...)
 	if err := runtime.Run(ctx); err != nil {
-		logger.ErrorContext(
-			context.Background(),
-			"service stopped with error",
-			"error_category",
-			"runtime_failure",
-		)
+		// Mirrors the configure path above: a reason code, when a component
+		// supplies one, is a bounded compile-time constant safe to log
+		// as-is, and the error itself is attached as a normal attribute
+		// value (not pre-formatted into the message) so the logging
+		// handler's redacting ReplaceAttr still processes it (CHAOS-3873).
+		attributes := []any{"error_category", "runtime_failure", "error", err}
+		var coded dependencyReason
+		if errors.As(err, &coded) {
+			attributes = append(attributes, "reason", coded.DependencyReason())
+		}
+		logger.ErrorContext(context.Background(), "service stopped with error", attributes...)
 		return 1
 	}
 	logger.InfoContext(context.Background(), "service stopped")

--- a/internal/platform/shell/shell_test.go
+++ b/internal/platform/shell/shell_test.go
@@ -38,6 +38,28 @@ func (component failingComponent) Start(context.Context) error {
 }
 func (failingComponent) Shutdown(context.Context) error { return nil }
 
+// asyncFailingComponent starts cleanly and then reports a failure on its
+// Errors() channel, exercising lifecycle.Runtime's asynchronous
+// component-failure path (as opposed to failingComponent's synchronous
+// Start-failure path) end to end through the shell.
+type asyncFailingComponent struct {
+	name  string
+	errCh chan error
+}
+
+func (component asyncFailingComponent) Name() string         { return component.name }
+func (asyncFailingComponent) Start(context.Context) error    { return nil }
+func (asyncFailingComponent) Shutdown(context.Context) error { return nil }
+func (component asyncFailingComponent) Errors() <-chan error { return component.errCh }
+
+// reasonedComponentError is a component-supplied error carrying a bounded
+// DependencyReason(), the same shape dependency adapters use on the
+// configure path (CHAOS-3873), but returned from the runtime path instead.
+type reasonedComponentError struct{ reason string }
+
+func (reasonedComponentError) Error() string                { return "dependency unavailable" }
+func (err reasonedComponentError) DependencyReason() string { return err.reason }
+
 func TestVersionFlagReportsMetadataWithoutLoadingRuntimeConfig(t *testing.T) {
 	t.Parallel()
 
@@ -278,6 +300,140 @@ func TestRuntimeFailureIsCategorizedWithoutLoggingComponentErrorText(t *testing.
 	}
 	if !strings.Contains(combined, "runtime_failure") {
 		t.Fatalf("runtime failure omitted safe category: %s", combined)
+	}
+}
+
+// TestRuntimeFailureCarriesComponentNameAndCause pins CHAOS-3906: an
+// operator reading the shell's runtime-failure log must be able to see
+// which component failed and why, not just an opaque category.
+func TestRuntimeFailureCarriesComponentNameAndCause(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	errCh <- errors.New("dial dependency: connection refused")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), Spec{
+		Service: "dev-health-worker",
+		ConfigureDependencies: func(
+			_ context.Context,
+			_ config.Config,
+			registry *health.Registry,
+		) ([]lifecycle.Component, error) {
+			if err := registry.RegisterRequired(
+				"test_dependency",
+				func(context.Context) error { return nil },
+			); err != nil {
+				return nil, err
+			}
+			return []lifecycle.Component{asyncFailingComponent{
+				name:  "sync-worker-loop",
+				errCh: errCh,
+			}}, nil
+		},
+	}, nil, testLookup(map[string]string{
+		"DEV_HEALTH_HTTP_ADDR": "127.0.0.1:0",
+	}), IO{Stdout: &stdout, Stderr: &stderr})
+	if code == 0 {
+		t.Fatal("expected async component failure to fail the process")
+	}
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, "sync-worker-loop") {
+		t.Fatalf("runtime failure log omitted the failing component name: %s", combined)
+	}
+	if !strings.Contains(combined, "connection refused") {
+		t.Fatalf("runtime failure log omitted the cause: %s", combined)
+	}
+	if !strings.Contains(combined, "component_failure") {
+		t.Fatalf("runtime component failure omitted its category: %s", combined)
+	}
+}
+
+// TestRuntimeFailureRedactsComponentErrorDSN proves the redacting slog
+// handler (internal/platform/logging.NewJSON) still scrubs a DSN carried by
+// a component's runtime-path error, which is what makes attaching the raw
+// error (rather than discarding it) safe (CHAOS-3873).
+func TestRuntimeFailureRedactsComponentErrorDSN(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	errCh <- fmt.Errorf("dial postgres://user:do-not-print@ch.internal/db")
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), Spec{
+		Service: "dev-health-worker",
+		ConfigureDependencies: func(
+			_ context.Context,
+			_ config.Config,
+			registry *health.Registry,
+		) ([]lifecycle.Component, error) {
+			if err := registry.RegisterRequired(
+				"test_dependency",
+				func(context.Context) error { return nil },
+			); err != nil {
+				return nil, err
+			}
+			return []lifecycle.Component{asyncFailingComponent{
+				name:  "async-dsn-component",
+				errCh: errCh,
+			}}, nil
+		},
+	}, nil, testLookup(map[string]string{
+		"DEV_HEALTH_HTTP_ADDR": "127.0.0.1:0",
+	}), IO{Stdout: &stdout, Stderr: &stderr})
+	if code == 0 {
+		t.Fatal("expected async component failure to fail the process")
+	}
+	combined := stdout.String() + stderr.String()
+	for _, forbidden := range []string{"postgres://", "do-not-print", "ch.internal"} {
+		if strings.Contains(combined, forbidden) {
+			t.Fatalf("runtime component failure leaked %q: %s", forbidden, combined)
+		}
+	}
+	// This is the assertion that actually proves the handler did the
+	// scrubbing rather than the DSN simply never being attached: it only
+	// appears once the component's cause is attached as a real attribute
+	// value and passed through the redacting ReplaceAttr handler.
+	if !strings.Contains(combined, "component async-dsn-component: dial [REDACTED]") {
+		t.Fatalf("runtime failure log did not show a redacted (not discarded) cause: %s", combined)
+	}
+}
+
+// TestRuntimeFailureHonoursComponentDependencyReason pins CHAOS-3906's core
+// asymmetry fix: a bounded DependencyReason() from a component was already
+// honoured on the configure path (CHAOS-3873) but discarded on the runtime
+// path. It must now be honoured there too.
+func TestRuntimeFailureHonoursComponentDependencyReason(t *testing.T) {
+	t.Parallel()
+
+	errCh := make(chan error, 1)
+	errCh <- reasonedComponentError{reason: "queue_backend_unreachable"}
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), Spec{
+		Service: "dev-health-worker",
+		ConfigureDependencies: func(
+			_ context.Context,
+			_ config.Config,
+			registry *health.Registry,
+		) ([]lifecycle.Component, error) {
+			if err := registry.RegisterRequired(
+				"test_dependency",
+				func(context.Context) error { return nil },
+			); err != nil {
+				return nil, err
+			}
+			return []lifecycle.Component{asyncFailingComponent{
+				name:  "reasoned-worker",
+				errCh: errCh,
+			}}, nil
+		},
+	}, nil, testLookup(map[string]string{
+		"DEV_HEALTH_HTTP_ADDR": "127.0.0.1:0",
+	}), IO{Stdout: &stdout, Stderr: &stderr})
+	if code == 0 {
+		t.Fatal("expected async component failure to fail the process")
+	}
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, `"reason":"queue_backend_unreachable"`) {
+		t.Fatalf("runtime failure did not honour the component's DependencyReason: %s", combined)
 	}
 }
 


### PR DESCRIPTION
Closes CHAOS-3906. From the [observability audit](https://linear.app/fullchaos/document/observability-audit-go-worker-runtime-2026-08-18-10308693ec48).

**Keystone of the batch** — four other tickets are unmeasurable until this lands.

`shell.go:261` bound `err` and never used it, logging only `error_category=runtime_failure`. Not redacted — discarded. This is the line an operator saw during the CHAOS-3903 crash-loop. `lifecycle/runtime.go:109` did the same for `component_failure`, dropping even the component name.

The configure path 25 lines earlier already had an `errors.As` reason-code hatch; the runtime path had none, so a component returning a bounded reason had it thrown away.

## Changes
- `shell.go`: attaches `err` as a raw slog attribute (not pre-stringified, so the redacting `ReplaceAttr` handler still processes it) plus the same `errors.As` reason branch as the configure path.
- `lifecycle/runtime.go`: new `componentFailure{name, err}` with `Unwrap()`, so the component name is recovered via `errors.As` rather than parsed out of formatted text — and a component's `DependencyReason()` still surfaces through the wrap.

## Why attaching the error is safe
The platform already redacts in three layers: `secrets.Value` type containment, the slog handler that scrubs `err.Error()` on any attribute (`logging.go:35-48`, whose own comment says it is defense in depth and was built to accept raw errors), and tests asserting both.

## Tests (4, each verified to fail against pre-fix code)
Includes `TestRuntimeFailureRedactsComponentErrorDSN`, which asserts a DSN is **absent** AND that `component async-dsn-component: dial [REDACTED]` is **present** — proving the handler scrubbed it rather than the code discarding it. A discard-everything implementation cannot pass.

Full `ci/check_go.sh all` green (RC=0).