### PR TITLE
fix(health): name the failing check in /metrics, not just the aggregate bit

### DIFF
--- a/internal/platform/health/health_test.go
+++ b/internal/platform/health/health_test.go
@@ -272,6 +272,167 @@ func TestMetricsSourcesAreStableAndFailWithoutPartialOutput(t *testing.T) {
 	}
 }
 
+func TestMetricsExposesPerCheckFailureGauge(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry(100 * time.Millisecond)
+	// Registered out of alphabetical order so a pass requires the handler to
+	// sort, not merely echo registration order.
+	if err := registry.RegisterRequired("queue_postgres", func(context.Context) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.RegisterRequired("domain_postgres", func(context.Context) error {
+		return errors.New("dial postgres://user:secret@db/app")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.RegisterRequired("cache_redis", func(context.Context) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	registry.SetReady(true)
+	server, err := NewServer(ServerOptions{Address: "127.0.0.1:0", Registry: registry, Service: "test", Version: "dev"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("metrics status = %d", response.Code)
+	}
+	body := response.Body.String()
+
+	// dev_health_runtime_ready must still collapse to the aggregate bit,
+	// unchanged, so existing alerts wired to it keep working.
+	if !strings.Contains(body, "dev_health_runtime_ready 0\n") {
+		t.Fatalf("aggregate ready gauge changed semantics:\n%s", body)
+	}
+
+	// A failing required check must be named, not just reflected in the
+	// aggregate boolean.
+	if !strings.Contains(body, `dev_health_runtime_check_failed{check="domain_postgres"} 1`) {
+		t.Fatalf("failing check was not named in per-check gauge:\n%s", body)
+	}
+	// Passing checks must emit an explicit 0, not be left absent, so an
+	// alert can fire on the absence of a failure value rather than the
+	// absence of a series.
+	for _, want := range []string{
+		`dev_health_runtime_check_failed{check="cache_redis"} 0`,
+		`dev_health_runtime_check_failed{check="queue_postgres"} 0`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("passing check missing explicit 0 series %q:\n%s", want, body)
+		}
+	}
+
+	if got := strings.Count(body, "# TYPE dev_health_runtime_check_failed gauge"); got != 1 {
+		t.Fatalf("expected exactly one TYPE line for dev_health_runtime_check_failed, got %d", got)
+	}
+
+	// Output ordering must be deterministic (sorted by check name), not
+	// registration order, so scrapes and diffs are stable.
+	first := strings.Index(body, `check="cache_redis"`)
+	second := strings.Index(body, `check="domain_postgres"`)
+	third := strings.Index(body, `check="queue_postgres"`)
+	if first < 0 || second < 0 || third < 0 || !(first < second && second < third) {
+		t.Fatalf("per-check gauge lines are not sorted by name:\n%s", body)
+	}
+
+	if strings.Contains(body, "secret") || strings.Contains(body, "postgres://") {
+		t.Fatalf("per-check gauge leaked dependency error text:\n%s", body)
+	}
+}
+
+func TestMetricsPerCheckGaugeOrderingIsStableAcrossScrapes(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry(100 * time.Millisecond)
+	for _, name := range []string{"zzz_last", "aaa_first", "mmm_middle"} {
+		if err := registry.RegisterRequired(name, func(context.Context) error { return nil }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	registry.SetReady(true)
+	server, err := NewServer(ServerOptions{Address: "127.0.0.1:0", Registry: registry, Service: "test", Version: "dev"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	extractCheckLines := func() []string {
+		request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		response := httptest.NewRecorder()
+		server.Handler().ServeHTTP(response, request)
+		var lines []string
+		for _, line := range strings.Split(response.Body.String(), "\n") {
+			if strings.HasPrefix(line, "dev_health_runtime_check_failed{") {
+				lines = append(lines, line)
+			}
+		}
+		return lines
+	}
+
+	first := extractCheckLines()
+	second := extractCheckLines()
+	third := extractCheckLines()
+	if len(first) != 3 {
+		t.Fatalf("expected 3 per-check gauge lines, got %d: %v", len(first), first)
+	}
+	if !slices.Equal(first, second) || !slices.Equal(second, third) {
+		t.Fatalf("per-check gauge ordering was not deterministic across scrapes:\n%v\n%v\n%v", first, second, third)
+	}
+	want := []string{
+		`dev_health_runtime_check_failed{check="aaa_first"} 0`,
+		`dev_health_runtime_check_failed{check="mmm_middle"} 0`,
+		`dev_health_runtime_check_failed{check="zzz_last"} 0`,
+	}
+	if !slices.Equal(first, want) {
+		t.Fatalf("per-check gauge lines = %v, want %v", first, want)
+	}
+}
+
+func TestReadinessCheckNamesRejectValuesThatWouldCorruptExpositionFormat(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry(100 * time.Millisecond)
+	for _, unsafeName := range []string{
+		`bad"name`,
+		"bad\nname",
+		"bad name",
+		"",
+	} {
+		if err := registry.RegisterRequired(unsafeName, func(context.Context) error { return nil }); err == nil {
+			t.Fatalf("expected registering unsafe check name %q to fail checkNamePattern", unsafeName)
+		}
+	}
+	if err := registry.RegisterRequired("safe_name", func(context.Context) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if got := registry.RequiredCount(); got != 1 {
+		t.Fatalf("expected only the safe name to register, got %d required checks", got)
+	}
+	registry.SetReady(true)
+
+	server, err := NewServer(ServerOptions{Address: "127.0.0.1:0", Registry: registry, Service: "test", Version: "dev"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, request)
+	body := response.Body.String()
+
+	// A rejected registration must never reach the exposition format: a raw
+	// quote or newline in a label value would corrupt the Prometheus text
+	// format for every metric after it in the scrape.
+	if strings.Contains(body, `bad"name`) || strings.Contains(body, "bad\nname") || strings.Contains(body, "bad name") {
+		t.Fatalf("unsafe check name reached /metrics output:\n%s", body)
+	}
+	if !strings.Contains(body, `dev_health_runtime_check_failed{check="safe_name"} 0`) {
+		t.Fatalf("safe check name missing from /metrics output:\n%s", body)
+	}
+}
+
 func TestServerStartsOnEphemeralPortAndShutsDown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/platform/health/registry.go
+++ b/internal/platform/health/registry.go
@@ -55,6 +55,21 @@ type checkExecution struct {
 type Readiness struct {
 	Ready  bool
 	Failed []string
+	// Checks is the per-check result for every required dependency, sorted by
+	// name. It is populated only when CheckRequired actually ran the required
+	// checks (the normal, gate-open path); the fail-closed sentinel paths
+	// below ("runtime", "dependencies") leave it nil since there is no real
+	// per-check data to report. Names come from RegisterRequired, which
+	// rejects anything not matching checkNamePattern, so every Name here is
+	// already a safe, unquoted-friendly label value.
+	Checks []CheckStatus
+}
+
+// CheckStatus is one required check's pass/fail result. Name is always a
+// pre-registered identifier matching checkNamePattern.
+type CheckStatus struct {
+	Name   string
+	Failed bool
 }
 
 func NewRegistry(checkTimeout time.Duration) *Registry {
@@ -248,25 +263,29 @@ func (r *Registry) CheckRequired(ctx context.Context) Readiness {
 		return Readiness{Ready: false, Failed: []string{"dependencies"}}
 	}
 
-	results := make(chan string, len(checks))
+	type outcome struct {
+		name   string
+		failed bool
+	}
+	results := make(chan outcome, len(checks))
 	for name, check := range checks {
 		go func() {
-			if !check.run(ctx, r.checkTimeout) {
-				results <- name
-				return
-			}
-			results <- ""
+			results <- outcome{name: name, failed: !check.run(ctx, r.checkTimeout)}
 		}()
 	}
 
 	failed := make([]string, 0)
+	statuses := make([]CheckStatus, 0, len(checks))
 	for range checks {
-		if name := <-results; name != "" {
-			failed = append(failed, name)
+		result := <-results
+		statuses = append(statuses, CheckStatus{Name: result.name, Failed: result.failed})
+		if result.failed {
+			failed = append(failed, result.name)
 		}
 	}
 	sort.Strings(failed)
-	return Readiness{Ready: len(failed) == 0, Failed: failed}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].Name < statuses[j].Name })
+	return Readiness{Ready: len(failed) == 0, Failed: failed, Checks: statuses}
 }
 
 // run shares a single in-flight execution across callers. A check that ignores

--- a/internal/platform/health/server.go
+++ b/internal/platform/health/server.go
@@ -184,6 +184,39 @@ func (s *Server) handleMetrics(response http.ResponseWriter, request *http.Reque
 		strconv.Quote(s.service),
 		strconv.Quote(s.version),
 	)
+	// dev_health_runtime_ready collapses every required check into one bit, so
+	// an alert fired from it cannot say which dependency is down — and a
+	// crash-looping process serves no /readyz at all, leaving that one good
+	// surface dark exactly when it is needed. Publish a labelled gauge per
+	// required check alongside it so a scrape (and a page) can name the
+	// failure. Every required check gets a series, passing or not, so an
+	// alert can be written against the absence of failure, not the absence of
+	// a series. readiness.Checks is sorted by name (Registry.CheckRequired),
+	// so the label ordering is stable scrape to scrape.
+	if len(readiness.Checks) > 0 {
+		_, _ = fmt.Fprint(
+			&output,
+			"# HELP dev_health_runtime_check_failed Whether a required readiness check is currently failing.\n"+
+				"# TYPE dev_health_runtime_check_failed gauge\n",
+		)
+		for _, check := range readiness.Checks {
+			failed := 0
+			if check.Failed {
+				failed = 1
+			}
+			// Name only, never dependency error text. Names are pre-registered
+			// and validated against checkNamePattern (see
+			// Registry.RegisterRequired), which is the same guarantee
+			// dev_health_runtime_metrics_source_failed already relies on for
+			// its source label below — reusing an already-reviewed pattern
+			// rather than a new one.
+			_, _ = fmt.Fprintf(
+				&output,
+				"dev_health_runtime_check_failed{check=%s} %d\n",
+				strconv.Quote(check.Name), failed,
+			)
+		}
+	}
 	// Degrade rather than fail: a source whose dependency is unreachable must
 	// not take the process-level gauges above down with it, since live/ready/
 	// uptime matter most while the process is unready. The per-source failure


### PR DESCRIPTION
Closes CHAOS-3908. From the [observability audit](https://linear.app/fullchaos/document/observability-audit-go-worker-runtime-2026-08-18-10308693ec48).

See the Linear issue for the full defect description, the decision rule applied, and acceptance criteria.

Every new test was verified to FAIL against the pre-fix code before being trusted. Full `ci/check_go.sh all` green (RC=0).