### PR TITLE
fix(pgbouncer): stop connection-log firehose, fix healthchecks, raise saturated queue pool

### DIFF
--- a/cmd/dev-health-workerctl/main_test.go
+++ b/cmd/dev-health-workerctl/main_test.go
@@ -348,12 +348,16 @@ func TestManifestQueueStatusSourceCombinesFreshQueueAndPresenceState(t *testing.
 	}
 	// sync-provider is its own declared process (CHAOS-3926), so its
 	// max_replicas x per-process connections count separately from sync: queue
-	// session 22 -> 26 against a pool raised 23 -> 27, server 89 -> 93. Both
-	// processes ship at zero replicas, so runtime usage is unchanged; this is
-	// the declared worst case the budget has to cover.
-	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 26, Limit: 27, Headroom: 1}) ||
+	// session 22 -> 26. CHAOS-3945 then raised the queue pool 27 -> 36 (the
+	// declared footprint was pinned at headroom 1 in production; a Go worker
+	// fleet's steady replica churn plus go-workerctl needs real slack, not a
+	// wafer-thin margin) and raised server_max_connections 100 -> 200 to keep
+	// room under it: server footprint 93 -> 102. Both processes ship at zero
+	// replicas, so runtime usage is unchanged; this is the declared worst
+	// case the budget has to cover.
+	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 26, Limit: 36, Headroom: 10}) ||
 		status.ConnectionBudget.CoordinatorSession != (connectionBudgetStatus{Used: 10, Limit: 11, Headroom: 1}) ||
-		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 93, Limit: 100, Headroom: 7}) {
+		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 102, Limit: 200, Headroom: 98}) {
 		t.Fatalf("connection budget = %#v", status.ConnectionBudget)
 	}
 }

--- a/compose.yml
+++ b/compose.yml
@@ -102,11 +102,33 @@ services:
       MIN_POOL_SIZE: "5"
       RESERVE_POOL_SIZE: "5"
       ADMIN_USERS: postgres
+      # CHAOS-3944: log_connections/log_disconnections default on and turn a
+      # Go worker fleet's steady attach/detach churn into a continuous,
+      # diagnostically worthless firehose (measured ~36 lines/min across the
+      # three production poolers). Keep log_pooler_errors and the default
+      # log_stats ON: the once-a-minute stats line is the only real pooler
+      # telemetry and it proved its worth in a live incident (wait
+      # 5683209 us during trouble, wait 16136 us after recovery). Do not
+      # "tidy away" that stats line.
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
     ports:
       - "6432:6432"
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      # CHAOS-3944: pg_isready with no -U/-d probes as OS user "postgres",
+      # which happens to match DB_USER here, but the port would still be
+      # relying on the default (rejection = healthy) semantics otherwise.
+      # Pin the user/db explicitly so a healthy result means the pooler can
+      # actually serve, not just that the port answers.
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432", "-U", "postgres", "-d", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
   clickhouse:
     image: clickhouse/clickhouse-server:latest@sha256:d7556a3841027651307b5aa08d72b5c467d0241d3db5b67d9e158ef3975626f5

--- a/compose.yml
+++ b/compose.yml
@@ -113,18 +113,22 @@ services:
       LOG_CONNECTIONS: "0"
       LOG_DISCONNECTIONS: "0"
       LOG_POOLER_ERRORS: "1"
+      # Healthcheck-only credential: PGPASSWORD is a libpq env var psql reads
+      # automatically, so it never appears in argv. Dev-only literal,
+      # matching DB_PASSWORD above.
+      PGPASSWORD: postgres
     ports:
       - "6432:6432"
     depends_on:
       postgres:
         condition: service_healthy
     healthcheck:
