### PR TITLE
fix(deploy): package River role provisioning with the image that runs it

### DIFF
--- a/deploy/docker-compose/compose.go-workers.yml
+++ b/deploy/docker-compose/compose.go-workers.yml
@@ -50,7 +50,9 @@ services:
   # role provisioning only after it completes so guarded grants see every
   # current semantic table, including an already-initialized local volume.
   go-river-provision:
-    image: postgres:18-alpine
+    # The Ops runtime image, not a bare postgres client image: it carries both
+    # psql and the provisioning SQL, so this step needs no source checkout.
+    image: ${DEV_HEALTH_IMAGE:-ghcr.io/your-org/dev-health-ops:latest}
     profiles: [go-workers]
     restart: "no"
     read_only: true
@@ -79,9 +81,7 @@ services:
           --set=domain_password="$$RIVER_DOMAIN_DATABASE_PASSWORD" \
           --set=queue_password="$$RIVER_QUEUE_DATABASE_PASSWORD" \
           --set=coordinator_password="$$RIVER_COORDINATOR_DATABASE_PASSWORD" \
-          --file=/opt/dev-health/provision_river_roles.sql
-    volumes:
-      - ../../scripts/worker/provision_river_roles.sql:/opt/dev-health/provision_river_roles.sql:ro
+          --file=/usr/local/share/dev-health/provision_river_roles.sql
     networks: [dev-health]
     depends_on:
       migrate:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,13 +77,25 @@ FROM python:3.14-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
   PYTHONUNBUFFERED=1
 
-# GitPython requires git; wget used by Docker/compose healthchecks
-RUN apt-get update && apt-get install -y --no-install-recommends git wget \
+# GitPython requires git; wget used by Docker/compose healthchecks;
+# postgresql-client runs the River role provisioning below (CHAOS-3925).
+RUN apt-get update && apt-get install -y --no-install-recommends git wget postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages from builder (no build tools, pip, or setuptools).
 COPY --from=builder /install /usr/local
 COPY --from=go-migrator-builder /out/dev-health-worker-migrate /usr/local/bin/dev-health-worker-migrate
+
+# River runtime-role provisioning travels WITH the image that runs it. It used
+# to be bind-mounted from a source checkout, which a pull-only host cannot
+# produce: Docker answers a missing bind-mount source by creating an empty
+# DIRECTORY, so the first Go bring-up failed as
+# `psql: could not read from input file: Is a directory` -- a message that
+# names psql rather than the missing artifact (CHAOS-3925).
+#
+# The SQL, not this image, remains the source of truth for the domain role's
+# grants; only its delivery changes.
+COPY scripts/worker/provision_river_roles.sql /usr/local/share/dev-health/provision_river_roles.sql
 
 # Fail the image build if the installed distribution cannot load the exact job
 # contract artifacts used by Python worker routing.

