### PR TITLE
fix(scheduler): derive sync due-ness from the occurrence ledger (CHAOS-3936)

### DIFF
--- a/cmd/dev-health-scheduler/dependencies_test.go
+++ b/cmd/dev-health-scheduler/dependencies_test.go
@@ -180,8 +180,8 @@ func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
 				context.Context,
 				schedulersync.HandoffTransaction,
 				schedulersync.Occurrence,
-			) error {
-				return nil
+			) (schedulersync.HandoffOutcome, error) {
+				return schedulersync.OccurrenceMinted, nil
 			})
 		},
 		newLoop: schedulersync.NewLoop,

--- a/cmd/dev-health-scheduler/logging_wiring_test.go
+++ b/cmd/dev-health-scheduler/logging_wiring_test.go
@@ -42,8 +42,8 @@ func TestSyncSchedulerLoopReceivesTheComposedLoggerFromSchedulerCompositionRoot(
 		newCoordinator: func() schedulersync.Coordinator {
 			return schedulersync.CoordinatorFunc(func(
 				context.Context, schedulersync.HandoffTransaction, schedulersync.Occurrence,
-			) error {
-				return nil
+			) (schedulersync.HandoffOutcome, error) {
+				return schedulersync.OccurrenceMinted, nil
 			})
 		},
 		newLoop: schedulersync.NewLoop,

--- a/internal/scheduler/sync/coordinator.go
+++ b/internal/scheduler/sync/coordinator.go
@@ -26,18 +26,20 @@ func NewOccurrenceCoordinator() Coordinator {
 }
 
 // Handoff inserts or verifies the occurrence through the scheduler's locking
-// transaction. A matching row is an idempotent success.
+// transaction. A matching row is an idempotent success, reported as
+// OccurrenceRepeated so the caller can tell a window that produced work from
+// one that only re-confirmed a row an earlier window already wrote.
 func (OccurrenceCoordinator) Handoff(
 	ctx context.Context,
 	transaction HandoffTransaction,
 	occurrence Occurrence,
-) error {
+) (HandoffOutcome, error) {
 	if ctx == nil || transaction == nil || occurrence.ID == "" ||
 		occurrence.IdentityVersion != OccurrenceIdentityVersion ||
 		occurrence.ConfigID == "" || occurrence.OrgID == "" ||
 		occurrence.JobID == "" || occurrence.ScheduledFor.IsZero() ||
 		occurrence.ObservedAt.IsZero() {
-		return ErrInvalidTransactionRequest
+		return "", ErrInvalidTransactionRequest
 	}
 	var insertedID string
 	err := transaction.QueryRow(
@@ -53,12 +55,12 @@ func (OccurrenceCoordinator) Handoff(
 	).Scan(&insertedID)
 	if err == nil {
 		if insertedID != occurrence.ID {
-			return ErrOccurrenceConflict
+			return "", ErrOccurrenceConflict
 		}
-		return nil
+		return OccurrenceMinted, nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
-		return fmt.Errorf("insert scheduled sync occurrence: %w", err)
+		return "", fmt.Errorf("insert scheduled sync occurrence: %w", err)
 	}
 
 	var identityVersion, orgID, configID, jobID string
@@ -75,18 +77,18 @@ func (OccurrenceCoordinator) Handoff(
 		&scheduledFor,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return ErrOccurrenceConflict
+			return "", ErrOccurrenceConflict
 		}
-		return fmt.Errorf("verify scheduled sync occurrence: %w", err)
+		return "", fmt.Errorf("verify scheduled sync occurrence: %w", err)
 	}
 	if identityVersion != occurrence.IdentityVersion ||
 		orgID != occurrence.OrgID ||
 		configID != occurrence.ConfigID ||
 		jobID != occurrence.JobID ||
 		!scheduledFor.Equal(occurrence.ScheduledFor) {
-		return ErrOccurrenceConflict
+		return "", ErrOccurrenceConflict
 	}
-	return nil
+	return OccurrenceRepeated, nil
 }
 
 const schedulerInsertOccurrenceSQL = `

--- a/internal/scheduler/sync/coordinator_test.go
+++ b/internal/scheduler/sync/coordinator_test.go
@@ -74,12 +74,16 @@ func TestOccurrenceCoordinatorInsertsStableHandoff(t *testing.T) {
 	transaction := &coordinatorTransaction{
 		rows: []pgx.Row{coordinatorRow{values: []any{occurrence.ID}}},
 	}
-	if err := NewOccurrenceCoordinator().Handoff(
+	outcome, err := NewOccurrenceCoordinator().Handoff(
 		context.Background(),
 		transaction,
 		occurrence,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if outcome != OccurrenceMinted {
+		t.Fatalf("outcome = %q, want %q", outcome, OccurrenceMinted)
 	}
 	if len(transaction.statements) != 1 || len(transaction.args) != 1 {
 		t.Fatalf("queries=%d args=%d", len(transaction.statements), len(transaction.args))
@@ -107,12 +111,19 @@ func TestOccurrenceCoordinatorAcceptsMatchingExistingHandoff(t *testing.T) {
 			}},
 		},
 	}
-	if err := NewOccurrenceCoordinator().Handoff(
+	outcome, err := NewOccurrenceCoordinator().Handoff(
 		context.Background(),
 		transaction,
 		occurrence,
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatal(err)
+	}
+	// An already-present row is still a success, but it must be reported as a
+	// repeat: an idle scheduler that re-confirms one frozen instant every tick
+	// is otherwise indistinguishable from a productive one (CHAOS-3936).
+	if outcome != OccurrenceRepeated {
+		t.Fatalf("outcome = %q, want %q", outcome, OccurrenceRepeated)
 	}
 	if len(transaction.statements) != 2 {
 		t.Fatalf("queries = %d, want 2", len(transaction.statements))
@@ -133,7 +144,7 @@ func TestOccurrenceCoordinatorRejectsConflictingExistingHandoff(t *testing.T) {
 			}},
 		},
 	}
-	err := NewOccurrenceCoordinator().Handoff(
+	_, err := NewOccurrenceCoordinator().Handoff(
 		context.Background(),
 		transaction,
 		occurrence,

--- a/internal/scheduler/sync/evaluate.go
+++ b/internal/scheduler/sync/evaluate.go
@@ -68,9 +68,20 @@ func evaluateContext(ctx context.Context, candidate Candidate, observedAt time.T
 		result.Timezone = timezoneName
 	}
 
+	// CHAOS-3936: last_sync_at advances only when a sync COMPLETES, so a run
+	// that never completes freezes the base and every later tick recomputes the
+	// same already-minted instant forever -- the schedule stops making forward
+	// progress precisely when a failure means it must. The occurrence ledger
+	// records what was already handed off regardless of that run's outcome, so
+	// taking the later of the two keeps the base moving across a failed run
+	// while leaving a config that has never minted an occurrence (the Python
+	// dispatch path, or a brand new config) on the exact Python-parity base.
 	base := candidate.CreatedAt
 	if candidate.LastSyncAt != nil {
 		base = *candidate.LastSyncAt
+	}
+	if candidate.LastOccurrenceAt != nil && candidate.LastOccurrenceAt.After(base) {
+		base = *candidate.LastOccurrenceAt
 	}
 	result.Base = base.UTC()
 	next, fallback, err := nextOccurrenceContext(ctx, cronExpr, result.Base, result.Timezone)

--- a/internal/scheduler/sync/evaluate.go
+++ b/internal/scheduler/sync/evaluate.go
@@ -80,8 +80,18 @@ func evaluateContext(ctx context.Context, candidate Candidate, observedAt time.T
 	if candidate.LastSyncAt != nil {
 		base = *candidate.LastSyncAt
 	}
-	if candidate.LastOccurrenceAt != nil && candidate.LastOccurrenceAt.After(base) {
-		base = *candidate.LastOccurrenceAt
+	if ledger := candidate.LastOccurrenceAt; ledger != nil {
+		// Clamped to observedAt deliberately. A ledger row dated in the FUTURE
+		// must not advance the base: it would push the next occurrence past now
+		// and make the config silently not-due until real time caught up --
+		// the same invisible freeze this change exists to remove, wearing a
+		// different hat. The scheduler only ever mints instants at or before
+		// observedAt, so the clamp is a no-op in normal operation; it is a
+		// guard against clock skew between replicas and against a hand-edited
+		// or restored row.
+		if instant := ledger.UTC(); instant.After(base) && !instant.After(observedAt) {
+			base = instant
+		}
 	}
 	result.Base = base.UTC()
 	next, fallback, err := nextOccurrenceContext(ctx, cronExpr, result.Base, result.Timezone)

--- a/internal/scheduler/sync/loop.go
+++ b/internal/scheduler/sync/loop.go
@@ -148,6 +148,9 @@ type Loop struct {
 	occurrencesCompleted   uint64
 	occurrencesRetried     uint64
 	occurrencesQuarantined uint64
+	occurrencesMinted      uint64
+	occurrencesRepeated    uint64
+	idleDueWindows         uint64
 }
 
 func NewLoop(stepper HandoffStepper, coordinator Coordinator, config LoopConfig) (*Loop, error) {
@@ -286,13 +289,46 @@ func (loop *Loop) step(parent context.Context, now time.Time) error {
 	loop.occurrencesQuarantined += uint64(reconciled.Quarantined)
 	loop.cycles++
 	loop.handoffs += uint64(len(result.HandedOff))
+	loop.occurrencesMinted += uint64(result.Minted())
+	loop.occurrencesRepeated += uint64(len(result.Repeated))
+	if result.TimingEligible > 0 && result.Minted() == 0 {
+		loop.idleDueWindows++
+	}
 	loop.unsupportedCron += uint64(result.UnsupportedCron)
 	loop.invalidCron += uint64(result.InvalidCron)
 	loop.consecutive = 0
 	loop.lastOK, loop.up = now.UTC(), true
 	loop.ready.Store(true)
 	loop.mu.Unlock()
+	loop.reportProductivity(parent, result)
 	return nil
+}
+
+// reportProductivity names the windows that succeeded without producing work.
+// CHAOS-3936 ran for hours as a stream of successful empty windows: every
+// existing counter and log line measured whether the scheduler RAN, none
+// measured whether it PRODUCED, so a schedule frozen on one instant looked
+// exactly like a healthy one. These two lines are the difference between an
+// outage that is visible and an outage found by counting missing rows by hand.
+func (loop *Loop) reportProductivity(ctx context.Context, result HandoffResult) {
+	for _, repeated := range result.Repeated {
+		loop.logger().WarnContext(
+			ctx,
+			"sync scheduler occurrence already existed; this schedule produced no new work",
+			"config_id", repeated.ConfigID,
+			"scheduled_for", repeated.ScheduledFor.UTC().Format(time.RFC3339),
+			"observed_at", repeated.ObservedAt.UTC().Format(time.RFC3339),
+		)
+	}
+	if result.TimingEligible > 0 && result.Minted() == 0 {
+		loop.logger().WarnContext(
+			ctx,
+			"sync scheduler window found due candidates but minted no occurrence",
+			"candidates", result.Candidates,
+			"timing_eligible", result.TimingEligible,
+			"repeated", len(result.Repeated),
+		)
+	}
 }
 
 func (loop *Loop) backoff() time.Duration {
@@ -376,6 +412,7 @@ func (loop *Loop) WritePrometheus(output io.Writer) error {
 	lastOK, up, now := loop.lastOK, loop.up, loop.clock.Now()
 	completed, retried := loop.occurrencesCompleted, loop.occurrencesRetried
 	quarantined := loop.occurrencesQuarantined
+	minted, repeated, idle := loop.occurrencesMinted, loop.occurrencesRepeated, loop.idleDueWindows
 	loop.mu.Unlock()
 
 	age := 0.0
@@ -388,6 +425,9 @@ func (loop *Loop) WritePrometheus(output io.Writer) error {
 	writeLoopCounter(&text, "sync_scheduler_unsupported_cron_fallback_total", "Unsupported cron candidates left for the existing scheduler owner.", unsupported)
 	writeLoopCounter(&text, "sync_scheduler_invalid_cron_total", "Invalid cron candidates left without marker mutation.", invalid)
 	writeLoopCounter(&text, "sync_scheduler_failures_total", "Failed bounded scheduler handoff windows.", failures)
+	writeLoopCounter(&text, "sync_scheduler_occurrences_minted_total", "Scheduled occurrences this scheduler actually created. A live scheduler whose handoffs_total climbs while this stays flat is repeating one frozen instant.", minted)
+	writeLoopCounter(&text, "sync_scheduler_occurrences_repeated_total", "Handed-off occurrences that already existed, so the window created nothing.", repeated)
+	writeLoopCounter(&text, "sync_scheduler_idle_due_windows_total", "Successful windows that found a due candidate and still minted no occurrence.", idle)
 	writeLoopCounter(&text, "sync_scheduler_occurrences_completed_total", "Pending scheduled sync occurrences materialized.", completed)
 	writeLoopCounter(&text, "sync_scheduler_occurrences_retried_total", "Pending scheduled sync occurrences deferred for retry.", retried)
 	writeLoopCounter(&text, "sync_scheduler_occurrences_quarantined_total", "Pending scheduled sync occurrences terminally quarantined.", quarantined)

--- a/internal/scheduler/sync/loop_test.go
+++ b/internal/scheduler/sync/loop_test.go
@@ -61,8 +61,8 @@ func (ticker *testLoopTicker) Stop() {
 func newTestLoop(t *testing.T, stepper HandoffStepper, clock *testLoopClock) (*Loop, *health.Registry) {
 	t.Helper()
 	registry := health.NewRegistry(time.Second)
-	loop, err := newLoop(stepper, CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
-		return nil
+	loop, err := newLoop(stepper, CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+		return OccurrenceMinted, nil
 	}), LoopConfig{
 		PollInterval: minLoopPollInterval,
 		StepTimeout:  time.Second,
@@ -320,7 +320,9 @@ func TestLoopDrivesTheOccurrenceConsumerEveryWindow(t *testing.T) {
 		schedulerHandoffStepper(func() (HandoffResult, error) {
 			return HandoffResult{}, nil
 		}),
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error { return nil }),
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+			return OccurrenceMinted, nil
+		}),
 		LoopConfig{
 			PollInterval: minLoopPollInterval,
 			StepTimeout:  time.Second,
@@ -367,7 +369,9 @@ func TestLoopFailsTheWindowWhenOccurrencesCannotBeConsumed(t *testing.T) {
 		schedulerHandoffStepper(func() (HandoffResult, error) {
 			return HandoffResult{}, nil
 		}),
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error { return nil }),
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+			return OccurrenceMinted, nil
+		}),
 		LoopConfig{
 			PollInterval: minLoopPollInterval,
 			StepTimeout:  time.Second,
@@ -394,7 +398,9 @@ func TestLoopRequiresAnOccurrenceConsumer(t *testing.T) {
 	registry := health.NewRegistry(time.Second)
 	_, err := newLoop(
 		schedulerHandoffStepper(func() (HandoffResult, error) { return HandoffResult{}, nil }),
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error { return nil }),
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+			return OccurrenceMinted, nil
+		}),
 		LoopConfig{
 			PollInterval: minLoopPollInterval,
 			StepTimeout:  time.Second,

--- a/internal/scheduler/sync/repository.go
+++ b/internal/scheduler/sync/repository.go
@@ -105,12 +105,12 @@ func readCandidates(ctx context.Context, rows candidateRows, capacity int) ([]Ca
 		var configCron, configTimezone, jobID, jobCron, jobTimezone *string
 		var jobStatus *int
 		var jobIsRunning *bool
-		var lastSyncAt, lastRunAt, updatedAt, nextRunAt *time.Time
+		var lastSyncAt, lastRunAt, updatedAt, nextRunAt, lastOccurrenceAt *time.Time
 		if err := rows.Scan(
 			&candidate.ConfigID, &candidate.Active, &configCron, &configTimezone,
 			&lastSyncAt, &candidate.CreatedAt,
 			&jobID, &jobCron, &jobTimezone, &jobStatus, &jobIsRunning,
-			&lastRunAt, &updatedAt, &nextRunAt,
+			&lastRunAt, &updatedAt, &nextRunAt, &lastOccurrenceAt,
 		); err != nil {
 			return nil, err
 		}
@@ -118,6 +118,7 @@ func readCandidates(ctx context.Context, rows candidateRows, capacity int) ([]Ca
 			return nil, err
 		}
 		candidate.LastSyncAt = lastSyncAt
+		candidate.LastOccurrenceAt = lastOccurrenceAt
 		if configCron != nil {
 			candidate.ScheduleCron = *configCron
 		}
@@ -163,7 +164,13 @@ SELECT
     job.is_running,
     job.last_run_at,
     job.updated_at,
-    job.next_run_at
+    job.next_run_at,
+    (
+        SELECT MAX(occurrence.scheduled_for)
+        FROM public.scheduled_sync_occurrences AS occurrence
+        WHERE occurrence.org_id = config.org_id
+            AND occurrence.sync_config_id = config.id
+    )
 FROM public.sync_configurations AS config
 LEFT JOIN public.scheduled_jobs AS job
     ON job.org_id = config.org_id

--- a/internal/scheduler/sync/schedule_progress_test.go
+++ b/internal/scheduler/sync/schedule_progress_test.go
@@ -1,0 +1,248 @@
+package sync
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// ledgerCoordinator models scheduled_sync_occurrences' unique
+// (sync_config_id, scheduled_for) constraint: the second insert of an instant
+// writes nothing and is reported as a repeat, exactly like the production
+// ON CONFLICT DO NOTHING path in OccurrenceCoordinator.Handoff.
+type ledgerCoordinator struct{ minted map[time.Time]bool }
+
+func newLedgerCoordinator() *ledgerCoordinator {
+	return &ledgerCoordinator{minted: map[time.Time]bool{}}
+}
+
+func (ledger *ledgerCoordinator) Handoff(
+	_ context.Context,
+	_ HandoffTransaction,
+	occurrence Occurrence,
+) (HandoffOutcome, error) {
+	instant := occurrence.ScheduledFor.UTC()
+	if ledger.minted[instant] {
+		return OccurrenceRepeated, nil
+	}
+	ledger.minted[instant] = true
+	return OccurrenceMinted, nil
+}
+
+// latest mirrors the MAX(scheduled_for) sub-select the handoff query reads.
+func (ledger *ledgerCoordinator) latest() *time.Time {
+	var newest time.Time
+	for instant := range ledger.minted {
+		if instant.After(newest) {
+			newest = instant
+		}
+	}
+	if newest.IsZero() {
+		return nil
+	}
+	return &newest
+}
+
+func (ledger *ledgerCoordinator) instants() []string {
+	instants := make([]string, 0, len(ledger.minted))
+	for instant := range ledger.minted {
+		instants = append(instants, instant.Format(time.RFC3339))
+	}
+	sort.Strings(instants)
+	return instants
+}
+
+// lockedLedgerRow is lockedRow plus the marker and occurrence-ledger columns
+// the handoff query now reads, so a test can replay consecutive windows the
+// way production does rather than one isolated window.
+func lockedLedgerRow(
+	configID, orgID, jobID, cron string,
+	createdAt, lastSyncAt time.Time,
+	nextRunAt, lastOccurrenceAt *time.Time,
+) []any {
+	row := lockedRow(configID, orgID, jobID, cron, createdAt, lastSyncAt)
+	if nextRunAt != nil {
+		row[14] = nextRunAt.UTC()
+	}
+	row = append(row, nil)
+	if lastOccurrenceAt != nil {
+		row[15] = lastOccurrenceAt.UTC()
+	}
+	return row
+}
+
+// TestFailedRunStillMintsAnOccurrenceEveryWindow is the CHAOS-3936 regression.
+// The config's sync never completes, so last_sync_at stays frozen at 20:38 for
+// the whole test -- the exact production state on 2026-08-19. Every hourly
+// window must still durably add one NEW instant. Before the fix this holds one
+// instant (21:00) forever while every window reports a successful handoff.
+func TestFailedRunStillMintsAnOccurrenceEveryWindow(t *testing.T) {
+	createdAt := at("2026-08-01T00:00:00Z")
+	frozenLastSync := at("2026-08-19T20:38:00Z")
+	ledger := newLedgerCoordinator()
+	var nextRunAt *time.Time
+
+	for tick := range 5 {
+		observedAt := at("2026-08-19T21:00:00Z").Add(time.Duration(tick) * time.Hour)
+		transaction := &fakeSchedulerTransaction{
+			rows: &fakeLockedRows{rows: [][]any{lockedLedgerRow(
+				"config-frozen", "org-a", "job-a", "0 * * * *",
+				createdAt, frozenLastSync, nextRunAt, ledger.latest(),
+			)}},
+			execTag: pgconn.NewCommandTag("UPDATE 1"),
+		}
+		result, err := mutationRepository(transaction).HandoffDueResult(
+			context.Background(), observedAt, 4, ledger,
+		)
+		if err != nil {
+			t.Fatalf("window %d HandoffDueResult() err = %v", tick, err)
+		}
+		if len(ledger.minted) != tick+1 {
+			t.Fatalf(
+				"after %d windows the occurrence ledger holds %d instants, want %d: %v",
+				tick+1, len(ledger.minted), tick+1, ledger.instants(),
+			)
+		}
+		if result.Minted() != 1 || len(result.Repeated) != 0 {
+			t.Fatalf("window %d minted=%d repeated=%d", tick, result.Minted(), len(result.Repeated))
+		}
+		advanced := transaction.execArgs[0][0].(time.Time)
+		nextRunAt = &advanced
+	}
+	want := []string{
+		"2026-08-19T21:00:00Z", "2026-08-19T22:00:00Z", "2026-08-19T23:00:00Z",
+		"2026-08-20T00:00:00Z", "2026-08-20T01:00:00Z",
+	}
+	if strings.Join(ledger.instants(), ",") != strings.Join(want, ",") {
+		t.Fatalf("ledger instants = %v, want %v", ledger.instants(), want)
+	}
+}
+
+// A completed sync must keep its Python-parity base: the ledger only ever
+// pushes the base forward, it never drags a config back to an older instant.
+func TestCompletedSyncKeepsLastSyncBaseWhenItLeadsTheLedger(t *testing.T) {
+	lastOccurrence := at("2026-08-19T21:00:00Z")
+	lastSync := at("2026-08-19T21:40:00Z")
+	evaluation := Evaluate(Candidate{
+		ConfigID:         "config-a",
+		Active:           true,
+		ScheduleCron:     "0 * * * *",
+		CreatedAt:        at("2026-08-01T00:00:00Z"),
+		LastSyncAt:       &lastSync,
+		LastOccurrenceAt: &lastOccurrence,
+	}, at("2026-08-19T22:00:00Z"))
+	if !evaluation.Base.Equal(lastSync) {
+		t.Fatalf("base = %s, want the later completed sync %s", evaluation.Base, lastSync)
+	}
+	if evaluation.NextOccurrence == nil || !evaluation.NextOccurrence.Equal(at("2026-08-19T22:00:00Z")) {
+		t.Fatalf("next occurrence = %v", evaluation.NextOccurrence)
+	}
+}
+
+// The kernel must distinguish an occurrence it created from one that was
+// already there. Both are successes; only the first is scheduler productivity.
+func TestHandoffWindowReportsAnAlreadyPresentOccurrenceAsRepeated(t *testing.T) {
+	observedAt := at("2026-08-19T21:00:00Z")
+	ledger := newLedgerCoordinator()
+	ledger.minted[observedAt] = true
+	transaction := &fakeSchedulerTransaction{
+		rows: &fakeLockedRows{rows: [][]any{lockedLedgerRow(
+			"config-frozen", "org-a", "job-a", "0 * * * *",
+			at("2026-08-01T00:00:00Z"), at("2026-08-19T20:38:00Z"), nil, nil,
+		)}},
+		execTag: pgconn.NewCommandTag("UPDATE 1"),
+	}
+	result, err := mutationRepository(transaction).HandoffDueResult(
+		context.Background(), observedAt, 4, ledger,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Minted() != 0 || len(result.Repeated) != 1 {
+		t.Fatalf("minted=%d repeated=%d", result.Minted(), len(result.Repeated))
+	}
+	if result.Repeated[0].ConfigID != "config-frozen" ||
+		!result.Repeated[0].ScheduledFor.Equal(observedAt) {
+		t.Fatalf("repeated occurrence = %#v", result.Repeated[0])
+	}
+	if !transaction.committed {
+		t.Fatal("a repeated occurrence must still commit and advance the marker")
+	}
+}
+
+// The 2026-08-19 outage emitted no error, no log line, and no metric: every
+// counter measured whether the scheduler RAN. A window that re-confirms an
+// existing instant must now name the config and the instant, and must move
+// minted and repeated apart so a dashboard can see a frozen schedule.
+func TestLoopNamesAndCountsWindowsThatProduceNoNewOccurrence(t *testing.T) {
+	repeated := Occurrence{
+		ConfigID:     "config-frozen",
+		OrgID:        "org-a",
+		JobID:        "job-a",
+		ScheduledFor: at("2026-08-19T21:00:00Z"),
+		ObservedAt:   at("2026-08-19T23:00:00Z"),
+	}
+	logs := &strings.Builder{}
+	clock := &testLoopClock{now: at("2026-08-19T23:00:00Z")}
+	registry := health.NewRegistry(time.Second)
+	loop, err := newLoop(
+		schedulerHandoffStepper(func() (HandoffResult, error) {
+			return HandoffResult{
+				Candidates:     1,
+				TimingEligible: 1,
+				HandedOff:      []Occurrence{repeated},
+				Repeated:       []Occurrence{repeated},
+			}, nil
+		}),
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+			return OccurrenceMinted, nil
+		}),
+		LoopConfig{
+			PollInterval: minLoopPollInterval,
+			StepTimeout:  time.Second,
+			MaxBackoff:   80 * time.Millisecond,
+			Limit:        3,
+			Registry:     registry,
+			Occurrences:  &stubOccurrences{},
+			Logger:       slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		},
+		clock,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = loop.Shutdown(context.Background()) }()
+
+	for _, want := range []string{
+		"config_id=config-frozen",
+		"scheduled_for=2026-08-19T21:00:00Z",
+		"found due candidates but minted no occurrence",
+	} {
+		if !strings.Contains(logs.String(), want) {
+			t.Errorf("scheduler logs omit %q; logs = %s", want, logs.String())
+		}
+	}
+	var metrics strings.Builder
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"sync_scheduler_occurrences_minted_total 0",
+		"sync_scheduler_occurrences_repeated_total 1",
+		"sync_scheduler_idle_due_windows_total 1",
+		"sync_scheduler_handoffs_total 1",
+	} {
+		if !strings.Contains(metrics.String(), want) {
+			t.Errorf("metrics omit %q; metrics = %s", want, metrics.String())
+		}
+	}
+}

--- a/internal/scheduler/sync/schedule_progress_test.go
+++ b/internal/scheduler/sync/schedule_progress_test.go
@@ -246,3 +246,33 @@ func TestLoopNamesAndCountsWindowsThatProduceNoNewOccurrence(t *testing.T) {
 		}
 	}
 }
+
+// A ledger row dated after observedAt must not advance the base. The scheduler
+// never mints a future instant itself, so such a row means clock skew between
+// replicas or a hand-edited/restored row -- and letting it through would push
+// the next occurrence past now and make the config silently not-due until real
+// time caught up. That is the CHAOS-3936 freeze again in a different hat, so
+// the fix must not introduce it while removing the original.
+func TestFutureDatedLedgerRowCannotSuppressADueOccurrence(t *testing.T) {
+	observedAt := at("2026-08-19T12:00:00Z")
+	lastSync := at("2026-08-19T10:00:00Z")
+	future := at("2026-08-19T20:00:00Z")
+	evaluation := Evaluate(Candidate{
+		ConfigID:         "config-skewed",
+		Active:           true,
+		ScheduleCron:     "0 * * * *",
+		CreatedAt:        at("2026-08-01T00:00:00Z"),
+		LastSyncAt:       &lastSync,
+		LastOccurrenceAt: &future,
+	}, observedAt)
+	if !evaluation.Due || evaluation.Decision != DecisionScheduleDue {
+		t.Fatalf("a future-dated ledger row froze the schedule: due=%v decision=%s base=%s",
+			evaluation.Due, evaluation.Decision, evaluation.Base)
+	}
+	if !evaluation.Base.Equal(lastSync) {
+		t.Fatalf("base = %s, want the last completed sync %s", evaluation.Base, lastSync)
+	}
+	if evaluation.NextOccurrence == nil || !evaluation.NextOccurrence.Equal(at("2026-08-19T11:00:00Z")) {
+		t.Fatalf("next occurrence = %v, want 11:00", evaluation.NextOccurrence)
+	}
+}

--- a/internal/scheduler/sync/scheduler_test.go
+++ b/internal/scheduler/sync/scheduler_test.go
@@ -268,7 +268,9 @@ func TestSnapshotSortsBoundsAndDigestsDeterministically(t *testing.T) {
 		!strings.HasPrefix(snapshot.CandidateDigest, "sha256:") || len(snapshot.CandidateDigest) != len("sha256:")+64 {
 		t.Fatalf("snapshot digest = %#v", snapshot)
 	}
-	if snapshot.CandidateDigest != "sha256:02fafd6dd76a45d41ef0fa24dba521ce0ff003b8f0f3a3e5a512b19ce9435360" {
+	// Re-pinned for EvaluationVersion v2 (CHAOS-3936): the evaluation version
+	// is a digest input precisely so a timing-rule change cannot pass silently.
+	if snapshot.CandidateDigest != "sha256:0b8279af3cb555f3d65e4025a0272dcaf479c5516758ef45a00f7d8e42e4550d" {
 		t.Fatalf("candidate digest = %s", snapshot.CandidateDigest)
 	}
 	again, err := BuildSnapshot(observed, 2, []Candidate{candidates[2], candidates[0], candidates[1]})

--- a/internal/scheduler/sync/transaction.go
+++ b/internal/scheduler/sync/transaction.go
@@ -52,7 +52,20 @@ type HandoffResult struct {
 	TimingEligible  int
 	UnsupportedCron int
 	InvalidCron     int
-	HandedOff       []Occurrence
+	// HandedOff is every occurrence durably present after this window,
+	// whichever window actually created it.
+	HandedOff []Occurrence
+	// Repeated is the subset of HandedOff that already existed when this
+	// window ran, so this window created no row for it. It exists because
+	// counting handoffs alone cannot tell a scheduler that is producing work
+	// from one that has re-confirmed the same frozen instant every tick for
+	// hours: both increment the handoff counter identically (CHAOS-3936).
+	Repeated []Occurrence
+}
+
+// Minted counts the occurrences this window actually created.
+func (result HandoffResult) Minted() int {
+	return len(result.HandedOff) - len(result.Repeated)
 }
 
 // HandoffTransaction is the same PostgreSQL transaction that protects the
@@ -64,24 +77,41 @@ type HandoffTransaction interface {
 	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
+// HandoffOutcome distinguishes an occurrence a window actually created from
+// one that was already durably present. Both are successes and both permit the
+// marker to advance; only the first is scheduler productivity.
+type HandoffOutcome string
+
+const (
+	// OccurrenceMinted means this window created the occurrence row.
+	OccurrenceMinted HandoffOutcome = "minted"
+	// OccurrenceRepeated means the identical occurrence already existed, so
+	// this window wrote nothing. Sustained repetition is the signature of a
+	// schedule that has stopped advancing (CHAOS-3936).
+	OccurrenceRepeated HandoffOutcome = "repeated"
+)
+
 // Coordinator owns every non-timing eligibility decision, including
 // organization existence and feature entitlement, then persists the durable
-// handoff. Returning nil means the authorized handoff is present in the
+// handoff. Returning a nil error means the authorized handoff is present in the
 // supplied transaction and permits the kernel to advance the schedule marker.
+// The returned outcome must report whether this call created the row: reporting
+// OccurrenceMinted for a row that already existed makes an idle scheduler
+// indistinguishable from a productive one.
 type Coordinator interface {
-	Handoff(context.Context, HandoffTransaction, Occurrence) error
+	Handoff(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error)
 }
 
 // CoordinatorFunc adapts a function to Coordinator.
-type CoordinatorFunc func(context.Context, HandoffTransaction, Occurrence) error
+type CoordinatorFunc func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error)
 
 func (function CoordinatorFunc) Handoff(
 	ctx context.Context,
 	tx HandoffTransaction,
 	occurrence Occurrence,
-) error {
+) (HandoffOutcome, error) {
 	if function == nil {
-		return ErrInvalidTransactionRequest
+		return "", ErrInvalidTransactionRequest
 	}
 	return function(ctx, tx, occurrence)
 }
@@ -226,6 +256,15 @@ func (repository *Repository) HandoffDueResult(
 			locked.candidate.Job == nil {
 			continue
 		}
+		// The marker is computed from observedAt, not from the occurrence this
+		// window just minted, so a window that runs late leaves the instants
+		// between them unminted: the schedule resumes rather than backfilling.
+		// Combined with the base rebasing onto a long run's COMPLETION time,
+		// that is why a sync spanning a cron instant leaves that hour with no
+		// occurrence row at all (observed 2026-08-20 23:00 UTC). Recorded here
+		// deliberately: it is bounded and self-correcting, unlike the CHAOS-3936
+		// freeze above, and changing it changes how much work a recovering
+		// scheduler dispatches at once. See CHAOS-3936 for the decision.
 		nextRunAt, _, err := nextOccurrenceContext(
 			ctx,
 			locked.candidate.Job.ScheduleCron,
@@ -243,8 +282,15 @@ func (repository *Repository) HandoffDueResult(
 			observedAt,
 			nextRunAt,
 		)
-		if err := coordinator.Handoff(ctx, transaction, occurrence); err != nil {
+		outcome, err := coordinator.Handoff(ctx, transaction, occurrence)
+		if err != nil {
 			return HandoffResult{}, fmt.Errorf("handoff scheduler occurrence %s: %w", occurrence.ID, err)
+		}
+		if outcome != OccurrenceMinted && outcome != OccurrenceRepeated {
+			return HandoffResult{}, fmt.Errorf(
+				"handoff scheduler occurrence %s: %w: unknown outcome %q",
+				occurrence.ID, ErrInvalidTransactionRequest, outcome,
+			)
 		}
 		if err := ctx.Err(); err != nil {
 			return HandoffResult{}, err
@@ -263,6 +309,9 @@ func (repository *Repository) HandoffDueResult(
 			return HandoffResult{}, ErrScheduleMarkerLost
 		}
 		result.HandedOff = append(result.HandedOff, occurrence)
+		if outcome == OccurrenceRepeated {
+			result.Repeated = append(result.Repeated, occurrence)
+		}
 	}
 
 	if err := transaction.Commit(ctx); err != nil {
@@ -303,6 +352,7 @@ func readLockedCandidates(
 			&job.LastRunAt,
 			&job.UpdatedAt,
 			&job.NextRunAt,
+			&locked.candidate.LastOccurrenceAt,
 		); err != nil {
 			return nil, err
 		}
@@ -361,7 +411,13 @@ SELECT
     job.is_running,
     job.last_run_at,
     job.updated_at,
-    job.next_run_at
+    job.next_run_at,
+    (
+        SELECT MAX(occurrence.scheduled_for)
+        FROM public.scheduled_sync_occurrences AS occurrence
+        WHERE occurrence.org_id = config.org_id
+            AND occurrence.sync_config_id = config.id
+    )
 FROM public.sync_configurations AS config
 JOIN public.scheduled_jobs AS job
     ON job.org_id = config.org_id

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -197,36 +197,76 @@ func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
 		t.Fatalf("rollback left handoffs=%d nextRunAt=%v", handoffs, rolledBackNextRunAt)
 	}
 
+	// CHAOS-3936 changed what replaying the same observed instant means, so
+	// this block now asserts the property that actually needs protecting.
+	//
+	// Before: the base was last_sync_at, which this fixture never advances, so
+	// every replay recomputed the ONE instant already minted and wrote nothing.
+	// This block asserted that no-op by requiring the same occurrence ID back.
+	// That is the freeze itself: the same behaviour that made a failed run pin
+	// its schedule forever also made a replay look idempotent.
+	//
+	// Now the base is the occurrence ledger, so a replay mints the next instant
+	// that is due and absent -- which is how a schedule recovers from a run
+	// that never completed. The invariants that must survive, and that this
+	// block proves against real PostgreSQL, are that catch-up ADVANCES (never
+	// re-mints an instant) and that it TERMINATES (it stops at the first cron
+	// instant in the future rather than running away at a fixed now).
+	//
+	// The ledger is empty here: every handoff above used a coordinator that
+	// writes only public.scheduler_handoffs, and the last of them rolled back.
 	coordinator := NewOccurrenceCoordinator()
+	clearMarker := func() {
+		t.Helper()
+		if _, err := pool.Exec(ctx, `
+			UPDATE public.scheduled_jobs SET next_run_at = NULL
+			WHERE id = '00000000-0000-4000-8000-000000003039'
+		`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Window 1: base is last_sync_at 10:00, so 11:00 is the first due instant.
 	occurrences, err := firstRepository.HandoffDue(ctx, observedAt, 1, coordinator)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(occurrences) != 1 {
-		t.Fatalf("occurrence handoffs = %d, want 1", len(occurrences))
+	if len(occurrences) != 1 || !occurrences[0].ScheduledFor.Equal(at("2026-01-01T11:00:00Z")) {
+		t.Fatalf("first window occurrences = %#v, want one at 11:00", occurrences)
 	}
-	if _, err := pool.Exec(ctx, `
-		UPDATE public.scheduled_jobs SET next_run_at = NULL
-		WHERE id = '00000000-0000-4000-8000-000000003039'
-	`); err != nil {
-		t.Fatal(err)
-	}
+	clearMarker()
+	// Window 2, same observedAt: the ledger now holds 11:00, so 12:00 is due
+	// and absent. Before the fix this returned 11:00 again and wrote nothing.
 	retried, err := firstRepository.HandoffDue(ctx, observedAt, 1, coordinator)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(retried) != 1 || retried[0].ID != occurrences[0].ID {
-		t.Fatalf("retried occurrences = %#v, want id %s", retried, occurrences[0].ID)
+	if len(retried) != 1 || !retried[0].ScheduledFor.Equal(at("2026-01-01T12:00:00Z")) {
+		t.Fatalf("second window occurrences = %#v, want one at 12:00", retried)
 	}
-	var occurrenceRows int
-	if err := pool.QueryRow(
-		ctx,
-		"SELECT count(*) FROM public.scheduled_sync_occurrences",
-	).Scan(&occurrenceRows); err != nil {
+	if retried[0].ID == occurrences[0].ID {
+		t.Fatal("catch-up re-minted the instant it had already minted")
+	}
+	clearMarker()
+	// Window 3, same observedAt: the next instant is 13:00, which is in the
+	// future, so catch-up stops. Without this the fix would mint forever at a
+	// fixed now, which is the opposite failure to the one it repairs.
+	settled, err := firstRepository.HandoffDue(ctx, observedAt, 1, coordinator)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if occurrenceRows != 1 {
-		t.Fatalf("scheduled occurrence rows = %d, want 1", occurrenceRows)
+	if len(settled) != 0 {
+		t.Fatalf("catch-up did not terminate: third window occurrences = %#v", settled)
+	}
+	var occurrenceRows, distinctInstants int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*), count(DISTINCT scheduled_for)
+		FROM public.scheduled_sync_occurrences
+	`).Scan(&occurrenceRows, &distinctInstants); err != nil {
+		t.Fatal(err)
+	}
+	if occurrenceRows != 2 || distinctInstants != 2 {
+		t.Fatalf("scheduled occurrence rows = %d over %d distinct instants, want 2 over 2",
+			occurrenceRows, distinctInstants)
 	}
 }
 

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -82,21 +82,21 @@ func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
 				handoffCtx context.Context,
 				transaction HandoffTransaction,
 				occurrence Occurrence,