-      # CHAOS-3944: pg_isready with no -U/-d probes as OS user "postgres",
-      # which happens to match DB_USER here, but the port would still be
-      # relying on the default (rejection = healthy) semantics otherwise.
-      # Pin the user/db explicitly so a healthy result means the pooler can
-      # actually serve, not just that the port answers.
-      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432", "-U", "postgres", "-d", "postgres"]
+      # CHAOS-3944: pg_isready cannot prove the pooler can authenticate and
+      # serve a query — it reports healthy even on an auth rejection
+      # regardless of username, so pinning -U/-d alone doesn't fix that (see
+      # deploy/docker-compose/compose.production.yml). Run a real query
+      # through the pooler instead.
+      test: ["CMD", "psql", "-w", "-h", "localhost", "-p", "6432", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -412,10 +412,33 @@ services:
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_MAX_CLIENT_CONN:-1000}
       DEFAULT_POOL_SIZE: ${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
+      # CHAOS-3944: log_connections/log_disconnections default on and turn a
+      # Go worker fleet's steady attach/detach churn into a continuous,
+      # diagnostically worthless firehose (measured ~36 lines/min across the
+      # three poolers in production). Keep log_pooler_errors and the default
+      # log_stats ON: the once-a-minute stats line is the only real pooler
+      # telemetry and it proved its worth in a live incident (wait
+      # 5683209 us during trouble, wait 16136 us after recovery). Do not
+      # "tidy away" that stats line.
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
     ports:
       - "${PGBOUNCER_PORT:-6432}:6432"
     networks:
       - dev-health
+    healthcheck:
+      # CHAOS-3944: pg_isready with no -U/-d probes as OS user "postgres",
+      # which is not in PgBouncer's auth file. That prior probe logged
+      # "no such user: postgres" on every check AND still reported healthy,
+      # because pg_isready treats an auth rejection as "server responding".
+      # Probe with the real DB_USER/DB_NAME so a healthy result means the
+      # pooler can actually serve, not just that the port answers.
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432", "-U", "${POSTGRES_USER:?set POSTGRES_USER}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     deploy:
       resources:
         limits:
@@ -425,6 +448,26 @@ services:
   # River listener/cancellation uses a session pool, never the transaction
   # endpoint above. DB_USER and DB_NAME are fixed, so DEFAULT_POOL_SIZE caps
   # the one relevant PgBouncer (database,user) backend pool.
+  #
+  # CHAOS-3945: keep this budget current — it silently went stale once
+  # already. Every long-lived process below holds one session on this
+  # endpoint for its whole lifetime, and each replica costs THREE backends:
+  # two from WORKER_DATABASE_MAX_CONNS (a pgxpool) plus one long-lived River
+  # notifier session that sits outside that pool budget. Services declared in
+  # deploy/docker-compose/compose.go-workers.yml at replicas: 1 each:
+  #   go-worker-sync, go-worker-heavy, go-worker-ops, go-worker-sync-provider,
+  #   go-reconciler, go-scheduler,
+  #   go-stream-external, go-stream-ingest, go-stream-pagerduty
+  # = 9 processes x 3 backends = 27, plus occasional go-workerctl invocations
+  # and rolling-restart overlap (a stopping container's session lingers until
+  # server_idle_timeout, so an old and a new replica can briefly both hold
+  # one). DEFAULT_POOL_SIZE below (36) is that 27 plus headroom for both. If
+  # you add a new long-lived service on this endpoint, or raise a replica
+  # count, recompute and update this list and the number together — do not
+  # bump the number alone. A derived formula was considered instead of a
+  # hardcoded default, but the service list only exists in
+  # compose.go-workers.yml's `services:` keys, which plain YAML cannot
+  # introspect at parse time, so the count is written out by hand here.
   pgbouncer-river-queue:
     profiles: ["pooler"]
     image: edoburu/pgbouncer:latest
@@ -439,10 +482,29 @@ services:
       POOL_MODE: session
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_QUEUE_MAX_CLIENT_CONN:-128}
-      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-27}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-36}
+      # CHAOS-3945: admin_users defaults to "postgres", which is not in this
+      # pooler's auth file (only the River queue role is). Without this,
+      # SHOW POOLS/SHOW CLIENTS/SHOW STATS are unreachable on exactly the
+      # pooler where saturation matters most.
+      ADMIN_USERS: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      # CHAOS-3944: see pgbouncer above for why connection logging is off and
+      # log_stats/log_pooler_errors stay on (5.7s vs 16ms wait during/after a
+      # real incident, read off the once-a-minute stats line).
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
     ports:
       - "${PGBOUNCER_RIVER_QUEUE_PORT:-6433}:6433"
     networks: [dev-health]