--- a/tests/tooling/test_river_provisioning_packaging.py
+++ b/tests/tooling/test_river_provisioning_packaging.py
@@ -1,0 +1,80 @@
+"""River role provisioning must travel with an image, not a host file.
+
+CHAOS-3925: the provisioning SQL was bind-mounted into the compose overlay from
+a relative source path (``../../scripts/worker/provision_river_roles.sql``). A
+host with only Docker and a compose file cannot produce that path, and Docker
+answers a missing bind-mount source by creating an empty DIRECTORY rather than
+failing -- so the first production bring-up died with
+``psql: could not read from input file: Is a directory``, a message that names
+psql instead of the missing artifact, and the empty directory then re-won on
+every recreate.
+
+The SQL remains the source of truth for the domain role's grants. Only its
+delivery changed, so these tests pin the delivery.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = ROOT / "docker" / "Dockerfile"
+OVERLAY = ROOT / "deploy" / "docker-compose" / "compose.go-workers.yml"
+SOURCE_SQL = ROOT / "scripts" / "worker" / "provision_river_roles.sql"
+
+_COPY = re.compile(
+    r"^COPY\s+scripts/worker/provision_river_roles\.sql\s+(?P<dest>\S+)\s*$",
+    re.MULTILINE,
+)
+
+
+def _packaged_path() -> str:
+    match = _COPY.search(DOCKERFILE.read_text(encoding="utf-8"))
+    assert match is not None, (
+        "docker/Dockerfile no longer packages provision_river_roles.sql; a "
+        "pull-only host cannot provision the River runtime roles without it"
+    )
+    return match.group("dest")
+
+
+def _provision_service() -> dict:
+    overlay = yaml.safe_load(OVERLAY.read_text(encoding="utf-8"))
+    return overlay["services"]["go-river-provision"]
+
+
+def test_the_provisioning_sql_is_packaged_into_the_runtime_image() -> None:
+    assert SOURCE_SQL.is_file()
+    assert _packaged_path()
+
+
+def test_the_overlay_does_not_bind_mount_the_provisioning_sql() -> None:
+    # A relative bind-mount source is the defect itself: absent on the host it
+    # becomes an empty directory instead of an error.
+    volumes = _provision_service().get("volumes") or []
+    offending = [
+        entry for entry in volumes if "provision_river_roles.sql" in str(entry)
+    ]
+    assert not offending, (
+        f"go-river-provision still mounts the SQL from the host: {offending}"
+    )
+
+
+def test_the_overlay_reads_the_packaged_path() -> None:
+    # The path drifting between Dockerfile and overlay is how this breaks
+    # silently again: the mount is gone, so a wrong path is a bare psql error.
+    entrypoint = _provision_service()["entrypoint"]
+    script = entrypoint[-1] if isinstance(entrypoint, list) else str(entrypoint)
+    assert f"--file={_packaged_path()}" in script
+
+
+def test_provisioning_runs_before_the_river_schema_migration() -> None:
+    # Ordering is a correctness property, not a convenience: the pinned River
+    # migration's preflight rejects a runtime role that does not yet exist.
+    overlay = yaml.safe_load(OVERLAY.read_text(encoding="utf-8"))
+    depends = overlay["services"]["go-river-migrate"]["depends_on"]
+    assert (
+        depends["go-river-provision"]["condition"] == "service_completed_successfully"
+    )

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -689,13 +689,16 @@ def test_go_compose_bootstrap_is_post_alembic_fail_closed_and_route_inert() -> N
     assert "--set=coordinator_role" in provision_command
     assert "--set=coordinator_password" in provision_command
     assert "RIVER_COORDINATOR_DATABASE_PASSWORD" in provision["environment"]
-    assert any(
-        str(volume).endswith(
-            "scripts/worker/provision_river_roles.sql:"
-            "/opt/dev-health/provision_river_roles.sql:ro"
-        )
-        for volume in provision["volumes"]
-    )
+    # The SQL travels in the image, not from the host. A relative bind-mount
+    # source is unproduceable on a pull-only host, and Docker answers a missing
+    # one by creating an empty DIRECTORY rather than failing -- which is how
+    # this reached production as `psql: ... Is a directory` (CHAOS-3925).
+    assert not [
+        volume
+        for volume in (provision.get("volumes") or [])
+        if "provision_river_roles.sql" in str(volume)
+    ]
+    assert "/usr/local/share/dev-health/provision_river_roles.sql" in provision_command
 
     river_migrate = services["go-river-migrate"]
     assert river_migrate["profiles"] == ["go-workers"]


### PR DESCRIPTION
## Summary

Closes CHAOS-3925. Hit in production during the first Go worker bring-up.

`go-river-provision` bind-mounted the provisioning SQL from a relative source path:

```yaml
volumes:
  - ../../scripts/worker/provision_river_roles.sql:/opt/dev-health/provision_river_roles.sql:ro
```

A host with only Docker and a compose file cannot produce that path. Docker does not error on a missing bind-mount source — it creates an empty **directory** — so the failure surfaces as:

```
psql: could not read from input file: Is a directory
```

That names psql rather than the missing artifact, and the empty directory then re-wins on every recreate until removed by hand.

## Changes

- `docker/Dockerfile` carries the SQL at `/usr/local/share/dev-health/provision_river_roles.sql`, alongside the `postgresql-client` that reads it.
- The overlay points at the packaged path and drops the mount. The step keeps its own one-shot container, its elevated credential, and its ordering ahead of the pinned River migration — only delivery changes.

## What this deliberately does not do

Provisioning is **not** folded into `dev-health-worker-migrate`, which would otherwise be its natural home — it already runs one-shot with the elevated DSN, before any worker.

The blocker is grant ownership. The SQL owns the domain role's semantic access (~15 conditional `GRANT`s guarded by `to_regclass`), while `MigrationOptions` at `cmd/dev-health-worker-migrate/main.go:99` passes only `Coordinator*` grants. Moving provisioning into that binary relocates a privilege surface that has its own integration coverage, and the psql meta-commands (`\gexec`, `\if`, `\set`) would need rewriting as `DO` blocks. Larger than this defect justifies; noted on the ticket as the follow-up.

Putting it in the Go worker startup was considered and rejected outright: role creation needs superuser, and the three-role split exists precisely so no long-running process holds that. It would also be circular — a worker cannot connect as `devhealth_queue` before that role exists — and N replicas would race.

## TEST-EVIDENCE

- `tests/tooling/test_river_provisioning_packaging.py` — 4 passed.
- Negative controls, both observed failing before passing:
  - removing the `COPY` fails the packaging and path-match tests;
  - reinstating a bind mount fails the mount test by name.
- The path-match test is the one that matters long-term: with the mount gone, a Dockerfile/overlay path drift would otherwise resurface as the same bare psql error.

## RISK-NOTES

- Adds `postgresql-client` to the Ops runtime image (a few MB). It is the same image the migration step already uses.
- `go-river-provision` now pulls `DEV_HEALTH_IMAGE` instead of `postgres:18-alpine`, so the tag must be current before the step runs. It already gates on `migrate` completing, which uses the same image.
- No change to what is granted, to whom, or in what order.