### PR TITLE
fix(ci): route ruff through the project-environment resolver too

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,8 +15,9 @@
 #     files) because per-file mypy is unreliable — it needs full module context.
 #     The glob "*.py" means it only fires when Python files are involved, and the
 #     incremental cache (.mypy_cache/) keeps warm runs well under a second.
-#     It goes through scripts/run_mypy.sh so the check always resolves the
-#     PROJECT environment. Bare `mypy` picks up whatever is first on PATH, and
+#     Every Python tool here goes through scripts/run_py_tool.sh so it always
+#     resolves the PROJECT environment. A bare tool name picks up whatever is
+#     first on PATH -- or nothing at all -- and
 #     in a worktree that is a global interpreter carrying a shadow copy of our
 #     dependencies -- which produced phantom errors in untouched files while CI
 #     stayed green (CHAOS-3913).
@@ -38,15 +39,15 @@ pre-commit:
   commands:
     ruff-format:
       glob: "*.py"
-      run: ruff format {staged_files}
+      run: scripts/run_py_tool.sh ruff format {staged_files}
       stage_fixed: true
     ruff-fix:
       glob: "*.py"
-      run: ruff check --fix {staged_files}
+      run: scripts/run_py_tool.sh ruff check --fix {staged_files}
       stage_fixed: true
     mypy:
       glob: "*.py"
-      run: scripts/run_mypy.sh
+      run: scripts/run_py_tool.sh mypy
       fail_text: "mypy found type errors. Fix them, or `git commit --no-verify` to bypass (discouraged)."
 
 pre-push:
@@ -54,13 +55,13 @@ pre-push:
   commands:
     ruff-format-check:
       glob: "*.py"
-      run: ruff format --check {push_files}
+      run: scripts/run_py_tool.sh ruff format --check {push_files}
       fail_text: "Run `ruff format .` locally, commit the result, push again. Or `git push --no-verify` to bypass."
     ruff-check:
       glob: "*.py"
-      run: ruff check {push_files}
+      run: scripts/run_py_tool.sh ruff check {push_files}
       fail_text: "Run `ruff check --fix .` locally, commit the result, push again. Or `git push --no-verify` to bypass."
     mypy:
       glob: "*.py"
-      run: scripts/run_mypy.sh
+      run: scripts/run_py_tool.sh mypy
       fail_text: "mypy found type errors. Run `mypy` locally, fix them, commit, push again. Or `git push --no-verify` to bypass."

--- a/scripts/run_py_tool.sh
+++ b/scripts/run_py_tool.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 #
-# Run mypy against the PROJECT environment, never against whatever `mypy`
-# happens to be first on PATH.
+# Run a Python dev tool (mypy, ruff, ...) from the PROJECT environment, never
+# from whatever happens to be first on PATH.
 #
-# Why this exists (CHAOS-3913): the lefthook gate used to invoke bare `mypy`.
+# Usage: scripts/run_py_tool.sh <tool> [args...]
+#
+# Why this exists (CHAOS-3913): the lefthook gates used to invoke bare `mypy`
+# and bare `ruff`.
 # Outside an activated project environment -- which is every git worktree, since
 # worktrees do not carry the repo root's untracked direnv setup -- that resolved
 # a global interpreter whose site-packages hold a SHADOW copy of this project's
@@ -15,7 +18,9 @@
 # Concretely: Homebrew's python3.14 site-packages carried openai 2.37.0
 # (`http_client: httpx.AsyncClient`) while pyproject declares openai>=3.0.0,
 # whose signature is `http_client: httpx2.AsyncClient`. Four phantom arg-type
-# errors, zero real defects.
+# errors, zero real defects. The same PATH lookup later stopped resolving at
+# all in a worktree ("pyenv: ruff: command not found"), blocking commits
+# outright -- the same root cause with a louder symptom.
 #
 # Resolution order:
 #   1. $VIRTUAL_ENV          -- an explicitly activated env is always intentional.
@@ -33,13 +38,14 @@
 # macOS still ships /bin/bash 3.2, and this must not depend on a Homebrew bash.
 set -euo pipefail
 
-MYPY_BIN=""
-MYPY_ORIGIN=""
+TOOL_BIN=""
+TOOL_ORIGIN=""
 
