### PR TITLE
fix(deploy): stop the PgBouncer log firehose and size the River queue pool from a model that counts notifier sessions (CHAOS-3944, CHAOS-3945)

### DIFF
--- a/cmd/dev-health-workerctl/main_test.go
+++ b/cmd/dev-health-workerctl/main_test.go
@@ -347,13 +347,18 @@ func TestManifestQueueStatusSourceCombinesFreshQueueAndPresenceState(t *testing.
 		t.Fatalf("custom queue status = %#v", status.Groups[1])
 	}
 	// sync-provider is its own declared process (CHAOS-3926), so its
-	// max_replicas x per-process connections count separately from sync: queue
-	// session 22 -> 26 against a pool raised 23 -> 27, server 89 -> 93. Both
-	// processes ship at zero replicas, so runtime usage is unchanged; this is
-	// the declared worst case the budget has to cover.
-	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 26, Limit: 27, Headroom: 1}) ||
+	// max_replicas x per-process connections count separately from sync.
+	//
+	// CHAOS-3945 then raised the queue-session figure again, from 26 to 34:
+	// a started River client holds one notifier LISTEN session outside its
+	// queue-control pool, so each of the four "river" runtime processes costs
+	// 3 per replica, not 2. The pool went 27 -> 37, which is that declared 34
+	// plus one whole replica of rolling-restart overlap, and the server
+	// requirement 100 -> 200. Every process ships at zero replicas, so runtime
+	// usage is unchanged; this is the declared worst case the budget covers.
+	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 34, Limit: 37, Headroom: 3}) ||
 		status.ConnectionBudget.CoordinatorSession != (connectionBudgetStatus{Used: 10, Limit: 11, Headroom: 1}) ||
-		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 93, Limit: 100, Headroom: 7}) {
+		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 103, Limit: 200, Headroom: 97}) {
 		t.Fatalf("connection budget = %#v", status.ConnectionBudget)
 	}
 }

--- a/cmd/dev-health-workerctl/main_test.go
+++ b/cmd/dev-health-workerctl/main_test.go
@@ -352,13 +352,17 @@ func TestManifestQueueStatusSourceCombinesFreshQueueAndPresenceState(t *testing.
 	// CHAOS-3945 then raised the queue-session figure again, from 26 to 34:
 	// a started River client holds one notifier LISTEN session outside its
 	// queue-control pool, so each of the four "river" runtime processes costs
-	// 3 per replica, not 2. The pool went 27 -> 37, which is that declared 34
-	// plus one whole replica of rolling-restart overlap, and the server
-	// requirement 100 -> 200. Every process ships at zero replicas, so runtime
-	// usage is unchanged; this is the declared worst case the budget covers.
-	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 34, Limit: 37, Headroom: 3}) ||
-		status.ConnectionBudget.CoordinatorSession != (connectionBudgetStatus{Used: 10, Limit: 11, Headroom: 1}) ||
-		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 103, Limit: 200, Headroom: 97}) {
+	// 3 per replica, not 2.
+	//
+	// Both session pools now also carry a fleet-wide rolling-restart reserve,
+	// because every process rolls as its own unit and one image change surges
+	// all of them at once: queue 34 + 16 = 50, coordinator 10 + 4 = 14. That
+	// takes the server requirement to 119, declared 200 (was 100). Every
+	// process ships at zero replicas, so runtime usage is unchanged; this is
+	// the declared worst case the budget covers.
+	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 34, Limit: 50, Headroom: 16}) ||
+		status.ConnectionBudget.CoordinatorSession != (connectionBudgetStatus{Used: 10, Limit: 14, Headroom: 4}) ||
+		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 119, Limit: 200, Headroom: 81}) {
 		t.Fatalf("connection budget = %#v", status.ConnectionBudget)
 	}
 }

--- a/compose.yml
+++ b/compose.yml
@@ -101,7 +101,33 @@ services:
       DEFAULT_POOL_SIZE: "25"
       MIN_POOL_SIZE: "5"
       RESERVE_POOL_SIZE: "5"
+      # DB_USER above is `postgres`, so admin_users names a role that really
+      # is in the auth file here. The two River poolers in
+      # deploy/docker-compose/compose.production.yml did not have that luck --
+      # see CHAOS-3945.
       ADMIN_USERS: postgres
+      # CHAOS-3944: PgBouncer defaults log_connections=1 and
+      # log_disconnections=1. Even this single-pooler dev stack cycles
+      # connections continuously, so those defaults bury the useful lines.
+      #
+      # log_stats is deliberately LEFT ON -- do NOT add LOG_STATS: "0". That
+      # once-a-minute line is the only real telemetry PgBouncer emits (the
+      # `wait` field is what identifies a saturated pool).
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
+    # CHAOS-3944: pg_isready with no -U falls back to the OS user `postgres`.
+    # That happens to be a real role on THIS pooler, but naming -U/-d
+    # explicitly is what makes the probe a can-serve check rather than a
+    # port-open one: pg_isready counts an auth rejection as "server
+    # responding" and reports healthy either way.
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432",
+             "-U", "postgres", "-d", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     ports:
       - "6432:6432"
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -116,11 +116,13 @@ services:
       LOG_CONNECTIONS: "0"
       LOG_DISCONNECTIONS: "0"
       LOG_POOLER_ERRORS: "1"
-    # CHAOS-3944: pg_isready with no -U falls back to the OS user `postgres`.
-    # That happens to be a real role on THIS pooler, but naming -U/-d
-    # explicitly is what makes the probe a can-serve check rather than a
-    # port-open one: pg_isready counts an auth rejection as "server
-    # responding" and reports healthy either way.
+    # CHAOS-3944: a liveness probe, not a can-serve probe. pg_isready exits 0
+    # for any server response including a rejection, and exits 2 only when
+    # nothing answers the port. Naming -U/-d does not change that; it keeps
+    # the probe from logging a pooler error on every interval, which matters
+    # now that LOG_POOLER_ERRORS is on. See the longer note in
+    # deploy/docker-compose/compose.production.yml for why a real query probe
+    # is deliberately not used on a session-mode pooler.
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432",
              "-U", "postgres", "-d", "postgres"]

--- a/contracts/jobs/v1/deployment-manifest.schema.json
+++ b/contracts/jobs/v1/deployment-manifest.schema.json
@@ -35,6 +35,7 @@
         "pgbouncer_transaction_server_pool_count",
         "pgbouncer_transaction_max_client_connections",
         "pgbouncer_queue_session_pool_size",
+        "queue_session_notifier_sessions_per_replica",
         "pgbouncer_queue_session_max_client_connections",
         "pgbouncer_coordinator_session_pool_size",
         "pgbouncer_coordinator_session_max_client_connections"
@@ -46,6 +47,7 @@
         "pgbouncer_transaction_server_pool_count": {"type": "integer", "minimum": 1},
         "pgbouncer_transaction_max_client_connections": {"type": "integer", "minimum": 1},
         "pgbouncer_queue_session_pool_size": {"type": "integer", "minimum": 1},
+        "queue_session_notifier_sessions_per_replica": {"type": "integer", "minimum": 1, "maximum": 4},
         "pgbouncer_queue_session_max_client_connections": {"type": "integer", "minimum": 1},
         "pgbouncer_coordinator_session_pool_size": {"type": "integer", "minimum": 1},
         "pgbouncer_coordinator_session_max_client_connections": {"type": "integer", "minimum": 1}

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -6,6 +6,9 @@ CLICKHOUSE_DB=default
 CLICKHOUSE_HTTP_PORT=8123
 CLICKHOUSE_NATIVE_PORT=9000
 
+# This server must allow at least postgres_budget.server_max_connections
+# from deploy/go-workers/deployment.json (currently 200). Nothing checks it
+# for you; verify with: psql ... -Atc 'SHOW max_connections'  (CHAOS-3945)
 POSTGRES_HOST=postgres.example.com
 POSTGRES_USER=devhealth
 POSTGRES_PASSWORD=devhealth

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -453,6 +453,45 @@ services:
   # River listener/cancellation uses a session pool, never the transaction
   # endpoint above. DB_USER and DB_NAME are fixed, so DEFAULT_POOL_SIZE caps
   # the one relevant PgBouncer (database,user) backend pool.
