### PR TITLE
fix(ci): rebuild images when the publish workflow itself changes

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -59,6 +59,13 @@ jobs:
               - '.dockerignore'
               - 'deploy/**'
               - 'Makefile'
+              # A change to this workflow IS a change to how images are built.
+              # Without this line the publish pipeline cannot republish itself:
+              # the CHAOS-3923 Go publish jobs merged to main and every build
+              # job skipped, because nothing in this list matches .github/**.
+              # `changes` went green while publishing zero images, so the run
+              # reported success and the registry stayed empty.
+              - '.github/workflows/docker-images.yml'
 
   build:
     name: Build Image

--- a/tests/tooling/test_go_image_publishing.py
+++ b/tests/tooling/test_go_image_publishing.py
@@ -76,3 +76,17 @@ def test_every_referenced_go_image_is_published() -> None:
     assert not unpublished, (
         f"deployment renderers name Go images that CI never publishes: {unpublished}"
     )
+
+
+def test_the_publish_workflow_rebuilds_when_it_changes() -> None:
+    """A change to the publish pipeline must republish.
+
+    The Go publish jobs landed on main and every build job skipped: the
+    `changes` filter matches src/cmd/internal/docker/deploy paths, none of
+    which a workflow edit touches. `changes` went green, the run reported
+    success, and the registry stayed empty -- the measurement said fine
+    because it never looked at the thing that changed.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    filters = yaml.safe_load(workflow["jobs"]["changes"]["steps"][1]["with"]["filters"])
+    assert ".github/workflows/docker-images.yml" in filters["code"]


### PR DESCRIPTION
## Summary

Follow-up to #1795 (CHAOS-3923). The Go publish jobs merged to main and published nothing.

[Run 32267877857](https://github.com/full-chaos/dev-health-ops/actions/runs/32267877857) on the merge commit:

```
changes            success
Build Go Image     skipped
Build Image        skipped
Merge Go Digests   skipped
Merge Digests      skipped
```

The `code` paths filter matches `src/**`, `cmd/**`, `internal/**`, `docker/**`, `deploy/**` and friends. Nothing in it matches `.github/**`, and the merge commit touched only the workflow and a test — so `needs.changes.outputs.code` was `false` and every build job skipped.

The run reported **success** while publishing zero images. A green publish workflow that published nothing looks exactly like one that published nine, unless you open the job list.

This is not new to the Go jobs: the pre-existing `runner`/`api` build has never rebuilt on a change to its own pipeline either. It only ever republished as a side effect of a source change landing in the same commit.

## Changes

- Add `.github/workflows/docker-images.yml` to the `code` filter, so editing the publish pipeline republishes.
- `test_the_publish_workflow_rebuilds_when_it_changes` asserts the path stays in the filter.

## TEST-EVIDENCE

- `tests/tooling/test_go_image_publishing.py` — 4 passed.
- Negative control: removing the filter line fails the new test, and only that test. Verified failing before passing.
- The images from #1795 are being published now by a `workflow_dispatch` run with `push_images=true`, which does not depend on the filter.

## RISK-NOTES

- Widens what triggers an image rebuild by exactly one file. Editing this workflow now costs a full 18-job build matrix, which is the intended behaviour rather than a side effect.
- Does not address the reverse gap: a `changes`-gated workflow that skips everything still reports success. Making "published nothing" a distinguishable outcome is a larger change than this fix.