### PR TITLE
fix(sync): drop day-boundary seams from backfill suggestions

### DIFF
--- a/internal/synccoverage/payload.go
+++ b/internal/synccoverage/payload.go
@@ -429,10 +429,13 @@ func canonicalBackfillWindows(pairs []pairCoverage) []any {
 				// sync ran (CHAOS-3915). The planner honours these instants:
 				// it chunks on whole days but keeps the requested edges.
 				//
-				// BackfillSelectorRequest still requires since < before, so an
-				// empty interval would suggest a window the API rejects with a
-				// 422. Mirrors _canonical_backfill_windows.
-				if !since.Before(before) {
+				// Intervals no wider than the adjacency tolerance are not gaps:
+				// they are the seam where one day-bounded window meets the next
+				// (23:59:59.999999 -> 00:00:00). On real data 66 of 114
+				// candidates were exactly one microsecond wide. This subsumes
+				// the empty-interval case, which BackfillSelectorRequest would
+				// reject with a 422. Mirrors _canonical_backfill_windows.
+				if before.Sub(since) <= intervalAdjacencyTolerance {
 					continue
 				}
 				key := scope{

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -1564,9 +1564,14 @@ def _canonical_backfill_windows(
     02:46:06.501450 boundary is planned as 02:46:06.501450, and a window inside
     a single day still yields one unit rather than none.
 
-    Empty intervals are still dropped: BackfillSelectorRequest requires
-    ``since < before``, so emitting one would suggest a window the server
-    rejects with a 422.
+    Intervals no wider than ``INTERVAL_ADJACENCY_TOLERANCE`` are dropped. They
+    are not gaps: they are the seam between two ranges the merge step already
+    treats as adjacent, and they show up as ``23:59:59.999999 -> 00:00:00``
+    where one day-bounded window meets the next. On real data 66 of 114
+    candidate windows were exactly one microsecond wide, so advertising them
+    would hand the operator 66 buttons that each plan a run covering no time
+    at all. This subsumes the empty-interval case, which
+    BackfillSelectorRequest would reject outright with a 422.
     """
 
     candidates_by_scope: dict[
@@ -1576,7 +1581,7 @@ def _canonical_backfill_windows(
         for interval in pair.gaps:
             since = ensure_utc(interval.since)
             before = ensure_utc(interval.before)
-            if since >= before:
+            if before - since <= INTERVAL_ADJACENCY_TOLERANCE:
                 continue
             candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(
                 "gap"
@@ -1584,7 +1589,7 @@ def _canonical_backfill_windows(
         for interval in pair.failed_ranges:
             since = ensure_utc(interval.since)
             before = ensure_utc(interval.before)
-            if since >= before:
+            if before - since <= INTERVAL_ADJACENCY_TOLERANCE:
                 continue
             candidates_by_scope[(since, before, pair.source_id, pair.dataset_key)].add(
                 "failed"

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -904,6 +904,35 @@ def test_canonical_backfill_windows_advertise_off_midnight_boundaries():
     ]
 
 
+def test_canonical_backfill_windows_drop_day_boundary_seams():
+    """A one-microsecond seam is not a gap.
+
+    Where one day-bounded window meets the next, coverage leaves a residue of
+    exactly INTERVAL_ADJACENCY_TOLERANCE -- the same span the merge step treats
+    as adjacent. These boundaries are taken verbatim from a live projection; 66
+    of 114 candidate windows in a populated org had this exact shape, and
+    advertising them would offer a backfill covering no time at all.
+    """
+    source_id = "11111111-1111-1111-1111-111111111111"
+    pair_coverages = [
+        sync_coverage_module._PairCoverage(
+            source_id=source_id,
+            dataset_key="commit-stats",
+            gaps=[
+                sync_coverage_module.CoverageInterval(
+                    since=datetime(
+                        2026, 3, 12, 23, 59, 59, 999999, tzinfo=timezone.utc
+                    ),
+                    before=datetime(2026, 3, 13, tzinfo=timezone.utc),
+                    source_ids=(source_id,),
+                )
+            ],
+        ),
+    ]
+
+    assert sync_coverage_module._canonical_backfill_windows(pair_coverages) == []
+
+
 def test_canonical_backfill_windows_drop_empty_intervals():
     """An empty interval is not a submittable selector.
 


### PR DESCRIPTION
Second half of CHAOS-3915. #1790 merged with only its first commit, so this needs its own PR — and the branch is currently in the worse of the two states without it.

## Why this is needed now

#1790 made the server advertise boundaries verbatim. That is correct, but on real data it surfaces a second class of non-gap: where one day-bounded coverage window meets the next, the merge step leaves a residue of exactly `INTERVAL_ADJACENCY_TOLERANCE`.

```
github  2026-03-12T23:59:59.999999+00:00 -> 2026-03-13T00:00:00+00:00  ['commit-stats']
github  2026-05-07T23:59:59.999999+00:00 -> 2026-05-08T00:00:00+00:00  ['files']
```

One microsecond wide. It satisfies `since < before`, so it is offered as a backfill covering no time at all.

Measured against the real account: **66 of 114 candidate windows (58%)** have exactly this shape. As merged, the focused-backfill dialog shows 114 suggestions of which two thirds are no-ops — arguably worse than the zero it showed before, because each one looks actionable.

No unit fixture produces this shape; it only appears in real coverage data.

## Change

Drop any interval no wider than the tolerance, in both the Python and Go builders. The merge step already treats spans that close as adjacent, so calling the residue a gap contradicts it. This subsumes the empty-interval case the previous `since < before` guard covered.

## Result on the real account

| | as merged (#1790) | with this PR |
|---|---|---|
| advertised windows | 114 | **48** |
| at/below adjacency tolerance | 66 | **0** |
| round-trip through `BackfillSelectorRequest` | — | accepted=48, rejected=0 |

Widths after: 43 at a day or more, 4 under a day, 1 under an hour.

## Verification

- Regression test uses boundaries taken verbatim from a live projection, not invented ones.
- Python and Go suites pass; Go integration suite passes; the live payload oracle passes, so the two implementations still agree.
- `ruff check` clean via the project venv. The pre-push `ruff-check` hook reports a failure only because bare `ruff` does not resolve in a worktree — the defect #1791 fixes.