+  #
+  # ---------------------------------------------------------------------------
+  # QUEUE-SESSION BUDGET (CHAOS-3945). This is a contract, not a tuning knob.
+  # Session mode pins one server connection per client session for the life of
+  # that session, so DEFAULT_POOL_SIZE is a hard ceiling: clients past it wait
+  # for a backend that never frees, and River leader election fails with
+  # "error beginning transaction: timeout: context deadline exceeded".
+  #
+  # Every declared client of this endpoint, at its manifest max_replicas
+  # (deploy/go-workers/deployment.json). A "river" runtime replica costs
+  # WORKER_DATABASE_MAX_CONNS (2) PLUS one long-lived River notifier LISTEN
+  # session that sits outside that pool. A "control" runtime replica costs only
+  # its pool: it builds a River client but drives it through the *Tx APIs and
+  # never calls Start, so no notifier attaches.
+  #
+  #   go-worker-sync           river    2 replicas x (2 + 1)  =  6
+  #   go-worker-heavy          river    2 replicas x (2 + 1)  =  6
+  #   go-worker-ops            river    2 replicas x (2 + 1)  =  6
+  #   go-worker-sync-provider  river    2 replicas x (2 + 1)  =  6
+  #   go-reconciler            control  2 replicas x  2       =  4
+  #   go-scheduler             control  2 replicas x  2       =  4
+  #   go-workerctl             CLI      1 invocation x 2      =  2
+  #   go-stream-external       stream   opens no queue pool   =  0
+  #   go-stream-ingest         stream   opens no queue pool   =  0
+  #   go-stream-pagerduty      stream   opens no queue pool   =  0
+  #                                                            ---
+  #                                              declared max   34
+  #   rolling-restart overlap: one replacement replica starts before the
+  #   stopping one's sessions expire at server_idle_timeout      +3
+  #                                                            ---
+  #                                            DEFAULT_POOL_SIZE 37
+  #
+  # This table is NOT the enforcement -- internal/deploymentcontract validates
+  # the same arithmetic from deployment.json on every build, and rejects a pool
+  # that cannot absorb one rolling restart. Adding a service that opens
+  # WORKER_DATABASE_URI means adding it to deployment.json, which moves this
+  # number; the previous version of this comment went stale silently when
+  # go-worker-sync-provider and the three stream runners were added.
+  # ---------------------------------------------------------------------------
   pgbouncer-river-queue:
     profiles: ["pooler"]
     image: edoburu/pgbouncer:latest
@@ -467,7 +506,7 @@ services:
       POOL_MODE: session
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_QUEUE_MAX_CLIENT_CONN:-128}
-      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-27}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-37}
       # CHAOS-3944: PgBouncer defaults log_connections=1 and
       # log_disconnections=1. The Go worker fleet cycles connections
       # continuously, so those defaults are a permanent firehose carrying no

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -412,6 +412,34 @@ services:
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_MAX_CLIENT_CONN:-1000}
       DEFAULT_POOL_SIZE: ${PGBOUNCER_DEFAULT_POOL_SIZE:-20}
+      # CHAOS-3944: PgBouncer defaults log_connections=1 and
+      # log_disconnections=1. The Go worker fleet cycles connections
+      # continuously, so those defaults are a permanent firehose carrying no
+      # diagnostic value -- measured at ~36 lines/minute across the three
+      # poolers, against 3/minute with them off.
+      #
+      # log_stats is deliberately LEFT ON -- do NOT add LOG_STATS: "0" here.
+      # That once-a-minute line is the only real telemetry PgBouncer emits,
+      # and it is what made a live pool-exhaustion incident diagnosable: the
+      # queue pooler reported `wait 5683209 us` (5.7 s mean connection wait)
+      # during the stall and `wait 16136 us` after recovery.
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
+    # CHAOS-3944: pg_isready with no -U falls back to the OS user
+    # `postgres`, which is not in PgBouncer's auth file. Every probe then
+    # logged `no such user: postgres` and STILL reported healthy, because
+    # pg_isready counts a rejection as "server responding". Naming this
+    # pooler's own role and database is what turns a port-open check into
+    # a can-serve check.
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432",
+             "-U", "${POSTGRES_USER:?set POSTGRES_USER}",
+             "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     ports:
       - "${PGBOUNCER_PORT:-6432}:6432"
     networks:
@@ -440,6 +468,40 @@ services:
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_QUEUE_MAX_CLIENT_CONN:-128}
       DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-27}
+      # CHAOS-3944: PgBouncer defaults log_connections=1 and
+      # log_disconnections=1. The Go worker fleet cycles connections
+      # continuously, so those defaults are a permanent firehose carrying no
+      # diagnostic value -- measured at ~36 lines/minute across the three
+      # poolers, against 3/minute with them off.
+      #
+      # log_stats is deliberately LEFT ON -- do NOT add LOG_STATS: "0" here.
+      # That once-a-minute line is the only real telemetry PgBouncer emits,
+      # and it is what made a live pool-exhaustion incident diagnosable: the
+      # queue pooler reported `wait 5683209 us` (5.7 s mean connection wait)
+      # during the stall and `wait 16136 us` after recovery.
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
+      # CHAOS-3945: without ADMIN_USERS, admin_users defaults to `postgres`,
+      # which is not in this pooler's auth file, so `SHOW POOLS` / `SHOW
+      # CLIENTS` / `SHOW STATS` were refused on exactly the endpoint where
+      # saturation matters -- pool exhaustion had to be inferred from
+      # pg_stat_activity and a River elector stack trace.
+      ADMIN_USERS: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+    # CHAOS-3944: pg_isready with no -U falls back to the OS user
+    # `postgres`, which is not in PgBouncer's auth file. Every probe then
+    # logged `no such user: postgres` and STILL reported healthy, because
+    # pg_isready counts a rejection as "server responding". Naming this
+    # pooler's own role and database is what turns a port-open check into
+    # a can-serve check.
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6433",
+             "-U", "${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}",
+             "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     ports:
       - "${PGBOUNCER_RIVER_QUEUE_PORT:-6433}:6433"
     networks: [dev-health]
@@ -461,6 +523,37 @@ services:
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_COORDINATOR_MAX_CLIENT_CONN:-32}
       DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-11}
+      # CHAOS-3944: PgBouncer defaults log_connections=1 and
+      # log_disconnections=1. The Go worker fleet cycles connections
+      # continuously, so those defaults are a permanent firehose carrying no
+      # diagnostic value -- measured at ~36 lines/minute across the three
+      # poolers, against 3/minute with them off.
+      #
+      # log_stats is deliberately LEFT ON -- do NOT add LOG_STATS: "0" here.
+      # That once-a-minute line is the only real telemetry PgBouncer emits,
+      # and it is what made a live pool-exhaustion incident diagnosable: the
+      # queue pooler reported `wait 5683209 us` (5.7 s mean connection wait)
+      # during the stall and `wait 16136 us` after recovery.
+      LOG_CONNECTIONS: "0"
+      LOG_DISCONNECTIONS: "0"
+      LOG_POOLER_ERRORS: "1"
+      # CHAOS-3945: see the queue pooler above -- admin_users must name this
+      # endpoint's own role or the SHOW commands are refused.
+      ADMIN_USERS: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+    # CHAOS-3944: pg_isready with no -U falls back to the OS user
+    # `postgres`, which is not in PgBouncer's auth file. Every probe then
+    # logged `no such user: postgres` and STILL reported healthy, because
+    # pg_isready counts a rejection as "server responding". Naming this
+    # pooler's own role and database is what turns a port-open check into
+    # a can-serve check.
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6434",
+             "-U", "${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}",
+             "-d", "${POSTGRES_DB:?set POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     ports:
       - "${PGBOUNCER_RIVER_COORDINATOR_PORT:-6434}:6434"
     networks: [dev-health]

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -496,12 +496,14 @@ services:
   #   go-stream-pagerduty      stream   opens no queue pool   =  0
   #                                                            ---
   #                                              declared max   34
-  #   Rolling-restart reserve: every one of these is its own independently
-  #   rolled unit, so a single image or config change surges ALL of them at
-  #   once (Helm renders one Deployment each with maxSurge 1 /
-  #   maxUnavailable 0). Each briefly runs one replica beyond its declared
+  #   Rolling-restart reserve. Each replica-bearing process group above is its
+  #   own independently rolled unit, so a single image or config change surges
+  #   ALL of them at once (Helm renders one Deployment each with maxSurge 1 /
+  #   maxUnavailable 0). Each then briefly runs one replica beyond its declared
   #   maximum while the outgoing replica's sessions linger until
