### PR TITLE
fix(providersync): survive JSON-decoded shapes at two durable boundaries (CHAOS-3949, CHAOS-3950)

### DIFF
--- a/internal/providersync/complete_route_comparator.go
+++ b/internal/providersync/complete_route_comparator.go
@@ -1,6 +1,7 @@
 package providersync
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"time"
@@ -42,12 +43,44 @@ func (ProductionContractComparator) CompareCompleteRoute(
 	}, nil
 }
 
+// decodeCompletionValue accepts both the live typed value a route handler
+// emits and the generic bool/float64/[]any shape produced when a durable
+// result is decoded from JSON, mirroring the retrofit
+// applyGitHubWorkItemsIncompletePolicy received for the same reason. An
+// absent key and a JSON null both fail closed: neither is a value the github
+// tests route ever writes, so accepting them would convert missing durable
+// evidence into a successful completion. The strict decoder still rejects
+// unknown fields and non-integral counts.
+func decodeCompletionValue(result map[string]any, key string, target any) error {
+	value, present := result[key]
+	if !present {
+		return ErrInvalidConfiguration
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return ErrInvalidConfiguration
+	}
+	if bytes.Equal(encoded, []byte("null")) {
+		return ErrInvalidConfiguration
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
 func validateGitHubTestsCompletion(claim Claim, batch CompleteRouteBatch) error {
-	complete, completeOK := batch.Result["reports_complete"].(bool)
-	skipped, skippedOK := batch.Result["reports_skipped"].(int)
-	incomplete, incompleteOK := batch.Result["incomplete"].([]GitHubTestsIncomplete)
-	if !completeOK || !skippedOK || !incompleteOK || skipped < 0 ||
-		githubTestsIncompleteCount(incomplete) != skipped {
+	var complete bool
+	var skipped int
+	var incomplete []GitHubTestsIncomplete
+	if decodeCompletionValue(batch.Result, "reports_complete", &complete) != nil ||
+		decodeCompletionValue(batch.Result, "reports_skipped", &skipped) != nil ||
+		decodeCompletionValue(batch.Result, "incomplete", &incomplete) != nil {
+		return ErrInvalidConfiguration
+	}
+	if skipped < 0 || githubTestsIncompleteCount(incomplete) != skipped {
 		return ErrInvalidConfiguration
 	}
 	seen := map[string]bool{}

--- a/internal/providersync/complete_route_comparator_decoded_test.go
+++ b/internal/providersync/complete_route_comparator_decoded_test.go
@@ -1,0 +1,135 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// jsonRoundTripCompletionResult re-encodes a completion result the way every
+// durable recovery plane does: through JSON. Typed Go values come back as the
+// generic shapes json.Unmarshal produces — bool stays bool, int becomes
+// float64, and []GitHubTestsIncomplete becomes []any of map[string]any.
+//
+// applyGitHubWorkItemsIncompletePolicy was retrofitted to accept exactly this
+// shape (see its doc comment); these tests pin the same contract onto the
+// production comparator so a decoded replay of a healthy github tests/cicd
+// completion is never refused.
+func jsonRoundTripCompletionResult(t *testing.T, result map[string]any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+func decodedGitHubTestsBatch(claim Claim, incomplete []GitHubTestsIncomplete) CompleteRouteBatch {
+	var watermark *time.Time
+	if len(incomplete) == 0 {
+		watermark = claim.BeforeAt
+	}
+	return CompleteRouteBatch{
+		Watermark: watermark,
+		Result: map[string]any{
+			"pipeline_runs_synced": 0, "job_runs_synced": 0,
+			"acceptance_checks_synced": 0, "test_suites_synced": 0,
+			"test_cases_synced": 0, "coverage_snapshots_synced": 0,
+			"repo":             "acme/api",
+			"reports_complete": len(incomplete) == 0,
+			"reports_skipped":  githubTestsIncompleteCount(incomplete),
+			"incomplete":       incomplete,
+		},
+	}
+}
+
+func TestProductionContractComparatorAcceptsDecodedGitHubTestsCompletion(t *testing.T) {
+	claim := nativeTestClaim("github", "tests")
+	batch := decodedGitHubTestsBatch(claim, make([]GitHubTestsIncomplete, 0))
+	batch.Result = jsonRoundTripCompletionResult(t, batch.Result)
+	comparison, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, batch,
+	)
+	if err != nil || !comparison.Match {
+		t.Fatalf("decoded complete result refused: comparison=%+v error=%v", comparison, err)
+	}
+}
+
+func TestProductionContractComparatorAcceptsDecodedGitHubTestsIncomplete(t *testing.T) {
+	claim := nativeTestClaim("github", "tests")
+	batch := decodedGitHubTestsBatch(claim, []GitHubTestsIncomplete{{
+		Component: "report_member", Cause: "malformed", Count: 2,
+	}})
+	batch.Result = jsonRoundTripCompletionResult(t, batch.Result)
+	comparison, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, batch,
+	)
+	if err != nil || !comparison.Match {
+		t.Fatalf("decoded incomplete result refused: comparison=%+v error=%v", comparison, err)
+	}
+	// The completion invariants must still bind on the decoded shape: an
+	// incomplete inventory advancing the watermark stays an error.
+	held := batch
+	held.Watermark = claim.BeforeAt
+	if _, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, held,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("decoded incomplete watermark accepted: error=%v", err)
+	}
+}
+
+func TestProductionContractComparatorDecodedShapeStillFailsClosed(t *testing.T) {
+	claim := nativeTestClaim("github", "tests")
+	for name, mutate := range map[string]func(result map[string]any){
+		"missing reports_complete": func(result map[string]any) {
+			delete(result, "reports_complete")
+		},
+		"null reports_complete": func(result map[string]any) {
+			result["reports_complete"] = nil
+		},
+		"missing reports_skipped": func(result map[string]any) {
+			delete(result, "reports_skipped")
+		},
+		"fractional reports_skipped": func(result map[string]any) {
+			result["reports_skipped"] = 0.5
+		},
+		"string reports_skipped": func(result map[string]any) {
+			result["reports_skipped"] = "0"
+		},
+		"missing incomplete": func(result map[string]any) {
+			delete(result, "incomplete")
+		},
+		"null incomplete": func(result map[string]any) {
+			result["incomplete"] = nil
+		},
+		"unknown field in incomplete entry": func(result map[string]any) {
+			result["incomplete"] = []any{map[string]any{
+				"component": "report_member", "cause": "malformed",
+				"count": 1, "member": "junit.xml",
+			}}
+			result["reports_complete"] = false
+			result["reports_skipped"] = 1
+		},
+		"non-array incomplete": func(result map[string]any) {
+			result["incomplete"] = map[string]any{}
+		},
+	} {
+		batch := decodedGitHubTestsBatch(claim, make([]GitHubTestsIncomplete, 0))
+		mutate(batch.Result)
+		batch.Result = jsonRoundTripCompletionResult(t, batch.Result)
+		if name == "unknown field in incomplete entry" {
+			batch.Watermark = nil
+		}
+		if _, err := (ProductionContractComparator{}).CompareCompleteRoute(
+			context.Background(), claim, batch,
+		); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("%s: decoded malformed result accepted: error=%v", name, err)
+		}
+	}
+}

--- a/internal/providersync/complete_route_comparator_decoded_test.go
+++ b/internal/providersync/complete_route_comparator_decoded_test.go
@@ -133,3 +133,72 @@ func TestProductionContractComparatorDecodedShapeStillFailsClosed(t *testing.T) 
 		}
 	}
 }
