### PR TITLE
fix(providersync): make GitHub work-item incompleteness normalization a fixed point (CHAOS-3940)

### DIFF
--- a/internal/providersync/github_work_items_incomplete.go
+++ b/internal/providersync/github_work_items_incomplete.go
@@ -63,9 +63,21 @@ func applyGitHubWorkItemsIncompletePolicy(
 	}
 
 	normalized := cloneCompletionResult(result)
-	normalized[githubWorkItemsIncompleteResultKey] = append(
-		[]GitHubWorkItemsIncomplete(nil), incomplete...,
-	)
+	// The normalized entry MUST be a non-nil slice. This policy is applied
+	// twice on every healthy GitHub work-items unit -- once by
+	// CompleteRouteExecutor.Execute (complete_route.go) on the collected batch,
+	// and again by PostgresRepository.Complete (repository_postgres.go) on the
+	// payload that batch produced -- and the prepared snapshot re-reads it a
+	// third time through JSON on recovery. json.Marshal renders a nil slice as
+	// `null`, which is exactly the "the route emitted no durable evidence"
+	// shape the reader above fails closed on. Writing `append(nil)` therefore
+	// made the empty-evidence case (no optional enrichment failed: the healthy
+	// path) accepted on the first application and refused on the second, so
+	// github/work-items committed its effects and then failed completion on
+	// every attempt, forever (CHAOS-3940). Normalization must be a fixed point.
+	entries := make([]GitHubWorkItemsIncomplete, 0, len(incomplete))
+	entries = append(entries, incomplete...)
+	normalized[githubWorkItemsIncompleteResultKey] = entries
 	if len(incomplete) != 0 {
 		return normalized, nil, nil
 	}

