### PR TITLE
fix(worker): resolve every River queue occupant at startup; stop scheduling impossible reindex work (CHAOS-3938, CHAOS-3939)

### DIFF
--- a/cmd/dev-health-reconciler/dependencies.go
+++ b/cmd/dev-health-reconciler/dependencies.go
@@ -242,7 +242,7 @@ func buildSyncMutationPipeline(
 		return nil, err
 	}
 	publisher, err := syncdispatchruntime.NewPublisher(riverClient, syncdispatchruntime.PublisherOptions{
-		Queue: "sync", MaxAttempts: 5,
+		Queue: syncdispatchcontract.RiverQueue, MaxAttempts: 5,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -20,6 +20,7 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providersync"
 	"github.com/full-chaos/dev-health-ops/internal/storage/postgres"
 	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchruntime"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -288,9 +289,21 @@ type workerDependencies struct {
 	queueTelemetryErr      error
 	queueTelemetryRequired bool
 	instanceID             string
-	shutdownGrace          time.Duration
-	workerDrainBudget      time.Duration
-	workerGroup            string
+	// logger is set by configureWorkerDependenciesWithSources. It exists so a
+	// readiness check that HAS bounded detail can emit it: the health registry
+	// reports check names only, so a refusal with no other outlet reaches an
+	// operator as "failed_checks=queued_contract_versions" and nothing more.
+	logger *slog.Logger
+	// unsupportedContractsMu guards the last reported offender set. Readiness
+	// is re-evaluated on EVERY /readyz probe and /metrics scrape, and a
+	// failing check does not stop an already-running process, so logging on
+	// each evaluation would turn one persistent incompatible row into
+	// probe-rate ERROR on every replica. Report a transition, not a state.
+	unsupportedContractsMu       sync.Mutex
+	reportedUnsupportedContracts string
+	shutdownGrace                time.Duration
+	workerDrainBudget            time.Duration
+	workerGroup                  string
 }
 
 type preclaimReadinessComponent struct {
@@ -450,6 +463,7 @@ func configureWorkerDependenciesWithSources(
 		logger = loggers[0]
 	}
 	dependencies := buildWorkerDependencies(ctx, cfg, sources)
+	dependencies.logger = logger
 	cfg.WorkerInstanceID = dependencies.instanceID
 	if registry == nil {
 		dependencies.close()
@@ -1186,12 +1200,52 @@ func (dependencies *workerDependencies) buildQueueTelemetry(
 	}
 	dependencies.queueTelemetry, dependencies.queueTelemetryErr = dependencies.database.NewQueueTelemetrySampler(
 		riverstore.QueueTelemetryConfig{
-			Schema:   cfg.RiverDatabaseSchema,
-			ClientID: dependencies.instanceID,
-			Queues:   queues,
-			Jobs:     jobs,
+			Schema:    cfg.RiverDatabaseSchema,
+			ClientID:  dependencies.instanceID,
+			Queues:    queues,
+			Jobs:      jobs,
+			Occupants: nonRegistryQueueOccupants(queueBudgets),
 		},
 	)
+}
+
+// nonRegistryQueueOccupants is the second half of "who may legitimately have
+// rows in the selected River queues". The first half is the bounded jobs
+// registry, already projected into Jobs above from
+// jobruntime.Registry.SelectedQueues.
+//
+// river.river_job is shared by two route planes that are deliberately distinct:
+// worker_job_routes governs the bounded registry kinds, and
+// sync_dispatch_transport_routes governs the coordinator kinds, which carry no
+// registry descriptor at all (see syncdispatchruntime.RegisterWorkers). Nothing
+// merges them, and nothing should -- the sync-dispatch kinds are outside the
+// registry until CUT-10 brings them in, and giving dispatch_sync_run a
+// registry entry today would additionally subject it to registry startup
+// validation, which is precisely the coverage this binary does NOT report for
+// it. So the reader unions the planes instead of the planes being merged.
+//
+// The union is derived, not enumerated: the occupancy comes from
+// syncdispatchruntime.RiverQueueOccupancy(), which is itself derived from the
+// frozen contract kinds. Adding one registry line for dispatch_sync_run would
+// have fixed exactly one kind and left the next one to trip the same wire
+// (CHAOS-3938).
+func nonRegistryQueueOccupants(queueBudgets []jobruntime.QueueBudget) []riverstore.QueueTelemetryOccupant {
+	selected := make(map[string]struct{}, len(queueBudgets))
+	for _, budget := range queueBudgets {
+		selected[budget.Queue] = struct{}{}
+	}
+	occupants := make([]riverstore.QueueTelemetryOccupant, 0, len(queueBudgets))
+	for _, occupancy := range syncdispatchruntime.RiverQueueOccupancy() {
+		if _, ok := selected[occupancy.Queue]; !ok {
+			continue
+		}
+		occupants = append(occupants, riverstore.QueueTelemetryOccupant{
+			Queue:             occupancy.Queue,
+			Kind:              occupancy.Kind,
+			SupportedVersions: append([]int(nil), occupancy.SupportedVersions...),
+		})
+	}
+	return occupants
 }
 
 func buildWorkerMetrics(
@@ -1386,9 +1440,42 @@ func (dependencies *workerDependencies) queuedContractVersionsReady(ctx context.
 		return errWorkerDependencyUnavailable
 	}
 	if err := dependencies.queueTelemetry.CheckAvailableContractVersions(ctx); err != nil {
+		// Name the offending contract. The health registry surface reports
+		// check names only, so without this an operator sees
+		// "failed_checks=queued_contract_versions" and has no way to tell
+		// which kind, which queue, or which version refused the start -- which
+		// is what turned CHAOS-3938 into a 20-minute outage instead of a
+		// one-line diagnosis. Only bounded, re-validated queue/kind/version
+		// labels are logged; see riverstore.UnsupportedContractVersionError.
+		var unsupported *riverstore.UnsupportedContractVersionError
+		if errors.As(err, &unsupported) {
+			dependencies.reportUnsupportedContracts(ctx, strings.Join(unsupported.Offenders, ","))
+		}
 		return errWorkerDependencyUnavailable
 	}
+	dependencies.reportUnsupportedContracts(ctx, "")
 	return nil
+}
+
+// reportUnsupportedContracts logs the offender set only when it CHANGES,
+// including the change back to empty. A repeat of the same set is the same
+// fact restated at probe rate; a different set, or a recurrence after
+// recovery, is new information and is logged again.
+func (dependencies *workerDependencies) reportUnsupportedContracts(ctx context.Context, offenders string) {
+	dependencies.unsupportedContractsMu.Lock()
+	changed := dependencies.reportedUnsupportedContracts != offenders
+	dependencies.reportedUnsupportedContracts = offenders
+	dependencies.unsupportedContractsMu.Unlock()
+	if !changed || offenders == "" || dependencies.logger == nil {
+		return
+	}
+	dependencies.logger.ErrorContext(
+		ctx,
+		"queued contract version is not supported by this worker",
+		"error_category", "dependency_unavailable",
+		"check", "queued_contract_versions",
+		"unsupported_contracts", offenders,
+	)
 }
 
 func (dependencies *workerDependencies) close() {

--- a/cmd/dev-health-worker/dependencies_test.go
+++ b/cmd/dev-health-worker/dependencies_test.go
@@ -2031,3 +2031,75 @@ func TestUnsetShutdownTimeoutIsDerivedFromTheSelectedQueues(t *testing.T) {
 		t.Fatalf("explicit 30s timeout = %v, want shutdown contract refusal", refused.startupErr)
 	}
 }
+
+// TestUnsupportedContractRefusalNamesTheContractOncePerChange covers both
+// halves of the diagnostic added for CHAOS-3938: the refusal must NAME the
+// offending queue/kind/version, and it must say so once per change rather than
+// once per readiness evaluation. Readiness is re-run on every /readyz probe
+// and /metrics scrape and a failing check does not stop a running process, so
+// logging per evaluation would turn one incompatible row into probe-rate ERROR
+// on every replica.
+func TestUnsupportedContractRefusalNamesTheContractOncePerChange(t *testing.T) {
+	logs := &bytes.Buffer{}
+	telemetry := &fakeQueueTelemetry{
+		checkErr: &riverstore.UnsupportedContractVersionError{
+			Offenders: []string{"sync/dispatch_sync_run@7"},
+		},
+	}
+	dependencies := &workerDependencies{
+		queueTelemetry:         telemetry,
+		queueTelemetryRequired: true,
+		logger:                 slog.New(slog.NewTextHandler(logs, nil)),
+	}
+
+	for range 3 {
+		if err := dependencies.queuedContractVersionsReady(context.Background()); err == nil {
+			t.Fatal("unsupported contract version was accepted")
+		}
+	}
+	if lines := countLogLines(logs.String()); lines != 1 {
+		t.Fatalf("logged %d times for one unchanged offender set, want 1: %s", lines, logs.String())
+	}
+	if !strings.Contains(logs.String(), "sync/dispatch_sync_run@7") {
+		t.Fatalf("refusal did not name the offending contract: %s", logs.String())
+	}
+
+	// A different offender set is new information.
+	telemetry.checkErr = &riverstore.UnsupportedContractVersionError{
+		Offenders: []string{"sync/post_sync@9"},
+	}
+	if err := dependencies.queuedContractVersionsReady(context.Background()); err == nil {
+		t.Fatal("unsupported contract version was accepted")
+	}
+	if lines := countLogLines(logs.String()); lines != 2 {
+		t.Fatalf("a changed offender set logged %d times in total, want 2: %s", lines, logs.String())
+	}
+
+	// So is a recurrence after the queue drained clean.
+	telemetry.checkErr = nil
+	if err := dependencies.queuedContractVersionsReady(context.Background()); err != nil {
+		t.Fatalf("clean queue refused readiness: %v", err)
+	}
+	if lines := countLogLines(logs.String()); lines != 2 {
+		t.Fatalf("recovery logged: %s", logs.String())
+	}
+	telemetry.checkErr = &riverstore.UnsupportedContractVersionError{
+		Offenders: []string{"sync/post_sync@9"},
+	}
+	if err := dependencies.queuedContractVersionsReady(context.Background()); err == nil {
+		t.Fatal("unsupported contract version was accepted")
+	}
+	if lines := countLogLines(logs.String()); lines != 3 {
+		t.Fatalf("a recurrence after recovery logged %d times in total, want 3: %s", lines, logs.String())
+	}
+}
+
+func countLogLines(output string) int {
+	lines := 0
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines++
+		}
+	}
+	return lines
+}

