### PR TITLE
fix(operator): name privilege denials in workerctl authentication (CHAOS-3100)

### DIFF
--- a/cmd/dev-health-workerctl/main.go
+++ b/cmd/dev-health-workerctl/main.go
@@ -286,7 +286,7 @@ func configureRuntime(ctx context.Context, lookup platformsecrets.LookupEnv, std
 	}
 	token, ok := resolveRequired("WORKER_OPERATOR_TOKEN", lookup)
 	if !ok {
-		return nil, writeError(stderr, "authentication_failed")
+		return nil, writeError(stderr, joboperator.ReasonAuthenticationFailed)
 	}
 	mode := databaseMode(lookup, "WORKER_DATABASE_MODE")
 	if !sessionSafeMode(mode) {
@@ -353,11 +353,18 @@ func configureRuntime(ctx context.Context, lookup platformsecrets.LookupEnv, std
 	// is coordinator-exclusive and has no domain grant at all.
 	authenticator, err := joboperator.NewAuthenticator(coordinatorPool)
 	if err != nil {
-		return nil, writeError(stderr, "authentication_failed")
+		return nil, writeError(stderr, joboperator.ReasonAuthenticationFailed)
 	}
 	authentication, err := authenticator.Authenticate(ctx, token.Reveal())
 	if err != nil {
-		return nil, writeError(stderr, "authentication_failed")
+		// The reason code comes from joboperator's bounded vocabulary rather
+		// than from the error text. A 42501 on internal_service_credentials
+		// means the connected role lacks its grant -- or that this binary was
+		// wired back onto a pool that never had one -- which is a different
+		// operator action entirely from a rotated or revoked token. Both codes
+		// are compile-time constants, so neither can carry credential or
+		// catalog material into the operator's terminal or logs.
+		return nil, writeError(stderr, joboperator.AuthenticationReason(err))
 	}
 	lockTx, err := pools.Domain.Begin(ctx)
 	if err != nil {

--- a/internal/joboperator/auth.go
+++ b/internal/joboperator/auth.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -19,11 +20,70 @@ const (
 	ScopeWorkerOperate    = "workers:operate"
 )
 
+// The bounded operator reason-code vocabulary for authentication outcomes,
+// following the same idiom as cmd/dev-health-stream-runner/dependencies.go's
+// DependencyReason: every code is a compile-time constant chosen from this
+// closed set, never interpolated from a token, a role name, a catalog row or
+// a driver message. That is what makes an operator-visible reason safe to
+// emit and log unredacted.
+const (
+	// ReasonAuthenticationFailed is the credential verdict: the statement ran
+	// and the supplied token did not resolve to a live, correctly scoped
+	// worker-operator credential. It is also the conservative default for any
+	// failure whose cause is not positively identified.
+	ReasonAuthenticationFailed = "authentication_failed"
+	// ReasonCredentialStoreForbidden is the deployment verdict, and is
+	// deliberately NOT a credential verdict: PostgreSQL refused the
+	// authentication statement with 42501 before the token was ever compared,
+	// so the connected role lacks SELECT/UPDATE on
+	// public.internal_service_credentials. Reporting this as
+	// ReasonAuthenticationFailed (CHAOS-3100) sent operators after a rotated
+	// token when the actual defect was a missing grant or a binary wired onto
+	// the wrong pool.
+	ReasonCredentialStoreForbidden = "credential_store_forbidden"
+)
+
+// insufficientPrivilege is PostgreSQL's SQLSTATE for a denied permission. It
+// is raised during execution, after parse analysis, so it cannot be confused
+// with an undefined table or column.
+const insufficientPrivilege = "42501"
+
 var (
 	ErrAuthentication = errors.New("worker operator authentication failed")
 	ErrAuthorization  = errors.New("worker operator authorization failed")
 	workerToken       = regexp.MustCompile(`^svc_worker_[A-Za-z0-9_-]{32,256}$`)
 )
+
+// authenticationFailure carries one bounded reason code alongside the
+// ErrAuthentication sentinel, so existing errors.Is(err, ErrAuthentication)
+// callers keep working unchanged while a caller that wants the finer verdict
+// can ask for it. Its reason field is only ever assigned a constant from the
+// vocabulary above.
+type authenticationFailure struct{ reason string }
+
+func (failure authenticationFailure) Error() string {
+	return ErrAuthentication.Error() + ": " + failure.reason
+}
+
+func (authenticationFailure) Unwrap() error { return ErrAuthentication }
+
+// AuthenticationReason satisfies the operator shell's reason-code interface.
+func (failure authenticationFailure) AuthenticationReason() string { return failure.reason }
+
+func authenticationDenied(reason string) error { return authenticationFailure{reason: reason} }
+
+// AuthenticationReason maps an Authenticate error onto the bounded reason-code
+// vocabulary above. Anything that does not positively identify itself — a bare
+// ErrAuthentication, a wrapped one, a nil error — reports
+// ReasonAuthenticationFailed, so a new failure mode can never widen what an
+// operator surface prints.
+func AuthenticationReason(err error) string {
+	var failure interface{ AuthenticationReason() string }
+	if errors.As(err, &failure) {
+		return failure.AuthenticationReason()
+	}
+	return ReasonAuthenticationFailed
+}
 
 // Authenticator verifies a worker operator bearer token against the semantic
 // database. Only the SHA-256 digest crosses the database boundary; plaintext
@@ -87,6 +147,15 @@ func (authenticator *Authenticator) Authenticate(ctx context.Context, token stri
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Authentication{}, ErrAuthentication
+		}
+		// A privilege denial is not a credential verdict: the CTE above never
+		// compared the digest, because the connected role may not read or
+		// touch the credential store at all. Only the SQLSTATE is inspected
+		// and only a constant is returned -- the driver's message can quote
+		// statement text, so it never reaches the operator surface.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == insufficientPrivilege {
+			return Authentication{}, authenticationDenied(ReasonCredentialStoreForbidden)
 		}
 		return Authentication{}, ErrAuthentication
 	}

--- a/internal/joboperator/auth_test.go
+++ b/internal/joboperator/auth_test.go
@@ -1,0 +1,84 @@
+package joboperator
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestAuthenticationReasonSeparatesPrivilegeDenialFromCredentialFailure pins
+// the CHAOS-3100 distinction at the unit boundary: an operator told
+// "authentication_failed" rotates a token, and an operator told
+// "credential_store_forbidden" goes looking at grants and pool wiring. The
+// integration half -- that a real 42501 from a real restricted role actually
+// produces the second code -- lives in postgres_integration_test.go, because
+// only a real server can raise the SQLSTATE.
+func TestAuthenticationReasonSeparatesPrivilegeDenialFromCredentialFailure(t *testing.T) {
+	denied := authenticationDenied(ReasonCredentialStoreForbidden)
+
+	for _, testCase := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"no error", nil, ReasonAuthenticationFailed},
+		{"credential verdict", ErrAuthentication, ReasonAuthenticationFailed},
+		{"no matching credential row", pgx.ErrNoRows, ReasonAuthenticationFailed},
+		// A raw driver error is deliberately NOT translated here. Only
+		// Authenticate decides that a 42501 was a credential-store denial,
+		// because only it knows which statement raised it; mapping the
+		// SQLSTATE in this function too would let an unrelated denial from
+		// some future caller inherit the code.
+		{"undecided driver error", &pgconn.PgError{Code: insufficientPrivilege}, ReasonAuthenticationFailed},
+		{"privilege denial", denied, ReasonCredentialStoreForbidden},
+		{"wrapped privilege denial", fmt.Errorf("configure runtime: %w", denied), ReasonCredentialStoreForbidden},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if reason := AuthenticationReason(testCase.err); reason != testCase.want {
+				t.Fatalf("AuthenticationReason(%v) = %q, want %q", testCase.err, reason, testCase.want)
+			}
+		})
+	}
+}
+
+// TestPrivilegeDenialStaysAnAuthenticationError keeps the new error type
+// compatible with every existing caller: the sentinel comparison is the
+// contract Authenticate has always offered, and widening the verdict must not
+// quietly turn a denial into an unhandled error somewhere upstream.
+func TestPrivilegeDenialStaysAnAuthenticationError(t *testing.T) {
+	denied := authenticationDenied(ReasonCredentialStoreForbidden)
+	if !errors.Is(denied, ErrAuthentication) {
+		t.Fatalf("errors.Is(%v, ErrAuthentication) = false", denied)
+	}
+	if errors.Is(denied, ErrAuthorization) {
+		t.Fatal("a credential-store denial must not be reported as an authorization failure")
+	}
+}
+
+// TestReasonCodesCarryNoInterpolatedMaterial is the property that lets these
+// codes be logged unredacted, following the same rule as
+// cmd/dev-health-stream-runner/dependencies.go's DependencyReason: the
+// vocabulary is closed and every member is a lowercase constant, so no token,
+// role name, statement text or driver message can ever ride out inside one.
+func TestReasonCodesCarryNoInterpolatedMaterial(t *testing.T) {
+	for _, reason := range []string{ReasonAuthenticationFailed, ReasonCredentialStoreForbidden} {
+		if reason == "" || strings.ToLower(reason) != reason || strings.ContainsAny(reason, " \t\n\"'%:;=/\\") {
+			t.Fatalf("reason code %q is not a bare lowercase identifier", reason)
+		}
+	}
+	if ReasonAuthenticationFailed == ReasonCredentialStoreForbidden {
+		t.Fatal("the two verdicts must be distinguishable by an operator")
+	}
+	// The error text is allowed to name the reason and nothing else: the
+	// driver's message can quote the failing statement, so it must not be
+	// carried along.
+	denied := authenticationDenied(ReasonCredentialStoreForbidden).Error()
+	if !strings.HasSuffix(denied, ReasonCredentialStoreForbidden) ||
+		strings.Contains(denied, "internal_service_credentials") {
+		t.Fatalf("denial error text = %q", denied)
+	}
+}