+    healthcheck:
+      # CHAOS-3944: probe as the real pool role, not the default "postgres"
+      # OS user, so healthy means the pooler can serve (see pgbouncer above).
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6433", "-U", "${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
   # Coordinator locks also need one stable session. This endpoint is separate
   # from queue control so each role has an independently auditable hard cap.
@@ -461,9 +523,26 @@ services:
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_COORDINATOR_MAX_CLIENT_CONN:-32}
       DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-11}
+      # CHAOS-3945: same admin-console gap as the queue pooler above — set
+      # ADMIN_USERS to this pooler's own role so SHOW POOLS/CLIENTS/STATS work.
+      ADMIN_USERS: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+      # CHAOS-3944: see pgbouncer above for why connection logging is off and
+      # log_stats/log_pooler_errors stay on (5.7s vs 16ms wait during/after a
+      # real incident, read off the once-a-minute stats line).
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
     ports:
       - "${PGBOUNCER_RIVER_COORDINATOR_PORT:-6434}:6434"
     networks: [dev-health]
+    healthcheck:
+      # CHAOS-3944: probe as the real pool role, not the default "postgres"
+      # OS user, so healthy means the pooler can serve (see pgbouncer above).
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6434", "-U", "${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
 volumes:
   clickhouse_data:

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -423,18 +423,28 @@ services:
       LOG_CONNECTIONS: "0"
       LOG_DISCONNECTIONS: "0"
       LOG_POOLER_ERRORS: "1"
+      # Healthcheck-only credential: PGPASSWORD is a libpq env var psql reads
+      # automatically, so the healthcheck below never puts the password in
+      # argv (visible to `docker inspect`/`ps`). Same value already used for
+      # DB_PASSWORD above, not a new secret.
+      PGPASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}
     ports:
       - "${PGBOUNCER_PORT:-6432}:6432"
     networks:
       - dev-health
     healthcheck:
-      # CHAOS-3944: pg_isready with no -U/-d probes as OS user "postgres",
-      # which is not in PgBouncer's auth file. That prior probe logged
-      # "no such user: postgres" on every check AND still reported healthy,
-      # because pg_isready treats an auth rejection as "server responding".
-      # Probe with the real DB_USER/DB_NAME so a healthy result means the
-      # pooler can actually serve, not just that the port answers.
-      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432", "-U", "${POSTGRES_USER:?set POSTGRES_USER}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      # CHAOS-3944: the original pg_isready probe had no -U/-d, so it probed
+      # as OS user "postgres", which is not in PgBouncer's auth file, logging
+      # "no such user: postgres" on every check AND STILL reporting healthy —
+      # pg_isready treats an authentication rejection as "server responding",
+      # not as a failure, no matter which username it's given. A pg_isready
+      # probe therefore cannot prove the pooler can actually authenticate and
+      # serve a query, only that something answers the port. Use `psql` to
+      # run a real query through the pooler and out to the backend instead;
+      # PGPASSWORD above supplies the password without it ever appearing in
+      # process arguments. -w disables the interactive password prompt so a
+      # missing/wrong password fails fast instead of hanging.
+      test: ["CMD", "psql", "-w", "-h", "localhost", "-p", "6432", "-U", "${POSTGRES_USER:?set POSTGRES_USER}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}", "-c", "SELECT 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -483,24 +493,36 @@ services:
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_QUEUE_MAX_CLIENT_CONN:-128}
       DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-36}
-      # CHAOS-3945: admin_users defaults to "postgres", which is not in this
-      # pooler's auth file (only the River queue role is). Without this,
-      # SHOW POOLS/SHOW CLIENTS/SHOW STATS are unreachable on exactly the
-      # pooler where saturation matters most.
-      ADMIN_USERS: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      # CHAOS-3945: stats_users defaults empty and admin_users defaults to
+      # "postgres", which is not in this pooler's auth file (only the River
+      # queue role is) — so SHOW POOLS/CLIENTS/STATS were unreachable on
+      # exactly the pooler where saturation matters most. Use STATS_USERS,
+      # not ADMIN_USERS: stats_users grants only read-only SHOW commands,
+      # while admin_users can PAUSE/KILL/SUSPEND/SHUTDOWN the pooler. The
+      # River queue role is the same credential every Go worker replica
+      # authenticates with for its normal database traffic, so granting it
+      # admin would let any process (or anything that can open a connection
+      # as that role) halt the shared pooler for the whole fleet, not just
+      # read its stats.
+      STATS_USERS: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
       # CHAOS-3944: see pgbouncer above for why connection logging is off and
       # log_stats/log_pooler_errors stay on (5.7s vs 16ms wait during/after a
       # real incident, read off the once-a-minute stats line).
       LOG_CONNECTIONS: "0"
       LOG_DISCONNECTIONS: "0"
       LOG_POOLER_ERRORS: "1"