--- a/cmd/dev-health-worker/queued_contract_versions_integration_test.go
+++ b/cmd/dev-health-worker/queued_contract_versions_integration_test.go
@@ -1,0 +1,245 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchruntime"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// queuedKind is one row this deployment can legitimately leave in a River
+// queue, and the plane that declares it.
+type queuedKind struct {
+	queue   string
+	kind    string
+	version int
+	plane   string
+}
+
+// TestQueuedContractVersionsReadinessResolvesEveryPlane is the CHAOS-3938
+// regression, and the guard that makes the class impossible rather than fixing
+// one kind.
+//
+// It enumerates BOTH route planes that can put rows in river.river_job -- the
+// bounded jobs registry and the sync-dispatch transport routes -- inserts one
+// state='available' row for every kind at its declared contract version, and
+// then runs the production startup readiness check against that non-empty
+// queue. A kind that any plane can enqueue but the check cannot resolve fails
+// this test the day it is added, which is what a single registry line for
+// dispatch_sync_run would not have done.
+//
+// A NON-EMPTY queue is the whole point: the bug only exists in that state, and
+// every earlier restart survived purely because the queue happened to be empty
+// at that moment.
+func TestQueuedContractVersionsReadinessResolvesEveryPlane(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+
+	postgres, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = postgres.Close(context.Background()) })
+	admin, err := pgxpool.New(ctx, postgres.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(admin.Close)
+	prepareMultiReplicaDatabase(t, ctx, admin)
+
+	registry, err := jobruntime.Load(defaultContractRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queued := everyQueuedKind(t, registry)
+	if len(queued) == 0 {
+		t.Fatal("enumerated no queued kinds; the assertions below would be vacuous")
+	}
+	queues := queuesOf(queued)
+
+	for _, entry := range queued {
+		insertAvailableRiverJob(t, ctx, admin, entry.queue, entry.kind, entry.version)
+	}
+	assertAvailableRows(t, ctx, admin, len(queued))
+
+	if err := queuedContractVersionsReadiness(t, ctx, postgres.URI, queues); err != nil {
+		t.Fatalf("startup readiness refused with every plane's kinds queued: %v", err)
+	}
+
+	// Mutation control. A row whose contract version is genuinely outside the
+	// declared window must still refuse, and the refusal must name the queue,
+	// the kind, and the version -- production got only
+	// "failed_checks=queued_contract_versions" and could not tell which.
+	insertAvailableRiverJob(t, ctx, admin, syncdispatchcontract.RiverQueue,
+		syncdispatchcontract.KindDispatchSyncRun, 99)
+	err = queuedContractVersionsReadiness(t, ctx, postgres.URI, queues)
+	var unsupported *riverstore.UnsupportedContractVersionError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("a genuinely unsupported contract version was accepted: %v", err)
+	}
+	want := syncdispatchcontract.RiverQueue + "/" + syncdispatchcontract.KindDispatchSyncRun + "@99"
+	if !containsString(unsupported.Offenders, want) {
+		t.Fatalf("refusal named %v, want it to name %q", unsupported.Offenders, want)
+	}
+}
+
+// everyQueuedKind unions the two planes. Both halves are derived from the
+// checked-in contracts, so a kind added to either one is covered here without
+// a second edit.
+func everyQueuedKind(t *testing.T, registry *jobruntime.Registry) []queuedKind {
+	t.Helper()
+	queued := make([]queuedKind, 0, len(registry.Descriptors()))
+	for _, descriptor := range registry.Descriptors() {
+		queued = append(queued, queuedKind{
+			queue:   descriptor.Queue,
+			kind:    descriptor.Kind,
+			version: descriptor.CurrentVersion,
+			plane:   "worker_job_routes",
+		})
+	}
+	for _, occupancy := range syncdispatchruntime.RiverQueueOccupancy() {
+		for _, version := range occupancy.SupportedVersions {
+			queued = append(queued, queuedKind{
+				queue:   occupancy.Queue,
+				kind:    occupancy.Kind,
+				version: version,
+				plane:   "sync_dispatch_transport_routes",
+			})
+		}
+	}
+	return queued
+}
+
+func queuesOf(queued []queuedKind) []string {
+	seen := make(map[string]struct{}, len(queued))
+	queues := make([]string, 0, len(queued))
+	for _, entry := range queued {
+		if _, ok := seen[entry.queue]; ok {
+			continue
+		}
+		seen[entry.queue] = struct{}{}
+		queues = append(queues, entry.queue)
+	}
+	sort.Strings(queues)
+	return queues
+}
+
+// queuedContractVersionsReadiness runs the production startup check. Only the
+// pool source is substituted: the registry load, the telemetry configuration,
+// and the check itself are the shipped code paths.
+func queuedContractVersionsReadiness(
+	t *testing.T,
+	ctx context.Context,
+	postgresURI string,
+	queues []string,
+) error {
+	t.Helper()
+	domain, err := pgxpool.New(ctx, postgresURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queuePool, err := pgxpool.New(ctx, postgresURI)
+	if err != nil {
+		domain.Close()
+		t.Fatal(err)
+	}
+	database := &postgresWorkerDatabase{
+		pools: &postgresstore.RuntimePools{Domain: domain, QueueControl: queuePool},
+	}
+	t.Cleanup(database.Close)
+
+	concurrency := make(map[string]int, len(queues))
+	for _, queue := range queues {
+		concurrency[queue] = 1
+	}
+	cfg := config.Config{
+		Service:                "dev-health-worker",
+		Queues:                 append([]string(nil), queues...),
+		WorkerQueueConcurrency: concurrency,
+		RiverDatabaseSchema:    "river",
+		// Left unset so the drain budget is derived from the selected kinds'
+		// longest timeout, exactly as an operator who configured nothing gets.
+	}
+	sources := productionWorkerDependencySources
+	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) {
+		return database, nil
+	}
+	sources.newRiverClientID = func() string { return uuid.NewString() }
+
+	dependencies := buildWorkerDependencies(ctx, cfg, sources)
+	dependencies.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	if dependencies.startupErr != nil {
+		t.Fatalf("worker dependencies did not compose: %v", dependencies.startupErr)
+	}
+	if !dependencies.queueTelemetryRequired {
+		t.Fatal("queue telemetry was not required; the readiness check would be a no-op")
+	}
+	if dependencies.queueTelemetryErr != nil {
+		t.Fatalf("queue telemetry sampler was not constructed: %v", dependencies.queueTelemetryErr)
+	}
+	return dependencies.queueTelemetry.CheckAvailableContractVersions(ctx)
+}
+
+func insertAvailableRiverJob(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	queue string,
+	kind string,
+	version int,
+) {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{"contract_version": version})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(
+		ctx,
+		`INSERT INTO river.river_job (state, max_attempts, args, kind, queue, scheduled_at)
+		 VALUES ('available', 3, $1::jsonb, $2, $3, now() - interval '1 minute')`,
+		string(args), kind, queue,
+	); err != nil {
+		t.Fatalf("insert available %s/%s: %v", queue, kind, err)
+	}
+}
+
+func assertAvailableRows(t *testing.T, ctx context.Context, pool *pgxpool.Pool, want int) {
+	t.Helper()
+	var available int
+	if err := pool.QueryRow(
+		ctx, `SELECT count(*) FROM river.river_job WHERE state = 'available'`,
+	).Scan(&available); err != nil {
+		t.Fatal(err)
+	}
+	if available != want {
+		t.Fatalf("queue holds %d available rows, want %d; the readiness check "+
+			"only inspects state='available' so an empty queue proves nothing", available, want)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/dev-health-worker/river_process.go
+++ b/cmd/dev-health-worker/river_process.go
@@ -59,16 +59,63 @@ func newRiverWorkerProcess(
 	}
 	client, err := river.NewClient(
 		riverpgxv5.New(postgresDatabase.pools.QueueControl),
-		&river.Config{
-			ID:      cfg.WorkerInstanceID,
-			Logger:  logger,
-			Queues:  queues,
-			Schema:  cfg.RiverDatabaseSchema,
-			Workers: workers,
-		},
+		riverWorkerClientConfig(cfg, queues, workers, logger),
 	)
 	if err != nil {
 		return nil, errWorkerDependencyUnavailable
 	}
 	return riverWorkerProcess{client: client, family: family}, nil
+}
+
+// reindexDisabled is River's documented way to schedule no reindex work:
+// river.Config.ReindexerIndexNames is "the exact list of indexes to reindex",
+// and a non-nil EMPTY list means there is nothing to rebuild. Leaving it nil
+// selects river.ReindexerIndexNamesDefault() instead, which is what produced
+// seven `maintenance.Reindexer: Error reindexing ... permission denied`
+// (SQLSTATE 42501) ERROR lines every midnight UTC from every worker process
+// that runs maintenance services (CHAOS-3939).
+//
+// DECISION -- do not re-enable this by widening the runtime role. REINDEX needs
+// either ownership of the index or, on PostgreSQL 16+, the MAINTAIN privilege,
+// and this deployment's own readiness checks refuse BOTH by construction:
+//
+//   - Ownership: rolePostureQuery asserts the runtime identity owns nothing at
+//     all -- NOT EXISTS (SELECT 1 FROM pg_class WHERE relowner = <this role>
+//     AND relkind IN ('r','p','v','m','f','S')) in
+//     internal/storage/postgres/domain_authorization.go. Making the role own
+//     river_job so REINDEX succeeds makes that predicate false, so CheckRolePosture
+//     starts FAILING rather than passing.
+//   - MAINTAIN: queueRolePostureQuery asserts the queue role holds SELECT,
+//     INSERT, UPDATE and DELETE on every River table and NOT MAINTAIN, guarded
+//     on server_version_num >= 170000
+//     (internal/storage/postgres/queue_authorization.go). This deployment runs
+//     PostgreSQL 18, so that branch is live and an added MAINTAIN grant reads
+//     as excess privilege -- again failing readiness.
+//
+// Either route would therefore need a posture change, and the derived GRANTs
+// ship in the dev-hops-runner image (docker/Dockerfile), NOT the Go worker
+// image, so a posture edit not accompanied by a runner rebuild breaks
+// production worse than the noise it removes. Reclaiming river_job index bloat
+// belongs in a privileged one-shot alongside the migration path, which already
+// runs as an owner-capable role.
+func reindexDisabled() []string { return []string{} }
+
+// riverWorkerClientConfig is the exact River client configuration the worker
+// process runs with. It is a named function so a test can assert the shipped
+// configuration's real behaviour against a real database, instead of asserting
+// against a look-alike config that could drift from this one.
+func riverWorkerClientConfig(
+	cfg config.Config,
+	queues map[string]river.QueueConfig,
+	workers *river.Workers,
+	logger *slog.Logger,
+) *river.Config {
+	return &river.Config{
+		ID:                  cfg.WorkerInstanceID,
+		Logger:              logger,
+		Queues:              queues,
+		ReindexerIndexNames: reindexDisabled(),
+		Schema:              cfg.RiverDatabaseSchema,
+		Workers:             workers,
+	}
 }

--- a/cmd/dev-health-worker/river_reindexer_integration_test.go
+++ b/cmd/dev-health-worker/river_reindexer_integration_test.go
@@ -1,0 +1,229 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+)
+
+const (
+	reindexDomainRole     = "reindex_domain_runtime"
+	reindexQueueRole      = "reindex_queue_runtime"
+	reindexRolePassword   = "reindex_test_password"
+	reindexObservedWindow = 90 * time.Second
+)
+
+// TestRiverWorkerClientRunsReindexerWithoutPermissionErrors is the CHAOS-3939
+// regression. It asserts the EFFECT the shipped River client configuration has
+// against a real least-privilege runtime role -- the reindexer runs and
+// rebuilds nothing -- and it proves the harness can see the bug by running the
+// same client with River's default index list, which must produce the
+// permission-denied ERROR lines production reported every midnight.
+func TestRiverWorkerClientRunsReindexerWithoutPermissionErrors(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	t.Cleanup(cancel)
+
+	postgres, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = postgres.Close(context.Background()) })
+
+	admin, err := pgxpool.New(ctx, postgres.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(admin.Close)
+	for _, statement := range []string{
+		"CREATE SCHEMA river",
+		"CREATE ROLE " + reindexDomainRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE " +
+			"NOREPLICATION NOBYPASSRLS PASSWORD '" + reindexRolePassword + "'",
+		"CREATE ROLE " + reindexQueueRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE " +
+			"NOREPLICATION NOBYPASSRLS PASSWORD '" + reindexRolePassword + "'",
+	} {
+		if _, err := admin.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, admin, riverstore.MigrationOptions{
+		Schema: "river", DomainRole: reindexDomainRole, QueueRole: reindexQueueRole,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	queuePool, err := pgxpool.New(ctx, reindexRoleURI(t, postgres.URI, reindexQueueRole))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(queuePool.Close)
+
+	// Premise check. If the runtime role could reindex, the bug this test
+	// guards would not exist and every assertion below would be vacuous.
+	_, reindexErr := queuePool.Exec(ctx, "REINDEX INDEX river.river_job_kind")
+	if reindexErr == nil {
+		t.Fatal("runtime queue role could REINDEX river_job_kind; the least-privilege premise no longer holds")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(reindexErr, &pgErr) || pgErr.Code != "42501" {
+		t.Fatalf("REINDEX as the runtime role failed for the wrong reason: %v", reindexErr)
+	}
+
+	// Control: River's default index list, everything else exactly as shipped.
+	// This must reproduce the production failure, or a passing shipped case
+	// below would prove nothing.
+	controlErrors, controlRuns := runReindexerOnce(t, ctx, queuePool, func(clientConfig *river.Config) {
+		clientConfig.ReindexerIndexNames = river.ReindexerIndexNamesDefault()
+	})
+	if len(controlErrors) == 0 {
+		t.Fatalf("control run reindexed cleanly with River's default index list; "+
+			"the harness cannot observe the CHAOS-3939 failure (runs=%d)", controlRuns)
+	}
+	if !strings.Contains(strings.Join(controlErrors, "\n"), "permission denied") {
+		t.Fatalf("control run failed for the wrong reason: %v", controlErrors)
+	}
+
+	// Shipped configuration: the reindexer still runs on schedule, initiates
+	// zero rebuilds, and logs no error.
+	shippedErrors, shippedRuns := runReindexerOnce(t, ctx, queuePool, nil)
+	if shippedRuns == 0 {
+		t.Fatal("shipped configuration never ran the reindexer; the assertion below would be vacuous")
+	}
+	if len(shippedErrors) != 0 {
+		t.Fatalf("shipped configuration produced reindex errors: %v", shippedErrors)
+	}
+}
+
+// runReindexerOnce starts the shipped worker client configuration, waits for at
+// least one reindexer run, and returns the reindex error messages it logged and
+// the number of completed runs it observed.
+//
+// mutate is nil for the shipped case: riverWorkerClientConfig's output is
+// passed through untouched, so deleting the ReindexerIndexNames field from it
+// fails this test. Only the control run mutates the configuration, and only to
+// restore River's default index list. The schedule override is applied to both
+// -- the shipped default fires at midnight UTC, which no test can wait for.
+func runReindexerOnce(
+	t *testing.T,
+	ctx context.Context,
+	queuePool *pgxpool.Pool,
+	mutate func(*river.Config),
+) ([]string, int) {
+	t.Helper()
+	recorder := &reindexLogRecorder{}
+	logger := slog.New(slog.NewTextHandler(recorder, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	workers := river.NewWorkers()
+	if err := river.AddWorkerSafely(workers, &reindexProbeWorker{}); err != nil {
+		t.Fatal(err)
+	}
+	clientConfig := riverWorkerClientConfig(
+		config.Config{WorkerInstanceID: uuid.NewString(), RiverDatabaseSchema: "river"},
+		map[string]river.QueueConfig{"heartbeat": {MaxWorkers: 1}},
+		workers,
+		logger,
+	)
+	if mutate != nil {
+		mutate(clientConfig)
+	}
+	clientConfig.ReindexerSchedule = fixedIntervalSchedule{interval: time.Second}
+
+	client, err := river.NewClient(riverpgxv5.New(queuePool), clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = client.Stop(stopCtx)
+	}()
+
+	deadline := time.Now().Add(reindexObservedWindow)
+	for time.Now().Before(deadline) {
+		if errorMessages, runs := recorder.observed(); runs > 0 || len(errorMessages) > 0 {
+			// One further beat so a run that is mid-flight finishes writing
+			// its per-index error lines before they are read.
+			time.Sleep(2 * time.Second)
+			return recorder.observed()
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	errorMessages, runs := recorder.observed()
+	t.Fatalf("reindexer never completed a run within %s (errors=%v)", reindexObservedWindow, errorMessages)
+	return errorMessages, runs
+}
+
+// reindexLogRecorder collects the two reindexer signals this test asserts on:
+// the per-index error line and the end-of-run line.
+type reindexLogRecorder struct {
+	mu            sync.Mutex
+	errorMessages []string
+	runs          int
+}
+
+func (recorder *reindexLogRecorder) Write(line []byte) (int, error) {
+	text := string(line)
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	switch {
+	case strings.Contains(text, "Reindexer: Error reindexing"):
+		recorder.errorMessages = append(recorder.errorMessages, strings.TrimSpace(text))
+	case strings.Contains(text, "Reindexer: Ran successfully"):
+		recorder.runs++
+	}
+	return len(line), nil
+}
+
+func (recorder *reindexLogRecorder) observed() ([]string, int) {
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	return append([]string(nil), recorder.errorMessages...), recorder.runs
+}
+
+// reindexRoleURI rewrites the container URI to connect as one of the
+// least-privilege runtime roles created above, leaving the database untouched.
+func reindexRoleURI(t *testing.T, rawURI, role string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed.User = url.UserPassword(role, reindexRolePassword)
+	return parsed.String()
+}
+
+type fixedIntervalSchedule struct{ interval time.Duration }
+
+func (schedule fixedIntervalSchedule) Next(from time.Time) time.Time {
+	return from.Add(schedule.interval)
+}
+
+// reindexProbeArgs exists only so the client has a worker and therefore starts
+// its maintenance services; no job of this kind is ever inserted.
+type reindexProbeArgs struct{}
+
+func (reindexProbeArgs) Kind() string { return "reindex.probe" }
+
+type reindexProbeWorker struct {
+	river.WorkerDefaults[reindexProbeArgs]
+}
+
+func (*reindexProbeWorker) Work(context.Context, *river.Job[reindexProbeArgs]) error { return nil }

--- a/cmd/dev-health-worker/sync_dispatch.go
+++ b/cmd/dev-health-worker/sync_dispatch.go
@@ -218,7 +218,11 @@ func postSyncWorkGraphScope(
 	return json.Marshal(scope)
 }
 
-const syncCoordinatorQueue = "sync"
+// syncCoordinatorQueue is the queue the sync-dispatch plane declares, not an
+// independent choice: the reconciler publishes dispatch_sync_run and its three
+// siblings into exactly this queue, and the startup contract-version check
+// resolves them from the same declaration (CHAOS-3938).
+const syncCoordinatorQueue = syncdispatchcontract.RiverQueue
 
 // buildSyncCoordinatorWorker hosts a mixed River client: four sync-dispatch
 // coordinator kinds that are outside the bounded job registry (CUT-10 brings

--- a/docs/operate/runbooks/worker-or-queue-failure.md
+++ b/docs/operate/runbooks/worker-or-queue-failure.md
@@ -69,6 +69,7 @@ For readiness failure, distinguish:
 - role-name mismatch or excessive privileges;
 - job registry/profile drift;
 - missing compiled handler for an admitted contract version;
+- a queued contract version this build does not support. The `queued_contract_versions` refusal names the offending queue, kind, and version, so read that log line before inspecting the queue by hand. It counts only jobs in the `available` state;
 - incompatible River schema;
 - dependency sampling failure.
 

--- a/internal/storage/river/telemetry.go
+++ b/internal/storage/river/telemetry.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"math"
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,10 +26,55 @@ const (
 var (
 	ErrQueueTelemetryConfiguration = errors.New("invalid River queue telemetry configuration")
 	ErrQueueTelemetryUnavailable   = errors.New("River queue telemetry is unavailable")
-	// ErrUnsupportedAvailableContractVersion is deliberately stable and does
-	// not disclose a River row, kind, version, or encoded argument.
+	// ErrUnsupportedAvailableContractVersion is the stable sentinel every
+	// caller matches on. It never discloses a River row or an encoded
+	// argument. UnsupportedContractVersionError wraps it and adds the
+	// offending queue/kind/version labels; see that type for why those three
+	// are safe to name when the arguments are not.
 	ErrUnsupportedAvailableContractVersion = errors.New("an available River job has an unsupported contract version")
 )
+
+// maximumUnsupportedOffenders bounds how many distinct queue/kind/version
+// labels the refusal names. The point is to identify the offending contract,
+// not to enumerate a backlog.
+const maximumUnsupportedOffenders = 8
+
+// maximumOffenderVersionLength bounds the contract-version text in an offender
+// label. Versions are small integers; this only stops an absurd JSON number
+// from widening the label.
+const maximumOffenderVersionLength = 16
+
+// UnsupportedContractVersionError names the bounded labels of the available
+// rows the check refused.
+//
+// Only queue, kind, and contract version are disclosed. All three are
+// low-cardinality bounded vocabulary that this process already publishes:
+// queue and kind are pre-registered Prometheus label values, and the version
+// is a small integer from the registered window. Every label is re-validated
+// in Go against the same character class and length limit the configuration
+// side enforces before it reaches an error string, and a version that is not
+// a JSON number is reported as "none" rather than echoed. Encoded arguments,
+// row identifiers, and payloads are never read.
+//
+// Naming them is the point: production saw only
+// "failed_checks=queued_contract_versions" and could not tell which kind,
+// which queue, or which version had refused startup, which is the same
+// bounded-code diagnosis gap as CHAOS-3928.
+type UnsupportedContractVersionError struct {
+	// Offenders are "queue/kind@version" labels, sorted and deduplicated.
+	Offenders []string
+}
+
+func (failure *UnsupportedContractVersionError) Error() string {
+	if failure == nil || len(failure.Offenders) == 0 {
+		return ErrUnsupportedAvailableContractVersion.Error()
+	}
+	return ErrUnsupportedAvailableContractVersion.Error() + ": " + strings.Join(failure.Offenders, ",")
+}
+
+func (*UnsupportedContractVersionError) Unwrap() error {
+	return ErrUnsupportedAvailableContractVersion
+}
 
 // QueueTelemetryQueue is one queue consumed by a River client. MaxWorkers
 // must be the same value supplied to river.QueueConfig for this process.
@@ -44,6 +91,29 @@ type QueueTelemetryJob struct {
 	SupportedVersions []int
 }
 
+// QueueTelemetryOccupant is one queue/kind pair that may legitimately hold
+// available rows in a configured queue although this process reports no
+// backlog metric for it.
+//
+// Jobs and Occupants are separate on purpose. Jobs is the metrics dimension:
+// every entry becomes a pre-registered jobs_available label, so it must stay
+// exactly the set of kinds the metrics collector was built with. Occupants is
+// the RESOLVABILITY set: kinds that share a River queue from another route
+// plane, which a reader of river_job must be able to resolve but must not
+// invent metric labels for. Folding the second into the first would make the
+// metrics write fail on an unregistered dimension instead.
+//
+// A River queue can be shared by more than one plane -- queue "sync" carries
+// the bounded registry's sync.team_autoimport AND the sync-dispatch plane's
+// dispatch_sync_run -- and a contract-version check that knows only one plane
+// reads the other plane's perfectly valid rows as unsupported, which refused
+// worker startup for as long as any were pending (CHAOS-3938).
+type QueueTelemetryOccupant struct {
+	Queue             string
+	Kind              string
+	SupportedVersions []int
+}
+
 // QueueTelemetryConfig binds database observations to one concrete River
 // client. ClientID must be client.ID(), after River has applied defaults.
 // Queue selection is the only scope label; profile names are intentionally not
@@ -54,6 +124,9 @@ type QueueTelemetryConfig struct {
 	QueryTimeout time.Duration
 	Queues       []QueueTelemetryQueue
 	Jobs         []QueueTelemetryJob
+	// Occupants are non-metric kinds that may legitimately occupy the
+	// configured queues. See QueueTelemetryOccupant.
+	Occupants []QueueTelemetryOccupant
 }
 
 // QueueJobTelemetry contains only pre-registered, low-cardinality labels.
@@ -120,7 +193,7 @@ type queueTelemetryRow struct {
 	oldestAgeSeconds     float64
 	localRunning         int64
 	queueRunning         int64
-	unsupportedAvailable bool
+	unsupportedOccupants []string
 }
 
 type queueTelemetryReadFunc func(context.Context) ([]queueTelemetryRow, error)
@@ -162,66 +235,73 @@ func (sampler *QueueTelemetrySampler) Snapshot(ctx context.Context) (QueueTeleme
 // CheckAvailableContractVersions fails closed if any state=available row in a
 // configured queue has an unknown queue/kind pairing, a missing or
 // non-integer contract_version, or a version outside the registered window.
-// It returns stable errors only and never loads or returns encoded arguments.
+// It never loads or returns encoded arguments. A refusal is an
+// *UnsupportedContractVersionError wrapping
+// ErrUnsupportedAvailableContractVersion, carrying the offending
+// queue/kind/version labels so the caller can say WHICH contract refused.
 func (sampler *QueueTelemetrySampler) CheckAvailableContractVersions(ctx context.Context) error {
-	_, unsupported, err := sampler.sample(ctx)
+	_, offenders, err := sampler.sample(ctx)
 	if err != nil {
 		return err
 	}
-	if unsupported {
-		return ErrUnsupportedAvailableContractVersion
+	if len(offenders) > 0 {
+		return &UnsupportedContractVersionError{Offenders: offenders}
 	}
 	return nil
 }
 
-func (sampler *QueueTelemetrySampler) sample(ctx context.Context) (QueueTelemetrySnapshot, bool, error) {
+func (sampler *QueueTelemetrySampler) sample(ctx context.Context) (QueueTelemetrySnapshot, []string, error) {
 	if sampler == nil || sampler.read == nil || ctx == nil {
-		return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+		return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 	}
 	queryContext, cancel := context.WithTimeout(ctx, sampler.config.queryTimeout)
 	defer cancel()
 	rows, err := sampler.read(queryContext)
 	if err != nil {
-		return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+		return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 	}
 	return sampler.snapshot(rows)
 }
 
-func (sampler *QueueTelemetrySampler) snapshot(rows []queueTelemetryRow) (QueueTelemetrySnapshot, bool, error) {
+func (sampler *QueueTelemetrySampler) snapshot(rows []queueTelemetryRow) (QueueTelemetrySnapshot, []string, error) {
 	if len(rows) != len(sampler.config.jobs) || len(rows) == 0 {
-		return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+		return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 	}
 	available := make(map[queueJobKey]int64, len(rows))
 	ages := make(map[string]time.Duration, len(sampler.config.queues))
 	seenAges := make(map[string]float64, len(sampler.config.queues))
 	running := make(map[string]int64, len(sampler.config.queues))
 	var localRunning int64
-	var unsupported bool
+	var offenders []string
 	for index, row := range rows {
 		key := queueJobKey{queue: row.queue, kind: row.kind}
 		if row.available < 0 || row.localRunning < 0 || row.queueRunning < 0 ||
 			math.IsNaN(row.oldestAgeSeconds) || math.IsInf(row.oldestAgeSeconds, 0) ||
-			row.oldestAgeSeconds < 0 {
-			return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+			row.oldestAgeSeconds < 0 || !validOffenderLabels(row.unsupportedOccupants) {
+			return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 		}
 		if _, duplicate := available[key]; duplicate || !sampler.hasJob(key) {
-			return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+			return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 		}
 		available[key] = row.available
 		if previous, ok := seenAges[row.queue]; ok && previous != row.oldestAgeSeconds {
-			return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+			return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 		}
 		seenAges[row.queue] = row.oldestAgeSeconds
 		ages[row.queue] = durationFromSeconds(row.oldestAgeSeconds)
 		if previous, ok := running[row.queue]; ok && previous != row.queueRunning {
-			return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+			return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 		}
 		running[row.queue] = row.queueRunning
+		// Both are whole-selection aggregates: every row of one read must
+		// carry the identical value, so a disagreement means the result set is
+		// not the single consistent observation this sampler contracts for.
 		if index == 0 {
 			localRunning = row.localRunning
-			unsupported = row.unsupportedAvailable
-		} else if localRunning != row.localRunning || unsupported != row.unsupportedAvailable {
-			return QueueTelemetrySnapshot{}, false, ErrQueueTelemetryUnavailable
+			offenders = append([]string(nil), row.unsupportedOccupants...)
+		} else if localRunning != row.localRunning ||
+			!slices.Equal(offenders, row.unsupportedOccupants) {
+			return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 		}
 	}
 
@@ -250,7 +330,49 @@ func (sampler *QueueTelemetrySampler) snapshot(rows []queueTelemetryRow) (QueueT
 			Saturation: executionSaturation(queueRunning, int64(queue.MaxWorkers)),
 		})
 	}
-	return result, unsupported, nil
+	return result, offenders, nil
+}
+
+// validOffenderLabels re-checks the bounded labels the database aggregated, so
+// a value that somehow escaped the SQL truncation -- or a row written outside
+// this application's insert paths -- can never reach an error string or a log
+// line. The label is "queue/kind@version"; queue and kind must satisfy the
+// same character class and length limit the configuration side enforces, and
+// the version must be digits or the literal "none".
+func validOffenderLabels(labels []string) bool {
+	if len(labels) > maximumUnsupportedOffenders {
+		return false
+	}
+	for _, label := range labels {
+		queueAndRest, version, found := strings.Cut(label, "@")
+		if !found || !validOffenderVersion(version) {
+			return false
+		}
+		queue, kind, found := strings.Cut(queueAndRest, "/")
+		if !found || !telemetryLabel(queue, maximumQueueTelemetryLabelLength) ||
+			!telemetryLabel(kind, maximumQueueTelemetryLabelLength) {
+			return false
+		}
+	}
+	return true
+}
+
+func validOffenderVersion(version string) bool {
+	// "none" is a missing or non-numeric contract_version; "invalid" is a JSON
+	// number that is not a canonical unsigned integer. Both are emitted by the
+	// query instead of the offending text itself.
+	if version == "none" || version == "invalid" {
+		return true
+	}
+	if len(version) == 0 || len(version) > maximumOffenderVersionLength {
+		return false
+	}
+	for _, character := range version {
+		if character < '0' || character > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func (sampler *QueueTelemetrySampler) hasJob(key queueJobKey) bool {
@@ -267,6 +389,7 @@ func normalizeQueueTelemetryConfig(config QueueTelemetryConfig) (normalizedQueue
 		len(config.ClientID) == 0 || len(config.ClientID) > 100 || strings.ContainsRune(config.ClientID, '\x00') ||
 		len(config.Queues) == 0 || len(config.Queues) > maximumQueueTelemetryQueues ||
 		len(config.Jobs) == 0 || len(config.Jobs) > maximumQueueTelemetryJobs ||
+		len(config.Occupants) > maximumQueueTelemetryJobs ||
 		config.QueryTimeout < 0 || config.QueryTimeout > maximumQueueTelemetryTimeout {
 		return normalizedQueueTelemetryConfig{}, ErrQueueTelemetryConfiguration
 	}
@@ -327,6 +450,47 @@ func normalizeQueueTelemetryConfig(config QueueTelemetryConfig) (normalizedQueue
 			previous = version
 		}
 	}
+	occupants := make([]QueueTelemetryOccupant, len(config.Occupants))
+	for index, occupant := range config.Occupants {
+		occupants[index] = QueueTelemetryOccupant{
+			Queue:             occupant.Queue,
+			Kind:              occupant.Kind,
+			SupportedVersions: append([]int(nil), occupant.SupportedVersions...),
+		}
+	}
+	sort.Slice(occupants, func(left, right int) bool {
+		if occupants[left].Queue != occupants[right].Queue {
+			return occupants[left].Queue < occupants[right].Queue
+		}
+		return occupants[left].Kind < occupants[right].Kind
+	})
+	for _, occupant := range occupants {
+		if !telemetryLabel(occupant.Queue, maximumQueueTelemetryLabelLength) ||
+			!telemetryLabel(occupant.Kind, maximumQueueTelemetryLabelLength) ||
+			len(occupant.SupportedVersions) == 0 ||
+			len(occupant.SupportedVersions) > maximumSupportedVersionsPerJob {
+			return normalizedQueueTelemetryConfig{}, ErrQueueTelemetryConfiguration
+		}
+		if _, ok := queueSet[occupant.Queue]; !ok {
+			return normalizedQueueTelemetryConfig{}, ErrQueueTelemetryConfiguration
+		}
+		// One (queue, kind) may be declared once, by exactly one plane. A
+		// duplicate would silently union two version windows and let a version
+		// neither plane accepts pass the check.
+		key := queueJobKey{queue: occupant.Queue, kind: occupant.Kind}
+		if _, duplicate := jobSet[key]; duplicate {
+			return normalizedQueueTelemetryConfig{}, ErrQueueTelemetryConfiguration
+		}
+		jobSet[key] = struct{}{}
+		usedQueues[occupant.Queue] = struct{}{}
+		previous := 0
+		for _, version := range occupant.SupportedVersions {
+			if version < 1 || version <= previous || version > math.MaxInt32 {
+				return normalizedQueueTelemetryConfig{}, ErrQueueTelemetryConfiguration
+			}
+			previous = version
+		}
+	}
 	if len(usedQueues) != len(queueSet) {
 		return normalizedQueueTelemetryConfig{}, ErrQueueTelemetryConfiguration
 	}
@@ -347,6 +511,16 @@ func normalizeQueueTelemetryConfig(config QueueTelemetryConfig) (normalizedQueue
 		for _, version := range job.SupportedVersions {
 			normalized.supportedQueues = append(normalized.supportedQueues, job.Queue)
 			normalized.supportedKinds = append(normalized.supportedKinds, job.Kind)
+			normalized.supportedVersions = append(normalized.supportedVersions, int32(version))
+		}
+	}
+	// Occupants widen only the supported-version set. They deliberately do NOT
+	// enter jobQueues/jobKinds: those drive expected_jobs, which becomes one
+	// pre-registered jobs_available metric label per entry.
+	for _, occupant := range occupants {
+		for _, version := range occupant.SupportedVersions {
+			normalized.supportedQueues = append(normalized.supportedQueues, occupant.Queue)
+			normalized.supportedKinds = append(normalized.supportedKinds, occupant.Kind)
 			normalized.supportedVersions = append(normalized.supportedVersions, int32(version))
 		}
 	}
@@ -392,6 +566,17 @@ func readQueueTelemetry(
 	config normalizedQueueTelemetryConfig,
 ) ([]queueTelemetryRow, error) {
 	statement := strings.ReplaceAll(queueTelemetrySQL, "{{river_job}}", table)
+	// The SQL truncation limits and the Go re-validation limits are the SAME
+	// constants, substituted here rather than restated as literals: a
+	// duplicated bound that drifts would make legitimate labels fail
+	// validation and read as an unreadable snapshot.
+	for placeholder, value := range map[string]int{
+		"{{offender_limit}}": maximumUnsupportedOffenders,
+		"{{label_length}}":   maximumQueueTelemetryLabelLength,
+		"{{version_length}}": maximumOffenderVersionLength,
+	} {
+		statement = strings.ReplaceAll(statement, placeholder, strconv.Itoa(value))
+	}
 	rows, err := pool.Query(
 		ctx,
 		statement,
@@ -417,7 +602,7 @@ func readQueueTelemetry(
 			&row.oldestAgeSeconds,
 			&row.localRunning,
 			&row.queueRunning,
-			&row.unsupportedAvailable,
+			&row.unsupportedOccupants,
 		); err != nil {
 			return nil, err
 		}
@@ -486,21 +671,57 @@ queue_running AS (
         AND river_job.attempted_by[array_upper(river_job.attempted_by, 1)] = $7::text
     GROUP BY river_job.queue
 ),
+-- The refusal names the offending contract instead of only asserting that one
+-- exists: an EXISTS boolean told an operator a version was unsupported but not
+-- which kind, queue, or version, so the only way to find out was to query the
+-- table by hand while the worker crash-looped (CHAOS-3938). Labels are
+-- truncated here and re-validated in Go; the version is emitted only when it
+-- is a JSON number, so nothing unbounded from args can reach a log line.
 unsupported_available AS (
-    SELECT EXISTS (
-        SELECT 1
-        FROM {{river_job}} AS river_job
-        WHERE river_job.queue = ANY($3::text[])
-            AND river_job.state = 'available'
-            AND NOT EXISTS (
-                SELECT 1
-                FROM supported_versions
-                WHERE supported_versions.queue = river_job.queue
-                    AND supported_versions.kind = river_job.kind
-                    AND jsonb_typeof(river_job.args -> 'contract_version') = 'number'
-                    AND river_job.args ->> 'contract_version' = supported_versions.version::text
-            )
-    ) AS present
+    SELECT coalesce(
+        (
+            SELECT array_agg(offender ORDER BY offender)
+            FROM (
+                SELECT DISTINCT
+                    left(river_job.queue, {{label_length}}) || '/' ||
+                    left(river_job.kind, {{label_length}}) || '@' ||
+                    CASE
+                        -- Three outcomes, not two. A JSON number that is not a
+                        -- canonical unsigned integer -- -1, 1.5, 1e3 -- is a
+                        -- real unsupported version, so it must reach the
+                        -- refusal as 'invalid' rather than be emitted verbatim:
+                        -- the Go re-validation would reject the verbatim text
+                        -- and turn the whole read into an unreadable snapshot,
+                        -- losing both the diagnostic and the queue metrics for
+                        -- exactly the malformed rows this check exists to name.
+                        -- IS DISTINCT FROM, not <>: an ABSENT key makes the
+                        -- args lookup SQL NULL, so jsonb_typeof returns NULL
+                        -- and a plain <> is unknown rather than true -- which
+                        -- would fall through and report a missing version as a
+                        -- malformed one.
+                        WHEN jsonb_typeof(river_job.args -> 'contract_version') IS DISTINCT FROM 'number'
+                        THEN 'none'
+                        WHEN river_job.args ->> 'contract_version' ~ '^[0-9]{1,{{version_length}}}$'
+                        THEN river_job.args ->> 'contract_version'
+                        ELSE 'invalid'
+                    END AS offender
+                FROM {{river_job}} AS river_job
+                WHERE river_job.queue = ANY($3::text[])
+                    AND river_job.state = 'available'
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM supported_versions
+                        WHERE supported_versions.queue = river_job.queue
+                            AND supported_versions.kind = river_job.kind
+                            AND jsonb_typeof(river_job.args -> 'contract_version') = 'number'
+                            AND river_job.args ->> 'contract_version' = supported_versions.version::text
+                    )
+                ORDER BY offender
+                LIMIT {{offender_limit}}
+            ) AS unsupported_rows
+        ),
+        ARRAY[]::text[]
+    ) AS offenders
 )
 SELECT
     available_counts.queue,
@@ -509,7 +730,7 @@ SELECT
     queue_ages.oldest_age_seconds,
     local_running.count,
     coalesce(queue_running.running, 0),
-    unsupported_available.present
+    unsupported_available.offenders
 FROM available_counts
 JOIN queue_ages USING (queue)
 LEFT JOIN queue_running USING (queue)

--- a/internal/storage/river/telemetry.go
+++ b/internal/storage/river/telemetry.go
@@ -277,7 +277,7 @@ func (sampler *QueueTelemetrySampler) snapshot(rows []queueTelemetryRow) (QueueT
 		key := queueJobKey{queue: row.queue, kind: row.kind}
 		if row.available < 0 || row.localRunning < 0 || row.queueRunning < 0 ||
 			math.IsNaN(row.oldestAgeSeconds) || math.IsInf(row.oldestAgeSeconds, 0) ||
-			row.oldestAgeSeconds < 0 || !validOffenderLabels(row.unsupportedOccupants) {
+			row.oldestAgeSeconds < 0 {
 			return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 		}
 		if _, duplicate := available[key]; duplicate || !sampler.hasJob(key) {
@@ -298,9 +298,9 @@ func (sampler *QueueTelemetrySampler) snapshot(rows []queueTelemetryRow) (QueueT
 		// not the single consistent observation this sampler contracts for.
 		if index == 0 {
 			localRunning = row.localRunning
-			offenders = append([]string(nil), row.unsupportedOccupants...)
+			offenders = sanitizeOffenderLabels(row.unsupportedOccupants)
 		} else if localRunning != row.localRunning ||
-			!slices.Equal(offenders, row.unsupportedOccupants) {
+			!slices.Equal(offenders, sanitizeOffenderLabels(row.unsupportedOccupants)) {
 			return QueueTelemetrySnapshot{}, nil, ErrQueueTelemetryUnavailable
 		}
 	}
@@ -333,28 +333,50 @@ func (sampler *QueueTelemetrySampler) snapshot(rows []queueTelemetryRow) (QueueT
 	return result, offenders, nil
 }
 
-// validOffenderLabels re-checks the bounded labels the database aggregated, so
-// a value that somehow escaped the SQL truncation -- or a row written outside
-// this application's insert paths -- can never reach an error string or a log
-// line. The label is "queue/kind@version"; queue and kind must satisfy the
-// same character class and length limit the configuration side enforces, and
-// the version must be digits or the literal "none".
-func validOffenderLabels(labels []string) bool {
-	if len(labels) > maximumUnsupportedOffenders {
-		return false
+// unprintableOffender replaces a label that is not in the bounded vocabulary.
+// It is deliberately a whole label, not a marker spliced into a real one: the
+// point is that nothing derived from row content reaches a log line unchecked.
+const unprintableOffender = "unprintable/unprintable@none"
+
+// sanitizeOffenderLabels re-checks the bounded labels the database aggregated
+// and REPLACES anything outside the vocabulary, so a value that somehow
+// escaped the SQL sanitisation -- or a row written outside this application's
+// insert paths -- can never reach an error string or a log line.
+//
+// It replaces rather than rejects on purpose. Rejecting made the whole read
+// unreadable, and this sampler's Snapshot contract is that an unsupported
+// contract never hides backlog metrics: an odd kind must cost the DIAGNOSTIC
+// its precision, never the metrics their availability. The refusal still
+// happens, because the row is still unsupported.
+//
+// The label is "queue/kind@version"; queue and kind must satisfy the same
+// character class and length limit the configuration side enforces, and the
+// version must be digits, "none", or "invalid".
+func sanitizeOffenderLabels(labels []string) []string {
+	if len(labels) == 0 {
+		return nil
 	}
+	sanitized := make([]string, 0, min(len(labels), maximumUnsupportedOffenders))
 	for _, label := range labels {
-		queueAndRest, version, found := strings.Cut(label, "@")
-		if !found || !validOffenderVersion(version) {
-			return false
+		if len(sanitized) == maximumUnsupportedOffenders {
+			break
 		}
-		queue, kind, found := strings.Cut(queueAndRest, "/")
-		if !found || !telemetryLabel(queue, maximumQueueTelemetryLabelLength) ||
-			!telemetryLabel(kind, maximumQueueTelemetryLabelLength) {
-			return false
-		}
+		sanitized = append(sanitized, sanitizeOffenderLabel(label))
 	}
-	return true
+	return sanitized
+}
+
+func sanitizeOffenderLabel(label string) string {
+	queueAndRest, version, found := strings.Cut(label, "@")
+	if !found || !validOffenderVersion(version) {
+		return unprintableOffender
+	}
+	queue, kind, found := strings.Cut(queueAndRest, "/")
+	if !found || !telemetryLabel(queue, maximumQueueTelemetryLabelLength) ||
+		!telemetryLabel(kind, maximumQueueTelemetryLabelLength) {
+		return unprintableOffender
+	}
+	return label
 }
 
 func validOffenderVersion(version string) bool {
@@ -683,8 +705,26 @@ unsupported_available AS (
             SELECT array_agg(offender ORDER BY offender)
             FROM (
                 SELECT DISTINCT
-                    left(river_job.queue, {{label_length}}) || '/' ||
-                    left(river_job.kind, {{label_length}}) || '@' ||
+                    -- Sanitised in SQL, not merely truncated. left() counts
+                    -- CHARACTERS while the Go re-validation counts BYTES, and
+                    -- the Go class is ASCII-only, so a multi-byte or
+                    -- out-of-class kind would produce a label the Go side
+                    -- rejects. That used to invalidate the whole read -- which
+                    -- would take the BACKLOG METRICS down with it, breaking
+                    -- this sampler's stated invariant that an unsupported
+                    -- contract never hides them. Emitting a placeholder keeps
+                    -- the refusal (the row really is unsupported) without
+                    -- costing the metrics.
+                    CASE
+                        WHEN river_job.queue ~ '^[A-Za-z0-9._:-]{1,{{label_length}}}$'
+                        THEN river_job.queue
+                        ELSE 'unprintable'
+                    END || '/' ||
+                    CASE
+                        WHEN river_job.kind ~ '^[A-Za-z0-9._:-]{1,{{label_length}}}$'
+                        THEN river_job.kind
+                        ELSE 'unprintable'
+                    END || '@' ||
                     CASE
                         -- Three outcomes, not two. A JSON number that is not a
                         -- canonical unsigned integer -- -1, 1.5, 1e3 -- is a

--- a/internal/storage/river/telemetry_integration_test.go
+++ b/internal/storage/river/telemetry_integration_test.go
@@ -167,6 +167,31 @@ func TestQueueTelemetrySamplerReadsPinnedRiverSchemaWithoutClaimingJobs(t *testi
 		t.Fatal(err)
 	}
 	assertRefusalNames(t, ctx, sampler, "heartbeat/unknown.kind@1")
+
+	// A kind outside the telemetry label character class is a real row an
+	// older producer could have written. It must still refuse, must not reach
+	// the message verbatim, and must NOT cost the backlog metrics: SQL left()
+	// counts characters while the Go re-validation counts bytes, so a
+	// multi-byte kind is exactly the case where truncation alone diverges.
+	if _, err := adminPool.Exec(
+		ctx,
+		`UPDATE river.river_job SET args='{"contract_version":1}'::jsonb, kind=$2 WHERE id=$1`,
+		// A slash is the sharpest trigger: it is the label's own separator,
+		// so an unsanitised kind containing one silently re-splits the label
+		// into the wrong queue/kind pair before validation even runs.
+		futureID, "legacy/cleanup kïnd",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sampler.Snapshot(ctx); err != nil {
+		t.Fatalf("an out-of-class kind made the backlog metrics unavailable: %v", err)
+	}
+	// Per-COMPONENT replacement, not whole-label: the queue and the version are
+	// in-vocabulary and survive, so the operator still learns where the row is
+	// and what version it claims, and only the unusable kind is redacted. The
+	// whole-label placeholder is the last resort for a label the query could
+	// not produce at all, covered by the unit test.
+	assertRefusalNames(t, ctx, sampler, "heartbeat/unprintable@1")
 }
 
 // assertRefusalNames requires the refusal to wrap the stable sentinel AND to

--- a/internal/storage/river/telemetry_integration_test.go
+++ b/internal/storage/river/telemetry_integration_test.go
@@ -5,6 +5,8 @@ package riverstore_test
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,23 +124,73 @@ func TestQueueTelemetrySamplerReadsPinnedRiverSchemaWithoutClaimingJobs(t *testi
 	if _, err := adminPool.Exec(ctx, `UPDATE river.river_job SET args='{"contract_version":2}'::jsonb WHERE id=$1`, futureID); err != nil {
 		t.Fatal(err)
 	}
-	if err := sampler.CheckAvailableContractVersions(ctx); err != riverstore.ErrUnsupportedAvailableContractVersion {
-		t.Fatalf("unsupported future contract readiness error = %v", err)
-	}
+	// Each refusal must also NAME the offending queue/kind/version, so an
+	// operator reading the crash-loop log can tell which contract refused
+	// instead of querying river_job by hand (CHAOS-3938).
+	assertRefusalNames(t, ctx, sampler, "heartbeat/system.heartbeat@2")
 
 	// A JSON string is not an integer contract version even when its text is 1.
 	if _, err := adminPool.Exec(ctx, `UPDATE river.river_job SET args='{"contract_version":"1"}'::jsonb WHERE id=$1`, futureID); err != nil {
 		t.Fatal(err)
 	}
-	if err := sampler.CheckAvailableContractVersions(ctx); !errors.Is(err, riverstore.ErrUnsupportedAvailableContractVersion) {
-		t.Fatalf("non-integer contract readiness error = %v", err)
+	assertRefusalNames(t, ctx, sampler, "heartbeat/system.heartbeat@none")
+
+	// A JSON number that is not a canonical unsigned integer is still an
+	// unsupported version, and must be NAMED. Emitting the raw text instead
+	// would fail the Go re-validation and collapse the whole read into an
+	// unreadable snapshot, taking the queue metrics down with it.
+	// jsonb normalises numbers to numeric, so an exponent form like 1e3 is
+	// stored as the canonical 1000; the forms that actually survive as
+	// non-canonical are negatives and fractions.
+	for _, malformed := range []string{"-1", "1.5"} {
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE river.river_job SET args=jsonb_build_object('contract_version', $2::numeric) WHERE id=$1`,
+			futureID, malformed,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := sampler.Snapshot(ctx); err != nil {
+			t.Fatalf("contract_version %s made the whole snapshot unreadable: %v", malformed, err)
+		}
+		assertRefusalNames(t, ctx, sampler, "heartbeat/system.heartbeat@invalid")
 	}
+	// An ABSENT contract_version is missing, not malformed. The two must stay
+	// distinguishable: one means a producer that never stamped a version, the
+	// other a producer that stamped a wrong one.
+	if _, err := adminPool.Exec(ctx, `UPDATE river.river_job SET args='{}'::jsonb WHERE id=$1`, futureID); err != nil {
+		t.Fatal(err)
+	}
+	assertRefusalNames(t, ctx, sampler, "heartbeat/system.heartbeat@none")
 
 	if _, err := adminPool.Exec(ctx, `UPDATE river.river_job SET args='{"contract_version":1}'::jsonb, kind='unknown.kind' WHERE id=$1`, futureID); err != nil {
 		t.Fatal(err)
 	}
-	if err := sampler.CheckAvailableContractVersions(ctx); !errors.Is(err, riverstore.ErrUnsupportedAvailableContractVersion) {
-		t.Fatalf("unknown kind readiness error = %v", err)
+	assertRefusalNames(t, ctx, sampler, "heartbeat/unknown.kind@1")
+}
+
+// assertRefusalNames requires the refusal to wrap the stable sentinel AND to
+// carry exactly the offending queue/kind/version label.
+func assertRefusalNames(
+	t *testing.T,
+	ctx context.Context,
+	sampler *riverstore.QueueTelemetrySampler,
+	want string,
+) {
+	t.Helper()
+	err := sampler.CheckAvailableContractVersions(ctx)
+	if !errors.Is(err, riverstore.ErrUnsupportedAvailableContractVersion) {
+		t.Fatalf("readiness error = %v, want it to wrap the unsupported-contract sentinel", err)
+	}
+	var unsupported *riverstore.UnsupportedContractVersionError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("readiness error = %v, want an *UnsupportedContractVersionError", err)
+	}
+	if !reflect.DeepEqual(unsupported.Offenders, []string{want}) {
+		t.Fatalf("refusal named %v, want [%s]", unsupported.Offenders, want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("refusal message %q does not name %q", err.Error(), want)
 	}
 }
 

--- a/internal/storage/river/telemetry_test.go
+++ b/internal/storage/river/telemetry_test.go
@@ -113,20 +113,48 @@ func TestQueueTelemetrySamplerBuildsStableBoundedSnapshot(t *testing.T) {
 
 func TestQueueTelemetrySamplerCompatibilityAndQueryErrorsAreStable(t *testing.T) {
 	t.Parallel()
+	// The refusal now NAMES the offending queue/kind/version. Those three are
+	// bounded, pre-registered labels this process already publishes as metric
+	// dimensions; the arguments behind them stay unread. Withholding them cost
+	// a production incident its diagnosis (CHAOS-3938).
 	t.Run("unsupported", func(t *testing.T) {
 		t.Parallel()
+		offenders := []string{"sync/dispatch_sync_run@7"}
 		sampler := testQueueTelemetrySampler(t, func(context.Context) ([]queueTelemetryRow, error) {
 			return []queueTelemetryRow{
-				{queue: "heartbeat", kind: "system.heartbeat", unsupportedAvailable: true},
-				{queue: "retention", kind: "system.retention_cleanup", unsupportedAvailable: true},
+				{queue: "heartbeat", kind: "system.heartbeat", unsupportedOccupants: offenders},
+				{queue: "retention", kind: "system.retention_cleanup", unsupportedOccupants: offenders},
 			}, nil
 		})
 		err := sampler.CheckAvailableContractVersions(context.Background())
-		if err != ErrUnsupportedAvailableContractVersion {
+		if !errors.Is(err, ErrUnsupportedAvailableContractVersion) {
 			t.Fatalf("compatibility error = %v", err)
 		}
-		if strings.Contains(err.Error(), "heartbeat") || strings.Contains(err.Error(), "payload") {
+		if !strings.Contains(err.Error(), "sync/dispatch_sync_run@7") {
+			t.Fatalf("compatibility error did not name the offending contract: %v", err)
+		}
+		var named *UnsupportedContractVersionError
+		if !errors.As(err, &named) || !reflect.DeepEqual(named.Offenders, offenders) {
+			t.Fatalf("compatibility error carried no offender labels: %v", err)
+		}
+		if strings.Contains(err.Error(), "payload") || strings.Contains(err.Error(), "encoded_args") {
 			t.Fatalf("compatibility error leaked row detail: %v", err)
+		}
+	})
+	// A label the database somehow returned outside the bounded vocabulary is
+	// refused as an unreadable snapshot rather than echoed into a log line.
+	t.Run("offender label out of vocabulary", func(t *testing.T) {
+		t.Parallel()
+		sampler := testQueueTelemetrySampler(t, func(context.Context) ([]queueTelemetryRow, error) {
+			leaked := []string{"sync/dispatch_sync_run@{\"token\":\"secret\"}"}
+			return []queueTelemetryRow{
+				{queue: "heartbeat", kind: "system.heartbeat", unsupportedOccupants: leaked},
+				{queue: "retention", kind: "system.retention_cleanup", unsupportedOccupants: leaked},
+			}, nil
+		})
+		err := sampler.CheckAvailableContractVersions(context.Background())
+		if err != ErrQueueTelemetryUnavailable || strings.Contains(err.Error(), "secret") {
+			t.Fatalf("out-of-vocabulary offender label was not refused: %v", err)
 		}
 	})
 	t.Run("query error", func(t *testing.T) {

--- a/internal/storage/river/telemetry_test.go
+++ b/internal/storage/river/telemetry_test.go
@@ -141,20 +141,35 @@ func TestQueueTelemetrySamplerCompatibilityAndQueryErrorsAreStable(t *testing.T)
 			t.Fatalf("compatibility error leaked row detail: %v", err)
 		}
 	})
-	// A label the database somehow returned outside the bounded vocabulary is
-	// refused as an unreadable snapshot rather than echoed into a log line.
+	// A label outside the bounded vocabulary is REPLACED, not echoed -- and
+	// crucially it does not take the backlog metrics down with it. Refusing
+	// the whole read would have broken this sampler's contract that an
+	// unsupported contract never hides metrics, and it is reachable from a
+	// pre-existing river_job row whose kind is not in the label character
+	// class: an odd kind must cost the diagnostic its precision, never the
+	// metrics their availability.
 	t.Run("offender label out of vocabulary", func(t *testing.T) {
 		t.Parallel()
+		leaked := []string{"sync/dispatch_sync_run@{\"token\":\"secret\"}"}
 		sampler := testQueueTelemetrySampler(t, func(context.Context) ([]queueTelemetryRow, error) {
-			leaked := []string{"sync/dispatch_sync_run@{\"token\":\"secret\"}"}
 			return []queueTelemetryRow{
 				{queue: "heartbeat", kind: "system.heartbeat", unsupportedOccupants: leaked},
 				{queue: "retention", kind: "system.retention_cleanup", unsupportedOccupants: leaked},
 			}, nil
 		})
+		if _, err := sampler.Snapshot(context.Background()); err != nil {
+			t.Fatalf("an odd offender label made the backlog metrics unavailable: %v", err)
+		}
 		err := sampler.CheckAvailableContractVersions(context.Background())
-		if err != ErrQueueTelemetryUnavailable || strings.Contains(err.Error(), "secret") {
+		if !errors.Is(err, ErrUnsupportedAvailableContractVersion) {
 			t.Fatalf("out-of-vocabulary offender label was not refused: %v", err)
+		}
+		if strings.Contains(err.Error(), "secret") || strings.Contains(err.Error(), "token") {
+			t.Fatalf("out-of-vocabulary offender label leaked row detail: %v", err)
+		}
+		var named *UnsupportedContractVersionError
+		if !errors.As(err, &named) || !reflect.DeepEqual(named.Offenders, []string{unprintableOffender}) {
+			t.Fatalf("offenders = %v, want [%s]", named, unprintableOffender)
 		}
 	})
 	t.Run("query error", func(t *testing.T) {

--- a/internal/syncdispatchcontract/routes.go
+++ b/internal/syncdispatchcontract/routes.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"unicode/utf8"
 )
 
@@ -26,6 +27,20 @@ const (
 	KindFinalizeSyncRun    = "finalize_sync_run"
 	KindPostSync           = "post_sync"
 	KindReferenceDiscovery = "reference_discovery"
+
+	// RiverQueue is the ONE River queue every river-routed sync-dispatch kind
+	// is published into. It is declared here, beside the frozen kinds, because
+	// the queue name is the join between this route plane and the bounded jobs
+	// registry plane: both put rows in river.river_job, and a reader of that
+	// table (the startup contract-version check, for one) can only resolve a
+	// kind if it knows which planes may occupy the queue it is reading.
+	//
+	// It used to be a bare "sync" literal in the reconciler and a private
+	// const in the worker, with nothing tying either to this package. Nothing
+	// then made it visible that queue "sync" carries dispatch_sync_run as well
+	// as the registry's sync.team_autoimport, and the worker refused to start
+	// whenever those rows were pending (CHAOS-3938).
+	RiverQueue = "sync"
 
 	DeliveryAtLeastOnce = "at_least_once"
 
@@ -119,6 +134,20 @@ func (parsed artifact) validate() error {
 		}
 	}
 	return nil
+}
+
+// Kinds returns every frozen sync-dispatch kind, sorted. It is DERIVED from
+// the frozen delivery table rather than restated, so a fifth kind added there
+// is automatically visible to every consumer that has to enumerate this
+// plane -- including the readiness check that must resolve each kind's rows in
+// RiverQueue.
+func Kinds() []string {
+	kinds := make([]string, 0, len(frozenDeliveries))
+	for kind := range frozenDeliveries {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	return kinds
 }
 
 var frozenDeliveries = map[string]string{

--- a/internal/syncdispatchcontract/routes_test.go
+++ b/internal/syncdispatchcontract/routes_test.go
@@ -174,3 +174,24 @@ const outOfOrderArtifact = `{
     {"kind": "reference_discovery", "delivery": "at_least_once", "route": "celery", "rollback_route": "celery"}
   ]
 }`
+
+// TestRiverQueueIsPinnedToItsWireValue pins the queue NAME, not just its use.
+//
+// RiverQueue is a wire value: it is written into river_job.queue by the
+// reconciler and read back by every worker's startup contract-version check.
+// Renaming the constant would keep this repository internally consistent and
+// still be a production incident -- rows already sitting in the old queue
+// would be invisible to the new readers, and during a rolling deploy the two
+// binaries would disagree about which queue the sync-dispatch plane occupies.
+//
+// Changing this string therefore requires a queue migration, not an edit. The
+// literal is repeated here deliberately: a test that read the constant would
+// agree with any rename and prove nothing.
+func TestRiverQueueIsPinnedToItsWireValue(t *testing.T) {
+	t.Parallel()
+	if RiverQueue != "sync" {
+		t.Fatalf("RiverQueue = %q, want \"sync\": this is a persisted wire value; "+
+			"changing it strands in-flight river_job rows and splits old and new "+
+			"binaries during a rolling deploy", RiverQueue)
+	}
+}

--- a/internal/syncdispatchruntime/occupancy.go
+++ b/internal/syncdispatchruntime/occupancy.go
@@ -1,0 +1,52 @@
+package syncdispatchruntime
+
+import (
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+)
+
+// QueueOccupancy is one (River queue, kind) pair this plane may leave rows for
+// in river.river_job, together with the complete contract-version window its
+// consumers accept.
+//
+// It exists because river.river_job is shared by two route planes that are
+// deliberately NOT one registry: the bounded jobs registry
+// (contracts/jobs/v1/registry.json, projected through jobruntime.Descriptor)
+// and the sync-dispatch transport routes
+// (contracts/sync-dispatch/v1/transport-routes.json, this package). Anything
+// that READS the table -- as opposed to executing a kind -- has to resolve
+// both, and until CHAOS-3938 the startup contract-version check resolved only
+// the first, so every pending dispatch_sync_run row read as an unsupported
+// contract version and refused readiness.
+type QueueOccupancy struct {
+	Queue             string
+	Kind              string
+	SupportedVersions []int
+}
+
+// RiverQueueOccupancy returns every queue/kind/version triple this plane can
+// put in a River queue.
+//
+// It is derived from syncdispatchcontract.Kinds() and the single publisher
+// queue, not hand-listed, so a new frozen kind cannot arrive here unresolved:
+// the same edit that makes a kind publishable makes it resolvable. That
+// derivation is the guard -- registering one missing kind by hand would have
+// left the next one to trip the identical wire.
+//
+// This is not a capability, route-activation, or executable-readiness claim:
+// it says only "a row of this shape in this queue is legitimate", which is
+// exactly the question a reader of river_job needs answered. It deliberately
+// stays independent of whether the durable route currently points at River,
+// because rows published before a rollback to Celery are still legitimately
+// sitting in the queue afterwards.
+func RiverQueueOccupancy() []QueueOccupancy {
+	kinds := syncdispatchcontract.Kinds()
+	occupancy := make([]QueueOccupancy, 0, len(kinds))
+	for _, kind := range kinds {
+		occupancy = append(occupancy, QueueOccupancy{
+			Queue:             syncdispatchcontract.RiverQueue,
+			Kind:              kind,
+			SupportedVersions: []int{ContractVersionV1},
+		})
+	}
+	return occupancy
+}

--- a/internal/syncdispatchruntime/occupancy_test.go
+++ b/internal/syncdispatchruntime/occupancy_test.go
@@ -1,0 +1,77 @@
+package syncdispatchruntime
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+)
+
+// TestRiverQueueOccupancyCoversEveryPublishableKind is the CHAOS-3938 class
+// guard at this plane's boundary: every kind this package can put in a River
+// queue must be declared as occupying that queue, so a reader of river_job can
+// always resolve it. Convert is the only door into a published job -- the
+// publisher calls nothing else -- so binding the occupancy to the exact set
+// Convert accepts leaves no publishable kind undeclared.
+func TestRiverQueueOccupancyCoversEveryPublishableKind(t *testing.T) {
+	t.Parallel()
+	reference := DomainReference{
+		OrganizationID: "0f9d3a1c-2b4e-4d6a-8c1f-5e7b9a0d3c42",
+		SyncRunID:      "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+	}
+	occupancy := RiverQueueOccupancy()
+	declared := make(map[string]QueueOccupancy, len(occupancy))
+	for _, occupant := range occupancy {
+		if _, duplicate := declared[occupant.Kind]; duplicate {
+			t.Fatalf("kind %q declared twice", occupant.Kind)
+		}
+		declared[occupant.Kind] = occupant
+	}
+
+	for _, kind := range syncdispatchcontract.Kinds() {
+		args, err := Convert(Claim{
+			OutboxID:        "2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e",
+			Kind:            kind,
+			RouteGeneration: 1,
+			DeliveryAttempt: 1,
+		}, reference)
+		if err != nil {
+			t.Fatalf("Convert rejected frozen kind %q: %v", kind, err)
+		}
+		occupant, ok := declared[args.Kind()]
+		if !ok {
+			t.Fatalf("publishable kind %q occupies a River queue but is not declared "+
+				"in RiverQueueOccupancy; the startup contract-version check cannot resolve it", args.Kind())
+		}
+		if occupant.Queue != syncdispatchcontract.RiverQueue {
+			t.Fatalf("kind %q declared for queue %q, want %q",
+				args.Kind(), occupant.Queue, syncdispatchcontract.RiverQueue)
+		}
+		if !reflect.DeepEqual(occupant.SupportedVersions, []int{ContractVersionV1}) {
+			t.Fatalf("kind %q declares versions %v, want %v",
+				args.Kind(), occupant.SupportedVersions, []int{ContractVersionV1})
+		}
+		delete(declared, args.Kind())
+	}
+	if len(declared) != 0 {
+		t.Fatalf("RiverQueueOccupancy declares kinds nothing can publish: %v", declared)
+	}
+}
+
+// TestPublisherOptionsAcceptOnlyTheDeclaredRiverQueue closes the other half of
+// the class. A well-formed queue name that is not the declared one used to be
+// accepted, so composition could publish into a queue the readiness reader had
+// no way to enumerate -- which is exactly what happened when the reconciler
+// passed a bare "sync" literal that nothing tied to this plane.
+func TestPublisherOptionsAcceptOnlyTheDeclaredRiverQueue(t *testing.T) {
+	t.Parallel()
+	if !(PublisherOptions{Queue: syncdispatchcontract.RiverQueue, MaxAttempts: 5}).valid() {
+		t.Fatal("declared River queue was rejected")
+	}
+	for _, queue := range []string{"sync_provider", "sync2", "metrics", ""} {
+		if (PublisherOptions{Queue: queue, MaxAttempts: 5}).valid() {
+			t.Fatalf("queue %q was accepted; only %q is resolvable by the readiness check",
+				queue, syncdispatchcontract.RiverQueue)
+		}
+	}
+}

--- a/internal/syncdispatchruntime/publisher.go
+++ b/internal/syncdispatchruntime/publisher.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -30,16 +31,25 @@ type InsertClient interface {
 	InsertTx(context.Context, pgx.Tx, river.JobArgs, *river.InsertOpts) (*rivertype.JobInsertResult, error)
 }
 
-// PublisherOptions are explicit because this package does not own dispatch
-// queue policy. Callers must choose a bounded queue and retry limit during a
-// separately approved composition step.
+// PublisherOptions carries the retry limit, which is composition policy, and
+// the queue, which is NOT: it must be syncdispatchcontract.RiverQueue.
+//
+// The queue was previously a free choice made at the composition site, and the
+// reconciler passed a bare "sync" literal that nothing tied back to this
+// plane. Readiness reads river_job by queue, so a queue this plane can publish
+// into but the reader cannot enumerate is unresolvable by construction --
+// which is how every pending dispatch_sync_run row came to read as an
+// unsupported contract version and refuse worker startup (CHAOS-3938). Pinning
+// the queue here closes that: what can be published is exactly what
+// RiverQueueOccupancy declares, so the reader can always resolve it.
 type PublisherOptions struct {
 	Queue       string
 	MaxAttempts int
 }
 
 func (options PublisherOptions) valid() bool {
-	return queuePattern.MatchString(options.Queue) && options.MaxAttempts >= 1 && options.MaxAttempts <= 100
+	return queuePattern.MatchString(options.Queue) && options.Queue == syncdispatchcontract.RiverQueue &&
+		options.MaxAttempts >= 1 && options.MaxAttempts <= 100
 }
 
 // Publisher performs exactly one supported River InsertTx call. It has no


### PR DESCRIPTION
Fixes two River-adjacent defects that are both live in production. They are unrelated in blast radius and are separate commits, so either can be reviewed or reverted on its own.

## CHAOS-3938 — go-worker-sync cannot start while `dispatch_sync_run` jobs are queued

`go-worker-sync` crash-looped on the 2026-08-19 deploy with `failed_checks=queued_contract_versions`, costing ~20 minutes of stalled sync.

**Cause.** River queue `sync` is shared by two deliberately distinct route planes. `worker_job_routes` governs the bounded jobs registry, which puts only `sync.team_autoimport` in that queue. `sync_dispatch_transport_routes` governs the coordinator kinds, and the reconciler publishes `dispatch_sync_run` into the same queue. `QueueTelemetrySampler` built `supported_versions` from the registry alone, so every pending `dispatch_sync_run` — correctly stamped `contract_version: 1`, which `syncdispatchruntime` does declare — read as an unsupported version.

Latent (checked only at startup), self-perpetuating (the reconciler keeps enqueueing; observed 58 → 113 → 240), and with no escape hatch (`queueTelemetryRequired` is unconditional). Earlier restarts survived only because the queue happened to be empty.

**Choice, and why not a registry entry.** Adding `dispatch_sync_run` to `contracts/jobs/v1/registry.json` was rejected. The coordinator kinds carry no registry descriptor by design (`syncdispatchruntime.RegisterWorkers`) and stay outside the bounded registry until CUT-10; a registry entry would additionally subject the kind to registry startup validation, for which this binary intentionally reports no handler coverage — trading one readiness refusal for another. So the **reader** unions the planes rather than the planes being merged:

- `syncdispatchcontract` declares `RiverQueue` and `Kinds()`, so the queue name is no longer a bare literal duplicated between the reconciler and the worker.
- `syncdispatchruntime.RiverQueueOccupancy()` derives `(queue, kind, versions)` from those frozen kinds.
- `QueueTelemetryConfig` gains `Occupants`, which widen only the supported-version set. They deliberately do not enter the metrics dimension — every `Jobs` entry becomes a pre-registered `jobs_available` label, so folding them in there would fail the metrics write on an unregistered dimension instead.

**Guarding the class, not the kind.** One registry line fixes one kind and leaves the next to trip the same wire, so:

- the occupancy is *derived* from the frozen kinds — the edit that makes a kind publishable is the edit that makes it resolvable;
- `PublisherOptions` now accepts only the declared queue, so composition can no longer publish into a queue the reader cannot enumerate;
- the regression test enumerates **both** planes from the checked-in contracts, inserts one `available` row per kind at its declared version, and runs the production readiness check against that non-empty queue.

Residual boundary, stated plainly: a hypothetical *third* insert plane would not be enumerated by that test. It would, however, fail closed at startup with the offending kind named in one log line, rather than silently. The two planes above are the only `InsertTx` call sites in the tree today.

**Diagnosis.** The refusal now names the offending queue, kind, and version. Only those three labels are disclosed: all are low-cardinality vocabulary already published as metric label values, they are truncated in SQL against the same constants the Go side re-validates with, a missing version reports `@none` and a malformed numeric one `@invalid` rather than being echoed. Encoded arguments are still never read.

## CHAOS-3939 — River Reindexer fails nightly

Seven `permission denied` (42501) ERROR lines at 00:00 UTC daily, on every worker that runs maintenance services. REINDEX needs ownership, which the least-privilege runtime role does not hold.

**Verdict: disable it, as the issue recommends — and the reasoning is stronger than stated, because *both* widening routes are refused by this deployment's own readiness checks:**

- **Ownership** — `rolePostureQuery` asserts the runtime identity owns nothing at all: `NOT EXISTS (SELECT 1 FROM pg_class WHERE relowner = <this role> AND relkind IN ('r','p','v','m','f','S'))` in `internal/storage/postgres/domain_authorization.go`. Owning `river_job` makes `CheckRolePosture` fail rather than pass.
- **MAINTAIN** (PostgreSQL 16+, the only non-ownership route to REINDEX) — the queue-role posture asserts SELECT/INSERT/UPDATE/DELETE on every River table **and NOT MAINTAIN**, guarded on `server_version_num >= 170000` in `internal/storage/postgres/queue_authorization.go`. This deployment runs PostgreSQL 18, so that branch is live and an added grant reads as excess privilege.

Disabling uses River's documented control: `ReindexerIndexNames` is the exact list of indexes to rebuild, and a non-nil empty list schedules no reindex work.

**Runner image: not affected by this PR.** No posture and no GRANT changes here, so `dev-hops-runner` needs no rebuild. Recording it because it constrains the alternatives: the derived GRANTs ship in `dev-hops-runner` (`docker/Dockerfile`), not the Go worker image, so any future posture edit must rebuild that image or production breaks worse than the noise being removed. Reclaiming `river_job` index bloat belongs in a privileged one-shot beside the migration path, which already runs as an owner-capable role.

## Verification

`PYTHON="$PWD/.venv/bin/python" bash ci/check_go.sh all` → **rc=0, 118 `ok` package lines**, on the frozen committed tree.

Every new test was watched failing first, against pre-fix behaviour:

| Test | Pre-fix failure |
| --- | --- |
| `TestQueuedContractVersionsReadinessResolvesEveryPlane` | `startup readiness refused with every plane's kinds queued: ... sync/dispatch_sync_run@1,sync/finalize_sync_run@1,sync/post_sync@1,sync/reference_discovery@1` |
| `TestRiverWorkerClientRunsReindexerWithoutPermissionErrors` | shipped case reported all seven production index names with `permission denied (SQLSTATE 42501)` |
| `TestUnsupportedContractRefusalNamesTheContractOncePerChange` | `logged 3 times for one unchanged offender set, want 1` |
| `telemetry_integration_test.go` malformed/absent version cases | `contract_version -1 made the whole snapshot unreadable` and `refusal named [.../@invalid], want [.../@none]` |

The 3938 regression test runs against a **non-empty** queue, which is the only state in which the bug exists.

Codex review ran twice; all four findings were reproduced with a failing test before being fixed:

1. a malformed numeric version (`-1`, `1.5`) collapsed the whole read into an unreadable snapshot, losing both the diagnostic and the queue metrics;
2. the new diagnostic logged on every readiness evaluation, so one persistent bad row meant probe-rate ERROR on every replica — it now reports transitions, not state;
3. an absent `contract_version` reported `@invalid` instead of `@none`, because `jsonb_typeof` of an absent key is NULL and `<>` is unknown, not true;
4. the reindex test overrode the field it was meant to protect — the shipped case now passes `riverWorkerClientConfig`'s output through untouched, and deleting that field from it fails the test.

Not merging.
