### PR TITLE
fix(ci): resolve the lefthook Python tools against the project environment

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,6 +15,11 @@
 #     files) because per-file mypy is unreliable — it needs full module context.
 #     The glob "*.py" means it only fires when Python files are involved, and the
 #     incremental cache (.mypy_cache/) keeps warm runs well under a second.
+#     It goes through scripts/run_mypy.sh so the check always resolves the
+#     PROJECT environment. Bare `mypy` picks up whatever is first on PATH, and
+#     in a worktree that is a global interpreter carrying a shadow copy of our
+#     dependencies -- which produced phantom errors in untouched files while CI
+#     stayed green (CHAOS-3913).
 #   - Either hook can be skipped with `--no-verify` for WIP or emergency pushes.
 #
 # Install: `make install` (wires `lefthook install` into the bootstrap).
@@ -41,7 +46,7 @@ pre-commit:
       stage_fixed: true
     mypy:
       glob: "*.py"
-      run: mypy
+      run: scripts/run_mypy.sh
       fail_text: "mypy found type errors. Fix them, or `git commit --no-verify` to bypass (discouraged)."
 
 pre-push:
@@ -57,5 +62,5 @@ pre-push:
       fail_text: "Run `ruff check --fix .` locally, commit the result, push again. Or `git push --no-verify` to bypass."
     mypy:
       glob: "*.py"