+      # See pgbouncer above: PGPASSWORD is read by the healthcheck's psql,
+      # never appears in argv, and reuses the DB_PASSWORD secret above.
+      PGPASSWORD: ${RIVER_QUEUE_DATABASE_PASSWORD:?set RIVER_QUEUE_DATABASE_PASSWORD}
     ports:
       - "${PGBOUNCER_RIVER_QUEUE_PORT:-6433}:6433"
     networks: [dev-health]
     healthcheck:
-      # CHAOS-3944: probe as the real pool role, not the default "postgres"
-      # OS user, so healthy means the pooler can serve (see pgbouncer above).
-      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6433", "-U", "${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      # CHAOS-3944: pg_isready cannot prove the pooler can authenticate and
+      # serve a query — it reports healthy even on an auth rejection, no
+      # matter the username (see pgbouncer above). Run a real query through
+      # the pooler instead.
+      test: ["CMD", "psql", "-w", "-h", "localhost", "-p", "6433", "-U", "${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}", "-c", "SELECT 1"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -524,21 +546,29 @@ services:
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_COORDINATOR_MAX_CLIENT_CONN:-32}
       DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-11}
       # CHAOS-3945: same admin-console gap as the queue pooler above — set
-      # ADMIN_USERS to this pooler's own role so SHOW POOLS/CLIENTS/STATS work.
-      ADMIN_USERS: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+      # STATS_USERS (read-only SHOW access), not ADMIN_USERS (which can
+      # PAUSE/KILL/SHUTDOWN the pooler), to this pooler's own role so
+      # SHOW POOLS/CLIENTS/STATS work without handing the runtime credential
+      # console-admin power.
+      STATS_USERS: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
       # CHAOS-3944: see pgbouncer above for why connection logging is off and
       # log_stats/log_pooler_errors stay on (5.7s vs 16ms wait during/after a
       # real incident, read off the once-a-minute stats line).
       LOG_CONNECTIONS: "0"
       LOG_DISCONNECTIONS: "0"
       LOG_POOLER_ERRORS: "1"
+      # See pgbouncer above: PGPASSWORD is read by the healthcheck's psql,
+      # never appears in argv, and reuses the DB_PASSWORD secret above.
+      PGPASSWORD: ${RIVER_COORDINATOR_DATABASE_PASSWORD:?set RIVER_COORDINATOR_DATABASE_PASSWORD}
     ports:
       - "${PGBOUNCER_RIVER_COORDINATOR_PORT:-6434}:6434"
     networks: [dev-health]
     healthcheck:
