### PR TITLE
fix(scheduler): declare the scheduled-report tables in the coordinator posture (CHAOS-3935)

### DIFF
--- a/internal/storage/postgres/coordinator_posture_scheduler_coverage_test.go
+++ b/internal/storage/postgres/coordinator_posture_scheduler_coverage_test.go
@@ -1,0 +1,132 @@
+package postgres
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The coordinator posture must cover every table the scheduler's SQL names.
+//
+// fixed_engine_statement_privileges_integration_test.go already proves that the
+// statements IT LISTS can run as the real restricted role. That is the right
+// check, and it caught the FOR UPDATE and ON CONFLICT traps its header
+// describes. What it cannot catch is a producer nobody added to the list: the
+// statement set is hand-maintained, so it shares an author with the code it
+// audits, exactly the way the posture and the grant list used to share one.
+//
+// The scheduled-report producer (internal/scheduler/fixed/reports.go) was added
+// after that suite and never got entries. Its three tables -- saved_reports,
+// scheduled_report_occurrences, report_runs -- were therefore absent from
+// coordinatorPosture, both the readiness assertion and the derived GRANTs
+// agreed they were not needed, and every scheduled_reports_dispatch cycle in
+// production failed with:
+//
+//	permission denied for table saved_reports (SQLSTATE 42501)
+//
+// This test derives the table set from the source instead of from a list, so a
+// producer added tomorrow either lands in the posture or fails here. It
+// deliberately proves only COVERAGE, never sufficiency of privileges: whether
+// SELECT is enough or a row lock demands UPDATE is what the integration suite
+// executes for real. Coverage is the part a static check can own completely.
+func TestCoordinatorPostureCoversSchedulerSQLTables(t *testing.T) {
+	declared := make(map[string]struct{})
+	posture := CoordinatorPosture()
+	for _, table := range posture.RequiredTables {
+		declared[table.TableName] = struct{}{}
+	}
+	// A column-scoped grant is a deliberate refusal to grant table-wide, not an
+	// omission, so those tables count as covered here.
+	for _, column := range posture.ColumnScoped {
+		declared[column.TableName] = struct{}{}
+	}
+
+	referenced := schedulerReferencedTables(t)
+	if len(referenced) == 0 {
+		t.Fatal("scanned the scheduler tree and found no public.<table> references: " +
+			"the scan is broken, and a broken scan reports success")
+	}
+
+	var missing []string
+	for table := range referenced {
+		if _, ok := declared[table]; !ok {
+			missing = append(missing, table)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf(
+			"internal/scheduler SQL names %d table(s) absent from coordinatorPosture: %s\n"+
+				"The scheduler runs on the coordinator pool, so an undeclared table is a "+
+				"runtime 42501, not a lint nit. Add each to coordinatorPosture with the "+
+				"privileges its statements actually need -- remember that FOR UPDATE "+
+				"requires UPDATE even when the statement writes nothing -- and add the "+
+				"statements to fixed_engine_statement_privileges_integration_test.go.",
+			len(missing), strings.Join(missing, ", "),
+		)
+	}
+}
+
+// TestCoordinatorPostureCoversReportProducerTables pins the three tables that
+// were missing, so a future narrowing of the posture cannot silently drop them
+// back out while the scan above still passes for some unrelated reason.
+func TestCoordinatorPostureCoversReportProducerTables(t *testing.T) {
+	required := map[string]bool{
+		// value is whether the table needs UPDATE
+		"saved_reports":                true, // dueScheduledReportsSQL: FOR UPDATE OF job, report
+		"scheduled_report_occurrences": true, // linkScheduledReportOccurrenceRunSQL + FOR UPDATE
+		"report_runs":                  false,
+	}
+	got := make(map[string]TablePrivilege)
+	for _, table := range CoordinatorPosture().RequiredTables {
+		got[table.TableName] = table
+	}
+	for name, needsUpdate := range required {
+		table, ok := got[name]
+		if !ok {
+			t.Errorf("coordinatorPosture is missing %s, required by internal/scheduler/fixed/reports.go", name)
+			continue
+		}
+		if table.AllowUpdate != needsUpdate {
+			t.Errorf("%s: AllowUpdate = %v, want %v", name, table.AllowUpdate, needsUpdate)
+		}
+	}
+}
+
+var schedulerTableReference = regexp.MustCompile(`public\.([a-z][a-z0-9_]*)`)
+
+// schedulerReferencedTables returns every public.<table> named in the
+// non-test Go sources under internal/scheduler.
+func schedulerReferencedTables(t *testing.T) map[string]struct{} {
+	t.Helper()
+	root := filepath.Join("..", "..", "scheduler")
+	tables := make(map[string]struct{})
+	walked := 0
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		contents, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		walked++
+		for _, match := range schedulerTableReference.FindAllStringSubmatch(string(contents), -1) {
+			tables[match[1]] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if walked == 0 {
+		t.Fatalf("walked %s and read no non-test Go files", root)
+	}
+	return tables
+}

--- a/internal/storage/postgres/domain_authorization.go
+++ b/internal/storage/postgres/domain_authorization.go
@@ -771,6 +771,27 @@ func coordinatorPosture() RolePosture {
 			{"scheduled_jobs", false, true, false},
 			{"scheduled_sync_occurrences", true, true, false},
 			{"fixed_schedule_occurrences", true, true, false},
+			// The fixed-schedule report producer (internal/scheduler/fixed/reports.go)
+			// runs entirely on the coordinator pool, so every table its SQL touches
+			// belongs in THIS manifest even when the domain role also declares it.
+			// Dual declaration is not a leak -- see CheckRolePosture's note on tables
+			// legitimately required by more than one role.
+			//
+			// saved_reports needs UPDATE, not merely SELECT: dueScheduledReportsSQL
+			// ends in `FOR UPDATE OF job, report SKIP LOCKED`, and `report` is the
+			// saved_reports alias. PostgreSQL requires the UPDATE privilege to take a
+			// FOR UPDATE row lock, exactly as scheduled_jobs above already reflects for
+			// the `job` alias in that same clause. A SELECT-only grant here would pass
+			// every DML-verb reading of the query and still fail at runtime.
+			{"saved_reports", false, true, false},
+			// scheduled_report_occurrences: INSERT (insertScheduledReportOccurrenceSQL),
+			// UPDATE (linkScheduledReportOccurrenceRunSQL), and an unqualified
+			// FOR UPDATE in selectScheduledReportOccurrenceSQL.
+			{"scheduled_report_occurrences", true, true, false},
+			// report_runs: INSERT (insertScheduledReportRunSQL) plus the SELECT in
+			// replayedReportRunSQL. The producer never updates a run row; the report
+			// worker does that on the domain pool, which declares UPDATE separately.
+			{"report_runs", true, false, false},
 			// syncreconciler.Materializer.Step executes coordinator-pool INSERTs at
 			// internal/syncreconciler/materializer.go:125,
 			// internal/syncreconciler/materializer.go:235,

--- a/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
+++ b/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
@@ -85,9 +85,25 @@ func reconciliationTables() []domainTable {
 			},
 		},
 		{
+			// Production column shape (alembic 0053), not a two-column stub: the
+			// scheduled-report producer's real statements name identity_version,
+			// org_id, report_id, scheduled_for and report_run_id, and an
+			// undefined column raises 42703 during parse analysis BEFORE the ACL
+			// check -- which would leave the privilege assertions in
+			// fixed_engine_statement_privileges_integration_test.go measuring
+			// nothing at all.
 			name: "scheduled_report_occurrences",
 			ddl: `CREATE TABLE public.scheduled_report_occurrences (
-				occurrence_id text PRIMARY KEY, scheduled_job_id uuid NOT NULL)`,
+				occurrence_id text PRIMARY KEY,
+				identity_version text NOT NULL,
+				org_id text NOT NULL,
+				report_id uuid NOT NULL,
+				scheduled_job_id uuid NOT NULL,
+				scheduled_for timestamptz NOT NULL,
+				report_run_id uuid UNIQUE,
+				created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				CONSTRAINT uq_scheduled_report_occurrence_report_time
+					UNIQUE (report_id, scheduled_for))`,
 			exercise: []string{
 				"SELECT occurrence_id, scheduled_job_id FROM public.scheduled_report_occurrences LIMIT 1",
 			},
@@ -448,8 +464,50 @@ func startGrantHarness(t *testing.T, ctx context.Context) (*pgxpool.Pool, string
 		)`,
 		"CREATE TABLE public.dev_conversations (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.dev_conversation_tombstones (id uuid PRIMARY KEY)",
-		"CREATE TABLE public.report_runs (id bigint PRIMARY KEY)",
-		"CREATE TABLE public.saved_reports (id bigint PRIMARY KEY)",
+		// The scheduled-report producer's tables, in their production column
+		// shape (alembic 0005/0053/0096) rather than as one-column stubs, for
+		// the same reason worker_job_outbox above is: the producer statements in
+		// fixed_engine_statement_privileges_integration_test.go name these
+		// columns, and PostgreSQL resolves every column during parse analysis
+		// BEFORE it checks the ACL. A stub table turns each of those privilege
+		// assertions into a 42703 that proves nothing about the grants.
+		//
+		// saved_reports.schedule_id carries alembic 0096's unique constraint so
+		// the harness cannot accept a schedule shape production rejects.
+		`CREATE TABLE public.report_runs (
+			id uuid PRIMARY KEY,
+			report_id uuid NOT NULL,
+			scheduled_occurrence_id text UNIQUE,
+			status text NOT NULL DEFAULT 'pending',
+			started_at timestamptz,
+			completed_at timestamptz,
+			duration_seconds double precision,
+			rendered_markdown text,
+			artifact_url text,
+			provenance_records json,
+			error text,
+			error_traceback text,
+			attempt_count integer NOT NULL DEFAULT 0,
+			artifact_fingerprint text,
+			notification_key text UNIQUE,
+			notification_status text NOT NULL DEFAULT 'pending',
+			notification_sent_at timestamptz,
+			triggered_by text NOT NULL DEFAULT 'manual',
+			created_at timestamptz NOT NULL DEFAULT now()
+		)`,
+		`CREATE TABLE public.saved_reports (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL DEFAULT '',
+			name text NOT NULL DEFAULT '',
+			report_plan json NOT NULL DEFAULT '{}',
+			is_template boolean NOT NULL DEFAULT FALSE,
+			schedule_id uuid CONSTRAINT uq_saved_reports_schedule_id UNIQUE,
+			is_active boolean NOT NULL DEFAULT TRUE,
+			last_run_at timestamptz,
+			last_run_status text,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			updated_at timestamptz NOT NULL DEFAULT now()
+		)`,
 		"CREATE TABLE public.webhook_deliveries (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.worker_job_runs (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.worker_concurrency_leases (id bigint PRIMARY KEY)",

--- a/internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go
+++ b/internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go
@@ -154,7 +154,10 @@ func fixedEngineStatements() []fixedEngineStatement {
 				JOIN public.saved_reports AS second_report
 				    ON second_report.schedule_id = job.id AND second_report.is_active
 				   AND second_report.id > first_report.id
-				WHERE job.job_type = 'report' AND job.status = 'active'
+				-- 0 is activeScheduledJobStatus (internal/scheduler/fixed/reports.go),
+				-- the value production binds here. A 'active' string literal would fail
+				-- coercion against the integer column (22P02) before the ACL check.
+				WHERE job.job_type = 'report' AND job.status = 0
 				LIMIT 1`,
 		},
 		{

--- a/internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go
+++ b/internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -114,6 +115,75 @@ func fixedEngineStatements() []fixedEngineStatement {
 					degraded_reason = NULL,
 					completed_at = now(), updated_at = now()
 				WHERE occurrence_key = '` + occurrenceKey + `' AND status = 'claimed'`,
+		},
+		// The scheduled-report producer. These statements post-date CHAOS-3114 and
+		// were never added here, which is precisely why coordinatorPosture lacked
+		// saved_reports, scheduled_report_occurrences, and report_runs until the
+		// production scheduler failed every cycle with 42501 on saved_reports.
+		//
+		// deniedBeforeThisChange is false for all four: that field pins the
+		// CHAOS-3114 boundary specifically, and these tables were untouched by
+		// that change. Their own mutation control is
+		// TestScheduledReportStatementsAreDeniedWithoutTheReportTableGrants below.
+		{
+			name:      "report producer enumerates due schedules under a row lock",
+			site:      "internal/scheduler/fixed/reports.go Produce -> dueScheduledReportsSQL",
+			privilege: "saved_reports UPDATE (implied by FOR UPDATE OF report), scheduled_jobs UPDATE",
+			sql: `SELECT job.id::text, report.id::text
+				FROM public.scheduled_jobs AS job
+				JOIN public.saved_reports AS report
+				    ON report.schedule_id = job.id
+				   AND report.is_active
+				   AND report.org_id = job.org_id
+				WHERE job.job_type = 'report'
+				LIMIT 1
+				FOR UPDATE OF job, report SKIP LOCKED`,
+		},
+		{
+			// The reason the outage was a 42501 and not a planning error: this
+			// statement takes no locks and writes nothing, so a verb-only reading
+			// concludes the coordinator needs no grant on saved_reports at all.
+			// It still needs SELECT, and it runs FIRST, ahead of the locking read.
+			name:      "report producer refuses ambiguous schedules",
+			site:      "internal/scheduler/fixed/reports.go refuseAmbiguousReportSchedules -> ambiguousReportSchedulesSQL",
+			privilege: "saved_reports SELECT",
+			sql: `SELECT job.id::text, first_report.id::text, second_report.id::text
+				FROM public.scheduled_jobs AS job
+				JOIN public.saved_reports AS first_report
+				    ON first_report.schedule_id = job.id AND first_report.is_active
+				JOIN public.saved_reports AS second_report
+				    ON second_report.schedule_id = job.id AND second_report.is_active
+				   AND second_report.id > first_report.id
+				WHERE job.job_type = 'report' AND job.status = 'active'
+				LIMIT 1`,
+		},
+		{
+			name:      "report producer verifies a duplicate occurrence under a row lock",
+			site:      "internal/scheduler/fixed/reports.go -> selectScheduledReportOccurrenceSQL",
+			privilege: "scheduled_report_occurrences UPDATE (implied by FOR UPDATE)",
+			sql: `SELECT identity_version, org_id, report_id::text, scheduled_job_id::text, scheduled_for
+				FROM public.scheduled_report_occurrences
+				WHERE occurrence_id = 'scheduled-report:probe:2026-07-25T00:00:00Z'
+				FOR UPDATE`,
+		},
+		{
+			name:      "report producer links the occurrence to its run",
+			site:      "internal/scheduler/fixed/reports.go -> linkScheduledReportOccurrenceRunSQL",
+			privilege: "scheduled_report_occurrences UPDATE",
+			sql: `UPDATE public.scheduled_report_occurrences
+				SET report_run_id = NULL
+				WHERE occurrence_id = 'scheduled-report:probe:2026-07-25T00:00:00Z'
+				  AND report_run_id IS NULL`,
+		},
+		{
+			name:      "report producer reads a replayed run",
+			site:      "internal/scheduler/fixed/reports.go -> replayedReportRunSQL",
+			privilege: "report_runs SELECT",
+			sql: `SELECT run.id::text
+				FROM public.scheduled_report_occurrences AS occurrence
+				LEFT JOIN public.report_runs AS run
+				    ON run.scheduled_occurrence_id = occurrence.occurrence_id
+				WHERE occurrence.occurrence_id = 'scheduled-report:probe:2026-07-25T00:00:00Z'`,
 		},
 		{
 			name:      "fan-out producer enumerates active organizations",
@@ -444,5 +514,78 @@ func TestFixedEngineCompletionFenceGrantStaysColumnScoped(t *testing.T) {
 			t.Errorf("%s: expected insufficient_privilege (42501), got: %v\n  statement: %s",
 				forbidden.name, err, collapse(forbidden.sql))
 		}
+	}
+}
+
+// reportProducerStatements are the fixedEngineStatements belonging to the
+// scheduled-report producer, selected by name prefix so a statement added to
+// the list above is automatically covered by the mutation control below.
+func reportProducerStatements() []fixedEngineStatement {
+	var selected []fixedEngineStatement
+	for _, statement := range fixedEngineStatements() {
+		if strings.HasPrefix(statement.name, "report producer ") {
+			selected = append(selected, statement)
+		}
+	}
+	return selected
+}
+
+// TestScheduledReportStatementsAreDeniedWithoutTheReportTableGrants is the
+// mutation control for the report half of coordinatorPosture, mirroring
+// TestFixedEngineStatementsAreDeniedByThePreCHAOS3114CoordinatorGrants.
+//
+// It reproduces the production failure exactly: with the three report tables
+// revoked, every report-producer statement must fail with 42501, and the very
+// first one the producer runs is the ambiguity check on saved_reports -- the
+// statement that took no locks and wrote nothing, and so looked to a
+// verb-only reading like it needed no grant at all.
+//
+// Without this control, adding the tables to the posture could pass the
+// permitted-statements test for reasons unrelated to the grants.
+func TestScheduledReportStatementsAreDeniedWithoutTheReportTableGrants(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	admin, uri := startGrantHarness(t, ctx)
+
+	coordinator := connectAs(t, ctx, uri, grantCoordinatorRole, grantCoordinatorPass)
+
+	statements := reportProducerStatements()
+	if len(statements) == 0 {
+		t.Fatal("no report-producer statements found, so this test proves nothing")
+	}
+	// Prove they PASS first. A revocation that denies statements which were
+	// already failing would measure nothing.
+	for _, statement := range statements {
+		if err := execInRolledBackTransaction(t, ctx, coordinator, statement.sql); err != nil {
+			t.Fatalf("%s: denied BEFORE the revocation, so the mutation below cannot be attributed\n  site: %s\n  error: %v",
+				statement.name, statement.site, err)
+		}
+	}
+
+	for _, table := range []string{"saved_reports", "scheduled_report_occurrences", "report_runs"} {
+		revocation := "REVOKE ALL PRIVILEGES ON TABLE public." + table + " FROM " + grantCoordinatorRole
+		if _, err := admin.Exec(ctx, revocation); err != nil {
+			t.Fatalf("%s: %v", revocation, err)
+		}
+	}
+
+	for _, statement := range statements {
+		err := execInRolledBackTransaction(t, ctx, coordinator, statement.sql)
+		if err == nil {
+			t.Errorf("%s: PERMITTED with the report tables revoked, so %s is not what unblocks it\n  site: %s\n  statement: %s",
+				statement.name, statement.privilege, statement.site, collapse(statement.sql))
+			continue
+		}
+		if !isInsufficientPrivilege(err) {
+			t.Errorf("%s: expected insufficient_privilege (42501), got a different failure: %v\n  site: %s\n  statement: %s",
+				statement.name, err, statement.site, collapse(statement.sql))
+		}
+	}
+
+	// The posture and the grants are one declaration, so a coordinator login
+	// missing the report grants must refuse to report ready rather than start
+	// and fail every schedule cycle -- which is exactly what production did.
+	if err := CheckCoordinatorAuthorization(ctx, coordinator, grantCoordinatorRole, grantSchema); err == nil {
+		t.Error("coordinator readiness passed without the report table grants, so it is not checking the posture it declares")
 	}
 }


### PR DESCRIPTION
## Production impact

Scheduled reports have not run since the Go scheduler was activated. Every
`scheduled_reports_dispatch` cycle fails:

```
permission denied for table saved_reports (SQLSTATE 42501)
```

## Cause

`coordinatorPosture()` omits the three tables `internal/scheduler/fixed/reports.go` uses on the
coordinator pool. The posture is the single declaration behind both the derived GRANTs
(`coordinatorGrantStatements` — *"the table list is never written here"*) and the readiness
assertion, so with the tables absent **both sides agreed they were not needed**: readiness passed,
the process started, and every cycle failed at runtime.

| Table | Added | Why |
|---|---|---|
| `saved_reports` | SELECT + **UPDATE** | `dueScheduledReportsSQL` ends `FOR UPDATE OF job, report SKIP LOCKED`; `report` is the `saved_reports` alias, and a row lock requires UPDATE |
| `scheduled_report_occurrences` | SELECT + INSERT + UPDATE | insert, link-run update, and an unqualified `FOR UPDATE` |
| `report_runs` | SELECT + INSERT | insert plus the replay read |

A DML-verb reading of the file finds no `UPDATE` against `saved_reports` and concludes SELECT is
enough — the same trap `scheduled_jobs` already reflects for the `job` alias in that same clause.

## Why the existing guard missed it

`fixed_engine_statement_privileges_integration_test.go` exists for exactly this, and its header
even names the `FOR UPDATE` trap. But it works from a **hand-maintained statement list** and had
zero report entries; the producer post-dates CHAOS-3114.

Its reasoning stops one step short. It argues the posture and the grant list "share an author and
a construction method, so they cannot check each other" — correct — but the **statement list also
shares an author with the code it audits**. A producer added without an entry is invisible: the
suite proves the statements it knows about can run, not that it knows all the statements.

## Changes

1. **Instance fix** — the three tables in `coordinatorPosture()`. GRANTs and readiness both follow.
2. **The five report statements** added to the integration suite, with
   `TestScheduledReportStatementsAreDeniedWithoutTheReportTableGrants` as their mutation control.
   It asserts the statements **pass before** the revocation, so the 42501s after it are
   attributable rather than incidental.
3. **Class fix** — `TestCoordinatorPostureCoversSchedulerSQLTables` derives every `public.<table>`
   named in `internal/scheduler` from the **source** and fails if any is absent from the posture.
   A producer added tomorrow either lands in the posture or fails the build. It proves coverage
   only; sufficiency stays with the integration suite, which runs the statements as the real
   restricted role.

## Verification

- Each of the three tables removed **individually** → the coverage test names exactly that table
  (checked per-table, not just in aggregate).
- The scan `t.Fatal`s if it reads zero files or finds zero tables, so a broken scan cannot report
  success.
- `PYTHON=.venv/bin/python bash ci/check_go.sh all` → **rc=0, 118 ok packages, 0 FAIL**.

## Deployment note

Applying this requires the pinned River migration to re-run so the coordinator GRANTs are
re-emitted. **A hand-run `GRANT` is not a valid workaround** — `CheckRolePosture` proves the role
holds the declared posture *"no more, no less, by any route"*, so granting an undeclared privilege
makes readiness **fail**.

Closes CHAOS-3935
