### PR TITLE
fix(sync): stop advertising backfill windows the API rejects

### DIFF
--- a/internal/synccoverage/payload.go
+++ b/internal/synccoverage/payload.go
@@ -426,6 +426,12 @@ func canonicalBackfillWindows(pairs []pairCoverage) []any {
 				if !isUTCMidnight(since) || !isUTCMidnight(before) {
 					continue
 				}
+				// BackfillSelectorRequest requires since < before, so an
+				// empty interval would suggest a window the API rejects
+				// with a 422. Mirrors _canonical_backfill_windows.
+				if !since.Before(before) {
+					continue
+				}
 				key := scope{
 					Since: since, Before: before,
 					SourceID: pair.SourceID, DatasetKey: pair.DatasetKey,

--- a/internal/synccoverage/types.go
+++ b/internal/synccoverage/types.go
@@ -12,13 +12,21 @@ import (
 
 const (
 	HistoryLookbackDays = 3650
-	projectionVersion   = 1
-	maxProjectionRows   = 1_000_000
-	maxSources          = 5_000
-	maxDatasets         = 100
-	maxPairs            = 20_000
-	maxCompactWindows   = 30_000
-	maxBackfillPairs    = 20_000
+	// projectionVersion must stay in lockstep with
+	// SYNC_COVERAGE_PROJECTION_VERSION in
+	// src/dev_health_ops/api/services/sync_coverage.py: the API reads
+	// projections filtered on this value, so a mismatch makes every
+	// projection unreadable and coverage returns 503 forever. Bump both
+	// whenever the payload shape changes. Version 1 stored backfill_windows
+	// as bare calendar dates with no source/dataset scope; version 2 stores
+	// exact UTC instants plus scope.
+	projectionVersion = 2
+	maxProjectionRows = 1_000_000
+	maxSources        = 5_000
+	maxDatasets       = 100
+	maxPairs          = 20_000
+	maxCompactWindows = 30_000
+	maxBackfillPairs  = 20_000
 )
 
 var (

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -420,11 +420,36 @@ class SyncCoverageBackfillWindow(BaseModel):
     or dataset.
     """
 
-    since: datetime
-    before: datetime
+    since: AwareDatetime
+    before: AwareDatetime
     source_ids: list[str] = Field(default_factory=list)
     dataset_keys: list[str] = Field(default_factory=list)
     reasons: list[Literal["gap", "failed"]] = Field(default_factory=list)
+
+    @field_validator("since", "before", mode="before")
+    @classmethod
+    def _assume_utc(cls, value: Any) -> Any:
+        """Attach UTC to a naive or date-only boundary read from a projection.
+
+        These windows are echoed straight back by clients as a
+        ``BackfillSelectorRequest``, whose boundaries are ``AwareDatetime``. A
+        naive value here therefore produces a selector the server itself
+        rejects with a 422. Version-1 projections stored bare calendar dates,
+        so coerce rather than reject: an unreadable suggestion is worse than a
+        UTC-assumed one, and every stored boundary is already UTC.
+        """
+        if isinstance(value, str):
+            try:
+                value = datetime.fromisoformat(value)
+            except ValueError:
+                return value
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=timezone.utc)
+            return value
+        if isinstance(value, date):
+            return datetime.combine(value, time.min, tzinfo=timezone.utc)
+        return value
 
 
 class SyncCoverageSummaryResponse(BaseModel):

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -37,7 +37,12 @@ from dev_health_ops.sync.family_flags import (
 logger = logging.getLogger(__name__)
 
 HISTORY_LOOKBACK_DAYS = 3650
-SYNC_COVERAGE_PROJECTION_VERSION = 1
+# Bump whenever the persisted payload shape changes. The read path filters on
+# this value, so a stale-shaped row becomes unreadable and is rebuilt instead of
+# being served as current. Version 1 stored ``backfill_windows`` as bare
+# calendar dates with no source/dataset scope; version 2 stores exact UTC
+# instants plus scope, which is what BackfillSelectorRequest requires.
+SYNC_COVERAGE_PROJECTION_VERSION = 2
 STALE_MINIMUM_GRACE = timedelta(hours=6)
 STALE_FALLBACK_GRACE = timedelta(hours=48)
 INTERVAL_ADJACENCY_TOLERANCE = timedelta(microseconds=1)
@@ -1550,6 +1555,10 @@ def _canonical_backfill_windows(
     suggestion only when the half-open coverage range has exact UTC-midnight
     boundaries. This keeps the server authoritative: an explicit empty list
     means a displayed row is not safely representable by that selector.
+
+    Empty intervals are dropped for the same reason: BackfillSelectorRequest
+    requires ``since < before``, so emitting one would suggest a window the
+    server rejects with a 422.
     """
 
     candidates_by_scope: dict[
@@ -1561,6 +1570,8 @@ def _canonical_backfill_windows(
             before = ensure_utc(interval.before)
             if since.time() != time.min or before.time() != time.min:
                 continue
+            if since >= before:
+                continue
             candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(
                 "gap"
             )
@@ -1568,6 +1579,8 @@ def _canonical_backfill_windows(
             since = ensure_utc(interval.since)
             before = ensure_utc(interval.before)
             if since.time() != time.min or before.time() != time.min:
+                continue
+            if since >= before:
                 continue
             candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(
                 "failed"

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -40,6 +40,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from dev_health_ops.api.admin.routers.integrations import _unit_to_response
 from dev_health_ops.api.admin.routers.sync import _job_run_response, _SyncRunUnitRollup
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.sync_coverage import (
+    SYNC_COVERAGE_PROJECTION_VERSION,
+)
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.integrations import (
@@ -371,7 +374,7 @@ async def test_backfill_fanout_creates_job_run_anchor(
                 org_id=seeded_state["org_id"],
                 sync_config_id=uuid.UUID(config_id),
                 history_lookback_days=3650,
-                projection_version=1,
+                projection_version=SYNC_COVERAGE_PROJECTION_VERSION,
                 generated_at=datetime.now(timezone.utc),
                 payload={},
             )

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -12,6 +12,10 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import event, insert, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from dev_health_ops.api.admin.schemas_flat import (
+    BackfillSelectorRequest,
+    SyncCoverageBackfillWindow,
+)
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.sync_coverage import (
     invalidate_sync_coverage_projection,
@@ -853,6 +857,72 @@ def test_canonical_backfill_windows_preserve_pair_scope_and_half_open_bounds():
             "reasons": ["failed"],
         },
     ]
+
+
+def test_canonical_backfill_windows_drop_empty_intervals():
+    """An empty interval is not a submittable selector.
+
+    BackfillSelectorRequest requires ``since < before``. Suggesting a window
+    that fails that validator hands the operator a button that always 422s.
+    """
+    source_id = "11111111-1111-1111-1111-111111111111"
+    instant = datetime(2026, 3, 12, tzinfo=timezone.utc)
+    pair_coverages = [
+        sync_coverage_module._PairCoverage(
+            source_id=source_id,
+            dataset_key="commits",
+            gaps=[
+                sync_coverage_module.CoverageInterval(
+                    since=instant,
+                    before=instant,
+                    source_ids=(source_id,),
+                )
+            ],
+            failed_ranges=[
+                sync_coverage_module.CoverageInterval(
+                    since=instant,
+                    before=instant,
+                    source_ids=(source_id,),
+                )
+            ],
+        ),
+    ]
+
+    assert sync_coverage_module._canonical_backfill_windows(pair_coverages) == []
+
+
+@pytest.mark.parametrize(
+    "stored",
+    [
+        pytest.param({"since": "2026-08-08", "before": "2026-08-13"}, id="v1-dates"),
+        pytest.param(
+            {"since": "2026-08-08T00:00:00", "before": "2026-08-13T00:00:00"},
+            id="naive-datetimes",
+        ),
+    ],
+)
+def test_advertised_backfill_window_is_accepted_by_the_backfill_selector(stored):
+    """A suggested window must survive being echoed back as a selector.
+
+    Web sends ``backfill_windows`` entries to POST /backfill verbatim. The
+    response model used to be naive-tolerant while the request model is
+    ``AwareDatetime``, so a version-1 projection produced
+    ``2026-08-08T00:00:00`` and the server rejected its own suggestion with a
+    ``timezone_aware`` 422.
+    """
+    window = SyncCoverageBackfillWindow.model_validate(
+        {**stored, "reasons": ["failed", "gap"]}
+    )
+    assert window.since.tzinfo is not None
+    assert window.before.tzinfo is not None
+
+    emitted = window.model_dump(mode="json")
+    selector = BackfillSelectorRequest.model_validate(
+        {"since": emitted["since"], "before": emitted["before"]}
+    )
+
+    assert selector.since == datetime(2026, 8, 8, tzinfo=timezone.utc)
+    assert selector.before == datetime(2026, 8, 13, tzinfo=timezone.utc)
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_coverage_concurrency.py
+++ b/tests/api/admin/test_sync_coverage_concurrency.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine, delete
 from sqlalchemy.orm import Session
 
 from dev_health_ops.api.services.sync_coverage import (
+    SYNC_COVERAGE_PROJECTION_VERSION,
     _sync_coverage_lock_statement,
     invalidate_sync_coverage_projection_sync,
 )
@@ -59,7 +60,7 @@ def test_invalidation_waits_for_inflight_projection_publication():
                 org_id=org_id,
                 sync_config_id=config.id,
                 history_lookback_days=3650,
-                projection_version=1,
+                projection_version=SYNC_COVERAGE_PROJECTION_VERSION,
                 generated_at=datetime.now(timezone.utc),
                 payload={"generation": "before"},
             )

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -14,6 +14,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
+from dev_health_ops.api.services.sync_coverage import (
+    SYNC_COVERAGE_PROJECTION_VERSION,
+)
 from dev_health_ops.models import (
     BackfillJob,
     Base,
@@ -2017,7 +2020,7 @@ def test_finalize_once_only_dispatches_metrics_once(db_session, monkeypatch):
         org_id=run.org_id,
         sync_config_id=config.id,
         history_lookback_days=3650,
-        projection_version=1,
+        projection_version=SYNC_COVERAGE_PROJECTION_VERSION,
         generated_at=datetime.now(timezone.utc),
         payload={},
     )


### PR DESCRIPTION
## Problem

Running a focused backfill from a coverage suggestion failed with a `timezone_aware` 422 on **every** advertised window:

```json
[{"type":"timezone_aware","loc":["body","selector","since"],
  "msg":"Input should have timezone info","input":"2026-08-08T00:00:00"},
 {"type":"timezone_aware","loc":["body","selector","before"],
  "msg":"Input should have timezone info","input":"2026-08-13T00:00:00"}]
```

The server was advertising a selector it then refused to accept.

## Root cause

Three defects combined.

**1. Contract asymmetry in `schemas_flat.py`.** The same logical field had two different strictnesses:

| | Declared | Effect |
|---|---|---|
| Response `SyncCoverageBackfillWindow.since` | `datetime` | naive-tolerant |
| Request `BackfillSelectorRequest.since` | `AwareDatetime` | naive-rejecting |

Web echoes an advertised window back verbatim, so a naive boundary on the way out became a 422 on the way back in.

**2. A payload shape change with no version bump.** The naive values came from version-1 projections, which stored `backfill_windows` as bare calendar dates with no source or dataset scope. Confirmed in a live database:

```json
{"before":"2026-08-13","reasons":["failed","gap"],"since":"2026-08-08"}
```

`71563d38d` changed that payload shape but left `SYNC_COVERAGE_PROJECTION_VERSION = 1`. Since the read path filters on that value, pre-change rows kept being served as current, and Pydantic coerced `"2026-08-08"` into a naive datetime that serialised as `2026-08-08T00:00:00`.

**3. Empty intervals.** Version-1 data also contained windows with `since == before` (e.g. `2026-03-12` to `2026-03-12`), which fail the selector's `since < before` validator — a second guaranteed 422.

## Changes

- Response boundaries are now `AwareDatetime`, with a `mode="before"` validator that attaches UTC to naive and date-only input. Coercing rather than rejecting keeps version-1 suggestions readable, and every stored boundary is already UTC. The response can no longer violate the request contract.
- Projection version 1 → 2, in **both** the Python reader and the Go projector that writes it. **These must move together**: the reader filters on this value, so bumping only one side would make every projection unreadable and return 503 forever. Both constants now carry a comment saying so.
- Empty intervals dropped in both `canonicalBackfillWindows` implementations.
- Tests seeding a projection now use the constant instead of a literal `1`, so a future bump cannot silently change what they seed.

## Deploy note

Existing version-1 rows are unreadable until rewritten. `RefreshDue` sweeps **all** configs (no version filter) every 300s with a limit of 100 per run, and `Rebuild` upserts `projection_version = EXCLUDED.projection_version`. So coverage returns 503 for at most one tick, then self-heals. No migration or manual intervention needed.

## Verification

- The exact failing window round-trips through the real validators: `"2026-08-08"` → emitted `2026-08-08T00:00:00Z` → accepted by `BackfillSelectorRequest`.
- Ops: 342 passed. Go: 21 passed, including the real-Postgres projector integration suite.
- The Python↔Go parity oracle (`TestPayloadMatchesLivePythonProduction`) passes. Proven non-vacuous by setting the Go constant to `3` — it failed and reported Python at `2`, confirming it compares `projection_version` and ran the modified source.
- Every new test was confirmed to fail without its fix.

## Note for reviewers

The pre-push mypy hook is red on this branch, on 4 pre-existing `arg-type` errors introduced by `ebdc8d28d chore(deps): migrate OpenAI clients to httpx2 (#1748)` in `llm/providers/openai.py`, `llm/agent/openai_compatible.py` and `llm/providers/local.py`. None of those files are touched here; `ruff-format-check` and `ruff-check` both pass. Worth tracking separately — it blocks the mypy gate for every Python commit on main and its descendants.