-      # CHAOS-3944: probe as the real pool role, not the default "postgres"
-      # OS user, so healthy means the pooler can serve (see pgbouncer above).
-      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6434", "-U", "${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      # CHAOS-3944: pg_isready cannot prove the pooler can authenticate and
+      # serve a query — it reports healthy even on an auth rejection, no
+      # matter the username (see pgbouncer above). Run a real query through
+      # the pooler instead.
+      test: ["CMD", "psql", "-w", "-h", "localhost", "-p", "6434", "-U", "${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}", "-d", "${POSTGRES_DB:?set POSTGRES_DB}", "-c", "SELECT 1"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -71,6 +71,16 @@ The contract gate validates that:
   and
 - maximum domain client connections stay below the PgBouncer client budget.
 
+`postgres_budget.server_max_connections` in `deployment.json` must equal the
+real, configured `max_connections` of the shared PostgreSQL server — it is not
+a Go-stack-only figure, because the transaction pool it counts is the same
+endpoint Python/Celery domain traffic uses too (CHAOS-3945). It was raised
+100 -> 200 to match a measured production value; the prior 100 predates that
+measurement and was already stale, independent of any pooler resize.
+`server_reserved_connections` is a flat, deliberately approximate buffer for
+everything this budget does not enumerate by name (operator psql sessions,
+managed-Postgres incidentals); it is not a per-consumer reconciliation.
+
 The budget is calculated from each group's `max_replicas`, including groups
 disabled by default, and one client per process. Enabling the complete declared
 topology cannot silently exceed the checked-in ceiling. Groups may remain at

--- a/deploy/go-workers/deployment.json
+++ b/deploy/go-workers/deployment.json
@@ -8,12 +8,12 @@
     "RIVER_QUEUE_DATABASE_ROLE"
   ],
   "postgres_budget": {
-    "server_max_connections": 100,
+    "server_max_connections": 200,
     "server_reserved_connections": 15,
     "pgbouncer_transaction_pool_size": 20,
     "pgbouncer_transaction_server_pool_count": 2,
     "pgbouncer_transaction_max_client_connections": 1000,
-    "pgbouncer_queue_session_pool_size": 27,
+    "pgbouncer_queue_session_pool_size": 36,
     "pgbouncer_queue_session_max_client_connections": 128,
     "pgbouncer_coordinator_session_pool_size": 11,
     "pgbouncer_coordinator_session_max_client_connections": 32

--- a/deploy/helm/dev-health/templates/go-pgbouncer.yaml
+++ b/deploy/helm/dev-health/templates/go-pgbouncer.yaml
@@ -75,6 +75,13 @@ spec:
             - {name: AUTH_TYPE, value: scram-sha-256}
             - {name: DEFAULT_POOL_SIZE, value: {{ $pooler.poolSize | quote }}}
             - {name: MAX_CLIENT_CONN, value: {{ $pooler.maxClientConnections | quote }}}
+          # CHAOS-3944: tcpSocket only proves the port accepts a TCP connection,
+          # not that PgBouncer can actually authenticate and serve a query
+          # (same "port-open is not can-serve" gap fixed for the compose
+          # poolers via an explicit pg_isready -U/-d probe). Left as tcpSocket
+          # here deliberately: an exec probe change for a k8s liveness/readiness
+          # gate has a different blast radius (pod restarts, rollout gating)
+          # than a compose healthcheck, so it is out of scope for this PR.
           readinessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 2, periodSeconds: 5}
           livenessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 10, periodSeconds: 10}
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}

--- a/deploy/helm/dev-health/templates/go-pgbouncer.yaml
+++ b/deploy/helm/dev-health/templates/go-pgbouncer.yaml
@@ -75,13 +75,24 @@ spec:
             - {name: AUTH_TYPE, value: scram-sha-256}
             - {name: DEFAULT_POOL_SIZE, value: {{ $pooler.poolSize | quote }}}
             - {name: MAX_CLIENT_CONN, value: {{ $pooler.maxClientConnections | quote }}}
+            # CHAOS-3944: log_connections/log_disconnections default on and
+            # turn steady Go worker replica churn into a continuous,
+            # diagnostically worthless log firehose, identically to the
+            # compose poolers (see deploy/docker-compose/compose.production.yml).
+            # log_pooler_errors and the default log_stats stay on: the
+            # once-a-minute stats line is the only real pooler telemetry.
+            - {name: LOG_CONNECTIONS, value: "0"}
+            - {name: LOG_DISCONNECTIONS, value: "0"}
+            - {name: LOG_POOLER_ERRORS, value: "1"}
           # CHAOS-3944: tcpSocket only proves the port accepts a TCP connection,
-          # not that PgBouncer can actually authenticate and serve a query
-          # (same "port-open is not can-serve" gap fixed for the compose
-          # poolers via an explicit pg_isready -U/-d probe). Left as tcpSocket
-          # here deliberately: an exec probe change for a k8s liveness/readiness
-          # gate has a different blast radius (pod restarts, rollout gating)
-          # than a compose healthcheck, so it is out of scope for this PR.
+          # not that PgBouncer can actually authenticate and serve a query —
+          # the compose poolers now run an authenticated `psql -c "SELECT 1"`
+          # exec probe for the same reason (a pg_isready probe, even pinned to
+          # the real user/db, still reports healthy on an auth rejection).
+          # Left as tcpSocket here deliberately: an exec probe change for a
+          # k8s liveness/readiness gate has a different blast radius (pod
+          # restarts, rollout gating) than a compose healthcheck, so it is
+          # out of scope for this PR.
           readinessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 2, periodSeconds: 5}
           livenessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 10, periodSeconds: 10}
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -241,7 +241,7 @@ goWorkers:
       maxClientConnections: 1000
     queueSession:
       port: 6433