+
+// A typed-nil slice marshals to JSON null, so the comparator refuses it the
+// same way every durable optional-evidence reader has since CHAOS-3940. The
+// contract is writer-side: every producer must emit a non-nil (possibly
+// empty) slice, and the chunked-route test below holds the one producer that
+// used to emit typed nil to that contract.
+func TestProductionContractComparatorRejectsTypedNilIncomplete(t *testing.T) {
+	claim := nativeTestClaim("github", "tests")
+	batch := decodedGitHubTestsBatch(claim, make([]GitHubTestsIncomplete, 0))
+	batch.Result["incomplete"] = []GitHubTestsIncomplete(nil)
+	if _, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, batch,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("typed-nil incomplete accepted: error=%v", err)
+	}
+}
+
+// A clean chunked run never appends to the cursor's Incomplete slice, and a
+// resumed cursor decodes it from JSON with omitempty, so the field reaches
+// final metadata as typed nil on every healthy unit. The terminal batch must
+// still pass the production comparator, and its durable form must be [] —
+// never null.
+func TestGitHubTestsChunkedFinalMetadataSurvivesComparator(t *testing.T) {
+	claim := nativeTestClaim("github", "tests")
+	batch, err := githubTestsFinalMetadataBatch(claim, githubTestsChunkCursor{
+		Phase: "done", Repo: "acme/api", Requests: 3, Pages: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, batch,
+	)
+	if err != nil || !comparison.Match {
+		t.Fatalf("clean chunked completion refused: comparison=%+v error=%v", comparison, err)
+	}
+	encoded, err := json.Marshal(batch.Result["incomplete"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) != "[]" {
+		t.Fatalf("durable incomplete form=%s, want []", encoded)
+	}
+	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("clean chunked completion watermark=%v", batch.Watermark)
+	}
+}
+
+func TestGitHubTestsChunkedFinalMetadataIncompleteRunSurvivesComparator(t *testing.T) {
+	claim := nativeTestClaim("github", "tests")
+	batch, err := githubTestsFinalMetadataBatch(claim, githubTestsChunkCursor{
+		Phase: "done", Repo: "acme/api", Requests: 3, Pages: 2,
+		Incomplete: []GitHubTestsIncomplete{{
+			Component: "report_member", Cause: "unreadable", Count: 1,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := (ProductionContractComparator{}).CompareCompleteRoute(
+		context.Background(), claim, batch,
+	)
+	if err != nil || !comparison.Match {
+		t.Fatalf("incomplete chunked completion refused: comparison=%+v error=%v", comparison, err)
+	}
+	if batch.Watermark != nil {
+		t.Fatalf("incomplete chunked completion advanced watermark=%v", batch.Watermark)
+	}
+}

--- a/internal/providersync/github_tests_chunked_route.go
+++ b/internal/providersync/github_tests_chunked_route.go
@@ -92,6 +92,48 @@ func encodeGitHubTestsChunkCursor(cursor githubTestsChunkCursor) (string, error)
 // CollectChunks streams GitHub TestOps pages. It mirrors Collect's fetch and
 // normalization rules, but emits one bounded run/report unit at a time and
 // persists an opaque page URL plus item index after every emission.
+// githubTestsFinalMetadataBatch builds the terminal completion batch for one
+// chunked github tests/cicd unit from its cursor.
+//
+// The cursor's Incomplete slice is typed nil on every healthy unit: a clean
+// first pass never appends to it, and a resumed cursor decodes it from JSON
+// with omitempty. A typed-nil slice marshals to JSON null, which the
+// production comparator — like every durable optional-evidence reader since
+// CHAOS-3940 — refuses. Normalize to a non-nil empty slice here, at the one
+// writer, so the durable form is always [] and readers stay strict.
+func githubTestsFinalMetadataBatch(claim Claim, cursor githubTestsChunkCursor) (CompleteRouteBatch, error) {
+	effects, err := testOpsEffects(nil, nil, nil, nil, nil, nil)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	incomplete := append(
+		make([]GitHubTestsIncomplete, 0, len(cursor.Incomplete)), cursor.Incomplete...,
+	)
+	return CompleteRouteBatch{
+		Effects: effects,
+		Result: map[string]any{
+			"pipeline_runs_synced": cursor.Pipelines, "job_runs_synced": cursor.Jobs,
+			"acceptance_checks_synced": cursor.Acceptance, "test_suites_synced": cursor.Suites,
+			"test_cases_synced": cursor.Cases, "coverage_snapshots_synced": cursor.Coverage,
+			"repo": cursor.Repo, "reports_complete": len(incomplete) == 0,
+			"reports_skipped": githubTestsIncompleteCount(incomplete),
+			"incomplete":      incomplete,
+		},
+		Watermark: func() *time.Time {
+			if len(incomplete) > 0 {
+				return nil
+			}
+			return claim.BeforeAt
+		}(),
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests: cursor.Requests, Pages: cursor.Pages,
+			Records: cursor.Pipelines + cursor.Jobs + cursor.Acceptance +
+				cursor.Suites + cursor.Cases + cursor.Coverage,
+		},
+	}, nil
+}
+
 func (handler GitHubTestsRouteHandler) CollectChunks(
 	ctx context.Context,
 	claim Claim,
@@ -123,33 +165,11 @@ func (handler GitHubTestsRouteHandler) CollectChunks(
 	}
 	emitFinalMetadata := func(cursor githubTestsChunkCursor) error {
 		cursor.Phase = "done"
-		effects, effectErr := testOpsEffects(nil, nil, nil, nil, nil, nil)
-		if effectErr != nil {
-			return effectErr
+		batch, batchErr := githubTestsFinalMetadataBatch(claim, cursor)
+		if batchErr != nil {
+			return batchErr
 		}
-		return emitCursorPair(cursor, CompleteRouteBatch{
-			Effects: effects,
-			Result: map[string]any{
-				"pipeline_runs_synced": cursor.Pipelines, "job_runs_synced": cursor.Jobs,
-				"acceptance_checks_synced": cursor.Acceptance, "test_suites_synced": cursor.Suites,
-				"test_cases_synced": cursor.Cases, "coverage_snapshots_synced": cursor.Coverage,
-				"repo": cursor.Repo, "reports_complete": len(cursor.Incomplete) == 0,
-				"reports_skipped": githubTestsIncompleteCount(cursor.Incomplete),
-				"incomplete":      cursor.Incomplete,
-			},
-			Watermark: func() *time.Time {
-				if len(cursor.Incomplete) > 0 {
-					return nil
-				}
-				return claim.BeforeAt
-			}(),
-			Evidence: FetchEvidence{
-				Provider: claim.Provider, Dataset: claim.Dataset,
-				Requests: cursor.Requests, Pages: cursor.Pages,
-				Records: cursor.Pipelines + cursor.Jobs + cursor.Acceptance +
-					cursor.Suites + cursor.Cases + cursor.Coverage,
-			},
-		}, emit)
+		return emitCursorPair(cursor, batch, emit)
 	}
 	if cursor.Phase == "done" {
 		return emitFinalMetadata(cursor)

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -73,20 +73,41 @@ func (repository *PostgresRepository) Claim(ctx context.Context, request ClaimRe
 	if decodeErr := decodeClaimJSON(processorFlags, &claim.ProcessorFlags); decodeErr != nil {
 		return Claim{}, decodeErr
 	}
-	for raw, target := range map[string]*map[string]any{
-		string(datasetOptions):    &claim.DatasetOptions,
-		string(unitResult):        &claim.Result,
-		string(sourceMetadata):    &claim.SourceMetadata,
-		string(integrationConfig): &claim.IntegrationConfig,
-	} {
-		if err := json.Unmarshal([]byte(raw), target); err != nil {
-			return Claim{}, ErrInvalidConfiguration
-		}
+	if decodeErr := decodeClaimDocuments(
+		&claim, datasetOptions, unitResult, sourceMetadata, integrationConfig,
+	); decodeErr != nil {
+		return Claim{}, decodeErr
 	}
 	if err := claim.Validate(); err != nil {
 		return Claim{}, err
 	}
 	return claim, nil
+}
+
+// decodeClaimDocuments decodes the four JSON documents that ride along with a
+// claimed unit into their claim fields. Every document must decode into its
+// own target: the claim SQL coalesces each column to '{}', so distinct
+// columns routinely carry byte-identical JSON, and pairing raw text with
+// targets through a map literal would collapse those duplicates and leave all
+// but one target untouched.
+func decodeClaimDocuments(
+	claim *Claim,
+	datasetOptions, unitResult, sourceMetadata, integrationConfig []byte,
+) error {
+	for _, document := range []struct {
+		raw    []byte
+		target *map[string]any
+	}{
+		{datasetOptions, &claim.DatasetOptions},
+		{unitResult, &claim.Result},
+		{sourceMetadata, &claim.SourceMetadata},
+		{integrationConfig, &claim.IntegrationConfig},
+	} {
+		if err := json.Unmarshal(document.raw, document.target); err != nil {
+			return ErrInvalidConfiguration
+		}
+	}
+	return nil
 }
 
 // Complete atomically terminalizes the authoritative unit, advances its

--- a/internal/providersync/repository_postgres_claim_decode_test.go
+++ b/internal/providersync/repository_postgres_claim_decode_test.go
@@ -1,0 +1,60 @@
+package providersync
+
+import (
+	"errors"
+	"testing"
+)
+
+// The claim SQL coalesces result, source metadata, dataset options, and
+// integration config to '{}', so on every fresh unit all four documents are
+// byte-identical. Decoding must still populate every target: pairing raw
+// text with targets through a map literal collapses duplicate raw values and
+// leaves all but one target as a nil map (CHAOS-3950).
+func TestDecodeClaimDocumentsPopulatesEveryTargetForIdenticalJSON(t *testing.T) {
+	var claim Claim
+	document := []byte(`{}`)
+	if err := decodeClaimDocuments(&claim, document, document, document, document); err != nil {
+		t.Fatal(err)
+	}
+	if claim.DatasetOptions == nil || claim.Result == nil ||
+		claim.SourceMetadata == nil || claim.IntegrationConfig == nil {
+		t.Fatalf(
+			"identical documents left targets nil: datasetOptions=%v result=%v sourceMetadata=%v integrationConfig=%v",
+			claim.DatasetOptions == nil, claim.Result == nil,
+			claim.SourceMetadata == nil, claim.IntegrationConfig == nil,
+		)
+	}
+}
+
+func TestDecodeClaimDocumentsKeepsEachDocumentOnItsOwnTarget(t *testing.T) {
+	var claim Claim
+	err := decodeClaimDocuments(&claim,
+		[]byte(`{"which":"dataset_options"}`),
+		[]byte(`{"which":"result"}`),
+		[]byte(`{"which":"source_metadata"}`),
+		[]byte(`{"which":"integration_config"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, got := range map[string]map[string]any{
+		"dataset_options":    claim.DatasetOptions,
+		"result":             claim.Result,
+		"source_metadata":    claim.SourceMetadata,
+		"integration_config": claim.IntegrationConfig,
+	} {
+		if got["which"] != name {
+			t.Fatalf("%s decoded from the wrong column: %v", name, got)
+		}
+	}
+}
+
+func TestDecodeClaimDocumentsStillFailsClosedOnMalformedJSON(t *testing.T) {
+	var claim Claim
+	document := []byte(`{}`)
+	if err := decodeClaimDocuments(
+		&claim, document, []byte(`{not json`), document, document,
+	); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("malformed document accepted: error=%v", err)
+	}
+}

--- a/internal/providersync/repository_postgres_claim_decode_test.go
+++ b/internal/providersync/repository_postgres_claim_decode_test.go
@@ -49,6 +49,43 @@ func TestDecodeClaimDocumentsKeepsEachDocumentOnItsOwnTarget(t *testing.T) {
 	}
 }
 
+// The duplicate-key collapse is data-dependent: it fires whenever ANY subset
+// of the four columns is byte-identical, not only when all four are. Iterate
+// every assignment of four payload labels to the four columns — a superset of
+// all 15 set partitions, partial overlaps included — and assert each claim
+// field decodes exactly its own column's content.
+func TestDecodeClaimDocumentsEveryOverlapPartitionKeepsFieldContent(t *testing.T) {
+	documents := [4][]byte{
+		[]byte(`{"label":"0"}`), []byte(`{"label":"1"}`),
+		[]byte(`{"label":"2"}`), []byte(`{"label":"3"}`),
+	}
+	for assignment := 0; assignment < 256; assignment++ {
+		labels := [4]int{
+			assignment & 3, (assignment >> 2) & 3,
+			(assignment >> 4) & 3, (assignment >> 6) & 3,
+		}
+		var claim Claim
+		if err := decodeClaimDocuments(&claim,
+			documents[labels[0]], documents[labels[1]],
+			documents[labels[2]], documents[labels[3]],
+		); err != nil {
+			t.Fatalf("assignment %v: %v", labels, err)
+		}
+		for position, decoded := range []map[string]any{
+			claim.DatasetOptions, claim.Result,
+			claim.SourceMetadata, claim.IntegrationConfig,
+		} {
+			want := string(rune('0' + labels[position]))
+			if decoded == nil || decoded["label"] != want {
+				t.Fatalf(
+					"assignment %v position %d: decoded=%v want label %q",
+					labels, position, decoded, want,
+				)
+			}
+		}
+	}
+}
+
 func TestDecodeClaimDocumentsStillFailsClosedOnMalformedJSON(t *testing.T) {
 	var claim Claim
 	document := []byte(`{}`)


### PR DESCRIPTION
Fixes two latent instances of the "semantically empty, structurally absent" defect class (the CHAOS-3940 shape), found in a targeted sweep. One commit per finding so each can be reviewed and reverted independently.

## CHAOS-3949 — comparator refuses JSON-decoded completion shapes

`validateGitHubTestsCompletion` asserted the live Go types directly:

```go
complete, completeOK := batch.Result["reports_complete"].(bool)
skipped, skippedOK := batch.Result["reports_skipped"].(int)
incomplete, incompleteOK := batch.Result["incomplete"].([]GitHubTestsIncomplete)
```

Any completion result that has crossed a JSON boundary — the shape every durable recovery plane produces — comes back as `float64` and `[]any`, so all assertions fail on **healthy** data and the completion is refused. `applyGitHubWorkItemsIncompletePolicy` was retrofitted for exactly this after CHAOS-3940 (see its doc comment); the comparator never got that retrofit. Today all comparator call sites happen to pass live typed batches, so this was latent — but github tests/cicd is a chunked, snapshot-persisted route family, one wiring change away from feeding it a decoded batch.

Fix mirrors the existing retrofit: marshal the value, fail closed on absent key and JSON `null`, strict-decode (`DisallowUnknownFields`) into the typed target. All completion invariants unchanged and now enforced on both shapes.

**Failing-first evidence** (new tests against unfixed code):

```
--- FAIL: TestProductionContractComparatorAcceptsDecodedGitHubTestsCompletion (0.00s)
    complete_route_comparator_decoded_test.go:60: decoded complete result refused: ... error=provider sync configuration is invalid
--- FAIL: TestProductionContractComparatorAcceptsDecodedGitHubTestsIncomplete (0.00s)
    complete_route_comparator_decoded_test.go:74: decoded incomplete result refused: ... error=provider sync configuration is invalid
```

## CHAOS-3950 — claim decode collapses byte-identical JSON documents

The claim decode loop paired raw column text with claim fields through a **map literal keyed by the raw JSON**:

```go
for raw, target := range map[string]*map[string]any{
    string(datasetOptions):    &claim.DatasetOptions,
    string(unitResult):        &claim.Result,
    ...
```

`claimUnitSQL` coalesces all four columns to `'{}'`, so on every fresh unit the documents are byte-identical; the duplicate map keys collapse and only `&claim.IntegrationConfig` (last assigned) is decoded — the other three claim maps stay nil where decoded-empty is intended. Latent: every current reader nil-guards to the same fallback, but decoding correctness silently depended on value-equality of unrelated columns, and any future marshal of those fields emits `null` where `{}` is expected.

Fix: the pairing is now an ordered slice of `(raw, target)` pairs, extracted into `decodeClaimDocuments` so it is unit-testable without a database.

**Failing-first evidence** (test against the verbatim-extracted original logic):

```
--- FAIL: TestDecodeClaimDocumentsPopulatesEveryTargetForIdenticalJSON (0.00s)
    repository_postgres_claim_decode_test.go:21: identical documents left targets nil: datasetOptions=true result=true sourceMetadata=true integrationConfig=false
```

## Deliberately out of scope

- **`sanitize_error_text('') → ''`** (second finding on CHAOS-3950): the chokepoint fix flips behaviour in `maintenance/scrub_error_text.py` — split out as **CHAOS-3956**, which carries the detail.
- **Cross-route "incomplete" encoding unification** (folded into CHAOS-3949 as a related section): not attempted here per scope agreement — cross-provider blast radius.

## Adversarial review round (codex, xhigh)

The review was prompted to refute both changes. Its findings and resolutions:

- **P1 (confirmed, fixed in `7d87d1eaa`):** the comparator hardening itself reintroduced the CHAOS-3940 shape — the chunked github tests/cicd route emits the cursor's `Incomplete` slice into final metadata, and that slice is typed nil on every healthy unit (clean pass never appends; resumed cursor decodes with `omitempty`). Old asserts accepted typed nil; the hardened comparator refuses JSON null, so a healthy clean chunked run would fail before finalization. Fixed writer-side, same convention as the CHAOS-3940 fix: final metadata always carries a non-nil slice (durable form `[]`), readers stay strict on null. Failing-first: the new clean-run test fails against the unnormalized construction (`clean chunked completion refused ... ErrInvalidConfiguration`).
- **Partial-overlap coverage gap (fixed in `d6ce93fc1`):** the collapse fires for ANY byte-identical subset of the four claim columns, not just all four; original tests covered only all-identical and all-distinct. Now all 256 label assignments (superset of the 15 set partitions) assert each field decodes its own column's content. The review's example — `dataset_options` = `unit.result` = `{"fetch_milestones":false}` — is a case where the OLD code silently read the fallback `true` instead of the operator's configured `false`; the new behaviour honours the stored config (behaviour change toward correctness, not a regression).
- **Accepted-as-intended:** decoded `float64`/`json.Number` integral counts and `[]any`-of-maps incomplete entries now pass — these are exactly the decoded shapes the change exists to accept; all invariants still bind on them. The review confirmed every previously-rejected malformed input (absent keys, null, wrong types, fractional counts, unknown fields, non-array) is still rejected. One caveat to know rather than rediscover: `float64(1.0)` marshals to `1`, so a non-integral *spelling* of an integral count is normalized rather than rejected — the value-level invariants (count/evidence consistency, non-negativity) are what actually bind, and they do. Truly fractional values (`0.5`) still fail.
- **Test-altitude pairing (deliberate):** the decoded-shape tests pin the contract at the function boundary (`CompareCompleteRoute` called directly) rather than through a durable-recovery call path — prepared-manifest recovery is currently enabled only for work-items. That is acceptable *because* the P1 chunked-route test covers the real live path (`githubTestsFinalMetadataBatch` → comparator, the exact pairing that regressed); the two test sets are a pair, not alternatives.

## Validation (final tree)

- `PYTHON="$PWD/.venv/bin/python" bash ci/check_go.sh all` → rc=0 (118 `ok` package lines)
- `GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=30m ./internal/providersync/...` → rc=0 (run explicitly; `check_go.sh all` does not execute integration tests — CHAOS-3948)