--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,13 +26,42 @@ import (
 )
 
 const (
-	operatorIntegrationDomainRole = "operator_domain_runtime"
-	operatorIntegrationQueueRole  = "operator_queue_runtime"
-	operatorIntegrationDomainPass = "operator_domain_runtime_password"
-	operatorIntegrationQueuePass  = "operator_queue_runtime_password"
-	operatorIntegrationToken      = "svc_worker_0123456789abcdefghijklmnopqrstuvwxyzAB"
-	operatorIntegrationCredential = "00000000-0000-4000-8000-000000000303"
+	operatorIntegrationDomainRole      = "operator_domain_runtime"
+	operatorIntegrationQueueRole       = "operator_queue_runtime"
+	operatorIntegrationCoordinatorRole = "operator_coordinator_runtime"
+	operatorIntegrationDomainPass      = "operator_domain_runtime_password"
+	operatorIntegrationQueuePass       = "operator_queue_runtime_password"
+	operatorIntegrationCoordinatorPass = "operator_coordinator_runtime_password"
+	operatorIntegrationToken           = "svc_worker_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	operatorIntegrationCredential      = "00000000-0000-4000-8000-000000000303"
 )
+
+// operatorIntegrationCoordinatorGrants translates postgres.CoordinatorPosture()
+// into the migration's grant shape. It is derived, never restated: the posture
+// is the same single authority CheckCoordinatorAuthorization asserts against
+// and cmd/dev-health-worker-migrate provisions from, so what this fixture
+// grants cannot drift from what production grants.
+func operatorIntegrationCoordinatorGrants() ([]riverstore.TableGrant, []riverstore.ColumnGrant, []string) {
+	posture := postgresstore.CoordinatorPosture()
+	tables := make([]riverstore.TableGrant, 0, len(posture.RequiredTables))
+	for _, table := range posture.RequiredTables {
+		tables = append(tables, riverstore.TableGrant{
+			TableName:   table.TableName,
+			AllowInsert: table.AllowInsert,
+			AllowUpdate: table.AllowUpdate,
+			AllowDelete: table.AllowDelete,
+		})
+	}
+	columns := make([]riverstore.ColumnGrant, 0, len(posture.ColumnScoped))
+	for _, column := range posture.ColumnScoped {
+		columns = append(columns, riverstore.ColumnGrant{
+			TableName:  column.TableName,
+			ColumnName: column.ColumnName,
+			Privilege:  column.Privilege,
+		})
+	}
+	return tables, columns, append([]string(nil), posture.RequiredSequences...)
+}
 
 type allowIntegrationDomainGuard struct{}
 
