### PR TITLE
fix(deploy): derive the River session pool sizes instead of hand-maintaining them (CHAOS-3945)

### DIFF
--- a/cmd/dev-health-workerctl/main_test.go
+++ b/cmd/dev-health-workerctl/main_test.go
@@ -355,9 +355,9 @@ func TestManifestQueueStatusSourceCombinesFreshQueueAndPresenceState(t *testing.
 	// room under it: server footprint 93 -> 102. Both processes ship at zero
 	// replicas, so runtime usage is unchanged; this is the declared worst
 	// case the budget has to cover.
-	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 26, Limit: 36, Headroom: 10}) ||
-		status.ConnectionBudget.CoordinatorSession != (connectionBudgetStatus{Used: 10, Limit: 11, Headroom: 1}) ||
-		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 102, Limit: 200, Headroom: 98}) {
+	if status.ConnectionBudget.QueueSession != (connectionBudgetStatus{Used: 34, Limit: 50, Headroom: 16}) ||
+		status.ConnectionBudget.CoordinatorSession != (connectionBudgetStatus{Used: 10, Limit: 14, Headroom: 4}) ||
+		status.ConnectionBudget.Server != (connectionBudgetStatus{Used: 119, Limit: 200, Headroom: 81}) {
 		t.Fatalf("connection budget = %#v", status.ConnectionBudget)
 	}
 }

--- a/contracts/jobs/v1/deployment-manifest.schema.json
+++ b/contracts/jobs/v1/deployment-manifest.schema.json
@@ -35,6 +35,7 @@
         "pgbouncer_transaction_server_pool_count",
         "pgbouncer_transaction_max_client_connections",
         "pgbouncer_queue_session_pool_size",
+        "queue_session_notifier_sessions_per_replica",
         "pgbouncer_queue_session_max_client_connections",
         "pgbouncer_coordinator_session_pool_size",
         "pgbouncer_coordinator_session_max_client_connections"
@@ -46,6 +47,7 @@
         "pgbouncer_transaction_server_pool_count": {"type": "integer", "minimum": 1},
         "pgbouncer_transaction_max_client_connections": {"type": "integer", "minimum": 1},
         "pgbouncer_queue_session_pool_size": {"type": "integer", "minimum": 1},
+        "queue_session_notifier_sessions_per_replica": {"type": "integer", "minimum": 1, "maximum": 4},
         "pgbouncer_queue_session_max_client_connections": {"type": "integer", "minimum": 1},
         "pgbouncer_coordinator_session_pool_size": {"type": "integer", "minimum": 1},
         "pgbouncer_coordinator_session_max_client_connections": {"type": "integer", "minimum": 1}

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -6,6 +6,9 @@ CLICKHOUSE_DB=default
 CLICKHOUSE_HTTP_PORT=8123
 CLICKHOUSE_NATIVE_PORT=9000
 
+# This server must allow at least postgres_budget.server_max_connections from
+# deploy/go-workers/deployment.json (currently 200). Nothing checks it for you;
+# verify with: psql "$MIGRATION_DATABASE_URI" -Atc 'SHOW max_connections'
 POSTGRES_HOST=postgres.example.com
 POSTGRES_USER=devhealth
 POSTGRES_PASSWORD=devhealth

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -459,25 +459,45 @@ services:
   # endpoint above. DB_USER and DB_NAME are fixed, so DEFAULT_POOL_SIZE caps
   # the one relevant PgBouncer (database,user) backend pool.
   #