-  #   server_idle_timeout: 3+3+3+3 river, 2+2 control            +16
+  #   server_idle_timeout. The streams cost nothing here and go-workerctl is a
+  #   one-shot invocation, not a rolled replica, so neither is reserved for:
+  #   3+3+3+3 river, 2+2 control                                  +16
   #                                                            ---
   #                                            DEFAULT_POOL_SIZE 50
   #

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -426,12 +426,28 @@ services:
       LOG_CONNECTIONS: "0"
       LOG_DISCONNECTIONS: "0"
       LOG_POOLER_ERRORS: "1"
-    # CHAOS-3944: pg_isready with no -U falls back to the OS user
-    # `postgres`, which is not in PgBouncer's auth file. Every probe then
-    # logged `no such user: postgres` and STILL reported healthy, because
-    # pg_isready counts a rejection as "server responding". Naming this
-    # pooler's own role and database is what turns a port-open check into
-    # a can-serve check.
+    # CHAOS-3944. Know exactly what this proves and what it does not.
+    #
+    # pg_isready reports "accepting connections" and exits 0 for ANY server
+    # response, including a rejection -- measured against this image: a
+    # nonexistent role and a nonexistent database both exit 0. It exits 2 only
+    # when nothing answers the port. So this is a liveness probe, not a
+    # can-serve probe, and naming -U/-d does not change that.
+    #
+    # What -U/-d does buy: with no -U, pg_isready probes as the OS user
+    # `postgres`, which is not in this pooler's auth file, so every interval
+    # logged `no such user: postgres` -- and with LOG_POOLER_ERRORS=1 above
+    # that is now a WARNING, which has to stay meaningful. Naming the pooler's
+    # own role and database keeps the probe silent when healthy.
+    #
+    # A genuine can-serve probe would have to open a real session and run a
+    # query. That is deliberately rejected here: on a session-mode endpoint
+    # sized exactly to the declared fleet, the probe would consume a pool slot,
+    # and under the saturation it is meant to detect it would block, time out,
+    # mark the pooler unhealthy and restart it -- dropping every live session
+    # at the worst possible moment. Pool saturation is observable through the
+    # admin console (ADMIN_USERS, above) and the log_stats `wait` field
+    # instead.
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432",
              "-U", "${POSTGRES_USER:?set POSTGRES_USER}",
@@ -480,14 +496,18 @@ services:
   #   go-stream-pagerduty      stream   opens no queue pool   =  0
   #                                                            ---
   #                                              declared max   34
-  #   rolling-restart overlap: one replacement replica starts before the
-  #   stopping one's sessions expire at server_idle_timeout      +3
+  #   Rolling-restart reserve: every one of these is its own independently
+  #   rolled unit, so a single image or config change surges ALL of them at
+  #   once (Helm renders one Deployment each with maxSurge 1 /
+  #   maxUnavailable 0). Each briefly runs one replica beyond its declared
+  #   maximum while the outgoing replica's sessions linger until
+  #   server_idle_timeout: 3+3+3+3 river, 2+2 control            +16
   #                                                            ---
-  #                                            DEFAULT_POOL_SIZE 37
+  #                                            DEFAULT_POOL_SIZE 50
   #
   # This table is NOT the enforcement -- internal/deploymentcontract validates
   # the same arithmetic from deployment.json on every build, and rejects a pool
-  # that cannot absorb one rolling restart. Adding a service that opens
+  # that cannot absorb a fleet-wide rolling restart. Adding a service that opens
   # WORKER_DATABASE_URI means adding it to deployment.json, which moves this
   # number; the previous version of this comment went stale silently when
   # go-worker-sync-provider and the three stream runners were added.
@@ -506,7 +526,7 @@ services:
       POOL_MODE: session
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_QUEUE_MAX_CLIENT_CONN:-128}
-      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-37}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-50}
       # CHAOS-3944: PgBouncer defaults log_connections=1 and
       # log_disconnections=1. The Go worker fleet cycles connections
       # continuously, so those defaults are a permanent firehose carrying no
@@ -527,12 +547,28 @@ services:
       # saturation matters -- pool exhaustion had to be inferred from
       # pg_stat_activity and a River elector stack trace.
       ADMIN_USERS: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
-    # CHAOS-3944: pg_isready with no -U falls back to the OS user
-    # `postgres`, which is not in PgBouncer's auth file. Every probe then
-    # logged `no such user: postgres` and STILL reported healthy, because
-    # pg_isready counts a rejection as "server responding". Naming this
-    # pooler's own role and database is what turns a port-open check into
-    # a can-serve check.
+    # CHAOS-3944. Know exactly what this proves and what it does not.
+    #
+    # pg_isready reports "accepting connections" and exits 0 for ANY server
+    # response, including a rejection -- measured against this image: a
+    # nonexistent role and a nonexistent database both exit 0. It exits 2 only
+    # when nothing answers the port. So this is a liveness probe, not a
+    # can-serve probe, and naming -U/-d does not change that.
+    #
+    # What -U/-d does buy: with no -U, pg_isready probes as the OS user
+    # `postgres`, which is not in this pooler's auth file, so every interval
+    # logged `no such user: postgres` -- and with LOG_POOLER_ERRORS=1 above
+    # that is now a WARNING, which has to stay meaningful. Naming the pooler's
+    # own role and database keeps the probe silent when healthy.
+    #
+    # A genuine can-serve probe would have to open a real session and run a
+    # query. That is deliberately rejected here: on a session-mode endpoint
+    # sized exactly to the declared fleet, the probe would consume a pool slot,
+    # and under the saturation it is meant to detect it would block, time out,
+    # mark the pooler unhealthy and restart it -- dropping every live session
+    # at the worst possible moment. Pool saturation is observable through the
+    # admin console (ADMIN_USERS, above) and the log_stats `wait` field
+    # instead.
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6433",
              "-U", "${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}",
@@ -561,7 +597,7 @@ services:
       POOL_MODE: session
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_COORDINATOR_MAX_CLIENT_CONN:-32}
-      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-11}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-14}
       # CHAOS-3944: PgBouncer defaults log_connections=1 and
       # log_disconnections=1. The Go worker fleet cycles connections
       # continuously, so those defaults are a permanent firehose carrying no
@@ -579,12 +615,28 @@ services:
       # CHAOS-3945: see the queue pooler above -- admin_users must name this
       # endpoint's own role or the SHOW commands are refused.
       ADMIN_USERS: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
-    # CHAOS-3944: pg_isready with no -U falls back to the OS user
-    # `postgres`, which is not in PgBouncer's auth file. Every probe then
-    # logged `no such user: postgres` and STILL reported healthy, because
-    # pg_isready counts a rejection as "server responding". Naming this
-    # pooler's own role and database is what turns a port-open check into
-    # a can-serve check.
+    # CHAOS-3944. Know exactly what this proves and what it does not.
+    #
+    # pg_isready reports "accepting connections" and exits 0 for ANY server
+    # response, including a rejection -- measured against this image: a
+    # nonexistent role and a nonexistent database both exit 0. It exits 2 only
+    # when nothing answers the port. So this is a liveness probe, not a
+    # can-serve probe, and naming -U/-d does not change that.
+    #
+    # What -U/-d does buy: with no -U, pg_isready probes as the OS user
+    # `postgres`, which is not in this pooler's auth file, so every interval
+    # logged `no such user: postgres` -- and with LOG_POOLER_ERRORS=1 above
+    # that is now a WARNING, which has to stay meaningful. Naming the pooler's
+    # own role and database keeps the probe silent when healthy.
+    #
+    # A genuine can-serve probe would have to open a real session and run a
+    # query. That is deliberately rejected here: on a session-mode endpoint
+    # sized exactly to the declared fleet, the probe would consume a pool slot,
+    # and under the saturation it is meant to detect it would block, time out,
+    # mark the pooler unhealthy and restart it -- dropping every live session
+    # at the worst possible moment. Pool saturation is observable through the
+    # admin console (ADMIN_USERS, above) and the log_stats `wait` field
+    # instead.
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6434",
              "-U", "${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}",

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -57,6 +57,9 @@ The contract gate validates that:
   and queue telemetry uses that same denominator;
 - disjoint and overlapping queue groups both validate;
 - each worker process has exactly one River client;
+- every started River client is charged one notifier session on the queue
+  endpoint in addition to its queue-control pool, and the queue pool retains
+  one whole replica of headroom for rolling restarts (CHAOS-3945);
 - every started River client registers type-only rescue workers for every
   bounded job kind it does not execute. River elects one maintenance leader
   per schema, not per queue, so a partial registry can otherwise discard

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -58,8 +58,9 @@ The contract gate validates that:
 - disjoint and overlapping queue groups both validate;
 - each worker process has exactly one River client;
 - every started River client is charged one notifier session on the queue
