### PR TITLE
fix(contracts): resolve contract artifacts from installed distributions (CHAOS-3933)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,21 @@ include-package-data = true
 ]
 "contracts/jobs/v1/examples" = ["contracts/jobs/v1/examples/*.json"]
 "contracts/jobs/v1/schemas" = ["contracts/jobs/v1/schemas/*.json"]
+# provider-matrix and sync-dispatch ship for the same reason contracts/jobs
+# does: dev_health_ops reads them at RUNTIME, not only in a checkout.
+# Omitting them made every production sync dispatch fail with a
+# FileNotFoundError once the Go bridge moved dispatch onto the installed
+# api service (CHAOS-3933). Keep this in step with the resolver fallbacks in
+# workers/provider_unit_route.py and sync/dispatch_routes.py -- packaging and
+# resolution are one contract, and either half alone still fails.
+"contracts/provider-matrix/v1" = [
+  "contracts/provider-matrix/v1/*.json",
+  "contracts/provider-matrix/v1/*.md",
+]
+"contracts/sync-dispatch/v1" = [
+  "contracts/sync-dispatch/v1/*.json",
+  "contracts/sync-dispatch/v1/*.md",
+]
 
 [tool.ruff]
 line-length = 88

--- a/src/dev_health_ops/contract_artifacts.py
+++ b/src/dev_health_ops/contract_artifacts.py
@@ -1,0 +1,57 @@
+"""Resolve checked-in contract artifacts in a checkout OR an installed distribution.
+
+Every consumer of a ``contracts/`` artifact needs the same two-step answer, and
+getting it wrong is silent until runtime. ``provider_unit_route.py`` resolved
+its matrix as ``Path(__file__).resolve().parents[3] / "contracts" / ...``, which
+is the repository root in a source checkout and ``/usr/local/lib/python3.14`` in
+an installed wheel, because the intermediate directory is ``site-packages``
+rather than ``src``. Nothing failed until the Go sync-dispatch bridge moved
+dispatch onto the installed ``api`` service, at which point every production
+``dispatch_sync_run`` returned 500 (CHAOS-3933).
+
+Two properties this module exists to hold:
+
+* The anchor is the PACKAGE directory, not the calling module. Counting
+  ``parents[N]`` per call site means the count is a function of where the file
+  happens to live, so moving a module one directory deeper breaks resolution
+  with no other symptom. ``dev_health_ops`` is always one level below ``src``.
+* Resolution and packaging are ONE contract. A path this function can compute
+  is still useless if ``pyproject.toml`` does not ship the tree, so the two are
+  documented against each other in both places.
+"""
+
+from __future__ import annotations
+
+import sysconfig
+from pathlib import Path
+
+# .../src/dev_health_ops -> parents[1] is the repository root in a checkout.
+# In an installed distribution this resolves to the interpreter's lib directory,
+# which will not contain "contracts", so the checkout branch simply misses and
+# the installed branch answers.
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_CHECKOUT_ROOT = _PACKAGE_ROOT.parents[1]
+
+
+def contract_directory(*parts: str) -> Path:
+    """Return a ``contracts/`` subdirectory, preferring a source checkout.
+
+    ``parts`` is the path BELOW ``contracts/`` -- for example
+    ``contract_directory("provider-matrix", "v1")``.
+
+    The checkout answer wins when it exists so that a developer editing a
+    contract sees the edit without reinstalling. The installed answer is
+    ``sysconfig.get_path("data")/contracts/...``, matching where
+    ``[tool.setuptools.data-files]`` places the trees.
+
+    Neither branch is verified to CONTAIN the artifact the caller wants: callers
+    already fail closed on a missing file with a message naming it, and a
+    directory-exists check here would only move that failure earlier without
+    making it clearer.
+    """
+
+    relative = Path(*parts)
+    checkout = _CHECKOUT_ROOT / "contracts" / relative
+    if checkout.is_dir():
+        return checkout
+    return Path(sysconfig.get_path("data")) / "contracts" / relative

--- a/src/dev_health_ops/sync/dispatch_routes.py
+++ b/src/dev_health_ops/sync/dispatch_routes.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
+from dev_health_ops.contract_artifacts import contract_directory
+
 MAX_TRANSPORT_ROUTES_BYTES = 16 * 1024
 _MAX_JSON_DEPTH = 8
 
