### PR TITLE
fix(scheduler): stop interval schedules latching on their baseline

### DIFF
--- a/internal/scheduler/fixed/interval_latch_test.go
+++ b/internal/scheduler/fixed/interval_latch_test.go
@@ -1,0 +1,133 @@
+package fixed
+
+import (
+	"testing"
+	"time"
+)
+
+func intervalSkipSchedule() Schedule {
+	return Schedule{
+		ID: "sync_coverage_refresh", Native: true,
+		Cadence: EveryInterval(300 * time.Second), Timezone: "UTC",
+		CatchUp: CatchUpSkip, UniquenessWindow: time.Hour,
+		TargetKind: "system.sync_coverage_refresh", ProducerID: "sync_coverage_refresh",
+		MaxAttempts: 3, AlertThreshold: 30 * time.Minute,
+		Rationale: "regression fixture for CHAOS-3914",
+	}
+}
+
+// An interval schedule with CatchUpSkip must keep producing work.
+//
+// CHAOS-3914: counting grid boundaries to decide staleness made this latch on
+// the cold-start baseline forever. The interval guard defers the first run to
+// the boundary after anchor.ObservedAt+period -- a process almost never starts
+// exactly on a grid point -- so scheduledFor lands two boundaries past the
+// anchor and a boundary count calls that "stale" on a scheduler that missed
+// nothing. In production sync_coverage_refresh recorded 314 baselines and 1
+// materialized occurrence, and the coverage projector never ran.
+func TestIntervalSkipScheduleKeepsMaterializing(t *testing.T) {
+	t.Parallel()
+	schedule := intervalSkipSchedule()
+	// Start 7s after a grid point: an ordinary process start, not a contrived one.
+	start := time.Date(2026, 8, 18, 12, 0, 7, 0, time.UTC)
+
+	var anchor *Anchor
+	materialized, baselines := 0, 0
+	for i := 0; i < 4*60*4; i++ { // 4 hours of 15s polls, the loop's default
+		now := start.Add(time.Duration(i) * 15 * time.Second)
+		decision, err := DueOccurrence(schedule, now, anchor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if decision.Occurrence == nil {
+			continue
+		}
+		if decision.ColdStart || decision.SkippedStale {
+			baselines++
+		} else {
+			materialized++
+		}
+		// The engine records every emitted occurrence, baseline or not.
+		anchor = &Anchor{
+			ScheduledFor: decision.Occurrence.ScheduledFor,
+			ObservedAt:   decision.Occurrence.ObservedAt,
+		}
+	}
+
+	if materialized == 0 {
+		t.Fatalf("interval schedule never materialized in 4h: baselines=%d", baselines)
+	}
+	// One cold-start baseline is expected; everything after it is real work.
+	if baselines != 1 {
+		t.Errorf("baselines = %d, want exactly 1 (the cold start)", baselines)
+	}
+
+	// 4h at a 300s cadence spans 48 boundaries, so ~47 runs would be exact
+	// pacing. We get about half that, and the shortfall is a SEPARATE defect
+	// this fix deliberately does not change: the guard above measures the next
+	// eligible instant from the anchor's OBSERVED time, which lands a poll
+	// jitter after the boundary, so `earliest` falls just past the following
+	// grid point and the schedule waits for the one after that. Effective rate
+	// is therefore half the nominal cadence -- a 300s schedule runs every 600s.
+	//
+	// Correcting that means measuring from the anchor's scheduled boundary
+	// instead, which breaks TestIntervalScheduleWaitsAFullPeriodAfterItsBaseline:
+	// after a 10:02 cold start the next grid point is 10:05, and firing three
+	// minutes after activation is the regression that test exists to prevent.
+	// Distinguishing the cold-start anchor from a steady-state one needs the
+	// ledger to expose whether the last occurrence was a baseline, which is a
+	// contract change rather than a bug fix. Asserted here so the dilation is
+	// recorded rather than mistaken for correct pacing.
+	const boundariesIn4h = 48
+	if materialized < boundariesIn4h/2-2 {
+		t.Errorf("materialized = %d in 4h, want at least %d (every other boundary)",
+			materialized, boundariesIn4h/2-2)
+	}
+	if materialized > boundariesIn4h-4 {
+		t.Logf("materialized = %d: pacing improved beyond every-other-boundary; "+
+			"if the observation-anchored guard was fixed, tighten this bound", materialized)
+	}
+}
+
+// The staleness skip must still fire after a REAL outage, otherwise this fix
+// would trade a latch for a backdated run.
+func TestIntervalSkipScheduleStillSkipsAfterOutage(t *testing.T) {
+	t.Parallel()
+	schedule := intervalSkipSchedule()
+	anchorAt := time.Date(2026, 8, 18, 12, 0, 7, 0, time.UTC)
+	anchor := &Anchor{
+		ScheduledFor: time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC),
+		ObservedAt:   anchorAt,
+	}
+
+	// The first boundary the guard releases (12:10, since `earliest` is
+	// 12:05:07 and 12:05 falls before it) must produce work, not a stale
+	// re-baseline. This is the case that latched before CHAOS-3914.
+	decision, err := DueOccurrence(schedule, mustUTC("2026-08-18T12:10:05Z"), anchor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Occurrence == nil || decision.SkippedStale {
+		t.Fatalf("first released boundary: occurrence=%v skippedStale=%v, want work",
+			decision.Occurrence != nil, decision.SkippedStale)
+	}
+
+	// An hour of downtime is more than two periods: resume without claiming
+	// the missed buckets ran.
+	decision, err = DueOccurrence(schedule, anchorAt.Add(time.Hour), anchor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Occurrence == nil || !decision.SkippedStale {
+		t.Fatalf("after an hour gap: occurrence=%v skippedStale=%v, want a stale re-baseline",
+			decision.Occurrence != nil, decision.SkippedStale)
+	}
+}
+
+func mustUTC(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return parsed.UTC()
+}

--- a/internal/scheduler/fixed/schedule.go
+++ b/internal/scheduler/fixed/schedule.go
@@ -269,6 +269,33 @@ func DueOccurrence(
 		// the process was absent, or prune under a cutoff the next night
 		// supersedes anyway. Re-baselining records where the schedule resumed
 		// without claiming work happened.
+		//
+		// Interval cadences measure that gap as ELAPSED TIME, not as grid
+		// distance, for the same reason the guard above exists: their grid
+		// points carry no meaning of their own. Counting boundaries here made
+		// every interval schedule with CatchUpSkip latch permanently
+		// (CHAOS-3914). The guard above defers a run to the boundary after
+		// `anchor.ObservedAt + period`, because a process almost never starts
+		// exactly on a grid point; by the time the run is allowed, scheduledFor
+		// has advanced two boundaries past the anchor, so a boundary count
+		// reports "stale" on a scheduler that never missed anything. It then
+		// re-baselines, observes a few seconds late again, and repeats forever.
+		// Live evidence: sync_coverage_refresh recorded 314 cold-start
+		// baselines and exactly 1 materialized occurrence, so the sync coverage
+		// projector never ran.
+		if schedule.Cadence.Kind == CadenceInterval {
+			// `earliest` is the instant the guard above releases this schedule,
+			// and the boundary it releases is the first grid point at or after
+			// it -- necessarily within one period of `earliest`. So scheduledFor
+			// landing a full period or more beyond `earliest` is the only proof
+			// that an allowed boundary went unrun. Anything closer is the guard
+			// working as designed, not a missed run.
+			earliest := lastRecorded.ObservedAt.UTC().Add(schedule.Cadence.Period())
+			if scheduledFor.Sub(earliest) >= schedule.Cadence.Period() {
+				return DueDecision{Occurrence: &occurrence, SkippedStale: true}, nil
+			}
+			break
+		}
 		priorBoundary, ok := schedule.Cadence.Previous(scheduledFor.Add(-time.Second), location)
 		if ok && anchor.Before(priorBoundary) {
 			return DueDecision{Occurrence: &occurrence, SkippedStale: true}, nil


### PR DESCRIPTION
Refs CHAOS-3914.

## Problem

Every fixed schedule with an **interval cadence and `CatchUpSkip`** stopped producing work after its cold-start baseline, permanently. The ledger says so directly:

```
schedule_id            | status       | skip_reason         | count
sync_coverage_refresh  | skipped      | cold_start_baseline |   314
sync_coverage_refresh  | materialized |                     |     1
scheduled_reports_dispatch | skipped  | cold_start_baseline |   315
```

Every **wall-clock** schedule took its baseline once and then ran normally (`phone_home_heartbeat`: 1 baseline, 6 materialized), which is what narrowed this to interval cadences.

The visible consequence: the Go sync coverage projector never ran, so `sync_coverage_projections` were never rebuilt — five days stale in the local stack, and `system.sync_coverage_refresh` never appeared in `river.river_job` even once. That looked like a queue or routing fault; it was neither. The job was never produced.

## Mechanism

Two guards interact, and neither is wrong alone.

1. `DueOccurrence` defers an interval schedule until the first grid point at or after `anchor.ObservedAt + period`. An observation lands a poll jitter *after* its boundary, so that instant falls just past the following grid point — and the run is deferred to the one after that, **two boundaries beyond the anchor**.
2. The `CatchUpSkip` staleness check then asks whether the anchor sits behind the *previous* boundary. After (1) it always does. So it re-baselines without producing work.

The new anchor is observed a few seconds late in turn, so this repeats forever. Nothing was ever actually missed — the scheduler was healthy the whole time.

## Change

Measure staleness for interval cadences as **distance past the instant the guard releases**, not as grid distance:

```go
earliest := lastRecorded.ObservedAt.UTC().Add(schedule.Cadence.Period())
if scheduledFor.Sub(earliest) >= schedule.Cadence.Period() { ... stale ... }
```

The released boundary is by construction within one period of `earliest`, so only a `scheduledFor` a full period or more beyond it proves an allowed boundary went unrun. Wall-clock cadences keep the boundary comparison unchanged: 01:00 means 01:00.

## Verification

The regression test simulates the real loop — 15s polls (the loop default) over 4 hours at a 300s cadence, feeding each decision back into the anchor exactly as the engine does:

| | before | after |
|---|---|---|
| materialized | **0** | 23 |
| baselines | 24 | 1 |

Reverting `schedule.go` alone reproduces `never materialized in 4h`, so the test is bound to this fix and not to something incidental.

A second test asserts the staleness skip **still fires after a real outage** — an hour of downtime re-baselines rather than backdating a run. Without that, this would trade a latch for a wrong run.

`ci/local_validate.sh`: **GATE PASSED, 8/8 stages**. `ci/check_go.sh all`: **rc=0, 118 packages**.

## A known deviation this does NOT fix

23 is not the ~47 that exact pacing would give. The observation-anchored guard halves the effective rate of every interval schedule — a 300s cadence runs every 600s.

Correcting that means measuring from the anchor's *scheduled* boundary, which breaks `TestIntervalScheduleWaitsAFullPeriodAfterItsBaseline`: after a 10:02 cold start the next grid point is 10:05, and firing three minutes after activation is exactly the regression that test exists to prevent. I tried it and reverted it. Telling a cold-start anchor apart from a steady-state one needs the ledger to expose whether the last occurrence was a baseline — a contract change, not a bug fix.

The test asserts the halved rate explicitly, with the reasoning inline, so it is recorded rather than mistaken for correct pacing. Happy to do the ledger change as a follow-up if you want exact cadence.