-      poolSize: 27
+      poolSize: 36
       maxClientConnections: 128
     coordinatorSession:
       port: 6434

--- a/docs/operate/configure/databases-and-storage.md
+++ b/docs/operate/configure/databases-and-storage.md
@@ -39,6 +39,15 @@ PGBOUNCER_TRANSACTION_MODE=true
 
 Run schema migrations against PostgreSQL directly, not through transaction-mode PgBouncer.
 
+PgBouncer's `log_connections` and `log_disconnections` default on. At Go
+worker fleet connection rates that logs every attach and detach with no
+diagnostic value — a firehose, not a signal. The compose poolers turn both
+off and keep `log_pooler_errors` and the default `log_stats` on: the
+once-a-minute stats line is the only telemetry that matters (it is what
+shows a growing `wait` time — average client wait for a server connection —
+during a pool-exhaustion incident). Do not enable connection logging as a
+debugging step; read the stats line instead.
+
 ### Go worker coexistence
 
 The Go foundation uses three distinct responsibilities:

--- a/internal/deploymentcontract/manifest.go
+++ b/internal/deploymentcontract/manifest.go
@@ -24,6 +24,21 @@ var (
 	envPattern   = regexp.MustCompile(`^[A-Z][A-Z0-9_]+$`)
 )
 