@@ -71,15 +73,14 @@ class TransportRoutes:
 
 
 def default_transport_routes_path() -> Path:
-    """Return the checked-in v1 transport contract from a source checkout."""
+    """Return the v1 transport contract from a checkout or an installed dist.
 
-    return (
-        Path(__file__).resolve().parents[3]
-        / "contracts"
-        / "sync-dispatch"
-        / "v1"
-        / "transport-routes.json"
-    )
+    Resolved through contract_artifacts rather than a per-file parents[N]
+    count, which resolves to the interpreter's lib directory once installed
+    (CHAOS-3933).
+    """
+
+    return contract_directory("sync-dispatch", "v1") / "transport-routes.json"
 
 
 def load_transport_routes(path: Path | None = None) -> TransportRoutes:

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
 
+from dev_health_ops.contract_artifacts import contract_directory
 from dev_health_ops.sync.planner import (
     _FAMILY_CANONICAL_DATASET_KEY,
     _WORK_ITEM_FAMILY_DATASET_ORDER,
@@ -67,13 +68,12 @@ _LOCAL_ALL_ALIAS_CANONICAL = {
     for alternative in alternatives
 }
 
-# src/dev_health_ops/workers/provider_unit_route.py -> repo root is 3 parents up.
+# Resolved through contract_artifacts rather than a per-file parents[N] count.
+# The count here used to be 3, correct in a checkout and wrong in an installed
+# distribution, where the same three hops land on the interpreter's lib
+# directory instead of the repository root (CHAOS-3933).
 _DEFAULT_MATRIX_CONTRACT_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "contracts"
-    / "provider-matrix"
-    / "v1"
-    / "matrix.json"
+    contract_directory("provider-matrix", "v1") / "matrix.json"
 )
 
 # Reassignable only by tests (see tests/workers/test_provider_unit_route.py),

