### PR TITLE
fix(jobroute): stop relabelling a failed rollback quiesce probe as live claims

### DIFF
--- a/internal/joboperator/service_test.go
+++ b/internal/joboperator/service_test.go
@@ -3,6 +3,7 @@ package joboperator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -534,6 +535,38 @@ func TestJobRouteApplyIsAuthorizedAndDurablyAudited(t *testing.T) {
 	if fixture.auditor.event.Action != ActionApplyJobRoute {
 		t.Fatalf("audit=%+v", fixture.auditor.event)
 	}
+}
+
+// TestJobRouteRollbackClassifiesQuiesceProbeFailureAsBackendNotPrecondition
+// covers the joboperator side of CHAOS-3904: once jobroute.Controller.Rollback
+// stops relabelling a failed quiescence probe as ErrLiveClaims, the error it
+// returns (ErrUnavailable wrapping the driver cause) must route through
+// mapBackendError -> CodeBackend, not mapJobRouteError -> CodePrecondition.
+func TestJobRouteRollbackClassifiesQuiesceProbeFailureAsBackendNotPrecondition(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	fixture.jobRoutes.err = fmt.Errorf("%w: %w", jobroute.ErrUnavailable, errors.New("dial tcp: connection refused"))
+
+	_, err := fixture.service.RollbackJobRoute(
+		context.Background(), testPrincipal(), jobcontract.KindBillingNotification,
+		"rollback", "corr-job-route-outage",
+	)
+	assertCode(t, err, CodeBackend)
+}
+
+// TestJobRouteRollbackNegativeControlStillClassifiesLiveClaimsAsPrecondition
+// is the negative control for the test above: a genuine live-claims error
+// must still classify as CodePrecondition after the fix.
+func TestJobRouteRollbackNegativeControlStillClassifiesLiveClaimsAsPrecondition(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	fixture.jobRoutes.err = jobroute.ErrLiveClaims
+
+	_, err := fixture.service.RollbackJobRoute(
+		context.Background(), testPrincipal(), jobcontract.KindBillingNotification,
+		"rollback", "corr-job-route-live-claims",
+	)
+	assertCode(t, err, CodePrecondition)
 }
 
 type fakeRouteController struct {

--- a/internal/jobroute/control.go
+++ b/internal/jobroute/control.go
@@ -221,7 +221,10 @@ func (controller *Controller) Rollback(ctx context.Context, kind string) (State,
 	}
 	if state.Transport != descriptor.RollbackRoute {
 		if err := controller.quiescer.Quiesce(ctx, kind); err != nil {
-			return State{}, ErrLiveClaims
+			if errors.Is(err, ErrLiveClaims) {
+				return State{}, ErrLiveClaims
+			}
+			return State{}, err
 		}
 	}
 	now := controller.now().UTC()

--- a/internal/jobroute/control_integration_test.go
+++ b/internal/jobroute/control_integration_test.go
@@ -315,6 +315,313 @@ func (quiescer *observedQuiescer) Quiesce(context.Context, string) error {
 	return quiescer.err
 }
 
+// TestRollbackSurfacesRiverQuiesceProbeFailureAsUnavailableNotLiveClaims
+// reproduces CHAOS-3904: a River quiescence probe that fails because the
+// database is unavailable (here, the river schema/table is simply absent)
+// must surface as ErrUnavailable, not be relabelled ErrLiveClaims. Before the
+// control.go fix, Rollback discarded the quiescer's error entirely and
+// always returned ErrLiveClaims, which mapJobRouteError/IsPrecondition would
+// have misdiagnosed as a precondition ("still has live claims, wait it out")
+// instead of a backend outage.
+func TestRollbackSurfacesRiverQuiesceProbeFailureAsUnavailableNotLiveClaims(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("close PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	// Deliberately do NOT create the river schema/table: the probe query
+	// fails exactly as it would during a database outage.
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE public.worker_job_routes (
+			job_kind text PRIMARY KEY, transport text NOT NULL, paused boolean NOT NULL,
+			generation bigint NOT NULL, updated_at timestamptz NOT NULL
+		);
+		CREATE TABLE public.worker_job_outbox (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		CREATE TABLE public.worker_job_runs (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		INSERT INTO public.worker_job_routes
+			(job_kind, transport, paused, generation, updated_at)
+		VALUES ('job.river_probe_outage', 'river_canary', FALSE, 1, statement_timestamp())`); err != nil {
+		t.Fatal(err)
+	}
+	quiescer, err := NewPostgresRiverQuiescer(pool, "river")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Directly proves the quiescer.go fix: the driver failure is wrapped,
+	// not discarded for a bare sentinel.
+	probeErr := quiescer.Quiesce(ctx, "job.river_probe_outage")
+	if !errors.Is(probeErr, ErrUnavailable) {
+		t.Fatalf("Quiesce() error = %v, want wrapped %v", probeErr, ErrUnavailable)
+	}
+	if errors.Is(probeErr, ErrLiveClaims) {
+		t.Fatalf("Quiesce() error = %v, must not present as live claims", probeErr)
+	}
+	if probeErr.Error() == ErrUnavailable.Error() {
+		t.Fatalf("Quiesce() error lost the driver cause: %v", probeErr)
+	}
+
+	controller, err := NewController(pool, integrationRegistry{jobruntime.Descriptor{
+		Kind: "job.river_probe_outage", Route: "river_canary", RollbackRoute: "celery",
+	}}, quiescer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := controller.Rollback(ctx, "job.river_probe_outage")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Rollback() error = %v, want wrapped %v", err, ErrUnavailable)
+	}
+	if errors.Is(err, ErrLiveClaims) {
+		t.Fatalf("Rollback() misdiagnosed a database outage as live claims: %v", err)
+	}
+	if IsPrecondition(err) {
+		t.Fatalf("Rollback() error classified as an operator precondition: %v", err)
+	}
+	if (state != State{}) {
+		t.Fatalf("Rollback() returned a non-zero state on failure: %+v", state)
+	}
+	inspected, err := controller.Inspect(ctx, "job.river_probe_outage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspected.Transport != "river_canary" || inspected.Generation != 1 {
+		t.Fatalf("route changed despite the outage: %+v", inspected)
+	}
+}
+
+// TestRollbackStillReportsGenuineRiverLiveClaimsAsPrecondition is the negative
+// control for the test above: a real live River claim must still surface as
+// ErrLiveClaims (and therefore IsPrecondition) after the control.go fix. This
+// proves the fix passes the underlying error through rather than blindly
+// discarding every quiescer error.
+func TestRollbackStillReportsGenuineRiverLiveClaimsAsPrecondition(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("close PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE public.worker_job_routes (
+			job_kind text PRIMARY KEY, transport text NOT NULL, paused boolean NOT NULL,
+			generation bigint NOT NULL, updated_at timestamptz NOT NULL
+		);
+		CREATE TABLE public.worker_job_outbox (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		CREATE TABLE public.worker_job_runs (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		CREATE SCHEMA river;
+		CREATE TABLE river.river_job (id bigint PRIMARY KEY, kind text NOT NULL, state text NOT NULL);
+		INSERT INTO river.river_job (id, kind, state) VALUES (1, 'job.river_probe_live', 'running');
+		INSERT INTO public.worker_job_routes
+			(job_kind, transport, paused, generation, updated_at)
+		VALUES ('job.river_probe_live', 'river_canary', FALSE, 1, statement_timestamp())`); err != nil {
+		t.Fatal(err)
+	}
+	quiescer, err := NewPostgresRiverQuiescer(pool, "river")
+	if err != nil {
+		t.Fatal(err)
+	}
+	probeErr := quiescer.Quiesce(ctx, "job.river_probe_live")
+	if !errors.Is(probeErr, ErrLiveClaims) {
+		t.Fatalf("Quiesce() error = %v, want %v", probeErr, ErrLiveClaims)
+	}
+
+	controller, err := NewController(pool, integrationRegistry{jobruntime.Descriptor{
+		Kind: "job.river_probe_live", Route: "river_canary", RollbackRoute: "celery",
+	}}, quiescer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = controller.Rollback(ctx, "job.river_probe_live")
+	if !errors.Is(err, ErrLiveClaims) {
+		t.Fatalf("Rollback() error = %v, want %v", err, ErrLiveClaims)
+	}
+	if !IsPrecondition(err) {
+		t.Fatalf("Rollback() genuine live-claims error not classified as a precondition: %v", err)
+	}
+}
+
+// TestRollbackSurfacesCelerySyncQuiesceProbeFailureAsUnavailableNotLiveClaims
+// is the same reproduction as the River case above, for the second quiescer
+// implementation named in CHAOS-3904's acceptance criteria.
+func TestRollbackSurfacesCelerySyncQuiesceProbeFailureAsUnavailableNotLiveClaims(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("close PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	// Deliberately do NOT create public.sync_run_units: the probe query
+	// fails exactly as it would during a database outage.
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE public.worker_job_routes (
+			job_kind text PRIMARY KEY, transport text NOT NULL, paused boolean NOT NULL,
+			generation bigint NOT NULL, updated_at timestamptz NOT NULL
+		);
+		CREATE TABLE public.worker_job_outbox (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		CREATE TABLE public.worker_job_runs (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		INSERT INTO public.worker_job_routes
+			(job_kind, transport, paused, generation, updated_at)
+		VALUES ('sync.provider_unit', 'river_canary', FALSE, 1, statement_timestamp())`); err != nil {
+		t.Fatal(err)
+	}
+	quiescer, err := NewPostgresCelerySyncProviderQuiescer(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	probeErr := quiescer.Quiesce(ctx, "sync.provider_unit")
+	if !errors.Is(probeErr, ErrUnavailable) {
+		t.Fatalf("Quiesce() error = %v, want wrapped %v", probeErr, ErrUnavailable)
+	}
+	if errors.Is(probeErr, ErrLiveClaims) {
+		t.Fatalf("Quiesce() error = %v, must not present as live claims", probeErr)
+	}
+	if probeErr.Error() == ErrUnavailable.Error() {
+		t.Fatalf("Quiesce() error lost the driver cause: %v", probeErr)
+	}
+
+	controller, err := NewController(pool, integrationRegistry{jobruntime.Descriptor{
+		Kind: "sync.provider_unit", Route: "river_canary", RollbackRoute: "celery",
+	}}, quiescer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := controller.Rollback(ctx, "sync.provider_unit")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Rollback() error = %v, want wrapped %v", err, ErrUnavailable)
+	}
+	if errors.Is(err, ErrLiveClaims) {
+		t.Fatalf("Rollback() misdiagnosed a database outage as live claims: %v", err)
+	}
+	if IsPrecondition(err) {
+		t.Fatalf("Rollback() error classified as an operator precondition: %v", err)
+	}
+	if (state != State{}) {
+		t.Fatalf("Rollback() returned a non-zero state on failure: %+v", state)
+	}
+	inspected, err := controller.Inspect(ctx, "sync.provider_unit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspected.Transport != "river_canary" || inspected.Generation != 1 {
+		t.Fatalf("route changed despite the outage: %+v", inspected)
+	}
+}
+
+// TestRollbackStillReportsGenuineCelerySyncLiveClaimsAsPrecondition is the
+// negative control for the Celery sync-provider quiescer.
+func TestRollbackStillReportsGenuineCelerySyncLiveClaimsAsPrecondition(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("close PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE public.worker_job_routes (
+			job_kind text PRIMARY KEY, transport text NOT NULL, paused boolean NOT NULL,
+			generation bigint NOT NULL, updated_at timestamptz NOT NULL
+		);
+		CREATE TABLE public.worker_job_outbox (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		CREATE TABLE public.worker_job_runs (
+			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
+		);
+		CREATE TABLE public.sync_run_units (
+			id uuid PRIMARY KEY, provider text NOT NULL, dataset_key text NOT NULL,
+			status text NOT NULL
+		);
+		INSERT INTO public.sync_run_units (id, provider, dataset_key, status) VALUES
+			('00000000-0000-4000-8000-000000000005', 'launchdarkly', 'feature-flags', 'dispatching');
+		INSERT INTO public.worker_job_routes
+			(job_kind, transport, paused, generation, updated_at)
+		VALUES ('sync.provider_unit', 'river_canary', FALSE, 1, statement_timestamp())`); err != nil {
+		t.Fatal(err)
+	}
+	quiescer, err := NewPostgresCelerySyncProviderQuiescer(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	probeErr := quiescer.Quiesce(ctx, "sync.provider_unit")
+	if !errors.Is(probeErr, ErrLiveClaims) {
+		t.Fatalf("Quiesce() error = %v, want %v", probeErr, ErrLiveClaims)
+	}
+
+	controller, err := NewController(pool, integrationRegistry{jobruntime.Descriptor{
+		Kind: "sync.provider_unit", Route: "river_canary", RollbackRoute: "celery",
+	}}, quiescer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = controller.Rollback(ctx, "sync.provider_unit")
+	if !errors.Is(err, ErrLiveClaims) {
+		t.Fatalf("Rollback() error = %v, want %v", err, ErrLiveClaims)
+	}
+	if !IsPrecondition(err) {
+		t.Fatalf("Rollback() genuine live-claims error not classified as a precondition: %v", err)
+	}
+}
+
 func waitForBlockedRouteUpdate(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)

--- a/internal/jobroute/quiescer.go
+++ b/internal/jobroute/quiescer.go
@@ -3,6 +3,7 @@ package jobroute
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -60,7 +61,7 @@ func (quiescer *PostgresRiverQuiescer) Quiesce(ctx context.Context, kind string)
 		kind,
 	).Scan(&count)
 	if err != nil {
-		return ErrUnavailable
+		return fmt.Errorf("%w: %w", ErrUnavailable, err)
 	}
 	if count != 0 {
 		return ErrLiveClaims
@@ -91,7 +92,7 @@ func (quiescer *PostgresCelerySyncProviderQuiescer) Quiesce(ctx context.Context,
 			  AND status IN ('dispatching', 'running')
 		)`).Scan(&active)
 	if err != nil {
-		return ErrUnavailable
+		return fmt.Errorf("%w: %w", ErrUnavailable, err)
 	}
 	if active {
 		return ErrLiveClaims


### PR DESCRIPTION
Closes CHAOS-3904. From the [observability audit](https://linear.app/fullchaos/document/observability-audit-go-worker-runtime-2026-08-18-10308693ec48).

See the Linear issue for the full defect description, the decision rule applied, and acceptance criteria.

Every new test was verified to FAIL against the pre-fix code before being trusted. Full `ci/check_go.sh all` green (RC=0).