-  endpoint in addition to its queue-control pool, and the queue pool retains
-  one whole replica of headroom for rolling restarts (CHAOS-3945);
+  endpoint in addition to its queue-control pool, and both session pools
+  retain one surge replica of every group as rolling-restart headroom, because
+  a single image or config change rolls all groups at once (CHAOS-3945);
 - every started River client registers type-only rescue workers for every
   bounded job kind it does not execute. River elects one maintenance leader
   per schema, not per queue, so a partial registry can otherwise discard

--- a/deploy/go-workers/deployment.json
+++ b/deploy/go-workers/deployment.json
@@ -8,12 +8,13 @@
     "RIVER_QUEUE_DATABASE_ROLE"
   ],
   "postgres_budget": {
-    "server_max_connections": 100,
+    "server_max_connections": 200,
     "server_reserved_connections": 15,
     "pgbouncer_transaction_pool_size": 20,
     "pgbouncer_transaction_server_pool_count": 2,
     "pgbouncer_transaction_max_client_connections": 1000,
-    "pgbouncer_queue_session_pool_size": 27,
+    "pgbouncer_queue_session_pool_size": 37,
+    "queue_session_notifier_sessions_per_replica": 1,
     "pgbouncer_queue_session_max_client_connections": 128,
     "pgbouncer_coordinator_session_pool_size": 11,
     "pgbouncer_coordinator_session_max_client_connections": 32

--- a/deploy/go-workers/deployment.json
+++ b/deploy/go-workers/deployment.json
@@ -13,10 +13,10 @@
     "pgbouncer_transaction_pool_size": 20,
     "pgbouncer_transaction_server_pool_count": 2,
     "pgbouncer_transaction_max_client_connections": 1000,
-    "pgbouncer_queue_session_pool_size": 37,
+    "pgbouncer_queue_session_pool_size": 50,
     "queue_session_notifier_sessions_per_replica": 1,
     "pgbouncer_queue_session_max_client_connections": 128,
-    "pgbouncer_coordinator_session_pool_size": 11,
+    "pgbouncer_coordinator_session_pool_size": 14,
     "pgbouncer_coordinator_session_max_client_connections": 32
   },
   "migration_job": {

--- a/deploy/helm/dev-health/templates/go-pgbouncer.yaml
+++ b/deploy/helm/dev-health/templates/go-pgbouncer.yaml
@@ -75,6 +75,16 @@ spec:
             - {name: AUTH_TYPE, value: scram-sha-256}
             - {name: DEFAULT_POOL_SIZE, value: {{ $pooler.poolSize | quote }}}
             - {name: MAX_CLIENT_CONN, value: {{ $pooler.maxClientConnections | quote }}}
+          # CHAOS-3944: these are tcpSocket probes, so they prove the port
+          # answers, not that the pooler can serve. That is the same
+          # port-open-is-not-can-serve weakness the Compose healthchecks had
+          # before they were given an explicit -U/-d. An exec probe running
+          # `pg_isready -U <this pooler's role> -d <database>` would close the
+          # gap, but changing k8s probes has a different blast radius (a
+          # failing liveness probe restarts the pooler and drops every session
+          # on a session-mode endpoint), so it is deliberately left for its own
+          # change. Do not "fix" this by copying the Compose test in without
+          # first reworking the liveness/readiness split.
           readinessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 2, periodSeconds: 5}
           livenessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 10, periodSeconds: 10}
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}

--- a/deploy/helm/dev-health/templates/go-pgbouncer.yaml
+++ b/deploy/helm/dev-health/templates/go-pgbouncer.yaml
@@ -75,16 +75,22 @@ spec:
             - {name: AUTH_TYPE, value: scram-sha-256}
             - {name: DEFAULT_POOL_SIZE, value: {{ $pooler.poolSize | quote }}}
             - {name: MAX_CLIENT_CONN, value: {{ $pooler.maxClientConnections | quote }}}
