### PR TITLE
ci(images): publish the Go runtime images to ghcr

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -197,3 +197,168 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/dev-hops-${{ matrix.target }}:${{ steps.meta.outputs.version }}
+
+  # ---------------------------------------------------------------------------
+  # Go runtime images (CHAOS-3923)
+  #
+  # Every deployment renderer -- deploy/docker-compose/compose.go-workers.yml,
+  # deploy/helm/dev-health/values.yaml, deploy/kubernetes/go-workers.yaml --
+  # references ghcr.io/<owner>/dev-health-go-<target>, but nothing published
+  # them: go.yml builds these same targets with a plain `docker build` for Trivy
+  # and SBOM only. A host with just Docker installed therefore could not start
+  # the Go topology at all, and the failure looked like a registry permission
+  # problem rather than a missing publish job.
+  #
+  # The target list is ci/check_go_containers.sh's ALL_TARGETS, kept whole on
+  # purpose: a second, shorter list is how the next target goes unpublished.
+  # ---------------------------------------------------------------------------
+  go-build:
+    name: Build Go Image
+    needs: [changes]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'release' ||
+      needs.changes.outputs.code == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - worker
+          - scheduler
+          - reconciler
+          - stream-runner
+          - operator
+          - contractcheck
+          - migrate
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-26.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.event.pull_request.head.sha || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Determine build metadata
+        id: versioning
+        run: |
+          SHA=$(git rev-parse HEAD)
+          VERSION="$(echo "${SHA}" | cut -c1-7)"
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          # The commit timestamp, not "now": the image stays byte-reproducible
+          # from a given commit, which is what ci/check_go_containers.sh asserts
+          # with its own fixed metadata.
+          EPOCH=$(git log -1 --pretty=%ct)
+          {
+            echo "version=${VERSION}"
+            echo "commit=${SHA}"
+            echo "build_time=$(date -u -d "@${EPOCH}" +%Y-%m-%dT%H:%M:%SZ)"
+            echo "source_date_epoch=${EPOCH}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/go-worker.Dockerfile
+          target: ${{ matrix.target }}
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ steps.versioning.outputs.version }}
+            COMMIT=${{ steps.versioning.outputs.commit }}
+            BUILD_TIME=${{ steps.versioning.outputs.build_time }}
+            SOURCE_DATE_EPOCH=${{ steps.versioning.outputs.source_date_epoch }}
+          tags: ghcr.io/${{ github.repository_owner }}/dev-health-go-${{ matrix.target }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true') }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Export digest
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true')
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-go-${{ matrix.target }}-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  go-merge:
+    name: Merge Go Digests
+    runs-on: ubuntu-latest
+    needs: go-build
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true')
+    strategy:
+      matrix:
+        target:
+          - worker
+          - scheduler
+          - reconciler
+          - stream-runner
+          - operator
+          - contractcheck
+          - migrate
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: /tmp/digests
+          pattern: digests-go-${{ matrix.target }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/dev-health-go-${{ matrix.target }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || (github.event_name == 'release' && !github.event.release.prerelease) }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ github.repository_owner }}/dev-health-go-${{ matrix.target }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/dev-health-go-${{ matrix.target }}:${{ steps.meta.outputs.version }}

--- a/tests/tooling/test_go_image_publishing.py
+++ b/tests/tooling/test_go_image_publishing.py
@@ -1,0 +1,78 @@
+"""Every Go image a deployment renderer names must be one CI publishes.
+
+CHAOS-3923: the renderers referenced ``ghcr.io/<owner>/dev-health-go-*`` while
+no workflow published those targets -- ``go.yml`` builds them with a plain
+``docker build`` for Trivy and SBOM only. A host with just Docker installed
+could not start the Go topology, and the pull failure read as a registry
+permission problem rather than a missing publish job. Nothing failed in CI,
+because no test connected the names renderers use to the names CI pushes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "docker-images.yml"
+CONTAINER_GATE = ROOT / "ci" / "check_go_containers.sh"
+DEPLOY = ROOT / "deploy"
+
+IMAGE_PREFIX = "dev-health-go-"
+_ALL_TARGETS = re.compile(r"^readonly ALL_TARGETS=\((?P<targets>[^)]*)\)", re.MULTILINE)
+_GHCR_IMAGE = re.compile(
+    r"ghcr\.io/[^/\s]+/" + IMAGE_PREFIX + r"(?P<target>[a-z0-9-]+)"
+)
+
+
+def _gate_targets() -> set[str]:
+    """The Go container targets ci/check_go_containers.sh knows about."""
+    match = _ALL_TARGETS.search(CONTAINER_GATE.read_text(encoding="utf-8"))
+    assert match is not None, "ALL_TARGETS is no longer declared as one literal array"
+    return set(match.group("targets").split())
+
+
+def _published_targets(job: str) -> set[str]:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return set(workflow["jobs"][job]["strategy"]["matrix"]["target"])
+
+
+def _renderer_image_targets() -> dict[str, set[Path]]:
+    """Map each referenced Go image target to the renderers that name it."""
+    referenced: dict[str, set[Path]] = {}
+    for path in sorted(DEPLOY.rglob("*")):
+        if path.suffix not in {".yml", ".yaml"} or "vendor" in path.parts:
+            continue
+        for match in _GHCR_IMAGE.finditer(path.read_text(encoding="utf-8")):
+            referenced.setdefault(match.group("target"), set()).add(path)
+    return referenced
+
+
+def test_publish_matrix_covers_every_container_gate_target() -> None:
+    # One list, not two. A second, shorter publish list is exactly how the next
+    # target ships unpublished.
+    assert _published_targets("go-build") == _gate_targets()
+
+
+def test_merge_matrix_matches_the_build_matrix() -> None:
+    # A target built but never merged pushes digests that no tag ever points
+    # at, which looks published until something tries to pull it.
+    assert _published_targets("go-merge") == _published_targets("go-build")
+
+
+def test_every_referenced_go_image_is_published() -> None:
+    published = _published_targets("go-merge")
+    referenced = _renderer_image_targets()
+    assert referenced, (
+        "no renderer references a Go image; the guard would pass vacuously"
+    )
+    unpublished = {
+        target: sorted(str(path.relative_to(ROOT)) for path in paths)
+        for target, paths in referenced.items()
+        if target not in published
+    }
+    assert not unpublished, (
+        f"deployment renderers name Go images that CI never publishes: {unpublished}"
+    )


### PR DESCRIPTION
## Summary

Closes CHAOS-3923.

Every deployment renderer references `ghcr.io/<owner>/dev-health-go-<target>`, but nothing published those images:

- `docker-images.yml` built only `[runner, api]` from `docker/Dockerfile`.
- `go.yml:244-258` builds the `docker/go-worker.Dockerfile` targets with a plain `docker build`, tagged `dev-health-go-<target>:security` for Trivy and SBOM only. Nothing is pushed.

A host with only Docker installed could not start the Go topology at all, and the failure arrives as an image pull error that reads like a registry permission problem rather than a missing publish job.

## Changes

- `go-build` / `go-merge` jobs mirroring the existing `build` / `merge` pair: multi-arch push-by-digest, then one manifest list per target, same tag scheme (`latest` on main, semver on release, short SHA).
- Publish matrix is `ci/check_go_containers.sh`'s `ALL_TARGETS` in full. `operator` matters as much as the four runtime images — it carries `dev-health-workerctl`, the only binary that can apply a route, and therefore the only way to finish a cutover. `dev-health-workerctl` is **not** in the runner image, unlike `dev-health-worker-migrate` (`docker/Dockerfile:86`), so there is no fallback path for it.
- Build metadata comes from the commit, not the clock: `BUILD_TIME` and `SOURCE_DATE_EPOCH` are both the commit timestamp, so a published image stays reproducible from its commit the way `ci/check_go_containers.sh` asserts with its own fixed metadata.
- `tests/tooling/test_go_image_publishing.py` binds the three lists: publish matrix == `ALL_TARGETS`, merge matrix == build matrix, and every ghcr Go image any renderer names is one the workflow publishes.

## TEST-EVIDENCE

- `tests/tooling/test_go_image_publishing.py` — 3 passed.
- Negative controls, all three observed failing before passing:
  - removing one target from `go-build` fails both the `ALL_TARGETS` and build/merge-parity guards;
  - pointing a Helm value at `dev-health-go-nonesuch` fails the renderer guard with the offending file named.
- `actionlint` introduces no new finding class: the added jobs contribute one more `ubuntu-26.04-arm` label warning and two more `SC2046` from the identical `imagetools create` line, both of which the existing `build`/`merge` jobs already produce. The one `SC2086` is pre-existing in the Python versioning step.
- `ruff` and `mypy` clean via lefthook.

## RISK-NOTES

- First push to `main` creates seven new ghcr packages. They inherit the repository's default package visibility; confirm it matches `dev-hops-runner` before a pull-only host tries to authenticate.
- CI cost rises by 14 build jobs (7 targets x 2 platforms). They are small distroless images sharing the gha cache.
- Not addressed here: the security-scan job still builds its own artifact with fixed metadata rather than scanning the published image. Different `VERSION`/`COMMIT` ldflags mean the scanned bytes are not identical to the published bytes. Worth a follow-up.
- `deploy/docker-compose/compose.go-workers.yml` still uses `build:` contexts for `go-river-migrate` and `go-contractcheck`. Now that both targets publish, switching them to `image:` would make that overlay usable on a pull-only host; left out to keep this change to publishing.