-resolve_mypy() {
-    if [ -n "${VIRTUAL_ENV:-}" ] && [ -x "${VIRTUAL_ENV}/bin/mypy" ]; then
-        MYPY_BIN="${VIRTUAL_ENV}/bin/mypy"
-        MYPY_ORIGIN="virtualenv"
+resolve_tool() {
+    local tool="$1"
+    if [ -n "${VIRTUAL_ENV:-}" ] && [ -x "${VIRTUAL_ENV}/bin/${tool}" ]; then
+        TOOL_BIN="${VIRTUAL_ENV}/bin/${tool}"
+        TOOL_ORIGIN="virtualenv"
         return 0
     fi
 
@@ -50,45 +56,52 @@ resolve_mypy() {
     if common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
         repo_root=${common_dir%/.git}
         repo_root=${repo_root%/}
-        if [ -x "${repo_root}/.venv/bin/mypy" ]; then
-            MYPY_BIN="${repo_root}/.venv/bin/mypy"
-            MYPY_ORIGIN="repo venv"
+        if [ -x "${repo_root}/.venv/bin/${tool}" ]; then
+            TOOL_BIN="${repo_root}/.venv/bin/${tool}"
+            TOOL_ORIGIN="repo venv"
             return 0
         fi
     fi
 
     local from_path
-    if from_path=$(command -v mypy 2>/dev/null); then
-        MYPY_BIN="${from_path}"
-        MYPY_ORIGIN="PATH"
+    if from_path=$(command -v "${tool}" 2>/dev/null); then
+        TOOL_BIN="${from_path}"
+        TOOL_ORIGIN="PATH"
         return 0
     fi
 
     return 1
 }
 
-if ! resolve_mypy; then
-    echo "run_mypy: no mypy found in \$VIRTUAL_ENV, the repo .venv, or PATH." >&2
-    echo "run_mypy: install the project's dev dependencies, then retry." >&2
+if [ "$#" -eq 0 ]; then
+    echo "run_py_tool: usage: run_py_tool.sh <tool> [args...]" >&2
+    exit 2
+fi
+TOOL="$1"
+shift
+
+if ! resolve_tool "${TOOL}"; then
+    echo "run_py_tool: no ${TOOL} in \$VIRTUAL_ENV, the repo .venv, or PATH." >&2
+    echo "run_py_tool: install the project's dev dependencies, then retry." >&2
     exit 1
 fi
 
 rc=0
-"${MYPY_BIN}" "$@" || rc=$?
+"${TOOL_BIN}" "$@" || rc=$?
 
-if [ "${rc}" -ne 0 ] && [ "${MYPY_ORIGIN}" = "PATH" ]; then
+if [ "${rc}" -ne 0 ] && [ "${TOOL_ORIGIN}" = "PATH" ]; then
     # Only annotate on failure: a green run needs no explanation, and a noisy
     # header on every commit is how people learn to stop reading hook output.
-    site_packages=$("${MYPY_BIN%/mypy}/python" -c \
+    site_packages=$("$(dirname "${TOOL_BIN}")/python" -c \
         'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null) || site_packages="unknown"
     cat >&2 <<EOF
 
-run_mypy: mypy came from PATH, not from a project environment.
-run_mypy:   mypy          ${MYPY_BIN}
-run_mypy:   site-packages ${site_packages}
-run_mypy: If these errors are in files you did not touch, that interpreter's
-run_mypy: packages may not match pyproject.toml -- confirm against CI's
-run_mypy: typecheck job before treating them as real. See CHAOS-3913.
+run_py_tool: ${TOOL} came from PATH, not from a project environment.
+run_py_tool:   ${TOOL} ${TOOL_BIN}
+run_py_tool:   site-packages ${site_packages}
+run_py_tool: If these errors are in files you did not touch, that interpreter's
+run_py_tool: packages may not match pyproject.toml -- confirm against CI
+run_py_tool: before treating them as real. See CHAOS-3913.
 EOF
 fi
 


### PR DESCRIPTION
Follows #1789 (CHAOS-3913), which landed the mypy half. This is the other half; it was written against that branch after it merged, so it needs its own PR.

## Problem

#1789 routed only `mypy` through the project-environment resolver and left `ruff` on a PATH lookup. That was an incomplete fix, and ruff hit the same defect harder within the hour. In a worktree:

```
pyenv: ruff: command not found
The `ruff' command exists in these Python versions: dev-health
```

`mypy` failing that way reports phantom errors in untouched files. `ruff` failing that way **blocks the commit outright**, because `ruff-format` and `ruff-fix` are `stage_fixed` commands in pre-commit. Leaving ruff on PATH resolution would have re-created CHAOS-3913 under a different tool name.

## Change

`scripts/run_mypy.sh` becomes `scripts/run_py_tool.sh`, taking the tool as its first argument. All five Python stages route through it: `ruff-format`, `ruff-fix`, `ruff-format-check`, `ruff-check`, `mypy`.

Resolution order and the PATH-fallback diagnostic are unchanged from #1789:

1. `$VIRTUAL_ENV` — an explicitly activated env is always intentional.
2. The **main worktree's** `.venv`, via `git rev-parse --git-common-dir`, since a linked worktree has none of its own. This is the case that breaks.
3. `PATH` — correct in CI, where requirements are installed into the job interpreter.

## Verification

Run from a worktree where **neither** bare `ruff` nor bare `mypy` resolves:

- `lefthook run pre-commit` and `lefthook run pre-push`: both pass.
- Resolver exercised on all three branches plus its two error paths (no argument → exit 2; unknown tool → exit 1 with a message).
- Confirmed under `/bin/bash` 3.2 — macOS still ships it, so the hook must not depend on a Homebrew bash. That is why the script uses no bash 4 builtins.
- The PATH fallback still fails on a genuine type error rather than suppressing it; it only annotates.

`ci/local_validate.sh`: **GATE PASSED, 8/8 stages executed** — `lint_format, lint_check, typecheck, ch_probe, ch_scratch_create, ch_migrate, unit_suite, ch_argmax_proof`.

## Note for anyone testing this

lefthook stashes unstaged changes during pre-commit, so it runs against **staged** content. Editing the script and running the hook without staging first executes the previous version — which looks like the fix failing when it is only unstaged. That cost me a wrong diagnosis before I spotted it.