-			) error {
+			) (HandoffOutcome, error) {
 				firstOccurrence = occurrence
 				if _, err := transaction.Exec(
 					handoffCtx,
 					"INSERT INTO public.scheduler_handoffs (id) VALUES ($1)",
 					occurrence.ID,
 				); err != nil {
-					return err
+					return "", err
 				}
 				close(firstEntered)
 				select {
 				case <-releaseFirst:
-					return nil
+					return OccurrenceMinted, nil
 				case <-handoffCtx.Done():
-					return handoffCtx.Err()
+					return "", handoffCtx.Err()
 				}
 			}),
 		)
@@ -115,8 +115,8 @@ func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
 		ctx,
 		observedAt,
 		1,
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
-			return fmt.Errorf("second replica reached locked occurrence")
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+			return "", fmt.Errorf("second replica reached locked occurrence")
 		}),
 	)
 	if err != nil {
@@ -170,15 +170,15 @@ func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
 			handoffCtx context.Context,
 			transaction HandoffTransaction,
 			occurrence Occurrence,
-		) error {
+		) (HandoffOutcome, error) {
 			if _, err := transaction.Exec(
 				handoffCtx,
 				"INSERT INTO public.scheduler_handoffs (id) VALUES ($1)",
 				occurrence.ID,
 			); err != nil {
-				return err
+				return "", err
 			}
-			return coordinatorErr
+			return "", coordinatorErr
 		}),
 	); !errors.Is(err, coordinatorErr) {
 		t.Fatalf("failed coordinator error = %v", err)
@@ -435,13 +435,13 @@ func TestHandoffDuePostgresSurvivesTransactionCrashWithoutPartialWrite(t *testin
 		handoffCtx context.Context,
 		transaction HandoffTransaction,
 		occurrence Occurrence,
-	) error {
+	) (HandoffOutcome, error) {
 		if _, execErr := transaction.Exec(
 			handoffCtx,
 			"INSERT INTO public.scheduler_handoffs (id) VALUES ($1)",
 			occurrence.ID,
 		); execErr != nil {
-			return execErr
+			return "", execErr
 		}
 		postgresTransaction, ok := transaction.(postgresSchedulerTransaction)
 		if !ok {
@@ -456,7 +456,7 @@ func TestHandoffDuePostgresSurvivesTransactionCrashWithoutPartialWrite(t *testin
 		if closeErr := postgresTransaction.Tx.Conn().Close(context.Background()); closeErr != nil {
 			t.Logf("closing simulated-crash connection: %v", closeErr)
 		}
-		return crashed
+		return "", crashed
 	}))
 	if err == nil {
 		t.Fatal("HandoffDue() succeeded despite a crashed connection")
@@ -494,6 +494,86 @@ func TestHandoffDuePostgresSurvivesTransactionCrashWithoutPartialWrite(t *testin
 	}
 	if len(occurrences) != 1 {
 		t.Fatalf("post-crash HandoffDue() occurrences = %d, want 1", len(occurrences))
+	}
+}
+
+// CHAOS-3936: last_sync_at advances only when a sync COMPLETES. This fixture
+// never completes one, so before the fix every window recomputed the same
+// 11:00 instant, the ON CONFLICT DO NOTHING insert wrote nothing, and the
+// coordinator reported idempotent success -- forever, against real PostgreSQL.
+// Each window must instead durably add one new instant.
+func TestHandoffDuePostgresKeepsMintingWhileLastSyncStaysFrozen(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	repository, err := newRepositoryWithOwnership(pool, reviewedGoMutationOwnershipPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"11:00", "12:00", "13:00"}
+	for index, observed := range []string{
+		"2026-01-01T12:00:00Z", "2026-01-01T13:00:00Z", "2026-01-01T14:00:00Z",
+	} {
+		result, err := repository.HandoffDueResult(ctx, at(observed), 4, NewOccurrenceCoordinator())
+		if err != nil {
+			t.Fatalf("window %d HandoffDueResult() err = %v", index, err)
+		}
+		if result.Minted() != 1 || len(result.Repeated) != 0 {
+			t.Fatalf("window %d minted=%d repeated=%d", index, result.Minted(), len(result.Repeated))
+		}
+		var frozen time.Time
+		if err := pool.QueryRow(ctx, `
+			SELECT last_sync_at FROM public.sync_configurations
+			WHERE id = '00000000-0000-4000-8000-000000003038'
+		`).Scan(&frozen); err != nil {
+			t.Fatal(err)
+		}
+		if !frozen.Equal(at("2026-01-01T10:00:00Z")) {
+			t.Fatalf("fixture no longer reproduces a run that never completes: last_sync_at = %s", frozen)
+		}
+		var minted []string
+		rows, err := pool.Query(ctx, `
+			SELECT to_char(scheduled_for AT TIME ZONE 'UTC', 'HH24:MI')
+			FROM public.scheduled_sync_occurrences
+			ORDER BY scheduled_for
+		`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for rows.Next() {
+			var instant string
+			if err := rows.Scan(&instant); err != nil {
+				rows.Close()
+				t.Fatal(err)
+			}
+			minted = append(minted, instant)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if fmt.Sprint(minted) != fmt.Sprint(want[:index+1]) {
+			t.Fatalf("after %d windows the occurrence ledger holds %v, want %v", index+1, minted, want[:index+1])
+		}
 	}
 }
 

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -617,6 +617,77 @@ func TestHandoffDuePostgresKeepsMintingWhileLastSyncStaysFrozen(t *testing.T) {
 	}
 }
 
+// CHAOS-3936 deploy safety: the ledger base reads occurrence rows written by
+// the OLD code, so on first deploy a config frozen for many hours has a ledger
+// far behind now. Catch-up must therefore be rate-limited by the persisted
+// marker, not by the loop's poll interval -- the scheduler loop ticks every
+// second by default, so if the marker did not gate re-entry a config that was
+// frozen for a day would mint a day of occurrences in seconds.
+//
+// This asserts the gate against real PostgreSQL: after a window mints, a
+// second window before the next cron instant produces nothing. The sibling
+// test deliberately clears next_run_at between windows to demonstrate the walk;
+// this one leaves the marker alone, which is what production does.
+func TestHandoffDuePostgresRateLimitsCatchUpToTheScheduleMarker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	repository, err := newRepositoryWithOwnership(pool, reviewedGoMutationOwnershipPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator := NewOccurrenceCoordinator()
+
+	minted, err := repository.HandoffDue(ctx, at("2026-01-01T12:00:00Z"), 4, coordinator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(minted) != 1 {
+		t.Fatalf("first window minted %d occurrences, want 1", len(minted))
+	}
+	// The marker now sits at 13:00. Every window before that instant must
+	// produce nothing, however often the loop ticks.
+	for _, observed := range []string{
+		"2026-01-01T12:00:01Z", "2026-01-01T12:15:00Z", "2026-01-01T12:59:59Z",
+	} {
+		later, err := repository.HandoffDue(ctx, at(observed), 4, coordinator)
+		if err != nil {
+			t.Fatalf("window at %s: %v", observed, err)
+		}
+		if len(later) != 0 {
+			t.Fatalf("window at %s minted %#v; the schedule marker did not rate-limit catch-up", observed, later)
+		}
+	}
+	var occurrenceRows int
+	if err := pool.QueryRow(
+		ctx,
+		"SELECT count(*) FROM public.scheduled_sync_occurrences",
+	).Scan(&occurrenceRows); err != nil {
+		t.Fatal(err)
+	}
+	if occurrenceRows != 1 {
+		t.Fatalf("ledger holds %d rows after four windows in one cron interval, want 1", occurrenceRows)
+	}
+}
+
 func createSchedulerIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) error {
 	for _, statement := range []string{
 		`CREATE TABLE public.sync_configurations (

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -688,6 +688,93 @@ func TestHandoffDuePostgresRateLimitsCatchUpToTheScheduleMarker(t *testing.T) {
 	}
 }
 
+// The CHAOS-3936 signal -- occurrences_repeated_total, the idle-due-window
+// warning, and the WARN naming the config and instant -- all rest on the real
+// coordinator mapping PostgreSQL's ON CONFLICT DO NOTHING onto
+// OccurrenceRepeated. That mapping was covered only against a fake pgx row, so
+// if it were wrong the metric would simply never fire and an outage would be
+// invisible again: a measurement layer that fails toward "fine".
+//
+// It is driven directly here rather than through a scheduler window on
+// purpose. With the base derived from the occurrence ledger, a window can no
+// longer compute an instant that already exists -- the ledger it just read
+// contains it, so the next window computes the NEXT instant. That makes
+// OccurrenceRepeated a regression alarm rather than a routine counter: it
+// fires if the base ever stops advancing again. Testing it through a window
+// would therefore be testing a path the fix deliberately closed; testing the
+// coordinator directly tests the mapping the signal actually depends on.
+func TestOccurrenceCoordinatorPostgresReportsOnConflictAsRepeated(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+
+	occurrence := newOccurrence(
+		"00000000-0000-4000-8000-000000003038",
+		"org-integration",
+		"00000000-0000-4000-8000-000000003039",
+		at("2026-01-01T11:00:00Z"),
+		at("2026-01-01T12:00:00Z"),
+		at("2026-01-01T13:00:00Z"),
+	)
+	coordinator := NewOccurrenceCoordinator()
+	handoff := func() (HandoffOutcome, error) {
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			return "", err
+		}
+		outcome, handoffErr := coordinator.Handoff(ctx, postgresSchedulerTransaction{Tx: tx}, occurrence)
+		if handoffErr != nil {
+			_ = tx.Rollback(ctx)
+			return outcome, handoffErr
+		}
+		return outcome, tx.Commit(ctx)
+	}
+
+	first, err := handoff()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != OccurrenceMinted {
+		t.Fatalf("first handoff outcome = %q, want %q", first, OccurrenceMinted)
+	}
+	// Identical envelope, real unique constraint, real ON CONFLICT DO NOTHING.
+	second, err := handoff()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second != OccurrenceRepeated {
+		t.Fatalf("second handoff outcome = %q, want %q -- the repeat signal cannot fire", second, OccurrenceRepeated)
+	}
+	var rows int
+	if err := pool.QueryRow(
+		ctx,
+		"SELECT count(*) FROM public.scheduled_sync_occurrences",
+	).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("ledger holds %d rows after two identical handoffs, want 1", rows)
+	}
+}
+
 func createSchedulerIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) error {
 	for _, statement := range []string{
 		`CREATE TABLE public.sync_configurations (

--- a/internal/scheduler/sync/transaction_test.go
+++ b/internal/scheduler/sync/transaction_test.go
@@ -149,13 +149,13 @@ func TestHandoffDuePersistsHandoffBeforeAdvancingMarker(t *testing.T) {
 		_ context.Context,
 		handoff HandoffTransaction,
 		occurrence Occurrence,
-	) error {
+	) (HandoffOutcome, error) {
 		if handoff != transaction {
 			t.Fatal("coordinator did not receive the locking transaction")
 		}
 		transaction.events = append(transaction.events, "handoff")
 		received = occurrence
-		return nil
+		return OccurrenceMinted, nil
 	})
 
 	occurrences, err := repository.HandoffDue(context.Background(), observedAt, 2, coordinator)
@@ -205,9 +205,9 @@ func TestHandoffDueRollsBackWithoutMarkerWhenCoordinatorFails(t *testing.T) {
 		context.Background(),
 		observedAt,
 		1,
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
 			transaction.events = append(transaction.events, "handoff")
-			return handoffErr
+			return "", handoffErr
 		}),
 	)
 	if !errors.Is(err, handoffErr) {
@@ -236,9 +236,9 @@ func TestHandoffDueResultLeavesUnsupportedCronForCeleryWithoutMarkerMutation(t *
 	}
 	result, err := mutationRepository(transaction).HandoffDueResult(
 		context.Background(), observedAt, 1,
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
 			t.Fatal("unsupported cron reached coordinator")
-			return nil
+			return OccurrenceMinted, nil
 		}),
 	)
 	if !errors.Is(err, ErrSchedulerFallbackRequired) {
@@ -269,9 +269,9 @@ func TestHandoffDueResultFailsClosedBeforeMixedFallbackWindowWrites(t *testing.T
 	coordinatorCalls := 0
 	result, err := mutationRepository(transaction).HandoffDueResult(
 		context.Background(), observedAt, 2,
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
 			coordinatorCalls++
-			return nil
+			return OccurrenceMinted, nil
 		}),
 	)
 	if !errors.Is(err, ErrSchedulerFallbackRequired) {
@@ -305,9 +305,9 @@ func TestHandoffDueRejectsLostMarkerAndRollsBackHandoff(t *testing.T) {
 		context.Background(),
 		observedAt,
 		1,
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
 			transaction.events = append(transaction.events, "handoff")
-			return nil
+			return OccurrenceMinted, nil
 		}),
 	)
 	if !errors.Is(err, ErrScheduleMarkerLost) {
@@ -400,8 +400,8 @@ func TestHandoffDueValidatesRequestBeforeOpeningTransaction(t *testing.T) {
 			return nil, errors.New("unexpected begin")
 		},
 	}