@@ -92,10 +122,15 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 	adminPool := openOperatorIntegrationPool(t, ctx, instance.URI)
 	defer adminPool.Close()
 	createOperatorIntegrationSchema(t, ctx, adminPool)
+	coordinatorTables, coordinatorColumns, coordinatorSequences := operatorIntegrationCoordinatorGrants()
 	if _, err := riverstore.ApplyPinnedMigrations(ctx, adminPool, riverstore.MigrationOptions{
-		Schema:     "river",
-		DomainRole: operatorIntegrationDomainRole,
-		QueueRole:  operatorIntegrationQueueRole,
+		Schema:                  "river",
+		DomainRole:              operatorIntegrationDomainRole,
+		QueueRole:               operatorIntegrationQueueRole,
+		CoordinatorRole:         operatorIntegrationCoordinatorRole,
+		CoordinatorGrants:       coordinatorTables,
+		CoordinatorColumnGrants: coordinatorColumns,
+		CoordinatorSequences:    coordinatorSequences,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -107,6 +142,10 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 		t, ctx, instance.URI, operatorIntegrationQueueRole, operatorIntegrationQueuePass,
 	)
 	defer queuePool.Close()
+	coordinatorPool := openOperatorIntegrationRolePool(
+		t, ctx, instance.URI, operatorIntegrationCoordinatorRole, operatorIntegrationCoordinatorPass,
+	)
+	defer coordinatorPool.Close()
 	if err := postgresstore.CheckDomainAuthorization(ctx, domainPool, operatorIntegrationDomainRole, "river"); err != nil {
 		t.Fatalf("domain role authorization: %v", err)
 	}
@@ -141,9 +180,15 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The operator credential store is intentionally outside the domain runtime
-	// allow-list, so authenticate through the fixture's operator/admin pool.
-	authenticator, err := NewAuthenticator(adminPool)
+	// CHAOS-3100. This used to authenticate through the fixture's ADMIN pool,
+	// on the reasoning that the credential store sits outside the domain
+	// allow-list. That reasoning was right and the fixture was still wrong:
+	// an admin pool can run any statement, so the test proved nothing about
+	// which runtime role can, and it would have passed identically while the
+	// real CLI was 100% broken. The restricted coordinator login is the pool
+	// cmd/dev-health-workerctl actually builds its authenticator on, so it is
+	// the only connection that measures the deployed privilege.
+	authenticator, err := NewAuthenticator(coordinatorPool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,6 +362,125 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 	}
 }
 
