### PR TITLE
fix(observability): give five silent components a logger and three services a reason code

### DIFF
--- a/cmd/dev-health-reconciler/dependencies.go
+++ b/cmd/dev-health-reconciler/dependencies.go
@@ -33,6 +33,30 @@ const (
 
 var errReconcilerDependencyUnavailable = errors.New("reconciler readiness dependency is unavailable")
 
+// dependencyFailure attaches a bounded reason code to the generic dependency
+// sentinel, mirroring cmd/dev-health-worker/dependencies.go's dependencyFailure
+// exactly. Before this, every distinct construction failure in this binary --
+// a database that would not open, a missing job registry, a broken sync
+// dispatch pipeline -- collapsed into the same bare
+// errReconcilerDependencyUnavailable, so an operator could not tell which
+// knob was wrong (CHAOS-3873/CHAOS-3907). The reason is always a
+// compile-time constant, never interpolated input, so logging it cannot leak
+// a DSN or a secret.
+type dependencyFailure struct {
+	reason string
+}
+
+func (failure dependencyFailure) Error() string {
+	return errReconcilerDependencyUnavailable.Error() + ": " + failure.reason
+}
+
+func (dependencyFailure) Unwrap() error { return errReconcilerDependencyUnavailable }
+
+// DependencyReason satisfies the shell's reason-code interface.
+func (failure dependencyFailure) DependencyReason() string { return failure.reason }
+
+func dependencyUnavailable(reason string) error { return dependencyFailure{reason: reason} }
+
 // reconcilerDatabase keeps the command's domain, queue-control, and
 // coordinator trust boundaries testable without weakening the production
 // RuntimePools contract.
@@ -396,7 +420,7 @@ func configureReconcilerDependenciesWithActivationSourcesAndLogger(
 	sources reconcilerDependencySources,
 ) ([]lifecycle.Component, error) {
 	if registry == nil {
-		return nil, errReconcilerDependencyUnavailable
+		return nil, dependencyUnavailable("reconciler_registry_unavailable")
 	}
 
 	dependencies := buildReconcilerDependencies(ctx, cfg, registry, logger, activation, sources)
@@ -463,21 +487,21 @@ func buildReconcilerDependencies(
 ) *reconcilerDependencies {
 	dependencies := &reconcilerDependencies{logger: logger, coordinatorRole: cfg.CoordinatorDatabaseRole}
 	if sources.openDatabase == nil {
-		dependencies.databaseErr = errReconcilerDependencyUnavailable
+		dependencies.databaseErr = dependencyUnavailable("reconciler_database_source_missing")
 	} else {
 		dependencies.database, dependencies.databaseErr = sources.openDatabase(ctx, cfg)
 		if dependencies.databaseErr != nil {
-			dependencies.databaseErr = errReconcilerDependencyUnavailable
+			dependencies.databaseErr = dependencyUnavailable("reconciler_database_open_failed")
 			dependencies.disableDatabase()
 		}
 	}
 	if sources.loadRuntimeRegistry == nil || sources.contractRoot == "" {
-		dependencies.registryErr = errReconcilerDependencyUnavailable
+		dependencies.registryErr = dependencyUnavailable("reconciler_job_registry_source_missing")
 	} else {
 		dependencies.runtimeRegistry, dependencies.registryErr = sources.loadRuntimeRegistry(sources.contractRoot)
 	}
 	if sources.loadSyncDispatchRegistry == nil || sources.syncDispatchContractRoot == "" {
-		dependencies.syncRegistryErr = errReconcilerDependencyUnavailable
+		dependencies.syncRegistryErr = dependencyUnavailable("reconciler_sync_dispatch_registry_source_missing")
 	} else {
 		dependencies.syncDispatchRegistry, dependencies.syncRegistryErr = sources.loadSyncDispatchRegistry(sources.syncDispatchContractRoot)
 	}
@@ -490,7 +514,7 @@ func buildReconcilerDependencies(
 		(activation.syncMutation && sources.buildSyncMutation == nil) ||
 		sources.newSyncRecorder == nil ||
 		sources.newSyncLoop == nil {
-		dependencies.relayErr = errReconcilerDependencyUnavailable
+		dependencies.relayErr = dependencyUnavailable("reconciler_build_sources_missing")
 		dependencies.disableDatabase()
 		return dependencies
 	}
@@ -503,20 +527,22 @@ func buildReconcilerDependencies(
 		dependencies.runtimeRegistry,
 	)
 	if err != nil || relay == nil {
-		dependencies.relayErr = errReconcilerDependencyUnavailable
+		dependencies.relayErr = dependencyUnavailable("reconciler_relay_construction_failed")
 		dependencies.disableDatabase()
 		return dependencies
 	}
-	loop, err := sources.newLoop(relay, joboutbox.DefaultReconcilerLoopConfig(registry))
+	loopConfig := joboutbox.DefaultReconcilerLoopConfig(registry)
+	loopConfig.Logger = logger
+	loop, err := sources.newLoop(relay, loopConfig)
 	if err != nil || loop == nil {
-		dependencies.loopErr = errReconcilerDependencyUnavailable
+		dependencies.loopErr = dependencyUnavailable("reconciler_relay_loop_construction_failed")
 		dependencies.disableDatabase()
 		return dependencies
 	}
 	dependencies.loop = loop
 	routeFence, err := sources.buildSyncRouteFence(dependencies.database.DomainPool(), dependencies.syncDispatchRegistry)
 	if err != nil || routeFence == nil {
-		dependencies.syncRouteFenceErr = errReconcilerDependencyUnavailable
+		dependencies.syncRouteFenceErr = dependencyUnavailable("reconciler_sync_route_fence_construction_failed")
 		dependencies.disableDatabase()
 		return dependencies
 	}
@@ -537,27 +563,28 @@ func buildReconcilerDependencies(
 		)
 	}
 	if err != nil || syncStepper == nil {
-		dependencies.syncObserverErr = errReconcilerDependencyUnavailable
+		dependencies.syncObserverErr = dependencyUnavailable("reconciler_sync_stepper_construction_failed")
 		dependencies.disableDatabase()
 		return dependencies
 	}
 	if logger == nil {
-		dependencies.syncRecorderErr = errReconcilerDependencyUnavailable
+		dependencies.syncRecorderErr = dependencyUnavailable("reconciler_sync_recorder_logger_missing")
 		dependencies.disableDatabase()
 		return dependencies
 	}
 	recorder, err := sources.newSyncRecorder(logger)
 	dependencies.syncRecorder = recorder
 	if err != nil || recorder == nil {
-		dependencies.syncRecorderErr = errReconcilerDependencyUnavailable
+		dependencies.syncRecorderErr = dependencyUnavailable("reconciler_sync_recorder_construction_failed")
 		dependencies.disableDatabase()
 		return dependencies
 	}
 	syncLoopConfig := syncreconciler.DefaultLoopConfig(registry)
 	syncLoopConfig.Recorder = recorder
+	syncLoopConfig.Logger = logger
 	syncLoop, err := sources.newSyncLoop(syncStepper, syncLoopConfig)
 	if err != nil || syncLoop == nil {
-		dependencies.syncLoopErr = errReconcilerDependencyUnavailable
+		dependencies.syncLoopErr = dependencyUnavailable("reconciler_sync_loop_construction_failed")
 		dependencies.disableDatabase()
 		return dependencies
 	}
@@ -713,7 +740,7 @@ func (dependencies *reconcilerDependencies) disableDatabase() {
 	dependencies.close()
 	dependencies.database = nil
 	if dependencies.databaseErr == nil {
-		dependencies.databaseErr = errReconcilerDependencyUnavailable
+		dependencies.databaseErr = dependencyUnavailable("reconciler_database_disabled_after_dependency_failure")
 	}
 }
 

--- a/cmd/dev-health-reconciler/logging_wiring_test.go
+++ b/cmd/dev-health-reconciler/logging_wiring_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncreconciler"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestOutboxReconcilerLoopReceivesTheComposedLoggerFromReconcilerCompositionRoot
+// proves the wiring, not just the field (CHAOS-3907): it goes through the
+// real composition root (configureReconcilerDependenciesWithSourcesAndLogger),
+// not a direct joboutbox.NewReconcilerLoop(..., ReconcilerLoopConfig{Logger:
+// ...}) call, which would prove nothing about cmd/dev-health-reconciler.
+// Before dependencies.go wired ReconcilerLoopConfig.Logger to the resolved
+// logger, this loop had zero slog references at all: a failed step closed
+// readiness with no output anywhere (CHAOS-3907).
+func TestOutboxReconcilerLoopReceivesTheComposedLoggerFromReconcilerCompositionRoot(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	sources := reconcilerSourcesForTest(t, database)
+	forcedErr := errors.New("outbox relay step probe failure")
+	sources.buildRelay = func(_, _, _ *pgxpool.Pool, _ string, _ *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, forcedErr
+		}), nil
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		logger,
+		sources,
+	)
+	if err != nil {
+		t.Fatalf("configureReconcilerDependenciesWithSourcesAndLogger() error = %v", err)
+	}
+
+	var loopComponent lifecycle.Component
+	for _, component := range components {
+		if component.Name() == "outbox-reconciler-loop" {
+			loopComponent = component
+		}
+	}
+	if loopComponent == nil {
+		t.Fatalf("outbox-reconciler-loop was not constructed: components=%v", componentNames(components))
+	}
+	if startErr := loopComponent.Start(context.Background()); startErr == nil {
+		t.Fatal("expected the forced relay step failure to fail Start")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "outbox reconciler initial step failed") {
+		t.Fatalf("composed logger did not observe the reconciler loop's failure: %s", output)
+	}
+	if !strings.Contains(output, forcedErr.Error()) {
+		t.Fatalf("composed logger output omitted the failure cause: %s", output)
+	}
+}
+
+// TestSyncDispatchObserverLoopReceivesTheComposedLoggerFromReconcilerCompositionRoot
+// is the same proof for syncreconciler.Loop, the fourth of the five silent
+// components from CHAOS-3907.
+func TestSyncDispatchObserverLoopReceivesTheComposedLoggerFromReconcilerCompositionRoot(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildRelay = func(_, _, _ *pgxpool.Pool, _ string, _ *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+	forcedErr := errors.New("sync dispatch observation probe failure")
+	sources.buildSyncMutation = func(
+		_, _, _ *pgxpool.Pool, _ string, _ *syncdispatchcontract.Registry,
+	) (syncreconciler.Stepper, error) {
+		return syncStepFunc(func(context.Context, time.Time, int) (syncreconciler.Observation, error) {
+			return syncreconciler.Observation{}, forcedErr
+		}), nil
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		logger,
+		sources,
+	)
+	if err != nil {
+		t.Fatalf("configureReconcilerDependenciesWithSourcesAndLogger() error = %v", err)
+	}
+
+	var loopComponent lifecycle.Component
+	for _, component := range components {
+		if component.Name() == "sync-dispatch-observer-loop" {
+			loopComponent = component
+		}
+	}
+	if loopComponent == nil {
+		t.Fatalf("sync-dispatch-observer-loop was not constructed: components=%v", componentNames(components))
+	}
+	if startErr := loopComponent.Start(context.Background()); startErr == nil {
+		t.Fatal("expected the forced sync-dispatch observation failure to fail Start")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "sync dispatch observer initial step failed") {
+		t.Fatalf("composed logger did not observe the sync loop's failure: %s", output)
+	}
+	if !strings.Contains(output, forcedErr.Error()) {
+		t.Fatalf("composed logger output omitted the failure cause: %s", output)
+	}
+}

--- a/cmd/dev-health-scheduler/dependencies.go
+++ b/cmd/dev-health-scheduler/dependencies.go
@@ -316,7 +316,7 @@ func buildSchedulerLoopWithSources(
 		sources.newRepository == nil || sources.newCoordinator == nil ||
 		sources.newLoop == nil || sources.newFixedLoop == nil ||
 		sources.newOccurrences == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_build_sources_unavailable")
 	}
 	database, err := sources.openDatabase(ctx, cfg)
 	if err != nil && postgres.ConfigurationRejected(err) {
@@ -346,7 +346,7 @@ func buildSchedulerLoopWithSources(
 		// Operational failure -- unreachable host, refused credentials, an
 		// unparseable DSN. Crash-loop rather than idle as an alive-but-unready
 		// zombie.
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_domain_database_open_failed")
 	}
 	closeOnError := true
 	defer func() {
@@ -383,31 +383,31 @@ func buildSchedulerLoopWithSources(
 	// closed with postgres.ErrUnavailable instead.
 	coordinatorPool, err := database.CoordinatorPool()
 	if err != nil || coordinatorPool == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_coordinator_pool_unavailable")
 	}
 	domainPool := database.DomainPool()
 	if domainPool == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_domain_pool_unavailable")
 	}
 	repository, err := sources.newRepository(coordinatorPool)
 	if err != nil || repository == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_handoff_repository_construction_failed")
 	}
 	coordinator := sources.newCoordinator()
 	if coordinator == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_occurrence_coordinator_unavailable")
 	}
 	occurrences, err := sources.newOccurrences(coordinatorPool, domainPool)
 	if err != nil || occurrences == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_occurrence_reconciler_construction_failed")
 	}
 	loop, err := sources.newLoop(
 		repository,
 		coordinator,
-		schedulersync.DefaultLoopConfig(registry).WithOccurrences(occurrences),
+		schedulersync.DefaultLoopConfig(registry).WithOccurrences(occurrences).WithLogger(logger),
 	)
 	if err != nil || loop == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_sync_loop_construction_failed")
 	}
 	// The fixed maintenance scheduler is deliberately optional. Product schedule
 	// handoff and pending-occurrence reconciliation are a different workload