-          # CHAOS-3944: these are tcpSocket probes, so they prove the port
-          # answers, not that the pooler can serve. That is the same
-          # port-open-is-not-can-serve weakness the Compose healthchecks had
-          # before they were given an explicit -U/-d. An exec probe running
-          # `pg_isready -U <this pooler's role> -d <database>` would close the
-          # gap, but changing k8s probes has a different blast radius (a
-          # failing liveness probe restarts the pooler and drops every session
-          # on a session-mode endpoint), so it is deliberately left for its own
-          # change. Do not "fix" this by copying the Compose test in without
-          # first reworking the liveness/readiness split.
+          # CHAOS-3944: these are tcpSocket probes -- they prove the port
+          # answers, not that the pooler can serve. Note that swapping in the
+          # Compose `pg_isready -U <role> -d <database>` exec probe would NOT
+          # close that gap: pg_isready exits 0 for any server response,
+          # including a rejection for a nonexistent role or database. It is a
+          # liveness probe there too.
+          #
+          # Closing the gap needs a probe that opens a session and runs a
+          # query, and that is a genuinely bad trade on a session-mode
+          # endpoint sized to the declared fleet: the probe consumes a pool
+          # slot, and under the saturation it would be there to detect it
+          # blocks, times out, and a failing liveness probe then restarts the
+          # pooler and drops every live session. Saturation is observable
+          # through the PgBouncer admin console and the log_stats `wait` field
+          # instead. Do not "fix" this without reworking the
+          # liveness/readiness split first.
           readinessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 2, periodSeconds: 5}
           livenessProbe: {tcpSocket: {port: pgbouncer}, initialDelaySeconds: 10, periodSeconds: 10}
           securityContext: {allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -241,7 +241,7 @@ goWorkers:
       maxClientConnections: 1000
     queueSession:
       port: 6433
-      poolSize: 27
+      poolSize: 37
       maxClientConnections: 128
     coordinatorSession:
       port: 6434

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -241,11 +241,11 @@ goWorkers:
       maxClientConnections: 1000
     queueSession:
       port: 6433
-      poolSize: 37
+      poolSize: 50
       maxClientConnections: 128
     coordinatorSession:
       port: 6434
-      poolSize: 11
+      poolSize: 14
       maxClientConnections: 32
     resources:
       requests: {cpu: 50m, memory: 64Mi}

--- a/docs/operate/configure/databases-and-storage.md
+++ b/docs/operate/configure/databases-and-storage.md
@@ -71,6 +71,37 @@ narrow `goWorkers.pgbouncer.postgres.networkPolicyCIDR`; the chart fails to
 render rather than silently blocking PgBouncer egress. The chart requires a
 digest-pinned PgBouncer image and adds TCP readiness probes for each endpoint.
 
+### Pooler logging and health probes
+
+The shipped Compose poolers set `LOG_CONNECTIONS=0` and `LOG_DISCONNECTIONS=0`.
+PgBouncer enables both by default, and a worker fleet that cycles connections
+continuously turns that into a permanent log firehose: roughly 36 lines per
+minute across the three poolers, against 3 per minute with them off. Nothing
+diagnostic is lost — the lines record that a connection happened, not how the
+pool is behaving.
+
+What is deliberately left on is `log_stats`, PgBouncer's once-a-minute
+aggregate line. Do not disable it. It is the only real telemetry PgBouncer
+emits without an exporter, and its `wait` field is the direct read on pool
+saturation: a healthy queue pooler reports a wait in the tens of milliseconds,
+while a saturated one reports seconds. `LOG_POOLER_ERRORS=1` keeps genuine
+rejections visible. If you want pooler telemetry in Prometheus rather than in
+logs, run a `pgbouncer_exporter` against the admin database — PgBouncer has no
+native Prometheus endpoint.
+
+Each pooler's healthcheck names its own role and database
+(`pg_isready -h localhost -p <port> -U <that pooler's role> -d <database>`).
+This matters more than it looks: `pg_isready` with no `-U` probes as the OS
+user `postgres`, which is not in the pooler's auth file, and it counts an
+authentication rejection as "server responding". Such a probe logs
+`no such user: postgres` on every interval and still reports the container
+healthy — it proves the port answers, never that the pooler can serve.
+
+The two River poolers also set `ADMIN_USERS` to their own role. PgBouncer
+otherwise defaults `admin_users` to `postgres`, so `SHOW POOLS`, `SHOW CLIENTS`
+and `SHOW STATS` are refused on exactly the endpoints where saturation matters
+and pool exhaustion has to be inferred from `pg_stat_activity` instead.
+
 ## Runtime roles
 
 Provision distinct unprivileged login roles for:

--- a/docs/operate/configure/databases-and-storage.md
+++ b/docs/operate/configure/databases-and-storage.md
@@ -54,6 +54,8 @@ The Go foundation uses three distinct responsibilities:
 
 Do not give long-running workers the migration DSN. Do not reuse the migration role for domain or queue-control access.
 
+Size the queue session endpoint from the deployment manifest, not from `WORKER_DATABASE_MAX_CONNS`. A worker process that starts a River client also holds one long-lived notifier `LISTEN` session, and that session sits outside the queue-control pool, so such a replica costs three session backends where the environment variable declares two. Reconciler and scheduler drive River transactionally and hold only their pool; the stream runners open no queue pool at all. The pool must additionally have room for one whole replica beyond every declared maximum, because a rolling restart runs the stopping and starting containers together and the stopping one's sessions linger until `server_idle_timeout`. The deployment-contract check enforces this arithmetic on every build and rejects a pool that cannot absorb a restart; a saturated session pool does not degrade gracefully — clients past the cap wait for a backend that never frees and River leader election fails with `error beginning transaction: timeout`.
+
 ### Helm Go-worker poolers
 
 The component chart keeps this topology disabled until `goWorkers.enabled` and

--- a/docs/operate/configure/databases-and-storage.md
+++ b/docs/operate/configure/databases-and-storage.md
@@ -54,7 +54,15 @@ The Go foundation uses three distinct responsibilities:
 
 Do not give long-running workers the migration DSN. Do not reuse the migration role for domain or queue-control access.
 
-Size the queue session endpoint from the deployment manifest, not from `WORKER_DATABASE_MAX_CONNS`. A worker process that starts a River client also holds one long-lived notifier `LISTEN` session, and that session sits outside the queue-control pool, so such a replica costs three session backends where the environment variable declares two. Reconciler and scheduler drive River transactionally and hold only their pool; the stream runners open no queue pool at all. The pool must additionally have room for one whole replica beyond every declared maximum, because a rolling restart runs the stopping and starting containers together and the stopping one's sessions linger until `server_idle_timeout`. The deployment-contract check enforces this arithmetic on every build and rejects a pool that cannot absorb a restart; a saturated session pool does not degrade gracefully — clients past the cap wait for a backend that never frees and River leader election fails with `error beginning transaction: timeout`.
+The three pools plus the migration and administrative reserve are a requirement on the PostgreSQL server you point the stack at, and nothing in the stack verifies it: the deployment manifest declares the required `max_connections` and validates the topology against that declaration, but it cannot read your server. Check it once, against the declared figure in `deploy/go-workers/deployment.json` (`postgres_budget.server_max_connections`, currently 200), before enabling the Go topology:
+
+```bash
+psql "$MIGRATION_DATABASE_URI" -Atc 'SHOW max_connections'
+```
+
+A managed PostgreSQL left at the common default of 100 does not have room for it. Raise the server setting, or lower the declared pools and re-run the contract check; do not leave the two disagreeing.
+
+Size the queue session endpoint from the deployment manifest, not from `WORKER_DATABASE_MAX_CONNS`. A worker process that starts a River client also holds one long-lived notifier `LISTEN` session, and that session sits outside the queue-control pool, so such a replica costs three session backends where the environment variable declares two. Reconciler and scheduler drive River transactionally and hold only their pool; the stream runners open no queue pool at all. The pool must additionally have room for one surge replica of *every* group beyond their declared maxima, not just one: each group is rendered as its own independently rolled unit, so a single image or config change surges all of them at once, and each briefly runs an extra replica while the outgoing one's sessions linger until `server_idle_timeout`. The same reserve applies to the coordinator session pool. The deployment-contract check enforces this arithmetic on every build and rejects a pool that cannot absorb a restart; a saturated session pool does not degrade gracefully — clients past the cap wait for a backend that never frees and River leader election fails with `error beginning transaction: timeout`.
 
 ### Helm Go-worker poolers
 
@@ -93,11 +101,22 @@ native Prometheus endpoint.
 
 Each pooler's healthcheck names its own role and database
 (`pg_isready -h localhost -p <port> -U <that pooler's role> -d <database>`).
-This matters more than it looks: `pg_isready` with no `-U` probes as the OS
-user `postgres`, which is not in the pooler's auth file, and it counts an
-authentication rejection as "server responding". Such a probe logs
-`no such user: postgres` on every interval and still reports the container
-healthy — it proves the port answers, never that the pooler can serve.
+Read it as a liveness probe and nothing more. `pg_isready` reports "accepting
+connections" and exits 0 for any server response, including a rejection —
+measured against this image, a nonexistent role and a nonexistent database
+both exit 0 — and exits non-zero only when nothing answers the port. Naming
+`-U`/`-d` does not make it a can-serve check. What it does buy is silence: with
+no `-U` the probe falls back to the OS user `postgres`, which is not in the
+pooler's auth file, so every interval logged `no such user: postgres`, and with
+`LOG_POOLER_ERRORS=1` that becomes a warning you want to stay meaningful.
+
+A probe that really proved the pooler could serve would have to open a session
+and run a query. That is deliberately avoided on the session-mode endpoints: a
+pool sized to the declared fleet has no spare slot for a probe, and under the
+saturation such a probe is meant to detect it would block, time out, mark the
+pooler unhealthy and restart it — dropping every live session at the worst
+moment. Watch the admin console and the `log_stats` `wait` field for that
+instead.
 
 The two River poolers also set `ADMIN_USERS` to their own role. PgBouncer
 otherwise defaults `admin_users` to `postgres`, so `SHOW POOLS`, `SHOW CLIENTS`

--- a/docs/operate/install/production.md
+++ b/docs/operate/install/production.md
@@ -102,6 +102,8 @@ MIGRATION_DATABASE_URI=postgres://devhealth_migrate:<secret>@postgres:5432/devhe
 
 Long-running workers must not receive `MIGRATION_DATABASE_URI`. Provision the domain and queue roles before the one-shot migration applies River grants.
 
+The Go topology requires `max_connections` on that PostgreSQL server to be at least the declared `postgres_budget.server_max_connections` in `deploy/go-workers/deployment.json` — currently **200**. Nothing in the stack checks this for you; a managed instance left at the common default of 100 cannot hold the three PgBouncer pools plus the migration and administrative reserve, and the shortfall only appears under the load that needs every pool at once. Confirm it with `psql "$MIGRATION_DATABASE_URI" -Atc 'SHOW max_connections'` before enabling the pooler profile.
+
 ## Docker Compose example
 
 Start from the checked-in [production Compose file](https://github.com/full-chaos/dev-health-ops/blob/main/deploy/docker-compose/compose.production.yml) and [environment template](https://github.com/full-chaos/dev-health-ops/blob/main/deploy/docker-compose/.env.example).

--- a/docs/operate/plan/capacity-and-sizing.md
+++ b/docs/operate/plan/capacity-and-sizing.md
@@ -54,6 +54,11 @@ contract checker after changing group replicas, queue concurrency, or pool
 limits. Include every group, even groups that are currently scaled to zero,
 when checking the declared upper bound.
 
+Count one River notifier session per replica that starts a River client, on
+top of that replica's queue-control pool. It is a separate long-lived session,
+not a pool member, and omitting it under-counts each such replica by a third.
+Reserve one further replica's worth of the queue pool for rolling restarts.
+
 Do not assume that a zero current replica count makes future activation free.
 The real admission budget is the sum of the actual group maxima and the
 operator and migration processes, with PostgreSQL and PgBouncer headroom.

--- a/docs/operate/plan/capacity-and-sizing.md
+++ b/docs/operate/plan/capacity-and-sizing.md
@@ -57,7 +57,9 @@ when checking the declared upper bound.
 Count one River notifier session per replica that starts a River client, on
 top of that replica's queue-control pool. It is a separate long-lived session,
 not a pool member, and omitting it under-counts each such replica by a third.
-Reserve one further replica's worth of the queue pool for rolling restarts.
+Reserve one surge replica of every group in both session pools for rolling
+restarts: the groups roll independently but a single image or config change
+starts all of them at once.
 
 Do not assume that a zero current replica count makes future activation free.
 The real admission budget is the sum of the actual group maxima and the

--- a/internal/deploymentcontract/manifest.go
+++ b/internal/deploymentcontract/manifest.go
@@ -25,12 +25,21 @@ var (
 )
 
 type PostgresBudget struct {
-	ServerMaxConnections                            int `json:"server_max_connections"`
-	ServerReservedConnections                       int `json:"server_reserved_connections"`
-	PgBouncerTransactionPoolSize                    int `json:"pgbouncer_transaction_pool_size"`
-	PgBouncerTransactionServerPoolCount             int `json:"pgbouncer_transaction_server_pool_count"`
-	PgBouncerTransactionMaxClientConnections        int `json:"pgbouncer_transaction_max_client_connections"`
-	PgBouncerQueueSessionPoolSize                   int `json:"pgbouncer_queue_session_pool_size"`
+	ServerMaxConnections                     int `json:"server_max_connections"`
+	ServerReservedConnections                int `json:"server_reserved_connections"`
+	PgBouncerTransactionPoolSize             int `json:"pgbouncer_transaction_pool_size"`
+	PgBouncerTransactionServerPoolCount      int `json:"pgbouncer_transaction_server_pool_count"`
+	PgBouncerTransactionMaxClientConnections int `json:"pgbouncer_transaction_max_client_connections"`
+	PgBouncerQueueSessionPoolSize            int `json:"pgbouncer_queue_session_pool_size"`
+	// A started River client holds ONE long-lived LISTEN session for its
+	// notifier, and that session lives outside the queue-control pgxpool that
+	// queue_control_max_connections declares. Counting only the pool
+	// under-counts a "river" runtime replica by a third -- which is how
+	// devhealth_queue came to sit at exactly DEFAULT_POOL_SIZE, with River
+	// leader election failing on "error beginning transaction: timeout", while
+	// every declared maximum in this manifest still looked satisfied
+	// (CHAOS-3945).
+	QueueSessionNotifierSessionsPerReplica          int `json:"queue_session_notifier_sessions_per_replica"`
 	PgBouncerQueueSessionMaxClientConnections       int `json:"pgbouncer_queue_session_max_client_connections"`
 	PgBouncerCoordinatorSessionPoolSize             int `json:"pgbouncer_coordinator_session_pool_size"`
 	PgBouncerCoordinatorSessionMaxClientConnections int `json:"pgbouncer_coordinator_session_max_client_connections"`
@@ -160,6 +169,11 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 	}
 
 	queueCoverage := buildQueueCoverage(registry)
+	// The most expensive single replica on the queue endpoint. A rolling
+	// restart briefly runs the old and new container together -- the stopping
+	// one's sessions linger until server_idle_timeout -- so the pool has to be
+	// able to absorb one of these on top of every declared maximum.
+	largestQueueReplicaFootprint := 0
 	seenNames := make(map[string]struct{}, len(manifest.Processes))
 	previousName := ""
 	summary := BudgetSummary{
@@ -184,7 +198,11 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 			return BudgetSummary{}, fmt.Errorf("deployment process %s: %w", process.Name, err)
 		}
 
-		summary.QueueSessionClientConnections += process.MaxReplicas * process.QueueControlMaxConnections
+		queueCostPerReplica := queueSessionCostPerReplica(process, manifest.PostgresBudget)
+		if queueCostPerReplica > largestQueueReplicaFootprint {
+			largestQueueReplicaFootprint = queueCostPerReplica
+		}
+		summary.QueueSessionClientConnections += process.MaxReplicas * queueCostPerReplica
 		summary.CoordinatorSessionClientConnections += process.MaxReplicas * process.CoordinatorMaxConnections
 		summary.DomainTransactionClientConnections += process.MaxReplicas * process.DomainMaxConnections
 
@@ -242,8 +260,12 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 		summary.DomainTransactionClientConnections
 	summary.ServerConnectionHeadroom = manifest.PostgresBudget.ServerMaxConnections -
 		summary.ServerConnectionFootprint
-	if summary.QueueSessionHeadroom <= 0 {
-		return BudgetSummary{}, errors.New("queue session PgBouncer headroom must be positive")
+	if summary.QueueSessionHeadroom < largestQueueReplicaFootprint {
+		return BudgetSummary{}, fmt.Errorf(
+			"queue session PgBouncer headroom %d cannot absorb a rolling restart of the largest declared replica (%d)",
+			summary.QueueSessionHeadroom,
+			largestQueueReplicaFootprint,
+		)
 	}
 	if summary.CoordinatorSessionHeadroom <= 0 {
 		return BudgetSummary{}, errors.New("coordinator session PgBouncer headroom must be positive")
@@ -255,6 +277,25 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 		return BudgetSummary{}, errors.New("PostgreSQL server connection headroom must be positive")
 	}
 	return summary, nil
+}
+
+// queueSessionCostPerReplica is what one replica of a process really costs the
+// queue-session endpoint: its queue-control pgxpool, plus River's notifier
+// session when the process actually starts a River client.
+//
+// Only the "river" runtime starts one (cmd/dev-health-worker/river_process.go
+// calls Client.Start). The "control" runtime builds a River client but drives
+// it exclusively through the *Tx APIs, so no notifier or elector is ever
+// attached; the "stream" runtime opens no queue pool at all. The operator CLI
+// is charged no notifier either, for the same reason as the control runtime.
+func queueSessionCostPerReplica(process Process, budget PostgresBudget) int {
+	if process.QueueControlMaxConnections <= 0 {
+		return 0
+	}
+	if process.Runtime != "river" {
+		return process.QueueControlMaxConnections
+	}
+	return process.QueueControlMaxConnections + budget.QueueSessionNotifierSessionsPerReplica
 }
 
 func minInt(left, right int) int {
@@ -310,6 +351,7 @@ func validatePostgresBudget(budget PostgresBudget) error {
 		budget.PgBouncerTransactionServerPoolCount < 1 || budget.PgBouncerTransactionServerPoolCount > 128 ||
 		budget.PgBouncerTransactionMaxClientConnections < 1 ||
 		budget.PgBouncerQueueSessionPoolSize < 1 || budget.PgBouncerQueueSessionMaxClientConnections < 1 ||
+		budget.QueueSessionNotifierSessionsPerReplica < 1 || budget.QueueSessionNotifierSessionsPerReplica > 4 ||
 		budget.PgBouncerCoordinatorSessionPoolSize < 1 || budget.PgBouncerCoordinatorSessionMaxClientConnections < 1 {
 		return errors.New("deployment PostgreSQL budget has invalid bounds")
 	}

--- a/internal/deploymentcontract/manifest.go
+++ b/internal/deploymentcontract/manifest.go
@@ -169,11 +169,16 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 	}
 
 	queueCoverage := buildQueueCoverage(registry)
-	// The most expensive single replica on the queue endpoint. A rolling
-	// restart briefly runs the old and new container together -- the stopping
-	// one's sessions linger until server_idle_timeout -- so the pool has to be
-	// able to absorb one of these on top of every declared maximum.
-	largestQueueReplicaFootprint := 0
+	// Rolling-restart reserve. Every process is rendered as its own
+	// independently rolled unit (a Compose service, a Helm Deployment with
+	// maxSurge 1 / maxUnavailable 0), so a single image or config change
+	// surges ALL of them at once: each group briefly runs one replica beyond
+	// its declared maximum while the outgoing replica's sessions linger until
+	// server_idle_timeout. Reserving only the largest single replica would
+	// hold for one serialized replacement and understate a fleet-wide rollout
+	// by the rest of the groups.
+	queueRollingSurgeReserve := 0
+	coordinatorRollingSurgeReserve := 0
 	seenNames := make(map[string]struct{}, len(manifest.Processes))
 	previousName := ""
 	summary := BudgetSummary{
@@ -199,9 +204,8 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 		}
 
 		queueCostPerReplica := queueSessionCostPerReplica(process, manifest.PostgresBudget)
-		if queueCostPerReplica > largestQueueReplicaFootprint {
-			largestQueueReplicaFootprint = queueCostPerReplica
-		}
+		queueRollingSurgeReserve += queueCostPerReplica
+		coordinatorRollingSurgeReserve += process.CoordinatorMaxConnections
 		summary.QueueSessionClientConnections += process.MaxReplicas * queueCostPerReplica
 		summary.CoordinatorSessionClientConnections += process.MaxReplicas * process.CoordinatorMaxConnections
 		summary.DomainTransactionClientConnections += process.MaxReplicas * process.DomainMaxConnections
@@ -260,15 +264,19 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 		summary.DomainTransactionClientConnections
 	summary.ServerConnectionHeadroom = manifest.PostgresBudget.ServerMaxConnections -
 		summary.ServerConnectionFootprint
-	if summary.QueueSessionHeadroom < largestQueueReplicaFootprint {
+	if summary.QueueSessionHeadroom < queueRollingSurgeReserve {
 		return BudgetSummary{}, fmt.Errorf(
-			"queue session PgBouncer headroom %d cannot absorb a rolling restart of the largest declared replica (%d)",
+			"queue session PgBouncer headroom %d cannot absorb a fleet-wide rolling restart (%d)",
 			summary.QueueSessionHeadroom,
-			largestQueueReplicaFootprint,
+			queueRollingSurgeReserve,
 		)
 	}
-	if summary.CoordinatorSessionHeadroom <= 0 {
-		return BudgetSummary{}, errors.New("coordinator session PgBouncer headroom must be positive")
+	if summary.CoordinatorSessionHeadroom < coordinatorRollingSurgeReserve {
+		return BudgetSummary{}, fmt.Errorf(
+			"coordinator session PgBouncer headroom %d cannot absorb a fleet-wide rolling restart (%d)",
+			summary.CoordinatorSessionHeadroom,
+			coordinatorRollingSurgeReserve,
+		)
 	}
 	if summary.DomainTransactionHeadroom <= 0 {
 		return BudgetSummary{}, errors.New("transaction PgBouncer headroom must be positive")

--- a/internal/deploymentcontract/manifest_test.go
+++ b/internal/deploymentcontract/manifest_test.go
@@ -40,13 +40,13 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if summary.QueueSessionClientConnections != 34 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 3 {
+	if summary.QueueSessionHeadroom != 16 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
 		t.Fatalf("coordinator session clients = %d", summary.CoordinatorSessionClientConnections)
 	}
-	if summary.CoordinatorSessionHeadroom != 1 {
+	if summary.CoordinatorSessionHeadroom != 4 {
 		t.Fatalf("coordinator session headroom = %d", summary.CoordinatorSessionHeadroom)
 	}
 	if summary.DomainTransactionClientConnections != 66 {
@@ -55,10 +55,10 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 103 {
+	if summary.ServerConnectionFootprint != 119 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 97 {
+	if summary.ServerConnectionHeadroom != 81 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -127,13 +127,13 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if summary.QueueSessionClientConnections != 34 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 3 {
+	if summary.QueueSessionHeadroom != 16 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
 		t.Fatalf("coordinator session clients = %d", summary.CoordinatorSessionClientConnections)
 	}
-	if summary.CoordinatorSessionHeadroom != 1 {
+	if summary.CoordinatorSessionHeadroom != 4 {
 		t.Fatalf("coordinator session headroom = %d", summary.CoordinatorSessionHeadroom)
 	}
 	if summary.DomainTransactionClientConnections != 66 {
@@ -142,10 +142,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 103 {
+	if summary.ServerConnectionFootprint != 119 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 97 {
+	if summary.ServerConnectionHeadroom != 81 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -166,13 +166,13 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if summary.QueueSessionClientConnections != 28 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 9 {
+	if summary.QueueSessionHeadroom != 22 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
 		t.Fatalf("coordinator session clients = %d", summary.CoordinatorSessionClientConnections)
 	}
-	if summary.CoordinatorSessionHeadroom != 1 {
+	if summary.CoordinatorSessionHeadroom != 4 {
 		t.Fatalf("coordinator session headroom = %d", summary.CoordinatorSessionHeadroom)
 	}
 	if summary.DomainTransactionClientConnections != 58 {
@@ -181,10 +181,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if summary.DomainTransactionHeadroom != 942 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 103 {
+	if summary.ServerConnectionFootprint != 119 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 97 {
+	if summary.ServerConnectionHeadroom != 81 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -595,10 +595,12 @@ func TestManifestRejectsAZeroNotifierSessionDeclaration(t *testing.T) {
 	}
 }
 
-// Headroom of one connection is not headroom. A rolling restart runs the
-// stopping and starting container together -- the stopping one's session
-// lingers until server_idle_timeout -- so the queue pool must be able to
-// absorb one whole replica beyond every declared maximum.
+// Headroom of one connection is not headroom. Every process is rendered as its
+// own independently rolled unit, so one image or config change surges all of
+// them together: each briefly runs a replica beyond its declared maximum while
+// the outgoing replica's sessions linger until server_idle_timeout. Reserving
+// only the largest single replica would hold for a serialized replacement and
+// understate a fleet-wide rollout by the rest of the groups.
 func TestManifestRejectsQueuePoolThatCannotAbsorbARollingRestart(t *testing.T) {
 	t.Parallel()
 	manifest, registry := loadFixture(t)

--- a/internal/deploymentcontract/manifest_test.go
+++ b/internal/deploymentcontract/manifest_test.go
@@ -37,10 +37,10 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.QueueSessionClientConnections != 26 {
+	if summary.QueueSessionClientConnections != 34 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 1 {
+	if summary.QueueSessionHeadroom != 3 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
@@ -55,10 +55,10 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 93 {
+	if summary.ServerConnectionFootprint != 103 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 7 {
+	if summary.ServerConnectionHeadroom != 97 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -124,10 +124,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.QueueSessionClientConnections != 26 {
+	if summary.QueueSessionClientConnections != 34 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 1 {
+	if summary.QueueSessionHeadroom != 3 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
@@ -142,10 +142,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 93 {
+	if summary.ServerConnectionFootprint != 103 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 7 {
+	if summary.ServerConnectionHeadroom != 97 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -163,10 +163,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.QueueSessionClientConnections != 22 {
+	if summary.QueueSessionClientConnections != 28 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 5 {
+	if summary.QueueSessionHeadroom != 9 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
@@ -181,10 +181,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if summary.DomainTransactionHeadroom != 942 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 93 {
+	if summary.ServerConnectionFootprint != 103 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 7 {
+	if summary.ServerConnectionHeadroom != 97 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -537,4 +537,78 @@ func unionRegistryKindsForQueues(registry jobcontract.Registry, queues []string)
 		}
 	}
 	return sortedKeys(kinds)
+}
+
+// CHAOS-3945: the queue-session budget used to count only each replica's
+// queue-control pgxpool. A started River client also holds a long-lived
+// notifier LISTEN session outside that pool, so a "river" runtime replica
+// costs one more connection than it declares. Charging only the pool is what
+// let devhealth_queue saturate at exactly DEFAULT_POOL_SIZE while every
+// declared maximum still validated.
+func TestManifestChargesRiverReplicasForTheirNotifierSession(t *testing.T) {
+	t.Parallel()
+	manifest, registry := loadFixture(t)
+
+	withNotifier, err := manifest.Validate(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Removing the notifier term must lower the footprint by exactly one
+	// connection per declared replica of every "river" runtime process, and
+	// by nothing at all for the control, stream, and operator clients.
+	riverReplicas := 0
+	for _, process := range manifest.Processes {
+		if process.Runtime == "river" && process.QueueControlMaxConnections > 0 {
+			riverReplicas += process.MaxReplicas
+		}
+	}
+	if riverReplicas == 0 {
+		t.Fatal("fixture declares no river runtime replicas, so this guard proves nothing")
+	}
+
+	expected := manifest.OperatorCLI.MaxConcurrentInvocations *
+		manifest.OperatorCLI.QueueControlMaxConnections
+	for _, process := range manifest.Processes {
+		expected += process.MaxReplicas * process.QueueControlMaxConnections
+	}
+	if withNotifier.QueueSessionClientConnections != expected+riverReplicas {
+		t.Fatalf(
+			"queue session clients = %d; pool-only total %d plus %d notifier sessions = %d",
+			withNotifier.QueueSessionClientConnections,
+			expected,
+			riverReplicas,
+			expected+riverReplicas,
+		)
+	}
+}
+
+// A notifier session is not optional: River always opens one per started
+// client. A manifest that declares zero must not validate, or the budget
+// silently reverts to the pool-only arithmetic that caused CHAOS-3945.
+func TestManifestRejectsAZeroNotifierSessionDeclaration(t *testing.T) {
+	t.Parallel()
+	manifest, registry := loadFixture(t)
+	manifest.PostgresBudget.QueueSessionNotifierSessionsPerReplica = 0
+	if _, err := manifest.Validate(registry); err == nil {
+		t.Fatal("expected a manifest declaring no River notifier session to fail validation")
+	}
+}
+
+// Headroom of one connection is not headroom. A rolling restart runs the
+// stopping and starting container together -- the stopping one's session
+// lingers until server_idle_timeout -- so the queue pool must be able to
+// absorb one whole replica beyond every declared maximum.
+func TestManifestRejectsQueuePoolThatCannotAbsorbARollingRestart(t *testing.T) {
+	t.Parallel()
+	manifest, registry := loadFixture(t)
+	summary, err := manifest.Validate(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.PostgresBudget.PgBouncerQueueSessionPoolSize =
+		summary.QueueSessionClientConnections + 1
+	if _, err := manifest.Validate(registry); err == nil {
+		t.Fatal("expected a queue pool with one spare connection to fail validation")
+	}
 }

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -876,8 +876,9 @@ def test_deployment_pgbouncer_budget_matches_production_compose_defaults() -> No
 
     # The SESSION pools are bound to the manifest too. Only the transaction
     # pool used to be, so the queue and coordinator defaults had drifted below
-    # the budget (22/10 against the manifest's 23/11) with nothing to catch it
-    # (CHAOS-3872).
+    # the budget with nothing to catch it (CHAOS-3872 -- 22/10 against 23/11 at
+    # the time). The manifest's own figures have moved since, which is exactly
+    # why this asserts the binding rather than a literal.
     services = _load_yaml(_PRODUCTION_COMPOSE)["services"]
     session_pools = {
         "pgbouncer-river-queue": (

--- a/tests/workers/test_helm_go_pgbouncer.py
+++ b/tests/workers/test_helm_go_pgbouncer.py
@@ -32,8 +32,9 @@ _PROFILE_NAMES = {
 _COORDINATOR_GROUPS = {"reconciler", "scheduler"}
 # Pool sizes and client caps come from the deployment manifest's postgres
 # budget rather than being restated here: the queue and coordinator session
-# defaults had drifted below it (22/10 against 23/11) precisely because this
-# oracle carried its own copy of the numbers (CHAOS-3872).
+# defaults had drifted below it precisely because this oracle carried its own
+# copy of the numbers (CHAOS-3872 -- 22/10 against 23/11 at the time; the
+# manifest's figures have moved since, which is the point).
 _POSTGRES_BUDGET = json.loads(_DEPLOYMENT.read_text(encoding="utf-8"))[
     "postgres_budget"
 ]


### PR DESCRIPTION
Lands in the tracked repo the two pooler fixes already applied and verified on the live host, plus the budget-model gap that let the second one happen silently.

## CHAOS-3944 — connection-log firehose, and a healthcheck probing a nonexistent user

PgBouncer defaults `log_connections=1` and `log_disconnections=1`. Against a worker fleet that cycles connections continuously that is a permanent firehose with no diagnostic value: **~36 lines/minute across the three production poolers, against 3/minute with them off**. All three now set `LOG_CONNECTIONS=0`, `LOG_DISCONNECTIONS=0`, `LOG_POOLER_ERRORS=1`.

`log_stats` is deliberately **kept on**, with a comment saying why so it does not get "tidied" away. That once-a-minute line is the only real telemetry PgBouncer emits without an exporter, and it is what made a live pool-exhaustion incident diagnosable: the queue pooler read `wait 5683209 us` (5.7 s mean connection wait) during the stall and `wait 16136 us` after recovery.

The three production poolers had **no healthcheck at all**. They now have one, naming each pooler's own role and database — and the comment says exactly what it proves. An earlier revision of this PR claimed `-U`/`-d` makes it a "can-serve" check. Measured against this image, it does not: `pg_isready` exits 0 for a nonexistent role and a nonexistent database alike, and exits non-zero only when nothing answers the port. What `-U`/`-d` buys is that the probe stops logging `no such user: postgres` every interval — which matters now that `LOG_POOLER_ERRORS=1` promotes that to a warning you want to stay meaningful.

A probe that really proved serving would have to open a session and run a query. That is deliberately rejected on the session-mode endpoints: the pool is sized to the declared fleet and has no spare slot for a probe, and under exactly the saturation such a probe is meant to detect it would block, time out, mark the pooler unhealthy and restart it — dropping every live session at the worst moment.

## CHAOS-3945 — the queue pool budget under-counted every River worker by a third

`internal/deploymentcontract` already computed declared client footprints and rejected non-positive headroom. It counted only each replica's queue-control pgxpool. A **started** River client also holds one long-lived notifier `LISTEN` session, outside that pool. That is how `devhealth_queue` came to sit at exactly `DEFAULT_POOL_SIZE` — leader election failing with `error beginning transaction: timeout: context deadline exceeded` — while every declared maximum in the manifest still validated.

The model is extended rather than replaced or duplicated. The notifier term is charged **per runtime**, traced to the code rather than assumed:

| runtime | opens queue pool | starts River client | queue cost / replica |
| --- | --- | --- | ---: |
| `river` (sync, heavy, ops, sync-provider) | yes | yes — `cmd/dev-health-worker/river_process.go:26` | 2 + 1 |
| `control` (reconciler, scheduler) | yes | no — `*Tx` APIs only | 2 |
| `stream` (external, ingest, pagerduty) | no | no | 0 |
| `workerctl` CLI | yes, short-lived | no | 2 |

Declared queue-session maximum is therefore **34, not 26**.

Headroom must also absorb a rolling restart. Reserving one replica would hold only for a serialized replacement — every process is rendered as its own independently rolled unit (Helm gives each its own Deployment with `maxSurge: 1`, `maxUnavailable: 0`), so one image or config change surges **all** of them together. The reserve is the sum across processes, and the same defect applied to the coordinator pool, which sat at headroom 1. That derives:

- queue `DEFAULT_POOL_SIZE = 34 + 16 = 50` (was 27)
- coordinator `DEFAULT_POOL_SIZE = 10 + 4 = 14` (was 11)
- declared server footprint 119 of 200

set consistently across the manifest, the production Compose file and the Helm values — the deployment-contract test binds all three.

`server_max_connections` rises 100 → 200. That is a requirement on a PostgreSQL the stack cannot read, and raising it silently would be its own defect, so it is now stated where an operator meets it — the production install page, the databases guide, and the Compose `.env` example — each with the `psql ... -Atc 'SHOW max_connections'` command to confirm it. A live admission check needs a runtime probe and is not attempted here.

`ADMIN_USERS` is now set on both River poolers to their own `DB_USER`. `admin_users` otherwise defaults to `postgres`, so `SHOW POOLS` / `SHOW CLIENTS` / `SHOW STATS` were refused on exactly the two endpoints where saturation matters — pool exhaustion had to be inferred from `pg_stat_activity` and an elector stack trace.

The prose budget comment is rewritten to enumerate every service by name and runtime, with the arithmetic shown. The previous version accounted for "two replicas of each of the three River worker groups plus the reconciler and scheduler" and went stale silently when `go-worker-sync-provider` and the three stream runners were added. It now also says explicitly that it is not the enforcement — the validator is.

## Guards added

- a river replica is charged exactly one notifier session and control/stream/CLI clients are charged none;
- a manifest declaring zero notifier sessions is rejected, so the budget cannot quietly revert to pool-only arithmetic;
- a session pool that cannot absorb a fleet-wide rolling restart is rejected — headroom of one is not headroom.

## Review

An adversarial review of the first draft returned three findings, all real, all addressed above: the false "can-serve" claim, the single-replica surge reserve, and the undocumented `max_connections` requirement. It cleared the runtime tracing behind the notifier arithmetic (reconciler constructs a River client but with no queues, so River 0.40's `willExecuteJobs()` is false and no notifier or elector is created), confirmed `MinConns` is 0 so there is no hidden pool floor, and confirmed the new tests are mechanism-sensitive rather than outcome-shaped.

## Deliberately not changed

`deploy/helm/dev-health/templates/go-pgbouncer.yaml` probes are `tcpSocket`, which has the identical port-open-is-not-can-serve weakness. Changing them has a different blast radius — a failing liveness probe restarts the pooler and drops every session on a session-mode endpoint — so the limitation is recorded in a comment referencing CHAOS-3944 and left for its own change.

Live pool **occupancy** is also out of scope here. This model proves declared maxima, which is a build-time property of checked-in files; occupancy is a runtime property and needs a scrape of the PgBouncer admin console (now reachable, which was the prerequisite). That belongs in an observability change, not in a manifest validator that has no runtime to observe.