+// PostgresBudget is the checked-in connection-budget contract for the
+// PostgreSQL server the Go deployment's three PgBouncer endpoints share
+// (CHAOS-3945). ServerMaxConnections must equal that server's real,
+// configured `max_connections` value, not a Go-stack-only figure: the
+// transaction pool counted here is the SAME endpoint the Python/Celery
+// stack's domain traffic uses (see docs/operate/configure/databases-and-storage.md),
+// so this budget already covers the one pooler shared across both runtimes.
+// ServerReservedConnections is a deliberate flat buffer for everything this
+// model does not enumerate by name — direct/non-pooled sessions (migrations
+// are tracked separately via MigrationJob), operator psql sessions, and
+// managed-Postgres incidentals (a live host has shown a ~10-connection
+// unmodeled role alongside this budget's four). It is NOT a per-consumer
+// reconciliation; widening what it needs to cover is a bigger cross-plane
+// exercise than this struct, and should be a deliberate size change with its
+// own evidence, not a silent one.
 type PostgresBudget struct {
 	ServerMaxConnections                            int `json:"server_max_connections"`
 	ServerReservedConnections                       int `json:"server_reserved_connections"`

--- a/internal/deploymentcontract/manifest_test.go
+++ b/internal/deploymentcontract/manifest_test.go
@@ -40,7 +40,7 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if summary.QueueSessionClientConnections != 26 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 1 {
+	if summary.QueueSessionHeadroom != 10 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
@@ -55,10 +55,10 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 93 {
+	if summary.ServerConnectionFootprint != 102 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 7 {
+	if summary.ServerConnectionHeadroom != 98 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -127,7 +127,7 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if summary.QueueSessionClientConnections != 26 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 1 {
+	if summary.QueueSessionHeadroom != 10 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
@@ -142,10 +142,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 93 {
+	if summary.ServerConnectionFootprint != 102 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 7 {
+	if summary.ServerConnectionHeadroom != 98 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -166,7 +166,7 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if summary.QueueSessionClientConnections != 22 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 5 {
+	if summary.QueueSessionHeadroom != 14 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
@@ -181,15 +181,22 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if summary.DomainTransactionHeadroom != 942 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 93 {
+	if summary.ServerConnectionFootprint != 102 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 7 {
+	if summary.ServerConnectionHeadroom != 98 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
 
 func TestManifestRejectsHeavyOrOpsReplicaBudgetXPlusOne(t *testing.T) {
+	// CHAOS-3945 raised pgbouncer_queue_session_pool_size to 36 (headroom 10
+	// at the reviewed heavy=2/ops=2 baseline) so the queue pooler is no
+	// longer pinned at its connection cap in normal operation. That headroom
+	// also means a single extra replica (3) no longer overflows the budget;
+	// 9 replicas of either group is the smallest bump that still does
+	// (26 clients + 2*(9-2) = 40 > 36), so this still proves an unreviewed
+	// replica increase is caught rather than silently accepted.
 	t.Parallel()
 	for _, tc := range []struct {
 		name    string
@@ -206,11 +213,11 @@ func TestManifestRejectsHeavyOrOpsReplicaBudgetXPlusOne(t *testing.T) {
 					manifest.Processes[index].MaxReplicas = 2
 				}
 				if manifest.Processes[index].Name == tc.changed {
-					manifest.Processes[index].MaxReplicas = 3
+					manifest.Processes[index].MaxReplicas = 9
 				}
 			}
 			if _, err := manifest.Validate(registry); err == nil {
-				t.Fatalf("expected %s at three replicas to fail validation", tc.changed)
+				t.Fatalf("expected %s at nine replicas to fail validation", tc.changed)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

**CHAOS-3944** — PgBouncer's `log_connections`/`log_disconnections` default on. At production connection rates (a Go worker fleet attaching/detaching constantly) that was a continuous, diagnostically worthless firehose: measured ~36 lines/min across the three poolers on the live host, vs ~3/min after turning both off. `log_pooler_errors` and the default `log_stats` stay on — the once-a-minute stats line is the only real telemetry PgBouncer emits, and it proved its worth in a live incident (`wait 5683209 us` during trouble, `wait 16136 us` after recovery).

Separately, a `pg_isready` healthcheck with no `-U`/`-d` probes as OS user `postgres`, which is not in PgBouncer's auth file. Every probe logged `no such user: postgres` **and still reported healthy**, because `pg_isready` counts an auth rejection as "server responding." Added healthchecks that probe with each pooler's real `DB_USER`/`DB_NAME`.

Both were fixed on the live host's untracked compose file; this PR lands the equivalent fix in the tracked files (`compose.production.yml`'s three poolers, the root `compose.yml` dev pooler, and a doc note) so it is not lost and does not ship to customers.

The Helm chart's `tcpSocket` probes have the same "port-open is not can-serve" gap. Left unchanged with an explanatory comment — a k8s liveness/readiness probe type change has a different blast radius (pod restarts, rollout gating) than a compose healthcheck, so it's out of scope here.

**CHAOS-3945** (folded in, same files) — The River queue pooler's budget was measured pinned at its 27-connection cap in production while River's leader election timed out waiting for a backend that never freed. The cost-model comment predates `go-worker-sync-provider` and the three stream runners; rewrote it to enumerate the current 9-service list and raised the pool to 36 for real rolling-restart/`go-workerctl` headroom. Also set `ADMIN_USERS` on both River poolers, which defaulted to a `postgres` admin role absent from their auth files — `SHOW POOLS` was unusable on exactly the poolers where saturation matters.

`internal/deploymentcontract/manifest.go` independently computes the declared connection footprint from the process registry and validates it against `deploy/go-workers/deployment.json` and the Helm values, so those two were bumped in lockstep with the compose default, and `server_max_connections` raised 100 -> 200 to keep headroom under the larger footprint. Updated the golden-value tests in `manifest_test.go` and `cmd/dev-health-workerctl/main_test.go` to match, and recalibrated the budget-overflow test to the replica count that now actually exceeds the new, larger pool.

## Test plan
- [x] `docker compose -f deploy/docker-compose/compose.production.yml --profile pooler config` parses (rc=0)
- [x] `docker compose -f compose.yml config` parses (rc=0)
- [x] `go build ./...` and `go test ./...` pass (whole module, including `internal/deploymentcontract` and `cmd/dev-health-workerctl`)
- [x] `.venv/bin/python -m pytest tests/workers/test_go_worker_deployment_contract.py tests/test_compose_config.py` passes (85 passed, 3 skipped)
- [x] Full `ci/local_validate.sh` gate run on the CHAOS-3944-only changeset: `GATE PASSED. [8/8]`