--- a/cmd/dev-health-scheduler/fixed.go
+++ b/cmd/dev-health-scheduler/fixed.go
@@ -190,7 +190,7 @@ func buildFixedScheduleLoop(
 	logger *slog.Logger,
 ) (fixedScheduleRuntime, error) {
 	if coordinatorPool == nil || registry == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_fixed_loop_inputs_unavailable")
 	}
 	jobs, err := jobruntime.Load(defaultContractRoot)
 	if err != nil {

--- a/cmd/dev-health-scheduler/logging_wiring_test.go
+++ b/cmd/dev-health-scheduler/logging_wiring_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	schedulersync "github.com/full-chaos/dev-health-ops/internal/scheduler/sync"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestSyncSchedulerLoopReceivesTheComposedLoggerFromSchedulerCompositionRoot
+// proves the wiring, not just the field (CHAOS-3907): it goes through the
+// real composition root (buildSchedulerLoopWithSources with a real
+// schedulersync.NewLoop), not a direct
+// schedulersync.NewLoop(..., LoopConfig{Logger: ...}) call, which would prove
+// nothing about cmd/dev-health-scheduler. scheduler/sync.Loop is the literal
+// sibling of scheduler/fixed.Loop (already fixed under CHAOS-3903); before
+// this wiring, sync.Loop had no Logger field at all and a handoff window
+// could fail forever with zero output.
+func TestSyncSchedulerLoopReceivesTheComposedLoggerFromSchedulerCompositionRoot(t *testing.T) {
+	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}, coordinatorPool: &pgxpool.Pool{}}
+	fixedLoop := &fakeFixedLoop{}
+	forcedErr := errors.New("handoff due-result probe failure")
+	sources := schedulerRuntimeSources{
+		openDatabase: func(context.Context, config.Config) (schedulerDatabase, error) {
+			return database, nil
+		},
+		newRepository: func(*pgxpool.Pool) (schedulersync.HandoffStepper, error) {
+			return schedulerHandoffStepperFunc(func(
+				context.Context, time.Time, int, schedulersync.Coordinator,
+			) (schedulersync.HandoffResult, error) {
+				return schedulersync.HandoffResult{}, forcedErr
+			}), nil
+		},
+		newCoordinator: func() schedulersync.Coordinator {
+			return schedulersync.CoordinatorFunc(func(
+				context.Context, schedulersync.HandoffTransaction, schedulersync.Occurrence,
+			) error {
+				return nil
+			})
+		},
+		newLoop: schedulersync.NewLoop,
+		newOccurrences: func(pool, domainPool *pgxpool.Pool) (schedulersync.OccurrenceStepper, error) {
+			return stubOccurrenceSource(pool, domainPool)
+		},
+		newFixedLoop: func(*pgxpool.Pool, *health.Registry, *slog.Logger) (fixedScheduleRuntime, error) {
+			return fixedLoop, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	component, err := buildSchedulerLoopWithSources(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		sources,
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("buildSchedulerLoopWithSources() error = %v", err)
+	}
+	if startErr := component.Start(context.Background()); startErr == nil {
+		t.Fatal("expected the forced handoff failure to fail Start")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "sync scheduler initial handoff failed") {
+		t.Fatalf("composed logger did not observe the sync scheduler loop's failure: %s", output)
+	}
+	if !strings.Contains(output, forcedErr.Error()) {
+		t.Fatalf("composed logger output omitted the failure cause: %s", output)
+	}
+}

--- a/cmd/dev-health-scheduler/main.go
+++ b/cmd/dev-health-scheduler/main.go
@@ -49,6 +49,30 @@ var schedulerOwnership = schedulersync.TransferScheduleMarkerOwnershipToGo()
 
 var errSchedulerActivationUnavailable = errors.New("scheduler activation is unavailable")
 
+// dependencyFailure attaches a bounded reason code to the generic activation
+// sentinel, mirroring cmd/dev-health-worker/dependencies.go's dependencyFailure
+// exactly. Before this, every distinct construction failure in this binary --
+// a missing coordinator pool, a failed handoff repository, a broken sync loop
+// -- collapsed into the same bare errSchedulerActivationUnavailable, so the
+// shell logged "dependency_configuration_failed" with no reason and an
+// operator could not tell which knob was wrong (CHAOS-3873/CHAOS-3907). The
+// reason is always a compile-time constant, never interpolated input, so
+// logging it cannot leak a DSN or a secret.
+type dependencyFailure struct {
+	reason string
+}
+
+func (failure dependencyFailure) Error() string {
+	return errSchedulerActivationUnavailable.Error() + ": " + failure.reason
+}
+
+func (dependencyFailure) Unwrap() error { return errSchedulerActivationUnavailable }
+
+// DependencyReason satisfies the shell's reason-code interface.
+func (failure dependencyFailure) DependencyReason() string { return failure.reason }
+
+func dependencyUnavailable(reason string) error { return dependencyFailure{reason: reason} }
+
 // errSchedulerDatabaseUnconfigured marks the one non-fatal outcome of building
 // the loop: the database contract was DECLARED-rejected (typically no DSN), so
 // buildSchedulerLoopWithSources has already closed the readiness names and the
@@ -123,7 +147,7 @@ func configureSchedulerDependenciesWithSources(
 		return nil, err
 	}
 	if registry == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_registry_unavailable")
 	}
 	if !activation.goOwnsMarkers {
 		// schedulerOwnership alone (CHAOS-3128) is not activation: until this
@@ -139,7 +163,7 @@ func configureSchedulerDependenciesWithSources(
 		)
 	}
 	if sources.buildLoop == nil {
-		return nil, errSchedulerActivationUnavailable
+		return nil, dependencyUnavailable("scheduler_loop_factory_missing")
 	}
 	loop, err := sources.buildLoop(ctx, cfg, registry, loggers...)
 	if errors.Is(err, errSchedulerDatabaseUnconfigured) {
@@ -147,8 +171,19 @@ func configureSchedulerDependenciesWithSources(
 		// registered unavailable by the loop factory.
 		return nil, nil
 	}
-	if err != nil || loop == nil {
-		return nil, errSchedulerActivationUnavailable
+	if err != nil {
+		// buildSchedulerLoopWithSources already names its own failing
+		// construction site with a bounded reason (see dependencies.go). Preserve
+		// it rather than flattening back to the bare sentinel here -- errors.Is
+		// still matches for any caller (or test double) that returns an
+		// unrelated error, which normalizes below to a reason of its own.
+		if errors.Is(err, errSchedulerActivationUnavailable) {
+			return nil, err
+		}
+		return nil, dependencyUnavailable("scheduler_loop_construction_failed")
+	}
+	if loop == nil {
+		return nil, dependencyUnavailable("scheduler_loop_unavailable")
 	}
 	return []lifecycle.Component{loop}, nil
 }

--- a/cmd/dev-health-stream-runner/dependencies.go
+++ b/cmd/dev-health-stream-runner/dependencies.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -25,6 +26,31 @@ import (
 )
 
 var errStreamDependencyUnavailable = errors.New("stream-runner dependency is unavailable")
+
+// dependencyFailure attaches a bounded reason code to the generic dependency
+// sentinel, mirroring cmd/dev-health-worker/dependencies.go's dependencyFailure
+// exactly. Before this, every distinct storage-construction failure -- a
+// missing URI, a domain Postgres pool that would not open, ClickHouse
+// refusing the connection, Valkey refusing the connection -- collapsed into
+// the same bare errStreamDependencyUnavailable, so the shell logged
+// "dependency_configuration_failed" with no reason and an operator could not
+// tell which knob was wrong (CHAOS-3873/CHAOS-3907). The reason is always a
+// compile-time constant, never interpolated input, so logging it cannot leak
+// a DSN or a secret.
+type dependencyFailure struct {
+	reason string
+}
+
+func (failure dependencyFailure) Error() string {
+	return errStreamDependencyUnavailable.Error() + ": " + failure.reason
+}
+
+func (dependencyFailure) Unwrap() error { return errStreamDependencyUnavailable }
+
+// DependencyReason satisfies the shell's reason-code interface.
+func (failure dependencyFailure) DependencyReason() string { return failure.reason }
+
+func dependencyUnavailable(reason string) error { return dependencyFailure{reason: reason} }
 
 type streamHandlerKind string
 
@@ -53,6 +79,7 @@ type productionStreamStorage struct {
 	riverSchema string
 	recompute   *externalrecompute.Controller
 	bridge      operationalBridgeSettings
+	logger      *slog.Logger
 }
 
 // operationalBridgeSettings is the transitional Python worker-bridge wiring the
@@ -68,20 +95,36 @@ type operationalBridgeSettings struct {
 	transport string
 }
 
-func openProductionStreamStorage(ctx context.Context, cfg config.Config) (streamStorage, error) {
+// newExternalRecomputeController is the one place this binary constructs the
+// external-ingest recompute controller. It exists as a named seam (rather than
+// inlining externalrecompute.DefaultConfig() at the call site) so a
+// composition-root test can prove the process's configured logger reaches the
+// controller without needing a live ClickHouse/Postgres/Valkey connection --
+// see TestExternalRecomputeControllerReceivesTheComposedLogger.
+func newExternalRecomputeController(
+	store externalrecompute.Store,
+	dispatcher externalrecompute.CompatibilityDispatcher,
+	logger *slog.Logger,
+) (*externalrecompute.Controller, error) {
+	cfg := externalrecompute.DefaultConfig()
+	cfg.Logger = logger
+	return externalrecompute.New(store, dispatcher, cfg)
+}
+
+func openProductionStreamStorage(ctx context.Context, cfg config.Config, logger *slog.Logger) (streamStorage, error) {
 	if !cfg.ClickHouseURI.Configured() || !cfg.DomainDatabaseURI.Configured() || !cfg.ValkeyURI.Configured() {
-		return nil, errStreamDependencyUnavailable
+		return nil, dependencyUnavailable("stream_storage_uris_unconfigured")
 	}
 	domainConfig := postgres.DefaultConfig(cfg.DomainDatabaseURI.Reveal())
 	domainConfig.MaxConns = cfg.DomainDatabaseMaxConns
 	domainPool, err := postgres.New(ctx, domainConfig)
 	if err != nil {
-		return nil, errStreamDependencyUnavailable
+		return nil, dependencyUnavailable("stream_domain_postgres_open_failed")
 	}
 	clickHouse, err := clickhouse.Open(ctx, clickhouse.DefaultConfig(cfg.ClickHouseURI.Reveal()))
 	if err != nil {
 		domainPool.Close()
-		return nil, errStreamDependencyUnavailable
+		return nil, dependencyUnavailable("stream_clickhouse_open_failed")
 	}
 	valkeyConfig := valkey.DefaultConfig(cfg.ValkeyURI.Reveal())
 	valkeyConfig.ClientName = "dev-health-stream-runner-" + cfg.Profile
@@ -89,11 +132,12 @@ func openProductionStreamStorage(ctx context.Context, cfg config.Config) (stream
 	if err != nil {
 		_ = clickHouse.Close()
 		domainPool.Close()
-		return nil, errStreamDependencyUnavailable
+		return nil, dependencyUnavailable("stream_valkey_open_failed")
 	}
 	return &productionStreamStorage{
 		clickHouse: clickHouse, domainPool: domainPool, valkey: valkeyClient,
 		domainRole: cfg.DomainDatabaseRole, riverSchema: cfg.RiverDatabaseSchema,
+		logger: logger,
 		bridge: operationalBridgeSettings{
 			baseURL:       cfg.OperationalBridgeURL,
 			token:         cfg.OperationalBridgeToken,
@@ -172,11 +216,7 @@ func (storage *productionStreamStorage) Handler(kind streamHandlerKind) (streamr
 		if err != nil {
 			return nil, err
 		}
-		storage.recompute, err = externalrecompute.New(
-			recomputeStore,
-			dispatcher,
-			externalrecompute.DefaultConfig(),
-		)
+		storage.recompute, err = newExternalRecomputeController(recomputeStore, dispatcher, storage.logger)
 		if err != nil {
 			return nil, err
 		}
@@ -243,23 +283,25 @@ func (storage *productionStreamStorage) Close() {
 }
 
 type streamDependencySources struct {
-	openStorage func(context.Context, config.Config) (streamStorage, error)
+	openStorage func(context.Context, config.Config, *slog.Logger) (streamStorage, error)
 }
 
 var productionStreamDependencySources = streamDependencySources{
 	openStorage: openProductionStreamStorage,
 }
 
-func configureStreamRunnerDependencies(
+func configureStreamRunnerDependenciesWithLogger(
 	ctx context.Context,
 	cfg config.Config,
 	registry *health.Registry,
+	logger *slog.Logger,
 ) ([]lifecycle.Component, error) {
 	return configureStreamRunnerDependenciesWithSources(
 		ctx,
 		cfg,
 		registry,
 		productionStreamDependencySources,
+		logger,
 	)
 }
 
@@ -268,11 +310,12 @@ func configureStreamRunnerDependenciesWithSources(
 	cfg config.Config,
 	registry *health.Registry,
 	sources streamDependencySources,
+	logger *slog.Logger,
 ) ([]lifecycle.Component, error) {
 	if registry == nil || sources.openStorage == nil {
-		return nil, errStreamDependencyUnavailable
+		return nil, dependencyUnavailable("stream_runner_sources_unavailable")
 	}
-	storage, err := sources.openStorage(ctx, cfg)
+	storage, err := sources.openStorage(ctx, cfg, logger)
 	if err != nil || storage == nil {
 		return nil, processreadiness.RegisterUnavailable(
 			registry,
@@ -345,7 +388,7 @@ func configureStreamRunnerDependenciesWithSources(
 				config: productTelemetryRunnerConfig(replicas),
 			},
 		} {
-			runner, err := buildStreamRunner(storage, registry, specification.kind, specification.config)
+			runner, err := buildStreamRunner(storage, registry, specification.kind, specification.config, logger)
 			if err != nil {
 				if errors.Is(err, streamrunner.ErrInvalidConfig) {
 					return nil, err
@@ -360,6 +403,7 @@ func configureStreamRunnerDependenciesWithSources(
 			registry,
 			externalIngestHandlerKind,
 			externalIngestRunnerConfig(replicas),
+			logger,
 		)
 		if err != nil {
 			if errors.Is(err, streamrunner.ErrInvalidConfig) {
@@ -375,6 +419,7 @@ func configureStreamRunnerDependenciesWithSources(
 			registry,
 			pagerdutyHandlerKind,
 			pagerdutyRunnerConfig(replicas),
+			logger,
 		)
 		if err != nil {
 			if errors.Is(err, streamrunner.ErrInvalidConfig) {
@@ -396,6 +441,7 @@ func buildStreamRunner(
 	registry *health.Registry,
 	kind streamHandlerKind,
 	cfg streamrunner.Config,
+	logger *slog.Logger,
 ) (*streamrunner.Runner, error) {
 	handler, err := storage.Handler(kind)
 	if err != nil {
@@ -405,6 +451,7 @@ func buildStreamRunner(
 	if err != nil {
 		return nil, err
 	}
+	cfg.Logger = logger
 	runner, err := streamrunner.New(transport, handler, cfg, registry)
 	if err != nil {
 		transport.Close()

--- a/cmd/dev-health-stream-runner/logging_wiring_test.go
+++ b/cmd/dev-health-stream-runner/logging_wiring_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/externalrecompute"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
+	"github.com/full-chaos/dev-health-ops/internal/streamhandlers"
+	"github.com/full-chaos/dev-health-ops/internal/streamrunner"
+)
+
+type failingPendingScopesDispatcher struct{ err error }
+
+func (dispatcher failingPendingScopesDispatcher) Dispatch(context.Context, externalrecompute.Claim) error {
+	return nil
+}
+
+func (dispatcher failingPendingScopesDispatcher) PendingScopes(
+	context.Context, int,
+) ([]streamhandlers.ExternalRecomputeScope, error) {
+	return nil, dispatcher.err
+}
+
+type noopRecomputeStore struct{}
+
+func (noopRecomputeStore) Coalesce(context.Context, streamhandlers.ExternalRecomputeScope, time.Time, time.Duration) error {
+	return nil
+}
+
+func (noopRecomputeStore) ClaimDue(context.Context, time.Time, int, time.Duration) ([]externalrecompute.Claim, error) {
+	return nil, nil
+}
+
+func (noopRecomputeStore) Complete(context.Context, externalrecompute.Claim) error { return nil }
+
+// TestExternalRecomputeControllerReceivesTheComposedLogger covers the seam
+// cmd/dev-health-stream-runner uses to construct this controller, rather than
+// calling externalrecompute.New directly with a hand-built Config -- which
+// would prove nothing about cmd/. Before this wiring, externalrecompute had
+// zero slog references at all: a failed step was discarded outright
+// (`_ = controller.step(ctx)`) with no counter and no readiness flip.
+//
+// KNOWN COVERAGE BOUNDARY (CHAOS-3907): this calls newExternalRecomputeController
+// itself, so it proves the seam propagates its logger argument -- it does NOT
+// prove the production call site passes the composed logger INTO the seam.
+// That call site is productionStreamStorage.Handler's external-ingest case
+// (`newExternalRecomputeController(recomputeStore, dispatcher, storage.logger)`),
+// which sits behind live ClickHouse/Valkey/Postgres construction and is not
+// reachable without containers. Verified by mutation: replacing that argument
+// with nil does NOT fail any test, whereas every other logger wiring site in
+// this batch does fail under the same treatment. If that line is ever changed,
+// nothing here will catch it -- close this with an integration-tagged test if
+// the controller's logging becomes load-bearing.
+func TestExternalRecomputeControllerReceivesTheComposedLogger(t *testing.T) {
+	forcedErr := errors.New("pending scopes probe failure")
+
+	var buf syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	controller, err := newExternalRecomputeController(
+		noopRecomputeStore{},
+		failingPendingScopesDispatcher{err: forcedErr},
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("newExternalRecomputeController() error = %v", err)
+	}
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatalf("start controller: %v", err)
+	}
+	t.Cleanup(func() { _ = controller.Shutdown(context.Background()) })
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(buf.String(), "external recompute step failed") {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "external recompute step failed") {
+		t.Fatalf("composed logger did not observe the controller's step failure: %s", output)
+	}
+	if !strings.Contains(output, forcedErr.Error()) {
+		t.Fatalf("composed logger output omitted the failure cause: %s", output)
+	}
+}
+
+// failingReadTransport discovers one stream successfully (so Start's initial
+// refreshStreams succeeds and the runner goroutine actually starts) but fails
+// every read, so the runner's background loop hits a cycle failure on its
+// first iteration.
+type failingReadTransport struct {
+	readErr error
+}
+
+func (*failingReadTransport) EnsureGroup(context.Context, string, string) error { return nil }
+func (t *failingReadTransport) ReadNew(context.Context, []string, string, string, int, time.Duration) ([]streamrunner.Message, error) {
+	return nil, t.readErr
+}
+func (*failingReadTransport) Pending(context.Context, string, string, int, time.Duration) ([]streamrunner.Pending, error) {
+	return nil, nil
+}
+func (*failingReadTransport) Claim(context.Context, string, string, string, []string, time.Duration) ([]streamrunner.Message, error) {
+	return nil, nil
+}
+func (*failingReadTransport) Ack(context.Context, string, string, string) error { return nil }
+func (*failingReadTransport) Quarantine(context.Context, streamrunner.Message, string) error {
+	return nil
+}
+func (*failingReadTransport) Stats(context.Context, string, string) (streamrunner.StreamStats, error) {
+	return streamrunner.StreamStats{}, nil
+}
+func (*failingReadTransport) Discover(context.Context, []string, int) ([]string, error) {
+	return []string{"probe-stream"}, nil
+}
+func (*failingReadTransport) Close() {}
+
+type failingReadStorage struct {
+	readErr error
+}
+
+func (*failingReadStorage) ClickHouseReady(context.Context) error     { return nil }
+func (*failingReadStorage) DomainPostgresReady(context.Context) error { return nil }
+func (*failingReadStorage) ValkeyReady(context.Context) error         { return nil }
+func (*failingReadStorage) Handler(streamHandlerKind) (streamrunner.Handler, error) {
+	return streamCommandHandler{}, nil
+}
+func (storage *failingReadStorage) NewTransport() (streamrunner.Transport, error) {
+	return &failingReadTransport{readErr: storage.readErr}, nil
+}
+func (*failingReadStorage) ControlComponents() []lifecycle.Component { return nil }
+func (*failingReadStorage) Close()                                   {}
+
+// TestStreamRunnerReceivesTheComposedLoggerFromStreamRunnerCompositionRoot
+// proves the wiring, not just the field (CHAOS-3907): it goes through the
+// real composition root (configureStreamRunnerDependenciesWithSources with a
+// real streamrunner.New), not a direct
+// streamrunner.New(..., Config{Logger: ...}) call, which would prove nothing
+// about cmd/dev-health-stream-runner. Before this wiring, a cycle failure
+// flipped ready=false with no output and no Errors() channel at all.
+func TestStreamRunnerReceivesTheComposedLoggerFromStreamRunnerCompositionRoot(t *testing.T) {
+	forcedErr := errors.New("stream read probe failure")
+	storage := &failingReadStorage{readErr: forcedErr}
+
+	var buf syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureStreamRunnerDependenciesWithSources(
+		context.Background(),
+		config.Config{Profile: "ingest", StreamConfiguredReplicas: 1},
+		registry,
+		streamDependencySources{
+			openStorage: func(context.Context, config.Config, *slog.Logger) (streamStorage, error) {
+				return storage, nil
+			},
+		},
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("configureStreamRunnerDependenciesWithSources() error = %v", err)
+	}
+
+	var runner lifecycle.Component
+	for _, component := range components {
+		if component.Name() == "stream-internal_ingest" {
+			runner = component
+		}
+	}
+	if runner == nil {
+		t.Fatalf("stream-internal_ingest was not constructed: components=%v", componentNames(components))
+	}
+	if err := runner.Start(context.Background()); err != nil {
+		t.Fatalf("start runner: %v", err)
+	}
+	t.Cleanup(func() { _ = runner.Shutdown(context.Background()) })
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(buf.String(), "stream runner cycle failed") {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "stream runner cycle failed") {
+		t.Fatalf("composed logger did not observe the runner's cycle failure: %s", output)
+	}
+	if !strings.Contains(output, forcedErr.Error()) {
+		t.Fatalf("composed logger output omitted the failure cause: %s", output)
+	}
+}
+
+func componentNames(components []lifecycle.Component) []string {
+	names := make([]string, 0, len(components))
+	for _, component := range components {
+		names = append(names, component.Name())
+	}
+	return names
+}
+
+// syncBuffer guards the capture buffer with a mutex. These tests start a real
+// component whose run loop logs from its own goroutine while the test polls
+// for the expected line, so an unguarded bytes.Buffer is a data race that
+// -race fails on (CHAOS-3907). slog handlers are safe for concurrent use; the
+// io.Writer underneath them is the caller's responsibility.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/cmd/dev-health-stream-runner/main.go
+++ b/cmd/dev-health-stream-runner/main.go
@@ -7,9 +7,9 @@ var streamRunnerSpec = shell.Spec{
 	// PagerDuty webhooks are an independently routable stream family (TRD 10.5)
 	// with their own producer, DLQ, and receipt store, so they get a dedicated
 	// profile rather than a third loop inside the ingest process.
-	Profiles:              []string{"ingest", "external", "pagerduty"},
-	DefaultProfile:        "ingest",
-	ConfigureDependencies: configureStreamRunnerDependencies,
+	Profiles:                        []string{"ingest", "external", "pagerduty"},
+	DefaultProfile:                  "ingest",
+	ConfigureDependenciesWithLogger: configureStreamRunnerDependenciesWithLogger,
 }
 
 func main() {

--- a/cmd/dev-health-stream-runner/main_test.go
+++ b/cmd/dev-health-stream-runner/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"slices"
@@ -79,14 +80,14 @@ func TestStreamRunnerSpecBuildsProductionProfiles(t *testing.T) {
 	if !slices.Equal(streamRunnerSpec.Profiles, []string{"ingest", "external", "pagerduty"}) {
 		t.Fatalf("unexpected stream profiles: %v", streamRunnerSpec.Profiles)
 	}
-	if streamRunnerSpec.ConfigureDependencies == nil {
+	if streamRunnerSpec.ConfigureDependenciesWithLogger == nil {
 		t.Fatal("stream-runner dependency configuration is not wired")
 	}
 
 	t.Run("unconfigured storage stays live and fails readiness", func(t *testing.T) {
 		registry := health.NewRegistry(100 * time.Millisecond)
-		components, err := configureStreamRunnerDependencies(
-			context.Background(), config.Config{}, registry,
+		components, err := configureStreamRunnerDependenciesWithLogger(
+			context.Background(), config.Config{}, registry, nil,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -111,10 +112,11 @@ func TestStreamRunnerSpecBuildsProductionProfiles(t *testing.T) {
 			config.Config{Profile: "ingest", StreamConfiguredReplicas: 1},
 			registry,
 			streamDependencySources{
-				openStorage: func(context.Context, config.Config) (streamStorage, error) {
+				openStorage: func(context.Context, config.Config, *slog.Logger) (streamStorage, error) {
 					return storage, nil
 				},
 			},
+			nil,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -146,10 +148,11 @@ func TestStreamRunnerSpecBuildsProductionProfiles(t *testing.T) {
 			config.Config{Profile: "ingest", StreamConfiguredReplicas: 1},
 			registry,
 			streamDependencySources{
-				openStorage: func(context.Context, config.Config) (streamStorage, error) {
+				openStorage: func(context.Context, config.Config, *slog.Logger) (streamStorage, error) {
 					return storage, nil
 				},
 			},
+			nil,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -174,10 +177,11 @@ func TestStreamRunnerSpecBuildsProductionProfiles(t *testing.T) {
 			config.Config{Profile: "ingest", StreamConfiguredReplicas: 1},
 			registry,
 			streamDependencySources{
-				openStorage: func(context.Context, config.Config) (streamStorage, error) {
+				openStorage: func(context.Context, config.Config, *slog.Logger) (streamStorage, error) {
 					return storage, nil
 				},
 			},
+			nil,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -202,10 +206,11 @@ func TestStreamRunnerSpecBuildsProductionProfiles(t *testing.T) {
 			config.Config{Profile: "pagerduty", StreamConfiguredReplicas: 2},
 			registry,
 			streamDependencySources{
-				openStorage: func(context.Context, config.Config) (streamStorage, error) {
+				openStorage: func(context.Context, config.Config, *slog.Logger) (streamStorage, error) {
 					return storage, nil
 				},
 			},
+			nil,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -236,10 +241,11 @@ func TestStreamRunnerSpecBuildsProductionProfiles(t *testing.T) {
 			config.Config{Profile: "pagerduty", StreamConfiguredReplicas: 1},
 			registry,
 			streamDependencySources{
-				openStorage: func(context.Context, config.Config) (streamStorage, error) {
+				openStorage: func(context.Context, config.Config, *slog.Logger) (streamStorage, error) {
 					return storage, nil
 				},
 			},
+			nil,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -263,10 +269,11 @@ func TestStreamRunnerSpecBuildsProductionProfiles(t *testing.T) {
 			config.Config{Profile: "external", StreamConfiguredReplicas: 2},
 			health.NewRegistry(time.Second),
 			streamDependencySources{
-				openStorage: func(context.Context, config.Config) (streamStorage, error) {
+				openStorage: func(context.Context, config.Config, *slog.Logger) (streamStorage, error) {
 					return storage, nil
 				},
 			},
+			nil,
 		)
 		if err == nil || !storage.closed {
 			t.Fatalf("duplicate external replicas: err=%v storage_closed=%v", err, storage.closed)

--- a/internal/externalrecompute/controller.go
+++ b/internal/externalrecompute/controller.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sync"
 	"time"
@@ -40,6 +41,15 @@ type Config struct {
 	PollInterval  time.Duration
 	InflightRetry time.Duration
 	BatchSize     int
+	// Logger receives step failures from the durable drain loop. It is
+	// optional so tests and embedders need not supply one; a nil Logger
+	// discards. Before this field existed, this controller had zero slog
+	// references at all: a failed step was discarded outright with no
+	// counter and no readiness flip (CHAOS-3907). It must never fall back to
+	// slog.Default(): that sends output to a sink other than the process's
+	// configured JSON logger, so log-capturing tests would pass while
+	// production ships nothing.
+	Logger *slog.Logger
 }
 
 func DefaultConfig() Config {
@@ -121,7 +131,9 @@ func (controller *Controller) run(ctx context.Context, done chan struct{}) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
-			_ = controller.step(ctx)
+			if err := controller.step(ctx); err != nil {
+				controller.logger().ErrorContext(ctx, "external recompute step failed", "error", err.Error())
+			}
 			timer.Reset(controller.config.PollInterval)
 		}
 	}
@@ -151,6 +163,16 @@ func (controller *Controller) step(ctx context.Context) error {
 		}
 	}
 	return errors.Join(pendingErr, claimErr, errors.Join(dispatchErrors...))
+}
+
+// logger is nil-safe: an unset Config.Logger discards rather than panicking,
+// and never falls back to slog.Default(), so an embedder cannot be surprised
+// by controller output appearing on a logger it did not choose.
+func (controller *Controller) logger() *slog.Logger {
+	if controller == nil || controller.config.Logger == nil {
+		return slog.New(slog.DiscardHandler)
+	}
+	return controller.config.Logger
 }
 
 func (controller *Controller) Shutdown(ctx context.Context) error {

--- a/internal/externalrecompute/controller_test.go
+++ b/internal/externalrecompute/controller_test.go
@@ -1,8 +1,10 @@
 package externalrecompute
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"slices"
 	"testing"
 	"time"
@@ -124,5 +126,54 @@ func TestControllerScheduleRejectsInvalidOrReversedScope(t *testing.T) {
 	})
 	if !errors.Is(err, ErrInvalidConfig) {
 		t.Fatalf("reversed window error = %v", err)
+	}
+}
+
+type controllerAlwaysFailingDispatcher struct{ err error }
+
+func (dispatcher controllerAlwaysFailingDispatcher) PendingScopes(
+	context.Context, int,
+) ([]streamhandlers.ExternalRecomputeScope, error) {
+	return nil, dispatcher.err
+}
+
+func (controllerAlwaysFailingDispatcher) Dispatch(context.Context, Claim) error { return nil }
+
+// TestControllerWithoutALoggerDoesNotFallBackToSlogDefault proves the
+// nil-logger path is inert: a controller given no Config.Logger must not
+// panic on a failed step, and it must not fall back to slog.Default() --
+// that would send output to a sink other than the process's configured JSON
+// logger, so a log-capturing test could pass while production ships nothing
+// (CHAOS-3907).
+func TestControllerWithoutALoggerDoesNotFallBackToSlogDefault(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(original)
+
+	cfg := DefaultConfig()
+	cfg.PollInterval = 100 * time.Millisecond
+	if cfg.Logger != nil {
+		t.Fatal("default config unexpectedly has a logger")
+	}
+	controller, err := New(
+		&controllerStoreFake{},
+		controllerAlwaysFailingDispatcher{err: errors.New("pending scopes probe failure")},
+		cfg,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = controller.Shutdown(context.Background()) }()
+
+	// Give the background loop several cycles' worth of time to hit (and,
+	// were the fallback present, log) its failure.
+	time.Sleep(100 * time.Millisecond)
+
+	if buf.Len() != 0 {
+		t.Fatalf("nil logger fell back to slog.Default(): %s", buf.String())
 	}
 }

--- a/internal/joboutbox/loop.go
+++ b/internal/joboutbox/loop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -42,6 +43,10 @@ type ReconcilerLoopConfig struct {
 	PollInterval time.Duration
 	Limit        int
 	Registry     *health.Registry
+	// Logger names why a step failed. It is optional so tests and embedders
+	// need not supply one; a nil Logger discards. Without it this loop could
+	// flip readiness closed forever and emit nothing at all (CHAOS-3907).
+	Logger *slog.Logger
 }
 
 func DefaultReconcilerLoopConfig(registry *health.Registry) ReconcilerLoopConfig {
@@ -168,6 +173,7 @@ func (loop *ReconcilerLoop) Start(ctx context.Context) error {
 
 	if err := loop.step(ctx, loop.clock.Now()); err != nil {
 		loop.setFailed()
+		loop.logger().ErrorContext(ctx, "outbox reconciler initial step failed", "error", err.Error())
 		return fmt.Errorf("initial outbox reconciliation: %w", err)
 	}
 
@@ -180,6 +186,7 @@ func (loop *ReconcilerLoop) Start(ctx context.Context) error {
 		ticker.Stop()
 		cancel()
 		loop.setFailed()
+		loop.logger().ErrorContext(ctx, "outbox reconciler stopped before its polling loop started")
 		return context.Canceled
 	}
 	loop.cancel = cancel
@@ -202,6 +209,7 @@ func (loop *ReconcilerLoop) run(ctx context.Context, ticker reconcilerTicker, do
 			}
 			if err := loop.step(ctx, now); err != nil {
 				loop.setFailed()
+				loop.logger().ErrorContext(ctx, "outbox reconciler step failed", "error", err.Error())
 				select {
 				case loop.errors <- fmt.Errorf("outbox reconciliation step: %w", err):
 				case <-ctx.Done():
@@ -244,6 +252,16 @@ func (loop *ReconcilerLoop) setFailed() {
 	loop.mu.Lock()
 	loop.up = false
 	loop.mu.Unlock()
+}
+
+// logger is nil-safe: an unset Config.Logger discards rather than panicking,
+// and never falls back to slog.Default(), so an embedder cannot be surprised
+// by reconciler output appearing on a logger it did not choose.
+func (loop *ReconcilerLoop) logger() *slog.Logger {
+	if loop == nil || loop.config.Logger == nil {
+		return slog.New(slog.DiscardHandler)
+	}
+	return loop.config.Logger
 }
 
 func (loop *ReconcilerLoop) readiness(context.Context) error {

--- a/internal/joboutbox/loop_test.go
+++ b/internal/joboutbox/loop_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -258,5 +259,33 @@ func TestReconcilerLoopRejectsUnboundedConfiguration(t *testing.T) {
 		if _, err := NewReconcilerLoop(stepper, config); !errors.Is(err, ErrInvalidConfiguration) {
 			t.Fatalf("NewReconcilerLoop(%#v) error = %v", config, err)
 		}
+	}
+}
+
+// TestReconcilerLoopWithoutALoggerDoesNotFallBackToSlogDefault proves the
+// mirror image of the logging tests above: a loop given no Logger must not
+// panic on a failed step, and it must not fall back to slog.Default() --
+// that would send output to a sink other than the process's configured JSON
+// logger, so a log-capturing test could pass while production ships nothing
+// (CHAOS-3907).
+func TestReconcilerLoopWithoutALoggerDoesNotFallBackToSlogDefault(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(original)
+
+	failure := errors.New("initial step probe failure")
+	stepper := loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
+		return StepResult{}, failure
+	})
+	loop, _ := newTestReconcilerLoop(t, stepper, &testReconcilerClock{})
+	if loop.config.Logger != nil {
+		t.Fatal("test loop unexpectedly has a logger")
+	}
+	if err := loop.Start(context.Background()); err == nil {
+		t.Fatal("Start() = nil, want the scripted initial step failure")
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("nil logger fell back to slog.Default(): %s", buf.String())
 	}
 }

--- a/internal/scheduler/sync/loop.go
+++ b/internal/scheduler/sync/loop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -54,6 +55,18 @@ type LoopConfig struct {
 	// a loop that can create pending occurrences but not consume them is the
 	// exact gap that leaves work stranded after the marker advances.
 	Occurrences OccurrenceStepper
+	// Logger names the failures that close this loop's readiness. It is
+	// optional so tests and embedders need not supply one; a nil Logger
+	// discards. Without it a loop can fail every window forever and emit
+	// nothing at all, mirroring the literal sibling scheduler/fixed.Loop's
+	// CHAOS-3903 fix -- see that package's LoopConfig.Logger.
+	Logger *slog.Logger
+}
+
+// WithLogger returns the config bound to a diagnostic logger.
+func (config LoopConfig) WithLogger(logger *slog.Logger) LoopConfig {
+	config.Logger = logger
+	return config
 }
 
 func DefaultLoopConfig(registry *health.Registry) LoopConfig {
@@ -182,6 +195,7 @@ func (loop *Loop) Start(ctx context.Context) error {
 
 	if err := loop.step(loopCtx, loop.clock.Now()); err != nil {
 		loop.setFailed()
+		loop.logger().ErrorContext(ctx, "sync scheduler initial handoff failed", "error", err.Error())
 		cancel()
 		close(done)
 		return fmt.Errorf("initial scheduler handoff: %w", err)
@@ -193,6 +207,7 @@ func (loop *Loop) Start(ctx context.Context) error {
 		ticker.Stop()
 		cancel()
 		loop.setFailed()
+		loop.logger().ErrorContext(ctx, "sync scheduler stopped before its polling loop started")
 		close(done)
 		if err := loopCtx.Err(); err != nil {
 			return err
@@ -216,6 +231,7 @@ func (loop *Loop) run(ctx context.Context, ticker loopTicker, done chan struct{}
 		case now, open := <-ticker.Chan():
 			if !open {
 				loop.setFailed()
+				loop.logger().ErrorContext(ctx, "sync scheduler ticker closed unexpectedly")
 				return
 			}
 			if !nextEligible.IsZero() && now.Before(nextEligible) {
@@ -223,6 +239,7 @@ func (loop *Loop) run(ctx context.Context, ticker loopTicker, done chan struct{}
 			}
 			if err := loop.step(ctx, now); err != nil {
 				loop.setFailed()
+				loop.logger().ErrorContext(ctx, "sync scheduler handoff window failed", "error", err.Error())
 				// Measure retry delay from failure completion. A slow or timed
 				// out step may leave old ticker values buffered; those must not
 				// collapse the intended backoff.
@@ -302,6 +319,17 @@ func (loop *Loop) setFailed() {
 	loop.mu.Lock()
 	loop.up = false
 	loop.mu.Unlock()
+}
+
+// logger is nil-safe: an unset Config.Logger discards rather than panicking,
+// and never falls back to slog.Default(), so an embedder cannot be surprised
+// by scheduler output appearing on a logger it did not choose. Mirrors
+// scheduler/fixed.Loop.logger exactly.
+func (loop *Loop) logger() *slog.Logger {
+	if loop == nil || loop.config.Logger == nil {
+		return slog.New(slog.DiscardHandler)
+	}
+	return loop.config.Logger
 }
 
 func (loop *Loop) readiness(context.Context) error {

--- a/internal/scheduler/sync/loop_test.go
+++ b/internal/scheduler/sync/loop_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -414,4 +415,32 @@ func (stepper schedulerHandoffStepper) HandoffDueResult(
 	context.Context, time.Time, int, Coordinator,
 ) (HandoffResult, error) {
 	return stepper()
+}
+
+// TestLoopWithoutALoggerDoesNotFallBackToSlogDefault proves the nil-logger
+// path is inert: a loop given no Logger must not panic on a failed handoff
+// window, and it must not fall back to slog.Default() -- that would send
+// output to a sink other than the process's configured JSON logger, so a
+// log-capturing test could pass while production ships nothing (CHAOS-3907).
+// Mirrors scheduler/fixed's own nil-logger test for its literal sibling loop.
+func TestLoopWithoutALoggerDoesNotFallBackToSlogDefault(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(original)
+
+	failure := errors.New("initial handoff probe failure")
+	stepper := loopStepFunc(func(context.Context, time.Time, int, Coordinator) (HandoffResult, error) {
+		return HandoffResult{}, failure
+	})
+	loop, _ := newTestLoop(t, stepper, &testLoopClock{})
+	if loop.config.Logger != nil {
+		t.Fatal("test loop unexpectedly has a logger")
+	}
+	if err := loop.Start(context.Background()); err == nil {
+		t.Fatal("Start() = nil, want the scripted initial handoff failure")
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("nil logger fell back to slog.Default(): %s", buf.String())
+	}
 }

--- a/internal/streamrunner/runner.go
+++ b/internal/streamrunner/runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -110,6 +111,10 @@ func (r *Runner) run(ctx context.Context, done chan struct{}) {
 		active, err := r.cycle(ctx, maintain)
 		if err != nil {
 			r.recordFailure()
+			r.logger().ErrorContext(ctx, "stream runner cycle failed",
+				"stream", r.config.Name,
+				"error", err.Error(),
+			)
 			idleDelay = initialIdleDelay
 			select {
 			case <-ctx.Done():
@@ -377,6 +382,16 @@ func (r *Runner) recordFailure() {
 	r.failures++
 	r.up = false
 	r.mu.Unlock()
+}
+
+// logger is nil-safe: an unset Config.Logger discards rather than panicking,
+// and never falls back to slog.Default(), so an embedder cannot be surprised
+// by stream-runner output appearing on a logger it did not choose.
+func (r *Runner) logger() *slog.Logger {
+	if r == nil || r.config.Logger == nil {
+		return slog.New(slog.DiscardHandler)
+	}
+	return r.config.Logger
 }
 
 func (r *Runner) readiness(context.Context) error {

--- a/internal/streamrunner/runner_test.go
+++ b/internal/streamrunner/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"slices"
 	"sync"
 	"testing"
@@ -524,5 +525,41 @@ func TestShutdownClosesReadinessAndLeavesUncommittedMessagePending(t *testing.T)
 	}
 	if !transport.closed || len(transport.acked) != 0 {
 		t.Fatalf("shutdown should close transport without ack: closed=%v acked=%v", transport.closed, transport.acked)
+	}
+}
+
+// TestRunnerWithoutALoggerDoesNotFallBackToSlogDefault proves the nil-logger
+// path is inert: a runner given no Config.Logger must not panic on a cycle
+// failure, and it must not fall back to slog.Default() -- that would send
+// output to a sink other than the process's configured JSON logger, so a
+// log-capturing test could pass while production ships nothing (CHAOS-3907).
+func TestRunnerWithoutALoggerDoesNotFallBackToSlogDefault(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(original)
+
+	transport := &fakeTransport{new: []Message{{Stream: "test:stream", ID: "1-0"}}, stats: StreamStats{Pending: 1}}
+	config := testConfig()
+	if config.Logger != nil {
+		t.Fatal("test config unexpectedly has a logger")
+	}
+	runner, err := New(transport, handlerFunc(func(context.Context, Message) error {
+		return errors.New("clickhouse unavailable")
+	}), config, health.NewRegistry(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = runner.Shutdown(context.Background()) }()
+
+	// Give the background loop several cycles' worth of time to hit (and,
+	// were the fallback present, log) its failure.
+	time.Sleep(100 * time.Millisecond)
+
+	if buf.Len() != 0 {
+		t.Fatalf("nil logger fell back to slog.Default(): %s", buf.String())
 	}
 }

--- a/internal/streamrunner/types.go
+++ b/internal/streamrunner/types.go
@@ -7,6 +7,7 @@ package streamrunner
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 )
 
@@ -106,6 +107,13 @@ type Config struct {
 	ShutdownDrain      time.Duration
 	Singleton          bool
 	ConfiguredReplicas int
+	// Logger names the cycle failures this runner hits. It is optional so
+	// tests and embedders need not supply one; a nil Logger discards. Without
+	// it a runner could flip ready=false forever and emit nothing at all
+	// (CHAOS-3907). It must never fall back to slog.Default(): that sends
+	// output to a sink other than the process's configured JSON logger, so
+	// log-capturing tests would pass while production ships nothing.
+	Logger *slog.Logger
 }
 
 func (c Config) validate() error {

--- a/internal/syncreconciler/loop.go
+++ b/internal/syncreconciler/loop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,6 +46,11 @@ type LoopConfig struct {
 	// this caller-owned dependency, so a contract-violating recorder can strand
 	// at most one goroutine without holding readiness or process shutdown.
 	Recorder ObservationRecorder
+	// Logger names why an observation step failed. It is optional so tests and
+	// embedders need not supply one; a nil Logger discards. Without it this
+	// loop could flip readiness closed forever and emit nothing at all
+	// (CHAOS-3907).
+	Logger *slog.Logger
 }
 
 // DefaultLoopConfig allows two seconds for one indexed read of at most 101
@@ -163,6 +169,7 @@ func (loop *Loop) Start(ctx context.Context) error {
 
 	if err := loop.step(loopCtx, loop.clock.Now()); err != nil {
 		loop.setFailed()
+		loop.logger().ErrorContext(ctx, "sync dispatch observer initial step failed", "error", err.Error())
 		cancel()
 		close(done)
 		return fmt.Errorf("initial sync dispatch observation: %w", err)
@@ -178,6 +185,7 @@ func (loop *Loop) Start(ctx context.Context) error {
 		ticker.Stop()
 		cancel()
 		loop.setFailed()
+		loop.logger().ErrorContext(ctx, "sync dispatch observer stopped before its polling loop started", "error", startErr.Error())
 		close(done)
 		return startErr
 	}
@@ -186,6 +194,7 @@ func (loop *Loop) Start(ctx context.Context) error {
 	go loop.run(loopCtx, ticker, done)
 	if err := loopCtx.Err(); err != nil {
 		loop.setFailed()
+		loop.logger().ErrorContext(ctx, "sync dispatch observer context failed after start", "error", err.Error())
 		return err
 	}
 	return nil
@@ -197,6 +206,7 @@ func (loop *Loop) run(ctx context.Context, ticker loopTicker, done chan struct{}
 	defer ticker.Stop()
 	defer func() {
 		if fatal != nil {
+			loop.logger().ErrorContext(ctx, "sync dispatch observer step failed", "error", fatal.Error())
 			loop.reportError(ctx, fatal)
 		}
 	}()
@@ -315,6 +325,16 @@ func (loop *Loop) setFailed() {
 	loop.up = false
 	loop.ready.Store(false)
 	loop.mu.Unlock()
+}
+
+// logger is nil-safe: an unset Config.Logger discards rather than panicking,
+// and never falls back to slog.Default(), so an embedder cannot be surprised
+// by observer output appearing on a logger it did not choose.
+func (loop *Loop) logger() *slog.Logger {
+	if loop == nil || loop.config.Logger == nil {
+		return slog.New(slog.DiscardHandler)
+	}
+	return loop.config.Logger
 }
 
 func (loop *Loop) readiness(context.Context) error {

--- a/internal/syncreconciler/loop_test.go
+++ b/internal/syncreconciler/loop_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -641,5 +642,32 @@ func TestMetricsOmitLastSuccessAgeBeforeFirstSuccess(t *testing.T) {
 	}
 	if strings.Contains(metrics.String(), "sync_dispatch_observer_last_success_age_seconds") {
 		t.Fatalf("pre-success metrics exported a fabricated age:\n%s", metrics.String())
+	}
+}
+
+// TestLoopWithoutALoggerDoesNotFallBackToSlogDefault proves the nil-logger
+// path is inert: a loop given no Logger must not panic on a failed step, and
+// it must not fall back to slog.Default() -- that would send output to a
+// sink other than the process's configured JSON logger, so a log-capturing
+// test could pass while production ships nothing (CHAOS-3907).
+func TestLoopWithoutALoggerDoesNotFallBackToSlogDefault(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(original)
+
+	failure := errors.New("initial observation probe failure")
+	stepper := loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		return Observation{}, failure
+	})
+	loop, _ := newTestLoop(t, stepper, &testClock{})
+	if loop.config.Logger != nil {
+		t.Fatal("test loop unexpectedly has a logger")
+	}
+	if err := loop.Start(context.Background()); err == nil {
+		t.Fatal("Start() = nil, want the scripted initial observation failure")
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("nil logger fell back to slog.Default(): %s", buf.String())
 	}
 }


### PR DESCRIPTION
Closes CHAOS-3907. From the [observability audit](https://linear.app/fullchaos/document/observability-audit-go-worker-runtime-2026-08-18-10308693ec48). **Merge last** — depends on #1781 (CHAOS-3906) to be observable.

## Part 1 — three services could not say why they failed
`DependencyReason()` was implemented by exactly one type (the worker's). `scheduler`, `stream-runner` and `reconciler` returned bare sentinels, so `errors.As` at `shell.go:240` found nothing and they logged `dependency_configuration_failed` with no reason. Each now has its own `dependencyFailure` with bounded compile-time reason constants at every distinct construction-failure site. `Unwrap()` returns the existing sentinel, so prior `errors.Is` tests still pass.

## Part 2 — five components had no logger at all
`externalrecompute.Controller` (its `_ = controller.step(ctx)` discard is fixed), `streamrunner.Runner`, `joboutbox.ReconcilerLoop`, `syncreconciler.Loop`, `scheduler/sync.Loop` — the last being the literal sibling of `scheduler/fixed.Loop`, which already had this fix.

Each uses the nil-safe accessor from `scheduler/fixed.Loop` (`slog.New(slog.DiscardHandler)`, **never** `slog.Default()` — that writes to a different sink than the process logger, so log-capturing tests pass while production ships nothing).

## Wiring is proven, not assumed
A `Logger` field that is never passed reads as done while shipping nothing. Five composition-root tests drive the real `configureX...WithSources` entry points with fakes only at the I/O boundary and assert the **process's** logger observed the failure.

Verified by mutation: nulling each wiring site fails its test. Coverage is 5 of 6 sites — the exception is `productionStreamStorage.Handler`'s `newExternalRecomputeController(..., storage.logger)` call, which sits behind live ClickHouse/Valkey/Postgres construction. That boundary is documented in the test rather than papered over.

Also fixed here: a data race in two new wiring tests (background component logging into an unguarded `bytes.Buffer`), caught by the gate's `-race` stage.

Full `ci/check_go.sh all` green (RC=0).