### PR TITLE
test(worker): guard the packaged path of the Compose stop-hook binary (CHAOS-3808)

### DIFF
--- a/tests/tooling/test_go_worker_stop_hook_packaging.py
+++ b/tests/tooling/test_go_worker_stop_hook_packaging.py
@@ -1,0 +1,135 @@
+"""The Compose-inherited stop hook must resolve inside the built worker image.
+
+CHAOS-3808: on the local Go-worker Compose stack, `docker compose stop
+go-worker` execs ``/usr/local/bin/dev-health-workerctl`` inside the running
+container as its lifecycle stop hook. The `worker` Docker target used to stage
+only `dev-health-worker`, so the exec failed closed with
+``stat /usr/local/bin/dev-health-workerctl: no such file or directory`` --
+Compose reported the stop as an error even though a bare `docker stop`
+(which never execs into the container) succeeded. The distroless runtime has
+no shell to fall back on, so the hook has exactly one way to work: the exact
+binary, at the exact path, staged in the image the hook runs against.
+
+A test that only greps the Dockerfile for the `cp` line survives someone
+renaming the build stage's staging prefix on one side and not the other, or
+letting the container smoke gate's own exec path drift from what actually
+gets packaged -- both would leave the literal string intact while the real
+path resolution silently breaks again. This instead recomputes the artifact's
+final in-image path from the Dockerfile's own build-stage structure and pins
+it against the one place that actually execs the binary inside a built image:
+ci/check_go_containers.sh's container smoke gate.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = ROOT / "docker" / "go-worker.Dockerfile"
+CONTAINER_GATE = ROOT / "ci" / "check_go_containers.sh"
+WORKERCTL_SOURCE = ROOT / "cmd" / "dev-health-workerctl"
+
+_STAGE_HEADER = re.compile(r"^FROM\s+.+\s+AS\s+(?P<name>\S+)\s*$", re.MULTILINE)
+_CP_WORKERCTL = re.compile(r"cp\s+/out/dev-health-workerctl\s+(?P<dest>\S+);")
+_SMOKE_ENTRYPOINT = re.compile(r"--entrypoint\s+(?P<path>\S+)")
+
+
+def _copy_from_build_source(body: str) -> str | None:
+    """The source path of a ``COPY --from=build ... <src> <dst>`` line,
+    tolerant of any number of intervening flags (``--chown=...`` etc.) --
+    only the token layout (COPY ... --from=build ... <src> <dst>) matters."""
+    for line in body.splitlines():
+        tokens = line.strip().split()
+        if len(tokens) < 3 or tokens[0] != "COPY":
+            continue
+        if not any(token.startswith("--from=build") for token in tokens):
+            continue
+        return tokens[-2]
+    return None
+
+
+def _dockerfile_text() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+def _build_stage_body() -> str:
+    """The Dockerfile's ``build`` stage, where binaries are compiled and
+    staged under /runtime/<target>/ before any final image copies from it."""
+    dockerfile = _dockerfile_text()
+    headers = list(_STAGE_HEADER.finditer(dockerfile))
+    for index, header in enumerate(headers):
+        if header.group("name") != "build":
+            continue
+        end = (
+            headers[index + 1].start() if index + 1 < len(headers) else len(dockerfile)
+        )
+        return dockerfile[header.end() : end]
+    raise AssertionError("docker/go-worker.Dockerfile has no 'build' stage")
+
+
+def _final_stage_body(name: str) -> str:
+    dockerfile = _dockerfile_text()
+    headers = list(_STAGE_HEADER.finditer(dockerfile))
+    for index, header in enumerate(headers):
+        if header.group("name") != name:
+            continue
+        end = (
+            headers[index + 1].start() if index + 1 < len(headers) else len(dockerfile)
+        )
+        return dockerfile[header.end() : end]
+    raise AssertionError(f"docker/go-worker.Dockerfile has no {name!r} build stage")
+
+
+def _packaged_worker_image_path() -> str:
+    """The absolute path dev-health-workerctl lands at inside the `worker`
+    image, derived from the build stage's staging `cp` plus the final
+    `worker` stage's `COPY --from=build` source prefix -- not a pinned
+    literal that could go stale on either side independently."""
+    cp_match = _CP_WORKERCTL.search(_build_stage_body())
+    assert cp_match is not None, (
+        "docker/go-worker.Dockerfile's build stage no longer stages "
+        "dev-health-workerctl for the worker image; the Compose-inherited "
+        "stop hook has nothing to exec"
+    )
+    dest = cp_match.group("dest")
+
+    prefix = _copy_from_build_source(_final_stage_body("worker"))
+    assert prefix is not None, (
+        "docker/go-worker.Dockerfile's worker stage no longer copies the "
+        "staged build output into the final image"
+    )
+
+    assert dest.startswith(prefix), (
+        f"dev-health-workerctl is staged at {dest!r}, which the worker "
+        f"stage's own COPY (source {prefix!r}) will not pick up -- it will "
+        "be absent from the final image"
+    )
+    return "/" + dest[len(prefix) :]
+
+
+def test_dev_health_workerctl_source_exists() -> None:
+    assert WORKERCTL_SOURCE.is_dir(), (
+        "cmd/dev-health-workerctl is missing; there is nothing to package"
+    )
+
+
+def test_the_worker_image_packages_dev_health_workerctl_at_a_real_path() -> None:
+    assert _packaged_worker_image_path() == "/usr/local/bin/dev-health-workerctl"
+
+
+def test_the_container_smoke_gate_execs_the_exact_path_the_image_packages() -> None:
+    # This gate is the one place that actually builds the worker image and
+    # execs this binary inside it as an entrypoint override, the same way
+    # Compose's inherited stop hook does. If the packaged path and the
+    # exec'd path ever drift, the exec fails closed with
+    # `stat ...: no such file or directory` -- the exact failure this ticket
+    # reproduced -- and this assertion is what would have caught it.
+    gate = CONTAINER_GATE.read_text(encoding="utf-8")
+    match = _SMOKE_ENTRYPOINT.search(gate)
+    assert match is not None, (
+        "ci/check_go_containers.sh no longer execs dev-health-workerctl as "
+        "an entrypoint override, so nothing proves the packaged binary is "
+        "actually runnable inside the built worker image"
+    )
+    assert match.group("path") == _packaged_worker_image_path()


### PR DESCRIPTION
## Summary

CHAOS-3808 offered two options: package `dev-health-workerctl` in the Go worker image, or remove the broken stop hook. **Packaging is correct** — `dev-health-workerctl routes apply` is the only supported way to move sync-dispatch routes off Celery, and no compose/k8s/helm manifest offers another way to run it against a live stack.

**The packaging fix is already on `main`.** What was missing was a guard that would notice if it regressed.

- `docker/go-worker.Dockerfile:74` — `cp /out/dev-health-workerctl /runtime/worker/usr/local/bin/dev-health-workerctl`
- `docker/go-worker.Dockerfile:82` — same into the operator runtime
- `ci/check_go_containers.sh:107` — builds the image and execs the binary via `--entrypoint`

Verified in the deployed production image: `{"service":"dev-health-workerctl","version":"b7aac01"}`.

## The gap this closes

The pre-existing check in `tests/workers/test_go_worker_deployment_contract.py` greps the Dockerfile for a literal `COPY` string. It stays green if the staging prefix and the smoke gate's exec path drift apart independently — it confirms a line exists, not that the binary lands where the runtime looks for it.

`tests/tooling/test_go_worker_stop_hook_packaging.py` derives the real path instead:

1. parses the `build` stage for where `dev-health-workerctl` is staged (the `cp` destination)
2. parses the `worker` final stage's `COPY --from=build` for the prefix that actually lands in the image
3. computes the resulting in-image path and asserts it equals `/usr/local/bin/dev-health-workerctl`
4. cross-checks that path against `ci/check_go_containers.sh`'s `--entrypoint` override — the one place that actually builds the image and execs the binary inside it

Verified it fails (2 of 3 assertions) with the packaging `cp` line reverted, and passes clean once restored.

## Notes

No compose/k8s/helm manifest declares a `pre_stop`/lifecycle hook invoking workerctl — grepped exhaustively. The packaging alone fixes the reproduced `docker compose stop` exec failure; there is nothing further to wire.

## Gate

`bash ci/local_validate.sh` → `GATE PASSED. [8/8: lint_format,lint_check,typecheck,ch_probe,ch_scratch_create,ch_migrate,unit_suite,ch_argmax_proof]`, with `declared=8 executed=8`. Plus full `go test ./...` clean and `pytest tests/tooling/ tests/workers/` at 749 passed / 2 pre-existing skips.