-  # CHAOS-3945: keep this budget current — it silently went stale once
-  # already. Every long-lived process below holds one session on this
-  # endpoint for its whole lifetime, and each replica costs THREE backends:
-  # two from WORKER_DATABASE_MAX_CONNS (a pgxpool) plus one long-lived River
-  # notifier session that sits outside that pool budget. Services declared in
-  # deploy/docker-compose/compose.go-workers.yml at replicas: 1 each:
-  #   go-worker-sync, go-worker-heavy, go-worker-ops, go-worker-sync-provider,
-  #   go-reconciler, go-scheduler,
-  #   go-stream-external, go-stream-ingest, go-stream-pagerduty
-  # = 9 processes x 3 backends = 27, plus occasional go-workerctl invocations
-  # and rolling-restart overlap (a stopping container's session lingers until
-  # server_idle_timeout, so an old and a new replica can briefly both hold
-  # one). DEFAULT_POOL_SIZE below (36) is that 27 plus headroom for both. If
-  # you add a new long-lived service on this endpoint, or raise a replica
-  # count, recompute and update this list and the number together — do not
-  # bump the number alone. A derived formula was considered instead of a
-  # hardcoded default, but the service list only exists in
-  # compose.go-workers.yml's `services:` keys, which plain YAML cannot
-  # introspect at parse time, so the count is written out by hand here.
+  # CHAOS-3945: this number is now DERIVED, not hand-maintained. The earlier
+  # version of this comment enumerated the service list by hand and went stale
+  # silently when services were added; it also charged every process three
+  # backends, which the code does not support. internal/deploymentcontract
+  # computes the figure from deploy/go-workers/deployment.json on every build
+  # and rejects a pool that does not match, so the list lives where something
+  # can actually read it. The formula:
+  #
+  #   A replica costs its queue-control pgxpool (WORKER_DATABASE_MAX_CONNS, 2)
+  #   plus one River notifier LISTEN session -- but ONLY if it starts a River
+  #   client. Traced to code, not assumed: only the "river" runtime does
+  #   (cmd/dev-health-worker/river_process.go calls Client.Start). The
+  #   "control" runtime builds a River client and drives it through the *Tx
+  #   APIs, so no notifier attaches; the "stream" runtime opens no queue pool
+  #   at all despite inheriting WORKER_DATABASE_URI from a YAML anchor; and
+  #   go-workerctl is insert/cancel only.
+  #
+  #   go-worker-sync           river    2 replicas x (2 + 1) =  6
+  #   go-worker-heavy          river    2 replicas x (2 + 1) =  6
+  #   go-worker-ops            river    2 replicas x (2 + 1) =  6
+  #   go-worker-sync-provider  river    2 replicas x (2 + 1) =  6
+  #   go-reconciler            control  2 replicas x  2      =  4
+  #   go-scheduler             control  2 replicas x  2      =  4
+  #   go-workerctl             CLI      1 invocation x 2     =  2
+  #   go-stream-external/-ingest/-pagerduty  no queue pool   =  0
+  #                                                            ---
+  #                                              declared max  34
+  #   Rolling-restart reserve: each replica-bearing group above is its own
+  #   independently rolled unit, so one image or config change surges ALL of
+  #   them at once, each briefly running a replica beyond its declared maximum
+  #   while the outgoing replica's sessions linger until server_idle_timeout.
+  #   3+3+3+3 river, 2+2 control (workerctl is a one-shot invocation, not a
+  #   rolled replica, and the streams cost nothing)              +16
+  #                                                            ---
+  #                                          DEFAULT_POOL_SIZE   50
+  #
+  # Adding a long-lived service on this endpoint means adding it to
+  # deployment.json, which moves the number and fails the contract until this
+  # default follows. Do not bump the number alone.
   pgbouncer-river-queue:
     profiles: ["pooler"]
     image: edoburu/pgbouncer:latest
@@ -492,7 +512,7 @@ services:
       POOL_MODE: session
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_QUEUE_MAX_CLIENT_CONN:-128}
-      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-36}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_QUEUE_POOL_SIZE:-50}
       # CHAOS-3945: stats_users defaults empty and admin_users defaults to
       # "postgres", which is not in this pooler's auth file (only the River
       # queue role is) — so SHOW POOLS/CLIENTS/STATS were unreachable on
@@ -544,7 +564,7 @@ services:
       POOL_MODE: session
       AUTH_TYPE: scram-sha-256
       MAX_CLIENT_CONN: ${PGBOUNCER_RIVER_COORDINATOR_MAX_CLIENT_CONN:-32}
-      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-11}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_RIVER_COORDINATOR_POOL_SIZE:-14}
       # CHAOS-3945: same admin-console gap as the queue pooler above — set
       # STATS_USERS (read-only SHOW access), not ADMIN_USERS (which can
       # PAUSE/KILL/SHUTDOWN the pooler), to this pooler's own role so