-      run: mypy
+      run: scripts/run_mypy.sh
       fail_text: "mypy found type errors. Run `mypy` locally, fix them, commit, push again. Or `git push --no-verify` to bypass."

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Run mypy against the PROJECT environment, never against whatever `mypy`
+# happens to be first on PATH.
+#
+# Why this exists (CHAOS-3913): the lefthook gate used to invoke bare `mypy`.
+# Outside an activated project environment -- which is every git worktree, since
+# worktrees do not carry the repo root's untracked direnv setup -- that resolved
+# a global interpreter whose site-packages hold a SHADOW copy of this project's
+# dependencies. mypy then type-checked our source against the wrong library
+# versions and reported errors in files the author never touched, while CI's
+# typecheck job stayed green. A gate that is usually wrong trains people to
+# bypass it, which is worse than no gate at all.
+#
+# Concretely: Homebrew's python3.14 site-packages carried openai 2.37.0
+# (`http_client: httpx.AsyncClient`) while pyproject declares openai>=3.0.0,
+# whose signature is `http_client: httpx2.AsyncClient`. Four phantom arg-type
+# errors, zero real defects.
+#
+# Resolution order:
+#   1. $VIRTUAL_ENV          -- an explicitly activated env is always intentional.
+#   2. <main worktree>/.venv -- the repo-local env. Resolved via
+#      `git rev-parse --git-common-dir` so this works from a linked worktree,
+#      which has no .venv of its own.
+#   3. PATH                  -- CI installs the project's requirements into the
+#      job interpreter, so bare mypy is correct there.
+#
+# In case 3 we cannot prove the environment is the project's, so a FAILURE is
+# annotated with the interpreter and its site-packages. That turns the next
+# occurrence of this bug into a one-line diagnosis instead of an afternoon.
+#
+# Kept POSIX-ish and free of bash 4 builtins (no mapfile/associative arrays):
+# macOS still ships /bin/bash 3.2, and this must not depend on a Homebrew bash.
+set -euo pipefail
+
+MYPY_BIN=""
+MYPY_ORIGIN=""
+
+resolve_mypy() {
+    if [ -n "${VIRTUAL_ENV:-}" ] && [ -x "${VIRTUAL_ENV}/bin/mypy" ]; then
+        MYPY_BIN="${VIRTUAL_ENV}/bin/mypy"
+        MYPY_ORIGIN="virtualenv"
+        return 0
+    fi
+
+    # --git-common-dir points at the MAIN worktree's .git even when we are
+    # inside a linked worktree, which is exactly how we find the shared .venv.
+    local common_dir
+    local repo_root
+    if common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+        repo_root=${common_dir%/.git}
+        repo_root=${repo_root%/}
+        if [ -x "${repo_root}/.venv/bin/mypy" ]; then
+            MYPY_BIN="${repo_root}/.venv/bin/mypy"
+            MYPY_ORIGIN="repo venv"
+            return 0
+        fi
+    fi
+
+    local from_path
+    if from_path=$(command -v mypy 2>/dev/null); then
+        MYPY_BIN="${from_path}"
+        MYPY_ORIGIN="PATH"
+        return 0
+    fi
+
+    return 1
+}
+
+if ! resolve_mypy; then
+    echo "run_mypy: no mypy found in \$VIRTUAL_ENV, the repo .venv, or PATH." >&2
+    echo "run_mypy: install the project's dev dependencies, then retry." >&2
+    exit 1
+fi
+
+rc=0
+"${MYPY_BIN}" "$@" || rc=$?
+
+if [ "${rc}" -ne 0 ] && [ "${MYPY_ORIGIN}" = "PATH" ]; then
+    # Only annotate on failure: a green run needs no explanation, and a noisy
+    # header on every commit is how people learn to stop reading hook output.
+    site_packages=$("${MYPY_BIN%/mypy}/python" -c \
+        'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null) || site_packages="unknown"
+    cat >&2 <<EOF
+
+run_mypy: mypy came from PATH, not from a project environment.
+run_mypy:   mypy          ${MYPY_BIN}
+run_mypy:   site-packages ${site_packages}
+run_mypy: If these errors are in files you did not touch, that interpreter's
+run_mypy: packages may not match pyproject.toml -- confirm against CI's
+run_mypy: typecheck job before treating them as real. See CHAOS-3913.
+EOF
+fi
+
+exit "${rc}"


### PR DESCRIPTION
Closes CHAOS-3913.

## Problem

The lefthook `mypy` gate (pre-commit **and** pre-push) failed on commits that CI accepts. It reported 4 `arg-type` errors:

```
src/dev_health_ops/llm/providers/openai.py:564,579
src/dev_health_ops/llm/agent/openai_compatible.py:412
src/dev_health_ops/llm/providers/local.py:163
  Argument "http_client" to "AsyncOpenAI" has incompatible type
  "httpx2._client.AsyncClient"; expected "httpx._client.AsyncClient | None"
```

**None of these are real.** CI's `typecheck-mypy` passes on the same commit. The code and `ebdc8d28d` (#1748) are both correct.

## Cause

`lefthook.yml` invoked bare `mypy`, resolved from PATH, and `[tool.mypy]` sets `python_version` but no `python_executable` — so mypy resolves packages from whichever interpreter it happens to run under. Outside an activated project environment (which is **every git worktree**, since worktrees do not carry the repo root's untracked direnv setup) that is a global interpreter holding a shadow copy of our dependencies:

| Interpreter | openai | `http_client` annotation |
|---|---|---|
| Homebrew python3.14 — what the hook resolved | **2.37.0** | `httpx.AsyncClient \| None` |
| pyenv `dev-health` / CI venv | **3.2.0** | `httpx2.AsyncClient \| None` |

`pyproject.toml` declares `openai>=3.0.0`, and openai 3.x requires `httpx2<3,>=2.7.0`.

That shadow `site-packages` also carries its own `httpx`, `pydantic 2.13.4`, `fastapi 0.136.3` and `sqlalchemy 2.0.52`, so fixing the `openai` version alone would only have deferred this to the next library that drifts. This fixes the class.

## Change

`scripts/run_mypy.sh` resolves, in order:

1. `$VIRTUAL_ENV` — an explicitly activated env is always intentional.
2. The **main worktree's** `.venv`, found via `git rev-parse --git-common-dir`, since a linked worktree has none of its own. This is the case that was broken.
3. PATH — correct in CI, where `requirements.txt` is installed into the job interpreter.

When it fell back to PATH **and** the run failed, it names the interpreter and its `site-packages`. That is the diagnostic whose absence made this expensive to identify. It only prints on failure — a banner on every green commit is how people learn to stop reading hook output.

Deliberately free of bash 4 builtins (no `mapfile`): macOS still ships `/bin/bash` 3.2, so this must not depend on a Homebrew bash being installed. Verified under 3.2 explicitly.

## Verification

Same tree, same commit, from a **worktree** — which is where the divergence appears:

| Command | Result |
|---|---|
| `mypy` (what the hook used to run) | RC=1, 4 phantom errors |
| `scripts/run_mypy.sh` | RC=0, `no issues found in 2184 source files` |

- `lefthook run pre-commit` and `lefthook run pre-push` both pass in a worktree; this branch was pushed **without** `--no-verify`.
- Resolver exercised on all three branches: `$VIRTUAL_ENV`, repo `.venv`, and PATH fallback.
- The PATH-fallback path was verified to still fail on a genuine type error (it annotates, it does not suppress).
- Confirmed to run under `/bin/bash` 3.2.

## Note

This does not touch the shadow packages in Homebrew's `site-packages`; it stops them from being consulted. Cleaning those up is optional and separate — `openai 2.37.0` there appears to have arrived via the `openai-whisper` brew formula, so removing it is not obviously safe.


---

## Update: extended to ruff

After the mypy resolver landed here, the same defect surfaced on **ruff**, harder. In a worktree, bare `ruff` stopped resolving at all:

```
pyenv: ruff: command not found
The `ruff' command exists in these Python versions: dev-health
```

That blocks every commit outright rather than merely reporting phantom errors, so leaving ruff on a PATH lookup would have re-created this issue under a different tool name within a day.

`scripts/run_mypy.sh` is now `scripts/run_py_tool.sh`, taking the tool as its first argument. `ruff-format`, `ruff-fix`, `ruff-format-check`, `ruff-check` and `mypy` all route through it. Resolution order and the PATH-fallback diagnostic are unchanged.

Verified from a worktree where neither bare `ruff` nor bare `mypy` resolves: `lefthook run pre-commit` and `lefthook run pre-push` both pass, and the follow-up commit was made and pushed **with hooks enabled**.

One thing worth knowing for anyone testing this: lefthook stashes unstaged changes during pre-commit, so it runs against **staged** content. Editing the script and running the hook without staging first executes the previous version — which looks like the fix failing when it is only unstaged.