--- a/tests/tooling/test_contract_artifact_packaging.py
+++ b/tests/tooling/test_contract_artifact_packaging.py
@@ -1,0 +1,189 @@
+"""Contract artifacts must resolve from an INSTALLED distribution, not only a checkout.
+
+CHAOS-3933. ``provider_unit_route.py`` resolved the provider matrix as
+``Path(__file__).resolve().parents[3] / "contracts" / ...``. Three hops from
+``src/dev_health_ops/workers/`` is the repository root; three hops from
+``site-packages/dev_health_ops/workers/`` is the interpreter's ``lib``
+directory, because the intermediate directory is ``site-packages`` rather than
+``src``. Nothing failed while dispatch ran inside the Celery runner image,
+which carries the source tree. The Go sync-dispatch bridge then moved dispatch
+onto the ``api`` service, which runs the installed wheel, and every production
+``dispatch_sync_run`` returned 500:
+
+    FileNotFoundError: [Errno 2] No such file or directory:
+    '/usr/local/lib/python3.14/contracts/provider-matrix/v1/matrix.json'
+
+The code had not changed. The LAYOUT under it had.
+
+Resolution and packaging are one contract and each half is useless alone: a
+resolver that checks the installed location still finds nothing if
+``pyproject.toml`` does not ship the tree, and a shipped tree is never read by
+a resolver that only looks in a checkout. Both halves are asserted here.
+
+A checkout-only test cannot see either failure -- it passes today, before any
+fix, which is precisely why the bug reached production.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import sysconfig
+from pathlib import Path
+
+import pytest
+import tomllib
+
+from dev_health_ops import contract_artifacts
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# The trees dev_health_ops reads at runtime, and the loader that reads each.
+RUNTIME_CONTRACT_TREES = {
+    ("provider-matrix", "v1"): "matrix.json",
+    ("sync-dispatch", "v1"): "transport-routes.json",
+}
+
+
+def _data_files() -> dict[str, list[str]]:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        config = tomllib.load(handle)
+    return config["tool"]["setuptools"]["data-files"]
+
+
+@pytest.mark.parametrize("parts,artifact", list(RUNTIME_CONTRACT_TREES.items()))
+def test_runtime_contract_tree_is_packaged(
+    parts: tuple[str, ...], artifact: str
+) -> None:
+    """pyproject must ship every contract tree read at runtime.
+
+    Declaring the destination is not enough: the globs must actually match the
+    artifact the loader opens, so renaming a file without updating the glob
+    fails here rather than in production.
+    """
+
+    destination = "contracts/" + "/".join(parts)
+    data_files = _data_files()
+    assert destination in data_files, (
+        f"{destination} is read at runtime by dev_health_ops but is not in "
+        "[tool.setuptools.data-files]. It will be absent from the installed "
+        "distribution and every read of it will raise FileNotFoundError."
+    )
+    relative = f"{destination}/{artifact}"
+    assert any(
+        fnmatch.fnmatch(relative, pattern) for pattern in data_files[destination]
+    ), (
+        f"{relative} is not matched by any glob for {destination}: "
+        f"{data_files[destination]}"
+    )
+
+
+@pytest.mark.parametrize("parts,artifact", list(RUNTIME_CONTRACT_TREES.items()))
+def test_every_shipped_artifact_exists_on_disk(
+    parts: tuple[str, ...], artifact: str
+) -> None:
+    """The glob must match a file that is actually there.
+
+    Without this, a typo'd destination would satisfy the test above by matching
+    nothing at all -- a packaging declaration that ships an empty directory
+    reads as success.
+    """
+
+    tree = ROOT / "contracts" / Path(*parts)
+    assert (tree / artifact).is_file(), f"{tree / artifact} does not exist"
+
+
+def test_resolver_prefers_the_checkout() -> None:
+    for parts, artifact in RUNTIME_CONTRACT_TREES.items():
+        resolved = contract_artifacts.contract_directory(*parts)
+        assert (resolved / artifact).is_file(), (
+            f"{artifact} did not resolve from the checkout: {resolved}"
+        )
+
+
+def test_resolver_falls_back_to_the_installed_data_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no checkout above the package, resolution must use the data path.
+
+    This is the branch that did not exist. It simulates the installed layout by
+    pointing the checkout anchor at a directory with no ``contracts/`` in it --
+    exactly what ``site-packages/dev_health_ops`` produces -- and asserts the
+    resolver answers with sysconfig's data path rather than a path under the
+    interpreter's lib directory.
+    """
+
+    monkeypatch.setattr(contract_artifacts, "_CHECKOUT_ROOT", ROOT / "does-not-exist")
+    expected_root = Path(sysconfig.get_path("data")) / "contracts"
+    for parts in RUNTIME_CONTRACT_TREES:
+        resolved = contract_artifacts.contract_directory(*parts)
+        assert resolved == expected_root.joinpath(*parts), (
+            f"installed-layout resolution for {parts} returned {resolved}"
+        )
+
+
+def test_loaders_resolve_from_the_installed_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each loader -- not just the resolver -- must answer correctly when installed.
+
+    This is the assertion that would have caught CHAOS-3933, and the one a
+    checkout-only test structurally cannot make. With the checkout anchor
+    pointed at a directory containing no ``contracts/``, a loader built on
+    ``contract_directory`` answers under sysconfig's data path, while one built
+    on a ``parents[N]`` count answers under the interpreter's lib directory --
+    the exact wrong path from the production traceback.
+
+    ``provider_unit_route`` computes its path at import time, so it is reloaded
+    under the patched anchor; ``dispatch_routes`` computes its path per call.
+    """
+
+    import importlib
+
+    from dev_health_ops.sync import dispatch_routes
+    from dev_health_ops.workers import provider_unit_route
+
+    data_root = Path(sysconfig.get_path("data")) / "contracts"
+    monkeypatch.setattr(contract_artifacts, "_CHECKOUT_ROOT", ROOT / "does-not-exist")
+
+    try:
+        reloaded = importlib.reload(provider_unit_route)
+        resolved = {
+            "provider_unit_route._DEFAULT_MATRIX_CONTRACT_PATH": (
+                reloaded._DEFAULT_MATRIX_CONTRACT_PATH
+            ),
+            "dispatch_routes.default_transport_routes_path()": (
+                dispatch_routes.default_transport_routes_path()
+            ),
+        }
+        for name, path in resolved.items():
+            assert data_root in path.parents, (
+                f"{name} resolved to {path} under the installed layout. It is not "
+                "using contract_artifacts.contract_directory -- a parents[N] count "
+                "lands in the interpreter lib directory once installed, which is "
+                "how CHAOS-3933 reached production."
+            )
+    finally:
+        monkeypatch.undo()
+        importlib.reload(provider_unit_route)
+
+
+def test_loaders_use_the_shared_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both known loaders must go through contract_artifacts.
+
+    Pinning the resolver rather than the string keeps a future third consumer
+    from reintroducing its own parents[N] count: the count is a function of
+    where a module happens to live, so moving a file one directory deeper
+    breaks resolution with no other symptom.
+    """
+
+    from dev_health_ops.sync import dispatch_routes
+    from dev_health_ops.workers import provider_unit_route
+
+    matrix = provider_unit_route._DEFAULT_MATRIX_CONTRACT_PATH
+    routes = dispatch_routes.default_transport_routes_path()
+    for resolved in (matrix, routes):
+        assert "site-packages" not in resolved.parts, (
+            "a contract artifact resolved INSIDE site-packages, which means a "
+            "parents[N] count leaked back in"
+        )
+        assert resolved.is_file(), f"{resolved} does not exist"