--- a/deploy/go-workers/deployment.json
+++ b/deploy/go-workers/deployment.json
@@ -13,9 +13,10 @@
     "pgbouncer_transaction_pool_size": 20,
     "pgbouncer_transaction_server_pool_count": 2,
     "pgbouncer_transaction_max_client_connections": 1000,
-    "pgbouncer_queue_session_pool_size": 36,
+    "pgbouncer_queue_session_pool_size": 50,
+    "queue_session_notifier_sessions_per_replica": 1,
     "pgbouncer_queue_session_max_client_connections": 128,
-    "pgbouncer_coordinator_session_pool_size": 11,
+    "pgbouncer_coordinator_session_pool_size": 14,
     "pgbouncer_coordinator_session_max_client_connections": 32
   },
   "migration_job": {

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -241,11 +241,11 @@ goWorkers:
       maxClientConnections: 1000
     queueSession:
       port: 6433
-      poolSize: 36
+      poolSize: 50
       maxClientConnections: 128
     coordinatorSession:
       port: 6434
-      poolSize: 11
+      poolSize: 14
       maxClientConnections: 32
     resources:
       requests: {cpu: 50m, memory: 64Mi}

--- a/docs/operate/configure/databases-and-storage.md
+++ b/docs/operate/configure/databases-and-storage.md
@@ -63,6 +63,8 @@ The Go foundation uses three distinct responsibilities:
 
 Do not give long-running workers the migration DSN. Do not reuse the migration role for domain or queue-control access.
 
+Size the River session endpoints from the deployment manifest, not from `WORKER_DATABASE_MAX_CONNS`. A worker process that starts a River client also holds one long-lived notifier `LISTEN` session outside its queue-control pool, so such a replica costs three session backends where the environment variable declares two; processes that drive River transactionally hold only their pool, and the stream runners open no queue pool at all. Both session pools additionally reserve one surge replica of *every* replica-bearing group, because the groups roll independently but a single image or config change starts all of them at once and each outgoing replica's sessions linger until `server_idle_timeout`. The deployment-contract check enforces this arithmetic on every build, so the pool sizes are derived rather than hand-maintained — a saturated session pool does not degrade gracefully: clients past the cap wait for a backend that never frees and River leader election fails with `error beginning transaction: timeout`.
+
 ### Helm Go-worker poolers
 
 The component chart keeps this topology disabled until `goWorkers.enabled` and

--- a/docs/operate/install/production.md
+++ b/docs/operate/install/production.md
@@ -102,6 +102,12 @@ MIGRATION_DATABASE_URI=postgres://devhealth_migrate:<secret>@postgres:5432/devhe
 
 Long-running workers must not receive `MIGRATION_DATABASE_URI`. Provision the domain and queue roles before the one-shot migration applies River grants.
 
+The Go topology requires `max_connections` on that PostgreSQL server to be at least the declared `postgres_budget.server_max_connections` in `deploy/go-workers/deployment.json` — currently **200**. Nothing in the stack checks this for you: the deployment contract validates the topology against its own declaration, but it cannot read your server. A managed instance left at the common default of 100 cannot hold the three PgBouncer pools plus the migration and administrative reserve, and the shortfall only appears under the load that needs every pool at once. Confirm it before enabling the pooler profile:
+
+```bash
+psql "$MIGRATION_DATABASE_URI" -Atc 'SHOW max_connections'
+```
+
 ## Docker Compose example
 
 Start from the checked-in [production Compose file](https://github.com/full-chaos/dev-health-ops/blob/main/deploy/docker-compose/compose.production.yml) and [environment template](https://github.com/full-chaos/dev-health-ops/blob/main/deploy/docker-compose/.env.example).

--- a/docs/operate/plan/capacity-and-sizing.md
+++ b/docs/operate/plan/capacity-and-sizing.md
@@ -54,6 +54,18 @@ contract checker after changing group replicas, queue concurrency, or pool
 limits. Include every group, even groups that are currently scaled to zero,
 when checking the declared upper bound.
 
+Count one River notifier session per replica that actually starts a River
+client, on top of that replica's queue-control pool. It is a separate
+long-lived `LISTEN` session, not a pool member, and omitting it under-counts
+such a replica by a third. Processes that build a River client but drive it
+transactionally hold no notifier, and processes with no queue pool hold nothing
+on that endpoint at all — do not charge them for one.
+
+Reserve one surge replica of every replica-bearing group in both session pools.
+The groups roll independently, but a single image or config change starts all
+of them at once, and each outgoing replica's sessions linger until
+`server_idle_timeout`.
+
 Do not assume that a zero current replica count makes future activation free.
 The real admission budget is the sum of the actual group maxima and the
 operator and migration processes, with PostgreSQL and PgBouncer headroom.

--- a/internal/deploymentcontract/manifest.go
+++ b/internal/deploymentcontract/manifest.go
@@ -40,12 +40,21 @@ var (
 // exercise than this struct, and should be a deliberate size change with its
 // own evidence, not a silent one.
 type PostgresBudget struct {
-	ServerMaxConnections                            int `json:"server_max_connections"`
-	ServerReservedConnections                       int `json:"server_reserved_connections"`
-	PgBouncerTransactionPoolSize                    int `json:"pgbouncer_transaction_pool_size"`
-	PgBouncerTransactionServerPoolCount             int `json:"pgbouncer_transaction_server_pool_count"`
-	PgBouncerTransactionMaxClientConnections        int `json:"pgbouncer_transaction_max_client_connections"`
-	PgBouncerQueueSessionPoolSize                   int `json:"pgbouncer_queue_session_pool_size"`
+	ServerMaxConnections                     int `json:"server_max_connections"`
+	ServerReservedConnections                int `json:"server_reserved_connections"`
+	PgBouncerTransactionPoolSize             int `json:"pgbouncer_transaction_pool_size"`
+	PgBouncerTransactionServerPoolCount      int `json:"pgbouncer_transaction_server_pool_count"`
+	PgBouncerTransactionMaxClientConnections int `json:"pgbouncer_transaction_max_client_connections"`
+	PgBouncerQueueSessionPoolSize            int `json:"pgbouncer_queue_session_pool_size"`
+	// A started River client holds ONE long-lived LISTEN session for its
+	// notifier, outside the queue-control pgxpool that
+	// queue_control_max_connections declares. Only the "river" runtime starts
+	// one (cmd/dev-health-worker/river_process.go calls Client.Start); the
+	// "control" runtime builds a client but drives it through the *Tx APIs, so
+	// no notifier or elector attaches, and the "stream" runtime opens no queue
+	// pool at all. Declaring the term here is what lets the pool size be
+	// derived instead of hand-maintained (CHAOS-3945).
+	QueueSessionNotifierSessionsPerReplica          int `json:"queue_session_notifier_sessions_per_replica"`
 	PgBouncerQueueSessionMaxClientConnections       int `json:"pgbouncer_queue_session_max_client_connections"`
 	PgBouncerCoordinatorSessionPoolSize             int `json:"pgbouncer_coordinator_session_pool_size"`
 	PgBouncerCoordinatorSessionMaxClientConnections int `json:"pgbouncer_coordinator_session_max_client_connections"`
@@ -175,6 +184,15 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 	}
 
 	queueCoverage := buildQueueCoverage(registry)
+	// Rolling-restart reserve. Each replica-bearing process is rendered as its
+	// own independently rolled unit (a Compose service; a Helm Deployment with
+	// maxSurge 1 / maxUnavailable 0), so one image or config change surges ALL
+	// of them at once: each briefly runs a replica beyond its declared maximum
+	// while the outgoing replica's sessions linger until server_idle_timeout.
+	// Reserving only the largest single replica would hold for one serialized
+	// replacement and understate a fleet-wide rollout by the rest.
+	queueRollingSurgeReserve := 0
+	coordinatorRollingSurgeReserve := 0
 	seenNames := make(map[string]struct{}, len(manifest.Processes))
 	previousName := ""
 	summary := BudgetSummary{
@@ -199,7 +217,10 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 			return BudgetSummary{}, fmt.Errorf("deployment process %s: %w", process.Name, err)
 		}
 
-		summary.QueueSessionClientConnections += process.MaxReplicas * process.QueueControlMaxConnections
+		queueCostPerReplica := queueSessionCostPerReplica(process, manifest.PostgresBudget)
+		queueRollingSurgeReserve += queueCostPerReplica
+		coordinatorRollingSurgeReserve += process.CoordinatorMaxConnections
+		summary.QueueSessionClientConnections += process.MaxReplicas * queueCostPerReplica
 		summary.CoordinatorSessionClientConnections += process.MaxReplicas * process.CoordinatorMaxConnections
 		summary.DomainTransactionClientConnections += process.MaxReplicas * process.DomainMaxConnections
 
@@ -257,11 +278,19 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 		summary.DomainTransactionClientConnections
 	summary.ServerConnectionHeadroom = manifest.PostgresBudget.ServerMaxConnections -
 		summary.ServerConnectionFootprint
-	if summary.QueueSessionHeadroom <= 0 {
-		return BudgetSummary{}, errors.New("queue session PgBouncer headroom must be positive")
+	if summary.QueueSessionHeadroom < queueRollingSurgeReserve {
+		return BudgetSummary{}, fmt.Errorf(
+			"queue session PgBouncer headroom %d cannot absorb a fleet-wide rolling restart (%d)",
+			summary.QueueSessionHeadroom,
+			queueRollingSurgeReserve,
+		)
 	}
-	if summary.CoordinatorSessionHeadroom <= 0 {
-		return BudgetSummary{}, errors.New("coordinator session PgBouncer headroom must be positive")
+	if summary.CoordinatorSessionHeadroom < coordinatorRollingSurgeReserve {
+		return BudgetSummary{}, fmt.Errorf(
+			"coordinator session PgBouncer headroom %d cannot absorb a fleet-wide rolling restart (%d)",
+			summary.CoordinatorSessionHeadroom,
+			coordinatorRollingSurgeReserve,
+		)
 	}
 	if summary.DomainTransactionHeadroom <= 0 {
 		return BudgetSummary{}, errors.New("transaction PgBouncer headroom must be positive")
@@ -270,6 +299,21 @@ func (manifest Manifest) Validate(registry jobcontract.Registry) (BudgetSummary,
 		return BudgetSummary{}, errors.New("PostgreSQL server connection headroom must be positive")
 	}
 	return summary, nil
+}
+
+// queueSessionCostPerReplica is what one replica really costs the queue-session
+// endpoint: its queue-control pgxpool, plus River's notifier session when the
+// process actually starts a River client. The operator CLI is charged no
+// notifier for the same reason as the control runtime -- it builds its River
+// client for insert/cancel and never calls Start.
+func queueSessionCostPerReplica(process Process, budget PostgresBudget) int {
+	if process.QueueControlMaxConnections <= 0 {
+		return 0
+	}
+	if process.Runtime != "river" {
+		return process.QueueControlMaxConnections
+	}
+	return process.QueueControlMaxConnections + budget.QueueSessionNotifierSessionsPerReplica
 }
 
 func minInt(left, right int) int {
@@ -325,6 +369,7 @@ func validatePostgresBudget(budget PostgresBudget) error {
 		budget.PgBouncerTransactionServerPoolCount < 1 || budget.PgBouncerTransactionServerPoolCount > 128 ||
 		budget.PgBouncerTransactionMaxClientConnections < 1 ||
 		budget.PgBouncerQueueSessionPoolSize < 1 || budget.PgBouncerQueueSessionMaxClientConnections < 1 ||
+		budget.QueueSessionNotifierSessionsPerReplica < 1 || budget.QueueSessionNotifierSessionsPerReplica > 4 ||
 		budget.PgBouncerCoordinatorSessionPoolSize < 1 || budget.PgBouncerCoordinatorSessionMaxClientConnections < 1 {
 		return errors.New("deployment PostgreSQL budget has invalid bounds")
 	}

--- a/internal/deploymentcontract/manifest_test.go
+++ b/internal/deploymentcontract/manifest_test.go
@@ -37,16 +37,16 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.QueueSessionClientConnections != 26 {
+	if summary.QueueSessionClientConnections != 34 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 10 {
+	if summary.QueueSessionHeadroom != 16 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
 		t.Fatalf("coordinator session clients = %d", summary.CoordinatorSessionClientConnections)
 	}
-	if summary.CoordinatorSessionHeadroom != 1 {
+	if summary.CoordinatorSessionHeadroom != 4 {
 		t.Fatalf("coordinator session headroom = %d", summary.CoordinatorSessionHeadroom)
 	}
 	if summary.DomainTransactionClientConnections != 66 {
@@ -55,10 +55,10 @@ func TestCheckedInManifestIsValidAndBounded(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 102 {
+	if summary.ServerConnectionFootprint != 119 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 98 {
+	if summary.ServerConnectionHeadroom != 81 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -124,16 +124,16 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.QueueSessionClientConnections != 26 {
+	if summary.QueueSessionClientConnections != 34 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 10 {
+	if summary.QueueSessionHeadroom != 16 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
 		t.Fatalf("coordinator session clients = %d", summary.CoordinatorSessionClientConnections)
 	}
-	if summary.CoordinatorSessionHeadroom != 1 {
+	if summary.CoordinatorSessionHeadroom != 4 {
 		t.Fatalf("coordinator session headroom = %d", summary.CoordinatorSessionHeadroom)
 	}
 	if summary.DomainTransactionClientConnections != 66 {
@@ -142,10 +142,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudget(t *testing.T) {
 	if summary.DomainTransactionHeadroom != 934 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 102 {
+	if summary.ServerConnectionFootprint != 119 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 98 {
+	if summary.ServerConnectionHeadroom != 81 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -163,16 +163,16 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.QueueSessionClientConnections != 22 {
+	if summary.QueueSessionClientConnections != 28 {
 		t.Fatalf("queue session clients = %d", summary.QueueSessionClientConnections)
 	}
-	if summary.QueueSessionHeadroom != 14 {
+	if summary.QueueSessionHeadroom != 22 {
 		t.Fatalf("queue session headroom = %d", summary.QueueSessionHeadroom)
 	}
 	if summary.CoordinatorSessionClientConnections != 10 {
 		t.Fatalf("coordinator session clients = %d", summary.CoordinatorSessionClientConnections)
 	}
-	if summary.CoordinatorSessionHeadroom != 1 {
+	if summary.CoordinatorSessionHeadroom != 4 {
 		t.Fatalf("coordinator session headroom = %d", summary.CoordinatorSessionHeadroom)
 	}
 	if summary.DomainTransactionClientConnections != 58 {
@@ -181,10 +181,10 @@ func TestManifestAcceptsReviewedHeavyAndOpsReplicaBudgetAtOneReplica(t *testing.
 	if summary.DomainTransactionHeadroom != 942 {
 		t.Fatalf("domain transaction headroom = %d", summary.DomainTransactionHeadroom)
 	}
-	if summary.ServerConnectionFootprint != 102 {
+	if summary.ServerConnectionFootprint != 119 {
 		t.Fatalf("server connection footprint = %d", summary.ServerConnectionFootprint)
 	}
-	if summary.ServerConnectionHeadroom != 98 {
+	if summary.ServerConnectionHeadroom != 81 {
 		t.Fatalf("server connection headroom = %d", summary.ServerConnectionHeadroom)
 	}
 }
@@ -544,4 +544,100 @@ func unionRegistryKindsForQueues(registry jobcontract.Registry, queues []string)
 		}
 	}
 	return sortedKeys(kinds)
+}
+
+// CHAOS-3945: the queue-session budget counted only each replica's
+// queue-control pgxpool. A started River client also holds a long-lived
+// notifier LISTEN session outside that pool, so a "river" runtime replica
+// costs one more connection than it declares.
+func TestManifestChargesRiverReplicasForTheirNotifierSession(t *testing.T) {
+	t.Parallel()
+	manifest, registry := loadFixture(t)
+
+	withNotifier, err := manifest.Validate(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	riverReplicas := 0
+	for _, process := range manifest.Processes {
+		if process.Runtime == "river" && process.QueueControlMaxConnections > 0 {
+			riverReplicas += process.MaxReplicas
+		}
+	}
+	if riverReplicas == 0 {
+		t.Fatal("fixture declares no river runtime replicas, so this guard proves nothing")
+	}
+
+	// Independently recomputed pool-only total: what the budget was before the
+	// notifier term existed. The difference must be exactly one session per
+	// declared river replica -- and nothing for the control, stream, or
+	// operator clients.
+	expected := manifest.OperatorCLI.MaxConcurrentInvocations *
+		manifest.OperatorCLI.QueueControlMaxConnections
+	for _, process := range manifest.Processes {
+		expected += process.MaxReplicas * process.QueueControlMaxConnections
+	}
+	if withNotifier.QueueSessionClientConnections != expected+riverReplicas {
+		t.Fatalf(
+			"queue session clients = %d; pool-only total %d plus %d notifier sessions = %d",
+			withNotifier.QueueSessionClientConnections,
+			expected,
+			riverReplicas,
+			expected+riverReplicas,
+		)
+	}
+}
+
+// A notifier session is not optional: River always opens one per started
+// client. A manifest declaring zero must not validate, or the budget silently
+// reverts to the pool-only arithmetic that caused CHAOS-3945.
+func TestManifestRejectsAZeroNotifierSessionDeclaration(t *testing.T) {
+	t.Parallel()
+	manifest, registry := loadFixture(t)
+	manifest.PostgresBudget.QueueSessionNotifierSessionsPerReplica = 0
+	if _, err := manifest.Validate(registry); err == nil {
+		t.Fatal("expected a manifest declaring no River notifier session to fail validation")
+	}
+}
+
+// Headroom of one connection is not headroom. Every replica-bearing process is
+// its own independently rolled unit, so a single image or config change surges
+// all of them together, each briefly running a replica beyond its declared
+// maximum while the outgoing replica's sessions linger until
+// server_idle_timeout. Both session pools must absorb that, not just one.
+func TestManifestRejectsSessionPoolsThatCannotAbsorbAFleetRollingRestart(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name  string
+		shave func(*Manifest, BudgetSummary)
+	}{
+		{
+			name: "queue",
+			shave: func(manifest *Manifest, summary BudgetSummary) {
+				manifest.PostgresBudget.PgBouncerQueueSessionPoolSize =
+					summary.QueueSessionClientConnections + 1
+			},
+		},
+		{
+			name: "coordinator",
+			shave: func(manifest *Manifest, summary BudgetSummary) {
+				manifest.PostgresBudget.PgBouncerCoordinatorSessionPoolSize =
+					summary.CoordinatorSessionClientConnections + 1
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			manifest, registry := loadFixture(t)
+			summary, err := manifest.Validate(registry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.shave(&manifest, summary)
+			if _, err := manifest.Validate(registry); err == nil {
+				t.Fatalf("expected a %s pool with one spare connection to fail validation", test.name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Follow-up to #1809. That PR landed the pooler logging, healthcheck and `STATS_USERS` fixes for CHAOS-3944/3945 and raised the queue pool 27 → 36. This PR does not revisit any of that; it replaces the one thing left hand-maintained.

#1809's Compose comment writes the pool size out by hand and says a derived formula was considered but that "the service list only exists in `compose.go-workers.yml`'s `services:` keys, which plain YAML cannot introspect at parse time". It does not have to be YAML that reads it: `internal/deploymentcontract` already holds the process list and already computes declared client footprints from it. Moving the derivation there means the next service addition fails the contract instead of quietly invalidating a comment — which is the failure mode CHAOS-3945 was filed about.

Moving it exposed two errors in the hand model.

## 1. The notifier session is not charged to every process

#1809's comment charges all nine processes three backends each — pool plus River notifier. Traced to code, that is not what happens:

| runtime | opens queue pool | starts River client | cost / replica |
| --- | --- | --- | ---: |
| `river` (sync, heavy, ops, sync-provider) | yes | **yes** — `cmd/dev-health-worker/river_process.go:26`, the only non-test `Client.Start` in the repo | 2 + 1 |
| `control` (reconciler, scheduler) | yes | no — builds a client, drives it through the `*Tx` APIs only | 2 |
| `stream` (external, ingest, pagerduty) | **no** | no | 0 |
| `workerctl` CLI | yes, short-lived | no | 2 |

The stream runners' `WORKER_DATABASE_URI` is inherited from a YAML anchor and never read — `deployment.json` already declares `queue_control_max_connections: 0` for them, so the compose comment and the manifest disagreed.

The notifier is now a **declared, validated** budget term (`queue_session_notifier_sessions_per_replica`) charged per runtime. Declared queue-session maximum: **34**. That is higher than the hand model's 27 despite charging fewer processes, because the contract sizes from `max_replicas` (2), not from the current `replicas: 1`.

## 2. The rolling-restart reserve is fleet-wide, not one replica

Every replica-bearing process is its own independently rolled unit — Helm renders each as a Deployment with `maxSurge: 1`, `maxUnavailable: 0` — so one image or config change surges **all** of them together, each briefly running a replica beyond its declared maximum while the outgoing replica's sessions linger until `server_idle_timeout`. The reserve is the sum across groups, and the same defect applied to the coordinator pool, which sat at headroom 1 and is where the reconciler and scheduler leader locks live.

```
queue        34 + 16 (3+3+3+3 river, 2+2 control) = 50   (was 36)
coordinator  10 +  4 (2+2 control)                = 14   (was 11)
server footprint 15 + (20x2) + 50 + 14 = 119 of a declared 200
```

`go-workerctl` is in the steady-state total but not the surge reserve: it is a one-shot invocation, not a rolled replica. The streams are in neither.

## 3. The PostgreSQL requirement is now stated

`server_max_connections` is a requirement on a server the stack cannot read — the contract validates the topology against its own declaration, not against your database. #1809 raised it 100 → 200 without telling an operator. It is now stated in `docs/operate/install/production.md`, the databases guide, and `deploy/docker-compose/.env.example`, each with `psql ... -Atc 'SHOW max_connections'` to confirm it. A live admission check needs a runtime probe and is not attempted here.

## Guards

- a `river` replica is charged exactly one notifier session; control, stream and CLI clients are charged none — verified against an independently recomputed pool-only total, so deleting the term fails the test;
- a manifest declaring zero notifier sessions is rejected, so the budget cannot quietly revert to pool-only arithmetic;
- **both** session pools are rejected when their headroom cannot absorb a fleet-wide rolling restart.

## Not changed

The Helm `tcpSocket` probes, per #1809's reasoning. Worth recording alongside it: swapping in the Compose `pg_isready -U/-d` probe would not close that gap either. Measured directly against `edoburu/pgbouncer`, `pg_isready` exits 0 for a nonexistent role *and* a nonexistent database, and non-zero only when nothing answers the port — which is why #1809 correctly moved to a real `psql` probe on Compose.

Live pool **occupancy** also stays out of scope. This model proves declared maxima, a build-time property of checked-in files. Occupancy is a runtime property needing a scrape of the PgBouncer admin console — reachable since #1809, so that is the prerequisite, not the same change.


## Static sizing is interim, not the destination

This derivation is the best available stopgap for Compose, which cannot introspect its own service list at parse time. It is not where connection pool sizing should live long-term: the Kubernetes deploy stack is meant to size pools dynamically from load (one of the issues CHAOS-3944/3945's follow-on work needs to address), so this hand-derived-but-computed Compose model should not be hardened further as a target — it should be replaced once k8s does that dynamically.

## Live host currently disagrees with the derived default

The river-queue PgBouncer on the live host is pinned via `PGBOUNCER_RIVER_QUEUE_POOL_SIZE=37` in the host `.env` (set directly, container recreated, verified) — not the Compose default. This PR raises that default to **50**. Since the host `.env` overrides the default, merging this PR does **not** change the live pool size; the host is currently under-provisioned relative to what this derivation says a full fleet rolling restart needs (50). Flagging here rather than changing the host: that's a separate deploy action for whoever owns that host.

## Unrelated: two CI checks were failing before this PR touched anything

`test` and `test-matrix (3.14)` were failing against a clean `origin/main` tree (`934 != 921` in `tests/tooling/test_go_integration_sharding.py`) before this branch rebased through it. This PR's own 3 new tests live in `internal/deploymentcontract`, which isn't part of the Go integration-shard package set at all — they have zero effect on that count. All of the drift predates this branch; this PR is an innocent messenger, red here only because it's the first Python-touching PR to rebase through main's silent redness (`go.yml`'s push trigger has been off since `f5e5ee4ff`, and it isn't a required check, so nothing surfaces this without a PR like this one crossing both a Go and a Python path filter at once).

Fixed in a separate commit (not squashed into the derivation work, so it's cherry-pickable on its own) that bumps the pinned expected counts from 921/107 to 934/108 — see that commit's message for which five merged commits moved the count and why CI never caught it.

Worth noting for the CI-gate ticket's scope, not fixed here: those counts are hand-transcribed literals with no generator script, so the next providersync test addition re-breaks them the same way, silently, until the next Python-touching PR happens to rebase through it.
