### PR TITLE
fix(sync): advertise backfill windows at their real boundaries

### DIFF
--- a/internal/synccoverage/intervals_test.go
+++ b/internal/synccoverage/intervals_test.go
@@ -79,22 +79,30 @@ func TestPayloadBackfillScheduleAndStatusSemantics(t *testing.T) {
 		len(workItems["gaps"].([]any)) != 1 {
 		t.Fatalf("work-items = %#v", workItems)
 	}
-	// The gap is real and still counted above -- but its range starts at
-	// 12:00, and the focused-backfill selector only accepts UTC-midnight
-	// boundaries, so no window is offered for it. Python's
-	// _canonical_backfill_windows skips it for the same reason; an empty list
-	// is the server saying "not safely representable by that selector".
+	// The gap starts at 12:00 and is advertised at exactly that instant. Two
+	// earlier revisions got this wrong in opposite directions: the first
+	// emitted {since: "2026-08-10", before: "2026-08-10"} -- a date-only,
+	// half-open range covering nothing, manufactured by truncating a partial
+	// day onto day boundaries -- and the second suppressed the window
+	// entirely, which made the dialog unable to offer any suggestion at all,
+	// since real gaps are almost never midnight-aligned (CHAOS-3915).
 	//
-	// This previously asserted a single {since: "2026-08-10", before:
-	// "2026-08-10"} window: a date-only, half-open range covering nothing,
-	// manufactured by truncating a partial day onto day boundaries. That was
-	// the defect, not the contract.
-	if backfillWindows := payload["backfill_windows"].([]any); len(backfillWindows) != 0 {
-		t.Fatalf("partial-day range must offer no backfill window, got %#v", backfillWindows)
+	// Verbatim boundaries are submittable: the planner chunks on whole days
+	// but keeps the requested instants at the outer edges.
+	backfillWindows := payload["backfill_windows"].([]any)
+	if len(backfillWindows) != 1 {
+		t.Fatalf("partial-day range must offer one backfill window, got %#v", backfillWindows)
+	}
+	window := backfillWindows[0].(map[string]any)
+	if window["since"] != "2026-08-10T12:00:00+00:00" {
+		t.Fatalf("window since = %#v, want the gap's exact start", window["since"])
+	}
+	if window["before"] != "2026-08-11T00:00:00+00:00" {
+		t.Fatalf("window before = %#v, want the gap's exact end", window["before"])
 	}
 }
 
-func TestCanonicalBackfillWindowsAreMidnightBoundedAndScoped(t *testing.T) {
+func TestCanonicalBackfillWindowsAreExactAndScoped(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
 	integrationID := uuid.New()
@@ -122,7 +130,8 @@ func TestCanonicalBackfillWindowsAreMidnightBoundedAndScoped(t *testing.T) {
 				SourceIDs: []string{second.String()}, DatasetKeys: []string{"commits"},
 			},
 			{
-				// Partial day on the `before` end -- skipped, not truncated.
+				// Partial day on the `before` end -- advertised verbatim, and
+				// neither truncated onto a day boundary nor suppressed.
 				Since: day(now.AddDate(0, 0, -5)), Before: now.AddDate(0, 0, -4),
 				SourceIDs: []string{first.String()}, DatasetKeys: []string{"prs"},
 			},
@@ -134,12 +143,17 @@ func TestCanonicalBackfillWindowsAreMidnightBoundedAndScoped(t *testing.T) {
 	}
 
 	windows := payload["backfill_windows"].([]any)
-	if len(windows) != 2 {
+	if len(windows) != 3 {
 		t.Fatalf("backfill windows = %#v", windows)
 	}
-	// Sorted by (since, before, dataset_keys, source_ids): "commits" precedes
-	// "prs" on an identical day range.
+	// Sorted by (since, before, dataset_keys, source_ids): the partial-day
+	// range sorts first on its earlier `since`, and "commits" precedes "prs"
+	// on an identical day range.
 	for index, want := range []map[string]any{
+		{
+			"since": "2026-08-07T00:00:00+00:00", "before": "2026-08-08T12:00:00+00:00",
+			"dataset_keys": "prs", "source_ids": first.String(),
+		},
 		{
 			"since": "2026-08-09T00:00:00+00:00", "before": "2026-08-10T00:00:00+00:00",
 			"dataset_keys": "commits", "source_ids": second.String(),

--- a/internal/synccoverage/payload.go
+++ b/internal/synccoverage/payload.go
@@ -423,12 +423,15 @@ func canonicalBackfillWindows(pairs []pairCoverage) []any {
 		}{{pair.Gaps, "gap"}, {pair.FailedRanges, "failed"}} {
 			for _, interval := range group.Intervals {
 				since, before := interval.Since.UTC(), interval.Before.UTC()
-				if !isUTCMidnight(since) || !isUTCMidnight(before) {
-					continue
-				}
-				// BackfillSelectorRequest requires since < before, so an
-				// empty interval would suggest a window the API rejects
-				// with a 422. Mirrors _canonical_backfill_windows.
+				// Boundaries are advertised verbatim. Gating on exact UTC
+				// midnight matched 0 of 138 real intervals, because coverage
+				// derives from sync run unit windows that start whenever a
+				// sync ran (CHAOS-3915). The planner honours these instants:
+				// it chunks on whole days but keeps the requested edges.
+				//
+				// BackfillSelectorRequest still requires since < before, so an
+				// empty interval would suggest a window the API rejects with a
+				// 422. Mirrors _canonical_backfill_windows.
 				if !since.Before(before) {
 					continue
 				}
@@ -478,14 +481,6 @@ func canonicalBackfillWindows(pairs []pairCoverage) []any {
 		})
 	}
 	return result
-}
-
-// isUTCMidnight reports whether value is exactly 00:00:00.000000000 UTC, the
-// only boundary the focused-backfill selector accepts.
-func isUTCMidnight(value time.Time) bool {
-	utc := value.UTC()
-	return utc.Hour() == 0 && utc.Minute() == 0 &&
-		utc.Second() == 0 && utc.Nanosecond() == 0
 }
 
 func day(value time.Time) time.Time {

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -1551,14 +1551,22 @@ def _canonical_backfill_windows(
 ) -> list[dict[str, Any]]:
     """Return exact, source/dataset-scoped actionable coverage windows.
 
-    The focused-backfill form only accepts day boundaries. We therefore emit a
-    suggestion only when the half-open coverage range has exact UTC-midnight
-    boundaries. This keeps the server authoritative: an explicit empty list
-    means a displayed row is not safely representable by that selector.
+    Boundaries are emitted verbatim, at whatever instant the coverage interval
+    actually has. An earlier revision emitted a suggestion only when both
+    boundaries fell on exact UTC midnight; coverage intervals derive from sync
+    run unit windows, which start whenever a sync happened, so that gate
+    matched 0 of 138 real intervals in a populated org and the feature could
+    never produce a suggestion (CHAOS-3915).
 
-    Empty intervals are dropped for the same reason: BackfillSelectorRequest
-    requires ``since < before``, so emitting one would suggest a window the
-    server rejects with a 422.
+    Sub-day and off-midnight windows are safe to advertise because the planner
+    honours them: ``_backfill_windows`` chunks on whole days but
+    ``_chunk_to_window`` keeps the requested instants at the outer edges, so a
+    02:46:06.501450 boundary is planned as 02:46:06.501450, and a window inside
+    a single day still yields one unit rather than none.
+
+    Empty intervals are still dropped: BackfillSelectorRequest requires
+    ``since < before``, so emitting one would suggest a window the server
+    rejects with a 422.
     """
 
     candidates_by_scope: dict[
@@ -1568,8 +1576,6 @@ def _canonical_backfill_windows(
         for interval in pair.gaps:
             since = ensure_utc(interval.since)
             before = ensure_utc(interval.before)
-            if since.time() != time.min or before.time() != time.min:
-                continue
             if since >= before:
                 continue
             candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(
@@ -1578,8 +1584,6 @@ def _canonical_backfill_windows(
         for interval in pair.failed_ranges:
             since = ensure_utc(interval.since)
             before = ensure_utc(interval.before)
-            if since.time() != time.min or before.time() != time.min:
-                continue
             if since >= before:
                 continue
             candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -849,12 +849,57 @@ def test_canonical_backfill_windows_preserve_pair_scope_and_half_open_bounds():
             "dataset_keys": ["commits"],
             "reasons": ["gap"],
         },
+        # An intra-day window is advertised verbatim rather than skipped: the
+        # planner keeps the requested instants at the window edges, so this is
+        # submittable exactly as shown.
+        {
+            "since": datetime(2026, 1, 2, 10, tzinfo=timezone.utc),
+            "before": datetime(2026, 1, 2, 11, tzinfo=timezone.utc),
+            "source_ids": [source_one],
+            "dataset_keys": ["deployments"],
+            "reasons": ["gap"],
+        },
         {
             "since": datetime(2026, 1, 3, tzinfo=timezone.utc),
             "before": datetime(2026, 1, 4, tzinfo=timezone.utc),
             "source_ids": [source_two],
             "dataset_keys": ["commits"],
             "reasons": ["failed"],
+        },
+    ]
+
+
+def test_canonical_backfill_windows_advertise_off_midnight_boundaries():
+    """Real coverage gaps almost never start at midnight.
+
+    Intervals derive from sync run unit windows, which begin whenever a sync
+    ran. Gating suggestions on exact UTC-midnight boundaries matched 0 of 138
+    real intervals in a populated org, so the focused-backfill dialog could
+    never offer a window (CHAOS-3915). These boundaries are taken verbatim
+    from a live projection.
+    """
+    source_id = "4addf46f-c4d2-4226-b0b0-2e7c51cb91fe"
+    since = datetime(2026, 8, 8, 2, 46, 6, 501450, tzinfo=timezone.utc)
+    before = datetime(2026, 8, 18, 22, 28, 46, 890654, tzinfo=timezone.utc)
+    pair_coverages = [
+        sync_coverage_module._PairCoverage(
+            source_id=source_id,
+            dataset_key="cicd",
+            gaps=[
+                sync_coverage_module.CoverageInterval(
+                    since=since, before=before, source_ids=(source_id,)
+                )
+            ],
+        ),
+    ]
+
+    assert sync_coverage_module._canonical_backfill_windows(pair_coverages) == [
+        {
+            "since": since,
+            "before": before,
+            "source_ids": [source_id],
+            "dataset_keys": ["cicd"],
+            "reasons": ["gap"],
         },
     ]
 


### PR DESCRIPTION
Closes CHAOS-3915. Follows #1788.

## Problem

Every actionable row in the focused-backfill dialog shows "No exact backfill suggestion". The server advertises a window only when **both** boundaries fall on exact UTC midnight, and real coverage data never satisfies that.

Measured across all 29 projections in a populated org, after rebuilding them at the current payload version:

| Metric | Count |
|---|---|
| Gap + failed intervals | 138 |
| Both boundaries at exact UTC midnight | **0** |
| Projections advertising any window | **0 of 29** |

Real boundaries look like this, because coverage derives from sync run unit windows that begin whenever a sync actually ran:

```
cicd   2026-08-08T02:46:06.501450+00:00 -> 2026-08-18T22:28:46.890654+00:00
tests  2026-05-07T13:25:42.994495+00:00 -> 2026-05-08T12:03:28.696534+00:00
```

## Why it stayed hidden

Stale version-1 projections carried date-granular windows from the pre-`71563d38d` algorithm, so suggestions appeared to work. Those same date-granular values are exactly what serialised as naive `2026-08-08T00:00:00` and produced the `timezone_aware` 422 fixed in #1788. Bumping the projection version removed the mask and revealed that the replacement gate matches nothing.

## Change

Advertise boundaries **verbatim**, in both the Python and Go builders. The alternative — snapping outward to whole days — would re-sync up to a day extra at each end; verbatim costs nothing and is honest about the gap.

This is safe because the planner already honours arbitrary instants. Probed directly rather than inferred from reading:

```
same-day sub-window: 1 window
     2026-08-08T02:46:06.501450+00:00 -> 2026-08-08T05:00:00+00:00
real gap (10 days) : 2 windows
     2026-08-08T02:46:06.501450+00:00 -> 2026-08-14T23:59:59.999999+00:00
     2026-08-15T00:00:00+00:00        -> 2026-08-18T22:28:46.890654+00:00
```

`_backfill_windows` chunks on whole days, but `_chunk_to_window` keeps the requested instants at the outer edges, and a window inside a single day still yields one unit rather than none. `BackfillSelectorRequest` already accepts any `AwareDatetime`, so **the request schema is unchanged**.

The `since < before` guard stays — its validator still requires it. `isUTCMidnight` loses its last caller and is deleted.

## Verification

- Two existing tests asserted the old behaviour and were updated deliberately, not deleted. A Go test asserted a partial-day range offers *no* window; it now asserts the exact `12:00Z -> next midnight` window. Its comment records both prior failure modes, since an even earlier revision emitted a zero-width `{since: "2026-08-10", before: "2026-08-10"}`.
- New Python test binds boundaries taken verbatim from a live projection.
- Python 321 passed; Go package and integration suites pass.
- The live payload oracle passes, so the two implementations still agree.

## Companion

Web needs the matching label change: with intra-day windows now advertised, a date-only label would print "2026-08-08 to 2026-08-08" and read like the zero-width bug. That is a separate web PR.

---

## Verified against the real account, not fixtures

Recomputed every projection in memory against the live database (read-only; `generated_at` confirmed unchanged afterwards).

**Before this PR:** 0 windows advertised across 29 configs.

**With verbatim boundaries alone**, 114 candidates appeared — and 66 of them (58%) were exactly one microsecond wide:

```
github  2026-03-12T23:59:59.999999+00:00 -> 2026-03-13T00:00:00+00:00  ['commit-stats']
github  2026-05-07T23:59:59.999999+00:00 -> 2026-05-08T00:00:00+00:00  ['files']
```

Those are day-boundary seams, not gaps: the residue left where one day-bounded window meets the next, exactly `INTERVAL_ADJACENCY_TOLERANCE` wide. They satisfy `since < before`, so they would have been offered as backfills covering no time at all. **No unit fixture would have produced this shape** — it only appears in real coverage data.

The second commit drops any interval no wider than the tolerance. Final state:

| provider | windows | configs with windows |
|---|---|---|
| pagerduty | 24 | 24 |
| github | 17 | 1 |
| gitlab | 7 | 1 |
| linear | 0 | 0 |
| launchdarkly | 0 | 0 |
| **total** | **48** | |

Width distribution: 43 at a day or more, 4 under a day, 1 under an hour, **0 at or below the adjacency tolerance**.

Every one of the 48 was serialised through `SyncCoverageBackfillWindow` and fed back into `BackfillSelectorRequest`, the way web echoes a suggestion:

```
round-trip through BackfillSelectorRequest: accepted=48 rejected=0
```

So on the real account the dialog goes from offering nothing, to offering 48 windows that the server accepts — no 422s, no no-op runs.
