### PR TITLE
fix(jobruntime): carry a bounded reason across the Adapter safe-error boundary

### DIFF
--- a/internal/jobruntime/adapter.go
+++ b/internal/jobruntime/adapter.go
@@ -286,14 +286,14 @@ func (adapter *Adapter[T]) execute(parent context.Context, job *river.Job[T], la
 			if job != nil && job.JobRow != nil && job.Attempt > 0 {
 				attempt = job.Attempt
 			}
-			choice = retryDecision(CategoryPanic, attempt, adapter.descriptor.MaxAttempts)
-			returned = &safeError{category: CategoryPanic}
+			choice = retryDecision(CategoryPanic, ReasonHandlerPanic, attempt, adapter.descriptor.MaxAttempts)
+			returned = &safeError{category: CategoryPanic, reason: ReasonHandlerPanic}
 			observe(func() { adapter.observer.JobPanicked(parent, labels) })
 			if claim != nil && claim.State() == ClaimProceed {
 				if err := finishClaim(parent, claim, Completion{
 					Result: choice.result, Category: choice.category, Terminal: choice.cancel,
 				}); err != nil {
-					choice = retryDecision(CategoryIdempotency, attempt, adapter.descriptor.MaxAttempts)
+					choice = retryDecision(CategoryIdempotency, Reason{}, attempt, adapter.descriptor.MaxAttempts)
 					returned = &safeError{category: CategoryIdempotency}
 				}
 			}

--- a/internal/jobruntime/errors.go
+++ b/internal/jobruntime/errors.go
@@ -28,6 +28,49 @@ const (
 	CategoryIdempotency    ErrorCategory = "idempotency"
 )
 
+// Reason is a bounded, compile-time-fixed elaboration of an ErrorCategory.
+// It crosses the same boundary ErrorCategory does -- logs, metrics, River
+// error rows, operator responses -- and is safe for the same reason: its
+// entire value space is the finite set of package-level constants declared
+// below, never a runtime string.
+//
+// The field is unexported and this package exports no function that builds
+// a Reason from a string. A call site outside this package cannot construct
+// one at all (only the zero value, via an unkeyed Reason{} literal, which
+// isZero treats as "no reason supplied"); a call site inside this package
+// cannot smuggle a runtime value past a Reason-typed parameter, because
+// doing so requires literally writing Reason{value: someExpr} in this file
+// next to -- and as conspicuous as -- the constants it would be duplicating.
+// That is the enforcement: passing err.Error(), a tenant ID, or a formatted
+// message anywhere a Reason is expected is a compile error, not a review
+// nit. See TestReasonConstructorRejectsRuntimeValue for the compiled proof.
+type Reason struct{ value string }
+
+func (reason Reason) isZero() bool { return reason == Reason{} }
+
+// String renders the bounded reason text. It is exported so operator-facing
+// formatting outside this package (if any) can read the value without
+// reaching into the safeError string; it can never return anything other
+// than one of the constants below.
+func (reason Reason) String() string { return reason.value }
+
+// reason is the package's only constructor. It is unexported, so nothing
+// outside jobruntime can call it, and every call site inside the package is
+// one of the "var Reason... = reason(...)" declarations immediately below --
+// there is no call to reason() anywhere else in the package.
+func reason(value string) Reason { return Reason{value: value} }
+
+// The fixed catalog. Adding a new bounded reason means adding a line here,
+// in code review, next to this comment -- the same bar Category constants
+// already clear.
+var (
+	// ReasonHandlerPanic marks the safeError built by Adapter.execute's
+	// recover path: the sole site in this package that turns a panic into a
+	// CategoryPanic result. It never carries the recovered value or a stack
+	// trace -- only the fact that this is where the panic was caught.
+	ReasonHandlerPanic = reason("handler_panic_recovered")
+)
+
 // Result is the runtime decision. A discard is represented by a normal safe
 // error on the final River attempt; River performs the durable state change.
 type Result string
@@ -45,6 +88,7 @@ type markedError struct {
 	cause    error
 	cancel   bool
 	snooze   time.Duration
+	reason   Reason
 }
 
 func (err *markedError) Error() string { return "job error category: " + string(err.category) }
@@ -112,6 +156,26 @@ func mark(category ErrorCategory, err error, cancel bool) error {
 	return &markedError{category: category, cause: nonNilError(err), cancel: cancel}
 }
 
+// WithReason attaches a bounded Reason to an error already produced by one of
+// this package's marking functions (Retryable, RetryableAfter, Permanent,
+// TerminalDomain, Cancel, DomainMismatch, BudgetContention, RateLimited).
+// Applied to anything else -- including a nil or unmarked error -- it is a
+// no-op, so an unclassified handler error still fails closed exactly as
+// before: a reason is opt-in, never a substitute for classification.
+//
+// Because its second parameter is the unexported-field Reason type, a caller
+// can only pass one of this package's exported Reason constants; there is no
+// way to pass err.Error(), a tenant ID, or any other runtime string.
+func WithReason(err error, why Reason) error {
+	var marked *markedError
+	if !errors.As(err, &marked) {
+		return err
+	}
+	updated := *marked
+	updated.reason = why
+	return &updated
+}
+
 func nonNilError(err error) error {
 	if err == nil {
 		return errors.New("unspecified")
@@ -124,6 +188,7 @@ type decision struct {
 	category ErrorCategory
 	cancel   bool
 	snooze   time.Duration
+	reason   Reason
 }
 
 func classify(ctx context.Context, err error, attempt, maxAttempts int) decision {
@@ -131,7 +196,7 @@ func classify(ctx context.Context, err error, attempt, maxAttempts int) decision
 		return decision{result: ResultSuccess, category: CategoryNone}
 	}
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return retryDecision(CategoryTimeout, attempt, maxAttempts)
+		return retryDecision(CategoryTimeout, Reason{}, attempt, maxAttempts)
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
 		// Do not wrap this in river.JobCancel. A remote River cancellation already
@@ -141,36 +206,43 @@ func classify(ctx context.Context, err error, attempt, maxAttempts int) decision
 	var marked *markedError
 	if errors.As(err, &marked) {
 		if marked.snooze > 0 {
-			return decision{result: ResultRetry, category: marked.category, snooze: marked.snooze}
+			return decision{result: ResultRetry, category: marked.category, snooze: marked.snooze, reason: marked.reason}
 		}
 		if marked.cancel {
-			return decision{result: ResultCancel, category: marked.category, cancel: true}
+			return decision{result: ResultCancel, category: marked.category, cancel: true, reason: marked.reason}
 		}
-		return retryDecision(marked.category, attempt, maxAttempts)
+		return retryDecision(marked.category, marked.reason, attempt, maxAttempts)
 	}
 	// Unclassified handler errors fail closed. Retrying requires an explicit
 	// Retryable wrapper so deterministic failures cannot create retry storms.
+	// No marker means no reason: this path never sets one.
 	return decision{result: ResultCancel, category: CategoryPermanent, cancel: true}
 }
 
-func retryDecision(category ErrorCategory, attempt, maxAttempts int) decision {
+func retryDecision(category ErrorCategory, why Reason, attempt, maxAttempts int) decision {
 	if attempt >= maxAttempts {
-		return decision{result: ResultDiscard, category: category}
+		return decision{result: ResultDiscard, category: category, reason: why}
 	}
-	return decision{result: ResultRetry, category: category}
+	return decision{result: ResultRetry, category: category, reason: why}
 }
 
-type safeError struct{ category ErrorCategory }
+type safeError struct {
+	category ErrorCategory
+	reason   Reason
+}
 
 func (err *safeError) Error() string {
-	return fmt.Sprintf("dev-health job failed [%s]", err.category)
+	if err.reason.isZero() {
+		return fmt.Sprintf("dev-health job failed [%s]", err.category)
+	}
+	return fmt.Sprintf("dev-health job failed [%s: %s]", err.category, err.reason)
 }
 
 func transportError(choice decision) error {
 	if choice.snooze > 0 {
 		return river.JobSnooze(choice.snooze)
 	}
-	safe := &safeError{category: choice.category}
+	safe := &safeError{category: choice.category, reason: choice.reason}
 	if choice.cancel {
 		return river.JobCancel(safe)
 	}

--- a/internal/jobruntime/reason_test.go
+++ b/internal/jobruntime/reason_test.go
@@ -1,0 +1,194 @@
+package jobruntime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// testReasonProbe exists only for these tests. It is built the same way
+// every real Reason constant is built -- by calling the unexported reason()
+// constructor from inside this package -- which is exactly the point: that
+// constructor is reachable from any file in jobruntime (subject to the same
+// code review as errors.go), but from nowhere else.
+var testReasonProbe = reason("test_probe_value")
+
+// TestReasonConstructorRejectsRuntimeValue is the compiled proof that Reason
+// cannot be built from a runtime-derived value from outside this package. It
+// shells out to the real Go compiler against small programs living under
+// testdata/reasonconstructor (a directory the Go toolchain always excludes
+// from ./... build/vet/test patterns, so these never affect the package's
+// own build) and asserts each one FAILS to compile, for the specific reason
+// that matters:
+//
+//   - bad_error_string.go tries the exact misuse CHAOS-3910 exists to
+//     prevent: jobruntime.WithReason(err, err.Error()). Reason is a distinct
+//     type, so a string argument is a type mismatch, not a warning.
+//   - bad_struct_literal.go tries to build a Reason directly from a string
+//     via a keyed struct literal (jobruntime.Reason{value: "..."}). The
+//     field is unexported, so this fails even though the caller can name the
+//     Reason type itself.
+//
+// A third program, valid_usage.go, performs the sanctioned call --
+// WithReason with a package-level constant -- and MUST compile, as a control
+// proving this test would catch a real regression rather than failing for an
+// unrelated reason (an import path typo, a moved package, etc).
+func TestReasonConstructorRejectsRuntimeValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		file       string
+		wantBuild  bool
+		wantErrSub string
+	}{
+		{
+			name:      "sanctioned: package-level constant",
+			file:      "testdata/reasonconstructor/valid_usage.go",
+			wantBuild: true,
+		},
+		{
+			name:       "rejected: err.Error() passed as a Reason",
+			file:       "testdata/reasonconstructor/bad_error_string.go",
+			wantBuild:  false,
+			wantErrSub: "cannot use err.Error()",
+		},
+		{
+			name:       "rejected: Reason built from a string literal outside the package",
+			file:       "testdata/reasonconstructor/bad_struct_literal.go",
+			wantBuild:  false,
+			wantErrSub: "unexported field",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := exec.Command("go", "build", "-o", os.DevNull, test.file)
+			out, err := cmd.CombinedOutput()
+			built := err == nil
+			if built != test.wantBuild {
+				t.Fatalf("go build %s: built=%v, want built=%v (output:\n%s)", test.file, built, test.wantBuild, out)
+			}
+			if !test.wantBuild && !strings.Contains(string(out), test.wantErrSub) {
+				t.Fatalf("go build %s: output %q does not contain %q", test.file, out, test.wantErrSub)
+			}
+		})
+	}
+}
+
+// TestSafeErrorNoReasonMatchesLegacyOutput proves a handler that supplies no
+// reason produces byte-for-byte today's output: no default-behaviour change
+// from adding the Reason field.
+func TestSafeErrorNoReasonMatchesLegacyOutput(t *testing.T) {
+	t.Parallel()
+	safe := &safeError{category: CategoryPermanent}
+	const want = "dev-health job failed [permanent]"
+	if got := safe.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+// unwrapSafe pulls the *safeError back out of whatever transportError
+// returned (a bare *safeError, or one wrapped in *river.JobCancelError).
+func unwrapSafe(t *testing.T, err error) error {
+	t.Helper()
+	var cancelErr interface{ Unwrap() error }
+	if errors.As(err, &cancelErr) {
+		return cancelErr.Unwrap()
+	}
+	return err
+}
+
+// TestSafeErrorReasonSurvivesToRiverErrorRow proves a handler-supplied
+// reason reaches the text that becomes the River error row (safeError.Error()
+// is what River persists), while the original cause stays discarded.
+func TestSafeErrorReasonSurvivesToRiverErrorRow(t *testing.T) {
+	t.Parallel()
+	cause := errors.New("dsn=postgres://svc:s3cr3t@db.internal:5432/tenant_42")
+	marked := WithReason(Permanent(cause), testReasonProbe)
+	choice := classify(context.Background(), marked, 1, 3)
+	got := unwrapSafe(t, transportError(choice)).Error()
+
+	if !strings.Contains(got, "test_probe_value") {
+		t.Fatalf("Error() = %q, want it to contain the reason %q", got, "test_probe_value")
+	}
+	if !strings.Contains(got, string(CategoryPermanent)) {
+		t.Fatalf("Error() = %q, want it to keep the category %q", got, CategoryPermanent)
+	}
+	if strings.Contains(got, "s3cr3t") || strings.Contains(got, "postgres://") || strings.Contains(got, "tenant_42") {
+		t.Fatalf("Error() = %q, leaked the DSN-bearing/tenant-identifying cause", got)
+	}
+}
+
+// TestSafeErrorUnreasonedFailureNeverLeaksCause is the DSN/tenant-identifying
+// acceptance case with no reason attached at all -- the common path today --
+// confirming the invariant errors.go documents still holds unmodified.
+func TestSafeErrorUnreasonedFailureNeverLeaksCause(t *testing.T) {
+	t.Parallel()
+	cause := errors.New("dsn=postgres://svc:s3cr3t@db.internal:5432/tenant_42")
+	choice := classify(context.Background(), Permanent(cause), 1, 3)
+	got := unwrapSafe(t, transportError(choice)).Error()
+
+	if got != "dev-health job failed [permanent]" {
+		t.Fatalf("Error() = %q, want exactly today's category-only output", got)
+	}
+	if strings.Contains(got, "s3cr3t") || strings.Contains(got, "postgres://") || strings.Contains(got, "tenant_42") {
+		t.Fatalf("Error() = %q, leaked the DSN-bearing/tenant-identifying cause", got)
+	}
+}
+
+// TestWithReasonIsANoOpOnUnmarkedErrors proves the reason stays strictly
+// opt-in: an unclassified handler error (the fail-closed default) is
+// unaffected by WithReason, because there is no markedError to attach it to.
+func TestWithReasonIsANoOpOnUnmarkedErrors(t *testing.T) {
+	t.Parallel()
+	plain := errors.New("unclassified")
+	decorated := WithReason(plain, testReasonProbe)
+	if decorated != plain {
+		t.Fatalf("WithReason mutated an unmarked error: %v", decorated)
+	}
+	choice := classify(context.Background(), decorated, 1, 3)
+	got := unwrapSafe(t, transportError(choice)).Error()
+	if got != "dev-health job failed [permanent]" {
+		t.Fatalf("Error() = %q, want the unchanged fail-closed default", got)
+	}
+}
+
+// TestAdapterPanicPathCarriesReason drives a real panicking handler through
+// Adapter.Work end to end (not just the classify/transportError pair) and
+// proves the resulting River-facing error names the recover site via
+// ReasonHandlerPanic -- while the recovered value ("panic-secret-do-not-log")
+// and any stack detail never appear in the log line or the returned error.
+func TestAdapterPanicPathCarriesReason(t *testing.T) {
+	t.Parallel()
+	var logs bytes.Buffer
+	observer := &recordingObserver{}
+	claim := &recordingClaim{state: ClaimProceed}
+	lease := &recordingLease{}
+	handler := HandlerFunc[RetentionCleanupArgs](func(context.Context, *Execution[RetentionCleanupArgs]) error {
+		panic("panic-secret-do-not-log")
+	})
+	adapter := newRetentionAdapter(t, handler, observer, claim, lease, &logs)
+	job := retentionJob(t, 1)
+
+	err := adapter.Work(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected a safe error from a panicking handler")
+	}
+	got := err.Error()
+	if !strings.Contains(got, string(CategoryPanic)) {
+		t.Fatalf("Error() = %q, want the panic category", got)
+	}
+	if !strings.Contains(got, ReasonHandlerPanic.String()) {
+		t.Fatalf("Error() = %q, want it to name the recover site via ReasonHandlerPanic (%q)", got, ReasonHandlerPanic)
+	}
+	combined := logs.String() + got
+	if strings.Contains(combined, "panic-secret-do-not-log") {
+		t.Fatalf("recovered panic value leaked into logs/error: %s", combined)
+	}
+}

--- a/internal/jobruntime/testdata/reasonconstructor/bad_error_string.go
+++ b/internal/jobruntime/testdata/reasonconstructor/bad_error_string.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+)
+
+func main() {
+	err := errors.New("boom")
+	_ = jobruntime.WithReason(jobruntime.Permanent(err), err.Error())
+}

--- a/internal/jobruntime/testdata/reasonconstructor/bad_struct_literal.go
+++ b/internal/jobruntime/testdata/reasonconstructor/bad_struct_literal.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/full-chaos/dev-health-ops/internal/jobruntime"
+
+func main() {
+	_ = jobruntime.Reason{value: "tenant-dsn-leak"}
+}

--- a/internal/jobruntime/testdata/reasonconstructor/valid_usage.go
+++ b/internal/jobruntime/testdata/reasonconstructor/valid_usage.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+)
+
+func main() {
+	_ = jobruntime.WithReason(jobruntime.Permanent(errors.New("boom")), jobruntime.ReasonHandlerPanic)
+}


### PR DESCRIPTION
Closes CHAOS-3910. From the [observability audit](https://linear.app/fullchaos/document/observability-audit-go-worker-runtime-2026-08-18-10308693ec48).

See the Linear issue for the full defect description, the decision rule applied, and acceptance criteria.

Every new test was verified to FAIL against the pre-fix code before being trusted. Full `ci/check_go.sh all` green (RC=0).