--- a/internal/providersync/github_work_items_incomplete_test.go
+++ b/internal/providersync/github_work_items_incomplete_test.go
@@ -1,6 +1,8 @@
 package providersync
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -144,6 +146,92 @@ func TestGitHubWorkItemsIncompletePolicyDoesNotAffectOtherRoutes(t *testing.T) {
 			if err != nil || reflect.ValueOf(normalized).Pointer() != reflect.ValueOf(result).Pointer() ||
 				gotWatermark != &watermark {
 				t.Fatalf("result=%v watermark=%v error=%v", normalized, gotWatermark, err)
+			}
+		})
+	}
+}
+
+// TestGitHubWorkItemsIncompletePolicyIsAFixedPoint pins CHAOS-3940.
+//
+// The policy is not applied once. CompleteRouteExecutor.Execute applies it to
+// the collected batch, PostgresRepository.Complete applies it again to the
+// payload that batch produced, and the prepared-snapshot recovery path applies
+// it a third time to the JSON decode of the same value. Its output must
+// therefore be accepted by its own input contract.
+//
+// Before the fix the empty case -- the healthy GitHub work-items unit, where
+// no optional enrichment failed -- normalized to a NIL typed slice. json.Marshal
+// renders that as `null`, the reader's fail-closed "no durable evidence" shape,
+// so the second application refused a unit whose sixteen ClickHouse effects had
+// already been committed. Length-only assertions cannot see this: a nil slice
+// and an empty slice both have len 0 and only differ once they are marshalled.
+func TestGitHubWorkItemsIncompletePolicyIsAFixedPoint(t *testing.T) {
+	t.Parallel()
+	for name, seed := range map[string]any{
+		// Exactly what GitHubWorkItemsRouteHandler.Collect emits when every
+		// optional phase succeeded (github_work_items_route.go:238,402).
+		"healthy empty batch": []GitHubWorkItemsIncomplete{},
+		"durable evidence": []GitHubWorkItemsIncomplete{
+			{Component: "milestones", Cause: "transient"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			watermark := time.Date(2026, 8, 20, 1, 0, 0, 0, time.UTC)
+			result := map[string]any{
+				"records":                          3,
+				githubWorkItemsIncompleteResultKey: seed,
+			}
+
+			// 1. CompleteRouteExecutor.Execute (complete_route.go).
+			executed, executedWatermark, err := applyGitHubWorkItemsIncompletePolicy(
+				"github", "work-items", result, &watermark,
+			)
+			if err != nil {
+				t.Fatalf("executor application rejected a well-formed batch: %v", err)
+			}
+			// A nil slice marshals to `null`; an empty slice marshals to `[]`.
+			// Assert the wire shape, not the length.
+			encoded, err := json.Marshal(executed[githubWorkItemsIncompleteResultKey])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Equal(encoded, []byte("null")) {
+				t.Fatalf(
+					"normalized incomplete evidence marshals to null: %#v",
+					executed[githubWorkItemsIncompleteResultKey],
+				)
+			}
+
+			// 2. PostgresRepository.Complete (repository_postgres.go:109),
+			//    on the very map the executor produced.
+			completed, _, err := applyGitHubWorkItemsIncompletePolicy(
+				"github", "work-items", executed, executedWatermark,
+			)
+			if err != nil {
+				t.Fatalf("completion application refused the executor's own output: %v", err)
+			}
+
+			// 3. Prepared-snapshot recovery: the executor's batch is persisted
+			//    as JSON and decoded back before the policy runs on it again
+			//    (complete_route.go:249). A failure here does not even surface
+			//    as this error -- the recovery path converts it to
+			//    ErrEffectLedgerConflict, which is what wedged every retry.
+			raw, err := json.Marshal(executed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := applyGitHubWorkItemsIncompletePolicy(
+				"github", "work-items", decoded, executedWatermark,
+			); err != nil {
+				t.Fatalf("recovery application refused the persisted snapshot: %v", err)
+			}
+			if _, present := completed[githubWorkItemsIncompleteResultKey]; !present {
+				t.Fatal("completion application dropped the evidence key")
 			}
 		})
 	}

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -950,6 +950,40 @@ func TestCompleteRouteExecutorRecoversASnapshotItPreparedItself(t *testing.T) {
 		t.Fatalf("first pass result=%+v prepares=%d", first, ledger.preparedPrepares)
 	}
 
+	// Production's second attempt does NOT arrive on the first attempt's
+	// session. It arrives on a fresh claim with a new owner and an advanced
+	// attempt count -- either released back to `dispatching` after a failed
+	// Complete, or recovered from an expired lease after a crash. Reusing the
+	// original session would test a retry shape production never takes, so
+	// re-claim here. The expired-lease path is the stricter of the two: it is
+	// the one that also sets Recovered.
+	retryAt := now.Add(10 * time.Minute)
+	retryClaim, err := session.Repository.Claim(context.Background(), ClaimRequest{
+		UnitID: claim.ID, OrgID: claim.OrgID, Owner: uuid.NewString(), Now: retryAt,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatalf("second attempt could not claim the unit: %v", err)
+	}
+	if retryClaim.Attempt <= claim.Attempt || retryClaim.Owner == claim.Owner ||
+		!retryClaim.Recovered {
+		t.Fatalf(
+			"retry claim must be a distinct attempt: attempt %d->%d owner_changed=%v recovered=%v",
+			claim.Attempt, retryClaim.Attempt, retryClaim.Owner != claim.Owner,
+			retryClaim.Recovered,
+		)
+	}
+	// The generation key is derived from the unit id alone (lease.go:146), so
+	// the advanced attempt must still resolve to the same durable artifact.
+	if retryClaim.GenerationKey() != claim.GenerationKey() {
+		t.Fatalf("generation drifted across attempts: %q -> %q",
+			claim.GenerationKey(), retryClaim.GenerationKey())
+	}
+	retrySession := &LeaseSession{
+		Repository: session.Repository, Claim: retryClaim, LeaseDuration: time.Minute,
+		Deadline: retryAt.Add(time.Hour), Now: func() time.Time { return retryAt },
+	}
+
 	// The durable artifact must be resumable. Recovery re-reads it through
 	// JSON, so a nil slice persisted as `null` fails here and nowhere earlier.
 	recovering := &staticCompleteRouteHandler{
@@ -957,8 +991,8 @@ func TestCompleteRouteExecutorRecoversASnapshotItPreparedItself(t *testing.T) {
 	}
 	recoverySink := &memoryEffectSink{}
 	second, err := completeRouteExecutor(
-		now.Add(10*time.Minute), recovering, ledger, recoverySink,
-	).Execute(context.Background(), session, descriptor)
+		retryAt, recovering, ledger, recoverySink,
+	).Execute(context.Background(), retrySession, descriptor)
 	if err != nil {
 		t.Fatalf("recovery refused the snapshot this route prepared: %v", err)
 	}

--- a/internal/providersync/prepared_route_snapshot_test.go
+++ b/internal/providersync/prepared_route_snapshot_test.go
@@ -897,3 +897,78 @@ func TestPreparedRecoveryWithholdsSuccessWhenASinkRefusesMidBatch(t *testing.T) 
 func sortStrings(values []string) {
 	sort.Strings(values)
 }
+
+// TestCompleteRouteExecutorRecoversASnapshotItPreparedItself closes the proof
+// gap CHAOS-3940 exposed.
+//
+// Every other recovery test here hands a batch straight to
+// ledger.PrepareRouteSnapshot. That skips the executor's OWN application of
+// applyGitHubWorkItemsIncompletePolicy, which is the step that rewrites
+// batch.Result before the snapshot is persisted -- so those tests persisted a
+// snapshot production never writes. Pre-fix the executor normalized an empty
+// evidence set to a nil slice, the snapshot stored `"incomplete": null`, and
+// recovery refused it as ErrEffectLedgerConflict (complete_route.go:253).
+// Production wedged; the suite stayed green.
+//
+// This drives Execute twice against one ledger: the first call collects,
+// normalizes, prepares and commits exactly as production does, and the second
+// recovers from the artifact the first one left behind. A route that cannot
+// resume its own durable snapshot is the failure this asserts against.
+func TestCompleteRouteExecutorRecoversASnapshotItPreparedItself(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 20, 1, 1, 40, 0, time.UTC)
+	claim, session := completeRouteSessionFor(t, now, false, "github", "work-items")
+	// The healthy shape: every optional enrichment phase succeeded, so the
+	// route reports an empty -- not absent -- evidence set.
+	batch := preparedGitHubWorkItemsFixture(t, claim)
+	if entries, ok := batch.Result[githubWorkItemsIncompleteResultKey].([]GitHubWorkItemsIncomplete); !ok ||
+		len(entries) != 0 {
+		t.Fatalf("fixture must carry an empty evidence set: %#v",
+			batch.Result[githubWorkItemsIncompleteResultKey])
+	}
+
+	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", "work-items")
+	if !ok || !descriptor.PreparedManifestRecovery {
+		t.Fatalf("descriptor=%+v ok=%v", descriptor, ok)
+	}
+	descriptor.Destinations = workItemRouteDestinations()
+	descriptor.RouteReady, descriptor.RouteEnabled = true, true
+
+	ledger := &memoryEffectLedger{}
+	collecting := &staticCompleteRouteHandler{batch: batch}
+	collectingExecutor := completeRouteExecutor(now, collecting, ledger, &memoryEffectSink{})
+	// The shared fixture pair issues a launchdarkly credential; this route's
+	// claim is github, and Execute requires the two to agree.
+	collectingExecutor.Credentials.Repository = executorCredentialRepository{}
+	collectingExecutor.Credentials.Decryptor = executorCredentialDecryptor{}
+	first, err := collectingExecutor.Execute(context.Background(), session, descriptor)
+	if err != nil {
+		t.Fatalf("live collect and prepare failed: %v", err)
+	}
+	if first.Effects.Written != len(workItemRouteDestinations()) ||
+		ledger.preparedPrepares != 1 {
+		t.Fatalf("first pass result=%+v prepares=%d", first, ledger.preparedPrepares)
+	}
+
+	// The durable artifact must be resumable. Recovery re-reads it through
+	// JSON, so a nil slice persisted as `null` fails here and nowhere earlier.
+	recovering := &staticCompleteRouteHandler{
+		batch: CompleteRouteBatch{Result: map[string]any{"live_provider": "must not be used"}},
+	}
+	recoverySink := &memoryEffectSink{}
+	second, err := completeRouteExecutor(
+		now.Add(10*time.Minute), recovering, ledger, recoverySink,
+	).Execute(context.Background(), session, descriptor)
+	if err != nil {
+		t.Fatalf("recovery refused the snapshot this route prepared: %v", err)
+	}
+	if second.Effects.Skipped != len(workItemRouteDestinations()) ||
+		second.Effects.Written != 0 || len(recoverySink.destinations) != 0 {
+		t.Fatalf("recovery result=%+v writes=%v", second, recoverySink.destinations)
+	}
+	// Recovery replays the snapshot; it must not re-collect or re-prepare.
+	if !recovering.normalizedAt.IsZero() || ledger.preparedPrepares != 1 {
+		t.Fatalf("recovery recollected at=%s prepares=%d",
+			recovering.normalizedAt, ledger.preparedPrepares)
+	}
+}

--- a/internal/providersync/repository_postgres_integration_test.go
+++ b/internal/providersync/repository_postgres_integration_test.go
@@ -693,3 +693,154 @@ const snapshotFixtureDDL = `CREATE TABLE public.sync_run_unit_effect_snapshots (
 		REFERENCES public.sync_run_units(org_id, id)
 		ON DELETE CASCADE
 )`
+
+// workItemsFamilyUnitID is the CHAOS-3940 fixture unit: a healthy GitHub
+// work-items claim carrying the complete five-dataset family flag set.
+const workItemsFamilyUnitID = "66666666-6666-4666-8666-666666666666"
+
+// TestPostgresCompleteLandsGitHubWorkItemsFamilyWatermarks pins CHAOS-3940 at
+// the effect boundary.
+//
+// github/work-items produced zero successful units after the Go cutover. Every
+// one committed all sixteen ClickHouse destinations and then failed, so the
+// ledger reported "committed" while the unit never terminalized and not one of
+// the five family watermarks ever advanced past the cutover instant. A test
+// that only asserted Complete was CALLED would have passed throughout.
+//
+// This drives the two real applications of applyGitHubWorkItemsIncompletePolicy
+// in their production order -- CompleteRouteExecutor.Execute, then
+// PostgresRepository.Complete -- against the real completion SQL, and asserts
+// the observable effect: the unit is terminal and all five alias watermarks
+// carry the window's close.
+func TestPostgresCompleteLandsGitHubWorkItemsFamilyWatermarks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	if _, err := pool.Exec(ctx, `
+INSERT INTO public.integration_datasets (id, org_id, integration_id, dataset_key, options)
+VALUES ($1, 'org-acme', $2, 'work-items', '{}'::jsonb)`,
+		uuid.NewString(), firstIntegrationID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+INSERT INTO public.sync_run_units (
+    id, org_id, sync_run_id, integration_id, source_id, provider,
+    dataset_key, cost_class, mode, since_at, before_at, status,
+    processor_flags, updated_at
+) VALUES (
+    $1, 'org-acme', $2, $3, $4, 'github', 'work-items', 'medium',
+    'incremental', '2026-08-19T20:00:00Z', '2026-08-20T01:00:00Z',
+    'dispatching',
+    '{"sync_prs":true,
+      "family_dataset_work_items":true,
+      "family_dataset_work_item_labels":true,
+      "family_dataset_work_item_history":true,
+      "family_dataset_work_item_comments":true,
+      "family_dataset_work_item_projects":true}'::jsonb,
+    NOW()
+)`, workItemsFamilyUnitID, firstRunID, firstIntegrationID, firstSourceID); err != nil {
+		t.Fatal(err)
+	}
+
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Date(2026, time.August, 20, 1, 1, 40, 0, time.UTC)
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: workItemsFamilyUnitID, OrgID: "org-acme", Owner: uuid.NewString(),
+		Now: startedAt, LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly what GitHubWorkItemsRouteHandler.Collect emits when every optional
+	// enrichment phase succeeded, then normalized once by the executor.
+	windowClose := time.Date(2026, time.August, 20, 1, 0, 0, 0, time.UTC)
+	routeResult, routeWatermark, err := applyGitHubWorkItemsIncompletePolicy(
+		claim.Provider, claim.Dataset,
+		map[string]any{
+			"records":                          48,
+			githubWorkItemsIncompleteResultKey: []GitHubWorkItemsIncomplete{},
+		},
+		&windowClose,
+	)
+	if err != nil {
+		t.Fatalf("executor-side policy rejected a healthy batch: %v", err)
+	}
+
+	if err := repository.Complete(
+		ctx, claim, routeResult, routeWatermark, startedAt,
+		startedAt.Add(2*time.Second),
+	); err != nil {
+		t.Fatalf("Complete refused a healthy GitHub work-items unit: %v", err)
+	}
+
+	var status string
+	if err := pool.QueryRow(ctx,
+		`SELECT status FROM public.sync_run_units WHERE id = $1`,
+		workItemsFamilyUnitID,
+	).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "success" {
+		t.Fatalf("unit status=%q want success", status)
+	}
+
+	// The effect that matters: every alias watermark advanced to the window
+	// close. While the bug stood these five rows did not exist at all, so the
+	// planner re-fetched the same window forever and coverage saw no gap.
+	rows, err := pool.Query(ctx, `
+SELECT dataset_key, last_synced_at FROM public.sync_watermarks
+WHERE org_id = 'org-acme' AND source_id = $1 ORDER BY dataset_key`,
+		claim.SourceExternalID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	landed := map[string]time.Time{}
+	for rows.Next() {
+		var datasetKey string
+		var syncedAt time.Time
+		if err := rows.Scan(&datasetKey, &syncedAt); err != nil {
+			t.Fatal(err)
+		}
+		landed[datasetKey] = syncedAt.UTC()
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	for _, datasetKey := range []string{
+		"work-items", "work-item-labels", "work-item-history",
+		"work-item-comments", "work-item-projects",
+	} {
+		got, present := landed[datasetKey]
+		if !present {
+			t.Fatalf("watermark for %q never landed; landed=%v", datasetKey, landed)
+		}
+		if !got.Equal(windowClose) {
+			t.Fatalf("watermark %q=%v want %v", datasetKey, got, windowClose)
+		}
+	}
+	if len(landed) != 5 {
+		t.Fatalf("unexpected watermark set: %v", landed)
+	}
+}


### PR DESCRIPTION
## What broke

`github/work-items` produced **zero** successful sync units after the Go cutover — 0 ok, 18 failed, while every other enabled GitHub dataset ran clean. Each unit committed all sixteen ClickHouse destinations and *then* failed `provider_unit_exhausted`, so the effect ledger recorded sixteen successful commits while not one of the five family watermarks advanced past the cutover instant. Coverage reporting saw no gap.

```
work-items | linear                      | 2026-08-20 01:00:00+00
work-items | full-chaos/dev-health-ops   | 2026-08-19 20:00:00+00
work-items | full-chaos/dev-health-web   | 2026-08-19 20:00:00+00
...                                        (all 9 github sources pinned)
```

## Mechanism

`applyGitHubWorkItemsIncompletePolicy` normalized an empty evidence set with `append([]GitHubWorkItemsIncomplete(nil), incomplete...)`, which yields a **nil** slice when there is nothing to append. `json.Marshal` renders a nil slice as `null` — exactly the "the route emitted no durable evidence" shape the same function's reader fails closed on (`github_work_items_incomplete.go:33-40`).

The policy runs three times on a healthy unit:

| # | site | input | outcome |
|---|---|---|---|
| 1 | `complete_route.go:352` — executor, collected batch | `[]T{}` from the route (`github_work_items_route.go:238,402`) → `[]` | **accepted**, writes a nil slice back |
| 2 | `repository_postgres.go:109` — `PostgresRepository.Complete` | that nil slice → `null` | **`ErrInvalidConfiguration`** |
| 3 | `complete_route.go:249` — prepared-snapshot recovery | persisted `"incomplete": null` → `null` | same refusal, rewritten to `ErrEffectLedgerConflict` by `:253` |

One defect, both production symptoms. Attempt 1 logged `provider sync configuration is invalid` **4 ms after** the sixteenth effect committed; attempts 2-5 logged `provider sync effect ledger conflicts with persisted state` until River exhausted the unit and `exhaustedFailureCategory` stamped the generic code (`providerunit.go:132,560-573`).

The reported `row_count: 0` was a red herring: two of the eighteen failed units committed 48 and 23 rows respectively and failed identically. Rows do land; the unit fails at completion regardless.

## Fix

Normalization must be a fixed point — emit a non-nil empty slice.

The reader is deliberately **not** loosened to accept `null`. A route that omits the evidence key entirely also marshals to `null`, and refusing that remains the load-bearing guard.

## Tests

Both were watched failing against unfixed code before the fix was applied.

- **`TestGitHubWorkItemsIncompletePolicyIsAFixedPoint`** — drives all three applications including the JSON snapshot round trip, and asserts the *wire shape* rather than the length.
  ```
  normalized incomplete evidence marshals to null: []providersync.GitHubWorkItemsIncomplete(nil)
  ```
- **`TestPostgresCompleteLandsGitHubWorkItemsFamilyWatermarks`** — testcontainers PostgreSQL against the real completion SQL. Asserts the **effect**, not the call: the unit is terminal *and* all five alias watermarks carry the window close. Pre-fix it reproduces production's exact string:
  ```
  Complete refused a healthy GitHub work-items unit: provider sync configuration is invalid
  ```

- **`TestCompleteRouteExecutorRecoversASnapshotItPreparedItself`** — the first `Execute` collects, normalizes, prepares and commits exactly as production does; the second **re-claims the unit** and recovers from the artifact the first left behind. The retry deliberately arrives the way production's does — a new owner and an advanced attempt count, via expired-lease recovery — and the test asserts the claim is genuinely distinct (`Attempt` advanced, owner changed, `Recovered` set) and that `GenerationKey()` is stable across attempts, which is *why* the advanced attempt still resolves to the same durable artifact. Pre-fix:
  ```
  recovery refused the snapshot this route prepared: provider sync effect ledger conflicts with persisted state
  ```

Both production symptoms are now pinned: `ErrInvalidConfiguration` at completion, and `ErrEffectLedgerConflict` on recovery.

Sixteen destinations reporting `committed` with zero rows is precisely the failure a call-assertion test misses, so the integration test asserts watermark rows landing.

### Why review missed this

Two independent blind spots, both now closed.

1. `github_work_items_incomplete_test.go:27` asserted `len(got) != 0`. A nil slice satisfies that — nil and empty diverge only once marshalled.
2. **Every** recovery test in `prepared_route_snapshot_test.go` (`:140`, `:227`, `:307`) hands a hand-built batch straight to `ledger.PrepareRouteSnapshot`, skipping the executor's own policy application — the step that rewrites `batch.Result` immediately before persisting. The suite therefore persisted `"incomplete": []` while production persisted `"incomplete": null`. The fixture at `:388` even seeds the correct non-nil `[]GitHubWorkItemsIncomplete{}`, so those tests exercised the shape the bug destroys, one call too early.

## Verification

`PYTHON="$PWD/.venv/bin/python" bash ci/check_go.sh all` — rc 0, 118 `ok` package lines.

## Operational note — why no migration is needed

Production holds 11 prepared snapshots, all `github/work-items`, all containing `"incomplete": null`. Every one belongs to a unit that is `failed` with `attempts = 5`.

Those rows were unreachable **because they are terminal**, and that much is enforced in SQL rather than by convention — `claimUnitSQL:470-484` admits a unit only when `status = 'dispatching'`, or `status = 'running'` with an expired lease, plus a fence on `run.status NOT IN ('success', 'partial_failed', 'failed')`. A `failed` unit matches neither branch. The generation key is `sync-unit:<unit_id>`, and a re-planned identical window mints a **new** unit id (production units `2ecc1f2e`, `fd2aec62` and `9d247a7e` share one source and window with three distinct ids), so a new run misses any old snapshot and collects fresh.

**Scope of that claim, stated precisely:** it covers terminal units only. A unit at attempts 1-4 sits in `dispatching` after `ReleaseForRetry` (`releaseForRetrySQL:653` sets exactly that), and a crashed one leaves an expired `running` unit — both are claimable. So a legacy `"incomplete": null` snapshot held by a non-terminal unit **is** reachable after rollout.

That case is bounded rather than dangerous: such a unit fails its remaining attempts and exhausts, which is precisely what it did before this fix — every pre-fix attempt hit `ErrInvalidConfiguration` or `ErrEffectLedgerConflict` and exhausted at attempt 5. No unit that could otherwise have succeeded is harmed, and the next scheduled run mints fresh units that complete. Production currently holds **0** prepared snapshots and no non-terminal `github/work-items` units, so present exposure is nil.

A legacy-null tolerance branch on the recovery path was considered and deliberately **not** added, including the narrow form gated on digest, tenant, generation and route identity. The digest covers the payload *including* the null, so a future producer emitting no evidence would also carry a valid digest and be canonicalized to "nothing was incomplete" — silently advancing all five watermarks on unreported incompleteness. That trades a permanent correctness hazard, on the path where the error is disguised as `ErrEffectLedgerConflict`, against rescuing units that are already doomed and self-heal next run.

If a rescue is wanted later, the better-shaped one already exists: `SafeReplanningCompleteRouteHandler.CanReplanRecovery` → `ResetPreparedEffectsForReplan` (`complete_route.go:105,315`), implemented today by `GitHubBlameRouteHandler` (`github_blame_route.go:176`). It drops the stale snapshot and re-collects, rescuing the unit without teaching any reader to accept `null`. Deliberately out of scope here and tracked as **CHAOS-3958**.

No deploy-ordering step is required.

No production mutation was performed during the investigation.

Closes CHAOS-3940.