-	coordinator := CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
-		return nil
+	coordinator := CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+		return OccurrenceMinted, nil
 	})
 	for _, test := range []struct {
 		name        string
@@ -440,7 +440,9 @@ func TestDefaultOwnershipPreventsHandoffBeforeOpeningTransaction(t *testing.T) {
 		context.Background(),
 		time.Now(),
 		1,
-		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error { return nil }),
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) (HandoffOutcome, error) {
+			return OccurrenceMinted, nil
+		}),
 	)
 	if !errors.Is(err, ErrSchedulerMutationDisabled) {
 		t.Fatalf("HandoffDue() err = %v", err)

--- a/internal/scheduler/sync/types.go
+++ b/internal/scheduler/sync/types.go
@@ -14,8 +14,13 @@ const (
 	// TimingDigestVersion identifies the fixed schedule/marker-only candidate
 	// framing for later cross-runtime comparison.
 	TimingDigestVersion = "sync_scheduler_timing_digest_v1"
-	// EvaluationVersion identifies the Python-compatible timing rules.
-	EvaluationVersion = "sync_scheduler_timing_evaluation_v1"
+	// EvaluationVersion identifies the timing rules. v2 adds the occurrence
+	// ledger to the cron base (CHAOS-3936) and is therefore deliberately NOT
+	// Python-compatible for a config whose run never completed: Python freezes
+	// on last_sync_at there and Go keeps advancing. The version is part of the
+	// candidate digest so a cross-runtime comparison cannot silently read a
+	// v2 digest as if both runtimes still applied the same rule.
+	EvaluationVersion = "sync_scheduler_timing_evaluation_v2"
 	// CronGrammarVersion identifies the deterministic five-field Croniter
 	// subset. Random R expressions and optional sixth/seventh fields are
 	// explicitly outside this grammar.
@@ -69,7 +74,13 @@ type Candidate struct {
 	ScheduleTZ   string
 	LastSyncAt   *time.Time
 	CreatedAt    time.Time
-	Job          *Job
+	// LastOccurrenceAt is the newest scheduled_for already present in this
+	// config's occurrence ledger, or nil when the config has never had one
+	// minted. It advances when an occurrence is HANDED OFF, so unlike
+	// LastSyncAt -- which advances only when a run COMPLETES -- a run that
+	// fails, hangs, or is never consumed cannot pin it (CHAOS-3936).
+	LastOccurrenceAt *time.Time
+	Job              *Job
 }
 
 type Job struct {


### PR DESCRIPTION
Fixes CHAOS-3936. A scheduled sync that fails to complete freezes its own schedule permanently and silently — 2.5 hours of production sync outage on 2026-08-19 with no error, no log line, and no metric.

## The freeze

`evaluate.go` computed the next cron occurrence from `sync_configurations.last_sync_at`, which only advances when a sync **completes**:

- The 21:00 runs never completed → `last_sync_at` froze at 20:38–20:50.
- Every later hourly tick recomputed "due at 21:00".
- The 21:00 occurrence already existed → `ON CONFLICT DO NOTHING` returned no rows.
- `OccurrenceCoordinator.Handoff` took the verify branch → **idempotent success**.
- The caller advanced `next_run_at` and moved on.

A successful no-op, hourly, forever. The scheduler's recovery path was disabled by the exact condition it needs to recover from — which is also why it never reproduces locally, where syncs complete and the base keeps moving.

## The fix: a base that advances regardless of outcome

Both the handoff and snapshot queries now read `MAX(scheduled_for)` from `scheduled_sync_occurrences` for the config (index-backed by `ix_scheduled_sync_occurrence_org_config_time`; no migration), and `evaluateContext` takes the **later** of that and `last_sync_at`.

The ledger advances when an occurrence is **handed off**, so a run that fails, hangs, or is never consumed cannot pin it. Chosen over replacing `last_sync_at` outright because it only ever pushes the base forward: a config that has never minted an occurrence — the Python dispatch path, or a new config — keeps the exact Python-parity base, and a completed sync that outruns its ledger keeps its own watermark. A stale ledger read can at worst repeat an instant (absorbed by the unique constraint, and now logged); it can never skip one.

`EvaluationVersion` moves to `v2`: the rule is deliberately no longer Python-compatible for a config whose run never completed, and that string is a candidate-digest input, so leaving it at v1 would let a cross-runtime comparison read a v2 digest as if both runtimes still applied the same rule. The pinned digest in `scheduler_test.go` is re-pinned accordingly.

## The signal

The outage was invisible because every scheduler metric measured whether the scheduler **ran**, not whether it **produced**. `sync_scheduler_handoffs_total` counted the frozen 21:00 re-confirmation as a handoff every hour, identically to real work.

`Coordinator.Handoff` now returns a `HandoffOutcome` (`minted` / `repeated`), so the kernel can tell a row it created from one that was already there. `HandoffResult` carries the repeated subset, and the loop emits:

| metric | meaning |
| --- | --- |
| `sync_scheduler_occurrences_minted_total` | rows this scheduler actually created |
| `sync_scheduler_occurrences_repeated_total` | handoffs that created nothing |
| `sync_scheduler_idle_due_windows_total` | window found a due candidate and minted nothing |

plus a WARN naming the config and the computed instant, and a WARN when a window finds due candidates and mints nothing. `handoffs_total` climbing while `minted_total` stays flat is now the outage's signature instead of its disguise.

## Tests — watched fail first

`TestFailedRunStillMintsAnOccurrenceEveryWindow` drives five consecutive hourly windows with `last_sync_at` frozen at 20:38 throughout, against a coordinator modelling the `(sync_config_id, scheduled_for)` unique constraint, and requires one **new** instant per window. Against today's main:

```
--- FAIL: TestFreezeReproMain (0.00s)
    after 2 windows the occurrence ledger holds 1 instants, want 2; instants = [2026-08-19T21:00:00Z]
```

Reverting just the base change on this branch reproduces it identically, and removing just the signal fails the loop test with empty logs and `repeated_total 0` while `handoffs_total 1`.

`TestHandoffDuePostgresKeepsMintingWhileLastSyncStaysFrozen` runs the same scenario against real PostgreSQL with the production coordinator and SQL (passes; also proves the new sub-select under `FOR UPDATE OF config, job SKIP LOCKED`).

## Recorded, not fixed: the skipped hour

Production on 2026-08-20 showed 21:00 (4), 22:00 (4), **23:00 (0)**, 00:00 (3), 01:00 (4). Two behaviours combine: the marker is computed from `observedAt` rather than from the occurrence just minted, and the base rebases onto a long run's **completion** time — so a sync spanning a cron instant leaves that hour with no occurrence row, and the fresh-running gate suppresses the tick in the meantime. Nothing in the code names this as a deliberate no-stampede policy. It is bounded and self-correcting (unlike the freeze), no sync data is lost (a scheduled sync fetches from its watermark), and changing it changes how much work a recovering scheduler dispatches at once. This PR documents it at the site and leaves the decision to CHAOS-3936.

Same-class defect, out of scope here: `src/dev_health_ops/workers/sync_scheduler.py:713-718` derives its base the same way. The Python path writes `job_runs`, not occurrences, so it has no ledger to lean on and needs a different mechanism.

## Follow-ups filed

- **CHAOS-3954** — the skipped-instant behaviour above, with the mechanism, the production counts, and the one-line alternative. Explicitly records that this PR leaves that behaviour unchanged rather than half-altering it.
- **CHAOS-3955** — `sync_scheduler.py:713-718` derives its base the same way, so the Python dispatch path can freeze identically and needs a different mechanism (it has no occurrence ledger).
- **CHAOS-3948** (filed by review) — `ci/check_go.sh all` never executes the Docker-backed integration suites.

## Verification

| check | result |
| --- | --- |
| `ci/check_go.sh all` | rc=0, 118 `ok` package lines, zero FAIL |
| `ci/check_go.sh integration-shard packages 3` | rc=0, 14/14 packages ok |
| `GOWORK=off go test -mod=readonly -tags=integration -count=1 ./internal/scheduler/sync/...` | rc=0, ok 29.8s |
| CI `go-storage-integration-shard-packages-3` | pass, 3m40s |

### Two measurement traps worth knowing, both hit during this work

**`grep -c '^ok  '` under-counts the gate's completeness signal.** The gate's verbs write concurrently, and an interleave concatenated one result onto a banner line:

```
go test -race: tests/compatibility/riverok	github.com/full-chaos/dev-health-ops/internal/providersync	54.220s
```

That line is a real `ok`, but it no longer starts at column 0, so the anchored grep reported **117** where the true count is **118**. Anyone using that count as a pass/fail signal should match `'ok  <TAB>github'` rather than anchoring to line start — an anchored count silently reads one package short and looks like a skipped package.

**A trailing `grep -c` inverts the exit code you are reporting.** Ending a gate command with `grep -cE '^(FAIL|--- FAIL)'` makes the shell exit 1 when the count is zero — i.e. the command reports failure precisely when nothing failed. Capture `rc=$?` from the gate itself, before any pipe or filter.