+// TestOperatorAuthenticationIsCoordinatorOnlyAndNamesPrivilegeDenials is the
+// CHAOS-3100 regression, and it deliberately proves BOTH halves of the fact
+// the ticket says must land together. Proving only that some role can
+// authenticate is what recreates the trap: the cheap way to make
+// authentication work is to widen the domain role, and that trades a runtime
+// 42501 for a permanent readiness failure across every domain worker, because
+// CheckDomainAuthorization asserts the domain role holds NOTHING outside its
+// own manifest.
+//
+//   - Half one: the restricted coordinator role -- the login
+//     cmd/dev-health-workerctl builds its authenticator on -- completes a real
+//     authentication against the real grants ApplyPinnedMigrations emits.
+//     Grants are derived from CoordinatorPosture(), so this fails if the
+//     migration and the posture ever disagree.
+//   - Half two: the domain role is still refused, and the domain role's own
+//     readiness still passes afterwards. A change that bought half one by
+//     granting the domain role fails the refusal; a change that bought it by
+//     granting without the matching allowlist row fails the readiness call.
+//
+// The refusal is also asserted by reason CODE, not merely by error identity.
+// Before this change auth.go collapsed a 42501 into a bare ErrAuthentication,
+// so workerctl printed `authentication_failed` for a missing grant and sent
+// operators to rotate a token that was never wrong. That assertion is the one
+// that fails without the auth.go half of this fix.
+func TestOperatorAuthenticationIsCoordinatorOnlyAndNamesPrivilegeDenials(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	adminPool := openOperatorIntegrationPool(t, ctx, instance.URI)
+	t.Cleanup(adminPool.Close)
+	createOperatorIntegrationSchema(t, ctx, adminPool)
+	coordinatorTables, coordinatorColumns, coordinatorSequences := operatorIntegrationCoordinatorGrants()
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, adminPool, riverstore.MigrationOptions{
+		Schema:                  "river",
+		DomainRole:              operatorIntegrationDomainRole,
+		QueueRole:               operatorIntegrationQueueRole,
+		CoordinatorRole:         operatorIntegrationCoordinatorRole,
+		CoordinatorGrants:       coordinatorTables,
+		CoordinatorColumnGrants: coordinatorColumns,
+		CoordinatorSequences:    coordinatorSequences,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	coordinatorPool := openOperatorIntegrationRolePool(
+		t, ctx, instance.URI, operatorIntegrationCoordinatorRole, operatorIntegrationCoordinatorPass,
+	)
+	t.Cleanup(coordinatorPool.Close)
+	domainPool := openOperatorIntegrationRolePool(
+		t, ctx, instance.URI, operatorIntegrationDomainRole, operatorIntegrationDomainPass,
+	)
+	t.Cleanup(domainPool.Close)
+
+	// Half one. Authenticate runs SELECT and UPDATE in one CTE, so a role
+	// holding only SELECT would fail here too -- authentication is a write.
+	coordinatorAuthenticator, err := NewAuthenticator(coordinatorPool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authentication, err := coordinatorAuthenticator.Authenticate(ctx, operatorIntegrationToken)
+	if err != nil {
+		t.Fatalf("restricted coordinator role cannot authenticate the operator token: %v", err)
+	}
+	if authentication.Principal().ID != operatorIntegrationCredential {
+		t.Fatalf("principal = %+v", authentication.Principal())
+	}
+
+	// Half two, part one: the domain role is refused, and says why. Note the
+	// token supplied is the VALID one -- so `authentication_failed` would be
+	// an actively false statement about it, not merely a vague one.
+	domainAuthenticator, err := NewAuthenticator(domainPool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := domainAuthenticator.Authenticate(ctx, operatorIntegrationToken); err == nil {
+		t.Fatal("the domain role authenticated against the coordinator-exclusive credential store, " +
+			"so it now holds a privilege its own readiness posture forbids")
+	} else {
+		if !errors.Is(err, ErrAuthentication) {
+			t.Fatalf("domain-role denial error = %v, want it to remain an ErrAuthentication", err)
+		}
+		if reason := AuthenticationReason(err); reason != ReasonCredentialStoreForbidden {
+			t.Fatalf("domain-role denial reason = %q, want %q -- a missing grant reported as a "+
+				"credential failure sends operators to rotate a token that was never wrong",
+				reason, ReasonCredentialStoreForbidden)
+		}
+	}
+
+	// Half two, part two: provisioning the coordinator did not widen the
+	// domain role. This is the assertion that fails if a future change fixes
+	// authentication by granting internal_service_credentials to the domain
+	// role -- readiness would then find an undeclared relation and every
+	// domain worker, not just workerctl, would fail closed at startup.
+	if err := postgresstore.CheckDomainAuthorization(
+		ctx, domainPool, operatorIntegrationDomainRole, "river",
+	); err != nil {
+		t.Fatalf("domain readiness broke once the coordinator was provisioned: %v", err)
+	}
+
+	// An invalid token on the correctly granted pool is the OTHER verdict, and
+	// must stay distinguishable from the denial above -- otherwise the two
+	// codes carry no information.
+	if _, err := coordinatorAuthenticator.Authenticate(ctx, "svc_worker_"+strings.Repeat("z", 40)); err == nil {
+		t.Fatal("an unknown token authenticated")
+	} else if reason := AuthenticationReason(err); reason != ReasonAuthenticationFailed {
+		t.Fatalf("unknown-token reason = %q, want %q", reason, ReasonAuthenticationFailed)
+	}
+}
+
 func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
 	t.Helper()
 	digest := sha256.Sum256([]byte(operatorIntegrationToken))
@@ -329,6 +493,12 @@ func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pg
 		"REVOKE TEMPORARY ON DATABASE worker_test FROM PUBLIC",
 		"CREATE ROLE " + operatorIntegrationDomainRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + operatorIntegrationDomainPass + "'",
 		"CREATE ROLE " + operatorIntegrationQueueRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + operatorIntegrationQueuePass + "'",
+		// Created here, before ApplyPinnedMigrations, because the migration's
+		// role-eligibility preflight rejects a coordinator role that does not
+		// yet exist as a least-privilege login. This mirrors the real deploy
+		// order: provision roles (scripts/worker/provision_river_roles.sql),
+		// then migrate.
+		"CREATE ROLE " + operatorIntegrationCoordinatorRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + operatorIntegrationCoordinatorPass + "'",
 		`CREATE TABLE public.internal_service_credentials (
 			id uuid PRIMARY KEY,
 			service_name text NOT NULL,
@@ -384,7 +554,16 @@ func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pg
 		"CREATE TABLE public.integrations (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.integration_sources (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.integration_datasets (id uuid PRIMARY KEY)",
-		"CREATE TABLE public.integration_credentials (id uuid PRIMARY KEY)",
+		// Carries the columns coordinatorPosture scopes its grants to. A
+		// column-level GRANT names the column, and PostgreSQL raises
+		// undefined_column (42703) for one that does not exist, so a
+		// one-column fixture would break the migration rather than exercise
+		// it. credentials_encrypted is present and deliberately NOT granted:
+		// it is the encrypted secret the coordinator must never reach.
+		`CREATE TABLE public.integration_credentials (
+			id uuid PRIMARY KEY, org_id text, provider text,
+			is_active boolean, config json, credentials_encrypted text
+		)`,
 		"CREATE TABLE public.provider_oauth_credentials (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_runs (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY, state text NOT NULL)",
@@ -438,6 +617,19 @@ func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pg
 			kind text PRIMARY KEY,
 			generation bigint NOT NULL
 		)`,
+		// The remaining coordinator-exclusive relations. They exist here for
+		// the same reason the domain tables above do, and the ordering is
+		// load-bearing in the same way: every coordinator GRANT in
+		// coordinatorGrantStatements is wrapped in `IF to_regclass(...) IS NOT
+		// NULL`, so a table created after ApplyPinnedMigrations would silently
+		// receive no grant at all. This fixture would then still pass while
+		// asserting nothing -- the exact vacuity that let CHAOS-3100 survive.
+		"CREATE TABLE public.sync_run_reference_discoveries (id uuid PRIMARY KEY)",
+		"CREATE TABLE public.sync_run_post_dispatches (id uuid PRIMARY KEY)",
+		"CREATE TABLE public.scheduled_sync_occurrences (id uuid PRIMARY KEY)",
+		"CREATE TABLE public.fixed_schedule_occurrences (id uuid PRIMARY KEY)",
+		"CREATE TABLE public.tier_limits (id bigint PRIMARY KEY)",
+		"CREATE TABLE public.job_runs (id uuid PRIMARY KEY)",
 	}
 	for _, statement := range statements {
 		if _, err := tx.Exec(ctx, statement); err != nil {


### PR DESCRIPTION
## Summary

CHAOS-3100 asked for a Postgres grant plus an allowlist row so `dev-health-workerctl` could authenticate as the restricted **domain** role. **That fix was not implemented, deliberately** — the ticket's central mechanism is stale, and implementing it as written would have caused an outage.

## Why the ticket's items 1 and 2 were not implemented

The ticket says `main.go` builds the authenticator on `pools.Domain`, so the domain role needs `SELECT, UPDATE` on `internal_service_credentials`. Authentication moved **off** the domain pool onto a dedicated coordinator pool in `3450c31c6` (CHAOS-3033/CHAOS-3113, PR #1291) — already fixed, in the opposite direction to the prescription.

- `cmd/dev-health-workerctl/main.go` — `joboperator.NewAuthenticator(coordinatorPool)`, commented "coordinator-exclusive and has no domain grant at all"
- `cmd/dev-health-workerctl/main.go` — `COORDINATOR_DATABASE_URI` is required; falling back to the domain pool "would reproduce the 42501 this change exists to remove"
- `internal/storage/postgres/domain_authorization.go:766` — `{"internal_service_credentials", false, true, false}` in `coordinatorPosture`, the only occurrence; there is no domain-side row to add

`CheckDomainAuthorization` asserts zero privileges on any relation outside `required_table_privileges`. Granting the domain role access to a coordinator-exclusive table — and adding the allowlist row to keep readiness green — would reverse the least-privilege split `3450c31c6` shipped.

Confirmed against production: `dev-health-workerctl status` returns `{"queue_control_mode":"session","river_schema_version":7,"status":"ready"}`. This was never blocking the cutover.

## What this PR does fix (the ticket's items 3 and 4)

`internal/joboperator/auth.go` collapsed a `42501 insufficient_privilege` into `ErrAuthentication`, so a privilege denial reached operators as `authentication_failed` — pointing at the token when the token was fine.

- Bounded reason vocabulary: `ReasonAuthenticationFailed`, `ReasonCredentialStoreForbidden`, with an `authenticationFailure` type that still unwraps to `ErrAuthentication` so every existing caller is unchanged
- `Authenticate` inspects SQLSTATE and returns `credential_store_forbidden` for 42501. Only the code is read and only a constant returned — driver messages can quote statement text and never reach the operator surface
- Unidentified errors default closed to `authentication_failed`; a raw `pgconn.PgError` is deliberately not translated, so an unrelated future 42501 cannot inherit the code
- Integration test provisions a third least-privilege coordinator login with grants derived from `CoordinatorPosture()` rather than restated

## Test

`TestOperatorAuthenticationIsCoordinatorOnlyAndNamesPrivilegeDenials` asserts both halves:

- the restricted **coordinator** role completes a real authentication against migration-emitted grants
- the **domain** role is still refused, **and** `CheckDomainAuthorization` still passes for it afterwards

The second half is the trap guard: a future change buying authentication by granting the domain role fails the refusal assertion; one granting without the allowlist row fails the readiness call.

Fails without the fix:
```
--- FAIL: TestOperatorAuthenticationIsCoordinatorOnlyAndNamesPrivilegeDenials
    domain-role denial reason = "authentication_failed", want "credential_store_forbidden"
```

## Gate

`PYTHON=.venv/bin/python bash ci/check_go.sh all` → rc=0, **118 ok packages, 0 failures**. Plus `go build`, `go vet`, `go vet -tags integration`, and integration suites for joboperator, dev-health-workerctl, storage/postgres, storage/river.

## Follow-up

CHAOS-3100's description still contains the stale mechanism. It has a correction comment; the description should be amended so nobody implements items 1 and 2.