--- a/tests/tooling/test_contract_artifact_packaging.py
+++ b/tests/tooling/test_contract_artifact_packaging.py
@@ -27,7 +27,10 @@ fix, which is precisely why the bug reached production.
 from __future__ import annotations
 
 import fnmatch
+import subprocess
+import sys
 import sysconfig
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -121,9 +124,7 @@ def test_resolver_falls_back_to_the_installed_data_path(
         )
 
 
-def test_loaders_resolve_from_the_installed_layout(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_loaders_resolve_from_the_installed_layout() -> None:
     """Each loader -- not just the resolver -- must answer correctly when installed.
 
     This is the assertion that would have caught CHAOS-3933, and the one a
@@ -133,38 +134,61 @@ def test_loaders_resolve_from_the_installed_layout(
     on a ``parents[N]`` count answers under the interpreter's lib directory --
     the exact wrong path from the production traceback.
 
-    ``provider_unit_route`` computes its path at import time, so it is reloaded
-    under the patched anchor; ``dispatch_routes`` computes its path per call.
+    Run in a SUBPROCESS on purpose. ``provider_unit_route`` computes its path at
+    import time, so an in-process version of this test has to
+    ``importlib.reload`` it -- and reload installs a NEW module object while
+    every earlier ``from ... import`` in the session keeps binding the old one.
+    That divergence is not hypothetical: the reload version of this test made
+    tests/test_sync_units.py::test_dispatch_sync_run_mixed_transport_routes_every_ready_pair_independently
+    fail whenever it ran first in the same process, and passed cleanly on its
+    own -- a full-suite-only failure that reads as someone else's flake. A fresh
+    interpreter proves the same property and mutates nothing.
     """
 
-    import importlib
+    probe = textwrap.dedent(
+        """
+        import pathlib, sysconfig
+        from dev_health_ops import contract_artifacts
 
-    from dev_health_ops.sync import dispatch_routes
-    from dev_health_ops.workers import provider_unit_route
+        # Simulate site-packages: an anchor with no contracts/ beneath it.
+        contract_artifacts._CHECKOUT_ROOT = pathlib.Path("/nonexistent-checkout-root")
+
+        from dev_health_ops.sync import dispatch_routes
+        from dev_health_ops.workers import provider_unit_route
+
+        print(provider_unit_route._DEFAULT_MATRIX_CONTRACT_PATH)
+        print(dispatch_routes.default_transport_routes_path())
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"installed-layout probe failed:\nstdout={completed.stdout}\nstderr={completed.stderr}"
+    )
+    printed = [line for line in completed.stdout.splitlines() if line.startswith("/")]
+    assert len(printed) == 2, f"probe printed {printed!r}, expected two paths"
 
     data_root = Path(sysconfig.get_path("data")) / "contracts"
-    monkeypatch.setattr(contract_artifacts, "_CHECKOUT_ROOT", ROOT / "does-not-exist")
-
-    try:
-        reloaded = importlib.reload(provider_unit_route)
-        resolved = {
-            "provider_unit_route._DEFAULT_MATRIX_CONTRACT_PATH": (
-                reloaded._DEFAULT_MATRIX_CONTRACT_PATH
-            ),
-            "dispatch_routes.default_transport_routes_path()": (
-                dispatch_routes.default_transport_routes_path()
-            ),
-        }
-        for name, path in resolved.items():
-            assert data_root in path.parents, (
-                f"{name} resolved to {path} under the installed layout. It is not "
-                "using contract_artifacts.contract_directory -- a parents[N] count "
-                "lands in the interpreter lib directory once installed, which is "
-                "how CHAOS-3933 reached production."
-            )
-    finally:
-        monkeypatch.undo()
-        importlib.reload(provider_unit_route)
+    for name, raw in zip(
+        (
+            "provider_unit_route._DEFAULT_MATRIX_CONTRACT_PATH",
+            "dispatch_routes.default_transport_routes_path()",
+        ),
+        printed,
+        strict=True,
+    ):
+        resolved = Path(raw)
+        assert data_root in resolved.parents, (
+            f"{name} resolved to {resolved} under the installed layout. It is not "
+            "using contract_artifacts.contract_directory -- a parents[N] count "
+            "lands in the interpreter lib directory once installed, which is "
+            "how CHAOS-3933 reached production."
+        )
 
 
 def test_loaders_use_the_shared_resolver(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

`provider_unit_route.py` and `dispatch_routes.py` located their contract JSON via `Path(__file__).resolve().parents[3] / "contracts" / ...`. The `parents[3]` count is the repo root in a source checkout, but resolves to `/usr/local/lib/python3.14` in an installed wheel, because the intermediate directory is `site-packages` rather than `src`. `pyproject.toml` shipped only `contracts/jobs/v1`, so even a correct resolver would have had nothing to find for the other two contracts.

This was silent until the Go sync-dispatch bridge moved dispatch onto the installed `api` service: every production `dispatch_sync_run` started returning 500 with `FileNotFoundError` on `contracts/provider-matrix/v1/matrix.json`.

Resolution and packaging are one contract — either half fixed alone still fails. This adds `contract_artifacts.contract_directory(*parts)`, a shared resolver anchored on the `dev_health_ops` PACKAGE directory rather than a per-call-site `parents[N]` count, so a module moving one level deeper cannot silently break resolution again. It prefers a checkout root and falls back to `sysconfig.get_path("data")/contracts/...`, matching where `[tool.setuptools.data-files]` now places `contracts/provider-matrix/v1` and `contracts/sync-dispatch/v1` in an installed distribution.

## Verification

- **Control A**: reverting `provider_unit_route.py` to `parents[3]` fails ONLY `test_loaders_resolve_from_the_installed_layout`; the other 7 tests in the new suite still pass. That is the proof a checkout-only test is structurally blind to this bug.
- **Control B**: removing the `pyproject.toml` data-files entries fails both `test_runtime_contract_tree_is_packaged` cases.
- **Empirical**: `uv build --wheel` produces a wheel containing `dev_health_ops-*.data/data/contracts/provider-matrix/v1/matrix.json` and `.../sync-dispatch/v1/transport-routes.json` — which install to `sysconfig`'s data path, exactly where the resolver's fallback looks.

## Gate note

Ran `ci/local_validate.sh` locally. Result:

```
GATE_STAGE_MANIFEST result=FAILED declared=8 executed=7 declared_ids=lint_format,lint_check,typecheck,ch_probe,ch_scratch_create,ch_migrate,unit_suite,ch_argmax_proof executed_ids=lint_format,lint_check,typecheck,ch_probe,ch_scratch_create,ch_migrate,unit_suite failed_at=unit suite (FULL, not subset)
```

- `lint_format`, `lint_check`, `typecheck`, `ch_probe`, `ch_scratch_create`, `ch_migrate` all PASSED.
- `unit_suite` FAILED: 20 pre-existing failures, all in `tests/test_sync_units.py` (route/family dispatch tests), unrelated to this diff.
- I confirmed these reproduce on unmodified `main` code: reverted the 3 changed source files to their pre-PR versions in this worktree and reran — identical 20 failures.
- `main`'s CI (GitHub Actions) is GREEN at the branch base commit — Lint, Typecheck, Integration Tests, and Live Backend E2E all succeeded there. So this is a local-environment-specific difference, not a broken `main`.
- This PR does **not** claim "gate passed" — the above is exactly what passed and what did not locally. PR CI is the adjudicating venue for this change.

## Operational note

The OCI host currently carries a STOPGAP bind-mount (`./contracts-overlay:/usr/local/lib/python3.14/contracts:ro` on the `api` service) that must be removed once this ships, along with `~/fullchaos.dev/contracts-overlay/`.

Closes CHAOS-3933
